### PR TITLE
Fix BootUI startup with Jackson 3

### DIFF
--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -30,7 +30,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ConfigMetadataCatalog.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ConfigMetadataCatalog.java
@@ -1,7 +1,5 @@
 package io.github.bootui.autoconfigure.web;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.bootui.core.BootUiDtos.ConfigPropertySuggestionDto;
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,6 +11,8 @@ import java.util.Enumeration;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 final class ConfigMetadataCatalog {
 
@@ -120,6 +120,6 @@ final class ConfigMetadataCatalog {
         if (node == null || node.isNull()) {
             return null;
         }
-        return objectMapper.convertValue(node, Object.class);
+        return objectMapper.treeToValue(node, Object.class);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Updates BootUI autoconfigure to use Spring Boot 4's managed Jackson 3 API when reading Spring configuration metadata.

## Why is this change needed?

BootUI failed during sample app startup because `ConfigMetadataCatalog` referenced Jackson 2 classes (`com.fasterxml.jackson.databind.ObjectMapper`) that are not present on the Spring Boot 4 sample application's runtime classpath. Aligning the dependency and imports with Jackson 3 fixes the `NoClassDefFoundError` while keeping metadata parsing behavior unchanged.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks run:

- `mvn -pl bootui-autoconfigure -am test -DfailIfNoTests=false -Dstyle.color=never`
- `mvn -pl bootui-sample-app -am test -Dstyle.color=never`
- `mvn -pl bootui-sample-app -am install -DskipTests -Dstyle.color=never`
- `mvn spring-boot:run -Dspring-boot.run.profiles=dev -Dspring-boot.run.arguments=--server.port=18080 -Dstyle.color=never`, then `GET /bootui/api/overview` returned HTTP 200

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed