### PR TITLE
Remove experimental UI labels

### DIFF
--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -48,12 +48,6 @@ onMounted(loadOverview)
                 :class="{ active: route.name === r.name }">
                 <i :class="['bi', r.meta.icon, 'me-2']"></i>
                 <span>{{ r.meta.title }}</span>
-                <span
-                  v-if="r.meta.experimental"
-                  class="badge bg-warning text-dark ms-auto"
-                  title="Experimental panel: behavior and APIs may change before the first stable release.">
-                  Experimental
-                </span>
               </router-link>
             </li>
           </ul>
@@ -65,14 +59,6 @@ onMounted(loadOverview)
 
         <main class="col-md-10 py-3">
           <div v-if="error" class="alert alert-danger">{{ error }}</div>
-          <div v-if="route.meta && route.meta.experimental" class="alert alert-warning d-flex align-items-start">
-            <i class="bi bi-exclamation-triangle-fill me-2 mt-1"></i>
-            <div>
-              <strong>Experimental panel.</strong>
-              This panel is not yet part of the supported BootUI surface.
-              Its behavior, data shape, and HTTP API may change or be removed before the first stable release.
-            </div>
-          </div>
           <router-view />
         </main>
       </div>

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -31,14 +31,14 @@ const router = createRouter({
     { path: '/mappings', name: 'mappings', component: Mappings, meta: { icon: 'bi-signpost-2', title: 'Mappings' } },
     { path: '/health', name: 'health', component: Health, meta: { icon: 'bi-heart-pulse', title: 'Health' } },
     { path: '/loggers', name: 'loggers', component: Loggers, meta: { icon: 'bi-journal-text', title: 'Loggers' } },
-    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data', experimental: true } },
-    { path: '/startup', name: 'startup', component: Startup, meta: { icon: 'bi-bar-chart-steps', title: 'Startup Timeline', experimental: true } },
-    { path: '/scheduled', name: 'scheduled', component: Scheduled, meta: { icon: 'bi-clock-history', title: 'Scheduled Tasks', experimental: true } },
-    { path: '/http-probe', name: 'http-probe', component: HttpProbe, meta: { icon: 'bi-send', title: 'HTTP Probe', experimental: true } },
-    { path: '/log-tail', name: 'log-tail', component: LogTail, meta: { icon: 'bi-terminal', title: 'Log Tail', experimental: true } },
-    { path: '/profiles', name: 'profiles', component: ProfileDiff, meta: { icon: 'bi-layers', title: 'Profile Diff', experimental: true } },
-    { path: '/security', name: 'security', component: Security, meta: { icon: 'bi-shield-lock', title: 'Security', experimental: true } },
-    { path: '/memory', name: 'memory', component: Memory, meta: { icon: 'bi-memory', title: 'Memory', experimental: true } }
+    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } },
+    { path: '/startup', name: 'startup', component: Startup, meta: { icon: 'bi-bar-chart-steps', title: 'Startup Timeline' } },
+    { path: '/scheduled', name: 'scheduled', component: Scheduled, meta: { icon: 'bi-clock-history', title: 'Scheduled Tasks' } },
+    { path: '/http-probe', name: 'http-probe', component: HttpProbe, meta: { icon: 'bi-send', title: 'HTTP Probe' } },
+    { path: '/log-tail', name: 'log-tail', component: LogTail, meta: { icon: 'bi-terminal', title: 'Log Tail' } },
+    { path: '/profiles', name: 'profiles', component: ProfileDiff, meta: { icon: 'bi-layers', title: 'Profile Diff' } },
+    { path: '/security', name: 'security', component: Security, meta: { icon: 'bi-shield-lock', title: 'Security' } },
+    { path: '/memory', name: 'memory', component: Memory, meta: { icon: 'bi-memory', title: 'Memory' } }
   ]
 })
 


### PR DESCRIPTION
## What does this PR do?

Removes the Experimental badge from sidebar entries and the experimental warning banner from panel pages.

## Why is this change needed?

The UI should present these panels without the experimental labeling now that the tag is no longer desired.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Ran `npm run build` in `bootui-ui/src/main/frontend`.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed