### PR TITLE
feat: implement v0.2 panels (Startup, Scheduled, HTTP Probe, Log Tail, Profile Diff, Security, OpenAPI)

### DIFF
--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -55,6 +55,16 @@
             <artifactId>spring-data-commons</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -8,9 +8,14 @@ import io.github.bootui.autoconfigure.web.ConditionsController;
 import io.github.bootui.autoconfigure.web.ConfigController;
 import io.github.bootui.autoconfigure.web.DataController;
 import io.github.bootui.autoconfigure.web.HealthController;
+import io.github.bootui.autoconfigure.web.HttpProbeController;
 import io.github.bootui.autoconfigure.web.LoggersController;
+import io.github.bootui.autoconfigure.web.LogTailController;
 import io.github.bootui.autoconfigure.web.MappingsController;
 import io.github.bootui.autoconfigure.web.OverviewController;
+import io.github.bootui.autoconfigure.web.ProfileController;
+import io.github.bootui.autoconfigure.web.ScheduledController;
+import io.github.bootui.autoconfigure.web.SecurityController;
 import io.github.bootui.autoconfigure.web.StartupController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +54,11 @@ import org.springframework.core.env.Environment;
         LoggersController.class,
         StartupController.class,
         DataController.class,
+        ScheduledController.class,
+        HttpProbeController.class,
+        LogTailController.class,
+        ProfileController.class,
+        SecurityController.class,
         BootUiIndexController.class
 })
 public class BootUiAutoConfiguration {

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/BootUiLogAppender.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/BootUiLogAppender.java
@@ -1,0 +1,87 @@
+package io.github.bootui.autoconfigure.web;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.AppenderBase;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+
+public class BootUiLogAppender extends AppenderBase<ILoggingEvent> {
+
+    private static final String APPENDER_NAME = "BOOTUI_LOG_TAIL";
+    private static final int MAX_LINES = 500;
+
+    private final ArrayDeque<LogLineDto> lines = new ArrayDeque<>(MAX_LINES);
+    private final CopyOnWriteArrayList<Consumer<LogLineDto>> subscribers = new CopyOnWriteArrayList<>();
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        LogLineDto line = new LogLineDto(
+                event.getTimeStamp(),
+                event.getLevel().toString(),
+                event.getLoggerName(),
+                event.getFormattedMessage(),
+                event.getThreadName());
+        synchronized (lines) {
+            if (lines.size() >= MAX_LINES) {
+                lines.removeFirst();
+            }
+            lines.addLast(line);
+        }
+        for (Consumer<LogLineDto> subscriber : subscribers) {
+            subscriber.accept(line);
+        }
+    }
+
+    public List<LogLineDto> getRecentLines() {
+        synchronized (lines) {
+            return new ArrayList<>(lines);
+        }
+    }
+
+    public Runnable subscribe(Consumer<LogLineDto> consumer) {
+        subscribers.add(consumer);
+        return () -> subscribers.remove(consumer);
+    }
+
+    public static synchronized BootUiLogAppender install() {
+        BootUiLogAppender existing = find();
+        if (existing != null) {
+            return existing;
+        }
+        ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+        if (!(factory instanceof LoggerContext context)) {
+            throw new IllegalStateException("Logback LoggerContext is not available");
+        }
+        Logger rootLogger = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+        BootUiLogAppender appender = new BootUiLogAppender();
+        appender.setContext(context);
+        appender.setName(APPENDER_NAME);
+        appender.start();
+        rootLogger.addAppender(appender);
+        return appender;
+    }
+
+    public static BootUiLogAppender find() {
+        ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+        if (!(factory instanceof LoggerContext context)) {
+            return null;
+        }
+        Logger rootLogger = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+        Appender<ILoggingEvent> appender = rootLogger.getAppender(APPENDER_NAME);
+        if (appender instanceof BootUiLogAppender bootUiLogAppender) {
+            return bootUiLogAppender;
+        }
+        return null;
+    }
+
+    public record LogLineDto(long timestamp, String level, String logger, String message, String thread) {
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/HttpProbeController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/HttpProbeController.java
@@ -1,0 +1,153 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.HttpProbeRequest;
+import io.github.bootui.core.BootUiDtos.HttpProbeResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/bootui/api/probe")
+public class HttpProbeController {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    private final Environment environment;
+
+    private final HttpClient httpClient;
+
+    public HttpProbeController(Environment environment) {
+        this.environment = environment;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(REQUEST_TIMEOUT)
+                .build();
+    }
+
+    @PostMapping
+    public HttpProbeResponse probe(@RequestBody HttpProbeRequest request) {
+        long start = System.currentTimeMillis();
+        String method = normalizeMethod(request == null ? null : request.method());
+        String path = normalizePath(request == null ? null : request.path());
+        String url = "http://localhost:" + resolveServerPort() + path;
+        if (!url.startsWith("http://localhost:") && !url.startsWith("http://127.0.0.1:")) {
+            return new HttpProbeResponse(0, "Forbidden", Map.of(), null, 0, "Only loopback probes allowed");
+        }
+
+        try {
+            HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(url))
+                    .timeout(REQUEST_TIMEOUT);
+            applyHeaders(builder, request == null ? null : request.headers());
+            builder.method(method, requestBodyPublisher(method, request == null ? null : request.body()));
+
+            HttpResponse<String> response = httpClient.send(
+                    builder.build(),
+                    HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            long durationMs = System.currentTimeMillis() - start;
+            return new HttpProbeResponse(
+                    response.statusCode(),
+                    statusText(response.statusCode()),
+                    filterHeaders(response.headers().map()),
+                    response.body(),
+                    durationMs,
+                    null);
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            long durationMs = System.currentTimeMillis() - start;
+            return new HttpProbeResponse(0, "Error", Map.of(), null, durationMs, e.getMessage());
+        } catch (IllegalArgumentException e) {
+            long durationMs = System.currentTimeMillis() - start;
+            return new HttpProbeResponse(0, "Error", Map.of(), null, durationMs, e.getMessage());
+        }
+    }
+
+    private void applyHeaders(HttpRequest.Builder builder, Map<String, String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            builder.header(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private HttpRequest.BodyPublisher requestBodyPublisher(String method, String body) {
+        if (!allowsBody(method)) {
+            return HttpRequest.BodyPublishers.noBody();
+        }
+        if (body == null || body.isEmpty()) {
+            return HttpRequest.BodyPublishers.noBody();
+        }
+        return HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8);
+    }
+
+    private boolean allowsBody(String method) {
+        return "POST".equals(method) || "PUT".equals(method) || "PATCH".equals(method);
+    }
+
+    private String resolveServerPort() {
+        return environment.getProperty("local.server.port",
+                environment.getProperty("server.port", "8080"));
+    }
+
+    private String normalizeMethod(String method) {
+        if (method == null || method.isBlank()) {
+            return "GET";
+        }
+        return method.trim().toUpperCase(Locale.ROOT);
+    }
+
+    private String normalizePath(String path) {
+        if (path == null || path.isBlank()) {
+            return "/";
+        }
+        return path.startsWith("/") ? path : "/" + path;
+    }
+
+    private Map<String, String> filterHeaders(Map<String, java.util.List<String>> headers) {
+        Map<String, String> filtered = new LinkedHashMap<>();
+        headers.forEach((name, values) -> {
+            if (name == null || values == null || values.isEmpty()) {
+                return;
+            }
+            String normalized = name.toLowerCase(Locale.ROOT);
+            if (!"content-type".equals(normalized)
+                    && !"content-length".equals(normalized)
+                    && !"location".equals(normalized)) {
+                return;
+            }
+            filtered.put(normalized, String.join(", ", values));
+        });
+        return filtered;
+    }
+
+    private String statusText(int status) {
+        return switch (status) {
+            case 200 -> "OK";
+            case 201 -> "Created";
+            case 204 -> "No Content";
+            case 400 -> "Bad Request";
+            case 401 -> "Unauthorized";
+            case 403 -> "Forbidden";
+            case 404 -> "Not Found";
+            case 405 -> "Method Not Allowed";
+            case 500 -> "Internal Server Error";
+            default -> "HTTP " + status;
+        };
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/LogTailController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/LogTailController.java
@@ -1,0 +1,84 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.LogLineDto;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/bootui/api/logs")
+@ConditionalOnClass(name = "ch.qos.logback.classic.LoggerContext")
+public class LogTailController {
+
+    private final BootUiLogAppender appender;
+    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    public LogTailController() {
+        this.appender = BootUiLogAppender.install();
+    }
+
+    @GetMapping("/recent")
+    public List<LogLineDto> recent() {
+        return appender.getRecentLines().stream()
+                .map(LogTailController::toDto)
+                .toList();
+    }
+
+    @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter stream() {
+        SseEmitter emitter = new SseEmitter(0L);
+        emitters.add(emitter);
+
+        AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {
+        });
+        emitter.onCompletion(() -> cleanup(emitter, unsubscribeRef.get()));
+        emitter.onTimeout(() -> cleanup(emitter, unsubscribeRef.get()));
+        emitter.onError(error -> cleanup(emitter, unsubscribeRef.get()));
+
+        try {
+            for (BootUiLogAppender.LogLineDto line : appender.getRecentLines()) {
+                sendLog(emitter, toDto(line));
+            }
+        }
+        catch (IOException ex) {
+            cleanup(emitter, unsubscribeRef.get());
+            emitter.completeWithError(ex);
+            return emitter;
+        }
+
+        Runnable unsubscribe = appender.subscribe(line -> {
+            try {
+                sendLog(emitter, toDto(line));
+            }
+            catch (IOException ex) {
+                cleanup(emitter, unsubscribeRef.get());
+                emitter.completeWithError(ex);
+            }
+        });
+        unsubscribeRef.set(unsubscribe);
+
+        return emitter;
+    }
+
+    private void cleanup(SseEmitter emitter, Runnable unsubscribe) {
+        emitters.remove(emitter);
+        unsubscribe.run();
+    }
+
+    private void sendLog(SseEmitter emitter, LogLineDto line) throws IOException {
+        emitter.send(SseEmitter.event()
+                .name("log")
+                .data(line, MediaType.APPLICATION_JSON));
+    }
+
+    private static LogLineDto toDto(BootUiLogAppender.LogLineDto line) {
+        return new LogLineDto(line.timestamp(), line.level(), line.logger(), line.message(), line.thread());
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/OverviewController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/OverviewController.java
@@ -56,7 +56,22 @@ public class OverviewController {
                         activation.enabled(),
                         properties.isLocalhostOnly() && !properties.isAllowNonLocalhost(),
                         activation.reason(),
-                        activation.warnings() == null ? List.of() : activation.warnings()));
+                        activation.warnings() == null ? List.of() : activation.warnings()),
+                detectOpenApiUrl());
+    }
+
+    private String detectOpenApiUrl() {
+        try {
+            Class.forName("org.springdoc.core.utils.SpringDocUtils");
+            return environment.getProperty("springdoc.swagger-ui.path", "/swagger-ui/index.html");
+        } catch (ClassNotFoundException e) {
+            try {
+                Class.forName("org.springdoc.webmvc.ui.SwaggerWelcomeWebMvc");
+                return environment.getProperty("springdoc.swagger-ui.path", "/swagger-ui/index.html");
+            } catch (ClassNotFoundException ex) {
+                return null;
+            }
+        }
     }
 
     private String detectWebType() {

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ProfileController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ProfileController.java
@@ -1,0 +1,91 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.autoconfigure.BootUiProperties;
+import io.github.bootui.autoconfigure.BootUiProperties.ValueExposure;
+import io.github.bootui.core.BootUiDtos.ConfigPropertyDto;
+import io.github.bootui.core.BootUiDtos.ProfileSourceDto;
+import io.github.bootui.core.BootUiDtos.ProfilesReport;
+import io.github.bootui.core.SecretMasker;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes a profile-aware view of the current configuration.
+ *
+ * <p>Groups properties by their profile-specific source so developers can see
+ * exactly which properties are contributed by each active profile.</p>
+ */
+@RestController
+@RequestMapping("/bootui/api/profiles")
+public class ProfileController {
+
+    private static final Pattern PROFILE_SOURCE_PATTERN =
+            Pattern.compile("(?:application-|Config resource 'file [^']*application-)([\\w-]+)(?:\\.properties|\\.ya?ml)");
+
+    private final ConfigurableEnvironment environment;
+    private final BootUiProperties properties;
+    private final SecretMasker masker = new SecretMasker();
+
+    public ProfileController(ConfigurableEnvironment environment, BootUiProperties properties) {
+        this.environment = environment;
+        this.properties = properties;
+    }
+
+    @GetMapping
+    public ProfilesReport profiles() {
+        List<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
+        List<ProfileSourceDto> profileSources = new ArrayList<>();
+
+        for (PropertySource<?> source : environment.getPropertySources()) {
+            String profile = extractProfile(source.getName());
+            if (profile == null) {
+                continue;
+            }
+            if (!(source instanceof EnumerablePropertySource<?> enumerable)) {
+                continue;
+            }
+            List<ConfigPropertyDto> props = new ArrayList<>();
+            for (String key : enumerable.getPropertyNames()) {
+                Object rawValue = enumerable.getProperty(key);
+                String strValue = rawValue == null ? null : rawValue.toString();
+                boolean masked = masker.isSecret(key);
+                String displayValue = masked ? SecretMasker.MASKED_VALUE : displayValue(strValue);
+                props.add(new ConfigPropertyDto(key, displayValue, source.getName(), null, masked, false, null, null));
+            }
+            props.sort(Comparator.comparing(ConfigPropertyDto::name, Comparator.nullsLast(String::compareTo)));
+            if (!props.isEmpty()) {
+                profileSources.add(new ProfileSourceDto(source.getName(), profile, props));
+            }
+        }
+
+        return new ProfilesReport(activeProfiles, profileSources);
+    }
+
+    private String extractProfile(String sourceName) {
+        if (sourceName == null) {
+            return null;
+        }
+        Matcher matcher = PROFILE_SOURCE_PATTERN.matcher(sourceName);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    private String displayValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        if (properties.getExposeValues() == ValueExposure.METADATA_ONLY) {
+            return null;
+        }
+        return value;
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ScheduledController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ScheduledController.java
@@ -1,0 +1,85 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.ScheduledReport;
+import io.github.bootui.core.BootUiDtos.ScheduledTaskDto;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.scheduling.config.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@ConditionalOnClass(name = "org.springframework.scheduling.config.ScheduledTaskHolder")
+@RequestMapping("/bootui/api/scheduled")
+public class ScheduledController {
+
+    private final ObjectProvider<ScheduledTaskHolder> scheduledTaskHolderProvider;
+
+    public ScheduledController(ObjectProvider<ScheduledTaskHolder> scheduledTaskHolderProvider) {
+        this.scheduledTaskHolderProvider = scheduledTaskHolderProvider;
+    }
+
+    @GetMapping
+    public ScheduledReport scheduled() {
+        ScheduledTaskHolder holder = scheduledTaskHolderProvider.getIfAvailable();
+        if (holder == null) {
+            return new ScheduledReport(false, 0, List.of());
+        }
+        Set<ScheduledTask> scheduledTasks = holder.getScheduledTasks();
+        List<ScheduledTaskDto> tasks = scheduledTasks == null ? List.of() : scheduledTasks.stream()
+                .map(this::toDto)
+                .sorted(Comparator.comparing(ScheduledTaskDto::runnable, Comparator.nullsLast(String::compareTo)))
+                .toList();
+        return new ScheduledReport(true, tasks.size(), tasks);
+    }
+
+    private ScheduledTaskDto toDto(ScheduledTask scheduledTask) {
+        Task task = scheduledTask.getTask();
+        Runnable runnable = task.getRunnable();
+        String runnableName = runnable == null ? null : runnable.getClass().getName();
+        if (task instanceof CronTask cronTask) {
+            return new ScheduledTaskDto(runnableName, "CRON", cronTask.getExpression(), null, null);
+        }
+        if (task instanceof FixedRateTask fixedRateTask) {
+            long intervalMs = fixedRateTask.getIntervalDuration().toMillis();
+            Long initialDelayMs = toMillis(fixedRateTask.getInitialDelayDuration());
+            return new ScheduledTaskDto(runnableName, "FIXED_RATE", Long.toString(intervalMs), initialDelayMs,
+                    intervalUnit(intervalMs, initialDelayMs));
+        }
+        if (task instanceof FixedDelayTask fixedDelayTask) {
+            long intervalMs = fixedDelayTask.getIntervalDuration().toMillis();
+            Long initialDelayMs = toMillis(fixedDelayTask.getInitialDelayDuration());
+            return new ScheduledTaskDto(runnableName, "FIXED_DELAY", Long.toString(intervalMs), initialDelayMs,
+                    intervalUnit(intervalMs, initialDelayMs));
+        }
+        if (task instanceof OneTimeTask oneTimeTask) {
+            Long initialDelayMs = toMillis(oneTimeTask.getInitialDelayDuration());
+            return new ScheduledTaskDto(runnableName, "ONE_SHOT", null, initialDelayMs,
+                    intervalUnit(null, initialDelayMs));
+        }
+        if (task instanceof TriggerTask triggerTask) {
+            return new ScheduledTaskDto(runnableName, "ONE_SHOT", String.valueOf(triggerTask.getTrigger()), null, null);
+        }
+        return new ScheduledTaskDto(runnableName, "ONE_SHOT", null, null, null);
+    }
+
+    private Long toMillis(Duration duration) {
+        return duration == null ? null : duration.toMillis();
+    }
+
+    private String intervalUnit(Long intervalMs, Long initialDelayMs) {
+        if (isWholeSeconds(intervalMs) && isWholeSeconds(initialDelayMs)) {
+            return "s";
+        }
+        return "ms";
+    }
+
+    private boolean isWholeSeconds(Long value) {
+        return value == null || value % 1000 == 0;
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/SecurityController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/SecurityController.java
@@ -1,0 +1,123 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.SecurityAuthDto;
+import io.github.bootui.core.BootUiDtos.SecurityChainDto;
+import io.github.bootui.core.BootUiDtos.SecurityReport;
+import jakarta.servlet.Filter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.annotation.OrderUtils;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@ConditionalOnClass(name = "org.springframework.security.web.SecurityFilterChain")
+@RequestMapping("/bootui/api/security")
+public class SecurityController {
+
+    private final ObjectProvider<List<SecurityFilterChain>> securityFilterChainsProvider;
+
+    private final ObjectProvider<ListableBeanFactory> beanFactoryProvider;
+
+    public SecurityController(ObjectProvider<List<SecurityFilterChain>> securityFilterChainsProvider,
+                              ObjectProvider<ListableBeanFactory> beanFactoryProvider) {
+        this.securityFilterChainsProvider = securityFilterChainsProvider;
+        this.beanFactoryProvider = beanFactoryProvider;
+    }
+
+    @GetMapping
+    public SecurityReport security() {
+        ListableBeanFactory beanFactory = beanFactoryProvider.getIfAvailable();
+        if (beanFactory == null) {
+            List<SecurityFilterChain> fallbackChains = securityFilterChainsProvider.getIfAvailable(List::of);
+            return new SecurityReport(true, toChainDtos(fallbackChains), new SecurityAuthDto(List.of(), null, false));
+        }
+
+        Map<String, SecurityFilterChain> chainBeans = beanFactory.getBeansOfType(SecurityFilterChain.class);
+        List<SecurityChainDto> chains = toChainDtos(beanFactory, chainBeans);
+
+        List<String> providerTypes = beanFactory.getBeansOfType(AuthenticationProvider.class).values().stream()
+                .map(provider -> provider.getClass().getSimpleName())
+                .sorted()
+                .toList();
+        String userDetailsServiceType = beanFactory.getBeansOfType(UserDetailsService.class).values().stream()
+                .map(service -> service.getClass().getSimpleName())
+                .sorted()
+                .findFirst()
+                .orElse(null);
+        boolean hasAutoConfiguredUser = beanFactory.containsBean("userDetailsServiceAutoConfiguration")
+                || beanFactory.containsBean("inMemoryUserDetailsManager");
+
+        return new SecurityReport(true, chains,
+                new SecurityAuthDto(providerTypes, userDetailsServiceType, hasAutoConfiguredUser));
+    }
+
+    private List<SecurityChainDto> toChainDtos(List<SecurityFilterChain> chains) {
+        List<SecurityFilterChain> sortedChains = new ArrayList<>(chains);
+        AnnotationAwareOrderComparator.sort(sortedChains);
+        return sortedChains.stream()
+                .map(chain -> toChainDto(Ordered.LOWEST_PRECEDENCE, chain))
+                .toList();
+    }
+
+    private List<SecurityChainDto> toChainDtos(ListableBeanFactory beanFactory, Map<String, SecurityFilterChain> chainBeans) {
+        List<NamedSecurityChain> chains = new ArrayList<>();
+        for (Map.Entry<String, SecurityFilterChain> entry : chainBeans.entrySet()) {
+            chains.add(new NamedSecurityChain(entry.getKey(), entry.getValue(), orderOf(beanFactory, entry.getKey(), entry.getValue())));
+        }
+        chains.sort(Comparator.comparingInt(NamedSecurityChain::order));
+        return chains.stream()
+                .map(chain -> toChainDto(chain.order(), chain.chain()))
+                .toList();
+    }
+
+    private int orderOf(ListableBeanFactory beanFactory, String beanName, SecurityFilterChain chain) {
+        Order order = beanFactory.findAnnotationOnBean(beanName, Order.class);
+        if (order != null) {
+            return order.value();
+        }
+        if (chain instanceof Ordered ordered) {
+            return ordered.getOrder();
+        }
+        return OrderUtils.getOrder(chain.getClass(), Ordered.LOWEST_PRECEDENCE);
+    }
+
+    private SecurityChainDto toChainDto(int order, SecurityFilterChain chain) {
+        if (!(chain instanceof DefaultSecurityFilterChain defaultChain)) {
+            return new SecurityChainDto(order, chain.toString(), List.of(), false, "UNKNOWN", false);
+        }
+        List<Filter> filters = defaultChain.getFilters();
+        List<String> filterNames = filters.stream()
+                .map(filter -> filter.getClass().getSimpleName())
+                .toList();
+        boolean csrfEnabled = filters.stream()
+                .anyMatch(filter -> filter.getClass().getName().contains("CsrfFilter"));
+        boolean corsEnabled = filters.stream()
+                .anyMatch(filter -> filter.getClass().getName().contains("CorsFilter"));
+        boolean stateless = filters.stream()
+                .anyMatch(filter -> "DisableEncodeUrlFilter".equals(filter.getClass().getSimpleName()));
+        return new SecurityChainDto(
+                order,
+                defaultChain.getRequestMatcher().toString(),
+                filterNames,
+                csrfEnabled,
+                stateless ? "STATELESS" : "UNKNOWN",
+                corsEnabled);
+    }
+
+    private record NamedSecurityChain(String beanName, SecurityFilterChain chain, int order) {
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/StartupController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/StartupController.java
@@ -1,9 +1,16 @@
 package io.github.bootui.autoconfigure.web;
 
+import io.github.bootui.core.BootUiDtos.StartupReport;
+import io.github.bootui.core.BootUiDtos.StartupStepDto;
+import io.github.bootui.core.BootUiDtos.TagDto;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.StreamSupport;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.startup.StartupEndpoint;
 import org.springframework.boot.actuate.startup.StartupEndpoint.StartupDescriptor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.boot.context.metrics.buffering.StartupTimeline.TimelineEvent;
+import org.springframework.core.metrics.StartupStep;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,11 +26,36 @@ public class StartupController {
     }
 
     @GetMapping
-    public ResponseEntity<StartupDescriptor> startup() {
+    public StartupReport startup() {
         StartupEndpoint se = endpoint.getIfAvailable();
         if (se == null) {
-            return ResponseEntity.noContent().build();
+            return new StartupReport(List.of());
         }
-        return ResponseEntity.ok(se.startupSnapshot());
+        return toReport(se.startupSnapshot());
+    }
+
+    private StartupReport toReport(StartupDescriptor descriptor) {
+        if (descriptor == null || descriptor.getTimeline() == null || descriptor.getTimeline().getEvents() == null) {
+            return new StartupReport(List.of());
+        }
+        return new StartupReport(descriptor.getTimeline().getEvents().stream()
+                .map(this::toStep)
+                .toList());
+    }
+
+    private StartupStepDto toStep(TimelineEvent event) {
+        StartupStep step = event.getStartupStep();
+        return new StartupStepDto(
+                step.getId(),
+                step.getParentId(),
+                step.getName(),
+                durationMs(event),
+                StreamSupport.stream(step.getTags().spliterator(), false)
+                        .map(tag -> new TagDto(tag.getKey(), tag.getValue()))
+                        .toList());
+    }
+
+    private long durationMs(TimelineEvent event) {
+        return event.getDuration() == null ? 0L : Duration.parse(event.getDuration().toString()).toMillis();
     }
 }

--- a/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
@@ -1,6 +1,7 @@
 package io.github.bootui.core;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Lightweight DTOs returned by the BootUI internal API.
@@ -27,7 +28,8 @@ public final class BootUiDtos {
             Integer managementPort,
             String contextPath,
             Long startupTimeMillis,
-            ActivationStatus activation) {
+            ActivationStatus activation,
+            String openApiUrl) {
     }
 
     /** Reason why BootUI activated, plus current safety settings. */
@@ -110,6 +112,24 @@ public final class BootUiDtos {
     public record MappingsReport(int total, List<MappingDto> mappings) {
     }
 
+    /** Request from the browser to probe a local HTTP endpoint. */
+    public record HttpProbeRequest(
+            String method,
+            String path,
+            String body,
+            Map<String, String> headers) {
+    }
+
+    /** Result of an HTTP probe. */
+    public record HttpProbeResponse(
+            int status,
+            String statusText,
+            Map<String, String> headers,
+            String body,
+            long durationMs,
+            String error) {
+    }
+
     /** Health node, possibly nested. */
     public record HealthNodeDto(
             String name,
@@ -127,6 +147,10 @@ public final class BootUiDtos {
     public record LoggersReport(List<String> availableLevels, List<LoggerDto> loggers) {
     }
 
+    /** A single log line for the live log tail. */
+    public record LogLineDto(long timestamp, String level, String logger, String message, String thread) {
+    }
+
     public record StartupStepDto(
             long id,
             Long parentId,
@@ -139,6 +163,18 @@ public final class BootUiDtos {
     }
 
     public record StartupReport(List<StartupStepDto> steps) {
+    }
+
+    /** Summary of a @Scheduled task registered in the application context. */
+    public record ScheduledTaskDto(
+            String runnable,
+            String triggerType,
+            String expression,
+            Long initialDelayMs,
+            String timeUnit) {
+    }
+
+    public record ScheduledReport(boolean schedulingPresent, int total, List<ScheduledTaskDto> tasks) {
     }
 
     /** Summary of one Spring Data repository discovered in the context. */
@@ -179,5 +215,41 @@ public final class BootUiDtos {
             boolean springDataPresent,
             int total,
             List<RepositoryDto> repositories) {
+    }
+
+    /** Properties contributed by a single profile-specific property source. */
+    public record ProfileSourceDto(
+            String sourceName,
+            String profile,
+            List<ConfigPropertyDto> properties) {
+    }
+
+    /** Profile-aware view of the active configuration. */
+    public record ProfilesReport(
+            List<String> activeProfiles,
+            List<ProfileSourceDto> profileSources) {
+    }
+
+    /** Summary of one SecurityFilterChain. */
+    public record SecurityChainDto(
+            int order,
+            String requestMatcherDescription,
+            List<String> filterNames,
+            boolean csrfEnabled,
+            String sessionCreationPolicy,
+            boolean corsEnabled) {
+    }
+
+    /** Summary of authentication configuration. */
+    public record SecurityAuthDto(
+            List<String> authenticationProviderTypes,
+            String userDetailsServiceType,
+            boolean hasAutoConfiguredUser) {
+    }
+
+    public record SecurityReport(
+            boolean springSecurityPresent,
+            List<SecurityChainDto> chains,
+            SecurityAuthDto auth) {
     }
 }

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -12,6 +12,12 @@ import Mappings from './views/Mappings.vue'
 import Health from './views/Health.vue'
 import Loggers from './views/Loggers.vue'
 import Data from './views/Data.vue'
+import Startup from './views/Startup.vue'
+import Scheduled from './views/Scheduled.vue'
+import HttpProbe from './views/HttpProbe.vue'
+import LogTail from './views/LogTail.vue'
+import ProfileDiff from './views/ProfileDiff.vue'
+import Security from './views/Security.vue'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -24,7 +30,13 @@ const router = createRouter({
     { path: '/mappings', name: 'mappings', component: Mappings, meta: { icon: 'bi-signpost-2', title: 'Mappings' } },
     { path: '/health', name: 'health', component: Health, meta: { icon: 'bi-heart-pulse', title: 'Health' } },
     { path: '/loggers', name: 'loggers', component: Loggers, meta: { icon: 'bi-journal-text', title: 'Loggers' } },
-    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } }
+    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } },
+    { path: '/startup', name: 'startup', component: Startup, meta: { icon: 'bi-bar-chart-steps', title: 'Startup Timeline' } },
+    { path: '/scheduled', name: 'scheduled', component: Scheduled, meta: { icon: 'bi-clock-history', title: 'Scheduled Tasks' } },
+    { path: '/http-probe', name: 'http-probe', component: HttpProbe, meta: { icon: 'bi-send', title: 'HTTP Probe' } },
+    { path: '/log-tail', name: 'log-tail', component: LogTail, meta: { icon: 'bi-terminal', title: 'Log Tail' } },
+    { path: '/profiles', name: 'profiles', component: ProfileDiff, meta: { icon: 'bi-layers', title: 'Profile Diff' } },
+    { path: '/security', name: 'security', component: Security, meta: { icon: 'bi-shield-lock', title: 'Security' } }
   ]
 })
 

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -1,0 +1,180 @@
+<script setup>
+import { computed, ref } from 'vue'
+
+const method = ref('GET')
+const path = ref('')
+const requestBody = ref('')
+const loading = ref(false)
+const response = ref(null)
+
+const methodsWithBody = ['POST', 'PUT', 'PATCH']
+
+const showRequestBody = computed(() => methodsWithBody.includes(method.value))
+
+const requestHeaders = computed(() => {
+  if (!showRequestBody.value) return {}
+  if (!requestBody.value.trim()) return {}
+  return { 'Content-Type': 'application/json' }
+})
+
+const formattedResponseBody = computed(() => {
+  const body = response.value?.body
+  if (!body) return ''
+  const trimmed = body.trim()
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return body
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2)
+  } catch {
+    return body
+  }
+})
+
+const statusBadgeClass = computed(() => {
+  if (response.value?.error) return 'bg-danger'
+  const status = response.value?.status ?? 0
+  if (status >= 200 && status < 300) return 'bg-success'
+  if (status >= 300 && status < 400) return 'bg-warning text-dark'
+  if (status >= 400) return 'bg-danger'
+  return 'bg-secondary'
+})
+
+async function sendProbe() {
+  loading.value = true
+  try {
+    const res = await fetch('api/probe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        method: method.value,
+        path: normalizePath(path.value),
+        body: showRequestBody.value && requestBody.value ? requestBody.value : null,
+        headers: requestHeaders.value
+      })
+    })
+    response.value = await res.json()
+  } catch (error) {
+    response.value = {
+      status: 0,
+      statusText: 'Error',
+      headers: {},
+      body: null,
+      durationMs: 0,
+      error: error.message
+    }
+  } finally {
+    loading.value = false
+  }
+}
+
+function normalizePath(value) {
+  const trimmed = (value || '').trim()
+  if (!trimmed) return '/'
+  return trimmed.startsWith('/') ? trimmed : '/' + trimmed
+}
+
+function clearForm() {
+  method.value = 'GET'
+  path.value = ''
+  requestBody.value = ''
+  response.value = null
+  loading.value = false
+}
+</script>
+
+<template>
+  <div>
+    <div class="d-flex justify-content-between align-items-start mb-3">
+      <div>
+        <h2 class="mb-1"><i class="bi bi-send me-2"></i>HTTP Probe</h2>
+        <p class="text-muted mb-0 small">
+          Send local HTTP requests against your running Spring Boot app without leaving BootUI.
+        </p>
+      </div>
+      <div class="d-flex gap-2">
+        <button class="btn btn-outline-secondary" @click="clearForm" :disabled="loading">
+          <i class="bi bi-x-circle me-1"></i>Clear
+        </button>
+        <button class="btn btn-primary" @click="sendProbe" :disabled="loading">
+          <span v-if="loading" class="spinner-border spinner-border-sm me-2" aria-hidden="true"></span>
+          <i v-else class="bi bi-send me-1"></i>
+          {{ loading ? 'Sending…' : 'Send' }}
+        </button>
+      </div>
+    </div>
+
+    <div class="card mb-4">
+      <div class="card-body">
+        <div class="row g-3 align-items-start">
+          <div class="col-md-3 col-lg-2">
+            <label class="form-label">Method</label>
+            <select class="form-select" v-model="method">
+              <option value="GET">GET</option>
+              <option value="POST">POST</option>
+              <option value="PUT">PUT</option>
+              <option value="DELETE">DELETE</option>
+              <option value="PATCH">PATCH</option>
+            </select>
+          </div>
+          <div class="col-md-9 col-lg-10">
+            <label class="form-label">Path</label>
+            <input
+              v-model="path"
+              class="form-control font-monospace"
+              placeholder="/api/sample/hello"
+              @keyup.enter="sendProbe"
+            />
+            <div class="form-text">
+              Relative to the application root. Requests are always sent to localhost.
+            </div>
+          </div>
+        </div>
+
+        <div v-if="showRequestBody" class="mt-3">
+          <label class="form-label">Request body</label>
+          <textarea
+            v-model="requestBody"
+            class="form-control font-monospace"
+            rows="10"
+            placeholder='{
+  "message": "hello"
+}'
+          ></textarea>
+          <div class="form-text" v-if="Object.keys(requestHeaders).length">
+            Content-Type: <code>application/json</code>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="response" class="card">
+      <div class="card-header d-flex flex-wrap justify-content-between gap-2 align-items-center">
+        <div class="d-flex align-items-center gap-2">
+          <strong>Response</strong>
+          <span class="badge" :class="statusBadgeClass">
+            {{ response.status || 0 }} {{ response.statusText || 'Error' }}
+          </span>
+        </div>
+        <small class="text-muted">{{ response.durationMs ?? 0 }} ms</small>
+      </div>
+      <div class="card-body">
+        <div v-if="response.error" class="alert alert-danger mb-3">
+          <i class="bi bi-exclamation-octagon me-2"></i>{{ response.error }}
+        </div>
+
+        <div v-if="response.headers && Object.keys(response.headers).length" class="mb-3">
+          <h6>Headers</h6>
+          <ul class="list-unstyled small mb-0">
+            <li v-for="(value, name) in response.headers" :key="name">
+              <code>{{ name }}</code>: {{ value }}
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <h6>Body</h6>
+          <pre class="bg-body-tertiary border rounded p-3 mb-0"><code>{{ formattedResponseBody || '(empty response body)' }}</code></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/LogTail.vue
+++ b/bootui-ui/src/main/frontend/src/views/LogTail.vue
@@ -1,0 +1,190 @@
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const lines = ref([])
+const textFilter = ref('')
+const levelFilter = ref('ALL')
+const autoScroll = ref(true)
+const status = ref('Paused')
+const pane = ref(null)
+let eventSource = null
+
+const levelRank = {
+  TRACE: 0,
+  DEBUG: 1,
+  INFO: 2,
+  WARN: 3,
+  ERROR: 4
+}
+
+const levelThreshold = {
+  ALL: -1,
+  'INFO+': levelRank.INFO,
+  'WARN+': levelRank.WARN,
+  ERROR: levelRank.ERROR
+}
+
+const visibleLines = computed(() => {
+  const filter = textFilter.value.trim().toLowerCase()
+  const threshold = levelThreshold[levelFilter.value] ?? -1
+
+  return lines.value.filter(line => {
+    const rank = levelRank[line.level] ?? -1
+    const logger = (line.logger || '').toLowerCase()
+    const message = (line.message || '').toLowerCase()
+    const matchesLevel = threshold < 0 || rank >= threshold
+    const matchesText = !filter
+      || logger.startsWith(filter)
+      || message.includes(filter)
+
+    return matchesLevel && matchesText
+  })
+})
+
+const statusClass = computed(() => ({
+  Connected: 'text-bg-success',
+  Paused: 'text-bg-secondary',
+  Disconnected: 'text-bg-danger'
+}[status.value] || 'text-bg-secondary'))
+
+function connect() {
+  disconnect(false)
+  status.value = 'Disconnected'
+  eventSource = new EventSource('api/logs/stream')
+  eventSource.onopen = () => {
+    status.value = 'Connected'
+  }
+  eventSource.addEventListener('log', event => {
+    const line = JSON.parse(event.data)
+    lines.value.push(line)
+    if (lines.value.length > 500) {
+      lines.value.splice(0, lines.value.length - 500)
+    }
+  })
+  eventSource.onerror = () => {
+    status.value = 'Disconnected'
+  }
+}
+
+function disconnect(paused = true) {
+  if (eventSource) {
+    eventSource.close()
+    eventSource = null
+  }
+  if (paused) {
+    status.value = 'Paused'
+  }
+}
+
+function toggleStreaming() {
+  if (status.value === 'Connected') {
+    disconnect(true)
+    return
+  }
+  connect()
+}
+
+function clearLines() {
+  lines.value = []
+}
+
+function formatTime(timestamp) {
+  const date = new Date(timestamp)
+  return date.toLocaleTimeString([], {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  })
+}
+
+function levelClass(level) {
+  return {
+    ERROR: 'text-danger',
+    WARN: 'text-warning',
+    INFO: 'text-success',
+    DEBUG: 'text-info',
+    TRACE: 'text-secondary'
+  }[level] || 'text-light'
+}
+
+async function scrollToBottom() {
+  if (!autoScroll.value || !pane.value) {
+    return
+  }
+  await nextTick()
+  pane.value.scrollTop = pane.value.scrollHeight
+}
+
+watch(visibleLines, scrollToBottom)
+watch(autoScroll, enabled => {
+  if (enabled) {
+    scrollToBottom()
+  }
+})
+
+onMounted(connect)
+onBeforeUnmount(() => disconnect(false))
+</script>
+
+<template>
+  <div>
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-3 mb-3">
+      <h2 class="mb-0"><i class="bi bi-terminal me-2"></i>Log Tail</h2>
+      <span class="badge" :class="statusClass">{{ status }}</span>
+    </div>
+
+    <div class="row g-3 mb-3 align-items-end">
+      <div class="col-lg-4">
+        <label class="form-label">Filter</label>
+        <input
+          v-model="textFilter"
+          class="form-control"
+          placeholder="Logger prefix or message text" />
+      </div>
+      <div class="col-sm-4 col-lg-2">
+        <label class="form-label">Level</label>
+        <select v-model="levelFilter" class="form-select">
+          <option value="ALL">All</option>
+          <option value="INFO+">Info+</option>
+          <option value="WARN+">Warn+</option>
+          <option value="ERROR">Error</option>
+        </select>
+      </div>
+      <div class="col-sm-4 col-lg-2">
+        <div class="form-check pt-sm-4">
+          <input id="auto-scroll" v-model="autoScroll" class="form-check-input" type="checkbox" />
+          <label class="form-check-label" for="auto-scroll">Auto-scroll</label>
+        </div>
+      </div>
+      <div class="col-sm-4 col-lg-4 d-flex gap-2 justify-content-sm-end">
+        <button class="btn btn-outline-secondary" @click="clearLines">
+          <i class="bi bi-trash me-1"></i>Clear
+        </button>
+        <button class="btn btn-outline-primary" @click="toggleStreaming">
+          <i :class="['bi', status === 'Connected' ? 'bi-pause-circle' : 'bi-play-circle', 'me-1']"></i>
+          {{ status === 'Connected' ? 'Pause' : 'Resume' }}
+        </button>
+      </div>
+    </div>
+
+    <pre ref="pane" class="log-pane rounded border p-3 mb-0"><code v-if="visibleLines.length"><span
+      v-for="(line, index) in visibleLines"
+      :key="`${line.timestamp}-${index}`"
+      class="d-block"
+    ><span class="text-secondary">[{{ formatTime(line.timestamp) }}]</span> <span :class="levelClass(line.level)">{{ line.level }}</span> <span class="text-info-emphasis">{{ line.logger }}</span> <span class="text-secondary">-</span> <span class="text-light">{{ line.message }}</span></span></code><span v-else class="text-secondary">No log lines to display.</span></pre>
+  </div>
+</template>
+
+<style scoped>
+.log-pane {
+  background: #111827;
+  color: #f8f9fa;
+  font-family: var(--bs-font-monospace);
+  font-size: 0.875rem;
+  height: 70vh;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -66,6 +66,15 @@ onMounted(load)
           </ul>
         </div>
 
+        <div v-if="data.openApiUrl" class="card mt-3">
+          <div class="card-header"><i class="bi bi-file-earmark-code me-1"></i>API Docs</div>
+          <div class="card-body">
+            <a :href="data.openApiUrl" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary">
+              <i class="bi bi-box-arrow-up-right me-1"></i>Open Swagger UI
+            </a>
+          </div>
+        </div>
+
         <div class="card mt-3">
           <div class="card-header">Activation</div>
           <div class="card-body">

--- a/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
+++ b/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
@@ -1,0 +1,95 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+
+const data = ref(null)
+const loading = ref(true)
+const error = ref(null)
+const filter = ref('')
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await fetch('api/profiles')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    data.value = await res.json()
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+const filteredSources = computed(() => {
+  if (!data.value) return []
+  const f = filter.value.toLowerCase()
+  if (!f) return data.value.profileSources
+  return data.value.profileSources.map(source => ({
+    ...source,
+    properties: source.properties.filter(p =>
+      p.name.toLowerCase().includes(f) ||
+      (p.value != null && String(p.value).toLowerCase().includes(f))
+    )
+  })).filter(source => source.properties.length > 0)
+})
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2><i class="bi bi-layers me-2"></i>Profile Diff</h2>
+      <button class="btn btn-sm btn-outline-secondary" @click="load">
+        <i class="bi bi-arrow-clockwise"></i> Refresh
+      </button>
+    </div>
+
+    <div v-if="loading" class="text-muted">Loading…</div>
+    <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-else-if="data">
+      <div class="mb-3">
+        <span class="me-2 text-muted small">Active profiles:</span>
+        <span v-if="data.activeProfiles.length">
+          <span v-for="p in data.activeProfiles" :key="p" class="badge bg-success me-1">{{ p }}</span>
+        </span>
+        <span v-else class="text-muted small">(none)</span>
+      </div>
+
+      <input class="form-control mb-3" v-model="filter" placeholder="Filter by property name or value…" />
+
+      <div v-if="filteredSources.length === 0" class="alert alert-info">
+        <i class="bi bi-info-circle me-1"></i>
+        No profile-specific configuration sources found. Properties that belong to
+        <code>application-{profile}.properties</code> or <code>application-{profile}.yml</code>
+        files will appear here when a profile is active.
+      </div>
+
+      <div v-for="source in filteredSources" :key="source.sourceName" class="mb-4">
+        <div class="d-flex align-items-center gap-2 mb-2">
+          <span class="badge bg-success fs-6">{{ source.profile }}</span>
+          <small class="text-muted font-monospace">{{ source.sourceName }}</small>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover mb-0">
+            <thead class="table-light">
+              <tr>
+                <th style="width:40%">Property</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="prop in source.properties" :key="prop.name">
+                <td><code>{{ prop.name }}</code></td>
+                <td>
+                  <span v-if="prop.masked" class="text-muted font-monospace">••••••••</span>
+                  <span v-else class="font-monospace">{{ prop.value ?? '(null)' }}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/Scheduled.vue
+++ b/bootui-ui/src/main/frontend/src/views/Scheduled.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+
+const report = ref(null)
+const loading = ref(true)
+const error = ref(null)
+const filter = ref('')
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await fetch('api/scheduled')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    report.value = await res.json()
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+const filtered = computed(() => {
+  if (!report.value) return []
+  const value = filter.value.trim().toLowerCase()
+  if (!value) return report.value.tasks
+  return report.value.tasks.filter(task =>
+    (task.runnable || '').toLowerCase().includes(value)
+    || (task.expression || '').toLowerCase().includes(value)
+  )
+})
+
+const triggerBadgeClass = triggerType => ({
+  CRON: 'bg-info text-dark',
+  FIXED_RATE: 'bg-success',
+  FIXED_DELAY: 'bg-warning text-dark',
+  ONE_SHOT: 'bg-secondary'
+}[triggerType] || 'bg-secondary')
+
+function formatDuration(value, timeUnit) {
+  if (value === null || value === undefined) return '—'
+  if (timeUnit === 's') return `${value / 1000} s`
+  return `${value} ms`
+}
+
+function formatExpression(task) {
+  if (!task.expression) return '—'
+  if (task.triggerType === 'CRON') return task.expression
+  const numericValue = Number(task.expression)
+  if (Number.isNaN(numericValue)) return task.expression
+  if (task.timeUnit === 's') return `${numericValue / 1000} s`
+  return `${numericValue} ms`
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2><i class="bi bi-clock-history me-2"></i>Scheduled Tasks</h2>
+      <button class="btn btn-sm btn-outline-secondary" @click="load">
+        <i class="bi bi-arrow-clockwise"></i> Refresh
+      </button>
+    </div>
+
+    <div v-if="loading" class="text-muted">Loading…</div>
+    <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-else-if="report && !report.schedulingPresent" class="alert alert-info">
+      No Spring Scheduling detected on the classpath.
+    </div>
+    <div v-else-if="report && report.total === 0" class="alert alert-secondary">
+      No scheduled tasks registered.
+    </div>
+    <template v-else-if="report">
+      <div class="row g-2 mb-3">
+        <div class="col-md-8">
+          <input
+            v-model="filter"
+            class="form-control"
+            placeholder="Filter by runnable name or expression…"
+          />
+        </div>
+        <div class="col-md-4 text-end small text-muted align-self-center">
+          {{ filtered.length }} / {{ report.total }} tasks
+        </div>
+      </div>
+
+      <div class="table-responsive">
+        <table class="table table-sm table-hover align-middle">
+          <thead>
+            <tr>
+              <th>Runnable</th>
+              <th style="width: 150px">Trigger Type</th>
+              <th style="width: 180px">Expression/Interval</th>
+              <th style="width: 160px">Initial Delay</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="(task, index) in filtered" :key="`${task.runnable}-${task.triggerType}-${task.expression}-${index}`">
+              <td><code>{{ task.runnable }}</code></td>
+              <td>
+                <span class="badge" :class="triggerBadgeClass(task.triggerType)">{{ task.triggerType }}</span>
+              </td>
+              <td>{{ formatExpression(task) }}</td>
+              <td>{{ formatDuration(task.initialDelayMs, task.timeUnit) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+  </div>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -1,0 +1,144 @@
+<script setup>
+import { onMounted, ref } from 'vue'
+
+const report = ref(null)
+const loading = ref(true)
+const error = ref('')
+
+async function load() {
+  loading.value = true
+  error.value = ''
+
+  try {
+    const response = await fetch('api/security')
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+    report.value = await response.json()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Failed to load security diagnostics'
+  } finally {
+    loading.value = false
+  }
+}
+
+function stateIcon(enabled) {
+  return enabled ? 'bi-check-circle-fill text-success' : 'bi-x-circle-fill text-danger'
+}
+
+function stateLabel(enabled) {
+  return enabled ? 'Enabled' : 'Disabled'
+}
+
+function sessionPolicyClass(policy) {
+  if (policy === 'STATELESS') {
+    return 'text-bg-primary'
+  }
+  if (policy === 'UNKNOWN') {
+    return 'text-bg-secondary'
+  }
+  return 'text-bg-dark'
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <h2><i class="bi bi-shield-lock me-2"></i>Security</h2>
+    <p class="text-muted">Read-only Spring Security diagnostics for 401/403 troubleshooting.</p>
+
+    <div v-if="loading" class="card">
+      <div class="card-body text-muted">Loading security diagnostics…</div>
+    </div>
+
+    <div v-else-if="error" class="alert alert-danger mb-0">
+      Failed to load security diagnostics: {{ error }}
+    </div>
+
+    <template v-else-if="report">
+      <div v-if="!report.springSecurityPresent" class="alert alert-info">
+        Spring Security is not on the classpath.
+      </div>
+
+      <template v-else>
+        <div v-if="report.auth" class="card mb-3">
+          <div class="card-header">Authentication</div>
+          <div class="card-body">
+            <div class="mb-3">
+              <div class="small text-muted mb-1">Authentication providers</div>
+              <div v-if="report.auth.authenticationProviderTypes.length" class="d-flex flex-wrap gap-2">
+                <span
+                  v-for="provider in report.auth.authenticationProviderTypes"
+                  :key="provider"
+                  class="badge text-bg-light"
+                >
+                  {{ provider }}
+                </span>
+              </div>
+              <div v-else class="text-muted">No AuthenticationProvider beans found.</div>
+            </div>
+
+            <div>
+              <div class="small text-muted mb-1">UserDetailsService</div>
+              <code v-if="report.auth.userDetailsServiceType">{{ report.auth.userDetailsServiceType }}</code>
+              <span v-else class="text-muted">None</span>
+            </div>
+
+            <div v-if="report.auth.hasAutoConfiguredUser" class="alert alert-warning mt-3 mb-0">
+              Using Spring Boot auto-configured in-memory user.
+            </div>
+          </div>
+        </div>
+
+        <div v-if="!report.chains.length" class="alert alert-info">
+          No SecurityFilterChain beans found.
+        </div>
+
+        <div v-else class="d-grid gap-3">
+          <div v-for="chain in report.chains" :key="`${chain.order}-${chain.requestMatcherDescription}`" class="card">
+            <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+              <div class="d-flex align-items-center gap-2">
+                <span class="badge text-bg-dark">Order {{ chain.order }}</span>
+                <code>{{ chain.requestMatcherDescription }}</code>
+              </div>
+              <span class="badge" :class="sessionPolicyClass(chain.sessionCreationPolicy)">
+                {{ chain.sessionCreationPolicy }}
+              </span>
+            </div>
+            <div class="card-body">
+              <div class="row g-3 align-items-start">
+                <div class="col-lg-4">
+                  <div class="small text-muted mb-2">Chain summary</div>
+                  <ul class="list-unstyled mb-0 d-grid gap-2">
+                    <li class="d-flex align-items-center gap-2">
+                      <i class="bi" :class="stateIcon(chain.csrfEnabled)"></i>
+                      <span>CSRF {{ stateLabel(chain.csrfEnabled) }}</span>
+                    </li>
+                    <li class="d-flex align-items-center gap-2">
+                      <i class="bi" :class="stateIcon(chain.corsEnabled)"></i>
+                      <span>CORS {{ stateLabel(chain.corsEnabled) }}</span>
+                    </li>
+                  </ul>
+                </div>
+                <div class="col-lg-8">
+                  <div class="small text-muted mb-2">Filter pipeline</div>
+                  <div v-if="chain.filterNames.length" class="d-flex flex-row flex-nowrap gap-2 overflow-auto pb-1">
+                    <span
+                      v-for="(filterName, index) in chain.filterNames"
+                      :key="`${filterName}-${index}`"
+                      class="badge text-bg-secondary"
+                    >
+                      {{ filterName }}
+                    </span>
+                  </div>
+                  <div v-else class="text-muted">No filters reported for this chain.</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </template>
+    </template>
+  </div>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/Startup.vue
+++ b/bootui-ui/src/main/frontend/src/views/Startup.vue
@@ -1,0 +1,148 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+
+const report = ref({ steps: [] })
+const filter = ref('')
+const loading = ref(true)
+const error = ref('')
+
+async function load() {
+  loading.value = true
+  error.value = ''
+
+  try {
+    const res = await fetch('api/startup')
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`)
+    }
+    const data = await res.json()
+    report.value = {
+      steps: Array.isArray(data?.steps) ? data.steps : []
+    }
+  } catch (err) {
+    report.value = { steps: [] }
+    error.value = err instanceof Error ? err.message : 'Unable to load startup data'
+  } finally {
+    loading.value = false
+  }
+}
+
+const sortedSteps = computed(() =>
+  [...report.value.steps].sort((a, b) => a.id - b.id)
+)
+
+const tree = computed(() => {
+  const byId = new Map()
+  const roots = []
+
+  sortedSteps.value.forEach(step => {
+    byId.set(step.id, { ...step, children: [] })
+  })
+
+  sortedSteps.value.forEach(step => {
+    const node = byId.get(step.id)
+    const parentId = step.parentId
+    if (!parentId || !byId.has(parentId)) {
+      roots.push(node)
+      return
+    }
+    byId.get(parentId).children.push(node)
+  })
+
+  return roots
+})
+
+function filterTree(nodes, query) {
+  if (!query) {
+    return nodes
+  }
+
+  return nodes.flatMap(node => {
+    const children = filterTree(node.children, query)
+    const matches = (node.name || '').toLowerCase().includes(query)
+    if (!matches && children.length === 0) {
+      return []
+    }
+    return [{ ...node, children }]
+  })
+}
+
+function flatten(nodes, depth = 0) {
+  return nodes.flatMap(node => [
+    { ...node, depth },
+    ...flatten(node.children, depth + 1)
+  ])
+}
+
+const visibleSteps = computed(() => {
+  const query = filter.value.trim().toLowerCase()
+  return flatten(filterTree(tree.value, query))
+})
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+      <div>
+        <h2 class="mb-1"><i class="bi bi-clock-history me-2"></i>Startup timeline</h2>
+        <p class="text-muted mb-0">
+          {{ report.steps.length }} steps<span v-if="filter"> · {{ visibleSteps.length }} shown</span>
+        </p>
+      </div>
+      <div class="col-12 col-md-5 col-lg-4 px-0">
+        <div class="input-group">
+          <span class="input-group-text"><i class="bi bi-search"></i></span>
+          <input
+            v-model="filter"
+            class="form-control"
+            placeholder="Filter by step name…"
+            type="search"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div v-if="loading" class="text-muted">
+      <i class="bi bi-hourglass-split me-2"></i>Loading startup data…
+    </div>
+    <div v-else-if="error" class="alert alert-danger" role="alert">
+      <i class="bi bi-exclamation-triangle me-2"></i>{{ error }}
+    </div>
+    <div v-else-if="report.steps.length === 0" class="alert alert-light border" role="status">
+      <i class="bi bi-info-circle me-2"></i>No startup data available
+    </div>
+    <div v-else-if="visibleSteps.length === 0" class="alert alert-light border" role="status">
+      <i class="bi bi-search me-2"></i>No startup steps match the current filter
+    </div>
+    <div v-else class="list-group">
+      <div
+        v-for="step in visibleSteps"
+        :key="step.id"
+        class="list-group-item py-3"
+        :style="{ paddingLeft: `${1 + step.depth * 1.25}rem` }"
+      >
+        <div class="d-flex align-items-start justify-content-between gap-3">
+          <div class="flex-grow-1 min-w-0">
+            <div class="d-flex align-items-center gap-2 flex-wrap mb-1">
+              <i class="bi bi-arrow-return-right text-muted" :class="{ 'opacity-0': step.depth === 0 }"></i>
+              <span class="fw-semibold text-break">{{ step.name }}</span>
+              <span class="badge text-bg-light">#{{ step.id }}</span>
+            </div>
+            <div v-if="step.tags?.length" class="d-flex flex-wrap gap-1 mt-2">
+              <span
+                v-for="tag in step.tags"
+                :key="`${step.id}-${tag.key}-${tag.value}`"
+                class="badge rounded-pill text-bg-secondary"
+              >
+                {{ tag.key }}={{ tag.value }}
+              </span>
+            </div>
+          </div>
+          <span class="badge text-bg-primary ms-auto">{{ step.durationMs }} ms</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Motivation

BootUI v0.1 covers the essentials (beans, config, health, loggers). This PR adds the v0.2 panel set, bringing BootUI closer to parity with Quarkus Dev UI and the Micronaut Control Panel for the inner development loop.

## What's included

### 7 new panels

| Panel | Route | Description |
|---|---|---|
| **Startup Timeline** | `/startup` | Tree view of Spring Boot startup steps with duration badges and tag pills. Fixes the existing `StartupController` to map to a proper `StartupReport` DTO instead of leaking a raw Actuator descriptor. |
| **Scheduled Tasks** | `/scheduled` | Lists all `@Scheduled` tasks via `ScheduledTaskHolder`: cron expressions, fixed-rate/delay intervals, initial delays. Gracefully absent when Spring Scheduling is not on the classpath. |
| **HTTP Probe** | `/http-probe` | A lightweight in-browser REST client. Requests are proxied server-side through `HttpProbeController` (Java `HttpClient`), which enforces a loopback-only guard and a 10s timeout. No CORS headaches, no extra tooling. |
| **Live Log Tail** | `/log-tail` | Streams log lines to the browser over SSE. A `BootUiLogAppender` (Logback `AppenderBase`) maintains a 500-line ring buffer; the SSE endpoint replays recent history then pushes new events. Supports level filtering, pause/resume, and auto-scroll. |
| **Profile Diff** | `/profiles` | Shows which properties are contributed by each active profile-specific source (`application-{profile}.properties/yml`). Helps answer "what does the dev profile actually add?" Secret masking and `bootui.expose-values` are respected. |
| **Spring Security** | `/security` | Read-only view of `SecurityFilterChain` beans: request matcher, ordered filter pipeline, CSRF/CORS/session policy. Auth providers and `UserDetailsService` types are surfaced. Gated by `@ConditionalOnClass`; `spring-security-web` added as an optional compile dep. |
| **OpenAPI link** | Overview panel | Detects springdoc-openapi on the classpath and adds a direct "Open Swagger UI" link to the Overview panel. URL is configurable via the standard `springdoc.swagger-ui.path` property. |

## Design notes

- All new controllers follow the existing pattern: `ObjectProvider<T>` injection, graceful empty response when the dependency is absent, BootUI DTOs in `bootui-core` (no raw Actuator types leaked).
- `SecurityController` and `ScheduledController` are `@ConditionalOnClass`-gated so they are no-ops for apps without those frameworks.
- The SSE log tail installs the Logback appender lazily at bean creation time and cleans up subscriptions on emitter completion -- no user configuration required.
- `HttpProbeController` validates that the target URL is loopback-only before forwarding, consistent with BootUI's fail-closed safety model.
- New DTOs (`StartupReport`, `ScheduledReport`, `HttpProbeRequest/Response`, `LogLineDto`, `ProfilesReport`, `SecurityReport`, and sub-records) are all added to `BootUiDtos.java`. `OverviewDto` gains an `openApiUrl` field (null when springdoc is absent).

## Testing

`mvn -B -ntp clean install` passes. Smoke-test path: start the sample app with `-Dspring-boot.run.profiles=dev` and visit `http://localhost:8080/bootui`.