### PR TITLE
Add collapsible startup timeline tree

### DIFF
--- a/bootui-sample-app/e2e/tests/startup.spec.js
+++ b/bootui-sample-app/e2e/tests/startup.spec.js
@@ -9,9 +9,17 @@ test.describe('Startup timeline view', () => {
     // Wait until the page is no longer in the loading state.
     await expect(page.locator('text=Loading startup data…')).toHaveCount(0)
 
+    await page.getByRole('button', { name: 'Expand all' }).click()
+
     // The sample app records a non-trivial number of startup steps.
     const steps = page.locator('.list-group .list-group-item')
     await expect.poll(async () => steps.count()).toBeGreaterThan(5)
+
+    await page.getByRole('button', { name: 'Collapse all' }).click()
+    const collapsedCount = await steps.count()
+    expect(collapsedCount).toBeGreaterThan(0)
+    await page.getByRole('button', { name: 'Expand all' }).click()
+    await expect.poll(async () => steps.count()).toBeGreaterThan(collapsedCount)
 
     await page.getByPlaceholder(/Filter by step name/).fill('spring.boot');
     // Either the filter produces a smaller list, or the explicit "no matches" state.

--- a/bootui-ui/src/main/frontend/src/views/Startup.vue
+++ b/bootui-ui/src/main/frontend/src/views/Startup.vue
@@ -3,8 +3,30 @@ import { computed, onMounted, ref } from 'vue'
 
 const report = ref({ steps: [] })
 const filter = ref('')
+const expandedStepIds = ref(new Set())
 const loading = ref(true)
 const error = ref('')
+
+function buildTree(steps) {
+  const byId = new Map()
+  const roots = []
+
+  steps.forEach(step => {
+    byId.set(step.id, { ...step, children: [] })
+  })
+
+  steps.forEach(step => {
+    const node = byId.get(step.id)
+    const parentId = step.parentId
+    if (!parentId || !byId.has(parentId)) {
+      roots.push(node)
+      return
+    }
+    byId.get(parentId).children.push(node)
+  })
+
+  return roots
+}
 
 async function load() {
   loading.value = true
@@ -16,11 +38,14 @@ async function load() {
       throw new Error(`Request failed with status ${res.status}`)
     }
     const data = await res.json()
+    const steps = Array.isArray(data?.steps) ? data.steps : []
     report.value = {
-      steps: Array.isArray(data?.steps) ? data.steps : []
+      steps
     }
+    expandedStepIds.value = new Set(buildTree(steps).map(step => step.id))
   } catch (err) {
     report.value = { steps: [] }
+    expandedStepIds.value = new Set()
     error.value = err instanceof Error ? err.message : 'Unable to load startup data'
   } finally {
     loading.value = false
@@ -31,26 +56,7 @@ const sortedSteps = computed(() =>
   [...report.value.steps].sort((a, b) => a.id - b.id)
 )
 
-const tree = computed(() => {
-  const byId = new Map()
-  const roots = []
-
-  sortedSteps.value.forEach(step => {
-    byId.set(step.id, { ...step, children: [] })
-  })
-
-  sortedSteps.value.forEach(step => {
-    const node = byId.get(step.id)
-    const parentId = step.parentId
-    if (!parentId || !byId.has(parentId)) {
-      roots.push(node)
-      return
-    }
-    byId.get(parentId).children.push(node)
-  })
-
-  return roots
-})
+const tree = computed(() => buildTree(sortedSteps.value))
 
 function filterTree(nodes, query) {
   if (!query) {
@@ -67,17 +73,52 @@ function filterTree(nodes, query) {
   })
 }
 
-function flatten(nodes, depth = 0) {
-  return nodes.flatMap(node => [
-    { ...node, depth },
-    ...flatten(node.children, depth + 1)
-  ])
+function flattenVisible(nodes, query, depth = 0) {
+  return nodes.flatMap(node => {
+    const expanded = Boolean(query) || expandedStepIds.value.has(node.id)
+    return [
+      { ...node, depth, expanded },
+      ...(expanded ? flattenVisible(node.children, query, depth + 1) : [])
+    ]
+  })
 }
 
 const visibleSteps = computed(() => {
   const query = filter.value.trim().toLowerCase()
-  return flatten(filterTree(tree.value, query))
+  return flattenVisible(filterTree(tree.value, query), query)
 })
+
+const branchStepCount = computed(() =>
+  report.value.steps.filter(step => step.parentId != null).length
+)
+
+function toggleStep(step) {
+  if (!step.children?.length) {
+    return
+  }
+
+  const next = new Set(expandedStepIds.value)
+  if (next.has(step.id)) {
+    next.delete(step.id)
+  } else {
+    next.add(step.id)
+  }
+  expandedStepIds.value = next
+}
+
+function expandAll() {
+  expandedStepIds.value = new Set(report.value.steps
+    .filter(step => treeStepHasChildren(step.id))
+    .map(step => step.id))
+}
+
+function collapseAll() {
+  expandedStepIds.value = new Set()
+}
+
+function treeStepHasChildren(stepId) {
+  return report.value.steps.some(step => step.parentId === stepId)
+}
 
 onMounted(load)
 </script>
@@ -88,10 +129,10 @@ onMounted(load)
       <div>
         <h2 class="mb-1"><i class="bi bi-clock-history me-2"></i>Startup timeline</h2>
         <p class="text-muted mb-0">
-          {{ report.steps.length }} steps<span v-if="filter"> · {{ visibleSteps.length }} shown</span>
+          {{ report.steps.length }} steps · {{ branchStepCount }} nested<span v-if="filter"> · {{ visibleSteps.length }} shown</span>
         </p>
       </div>
-      <div class="col-12 col-md-5 col-lg-4 px-0">
+      <div class="col-12 col-md-7 col-lg-6 px-0">
         <div class="input-group">
           <span class="input-group-text"><i class="bi bi-search"></i></span>
           <input
@@ -100,6 +141,22 @@ onMounted(load)
             placeholder="Filter by step name…"
             type="search"
           />
+          <button
+            class="btn btn-outline-secondary"
+            type="button"
+            :disabled="loading || report.steps.length === 0"
+            @click="expandAll"
+          >
+            Expand all
+          </button>
+          <button
+            class="btn btn-outline-secondary"
+            type="button"
+            :disabled="loading || report.steps.length === 0"
+            @click="collapseAll"
+          >
+            Collapse all
+          </button>
         </div>
       </div>
     </div>
@@ -126,9 +183,21 @@ onMounted(load)
         <div class="d-flex align-items-start justify-content-between gap-3">
           <div class="flex-grow-1 min-w-0">
             <div class="d-flex align-items-center gap-2 flex-wrap mb-1">
-              <i class="bi bi-arrow-return-right text-muted" :class="{ 'opacity-0': step.depth === 0 }"></i>
+              <button
+                class="btn btn-sm btn-link text-decoration-none p-0 startup-tree-toggle"
+                type="button"
+                :class="{ 'invisible': !step.children?.length }"
+                :aria-expanded="step.expanded"
+                :aria-label="`${step.expanded ? 'Collapse' : 'Expand'} ${step.name}`"
+                @click="toggleStep(step)"
+              >
+                <i class="bi" :class="step.expanded ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
+              </button>
               <span class="fw-semibold text-break">{{ step.name }}</span>
               <span class="badge text-bg-light">#{{ step.id }}</span>
+              <span v-if="step.children?.length" class="badge text-bg-light">
+                {{ step.children.length }} child{{ step.children.length === 1 ? '' : 'ren' }}
+              </span>
             </div>
             <div v-if="step.tags?.length" class="d-flex flex-wrap gap-1 mt-2">
               <span


### PR DESCRIPTION
## What does this PR do?

Adds collapsible tree navigation to the Startup timeline panel so users can expand individual startup steps, collapse noisy branches, and expand all steps when they need the full timeline.

## Why is this change needed?

The startup panel already had parent/child data, but it rendered as a permanently expanded flat list. Making the hierarchy collapsible makes it easier to drill into slow or suspicious startup branches without losing the broader context.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `npm run build` passes in `bootui-ui/src/main/frontend`
- [x] `mvn -pl bootui-ui install -DskipTests` passes locally
- [ ] Focused Playwright startup spec was attempted, but the run hung after dependency install without additional output and was stopped

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed