### PR TITLE
Improve health panel UI

### DIFF
--- a/bootui-sample-app/e2e/tests/health.spec.js
+++ b/bootui-sample-app/e2e/tests/health.spec.js
@@ -3,11 +3,14 @@ import { test, expect } from './fixtures.js'
 
 test.describe('Health view', () => {
 
-  test('renders the root health node with a status badge', async ({ openView, page }) => {
+  test('renders friendly health summary and tree', async ({ openView, page }) => {
     await openView('health', 'Health')
 
+    await expect(page.getByText('Overall status')).toBeVisible()
+    await expect(page.getByText('Component tree')).toBeVisible()
     const rootCard = page.locator('main .card').first()
     await expect(rootCard).toBeVisible()
     await expect(rootCard.locator('.badge')).toHaveText(/UP|DOWN|UNKNOWN|OUT_OF_SERVICE/)
+    await expect(page.locator('main pre')).toHaveCount(0)
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -1,21 +1,116 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import HealthNode from './HealthNode.vue'
 
 const root = ref(null)
+const loading = ref(true)
+const error = ref(null)
 
 async function load() {
-  const res = await fetch('api/health')
-  root.value = await res.json()
+  loading.value = true
+  error.value = null
+  try {
+    const res = await fetch('api/health')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    root.value = await res.json()
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
 }
+
+function flatten(node) {
+  if (!node) return []
+  return [node, ...(node.components || []).flatMap(flatten)]
+}
+
+const nodes = computed(() => flatten(root.value))
+const componentCount = computed(() => Math.max(nodes.value.length - 1, 0))
+const problemNodes = computed(() =>
+  nodes.value.filter(node => !['UP', 'UNKNOWN'].includes(node.status)))
+const detailsHidden = computed(() =>
+  root.value && !root.value.details && (!root.value.components || root.value.components.length === 0))
+
+const statusMessage = computed(() => {
+  if (!root.value) return ''
+  if (problemNodes.value.length) {
+    return problemNodes.value.length + ' component' + (problemNodes.value.length === 1 ? ' needs' : 's need') + ' attention'
+  }
+  if (root.value.status === 'UP') return 'All reported components are healthy'
+  if (root.value.status === 'UNKNOWN') return 'Health endpoint did not report component details'
+  return 'Application health is ' + root.value.status
+})
 
 onMounted(load)
 </script>
 
 <template>
   <div>
-    <h2><i class="bi bi-heart-pulse me-2"></i>Health</h2>
-    <HealthNode v-if="root" :node="root" />
-    <p v-else class="text-muted">Loading…</p>
+    <div class="d-flex justify-content-between align-items-start mb-3">
+      <div>
+        <h2 class="mb-1"><i class="bi bi-heart-pulse me-2"></i>Health</h2>
+        <p class="text-muted mb-0 small">
+          Inspect application and dependency health without reading raw Actuator JSON.
+        </p>
+      </div>
+      <button class="btn btn-outline-secondary" @click="load" :disabled="loading" title="Refresh">
+        <i class="bi bi-arrow-clockwise"></i>
+      </button>
+    </div>
+
+    <div v-if="loading" class="text-muted">Loading…</div>
+    <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
+
+    <template v-else-if="root">
+      <div class="row g-3 mb-3">
+        <div class="col-md-4">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small text-uppercase">Overall status</div>
+              <div class="fs-4 fw-semibold">
+                <span class="badge" :class="{
+                  'bg-success': root.status === 'UP',
+                  'bg-danger': root.status === 'DOWN',
+                  'bg-warning text-dark': root.status === 'OUT_OF_SERVICE',
+                  'bg-secondary': !['UP', 'DOWN', 'OUT_OF_SERVICE'].includes(root.status)
+                }">
+                  {{ root.status }}
+                </span>
+              </div>
+              <div class="small text-muted mt-2">{{ statusMessage }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-md-4">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small text-uppercase">Contributors</div>
+              <div class="fs-4 fw-semibold">{{ componentCount }}</div>
+              <div class="small text-muted mt-2">Nested health components reported by Actuator</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-md-4">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small text-uppercase">Attention needed</div>
+              <div class="fs-4 fw-semibold">{{ problemNodes.length }}</div>
+              <div class="small text-muted mt-2">DOWN or OUT_OF_SERVICE contributors</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="detailsHidden" class="alert alert-info small">
+        Health contributor details are not available. In local development, set
+        <code>management.endpoint.health.show-details=always</code> to show component details.
+      </div>
+
+      <h5 class="mb-2">Component tree</h5>
+      <HealthNode :node="root" />
+    </template>
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
@@ -1,0 +1,66 @@
+<script>
+export default { name: 'HealthDetails' }
+</script>
+
+<script setup>
+defineProps({
+  value: { required: false, default: null }
+})
+
+function isPlainObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]'
+}
+
+function isScalar(value) {
+  return value === null || value === undefined || ['string', 'number', 'boolean'].includes(typeof value)
+}
+
+function entries(value) {
+  return isPlainObject(value) ? Object.entries(value) : []
+}
+
+function labelFor(key) {
+  const label = String(key)
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[._-]+/g, ' ')
+    .trim()
+  return label ? label.charAt(0).toUpperCase() + label.slice(1) : key
+}
+
+function formatScalar(value) {
+  if (value === null || value === undefined || value === '') return '—'
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  return String(value)
+}
+</script>
+
+<template>
+  <span v-if="isScalar(value)">{{ formatScalar(value) }}</span>
+
+  <div v-else-if="Array.isArray(value)">
+    <span v-if="value.length === 0" class="text-muted">None</span>
+    <ol v-else class="mb-0 ps-3">
+      <li v-for="(item, index) in value" :key="index" class="mb-1">
+        <HealthDetails :value="item" />
+      </li>
+    </ol>
+  </div>
+
+  <div v-else-if="isPlainObject(value)" class="table-responsive">
+    <table class="table table-sm table-borderless align-middle mb-0">
+      <tbody>
+        <tr v-for="[key, item] in entries(value)" :key="key">
+          <th class="text-muted fw-normal ps-0" style="width: 34%">{{ labelFor(key) }}</th>
+          <td class="pe-0">
+            <code v-if="isScalar(item)">{{ formatScalar(item) }}</code>
+            <div v-else class="border rounded bg-light-subtle p-2">
+              <HealthDetails :value="item" />
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <code v-else>{{ formatScalar(value) }}</code>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthNode.vue
@@ -3,7 +3,12 @@ export default { name: 'HealthNode' }
 </script>
 
 <script setup>
-const props = defineProps({ node: { type: Object, required: true } })
+import HealthDetails from './HealthDetails.vue'
+
+const props = defineProps({
+  node: { type: Object, required: true },
+  depth: { type: Number, default: 0 }
+})
 
 const statusClass = s => ({
   UP: 'bg-success',
@@ -11,17 +16,52 @@ const statusClass = s => ({
   OUT_OF_SERVICE: 'bg-warning text-dark',
   UNKNOWN: 'bg-secondary'
 }[s] || 'bg-secondary')
+
+const statusIcon = s => ({
+  UP: 'bi-check-circle-fill text-success',
+  DOWN: 'bi-x-circle-fill text-danger',
+  OUT_OF_SERVICE: 'bi-exclamation-triangle-fill text-warning',
+  UNKNOWN: 'bi-question-circle-fill text-secondary'
+}[s] || 'bi-question-circle-fill text-secondary')
+
+const childCount = node => (node.components || []).length
+
+const detailCount = node => {
+  if (!node.details || typeof node.details !== 'object' || Array.isArray(node.details)) return node.details ? 1 : 0
+  return Object.keys(node.details).length
+}
 </script>
 
 <template>
-  <div class="card mb-2">
-    <div class="card-header d-flex justify-content-between">
-      <strong>{{ node.name }}</strong>
+  <details class="card mb-2" :open="depth < 2 || node.status !== 'UP'">
+    <summary class="card-header d-flex justify-content-between align-items-center gap-2">
+      <span class="d-flex align-items-center gap-2">
+        <i class="bi" :class="statusIcon(node.status)"></i>
+        <strong>{{ node.name }}</strong>
+        <span v-if="childCount(node)" class="text-muted small">
+          {{ childCount(node) }} {{ childCount(node) === 1 ? 'component' : 'components' }}
+        </span>
+        <span v-if="detailCount(node)" class="text-muted small">
+          {{ detailCount(node) }} {{ detailCount(node) === 1 ? 'detail' : 'details' }}
+        </span>
+      </span>
       <span class="badge" :class="statusClass(node.status)">{{ node.status }}</span>
+    </summary>
+
+    <div v-if="childCount(node) || node.details" class="card-body">
+      <section v-if="node.details" class="mb-3">
+        <h6 class="text-muted text-uppercase small mb-2">Details</h6>
+        <HealthDetails :value="node.details" />
+      </section>
+
+      <section v-if="childCount(node)">
+        <h6 v-if="node.details" class="text-muted text-uppercase small mb-2">Components</h6>
+        <HealthNode
+          v-for="c in node.components"
+          :key="c.name"
+          :node="c"
+          :depth="depth + 1" />
+      </section>
     </div>
-    <div v-if="(node.components && node.components.length) || node.details" class="card-body">
-      <pre v-if="node.details" class="small mb-0">{{ JSON.stringify(node.details, null, 2) }}</pre>
-      <HealthNode v-for="c in (node.components || [])" :key="c.name" :node="c" />
-    </div>
-  </div>
+  </details>
 </template>


### PR DESCRIPTION
## What does this PR do?

Reworks the Health panel so developers see a friendly dashboard and component tree instead of raw JSON details.

## Why is this change needed?

The Health panel currently exposes Actuator detail payloads as JSON, which makes it harder to quickly identify overall health, failing contributors, and useful component details during local development.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks run:

- `npm run build`
- `mvn -pl bootui-ui install`

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed