### PR TITLE
Skip CodeQL when code scanning is unavailable

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,10 +21,23 @@ jobs:
       matrix:
         language: ['java-kotlin', 'javascript-typescript']
     steps:
+      - name: Check code scanning availability
+        id: code-scanning
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api "repos/${GITHUB_REPOSITORY}/code-scanning/alerts?per_page=1" >/dev/null 2>&1; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Code scanning is not enabled or unavailable for this repository; skipping CodeQL analysis."
+          fi
+
       - uses: actions/checkout@v4
+        if: steps.code-scanning.outputs.enabled == 'true'
 
       - name: Set up JDK 25
-        if: matrix.language == 'java-kotlin'
+        if: steps.code-scanning.outputs.enabled == 'true' && matrix.language == 'java-kotlin'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -32,21 +45,23 @@ jobs:
           cache: maven
 
       - name: Set up Node.js
-        if: matrix.language == 'java-kotlin'
+        if: steps.code-scanning.outputs.enabled == 'true' && matrix.language == 'java-kotlin'
         uses: actions/setup-node@v4
         with:
           node-version: '24'
 
       - name: Initialize CodeQL
+        if: steps.code-scanning.outputs.enabled == 'true'
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Build (Java)
-        if: matrix.language == 'java-kotlin'
+        if: steps.code-scanning.outputs.enabled == 'true' && matrix.language == 'java-kotlin'
         run: mvn -B -ntp -DskipTests package
 
       - name: Perform CodeQL Analysis
+        if: steps.code-scanning.outputs.enabled == 'true'
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What does this PR do?

Skips the CodeQL workflow when GitHub code scanning is not enabled or available for the repository, and emits a notice explaining why analysis was skipped.

## Why is this change needed?

The main branch CodeQL check was failing because CodeQL analysis could not upload results to a repository where code scanning is disabled. This keeps the workflow from failing on repository configuration while preserving CodeQL analysis automatically when code scanning becomes available.

Closes N/A

## How was it tested?

- [x] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed