### PR TITLE
Constrain Beans and Loggers table columns

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Beans.vue
+++ b/bootui-ui/src/main/frontend/src/views/Beans.vue
@@ -48,7 +48,14 @@ onMounted(load)
     </div>
 
     <div class="table-responsive">
-      <table class="table table-sm table-hover">
+      <table class="table table-sm table-hover beans-table">
+        <colgroup>
+          <col class="beans-table-name" />
+          <col class="beans-table-type" />
+          <col class="beans-table-scope" />
+          <col class="beans-table-classification" />
+          <col class="beans-table-dependencies" />
+        </colgroup>
         <thead>
           <tr>
             <th>Name</th>
@@ -60,14 +67,40 @@ onMounted(load)
         </thead>
         <tbody>
           <tr v-for="b in filtered" :key="b.name">
-            <td><code>{{ b.name }}</code></td>
-            <td><small>{{ b.type }}</small></td>
+            <td><code class="text-truncate d-block" :title="b.name">{{ b.name }}</code></td>
+            <td><small class="text-truncate d-block" :title="b.type">{{ b.type }}</small></td>
             <td>{{ b.scope }}</td>
             <td><span class="badge bg-light text-dark">{{ b.classification }}</span></td>
-            <td><small class="text-muted">{{ b.dependencies.join(', ') }}</small></td>
+            <td><small class="text-muted text-truncate d-block" :title="b.dependencies.join(', ')">{{ b.dependencies.join(', ') }}</small></td>
           </tr>
         </tbody>
       </table>
     </div>
   </div>
 </template>
+
+<style scoped>
+.beans-table {
+  table-layout: fixed;
+}
+
+.beans-table-name {
+  width: 22%;
+}
+
+.beans-table-type {
+  width: 34%;
+}
+
+.beans-table-scope {
+  width: 10%;
+}
+
+.beans-table-classification {
+  width: 14%;
+}
+
+.beans-table-dependencies {
+  width: 20%;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -52,18 +52,24 @@ onMounted(load)
     <div v-if="message" class="alert alert-success">{{ message }}</div>
     <input class="form-control mb-3" v-model="filter" placeholder="Filter loggers by name…" />
     <div class="table-responsive">
-      <table class="table table-sm table-hover">
+      <table class="table table-sm table-hover loggers-table">
+        <colgroup>
+          <col class="loggers-table-name" />
+          <col class="loggers-table-level" />
+          <col class="loggers-table-level" />
+          <col class="loggers-table-actions" />
+        </colgroup>
         <thead>
           <tr>
             <th>Logger</th>
-            <th style="width:120px">Configured</th>
-            <th style="width:120px">Effective</th>
-            <th style="width:340px">Set level</th>
+            <th>Configured</th>
+            <th>Effective</th>
+            <th>Set level</th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="l in filtered" :key="l.name">
-            <td><code>{{ l.name }}</code></td>
+            <td><code class="text-truncate d-block" :title="l.name">{{ l.name }}</code></td>
             <td :class="levelClass(l.configuredLevel)">{{ l.configuredLevel || '—' }}</td>
             <td :class="levelClass(l.effectiveLevel)">{{ l.effectiveLevel || '—' }}</td>
             <td>
@@ -81,3 +87,22 @@ onMounted(load)
     </div>
   </div>
 </template>
+
+<style scoped>
+.loggers-table {
+  table-layout: fixed;
+  min-width: 760px;
+}
+
+.loggers-table-name {
+  width: 34%;
+}
+
+.loggers-table-level {
+  width: 15%;
+}
+
+.loggers-table-actions {
+  width: 36%;
+}
+</style>


### PR DESCRIPTION
## What does this PR do?

Constrains the Beans and Loggers panel table layouts so long bean or logger names do not obscure the other columns.

## Why is this change needed?

Long names in the first column could make it unclear that additional columns existed to the right. Fixed column proportions and truncated cell content keep key data and controls visible while preserving full values in hover titles.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable: N/A
- [x] `npm run build` passes locally

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes: N/A, visual-only table layout change
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed