### PR TITLE
Fix overview access card overflow

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -335,6 +335,10 @@ onMounted(load)
   transition: transform 180ms ease, box-shadow 180ms ease;
 }
 
+.metric-card > div {
+  min-width: 0;
+}
+
 .metric-card:hover {
   box-shadow: 0 1.25rem 2.8rem rgba(15, 23, 42, 0.12);
   transform: translateY(-3px);
@@ -383,14 +387,13 @@ onMounted(load)
 .metric-value {
   font-size: 1.12rem;
   font-weight: 850;
+  overflow-wrap: anywhere;
 }
 
 .metric-detail {
   color: #64748b;
   font-size: 0.82rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .app-map-card {


### PR DESCRIPTION
## What does this PR do?

Fixes the overview Access metric card so long loopback activation text wraps inside the card instead of overflowing horizontally.

## Why is this change needed?

The overview screen could render the Access/Loopback status text wider than its card, making the UI look broken at narrower widths or with longer activation reasons.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran `npm run build -- --logLevel warn` in `bootui-ui/src/main/frontend`.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed