### PR TITLE
Add configuration property suggestions

### DIFF
--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ConfigController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ConfigController.java
@@ -7,6 +7,7 @@ import io.github.bootui.autoconfigure.config.ConfigOverrideService;
 import io.github.bootui.core.BootUiDtos.ConfigOverrideRequest;
 import io.github.bootui.core.BootUiDtos.ConfigOverrideResult;
 import io.github.bootui.core.BootUiDtos.ConfigPropertyDto;
+import io.github.bootui.core.BootUiDtos.ConfigPropertySuggestionDto;
 import io.github.bootui.core.BootUiDtos.ConfigReport;
 import io.github.bootui.core.SecretMasker;
 import java.util.ArrayList;
@@ -36,14 +37,24 @@ public class ConfigController {
 
     private final BootUiProperties properties;
 
+    private final ConfigMetadataCatalog metadataCatalog;
+
     private final SecretMasker masker = new SecretMasker();
 
     public ConfigController(ConfigurableEnvironment environment,
                             ConfigOverrideService overrideService,
                             BootUiProperties properties) {
+        this(environment, overrideService, properties, new ConfigMetadataCatalog(ConfigController.class.getClassLoader()));
+    }
+
+    ConfigController(ConfigurableEnvironment environment,
+                     ConfigOverrideService overrideService,
+                     BootUiProperties properties,
+                     ConfigMetadataCatalog metadataCatalog) {
         this.environment = environment;
         this.overrideService = overrideService;
         this.properties = properties;
+        this.metadataCatalog = metadataCatalog;
     }
 
     @GetMapping
@@ -70,7 +81,8 @@ public class ConfigController {
         return new ConfigReport(
                 Arrays.asList(environment.getActiveProfiles()),
                 sources,
-                sorted);
+                sorted,
+                metadataCatalog.suggestions());
     }
 
     @PostMapping("/overrides")
@@ -88,6 +100,7 @@ public class ConfigController {
 
     private ConfigPropertyDto toDto(String name, Object value, String sourceName) {
         boolean isOverride = BootUiOverridesPropertySource.NAME.equals(sourceName);
+        ConfigPropertySuggestionDto metadata = metadataCatalog.get(name);
         Object displayValue = value;
         boolean masked = false;
         if (properties.getExposeValues() == ValueExposure.METADATA_ONLY) {
@@ -103,7 +116,7 @@ public class ConfigController {
                 null,
                 masked,
                 isOverride,
-                null,
-                null);
+                metadata == null ? null : metadata.description(),
+                metadata == null ? null : metadata.defaultValue());
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ConfigMetadataCatalog.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ConfigMetadataCatalog.java
@@ -1,0 +1,125 @@
+package io.github.bootui.autoconfigure.web;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bootui.core.BootUiDtos.ConfigPropertySuggestionDto;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class ConfigMetadataCatalog {
+
+    private static final String RESOURCE_NAME = "META-INF/spring-configuration-metadata.json";
+
+    private final Map<String, ConfigPropertySuggestionDto> properties;
+
+    ConfigMetadataCatalog(ClassLoader classLoader) {
+        this(classLoader, new ObjectMapper());
+    }
+
+    ConfigMetadataCatalog(ClassLoader classLoader, ObjectMapper objectMapper) {
+        this.properties = Collections.unmodifiableMap(load(classLoader, objectMapper));
+    }
+
+    ConfigPropertySuggestionDto get(String name) {
+        return properties.get(name);
+    }
+
+    List<ConfigPropertySuggestionDto> suggestions() {
+        return new ArrayList<>(properties.values());
+    }
+
+    private static Map<String, ConfigPropertySuggestionDto> load(ClassLoader classLoader, ObjectMapper objectMapper) {
+        ClassLoader effectiveClassLoader = classLoader != null
+                ? classLoader
+                : Thread.currentThread().getContextClassLoader();
+        if (effectiveClassLoader == null) {
+            effectiveClassLoader = ConfigMetadataCatalog.class.getClassLoader();
+        }
+        Map<String, ConfigPropertySuggestionDto> result = new LinkedHashMap<>();
+        try {
+            Enumeration<URL> resources = effectiveClassLoader.getResources(RESOURCE_NAME);
+            while (resources.hasMoreElements()) {
+                URL resource = resources.nextElement();
+                try (InputStream input = resource.openStream()) {
+                    JsonNode propertiesNode = objectMapper.readTree(input).path("properties");
+                    if (propertiesNode.isArray()) {
+                        for (JsonNode propertyNode : propertiesNode) {
+                            addProperty(result, propertyNode, objectMapper);
+                        }
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not read Spring configuration metadata", ex);
+        }
+        return sortByName(result);
+    }
+
+    private static void addProperty(Map<String, ConfigPropertySuggestionDto> result,
+                                    JsonNode propertyNode,
+                                    ObjectMapper objectMapper) {
+        String name = text(propertyNode, "name");
+        if (name == null || propertyNode.has("deprecation")) {
+            return;
+        }
+        ConfigPropertySuggestionDto candidate = new ConfigPropertySuggestionDto(
+                name,
+                text(propertyNode, "type"),
+                text(propertyNode, "description"),
+                toObject(propertyNode.get("defaultValue"), objectMapper));
+        ConfigPropertySuggestionDto current = result.get(name);
+        if (current == null || isRicher(candidate, current)) {
+            result.put(name, candidate);
+        }
+    }
+
+    private static boolean isRicher(ConfigPropertySuggestionDto candidate, ConfigPropertySuggestionDto current) {
+        return richness(candidate) > richness(current);
+    }
+
+    private static int richness(ConfigPropertySuggestionDto suggestion) {
+        int score = 0;
+        if (suggestion.type() != null) {
+            score++;
+        }
+        if (suggestion.description() != null) {
+            score++;
+        }
+        if (suggestion.defaultValue() != null) {
+            score++;
+        }
+        return score;
+    }
+
+    private static Map<String, ConfigPropertySuggestionDto> sortByName(
+            Map<String, ConfigPropertySuggestionDto> unsorted) {
+        Map<String, ConfigPropertySuggestionDto> sorted = new LinkedHashMap<>();
+        unsorted.values().stream()
+                .sorted(Comparator.comparing(ConfigPropertySuggestionDto::name))
+                .forEach(suggestion -> sorted.put(suggestion.name(), suggestion));
+        return sorted;
+    }
+
+    private static String text(JsonNode node, String fieldName) {
+        JsonNode value = node.get(fieldName);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        return value.asText();
+    }
+
+    private static Object toObject(JsonNode node, ObjectMapper objectMapper) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        return objectMapper.convertValue(node, Object.class);
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/ConfigMetadataCatalogTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/ConfigMetadataCatalogTests.java
@@ -1,0 +1,60 @@
+package io.github.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.bootui.core.BootUiDtos.ConfigPropertySuggestionDto;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConfigMetadataCatalogTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void readsConfigurationMetadataPropertiesWithDefaults() throws Exception {
+        Path metadataFile = tempDir.resolve("META-INF/spring-configuration-metadata.json");
+        Files.createDirectories(metadataFile.getParent());
+        Files.writeString(metadataFile, """
+                {
+                  "properties": [
+                    {
+                      "name": "server.port",
+                      "type": "java.lang.Integer",
+                      "description": "Server HTTP port.",
+                      "defaultValue": 8080
+                    },
+                    {
+                      "name": "spring.main.banner-mode",
+                      "type": "org.springframework.boot.Banner$Mode",
+                      "description": "Mode used to display the banner.",
+                      "defaultValue": "console"
+                    },
+                    {
+                      "name": "spring.old",
+                      "deprecation": {
+                        "reason": "No longer used."
+                      }
+                    }
+                  ]
+                }
+                """);
+
+        try (URLClassLoader classLoader = new URLClassLoader(new java.net.URL[] { tempDir.toUri().toURL() }, null)) {
+            ConfigMetadataCatalog catalog = new ConfigMetadataCatalog(classLoader);
+
+            List<ConfigPropertySuggestionDto> suggestions = catalog.suggestions();
+
+            assertThat(suggestions)
+                    .extracting(ConfigPropertySuggestionDto::name)
+                    .containsExactly("server.port", "spring.main.banner-mode");
+            assertThat(catalog.get("server.port").defaultValue()).isEqualTo(8080);
+            assertThat(catalog.get("spring.main.banner-mode").defaultValue()).isEqualTo("console");
+            assertThat(catalog.get("spring.old")).isNull();
+        }
+    }
+}

--- a/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
@@ -79,10 +79,19 @@ public final class BootUiDtos {
             Object defaultValue) {
     }
 
+    /** A known configuration property that can be used for new overrides. */
+    public record ConfigPropertySuggestionDto(
+            String name,
+            String type,
+            String description,
+            Object defaultValue) {
+    }
+
     public record ConfigReport(
             List<String> activeProfiles,
             List<String> sources,
-            List<ConfigPropertyDto> properties) {
+            List<ConfigPropertyDto> properties,
+            List<ConfigPropertySuggestionDto> propertySuggestions) {
     }
 
     /** Request to add/update a runtime property override. */

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -18,6 +18,17 @@ const newNameInput = ref(null)
 const editInput = ref(null)
 const banner = ref(null)
 
+const propertySuggestions = computed(() => data.value?.propertySuggestions || [])
+
+const suggestionByName = computed(() => {
+  const byName = new Map()
+  propertySuggestions.value.forEach(s => byName.set(s.name, s))
+  return byName
+})
+
+const selectedNewSuggestion = computed(() =>
+  suggestionByName.value.get((newRowName.value || '').trim()) || null)
+
 async function load() {
   loading.value = true
   try {
@@ -39,7 +50,9 @@ const filtered = computed(() => {
     if (filter.value) {
       const f = filter.value.toLowerCase()
       return p.name.toLowerCase().includes(f) ||
-             String(p.value ?? '').toLowerCase().includes(f)
+             String(p.value ?? '').toLowerCase().includes(f) ||
+             String(p.description ?? '').toLowerCase().includes(f) ||
+             String(p.defaultValue ?? '').toLowerCase().includes(f)
     }
     return true
   })
@@ -76,6 +89,34 @@ function startCreate() {
 function cancelCreate() {
   newRow.value = null
   newRowError.value = null
+}
+
+function hasDefaultValue(suggestion) {
+  return suggestion && suggestion.defaultValue !== null && suggestion.defaultValue !== undefined
+}
+
+function formatDefaultValue(value) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+function suggestionLabel(suggestion) {
+  const parts = []
+  if (hasDefaultValue(suggestion)) parts.push('default: ' + formatDefaultValue(suggestion.defaultValue))
+  if (suggestion.type) parts.push(suggestion.type)
+  if (suggestion.description) parts.push(suggestion.description)
+  return parts.join(' - ')
+}
+
+function useSelectedDefault() {
+  if (hasDefaultValue(selectedNewSuggestion.value)) {
+    newRowValue.value = formatDefaultValue(selectedNewSuggestion.value.defaultValue)
+  }
+}
+
+function metadataFor(name) {
+  return suggestionByName.value.get(name)
 }
 
 async function saveCreate() {
@@ -171,6 +212,7 @@ onMounted(load)
         Click <span class="badge bg-primary"><i class="bi bi-pencil"></i> Edit</span>
         on any row to set a runtime override, or use
         <strong>Add override</strong> to add a new property.
+        The new-property picker includes known Spring Boot configuration keys and their defaults.
         Overrides are persisted to
         <code>.bootui/application-bootui.properties</code> and take precedence over all other property sources.
         <span class="text-muted">
@@ -220,10 +262,11 @@ onMounted(load)
       <table class="table table-sm align-middle">
         <thead class="table-light">
           <tr>
-            <th style="width:35%">Property</th>
-            <th style="width:35%">Value</th>
-            <th style="width:15%">Source</th>
-            <th style="width:15%" class="text-end">Actions</th>
+            <th style="width:30%">Property</th>
+            <th style="width:25%">Value</th>
+            <th style="width:20%">Default</th>
+            <th style="width:13%">Source</th>
+            <th style="width:12%" class="text-end">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -232,19 +275,52 @@ onMounted(load)
             <td>
               <input ref="newNameInput" class="form-control form-control-sm font-monospace"
                      v-model="newRowName"
-                     placeholder="my.property.name"
+                     list="bootPropertySuggestions"
+                     placeholder="spring.application.name"
                      @keyup.enter="saveCreate"
                      @keyup.esc="cancelCreate" />
+              <datalist id="bootPropertySuggestions">
+                <option v-for="s in propertySuggestions"
+                        :key="s.name"
+                        :value="s.name"
+                        :label="suggestionLabel(s)"></option>
+              </datalist>
+              <div v-if="selectedNewSuggestion" class="small text-muted mt-1">
+                <div v-if="selectedNewSuggestion.description">{{ selectedNewSuggestion.description }}</div>
+                <div>
+                  <span v-if="selectedNewSuggestion.type">Type: <code>{{ selectedNewSuggestion.type }}</code></span>
+                  <span v-if="selectedNewSuggestion.type && hasDefaultValue(selectedNewSuggestion)" class="mx-1">·</span>
+                  <span v-if="hasDefaultValue(selectedNewSuggestion)">
+                    Default: <code>{{ formatDefaultValue(selectedNewSuggestion.defaultValue) }}</code>
+                  </span>
+                </div>
+              </div>
               <div v-if="newRowError" class="text-danger small mt-1">
                 <i class="bi bi-exclamation-circle"></i> {{ newRowError }}
               </div>
             </td>
             <td>
-              <input class="form-control form-control-sm font-monospace"
-                     v-model="newRowValue"
-                     placeholder="new value"
-                     @keyup.enter="saveCreate"
-                     @keyup.esc="cancelCreate" />
+              <div class="input-group input-group-sm">
+                <input class="form-control font-monospace"
+                       v-model="newRowValue"
+                       :placeholder="hasDefaultValue(selectedNewSuggestion)
+                         ? 'default: ' + formatDefaultValue(selectedNewSuggestion.defaultValue)
+                         : 'new value'"
+                       @keyup.enter="saveCreate"
+                       @keyup.esc="cancelCreate" />
+                <button v-if="hasDefaultValue(selectedNewSuggestion)"
+                        class="btn btn-outline-secondary"
+                        type="button"
+                        @click="useSelectedDefault">
+                  Use default
+                </button>
+              </div>
+            </td>
+            <td>
+              <code v-if="hasDefaultValue(selectedNewSuggestion)" class="text-body">
+                {{ formatDefaultValue(selectedNewSuggestion.defaultValue) }}
+              </code>
+              <span v-else class="text-muted">—</span>
             </td>
             <td><span class="badge bg-warning text-dark">new override</span></td>
             <td class="text-end">
@@ -263,6 +339,7 @@ onMounted(load)
             <td class="align-top pt-2">
               <code class="text-body">{{ p.name }}</code>
               <span v-if="p.override" class="badge bg-warning text-dark ms-2">override</span>
+              <div v-if="p.description" class="small text-muted mt-1">{{ p.description }}</div>
             </td>
             <td>
               <template v-if="editingName === p.name">
@@ -275,6 +352,15 @@ onMounted(load)
                 <code v-if="!p.masked" class="text-body">{{ p.value }}</code>
                 <span v-else class="text-muted"><i class="bi bi-lock-fill"></i> masked</span>
               </template>
+            </td>
+            <td class="align-top pt-2">
+              <code v-if="p.defaultValue !== null && p.defaultValue !== undefined" class="text-body">
+                {{ formatDefaultValue(p.defaultValue) }}
+              </code>
+              <span v-else-if="metadataFor(p.name)?.type" class="text-muted small">
+                {{ metadataFor(p.name).type }}
+              </span>
+              <span v-else class="text-muted">—</span>
             </td>
             <td class="align-top pt-2"><small class="text-muted">{{ p.source }}</small></td>
             <td class="text-end align-top pt-1">
@@ -299,7 +385,7 @@ onMounted(load)
           </tr>
 
           <tr v-if="!loading && filtered.length === 0 && !newRow">
-            <td colspan="4" class="text-center text-muted py-4">
+            <td colspan="5" class="text-center text-muted py-4">
               No properties match your filters.
             </td>
           </tr>

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -151,6 +151,8 @@ Included:
 - Beans Explorer.
 - Conditions Explorer.
 - Configuration Explorer.
+  - metadata descriptions and defaults where available.
+  - known Spring Boot property suggestions when creating overrides.
 - Mappings Browser.
 - Health Dashboard.
 - Logger Controls.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -235,6 +235,7 @@ Features:
 - Show active profiles.
 - Show known default where metadata is available.
 - Show description from configuration metadata where available.
+- Suggest known Spring Boot configuration keys when creating an override.
 - Group by prefix:
   - `spring.*`
   - `server.*`


### PR DESCRIPTION
## What does this PR do?

Adds a Spring Boot configuration metadata catalog to the Config panel so developers can pick known properties when creating overrides and see default values alongside effective runtime values.

## Why is this change needed?

The Config UI already supported manually adding overrides, but users had to know exact property names and defaults. This makes common Spring Boot configuration easier to discover and safer to edit during local development.

N/A

## How was it tested?

- [x] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed