### PR TITLE
Add e2e coverage for health and memory views

### DIFF
--- a/bootui-sample-app/e2e/tests/health.spec.js
+++ b/bootui-sample-app/e2e/tests/health.spec.js
@@ -13,4 +13,15 @@ test.describe('Health view', () => {
     await expect(rootCard.locator('.badge')).toHaveText(/UP|DOWN|UNKNOWN|OUT_OF_SERVICE/)
     await expect(page.locator('main pre')).toHaveCount(0)
   })
+
+  test('renders nested component details in a readable table', async ({ openView, page }) => {
+    await openView('health', 'Health')
+
+    const diskSpaceSummary = page.locator('details.card > summary', { hasText: /^diskSpace/ }).first()
+    const diskSpaceNode = diskSpaceSummary.locator('xpath=..')
+    await expect(diskSpaceNode).toBeVisible()
+    await expect(diskSpaceNode).toContainText('Details')
+    await expect(diskSpaceNode.locator('table')).toBeVisible()
+    await expect(diskSpaceNode).toContainText(/Path|Exists|Free|Total/)
+  })
 })

--- a/bootui-sample-app/e2e/tests/memory.spec.js
+++ b/bootui-sample-app/e2e/tests/memory.spec.js
@@ -26,4 +26,18 @@ test.describe('Memory view', () => {
     await copyButton.click()
     await expect(page.getByRole('button', { name: /Copied!/ })).toBeVisible({ timeout: 5_000 })
   })
+
+  test('renders the memory pools table with usage values', async ({ openView, page }) => {
+    await openView('memory', 'Memory')
+
+    const poolsCard = page.locator('.card', { hasText: 'Memory Pools' })
+    await expect(poolsCard).toBeVisible()
+    await expect(poolsCard.locator('thead')).toContainText('Pool')
+    await expect(poolsCard.locator('thead')).toContainText('Usage')
+
+    const rows = poolsCard.locator('tbody tr')
+    await expect.poll(async () => rows.count()).toBeGreaterThan(0)
+    await expect(rows.first().locator('td').nth(0)).not.toBeEmpty()
+    await expect(rows.first().locator('td').nth(4)).toContainText(/%/)
+  })
 })


### PR DESCRIPTION
## What does this PR do?

Adds focused Playwright e2e coverage for the Health and Memory views, covering nested health detail tables and memory pool usage rows.

## Why is this change needed?

Recent UI work added richer detail rendering in these views, so the e2e suite should verify the important user-visible paths beyond basic page rendering.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Notes: `mvn -DskipTests install` passed locally. The normal Playwright test runner hung before test collection in this environment, so I validated the new assertions directly with Playwright against the running sample app.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed