### PR TITLE
Add Spring Security panel

### DIFF
--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>spring-data-commons</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -11,6 +11,7 @@ import io.github.bootui.autoconfigure.web.HealthController;
 import io.github.bootui.autoconfigure.web.LoggersController;
 import io.github.bootui.autoconfigure.web.MappingsController;
 import io.github.bootui.autoconfigure.web.OverviewController;
+import io.github.bootui.autoconfigure.web.SecurityController;
 import io.github.bootui.autoconfigure.web.StartupController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,7 @@ import org.springframework.core.env.Environment;
         LoggersController.class,
         StartupController.class,
         DataController.class,
+        SecurityController.class,
         BootUiIndexController.class
 })
 public class BootUiAutoConfiguration {

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/SecurityController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/SecurityController.java
@@ -1,0 +1,340 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.autoconfigure.BootUiProperties;
+import io.github.bootui.core.BootUiDtos.SecurityAuthDto;
+import io.github.bootui.core.BootUiDtos.SecurityExplainDto;
+import io.github.bootui.core.BootUiDtos.SecurityFilterChainDto;
+import io.github.bootui.core.BootUiDtos.SecurityReport;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.MappingMatch;
+import jakarta.servlet.http.Part;
+import java.io.BufferedReader;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes Spring Security filter chain configuration for the BootUI developer console.
+ *
+ * <p>Read-only. Never surfaces credentials, signing keys, or session identifiers.
+ * Activated only when {@code spring-security-web} is on the classpath.</p>
+ */
+@RestController
+@ConditionalOnClass(FilterChainProxy.class)
+@RequestMapping("/bootui/api/security")
+public class SecurityController {
+
+    private final ObjectProvider<FilterChainProxy> filterChainProxyProvider;
+    private final ObjectProvider<AuthenticationProvider> authenticationProviderProvider;
+    private final ObjectProvider<UserDetailsService> userDetailsServiceProvider;
+    private final Environment environment;
+    private final BootUiProperties properties;
+
+    public SecurityController(ObjectProvider<FilterChainProxy> filterChainProxyProvider,
+                              ObjectProvider<AuthenticationProvider> authenticationProviderProvider,
+                              ObjectProvider<UserDetailsService> userDetailsServiceProvider,
+                              Environment environment,
+                              BootUiProperties properties) {
+        this.filterChainProxyProvider = filterChainProxyProvider;
+        this.authenticationProviderProvider = authenticationProviderProvider;
+        this.userDetailsServiceProvider = userDetailsServiceProvider;
+        this.environment = environment;
+        this.properties = properties;
+    }
+
+    @GetMapping
+    public SecurityReport security() {
+        FilterChainProxy proxy = filterChainProxyProvider.getIfAvailable();
+        if (proxy == null) {
+            return new SecurityReport(false, List.of(), null);
+        }
+        List<SecurityFilterChain> chains = proxy.getFilterChains();
+        List<SecurityFilterChainDto> chainDtos = new ArrayList<>(chains.size());
+        for (int i = 0; i < chains.size(); i++) {
+            chainDtos.add(toChainDto(i, chains.get(i)));
+        }
+        return new SecurityReport(true, chainDtos, buildAuth());
+    }
+
+    /**
+     * Best-effort explain: given an HTTP method and path, returns the first matching chain
+     * and its filter pipeline.
+     *
+     * <p>Matching is performed with a minimal request stub that covers method and path only.
+     * Header- or session-based matchers may not match correctly; {@code bestEffort} is
+     * {@code true} when the stub detected that such matchers were consulted.</p>
+     */
+    @GetMapping("/explain")
+    public SecurityExplainDto explain(@RequestParam(defaultValue = "GET") String method,
+                                      @RequestParam(defaultValue = "/") String path) {
+        FilterChainProxy proxy = filterChainProxyProvider.getIfAvailable();
+        if (proxy == null) {
+            return new SecurityExplainDto(false, false, null, null, List.of());
+        }
+        ExplainRequest request = new ExplainRequest(method, path);
+        List<SecurityFilterChain> chains = proxy.getFilterChains();
+        for (int i = 0; i < chains.size(); i++) {
+            SecurityFilterChain chain = chains.get(i);
+            boolean matches;
+            try {
+                matches = chain.matches(request);
+            } catch (Exception ex) {
+                return new SecurityExplainDto(false, true, null,
+                        "Chain " + i + " matcher threw " + ex.getClass().getSimpleName()
+                                + " — requires more request context than available",
+                        List.of());
+            }
+            if (matches) {
+                return new SecurityExplainDto(
+                        true,
+                        request.isBestEffort(),
+                        i,
+                        matcherDescription(chain),
+                        filterNames(chain.getFilters()));
+            }
+        }
+        return new SecurityExplainDto(false, request.isBestEffort(), null, "No chain matched", List.of());
+    }
+
+    private SecurityFilterChainDto toChainDto(int order, SecurityFilterChain chain) {
+        return new SecurityFilterChainDto(
+                order,
+                matcherDescription(chain),
+                matcherTypeName(chain),
+                filterNames(chain.getFilters()),
+                hasFilter(chain, "CsrfFilter"),
+                hasFilter(chain, "CorsFilter"),
+                hasFilter(chain, "SessionManagementFilter"));
+    }
+
+    private String matcherDescription(SecurityFilterChain chain) {
+        if (chain instanceof DefaultSecurityFilterChain dfc) {
+            return dfc.getRequestMatcher().toString();
+        }
+        return "(custom chain: " + chain.getClass().getSimpleName() + ")";
+    }
+
+    private String matcherTypeName(SecurityFilterChain chain) {
+        if (chain instanceof DefaultSecurityFilterChain dfc) {
+            return dfc.getRequestMatcher().getClass().getSimpleName();
+        }
+        return chain.getClass().getSimpleName();
+    }
+
+    private List<String> filterNames(List<? extends jakarta.servlet.Filter> filters) {
+        return filters.stream()
+                .map(f -> f.getClass().getSimpleName())
+                .collect(Collectors.toList());
+    }
+
+    private boolean hasFilter(SecurityFilterChain chain, String simpleClassName) {
+        return chain.getFilters().stream()
+                .anyMatch(f -> f.getClass().getSimpleName().equals(simpleClassName));
+    }
+
+    private SecurityAuthDto buildAuth() {
+        List<String> providerTypes = authenticationProviderProvider.stream()
+                .map(p -> p.getClass().getName())
+                .sorted()
+                .collect(Collectors.toList());
+        List<String> udsTypes = userDetailsServiceProvider.stream()
+                .map(u -> u.getClass().getName())
+                .sorted()
+                .collect(Collectors.toList());
+        // spring.security.user.name is a username, not a secret; expose it to help
+        // developers identify the auto-generated user when no custom UserDetailsService
+        // is configured. Never read spring.security.user.password.
+        String configuredUsername = null;
+        if (properties.getExposeValues() != BootUiProperties.ValueExposure.METADATA_ONLY) {
+            configuredUsername = environment.getProperty("spring.security.user.name");
+        }
+        return new SecurityAuthDto(providerTypes, udsTypes, configuredUsername);
+    }
+
+    /**
+     * Minimal {@link HttpServletRequest} stub used for best-effort chain matching in the
+     * explain endpoint. Provides method, path, and common safe defaults. Any method call
+     * that indicates header- or session-based matching sets {@link #isBestEffort()} so the
+     * caller can communicate reduced confidence to the client.
+     */
+    private static final class ExplainRequest implements HttpServletRequest {
+
+        private final String method;
+        private final String path;
+        private boolean bestEffort;
+
+        ExplainRequest(String method, String path) {
+            this.method = method != null ? method.toUpperCase(Locale.ROOT) : "GET";
+            this.path = path != null ? (path.startsWith("/") ? path : "/" + path) : "/";
+        }
+
+        boolean isBestEffort() {
+            return bestEffort;
+        }
+
+        // ── Core path/method ──────────────────────────────────────────────────────
+
+        @Override public String getMethod() { return method; }
+        @Override public String getServletPath() { return path; }
+        @Override public String getRequestURI() { return path; }
+        @Override public StringBuffer getRequestURL() { return new StringBuffer("http://localhost" + path); }
+        @Override public String getContextPath() { return ""; }
+        @Override public String getPathInfo() { return null; }
+        @Override public String getPathTranslated() { return null; }
+        @Override public String getQueryString() { return null; }
+
+        // ── Remote / connection ───────────────────────────────────────────────────
+
+        @Override public String getRemoteAddr() { return "127.0.0.1"; }
+        @Override public String getRemoteHost() { return "localhost"; }
+        @Override public int getRemotePort() { return 0; }
+        @Override public String getLocalAddr() { return "127.0.0.1"; }
+        @Override public String getLocalName() { return "localhost"; }
+        @Override public int getLocalPort() { return 80; }
+        @Override public String getScheme() { return "http"; }
+        @Override public String getServerName() { return "localhost"; }
+        @Override public int getServerPort() { return 80; }
+        @Override public String getProtocol() { return "HTTP/1.1"; }
+        @Override public boolean isSecure() { return false; }
+
+        // ── Headers — mark best-effort since header matchers may produce wrong results ──
+
+        @Override
+        public String getHeader(String name) {
+            bestEffort = true;
+            return null;
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(String name) {
+            bestEffort = true;
+            return Collections.emptyEnumeration();
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            bestEffort = true;
+            return Collections.emptyEnumeration();
+        }
+
+        @Override public long getDateHeader(String name) { bestEffort = true; return -1L; }
+        @Override public int getIntHeader(String name) { bestEffort = true; return -1; }
+
+        // ── Session / auth — mark best-effort ─────────────────────────────────────
+
+        @Override public HttpSession getSession(boolean create) { bestEffort = true; return null; }
+        @Override public HttpSession getSession() { bestEffort = true; return null; }
+        @Override public String getRequestedSessionId() { return null; }
+        @Override public boolean isRequestedSessionIdValid() { return false; }
+        @Override public boolean isRequestedSessionIdFromCookie() { return false; }
+        @Override public boolean isRequestedSessionIdFromURL() { return false; }
+        @Override public Principal getUserPrincipal() { return null; }
+        @Override public String getRemoteUser() { return null; }
+        @Override public boolean isUserInRole(String role) { return false; }
+        @Override public String getAuthType() { return null; }
+        @Override public Cookie[] getCookies() { return null; }
+
+        // ── Attributes ────────────────────────────────────────────────────────────
+
+        @Override public Object getAttribute(String name) { return null; }
+        @Override public Enumeration<String> getAttributeNames() { return Collections.emptyEnumeration(); }
+        @Override public void setAttribute(String name, Object o) { /* no-op */ }
+        @Override public void removeAttribute(String name) { /* no-op */ }
+
+        // ── Parameters ────────────────────────────────────────────────────────────
+
+        @Override public String getParameter(String name) { return null; }
+        @Override public Enumeration<String> getParameterNames() { return Collections.emptyEnumeration(); }
+        @Override public String[] getParameterValues(String name) { return null; }
+        @Override public Map<String, String[]> getParameterMap() { return Map.of(); }
+
+        // ── Content / encoding ────────────────────────────────────────────────────
+
+        @Override public String getCharacterEncoding() { return "UTF-8"; }
+        @Override public void setCharacterEncoding(String env) { /* no-op */ }
+        @Override public int getContentLength() { return -1; }
+        @Override public long getContentLengthLong() { return -1L; }
+        @Override public String getContentType() { return null; }
+        @Override public ServletInputStream getInputStream() { throw new UnsupportedOperationException(); }
+        @Override public BufferedReader getReader() { throw new UnsupportedOperationException(); }
+
+        // ── Locale ────────────────────────────────────────────────────────────────
+
+        @Override public Locale getLocale() { return Locale.getDefault(); }
+        @Override public Enumeration<Locale> getLocales() { return Collections.enumeration(List.of(Locale.getDefault())); }
+
+        // ── Dispatch ──────────────────────────────────────────────────────────────
+
+        @Override public DispatcherType getDispatcherType() { return DispatcherType.REQUEST; }
+        @Override public RequestDispatcher getRequestDispatcher(String path) { return null; }
+        @Override public ServletContext getServletContext() { return null; }
+        @Override public boolean isAsyncSupported() { return false; }
+        @Override public boolean isAsyncStarted() { return false; }
+        @Override public AsyncContext getAsyncContext() { return null; }
+        @Override public AsyncContext startAsync() { throw new UnsupportedOperationException(); }
+        @Override public AsyncContext startAsync(ServletRequest req, ServletResponse res) { throw new UnsupportedOperationException(); }
+
+        // ── HTTP upgrade / parts ──────────────────────────────────────────────────
+
+        @Override public Collection<Part> getParts() { return List.of(); }
+        @Override public Part getPart(String name) { return null; }
+        @Override public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) { throw new UnsupportedOperationException(); }
+        @Override public String changeSessionId() { throw new UnsupportedOperationException(); }
+        @Override public boolean authenticate(HttpServletResponse response) { throw new UnsupportedOperationException(); }
+        @Override public void login(String username, String password) { throw new UnsupportedOperationException(); }
+        @Override public void logout() { throw new UnsupportedOperationException(); }
+
+        // ── Trailer fields ────────────────────────────────────────────────────────
+
+        @Override public Map<String, String> getTrailerFields() { return Map.of(); }
+        @Override public boolean isTrailerFieldsReady() { return true; }
+
+        // ── Servlet connection / request ID (Servlet 6) ───────────────────────────
+
+        @Override public String getRequestId() { return ""; }
+        @Override public String getProtocolRequestId() { return ""; }
+        @Override public ServletConnection getServletConnection() { return null; }
+
+        // ── HTTP servlet mapping ──────────────────────────────────────────────────
+
+        @Override
+        public jakarta.servlet.http.HttpServletMapping getHttpServletMapping() {
+            return new jakarta.servlet.http.HttpServletMapping() {
+                @Override public String getMatchValue() { return ""; }
+                @Override public String getPattern() { return ""; }
+                @Override public String getServletName() { return ""; }
+                @Override public MappingMatch getMappingMatch() { return null; }
+            };
+        }
+    }
+}

--- a/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
@@ -180,4 +180,44 @@ public final class BootUiDtos {
             int total,
             List<RepositoryDto> repositories) {
     }
+
+    /** One Spring Security filter chain. */
+    public record SecurityFilterChainDto(
+            int order,
+            String requestMatcher,
+            String requestMatcherType,
+            List<String> filters,
+            boolean csrfEnabled,
+            boolean corsEnabled,
+            boolean sessionManagementPresent) {
+    }
+
+    /** Authentication and user-details summary. */
+    public record SecurityAuthDto(
+            List<String> authenticationProviderTypes,
+            List<String> userDetailsServiceTypes,
+            String configuredUsername) {
+    }
+
+    /**
+     * Result of the best-effort chain-matching explain.
+     *
+     * <p>{@code bestEffort} is {@code true} when the matching was performed
+     * with limited request state and may be inaccurate for header- or
+     * session-based matchers.</p>
+     */
+    public record SecurityExplainDto(
+            boolean matched,
+            boolean bestEffort,
+            Integer chainIndex,
+            String matcherDescription,
+            List<String> filters) {
+    }
+
+    /** Top-level Spring Security report. */
+    public record SecurityReport(
+            boolean springSecurityPresent,
+            List<SecurityFilterChainDto> chains,
+            SecurityAuthDto auth) {
+    }
 }

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -22,6 +22,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -12,6 +12,7 @@ import Mappings from './views/Mappings.vue'
 import Health from './views/Health.vue'
 import Loggers from './views/Loggers.vue'
 import Data from './views/Data.vue'
+import Security from './views/Security.vue'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -24,7 +25,8 @@ const router = createRouter({
     { path: '/mappings', name: 'mappings', component: Mappings, meta: { icon: 'bi-signpost-2', title: 'Mappings' } },
     { path: '/health', name: 'health', component: Health, meta: { icon: 'bi-heart-pulse', title: 'Health' } },
     { path: '/loggers', name: 'loggers', component: Loggers, meta: { icon: 'bi-journal-text', title: 'Loggers' } },
-    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } }
+    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } },
+    { path: '/security', name: 'security', component: Security, meta: { icon: 'bi-shield-lock', title: 'Security' } }
   ]
 })
 

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -1,0 +1,232 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const report = ref(null)
+const error = ref(null)
+const springSecurityPresent = ref(true)
+
+const explainMethod = ref('GET')
+const explainPath = ref('/')
+const explainResult = ref(null)
+const explainLoading = ref(false)
+
+async function load() {
+  try {
+    const res = await fetch('api/security')
+    if (res.status === 404) {
+      springSecurityPresent.value = false
+      return
+    }
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    report.value = await res.json()
+    if (!report.value.springSecurityPresent) {
+      springSecurityPresent.value = false
+    }
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function explain() {
+  explainLoading.value = true
+  explainResult.value = null
+  try {
+    const params = new URLSearchParams({ method: explainMethod.value, path: explainPath.value })
+    const res = await fetch('api/security/explain?' + params)
+    if (res.ok) {
+      explainResult.value = await res.json()
+    } else {
+      explainResult.value = { matched: false, bestEffort: false, matcherDescription: 'Error: HTTP ' + res.status, filters: [] }
+    }
+  } finally {
+    explainLoading.value = false
+  }
+}
+
+const httpMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
+
+const filterBadgeClass = name => {
+  if (name.includes('Csrf')) return 'bg-warning text-dark'
+  if (name.includes('Cors')) return 'bg-info text-dark'
+  if (name.includes('Session')) return 'bg-secondary'
+  if (name.includes('Authentication') || name.includes('Login') || name.includes('Logout')) return 'bg-primary'
+  if (name.includes('Authorization') || name.includes('Access')) return 'bg-danger'
+  if (name.includes('Security') || name.includes('Exception')) return 'bg-dark'
+  return 'bg-light text-dark border'
+}
+
+const shortName = name => {
+  if (!name) return ''
+  const i = name.lastIndexOf('.')
+  return i < 0 ? name : name.substring(i + 1)
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <h2><i class="bi bi-shield-lock me-2"></i>Spring Security</h2>
+
+    <div v-if="!springSecurityPresent" class="alert alert-info">
+      Spring Security is not on the classpath of this application. Add
+      <code>spring-boot-starter-security</code> to see security configuration here.
+    </div>
+
+    <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
+
+    <template v-else-if="report">
+
+      <!-- Filter chains -->
+      <h5 class="mt-3 mb-2">Filter chains <span class="badge bg-secondary">{{ report.chains.length }}</span></h5>
+
+      <div v-if="report.chains.length === 0" class="alert alert-secondary">
+        No filter chains detected. Spring Security may be present but not configured.
+      </div>
+
+      <div v-else class="accordion mb-4" id="chains-accordion">
+        <div
+          v-for="chain in report.chains"
+          :key="chain.order"
+          class="accordion-item">
+          <h2 class="accordion-header">
+            <button
+              class="accordion-button collapsed"
+              type="button"
+              data-bs-toggle="collapse"
+              :data-bs-target="'#chain-' + chain.order">
+              <div class="d-flex align-items-center gap-2 flex-wrap">
+                <span class="badge bg-secondary">#{{ chain.order }}</span>
+                <code class="small">{{ chain.requestMatcher }}</code>
+                <span class="badge bg-light text-dark border small">{{ chain.requestMatcherType }}</span>
+                <span v-if="chain.csrfEnabled" class="badge bg-warning text-dark">CSRF</span>
+                <span v-if="chain.corsEnabled" class="badge bg-info text-dark">CORS</span>
+                <span v-if="chain.sessionManagementPresent" class="badge bg-secondary">Session</span>
+                <span class="ms-auto text-muted small">{{ chain.filters.length }} filters</span>
+              </div>
+            </button>
+          </h2>
+          <div :id="'chain-' + chain.order" class="accordion-collapse collapse">
+            <div class="accordion-body">
+              <div class="mb-2 small text-muted">
+                <strong>Request matcher:</strong> {{ chain.requestMatcher }}
+                <span class="ms-2 badge bg-light text-dark border">{{ chain.requestMatcherType }}</span>
+              </div>
+              <div class="mb-1 small"><strong>Filters ({{ chain.filters.length }}):</strong></div>
+              <div class="d-flex flex-wrap gap-1">
+                <span
+                  v-for="filter in chain.filters"
+                  :key="filter"
+                  class="badge"
+                  :class="filterBadgeClass(filter)">
+                  {{ filter }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Authentication -->
+      <h5 class="mt-4 mb-2">Authentication</h5>
+      <div v-if="report.auth">
+        <dl class="row small">
+          <template v-if="report.auth.authenticationProviderTypes.length">
+            <dt class="col-sm-3">Authentication providers</dt>
+            <dd class="col-sm-9">
+              <div v-for="t in report.auth.authenticationProviderTypes" :key="t">
+                <code>{{ shortName(t) }}</code>
+                <span class="text-muted ms-1">({{ t }})</span>
+              </div>
+            </dd>
+          </template>
+
+          <template v-if="report.auth.userDetailsServiceTypes.length">
+            <dt class="col-sm-3">UserDetailsService</dt>
+            <dd class="col-sm-9">
+              <div v-for="t in report.auth.userDetailsServiceTypes" :key="t">
+                <code>{{ shortName(t) }}</code>
+                <span class="text-muted ms-1">({{ t }})</span>
+              </div>
+            </dd>
+          </template>
+
+          <template v-if="report.auth.configuredUsername">
+            <dt class="col-sm-3">Configured username</dt>
+            <dd class="col-sm-9">
+              <code>{{ report.auth.configuredUsername }}</code>
+              <span class="text-muted ms-2 small">(spring.security.user.name)</span>
+            </dd>
+          </template>
+        </dl>
+
+        <div
+          v-if="!report.auth.authenticationProviderTypes.length && !report.auth.userDetailsServiceTypes.length"
+          class="alert alert-secondary small">
+          No <code>AuthenticationProvider</code> or <code>UserDetailsService</code> beans found in the
+          application context. These may be configured internally by a parent context.
+        </div>
+      </div>
+
+      <!-- Explain tool -->
+      <h5 class="mt-4 mb-2">Explain a request</h5>
+      <p class="text-muted small">
+        Enter a method and path to see which filter chain would handle that request.
+        Matching is best-effort: header- or session-based matchers may not be evaluated accurately.
+      </p>
+      <div class="row g-2 mb-3">
+        <div class="col-auto">
+          <select class="form-select form-select-sm" v-model="explainMethod" style="width:auto">
+            <option v-for="m in httpMethods" :key="m" :value="m">{{ m }}</option>
+          </select>
+        </div>
+        <div class="col">
+          <input
+            class="form-control form-control-sm"
+            v-model="explainPath"
+            placeholder="/api/example"
+            @keyup.enter="explain" />
+        </div>
+        <div class="col-auto">
+          <button class="btn btn-sm btn-primary" @click="explain" :disabled="explainLoading">
+            <span v-if="explainLoading" class="spinner-border spinner-border-sm me-1"></span>
+            Explain
+          </button>
+        </div>
+      </div>
+
+      <div v-if="explainResult" class="card">
+        <div class="card-body small">
+          <div class="mb-2">
+            <span v-if="explainResult.matched" class="badge bg-success me-2">Matched</span>
+            <span v-else class="badge bg-danger me-2">No match</span>
+            <span v-if="explainResult.bestEffort" class="badge bg-warning text-dark me-2">Best effort</span>
+            <span v-if="explainResult.chainIndex != null" class="text-muted">Chain #{{ explainResult.chainIndex }}</span>
+          </div>
+          <div v-if="explainResult.matcherDescription" class="mb-2">
+            <strong>Matcher:</strong> <code>{{ explainResult.matcherDescription }}</code>
+          </div>
+          <div v-if="explainResult.filters && explainResult.filters.length">
+            <strong>Filter pipeline:</strong>
+            <div class="d-flex flex-wrap gap-1 mt-1">
+              <span
+                v-for="filter in explainResult.filters"
+                :key="filter"
+                class="badge"
+                :class="filterBadgeClass(filter)">
+                {{ filter }}
+              </span>
+            </div>
+          </div>
+          <div v-if="explainResult.bestEffort" class="alert alert-warning mt-2 mb-0 py-1 px-2 small">
+            <i class="bi bi-exclamation-triangle me-1"></i>
+            Result may be inaccurate for chains that match on headers, cookies, or session state.
+          </div>
+        </div>
+      </div>
+
+    </template>
+
+    <div v-else class="text-muted small">Loading…</div>
+  </div>
+</template>


### PR DESCRIPTION
## What does this PR do?

Adds a read-only Spring Security panel to the BootUI developer console, surfacing filter chain configuration, authentication providers, and a best-effort "explain a request" tool.

## Why is this change needed?

One of the most common questions during local development is "why am I getting 401/403?" This panel answers that without leaving the browser. It is described as a v0.2/v0.3 candidate in `docs/PLAN.md` (section 6 and 4.1).

Closes #

## How was it tested?

- [x] `mvn clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

The new Security panel (accessible via the `bi-shield-lock` sidebar icon) shows:

- An accordion of filter chains, each displaying its request matcher, filter pipeline, and CSRF/CORS/session badges.
- An authentication section listing `AuthenticationProvider` and `UserDetailsService` bean types, plus the configured username (never the password).
- An "Explain a request" tool: select a method and enter a path to see which chain would handle it and its filter pipeline. Responses carry a `bestEffort` flag when header- or session-based matchers were consulted.

## Implementation notes

**Backend (`bootui-autoconfigure`)**

- `SecurityController` -- gated by `@ConditionalOnClass(FilterChainProxy.class)` so it is completely absent when Spring Security is not on the classpath. Uses `ObjectProvider<FilterChainProxy>` to get the ordered list of chains from `FilterChainProxy.getFilterChains()`.
- The explain endpoint uses an inner `ExplainRequest` stub that implements `HttpServletRequest` with real method/path values. Methods that indicate header or session matchers (e.g., `getHeader()`, `getSession()`) set `bestEffort = true` so the client can display a reduced-confidence warning.
- `spring-security-web` added as an optional dependency to `bootui-autoconfigure`.
- New DTOs in `BootUiDtos`: `SecurityFilterChainDto`, `SecurityAuthDto`, `SecurityExplainDto`, `SecurityReport`.
- `SecurityController` registered in the `@Import(...)` list on `BootUiAutoConfiguration`.

**Frontend (`bootui-ui`)**

- `Security.vue` -- shows the panel; gracefully displays a "not present" alert when the API returns 404.
- Route registered in `main.js` with icon `bi-shield-lock` and title `Security`.

**Sample app**

- `spring-boot-starter-security` added so the panel has real data (Spring Boot's default `InMemoryUserDetailsManager` auto-configuration).

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed