### PR TITLE
docs: promote Spring Security panel to v0.2 with scoped plan

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -288,13 +288,48 @@ Potential features:
 - Better WebFlux support.
 - Services panel for Docker Compose and Testcontainers.
 - Link from UI to source files when possible.
+- Spring Security panel (read-only). See section 4.1 below.
+
+### 4.1 Spring Security panel (v0.2 / v0.3)
+
+Goal: answer "why am I getting 401/403?" without leaving the browser. Strictly
+read-only, fail-closed when Spring Security is not on the classpath.
+
+Scope:
+
+- List of `SecurityFilterChain` beans with order, request matcher, and the
+  effective ordered list of filters.
+- Per-request "explain" tool: enter an HTTP method and path, show which chain
+  matches and the resulting filter pipeline.
+- Summary of CSRF, CORS, and session-management configuration per chain.
+- Active `AuthenticationProvider`s and the type of `UserDetailsService` in use
+  (type names only, never credentials).
+- In dev, surface the auto-generated user name from
+  `UserDetailsServiceAutoConfiguration` but never its password.
+
+Non-goals for v0.x:
+
+- No "test login as user X" or impersonation.
+- No mutation of security configuration at runtime.
+- No display of client secrets, JWT signing keys, or in-memory passwords.
+
+Implementation notes:
+
+- New `bootui-autoconfigure` module slice gated by
+  `@ConditionalOnClass(SecurityFilterChain.class)` and
+  `ObjectProvider<List<SecurityFilterChain>>`; absent classpath ⇒ panel hidden.
+- DTOs in `BootUiDtos` to insulate the UI from Spring Security internals,
+  which change between minor versions.
+- Every string surfaced to the browser routed through `SecretMasker` and
+  honoring `bootui.expose-values`.
+- Pairs with the existing Mappings panel: link each mapping to its matching
+  chain.
 
 ## 5. v1.0 scope
 
 Potential features:
 
 - Extension SPI.
-- Spring Security panel.
 - Spring Data panel.
 - Spring Batch panel.
 - Spring Cloud panel.


### PR DESCRIPTION
## What does this PR do?

Promotes the Spring Security panel from the v1.0 wish list to the v0.2 scope in `docs/PLAN.md` and adds a dedicated subsection (4.1) that scopes the feature concretely.

## Why is this change needed?

"Why am I getting 401/403?" is one of the most common local dev frustrations, and none of the existing panels (Mappings, Conditions, Beans) surface it well. Spring Security introspection is naturally read-only and fits BootUI's safety model, so it deserves an earlier slot than v1.0. Pinning down the scope now also de-risks the v0.2 milestone.

The new §4.1 captures:

- **Scope:** list `SecurityFilterChain` beans with order/matcher/filter list, a per-request explain tool, CSRF/CORS/session summary, active providers and `UserDetailsService` type.
- **Non-goals:** no impersonation, no runtime mutation, no client secrets / JWT keys / in-memory passwords.
- **Implementation notes:** gated by `@ConditionalOnClass(SecurityFilterChain.class)` so the panel fails closed when Spring Security is absent; DTOs in `BootUiDtos` to insulate the UI from Spring Security internals; every value routed through `SecretMasker` and honoring `bootui.expose-values`; pairs with the existing Mappings panel.

Closes #

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Docs-only change; no code, build, or runtime behaviour is affected.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed