### PR TITLE
Add startup timeline duration tags

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Startup.vue
+++ b/bootui-ui/src/main/frontend/src/views/Startup.vue
@@ -7,6 +7,17 @@ const expandedStepIds = ref(new Set())
 const loading = ref(true)
 const error = ref('')
 
+const durationThresholds = [
+  { minMs: 500, label: '500ms', className: 'startup-duration-tag--500' },
+  { minMs: 200, label: '200ms', className: 'startup-duration-tag--200' },
+  { minMs: 100, label: '100ms', className: 'startup-duration-tag--100' },
+  { minMs: 50, label: '50ms', className: 'startup-duration-tag--50' }
+]
+
+function durationTagFor(durationMs) {
+  return durationThresholds.find(threshold => durationMs >= threshold.minMs)
+}
+
 function buildTree(steps) {
   const byId = new Map()
   const roots = []
@@ -194,6 +205,14 @@ onMounted(load)
                 <i class="bi" :class="step.expanded ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
               </button>
               <span class="fw-semibold text-break">{{ step.name }}</span>
+              <span
+                v-if="durationTagFor(step.durationMs)"
+                class="badge rounded-pill startup-duration-tag"
+                :class="durationTagFor(step.durationMs).className"
+                :title="`Took at least ${durationTagFor(step.durationMs).label}`"
+              >
+                {{ durationTagFor(step.durationMs).label }}
+              </span>
               <span class="badge text-bg-light">#{{ step.id }}</span>
               <span v-if="step.children?.length" class="badge text-bg-light">
                 {{ step.children.length }} child{{ step.children.length === 1 ? '' : 'ren' }}
@@ -215,3 +234,29 @@ onMounted(load)
     </div>
   </div>
 </template>
+
+<style scoped>
+.startup-duration-tag {
+  font-weight: 700;
+}
+
+.startup-duration-tag--50 {
+  background-color: #ffc107;
+  color: #212529;
+}
+
+.startup-duration-tag--100 {
+  background-color: #fd7e14;
+  color: #212529;
+}
+
+.startup-duration-tag--200 {
+  background-color: #dc3545;
+  color: #fff;
+}
+
+.startup-duration-tag--500 {
+  background-color: #ff0033;
+  color: #fff;
+}
+</style>


### PR DESCRIPTION
## What does this PR do?

Adds colored duration threshold tags to startup timeline items so slower startup steps are easier to spot at a glance.

## Why is this change needed?

The startup timeline already shows exact durations, but scanning a long list for the slowest steps requires reading each value. Threshold tags like `50ms`, `100ms`, `200ms`, and `500ms` make relative hotspots visually obvious with colors from yellow through bright red.

Closes N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Ran `npm run build` in `bootui-ui/src/main/frontend` and `mvn -pl bootui-ui install -DskipTests -ntp`.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed