### PR TITLE
Pin Maven resources plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <spring-boot.version>4.0.6</spring-boot.version>
         <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <node.version>v24.16.0</node.version>
         <npm.version>11.15.0</npm.version>
     </properties>
@@ -81,6 +82,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.5</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-resources-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## What does this PR do?

Pins `maven-resources-plugin` in parent plugin management so the UI module no longer declares the plugin without a managed version.

## Why is this change needed?

Maven warns that the `bootui-ui` effective model is malformed because `maven-resources-plugin` has no explicit version. Future Maven versions may reject builds with this issue.

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

`mvn validate` runs without the missing plugin version warning.
`mvn -DskipTests clean install` passes locally.
`mvn clean install` is currently blocked by existing `BootUiAutoConfigurationTests` failures around `ConfigController` startup, unrelated to this POM change.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed