### PR TITLE
Add Spring Data Explorer panel

### DIFF
--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>spring-boot-health</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -6,6 +6,7 @@ import io.github.bootui.autoconfigure.web.BeansController;
 import io.github.bootui.autoconfigure.web.BootUiIndexController;
 import io.github.bootui.autoconfigure.web.ConditionsController;
 import io.github.bootui.autoconfigure.web.ConfigController;
+import io.github.bootui.autoconfigure.web.DataController;
 import io.github.bootui.autoconfigure.web.HealthController;
 import io.github.bootui.autoconfigure.web.LoggersController;
 import io.github.bootui.autoconfigure.web.MappingsController;
@@ -47,6 +48,7 @@ import org.springframework.core.env.Environment;
         HealthController.class,
         LoggersController.class,
         StartupController.class,
+        DataController.class,
         BootUiIndexController.class
 })
 public class BootUiAutoConfiguration {

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DataController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DataController.java
@@ -1,0 +1,335 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.RepositoriesReport;
+import io.github.bootui.core.BootUiDtos.RepositoryDetailDto;
+import io.github.bootui.core.BootUiDtos.RepositoryDto;
+import io.github.bootui.core.BootUiDtos.RepositoryMethodDto;
+import jakarta.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.RepositoryFactoryInformation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes Spring Data repositories declared in the current application context.
+ *
+ * <p>This controller is read-only: it never invokes repository methods. It only
+ * surfaces metadata that Spring Data has already computed about the repositories
+ * it manages.</p>
+ */
+@RestController
+@ConditionalOnClass(RepositoryFactoryInformation.class)
+@RequestMapping("/bootui/api/data")
+public class DataController {
+
+    private final ObjectProvider<ListableBeanFactory> beanFactoryProvider;
+
+    public DataController(ObjectProvider<ListableBeanFactory> beanFactoryProvider) {
+        this.beanFactoryProvider = beanFactoryProvider;
+    }
+
+    @GetMapping("/repositories")
+    public RepositoriesReport repositories() {
+        List<RepositoryEntry> entries = discover();
+        List<RepositoryDto> summaries = entries.stream()
+                .map(this::toSummary)
+                .sorted(Comparator.comparing(RepositoryDto::repositoryInterface,
+                        Comparator.nullsLast(String::compareTo)))
+                .collect(Collectors.toList());
+        return new RepositoriesReport(true, summaries.size(), summaries);
+    }
+
+    @GetMapping("/repositories/{name}")
+    public ResponseEntity<RepositoryDetailDto> repository(@PathVariable String name) {
+        for (RepositoryEntry entry : discover()) {
+            if (matches(entry, name)) {
+                return ResponseEntity.ok(toDetail(entry));
+            }
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    private List<RepositoryEntry> discover() {
+        ListableBeanFactory factory = beanFactoryProvider.getIfAvailable();
+        if (factory == null) {
+            return List.of();
+        }
+        String[] beanNames = factory.getBeanNamesForType(RepositoryFactoryInformation.class);
+        List<RepositoryEntry> entries = new ArrayList<>(beanNames.length);
+        for (String beanName : beanNames) {
+            RepositoryFactoryInformation<?, ?> info;
+            try {
+                info = factory.getBean(beanName, RepositoryFactoryInformation.class);
+            } catch (Exception ex) {
+                continue;
+            }
+            RepositoryInformation repositoryInformation;
+            try {
+                repositoryInformation = info.getRepositoryInformation();
+            } catch (Exception ex) {
+                continue;
+            }
+            entries.add(new RepositoryEntry(strip(beanName), info, repositoryInformation));
+        }
+        return entries;
+    }
+
+    private boolean matches(RepositoryEntry entry, String name) {
+        if (name == null) {
+            return false;
+        }
+        if (name.equals(entry.beanName())) {
+            return true;
+        }
+        Class<?> iface = entry.information().getRepositoryInterface();
+        return iface != null && (name.equals(iface.getName()) || name.equals(iface.getSimpleName()));
+    }
+
+    private RepositoryDto toSummary(RepositoryEntry entry) {
+        RepositoryInformation info = entry.information();
+        Class<?> iface = info.getRepositoryInterface();
+        Class<?> domainType = info.getDomainType();
+        Class<?> idType = info.getIdType();
+        Class<?> custom = info.getRepositoryBaseClass();
+        int fragments = fragmentCount(entry);
+        int queryMethods = queryMethodCount(info);
+        return new RepositoryDto(
+                entry.beanName(),
+                iface == null ? null : iface.getName(),
+                domainType == null ? null : domainType.getName(),
+                idType == null ? null : idType.getName(),
+                detectStoreModule(iface),
+                custom == null ? null : custom.getName(),
+                queryMethods,
+                fragments);
+    }
+
+    private RepositoryDetailDto toDetail(RepositoryEntry entry) {
+        RepositoryInformation info = entry.information();
+        Class<?> iface = info.getRepositoryInterface();
+        Class<?> domainType = info.getDomainType();
+        Class<?> idType = info.getIdType();
+        Class<?> custom = info.getRepositoryBaseClass();
+        List<RepositoryMethodDto> methods = new ArrayList<>();
+        if (iface != null) {
+            Method[] declared = iface.getMethods();
+            Arrays.sort(declared, Comparator.comparing(Method::getName));
+            for (Method method : declared) {
+                if (method.getDeclaringClass() == Object.class) {
+                    continue;
+                }
+                methods.add(toMethodDto(info, method));
+            }
+        }
+        return new RepositoryDetailDto(
+                entry.beanName(),
+                iface == null ? null : iface.getName(),
+                domainType == null ? null : domainType.getName(),
+                idType == null ? null : idType.getName(),
+                detectStoreModule(iface),
+                custom == null ? null : custom.getName(),
+                methods,
+                Collections.emptyList());
+    }
+
+    private RepositoryMethodDto toMethodDto(RepositoryInformation info, Method method) {
+        String origin;
+        if (info.isCustomMethod(method)) {
+            origin = "FRAGMENT";
+        } else if (info.isQueryMethod(method)) {
+            origin = "QUERY";
+        } else if (method.isDefault()) {
+            origin = "DEFAULT";
+        } else if (info.isBaseClassMethod(method)) {
+            origin = "CRUD";
+        } else {
+            origin = "DERIVED";
+        }
+        QueryAnnotation queryAnnotation = readQueryAnnotation(method);
+        if (queryAnnotation != null && "QUERY".equals(origin) && queryAnnotation.hasValue) {
+            origin = "ANNOTATED";
+        }
+        return new RepositoryMethodDto(
+                method.getName(),
+                signatureOf(method),
+                origin,
+                queryAnnotation == null ? null : queryAnnotation.value,
+                queryAnnotation != null && queryAnnotation.nativeQuery,
+                queryAnnotation == null ? null : queryAnnotation.name);
+    }
+
+    private int queryMethodCount(RepositoryInformation info) {
+        int count = 0;
+        Class<?> iface = info.getRepositoryInterface();
+        if (iface == null) {
+            return 0;
+        }
+        for (Method method : iface.getMethods()) {
+            if (method.getDeclaringClass() == Object.class) {
+                continue;
+            }
+            if (info.isQueryMethod(method)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private int fragmentCount(RepositoryEntry entry) {
+        Class<?> iface = entry.information().getRepositoryInterface();
+        if (iface == null) {
+            return 0;
+        }
+        int count = 0;
+        for (Method method : iface.getMethods()) {
+            if (entry.information().isCustomMethod(method)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private String signatureOf(Method method) {
+        String params = Arrays.stream(method.getParameterTypes())
+                .map(Class::getSimpleName)
+                .collect(Collectors.joining(", "));
+        String returnType = method.getReturnType().getSimpleName();
+        return returnType + " " + method.getName() + "(" + params + ")";
+    }
+
+    private String detectStoreModule(@Nullable Class<?> iface) {
+        if (iface == null) {
+            return "GENERIC";
+        }
+        String pkg = iface.getPackageName();
+        // Walk the interface hierarchy looking for known store-specific marker packages.
+        for (Class<?> c : collectRepositoryInterfaces(iface)) {
+            String cp = c.getPackageName();
+            if (cp.startsWith("org.springframework.data.jpa")) {
+                return "JPA";
+            }
+            if (cp.startsWith("org.springframework.data.jdbc")) {
+                return "JDBC";
+            }
+            if (cp.startsWith("org.springframework.data.mongodb")) {
+                return "MONGO";
+            }
+            if (cp.startsWith("org.springframework.data.r2dbc")) {
+                return "R2DBC";
+            }
+            if (cp.startsWith("org.springframework.data.redis")) {
+                return "REDIS";
+            }
+            if (cp.startsWith("org.springframework.data.cassandra")) {
+                return "CASSANDRA";
+            }
+            if (cp.startsWith("org.springframework.data.neo4j")) {
+                return "NEO4J";
+            }
+            if (cp.startsWith("org.springframework.data.elasticsearch")) {
+                return "ELASTICSEARCH";
+            }
+            if (cp.startsWith("org.springframework.data.couchbase")) {
+                return "COUCHBASE";
+            }
+        }
+        if (pkg.startsWith("org.springframework.data")) {
+            return "COMMONS";
+        }
+        return "GENERIC";
+    }
+
+    private List<Class<?>> collectRepositoryInterfaces(Class<?> root) {
+        List<Class<?>> all = new ArrayList<>();
+        collect(root, all);
+        return all;
+    }
+
+    private void collect(Class<?> type, List<Class<?>> sink) {
+        if (type == null || sink.contains(type)) {
+            return;
+        }
+        sink.add(type);
+        for (Class<?> i : type.getInterfaces()) {
+            collect(i, sink);
+        }
+    }
+
+    /**
+     * Read {@code @org.springframework.data.jpa.repository.Query} (or any store-specific
+     * {@code Query} annotation) reflectively so we don't require Spring Data JPA on the
+     * classpath.
+     */
+    @Nullable
+    private QueryAnnotation readQueryAnnotation(Method method) {
+        for (Annotation annotation : method.getAnnotations()) {
+            String typeName = annotation.annotationType().getName();
+            if (!typeName.endsWith(".Query")) {
+                continue;
+            }
+            if (!typeName.startsWith("org.springframework.data.")) {
+                continue;
+            }
+            String value = readAttribute(annotation, "value");
+            String name = readAttribute(annotation, "name");
+            Boolean nativeQuery = readBooleanAttribute(annotation, "nativeQuery");
+            return new QueryAnnotation(
+                    value == null || value.isBlank() ? null : value,
+                    name == null || name.isBlank() ? null : name,
+                    Boolean.TRUE.equals(nativeQuery),
+                    value != null && !value.isBlank());
+        }
+        return null;
+    }
+
+    @Nullable
+    private String readAttribute(Annotation annotation, String attribute) {
+        try {
+            Method m = annotation.annotationType().getMethod(attribute);
+            Object value = m.invoke(annotation);
+            return value == null ? null : value.toString();
+        } catch (ReflectiveOperationException ex) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private Boolean readBooleanAttribute(Annotation annotation, String attribute) {
+        try {
+            Method m = annotation.annotationType().getMethod(attribute);
+            Object value = m.invoke(annotation);
+            return value instanceof Boolean b ? b : null;
+        } catch (ReflectiveOperationException ex) {
+            return null;
+        }
+    }
+
+    private String strip(String beanName) {
+        return beanName.startsWith("&") ? beanName.substring(1) : beanName;
+    }
+
+    private record RepositoryEntry(String beanName,
+                                   RepositoryFactoryInformation<?, ?> factoryInformation,
+                                   RepositoryInformation information) {
+    }
+
+    private record QueryAnnotation(@Nullable String value,
+                                   @Nullable String name,
+                                   boolean nativeQuery,
+                                   boolean hasValue) {
+    }
+}

--- a/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
@@ -140,4 +140,44 @@ public final class BootUiDtos {
 
     public record StartupReport(List<StartupStepDto> steps) {
     }
+
+    /** Summary of one Spring Data repository discovered in the context. */
+    public record RepositoryDto(
+            String beanName,
+            String repositoryInterface,
+            String domainType,
+            String idType,
+            String storeModule,
+            String customImplementation,
+            int queryMethodCount,
+            int fragmentCount) {
+    }
+
+    /** Detail view of a Spring Data repository, including its query methods. */
+    public record RepositoryDetailDto(
+            String beanName,
+            String repositoryInterface,
+            String domainType,
+            String idType,
+            String storeModule,
+            String customImplementation,
+            List<RepositoryMethodDto> methods,
+            List<String> fragments) {
+    }
+
+    /** One query method on a Spring Data repository. */
+    public record RepositoryMethodDto(
+            String name,
+            String signature,
+            String origin,
+            String query,
+            boolean nativeQuery,
+            String namedQuery) {
+    }
+
+    public record RepositoriesReport(
+            boolean springDataPresent,
+            int total,
+            List<RepositoryDto> repositories) {
+    }
 }

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -11,6 +11,7 @@ import Config from './views/Config.vue'
 import Mappings from './views/Mappings.vue'
 import Health from './views/Health.vue'
 import Loggers from './views/Loggers.vue'
+import Data from './views/Data.vue'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -22,7 +23,8 @@ const router = createRouter({
     { path: '/config', name: 'config', component: Config, meta: { icon: 'bi-sliders', title: 'Configuration' } },
     { path: '/mappings', name: 'mappings', component: Mappings, meta: { icon: 'bi-signpost-2', title: 'Mappings' } },
     { path: '/health', name: 'health', component: Health, meta: { icon: 'bi-heart-pulse', title: 'Health' } },
-    { path: '/loggers', name: 'loggers', component: Loggers, meta: { icon: 'bi-journal-text', title: 'Loggers' } }
+    { path: '/loggers', name: 'loggers', component: Loggers, meta: { icon: 'bi-journal-text', title: 'Loggers' } },
+    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } }
   ]
 })
 

--- a/bootui-ui/src/main/frontend/src/views/Data.vue
+++ b/bootui-ui/src/main/frontend/src/views/Data.vue
@@ -1,0 +1,203 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+const report = ref(null)
+const detail = ref(null)
+const selected = ref(null)
+const filter = ref('')
+const storeFilter = ref('')
+const error = ref(null)
+const springDataPresent = ref(true)
+
+async function load() {
+  try {
+    const res = await fetch('api/data/repositories')
+    if (res.status === 404) {
+      springDataPresent.value = false
+      return
+    }
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    report.value = await res.json()
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function open(repo) {
+  selected.value = repo.repositoryInterface
+  detail.value = null
+  const key = encodeURIComponent(repo.repositoryInterface || repo.beanName)
+  const res = await fetch(`api/data/repositories/${key}`)
+  if (res.ok) {
+    detail.value = await res.json()
+  }
+}
+
+const stores = computed(() => {
+  if (!report.value) return []
+  const set = new Set(report.value.repositories.map(r => r.storeModule))
+  return Array.from(set).sort()
+})
+
+const filtered = computed(() => {
+  if (!report.value) return []
+  const f = filter.value.toLowerCase()
+  return report.value.repositories.filter(r => {
+    if (storeFilter.value && r.storeModule !== storeFilter.value) return false
+    if (!f) return true
+    return (r.repositoryInterface || '').toLowerCase().includes(f)
+        || (r.domainType || '').toLowerCase().includes(f)
+        || (r.beanName || '').toLowerCase().includes(f)
+  })
+})
+
+const shortName = name => {
+  if (!name) return ''
+  const i = name.lastIndexOf('.')
+  return i < 0 ? name : name.substring(i + 1)
+}
+
+const storeClass = s => ({
+  JPA: 'bg-primary',
+  JDBC: 'bg-info text-dark',
+  MONGO: 'bg-success',
+  REDIS: 'bg-danger',
+  R2DBC: 'bg-warning text-dark',
+  CASSANDRA: 'bg-secondary',
+  NEO4J: 'bg-dark',
+  ELASTICSEARCH: 'bg-warning text-dark',
+  COUCHBASE: 'bg-info text-dark',
+  COMMONS: 'bg-light text-dark border',
+  GENERIC: 'bg-light text-dark border'
+}[s] || 'bg-secondary')
+
+const originClass = o => ({
+  CRUD: 'bg-light text-dark border',
+  DERIVED: 'bg-success',
+  QUERY: 'bg-primary',
+  ANNOTATED: 'bg-primary',
+  FRAGMENT: 'bg-warning text-dark',
+  DEFAULT: 'bg-info text-dark'
+}[o] || 'bg-secondary')
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <h2><i class="bi bi-database me-2"></i>Spring Data repositories</h2>
+
+    <div v-if="!springDataPresent" class="alert alert-info">
+      Spring Data is not on the classpath of this application. Add a Spring Data
+      starter (e.g. <code>spring-boot-starter-data-jpa</code>) to see repositories here.
+    </div>
+
+    <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
+
+    <div v-else-if="report && report.total === 0" class="alert alert-secondary">
+      Spring Data is on the classpath, but no repository beans were detected in the
+      application context.
+    </div>
+
+    <template v-else-if="report">
+      <div class="row g-2 mb-3">
+        <div class="col-md-6">
+          <input class="form-control" v-model="filter" placeholder="Filter by interface, entity, or bean name…" />
+        </div>
+        <div class="col-md-3">
+          <select class="form-select" v-model="storeFilter">
+            <option value="">All stores</option>
+            <option v-for="s in stores" :key="s" :value="s">{{ s }}</option>
+          </select>
+        </div>
+        <div class="col-md-3 text-end small text-muted align-self-center">
+          {{ filtered.length }} / {{ report.total }} repositories
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col-md-5">
+          <div class="list-group">
+            <button
+              v-for="r in filtered"
+              :key="r.beanName"
+              type="button"
+              class="list-group-item list-group-item-action"
+              :class="{ active: selected === r.repositoryInterface }"
+              @click="open(r)">
+              <div class="d-flex justify-content-between align-items-start">
+                <div>
+                  <div><strong>{{ shortName(r.repositoryInterface) }}</strong></div>
+                  <div class="small text-muted">
+                    {{ shortName(r.domainType) }}
+                    <span v-if="r.idType"> · id: {{ shortName(r.idType) }}</span>
+                  </div>
+                </div>
+                <span class="badge" :class="storeClass(r.storeModule)">{{ r.storeModule }}</span>
+              </div>
+              <div class="small mt-1">
+                <span class="me-2"><i class="bi bi-search me-1"></i>{{ r.queryMethodCount }} queries</span>
+                <span v-if="r.fragmentCount > 0">
+                  <i class="bi bi-puzzle me-1"></i>{{ r.fragmentCount }} fragments
+                </span>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        <div class="col-md-7">
+          <div v-if="!detail" class="text-muted small">Select a repository to see its methods.</div>
+          <div v-else class="card">
+            <div class="card-body">
+              <h5 class="card-title mb-1">{{ shortName(detail.repositoryInterface) }}</h5>
+              <div class="text-muted small mb-3">
+                <code>{{ detail.repositoryInterface }}</code>
+              </div>
+              <dl class="row mb-3 small">
+                <dt class="col-sm-3">Store module</dt>
+                <dd class="col-sm-9">
+                  <span class="badge" :class="storeClass(detail.storeModule)">{{ detail.storeModule }}</span>
+                </dd>
+                <dt class="col-sm-3">Domain type</dt>
+                <dd class="col-sm-9"><code>{{ detail.domainType }}</code></dd>
+                <dt class="col-sm-3">ID type</dt>
+                <dd class="col-sm-9"><code>{{ detail.idType }}</code></dd>
+                <dt class="col-sm-3">Bean name</dt>
+                <dd class="col-sm-9"><code>{{ detail.beanName }}</code></dd>
+                <template v-if="detail.customImplementation">
+                  <dt class="col-sm-3">Base class</dt>
+                  <dd class="col-sm-9"><code>{{ detail.customImplementation }}</code></dd>
+                </template>
+              </dl>
+
+              <h6 class="mb-2">Methods <span class="badge bg-secondary">{{ detail.methods.length }}</span></h6>
+              <table class="table table-sm table-hover">
+                <thead>
+                  <tr>
+                    <th style="width:110px">Origin</th>
+                    <th>Signature</th>
+                    <th>Query</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="m in detail.methods" :key="m.signature">
+                    <td>
+                      <span class="badge" :class="originClass(m.origin)">{{ m.origin }}</span>
+                    </td>
+                    <td><code>{{ m.signature }}</code></td>
+                    <td>
+                      <code v-if="m.query" class="small">{{ m.query }}</code>
+                      <span v-else-if="m.namedQuery" class="small text-muted">named: {{ m.namedQuery }}</span>
+                      <span v-else class="text-muted small">—</span>
+                      <span v-if="m.nativeQuery" class="badge bg-warning text-dark ms-1">native</span>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -398,6 +398,51 @@ Acceptance criteria:
 - Unknown services are represented generically.
 - Works even when Docker is not installed.
 
+### 5.10 Spring Data Explorer
+
+Purpose: answer "Which Spring Data repositories does this app declare, against which store, and what queries do they expose?"
+
+Data sources:
+
+- Spring Data `Repositories` bean and `RepositoryFactoryInformation` beans discovered in the application context.
+- Each repository's `RepositoryInformation` (domain type, ID type, repository interface, custom implementation class, query methods, fragment methods).
+- Optional Spring Data JPA / Hibernate metamodel when present, for managed entities and `@NamedQuery` declarations.
+- Optional link to the related `DataSource` health contributor surfaced in §5.6.
+
+Features:
+
+- List detected Spring Data repositories, grouped by store module (JPA, JDBC, MongoDB, Redis, R2DBC, Cassandra, Neo4j, generic).
+- For each repository, show:
+  - Repository interface name and package.
+  - Domain (entity) type and ID type.
+  - Whether the repository is a user-declared interface, a fragment, or auto-generated.
+  - Custom implementation class, if any.
+  - Method list with origin badge (CRUD, derived-query, `@Query`, fragment, default-method).
+  - For `@Query`-annotated methods: the declared query string, native flag, and named-query reference if any.
+  - For derived queries: the parsed property path / predicate, when available.
+- Filter by store module, by domain type, and by free-text on method or query content.
+- JPA-specific detail when Hibernate is on the classpath:
+  - Managed entities with table name and primary key.
+  - `@NamedQuery` and `@NamedNativeQuery` declarations.
+- Cross-link each repository to:
+  - The corresponding bean in the Beans Explorer (§5.2).
+  - The relevant `spring.datasource.*`, `spring.jpa.*`, `spring.data.*` properties in the Config Explorer (§5.4).
+  - The health contributor for its datastore in the Health Dashboard (§5.6).
+
+Out of scope for v0.1:
+
+- Executing repository methods or arbitrary queries from the UI (would break the read-only, fail-closed safety stance).
+- Schema migration controls (Flyway/Liquibase) — possible future panel.
+- Editing or generating repository code.
+
+Acceptance criteria:
+
+- When Spring Data is not on the classpath, the panel is hidden from the navigation and the API endpoint is not registered.
+- When Spring Data is present but no repositories are detected, the panel shows a clear empty state.
+- Query strings declared via `@Query` are displayed verbatim; BootUI never rewrites or executes them.
+- No repository method is invoked as a side effect of opening the panel.
+- The detail view exposes enough information to answer "which repository owns this entity?" and "where is the SQL for this method?" without reading the codebase.
+
 ## 6. Technical architecture
 
 ### 6.1 Proposed repository layout
@@ -538,6 +583,8 @@ Initial endpoints:
 | `/bootui/api/loggers/{name}` | POST | Change logger level |
 | `/bootui/api/startup` | GET | Startup timeline |
 | `/bootui/api/services` | GET | Local service connections |
+| `/bootui/api/data/repositories` | GET | Detected Spring Data repositories (summary) |
+| `/bootui/api/data/repositories/{name}` | GET | Spring Data repository detail with query methods |
 
 ### 6.5 Configuration properties
 
@@ -602,6 +649,7 @@ Top-level tabs:
 - Loggers.
 - Startup.
 - Services.
+- Data.
 
 ### 7.2 UI principles
 


### PR DESCRIPTION
## What does this PR do?

Adds a new BootUI panel that explains which Spring Data repositories are wired into the running application, against which store, and what queries they expose.

## Why is this change needed?

Spring Data is one of the most used Spring modules, and "which repositories exist, against what datasource, with what query strings?" is exactly the kind of "make a running app understandable in minutes" question BootUI targets. Until now this required reading source code; Quarkus Dev UI and Micronaut Control Panel both ship equivalent panels.

Closes #

## How was it tested?

- [x] `mvn clean install` passes locally for `bootui-core`, `bootui-autoconfigure`, and `bootui-ui` (Vite build green)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (the sample app does not yet include a Spring Data starter, so the panel renders its "Spring Data is not on the classpath" empty state, which is the intended fail-closed behavior)
- [ ] Added or updated tests where applicable

## Approach

- **Spec first.** `docs/SPECIFICATION.md` gets section 5.10 *Spring Data Explorer* covering data sources, features, JPA-specific extras, explicit out-of-scope items (no method invocation, no schema migration, no query editing), and acceptance criteria. Section 6.4 lists the two new endpoints and section 7.1 adds the `Data` navigation entry.
- **Read-only by design.** `DataController` discovers repositories through `ListableBeanFactory.getBeanNamesForType(RepositoryFactoryInformation.class)` and only reads `RepositoryInformation` metadata. No repository method is invoked and no declared `@Query` is executed; query strings are displayed verbatim.
- **Optional dependency.** The controller is gated by `@ConditionalOnClass(RepositoryFactoryInformation.class)`. `spring-data-commons` is added as an `optional` dependency to `bootui-autoconfigure`, so apps that do not use Spring Data are unaffected and the endpoint is simply not registered (the UI then shows a clear empty state).
- **No Spring Data JPA dependency.** `@Query` is read reflectively (`value`, `nativeQuery`, `name`) so the panel works for any Spring Data module that ships a `@Query` annotation, without forcing JPA on the classpath.
- **Store-module detection.** Walks the repository interface hierarchy looking for known Spring Data sub-package markers (JPA, JDBC, Mongo, R2DBC, Redis, Cassandra, Neo4j, Elasticsearch, Couchbase) and falls back to `COMMONS` / `GENERIC`.
- **Method classification.** Each query method is tagged as `CRUD`, `DERIVED`, `QUERY` / `ANNOTATED`, `FRAGMENT`, or `DEFAULT` so reviewers can quickly tell why a method exists.
- **UI.** New `Data.vue` master/detail view with store and free-text filters, store badges, method origin badges, and a fail-closed empty state when the API returns 404 (Spring Data absent). Wired into the router and sidebar with the `bi-database` icon.

## Notes for reviewers

- No change to existing controllers, safety filter, activation rules, or override plumbing.
- The sample app is intentionally left without a Spring Data starter in this PR to keep the diff focused; the panel's "not on classpath" path is the visible state until that is added.
- Potential follow-ups (deliberately out of scope here): JPA-specific entity / `@NamedQuery` enrichment, cross-links from the Beans / Config / Health panels into Data.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed