### PR TITLE
Add sample app fixtures for BootUI panels

### DIFF
--- a/bootui-sample-app/e2e/README.md
+++ b/bootui-sample-app/e2e/README.md
@@ -22,13 +22,13 @@ flow) exposed by the sample app:
 | `loggers.spec.js`          | Logger search, change `io.github.bootui.sample` to `WARN`, reset                       |
 | `data.spec.js`             | `ProductRepository` is listed, detail panel shows `searchByName`                       |
 | `startup.spec.js`          | Startup timeline displays step rows                                                    |
-| `scheduled.spec.js`        | Scheduled tasks view renders (empty-state allowed)                                     |
-| `http-probe.spec.js`       | Probe `/api/sample/hello` and assert the JSON response is shown                        |
+| `scheduled.spec.js`        | Scheduled tasks view lists the sample echo scheduler                                  |
+| `http-probe.spec.js`       | Probe `/api/hello` and assert the response body is shown                              |
 | `log-tail.spec.js`         | Log Tail connects, streams new events, pause / resume / clear controls work           |
 | `profile-diff.spec.js`     | Profile sources & properties render with filtering                                     |
-| `security.spec.js`         | Filter chains list `/admin/**`, explain endpoint returns a match                       |
+| `security.spec.js`         | Filter chains list `/api/secure`, explain endpoint returns a match                     |
 | `memory.spec.js`           | Heap / non-heap cards render, JVM options copy button                                  |
-| `sample-api.spec.js`       | Sample REST API (`/api/sample/hello`, `/api/sample/products`) and basic-auth on `/admin` |
+| `sample-api.spec.js`       | Sample REST API (`/api/hello`, `/api/secure`, `/api/sample/hello`, `/api/sample/products`) and basic-auth on `/admin` |
 
 ## Prerequisites
 

--- a/bootui-sample-app/e2e/tests/http-probe.spec.js
+++ b/bootui-sample-app/e2e/tests/http-probe.spec.js
@@ -7,13 +7,13 @@ test.describe('HTTP Probe view', () => {
     await openView('http-probe', 'HTTP Probe')
 
     await page.locator('select.form-select').selectOption('GET')
-    await page.getByPlaceholder('/api/sample/hello').fill('/api/sample/hello')
+    await page.getByPlaceholder('/api/sample/hello').fill('/api/hello')
     await page.getByRole('button', { name: /^Send/ }).click()
 
     const responseCard = page.locator('.card', { hasText: /^Response/ })
     await expect(responseCard).toBeVisible()
     await expect(responseCard.locator('.badge', { hasText: /200 OK/ })).toBeVisible()
-    await expect(responseCard.locator('pre')).toContainText('Hello, BootUI!')
+    await expect(responseCard.locator('pre')).toContainText('Hello, world')
   })
 
   test('switching to POST reveals the request body editor', async ({ openView, page }) => {

--- a/bootui-sample-app/e2e/tests/mappings.spec.js
+++ b/bootui-sample-app/e2e/tests/mappings.spec.js
@@ -10,6 +10,8 @@ test.describe('HTTP mappings view', () => {
     await expect.poll(async () => rows.count()).toBeGreaterThan(5)
 
     // The sample API and admin endpoints must be present.
+    await expect(page.locator('table tbody')).toContainText('/api/hello')
+    await expect(page.locator('table tbody')).toContainText('/api/secure')
     await expect(page.locator('table tbody')).toContainText('/api/sample/hello')
     await expect(page.locator('table tbody')).toContainText('/api/sample/products')
     await expect(page.locator('table tbody')).toContainText('/admin')

--- a/bootui-sample-app/e2e/tests/sample-api.spec.js
+++ b/bootui-sample-app/e2e/tests/sample-api.spec.js
@@ -8,6 +8,12 @@ import { test, expect } from '@playwright/test'
  */
 test.describe('Sample application REST API', () => {
 
+  test('GET /api/hello returns a simple HTTP probe greeting', async ({ request }) => {
+    const response = await request.get('/api/hello')
+    expect(response.status()).toBe(200)
+    expect(await response.text()).toBe('Hello, world')
+  })
+
   test('GET /api/sample/hello returns the configured greeting', async ({ request }) => {
     const response = await request.get('/api/sample/hello')
     expect(response.status()).toBe(200)
@@ -46,5 +52,22 @@ test.describe('Sample application REST API', () => {
     })
     expect(asAdmin.status()).toBe(200)
     expect(await asAdmin.text()).toBe('BootUI sample admin')
+  })
+
+  test('/api/secure requires basic authentication with the ADMIN role', async ({ request }) => {
+    const anonymous = await request.get('/api/secure', { failOnStatusCode: false })
+    expect(anonymous.status()).toBe(401)
+
+    const asUser = await request.get('/api/secure', {
+      headers: { Authorization: 'Basic ' + Buffer.from('developer:developer').toString('base64') },
+      failOnStatusCode: false
+    })
+    expect(asUser.status()).toBe(403)
+
+    const asAdmin = await request.get('/api/secure', {
+      headers: { Authorization: 'Basic ' + Buffer.from('admin:admin').toString('base64') }
+    })
+    expect(asAdmin.status()).toBe(200)
+    expect(await asAdmin.text()).toBe('Secure Hello, world')
   })
 })

--- a/bootui-sample-app/e2e/tests/scheduled.spec.js
+++ b/bootui-sample-app/e2e/tests/scheduled.spec.js
@@ -3,15 +3,13 @@ import { test, expect } from './fixtures.js'
 
 test.describe('Scheduled tasks view', () => {
 
-  test('renders the scheduled tasks view (table or empty-state)', async ({ openView, page }) => {
+  test('renders the sample echo scheduled task', async ({ openView, page }) => {
     await openView('scheduled', 'Scheduled Tasks')
 
-    // The sample app does not declare @Scheduled methods, so the empty-state alert
-    // is the expected outcome — but the view must always render successfully.
     await expect(page.locator('text=Loading…')).toHaveCount(0)
 
-    const tableVisible = await page.locator('table tbody tr').count()
-    const emptyVisible = await page.locator('.alert', { hasText: /No scheduled tasks registered|No Spring Scheduling detected/ }).count()
-    expect(tableVisible + emptyVisible).toBeGreaterThan(0)
+    await expect(page.locator('table tbody tr', { hasText: 'EchoScheduler' })).toBeVisible()
+    await expect(page.locator('table tbody tr', { hasText: 'FIXED_RATE' })).toBeVisible()
+    await expect(page.locator('table tbody tr', { hasText: '30 s' })).toBeVisible()
   })
 })

--- a/bootui-sample-app/e2e/tests/security.spec.js
+++ b/bootui-sample-app/e2e/tests/security.spec.js
@@ -3,13 +3,13 @@ import { test, expect } from './fixtures.js'
 
 test.describe('Security view', () => {
 
-  test('lists filter chains including the /admin chain', async ({ openView, page }) => {
+  test('lists filter chains including the ADMIN-only chain', async ({ openView, page }) => {
     await openView('security', 'Spring Security')
 
     const chains = page.locator('.accordion-item')
     await expect.poll(async () => chains.count()).toBeGreaterThan(0)
 
-    const adminChain = chains.filter({ hasText: '/admin/**' }).first()
+    const adminChain = chains.filter({ hasText: '/api/secure' }).first()
     await expect(adminChain).toBeVisible()
 
     // Authentication card mentions our in-memory users.
@@ -17,16 +17,16 @@ test.describe('Security view', () => {
     await expect(page.locator('main')).toContainText('InMemoryUserDetailsManager')
   })
 
-  test('explain endpoint matches GET /admin against the admin chain', async ({ openView, page }) => {
+  test('explain endpoint matches GET /api/secure against the ADMIN-only chain', async ({ openView, page }) => {
     await openView('security', 'Spring Security')
 
     await page.locator('select.form-select').selectOption('GET')
-    await page.getByPlaceholder('/api/example').fill('/admin')
+    await page.getByPlaceholder('/api/example').fill('/api/secure')
     await page.getByRole('button', { name: /^Explain/ }).click()
 
     const result = page.locator('.card', { hasText: /Request matcher|Filters/ }).first()
     await expect(result).toBeVisible()
-    await expect(result).toContainText('/admin/**')
+    await expect(result).toContainText('/api/secure')
     await expect(result).toContainText('BasicAuthenticationFilter')
   })
 })

--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/BootUiSampleApplication.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/BootUiSampleApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableConfigurationProperties(BootUiSampleApplication.SampleSettings.class)
 public class BootUiSampleApplication {
 
@@ -70,6 +72,21 @@ public class BootUiSampleApplication {
 
         static ProductSummary from(Product product) {
             return new ProductSummary(product.getId(), product.getName(), product.getCategory(), product.isActive());
+        }
+    }
+
+    @RestController
+    @RequestMapping("/api")
+    public static class HelloController {
+
+        @GetMapping("/hello")
+        public String hello() {
+            return "Hello, world";
+        }
+
+        @GetMapping("/secure")
+        public String secure() {
+            return "Secure Hello, world";
         }
     }
 

--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/EchoScheduler.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/EchoScheduler.java
@@ -1,0 +1,13 @@
+package io.github.bootui.sample;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EchoScheduler {
+
+    @Scheduled(fixedRate = 30_000)
+    public void echo() {
+        System.out.println("echo");
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/SecurityConfiguration.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/SecurityConfiguration.java
@@ -30,7 +30,7 @@ class SecurityConfiguration {
     @Order(2)
     SecurityFilterChain adminSecurity(HttpSecurity http) throws Exception {
         return http
-                .securityMatcher("/admin/**")
+                .securityMatcher("/admin/**", "/api/secure")
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().hasRole("ADMIN"))
                 .httpBasic(withDefaults())
                 .csrf(csrf -> csrf.disable())

--- a/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -221,6 +221,10 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void sampleAppEndpointsRemainPublicButAdminRequiresPassword() {
+        ResponseEntity<String> plainHello = getString("/api/hello");
+        assertThat(plainHello.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(plainHello.getBody()).isEqualTo("Hello, world");
+
         ResponseEntity<String> hello = getString("/api/sample/hello");
         assertThat(hello.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(hello.getBody()).contains("Hello, BootUI!");
@@ -234,6 +238,20 @@ class BootUiSampleApplicationIntegrationTests {
         ResponseEntity<String> adminWithAdminCredentials = getStringWithBasicAuth("/admin", "admin", "admin");
         assertThat(adminWithAdminCredentials.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(adminWithAdminCredentials.getBody()).isEqualTo("BootUI sample admin");
+    }
+
+    @Test
+    void secureApiEndpointRequiresAdminRole() {
+        ResponseEntity<String> secureWithoutCredentials = getString("/api/secure");
+        assertThat(secureWithoutCredentials.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        ResponseEntity<String> secureWithDeveloperCredentials = getStringWithBasicAuth("/api/secure", "developer",
+                "developer");
+        assertThat(secureWithDeveloperCredentials.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+
+        ResponseEntity<String> secureWithAdminCredentials = getStringWithBasicAuth("/api/secure", "admin", "admin");
+        assertThat(secureWithAdminCredentials.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(secureWithAdminCredentials.getBody()).isEqualTo("Secure Hello, world");
     }
 
     @Test
@@ -282,7 +300,7 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat((Iterable<?>) body.get("chains"))
                 .anySatisfy(chain -> {
                     Map<?, ?> dto = (Map<?, ?>) chain;
-                    assertThat(dto.get("requestMatcher")).asString().contains("/admin/**");
+                    assertThat(dto.get("requestMatcher")).asString().contains("/api/secure");
                     assertThat((Iterable<?>) dto.get("filters"))
                             .anySatisfy(filter -> assertThat(filter).isEqualTo("BasicAuthenticationFilter"));
                 });
@@ -294,14 +312,14 @@ class BootUiSampleApplicationIntegrationTests {
     }
 
     @Test
-    void securityExplainMatchesAdminRequest() {
-        ResponseEntity<Map> response = getMap("/bootui/api/security/explain?method=GET&path=/admin");
+    void securityExplainMatchesSecureApiRequest() {
+        ResponseEntity<Map> response = getMap("/bootui/api/security/explain?method=GET&path=/api/secure");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
         assertThat(body).isNotNull();
         assertThat(body.get("matched")).isEqualTo(true);
-        assertThat(body.get("matcherDescription")).asString().contains("/admin/**");
+        assertThat(body.get("matcherDescription")).asString().contains("/api/secure");
         assertThat((Iterable<?>) body.get("filters"))
                 .anySatisfy(filter -> assertThat(filter).isEqualTo("BasicAuthenticationFilter"));
     }


### PR DESCRIPTION
The sample app needs concrete runtime fixtures so the newer BootUI panels can be exercised without relying on empty states or unrelated routes.

This adds a fixed-rate scheduler that prints `echo` every 30 seconds, a public `/api/hello` endpoint for the HTTP probe, and an ADMIN-only `/api/secure` endpoint for the security panel. The sample API, mappings, scheduled task, HTTP probe, and security tests now assert those fixtures explicitly.