### PR TITLE
Update sample app for Data and Security panels

### DIFF
--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -24,6 +24,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -33,6 +37,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/BootUiSampleApplication.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/BootUiSampleApplication.java
@@ -1,5 +1,6 @@
 package io.github.bootui.sample;
 
+import java.util.List;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -45,14 +46,40 @@ public class BootUiSampleApplication {
     public static class SampleController {
 
         private final SampleSettings settings;
+        private final ProductRepository products;
 
-        public SampleController(SampleSettings settings) {
+        public SampleController(SampleSettings settings, ProductRepository products) {
             this.settings = settings;
+            this.products = products;
         }
 
         @GetMapping("/hello")
         public String hello() {
             return settings.getGreeting() + ", BootUI! (retries=" + settings.getRetries() + ")";
+        }
+
+        @GetMapping("/products")
+        public List<ProductSummary> products() {
+            return products.findByActiveTrueOrderByNameAsc().stream()
+                    .map(ProductSummary::from)
+                    .toList();
+        }
+    }
+
+    public record ProductSummary(Long id, String name, String category, boolean active) {
+
+        static ProductSummary from(Product product) {
+            return new ProductSummary(product.getId(), product.getName(), product.getCategory(), product.isActive());
+        }
+    }
+
+    @RestController
+    @RequestMapping("/admin")
+    public static class AdminController {
+
+        @GetMapping
+        public String admin() {
+            return "BootUI sample admin";
         }
     }
 }

--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/Product.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/Product.java
@@ -1,0 +1,47 @@
+package io.github.bootui.sample;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "sample_products")
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String category;
+
+    private boolean active;
+
+    protected Product() {
+    }
+
+    public Product(String name, String category, boolean active) {
+        this.name = name;
+        this.category = category;
+        this.active = active;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/ProductRepository.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/ProductRepository.java
@@ -1,0 +1,18 @@
+package io.github.bootui.sample;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    List<Product> findByActiveTrueOrderByNameAsc();
+
+    List<Product> findByCategoryIgnoreCase(String category);
+
+    long countByCategory(String category);
+
+    @Query("select p from Product p where lower(p.name) like lower(concat('%', :term, '%')) order by p.name")
+    List<Product> searchByName(@Param("term") String term);
+}

--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/SampleDataInitializer.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/SampleDataInitializer.java
@@ -1,0 +1,23 @@
+package io.github.bootui.sample;
+
+import java.util.List;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+class SampleDataInitializer {
+
+    @Bean
+    ApplicationRunner seedSampleProducts(ProductRepository products) {
+        return args -> {
+            if (products.count() > 0) {
+                return;
+            }
+            products.saveAll(List.of(
+                    new Product("BootUI Starter", "library", true),
+                    new Product("Sample Console", "demo", true),
+                    new Product("Archived Prototype", "demo", false)));
+        };
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/SecurityConfiguration.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/SecurityConfiguration.java
@@ -1,0 +1,66 @@
+package io.github.bootui.sample;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration(proxyBeanMethods = false)
+class SecurityConfiguration {
+
+    @Bean
+    @Order(1)
+    SecurityFilterChain bootUiSecurity(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher("/bootui/**")
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable())
+                .build();
+    }
+
+    @Bean
+    @Order(2)
+    SecurityFilterChain adminSecurity(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher("/admin/**")
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().hasRole("ADMIN"))
+                .httpBasic(withDefaults())
+                .csrf(csrf -> csrf.disable())
+                .build();
+    }
+
+    @Bean
+    @Order(3)
+    SecurityFilterChain applicationSecurity(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable())
+                .build();
+    }
+
+    @Bean
+    UserDetailsService users(PasswordEncoder passwordEncoder) {
+        return new InMemoryUserDetailsManager(
+                User.withUsername("developer")
+                        .password(passwordEncoder.encode("developer"))
+                        .roles("USER")
+                        .build(),
+                User.withUsername("admin")
+                        .password(passwordEncoder.encode("admin"))
+                        .roles("ADMIN")
+                        .build());
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/bootui-sample-app/src/main/resources/application.properties
+++ b/bootui-sample-app/src/main/resources/application.properties
@@ -4,6 +4,12 @@ server.port=8080
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always
 
+spring.datasource.url=jdbc:h2:mem:bootui-sample;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.open-in-view=false
+
 sample.greeting=Hello
 sample.retries=3
 

--- a/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.web.client.RestClient;
 
 /**
@@ -72,6 +73,18 @@ class BootUiSampleApplicationIntegrationTests {
 
     private ResponseEntity<Map> postMap(String path, Object body) {
         return client().post().uri(path).body(body).retrieve().toEntity(Map.class);
+    }
+
+    private ResponseEntity<String> getString(String path) {
+        return client().get().uri(path).retrieve().toEntity(String.class);
+    }
+
+    private ResponseEntity<String> getStringWithBasicAuth(String path, String username, String password) {
+        return client().get()
+                .uri(path)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .retrieve()
+                .toEntity(String.class);
     }
 
     @Test
@@ -204,6 +217,93 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(body).isNotNull();
         // Mappings controller returns the raw ApplicationMappingsDescriptor.
         assertThat(body.containsKey("contexts")).isTrue();
+    }
+
+    @Test
+    void sampleAppEndpointsRemainPublicButAdminRequiresPassword() {
+        ResponseEntity<String> hello = getString("/api/sample/hello");
+        assertThat(hello.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(hello.getBody()).contains("Hello, BootUI!");
+
+        ResponseEntity<String> adminWithoutCredentials = getString("/admin");
+        assertThat(adminWithoutCredentials.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        ResponseEntity<String> adminWithDeveloperCredentials = getStringWithBasicAuth("/admin", "developer", "developer");
+        assertThat(adminWithDeveloperCredentials.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+
+        ResponseEntity<String> adminWithAdminCredentials = getStringWithBasicAuth("/admin", "admin", "admin");
+        assertThat(adminWithAdminCredentials.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(adminWithAdminCredentials.getBody()).isEqualTo("BootUI sample admin");
+    }
+
+    @Test
+    void dataEndpointFindsSampleJpaRepository() {
+        ResponseEntity<Map> response = getMap("/bootui/api/data/repositories");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.get("springDataPresent")).isEqualTo(true);
+        assertThat(((Number) body.get("total")).intValue()).isGreaterThan(0);
+        assertThat((Iterable<?>) body.get("repositories"))
+                .anySatisfy(repository -> {
+                    Map<?, ?> dto = (Map<?, ?>) repository;
+                    assertThat(dto.get("repositoryInterface")).isEqualTo(ProductRepository.class.getName());
+                    assertThat(dto.get("domainType")).isEqualTo(Product.class.getName());
+                    assertThat(dto.get("storeModule")).isEqualTo("JPA");
+                    assertThat(((Number) dto.get("queryMethodCount")).intValue()).isGreaterThan(0);
+                });
+    }
+
+    @Test
+    void dataRepositoryDetailIncludesAnnotatedQueryMethod() {
+        ResponseEntity<Map> response = getMap("/bootui/api/data/repositories/" + ProductRepository.class.getName());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat((Iterable<?>) body.get("methods"))
+                .anySatisfy(method -> {
+                    Map<?, ?> dto = (Map<?, ?>) method;
+                    assertThat(dto.get("name")).isEqualTo("searchByName");
+                    assertThat(dto.get("origin")).isEqualTo("ANNOTATED");
+                    assertThat((String) dto.get("query")).contains("select p from Product p");
+                });
+    }
+
+    @Test
+    void securityEndpointFindsSampleFilterChains() {
+        ResponseEntity<Map> response = getMap("/bootui/api/security");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.get("springSecurityPresent")).isEqualTo(true);
+        assertThat((Iterable<?>) body.get("chains"))
+                .anySatisfy(chain -> {
+                    Map<?, ?> dto = (Map<?, ?>) chain;
+                    assertThat(dto.get("requestMatcher")).asString().contains("/admin/**");
+                    assertThat((Iterable<?>) dto.get("filters"))
+                            .anySatisfy(filter -> assertThat(filter).isEqualTo("BasicAuthenticationFilter"));
+                });
+
+        Map<?, ?> auth = (Map<?, ?>) body.get("auth");
+        assertThat(auth).isNotNull();
+        assertThat((Iterable<?>) auth.get("userDetailsServiceTypes"))
+                .anySatisfy(type -> assertThat(type).isEqualTo(InMemoryUserDetailsManager.class.getName()));
+    }
+
+    @Test
+    void securityExplainMatchesAdminRequest() {
+        ResponseEntity<Map> response = getMap("/bootui/api/security/explain?method=GET&path=/admin");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.get("matched")).isEqualTo(true);
+        assertThat(body.get("matcherDescription")).asString().contains("/admin/**");
+        assertThat((Iterable<?>) body.get("filters"))
+                .anySatisfy(filter -> assertThat(filter).isEqualTo("BasicAuthenticationFilter"));
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Updates the sample app so BootUI's new Spring Data and Spring Security panels have realistic application metadata to inspect.

## Why is this change needed?

The sample app should make it easy to manually validate newly merged Spring Data and Spring Security support. This adds a small JPA/H2 product catalog and explicit security filter chains, while keeping the default sample routes publicly accessible and protecting only `/admin` with the sample admin user.

Closes N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran `mvn -pl bootui-sample-app -am test -Dtest=BootUiSampleApplicationIntegrationTests -Dsurefire.failIfNoSpecifiedTests=false -Dskip.frontend=true`.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed