### PR TITLE
Fix recommended JVM options for Spring Boot 4 on Java 25

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/MemoryController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/MemoryController.java
@@ -50,11 +50,37 @@ public class MemoryController {
     /**
      * Calculates recommended JVM startup options based on current heap usage.
      *
+     * <p>Targets Spring Boot 4 on Java 25.
+     *
      * <p>The strategy:
      * <ul>
      *   <li>-Xms: next multiple of 128 MB above current heap committed (minimum 64 MB)</li>
      *   <li>-Xmx: next multiple of 256 MB above current heap max (or committed when max is -1)</li>
-     *   <li>G1GC, container-support, and other best-practice flags</li>
+     *   <li>G1GC for heaps &lt; 4 GB; ZGC (generational by default on JDK 24+) for larger heaps</li>
+     *   <li>{@code -XX:+UseStringDeduplication}: Spring apps allocate many duplicate strings
+     *       (bean names, config keys, JSON property names, log templates); deduplication
+     *       typically saves 5–15% of heap on G1 and ZGC (since JDK 18)</li>
+     *   <li>{@code -XX:+UseCompactObjectHeaders}: JEP 519 graduated this to a product flag
+     *       in JDK 25 — shrinks every object header from 12 to 8 bytes on 64-bit JVMs with
+     *       compressed oops, saving roughly 10–20% of heap on Spring's small-object-heavy
+     *       allocation pattern</li>
+     *   <li>OOM safety flags with a writable HeapDumpPath suitable for containers</li>
+     * </ul>
+     *
+     * <p>Notes on flags intentionally <em>not</em> emitted:
+     * <ul>
+     *   <li>{@code -XX:+UseContainerSupport} is enabled by default since JDK 10.</li>
+     *   <li>{@code -XX:+ZGenerational} was removed in JDK 24 (JEP 490); generational
+     *       mode is now the default for ZGC and the flag is rejected as unrecognized.</li>
+     *   <li>{@code -XX:MaxRAMPercentage} / {@code -XX:InitialRAMPercentage} are only
+     *       honored when {@code -Xmx} / {@code -Xms} are <em>not</em> set, so mixing
+     *       them with explicit heap sizes is a no-op and misleading.</li>
+     *   <li>{@code -Djava.security.egd=file:/dev/./urandom} has been obsolete since
+     *       JDK 9 — {@code SecureRandom} already uses {@code NativePRNGNonBlocking}
+     *       (which reads {@code /dev/urandom}) by default on Linux.</li>
+     *   <li>AOT cache ({@code -XX:AOTCache=...}, JEP 514 stable in JDK 25) is Spring
+     *       Boot 4's biggest startup-time win but requires a multi-step training
+     *       workflow, so it belongs in documentation, not a copy-paste options string.</li>
      * </ul>
      */
     private String buildSuggestedOptions(MemoryUsage heapUsage) {
@@ -67,18 +93,16 @@ public class MemoryController {
         long xmxMb = roundUpTo(max / (1024 * 1024), 256);
         if (xmxMb < 256) xmxMb = 256;
 
-        // Determine GC recommendation: prefer ZGC for large heaps (>= 4 GB), G1GC otherwise
-        String gcFlag = xmxMb >= 4096 ? "-XX:+UseZGC -XX:+ZGenerational" : "-XX:+UseG1GC";
+        String gcFlag = xmxMb >= 4096 ? "-XX:+UseZGC" : "-XX:+UseG1GC";
 
         return "-Xms" + xmsMb + "m" +
                " -Xmx" + xmxMb + "m" +
                " " + gcFlag +
-               " -XX:+UseContainerSupport" +
-               " -XX:MaxRAMPercentage=75.0" +
-               " -XX:InitialRAMPercentage=50.0" +
+               " -XX:+UseStringDeduplication" +
+               " -XX:+UseCompactObjectHeaders" +
                " -XX:+ExitOnOutOfMemoryError" +
                " -XX:+HeapDumpOnOutOfMemoryError" +
-               " -Djava.security.egd=file:/dev/./urandom";
+               " -XX:HeapDumpPath=/tmp";
     }
 
     private long roundUpTo(long value, long multiple) {

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -89,11 +89,10 @@ onBeforeUnmount(() => {
         </div>
         <div class="card-body">
           <p class="text-muted small mb-2">
-            Calculated from current memory usage. Includes Kubernetes container-aware settings and best practices.
+            Calculated from current heap usage. Tuned for Java 24+ (generational ZGC is the default; container support is built in).
           </p>
           <pre class="bg-dark text-light rounded p-3 mb-0 options-box"><code>{{ data.suggestedJvmOptions }}</code></pre>
           <div class="mt-2">
-            <span class="badge text-bg-secondary me-1"><i class="bi bi-box me-1"></i>Kubernetes-ready</span>
             <span class="badge text-bg-secondary me-1"><i class="bi bi-shield-check me-1"></i>OOM protection</span>
             <span class="badge text-bg-secondary me-1"><i class="bi bi-gear me-1"></i>GC tuned</span>
           </div>


### PR DESCRIPTION
## What does this PR do?

Replaces broken, redundant, and obsolete flags in the Memory panel's "Recommended JVM Options" with a set tuned for the project's actual Spring Boot 4 / Java 25 target.

## Why is this change needed?

The previous suggestions had real problems on Java 25:

- `-XX:+ZGenerational` was **removed in JDK 24** (JEP 490). Generational ZGC is now the default and the flag is rejected as `Unrecognized VM option`. This silently broke every recommended command for heaps `>= 4 GB`.
- `-XX:MaxRAMPercentage` / `-XX:InitialRAMPercentage` are only honored when `-Xms` / `-Xmx` are not set. The command set both, so the percentage flags were a misleading no-op (verified with `-XX:+PrintFlagsFinal`).
- `-XX:+UseContainerSupport` has been on by default since JDK 10.
- `-Djava.security.egd=file:/dev/./urandom` has been obsolete since JDK 9; `SecureRandom` already uses `NativePRNGNonBlocking` on Linux.

While I was in there, I also added two flags that meaningfully help any Spring Boot 4 app on Java 25:

- `-XX:+UseStringDeduplication`: Spring apps allocate many duplicate strings (bean names, config keys, JSON property names, log templates). Works with G1 and ZGC (since JDK 18). Typical savings: 5-15% of heap.
- `-XX:+UseCompactObjectHeaders`: JEP 519 graduated this from experimental to product in JDK 25, so no `-XX:+UnlockExperimentalVMOptions` is needed. Shrinks every object header from 12 to 8 bytes under compressed oops. Typical savings: 10-20% of heap on Spring's small-object-heavy workloads.

Also set `-XX:HeapDumpPath=/tmp` so `HeapDumpOnOutOfMemoryError` lands in a writable location in containers rather than the JVM working directory.

## How was it tested?

- [x] `mvn clean install` passes locally (all 90 tests green across modules)
- [x] Both emitted variants (G1 for `<4 GB`, ZGC for `>=4 GB`) were smoke-tested directly with `java <opts> -version` on JDK 25/26 -- both start clean with no warnings, no `Unrecognized VM option` errors
- [x] No new tests added (the controller's logic is a pure string template; verification was empirical against the real JVM)

## Screenshots (UI changes)

The `Memory.vue` panel was updated to match: the description no longer advertises Kubernetes-RAMPercentage-style sizing (since the related flags were dropped), and the "Kubernetes-ready" badge was removed. The `OOM protection` and `GC tuned` badges remain.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes -- N/A, `docs/` does not cover this panel
- [x] Public API kept backward compatible (only the value of the `suggestedJvmOptions` string changes; the DTO shape is unchanged)
- [x] No secrets, tokens, or local paths committed