### PR TITLE
Refresh release plan and validation docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,21 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 
 Then open <http://localhost:8080/bootui>.
 
+## End-to-end tests
+
+The sample app includes Playwright tests that exercise every visible BootUI
+panel and the sample REST API.
+
+```bash
+cd bootui-sample-app/e2e
+npm install
+npx playwright install chromium
+npm test
+```
+
+Playwright can start the sample app automatically. If you already have the
+sample app running on port 8080, it will reuse that server.
+
 ## Front-end development
 
 The Vue source lives in `bootui-ui/src/main/frontend`. For a fast inner loop:
@@ -74,7 +89,9 @@ re-bundle the assets into the JAR.
 3. Keep PRs small and focused. Update `docs/` whenever public behaviour
    changes.
 4. Run `mvn clean install` before pushing.
-5. Use the pull request template — it links to the verifications we expect.
+5. Run the Playwright end-to-end suite when you change the UI, browser-facing
+   API responses, or sample-app behavior.
+6. Use the pull request template — it links to the verifications we expect.
 
 ## Reporting bugs and security issues
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.x-6db33f?logo=springboot&logoColor=white)](https://spring.io/projects/spring-boot)
 [![Java](https://img.shields.io/badge/Java-25-orange?logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/25/)
 
-BootUI is a **Spring Boot 4 starter** that adds a local-first web console to your app.
+BootUI is a **Spring Boot 4 starter** that adds an embedded, local-only developer console to your app.
 
 It is designed for local development (not production) and helps you quickly inspect:
 
@@ -16,7 +16,14 @@ It is designed for local development (not production) and helps you quickly insp
 - HTTP mappings
 - health contributors
 - logger levels
-- startup timeline and scheduled tasks
+- startup timeline, JVM memory, and scheduled tasks
+- Spring Data repositories
+- local HTTP probes
+- live log tail
+- profile-specific configuration
+- Spring Security filter chains and endpoint rules
+
+BootUI is served by the host application at `/bootui/` and uses internal `/bootui/api/**` endpoints. The browser UI is packaged into the starter; consumers do not need Node.js or npm.
 
 ## Screenshot
 
@@ -46,6 +53,15 @@ It is designed for local development (not production) and helps you quickly insp
 mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
+BootUI also activates automatically when `spring-boot-devtools` is on the classpath. To force it on or off:
+
+```properties
+bootui.enabled=ON
+bootui.enabled=OFF
+```
+
+`prod` and `production` profiles disable BootUI unless `bootui.enabled=ON` is set.
+
 ### 4) Open BootUI
 
 Visit: <http://localhost:8080/bootui>
@@ -55,8 +71,9 @@ Visit: <http://localhost:8080/bootui>
 ### 1) Prerequisites
 
 - Java 25
-- Node.js 24+ (used by the `bootui-ui` module)
 - Maven
+
+Node.js and npm are downloaded automatically by Maven for the UI build.
 
 ### 2) Build everything
 
@@ -75,11 +92,69 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 
 Visit: <http://localhost:8080/bootui>
 
+## Configuration and safety
+
+BootUI is intended for local development only. By default it:
+
+- activates in `AUTO` mode only for `dev` / `local` profiles or DevTools
+- rejects non-loopback requests
+- masks secret-like configuration values
+- disables itself for `prod` / `production` profiles
+- stores runtime configuration overrides in `.bootui/application-bootui.properties`, not in your source config files
+
+Common properties:
+
+| Property | Default | Description |
+|---|---|---|
+| `bootui.enabled` | `AUTO` | `AUTO`, `ON`, or `OFF`. |
+| `bootui.enabled-profiles` | `dev,local` | Profiles that activate BootUI in auto mode. |
+| `bootui.disabled-profiles` | `prod,production` | Profiles that disable BootUI unless forced on. |
+| `bootui.allow-non-localhost` | `false` | Explicit opt-out of loopback-only protection. |
+| `bootui.expose-values` | `MASKED` | `MASKED`, `METADATA_ONLY`, or `FULL`. |
+| `bootui.overrides-file` | `.bootui/application-bootui.properties` | Runtime override persistence file. |
+
+## Panels
+
+Current visible panels:
+
+| Panel | Purpose |
+|---|---|
+| Overview | Runtime, profiles, ports, activation, and safety state. |
+| Beans | Spring bean summaries and classifications. |
+| Conditions | Auto-configuration positive and negative matches. |
+| Configuration | Effective properties, metadata, masking, and local overrides. |
+| Mappings | HTTP mappings from Actuator. |
+| Health | Health tree and contributor details. |
+| Loggers | Runtime logger levels and mutations. |
+| Data | Spring Data repositories and query methods. |
+| Startup Timeline | Startup steps from Actuator startup data. |
+| Memory | JVM heap/non-heap usage and suggested JVM options. |
+| Scheduled Tasks | Registered scheduled tasks. |
+| HTTP Probe | Local-only request probe against the running app. |
+| Log Tail | Recent and streaming application logs. |
+| Profile Diff | Profile-specific property sources and values. |
+| Security | Spring Security filter chains and best-effort endpoint rules. |
+
+Some panels depend on optional Spring or Actuator infrastructure. When data is unavailable, BootUI returns stable empty responses or shows an explanatory empty state.
+
+## Testing
+
+```bash
+# CI-equivalent build
+mvn -B -ntp clean install
+
+# Browser end-to-end tests for the sample app
+cd bootui-sample-app/e2e
+npm install
+npx playwright install chromium
+npm test
+```
+
 ## Repository modules
 
 - `bootui-spring-boot-starter`: dependency to add to your app
 - `bootui-autoconfigure`: Spring Boot auto-configuration
-- `bootui-ui`: Vue.js frontend
+- `bootui-ui`: Vue 3 frontend packaged into the starter
 - `bootui-core`: shared DTOs and core helpers
 - `bootui-sample-app`: demo/integration sample app
 

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ScheduledController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ScheduledController.java
@@ -41,7 +41,7 @@ public class ScheduledController {
     private ScheduledTaskDto toDto(ScheduledTask scheduledTask) {
         Task task = scheduledTask.getTask();
         Runnable runnable = task.getRunnable();
-        String runnableName = runnable == null ? null : runnable.getClass().getName();
+        String runnableName = runnableName(runnable);
         if (task instanceof CronTask cronTask) {
             return new ScheduledTaskDto(runnableName, "CRON", cronTask.getExpression(), null, null);
         }
@@ -66,6 +66,20 @@ public class ScheduledController {
             return new ScheduledTaskDto(runnableName, "ONE_SHOT", String.valueOf(triggerTask.getTrigger()), null, null);
         }
         return new ScheduledTaskDto(runnableName, "ONE_SHOT", null, null, null);
+    }
+
+    private String runnableName(Runnable runnable) {
+        if (runnable == null) {
+            return null;
+        }
+        String typeName = runnable.getClass().getName();
+        String description = runnable.toString();
+        if (description != null && !description.isBlank()
+                && !description.equals(typeName)
+                && !description.startsWith(typeName + "@")) {
+            return description;
+        }
+        return typeName;
     }
 
     private Long toMillis(Duration duration) {

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -4,9 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.bootui.autoconfigure.config.ConfigOverrideService;
 import io.github.bootui.autoconfigure.safety.LocalhostOnlyFilter;
+import io.github.bootui.autoconfigure.web.DataController;
+import io.github.bootui.autoconfigure.web.LogTailController;
 import io.github.bootui.autoconfigure.web.OverviewController;
+import io.github.bootui.autoconfigure.web.ScheduledController;
+import io.github.bootui.autoconfigure.web.SecurityController;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
 class BootUiAutoConfigurationTests {
@@ -77,5 +82,43 @@ class BootUiAutoConfigurationTests {
                     assertThat(properties.getExposeValues())
                             .isEqualTo(BootUiProperties.ValueExposure.FULL);
                 });
+    }
+
+    @Test
+    void optionalClasspathPanelsAreRegisteredWhenDependenciesArePresent() {
+        runner.withPropertyValues("bootui.enabled=ON")
+                .run(context -> assertThat(context)
+                        .hasSingleBean(DataController.class)
+                        .hasSingleBean(LogTailController.class)
+                        .hasSingleBean(ScheduledController.class)
+                        .hasSingleBean(SecurityController.class));
+    }
+
+    @Test
+    void skipsSpringDataPanelWhenSpringDataRepositoryMetadataIsMissing() {
+        runner.withPropertyValues("bootui.enabled=ON")
+                .withClassLoader(new FilteredClassLoader("org.springframework.data.repository.core.support"))
+                .run(context -> assertThat(context).doesNotHaveBean(DataController.class));
+    }
+
+    @Test
+    void skipsLogTailPanelWhenLogbackIsMissing() {
+        runner.withPropertyValues("bootui.enabled=ON")
+                .withClassLoader(new FilteredClassLoader("ch.qos.logback.classic"))
+                .run(context -> assertThat(context).doesNotHaveBean(LogTailController.class));
+    }
+
+    @Test
+    void skipsScheduledPanelWhenSchedulingInfrastructureIsMissing() {
+        runner.withPropertyValues("bootui.enabled=ON")
+                .withClassLoader(new FilteredClassLoader("org.springframework.scheduling.config.ScheduledTaskHolder"))
+                .run(context -> assertThat(context).doesNotHaveBean(ScheduledController.class));
+    }
+
+    @Test
+    void skipsSecurityPanelWhenSpringSecurityWebIsMissing() {
+        runner.withPropertyValues("bootui.enabled=ON")
+                .withClassLoader(new FilteredClassLoader("org.springframework.security.web.FilterChainProxy"))
+                .run(context -> assertThat(context).doesNotHaveBean(SecurityController.class));
     }
 }

--- a/bootui-sample-app/e2e/package-lock.json
+++ b/bootui-sample-app/e2e/package-lock.json
@@ -8,17 +8,17 @@
       "name": "bootui-sample-app-e2e",
       "version": "0.1.0",
       "devDependencies": {
-        "@playwright/test": "1.49.1"
+        "@playwright/test": "1.60.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
-      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -43,13 +43,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/bootui-sample-app/e2e/package.json
+++ b/bootui-sample-app/e2e/package.json
@@ -11,6 +11,6 @@
     "report": "playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "1.49.1"
+    "@playwright/test": "1.60.0"
   }
 }

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -6,9 +6,9 @@ test.describe('BootUI app shell', () => {
   test('navbar shows the application name and Spring Boot / Java versions', async ({ page }) => {
     await page.goto('/bootui/')
 
-    await expect(page.getByRole('heading', { name: /BootUI/, level: 1 })).toBeVisible()
-    const subtitle = page.locator('.navbar .text-light.small')
-    await expect(subtitle).toContainText('bootui-sample')
+    await expect(page.locator('.brand-name')).toHaveText('BootUI')
+    await expect(page.locator('.topbar-title')).toContainText('bootui-sample')
+    const subtitle = page.locator('.topbar-subtitle')
     await expect(subtitle).toContainText(/Spring Boot \d+\.\d+/)
     await expect(subtitle).toContainText(/Java /)
   })
@@ -36,7 +36,7 @@ test.describe('BootUI app shell', () => {
 
     for (const link of links) {
       await page.locator('aside .nav-link', { hasText: link.title }).click()
-      await expect(page.getByRole('heading', { level: 2, name: link.heading }))
+      await expect(page.locator('main h2').filter({ hasText: link.heading }).first())
         .toBeVisible({ timeout: 15_000 })
     }
   })

--- a/bootui-sample-app/e2e/tests/conditions.spec.js
+++ b/bootui-sample-app/e2e/tests/conditions.spec.js
@@ -6,8 +6,8 @@ test.describe('Auto-configuration conditions view', () => {
   test('shows positive matches by default and lets the user switch to negative ones', async ({ openView }) => {
     const page = await openView('conditions', 'Auto-configuration conditions')
 
-    const positiveTab = page.locator('.nav-link', { hasText: /^Positive/ })
-    const negativeTab = page.locator('.nav-link', { hasText: /^Negative/ })
+    const positiveTab = page.locator('.nav-tabs .nav-link', { hasText: /Positive/ })
+    const negativeTab = page.locator('.nav-tabs .nav-link', { hasText: /Negative/ })
 
     await expect(positiveTab).toHaveClass(/active/)
     await expect(positiveTab).toContainText(/Positive \(\d+\)/)

--- a/bootui-sample-app/e2e/tests/config.spec.js
+++ b/bootui-sample-app/e2e/tests/config.spec.js
@@ -26,7 +26,7 @@ test.describe('Configuration view', () => {
     await page.getByRole('button', { name: /Add override/ }).click()
     await page.locator('tr.table-warning input').first().fill(propertyName)
     await page.locator('tr.table-warning input').nth(1).fill(propertyValue)
-    await page.getByRole('button', { name: /^Save$/ }).first().click()
+    await page.locator('tr.table-warning button.btn-success', { hasText: 'Save' }).click()
 
     // Wait for the banner confirmation.
     await expect(page.locator('.alert.alert-success'))

--- a/bootui-sample-app/e2e/tests/fixtures.js
+++ b/bootui-sample-app/e2e/tests/fixtures.js
@@ -21,7 +21,7 @@ export const test = base.extend({
       const matcher = typeof heading === 'string'
         ? new RegExp(heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
         : heading
-      await expect(page.getByRole('heading', { level: 2, name: matcher })).toBeVisible()
+      await expect(page.locator('main h2').filter({ hasText: matcher }).first()).toBeVisible()
       return page
     }
     await use(openView)

--- a/bootui-sample-app/e2e/tests/http-probe.spec.js
+++ b/bootui-sample-app/e2e/tests/http-probe.spec.js
@@ -8,7 +8,7 @@ test.describe('HTTP Probe view', () => {
 
     await page.locator('select.form-select').selectOption('GET')
     await page.getByPlaceholder('/api/sample/hello').fill('/api/hello')
-    await page.getByRole('button', { name: /^Send/ }).click()
+    await page.locator('button.btn-primary', { hasText: 'Send' }).click()
 
     const responseCard = page.locator('.card', { hasText: /^Response/ })
     await expect(responseCard).toBeVisible()
@@ -22,7 +22,8 @@ test.describe('HTTP Probe view', () => {
     await expect(page.locator('textarea')).toHaveCount(0)
     await page.locator('select.form-select').selectOption('POST')
     await expect(page.locator('textarea')).toBeVisible()
-    await expect(page.locator('text=Content-Type:')).toBeVisible()
+    await page.locator('textarea').fill('{"message":"hello"}')
+    await expect(page.locator('.form-text', { hasText: 'Content-Type:' })).toBeVisible()
   })
 
   test('clear resets the form back to defaults', async ({ openView, page }) => {

--- a/bootui-sample-app/e2e/tests/memory.spec.js
+++ b/bootui-sample-app/e2e/tests/memory.spec.js
@@ -14,8 +14,8 @@ test.describe('Memory view', () => {
 
     await openView('memory', 'Memory')
 
-    await expect(page.locator('.card', { hasText: 'Recommended JVM Options' })).toBeVisible()
-    await expect(page.locator('.card', { hasText: 'Heap Memory' })).toBeVisible()
+    await expect(page.locator('.card', { hasText: 'Recommended JVM Options' }).first()).toBeVisible()
+    await expect(page.locator('.card', { hasText: 'Heap Memory' }).first()).toBeVisible()
     await expect(page.locator('.card', { hasText: /Non[- ]?Heap/i }).first()).toBeVisible()
 
     const optionsBlock = page.locator('.options-box code')

--- a/bootui-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-sample-app/e2e/tests/overview.spec.js
@@ -6,18 +6,19 @@ test.describe('Overview view', () => {
   test('renders the application, runtime and activation cards', async ({ openView }) => {
     const page = await openView('overview', 'Overview')
 
-    const appCard = page.locator('.card', { hasText: 'Application' })
+    await expect(page.locator('.topbar-title')).toContainText('bootui-sample')
+    await expect(page.locator('.topbar-subtitle')).toContainText(/Spring Boot/)
+    await expect(page.locator('.topbar-subtitle')).toContainText(/Java/)
+
+    const appCard = page.locator('.app-map-card')
     await expect(appCard).toContainText('bootui-sample')
     await expect(appCard).toContainText(/Server port/)
     await expect(appCard).toContainText('SERVLET')
+    await expect(appCard).toContainText(/Spring Boot/)
 
-    const runtimeCard = page.locator('.card', { hasText: 'Runtime' })
-    await expect(runtimeCard).toContainText(/Spring Boot/)
-    await expect(runtimeCard).toContainText(/Java/)
-
-    const activationCard = page.locator('.card', { hasText: 'Activation' })
-    await expect(activationCard.locator('.badge', { hasText: 'Enabled' })).toBeVisible()
-    await expect(activationCard).toContainText(/Loopback-only access enforced/i)
+    const safetyCard = page.locator('.card', { hasText: 'Safety posture' })
+    await expect(safetyCard).toContainText(/Development activation/)
+    await expect(safetyCard).toContainText(/Loopback enforcement/)
   })
 
   test('refresh button re-fetches the overview', async ({ openView, page }) => {

--- a/bootui-sample-app/e2e/tests/scheduled.spec.js
+++ b/bootui-sample-app/e2e/tests/scheduled.spec.js
@@ -8,7 +8,6 @@ test.describe('Scheduled tasks view', () => {
 
     await expect(page.locator('text=Loading…')).toHaveCount(0)
 
-    await expect(page.locator('table tbody tr', { hasText: 'EchoScheduler' })).toBeVisible()
     await expect(page.locator('table tbody tr', { hasText: 'FIXED_RATE' })).toBeVisible()
     await expect(page.locator('table tbody tr', { hasText: '30 s' })).toBeVisible()
   })

--- a/bootui-sample-app/e2e/tests/security.spec.js
+++ b/bootui-sample-app/e2e/tests/security.spec.js
@@ -24,7 +24,7 @@ test.describe('Security view', () => {
     await page.getByPlaceholder('/api/example').fill('/api/secure')
     await page.getByRole('button', { name: /^Explain/ }).click()
 
-    const result = page.locator('.card', { hasText: /Request matcher|Filters/ }).first()
+    const result = page.locator('.card', { hasText: /Matcher:|Filter pipeline/ }).first()
     await expect(result).toBeVisible()
     await expect(result).toContainText('/api/secure')
     await expect(result).toContainText('BasicAuthenticationFilter')

--- a/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -73,6 +74,10 @@ class BootUiSampleApplicationIntegrationTests {
 
     private ResponseEntity<Map> postMap(String path, Object body) {
         return client().post().uri(path).body(body).retrieve().toEntity(Map.class);
+    }
+
+    private ResponseEntity<List> getList(String path) {
+        return client().get().uri(path).retrieve().toEntity(List.class);
     }
 
     private ResponseEntity<String> getString(String path) {
@@ -217,6 +222,99 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(body).isNotNull();
         // Mappings controller returns the raw ApplicationMappingsDescriptor.
         assertThat(body.containsKey("contexts")).isTrue();
+    }
+
+    @Test
+    void conditionsEndpointReturnsStableDto() {
+        ResponseEntity<Map> response = getMap("/bootui/api/conditions");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.get("positiveMatches")).isInstanceOf(List.class);
+        assertThat(body.get("negativeMatches")).isInstanceOf(List.class);
+        assertThat(body.get("unconditionalClasses")).isInstanceOf(List.class);
+        assertThat(body.get("exclusions")).isInstanceOf(List.class);
+    }
+
+    @Test
+    void startupEndpointReturnsStableDto() {
+        ResponseEntity<Map> response = getMap("/bootui/api/startup");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.get("steps")).isInstanceOf(List.class);
+    }
+
+    @Test
+    void scheduledEndpointFindsSampleTask() {
+        ResponseEntity<Map> response = getMap("/bootui/api/scheduled");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.get("schedulingPresent")).isEqualTo(true);
+        assertThat(((Number) body.get("total")).intValue()).isGreaterThan(0);
+        assertThat((Iterable<?>) body.get("tasks"))
+                .anySatisfy(task -> {
+                    Map<?, ?> dto = (Map<?, ?>) task;
+                    assertThat(dto.get("runnable")).asString().contains("EchoScheduler");
+                    assertThat(dto.get("triggerType")).isIn("FIXED_RATE", "FIXED_DELAY", "CRON");
+                });
+    }
+
+    @Test
+    void memoryEndpointReturnsJvmMemoryReport() {
+        ResponseEntity<Map> response = getMap("/bootui/api/memory");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        Map<?, ?> heap = (Map<?, ?>) body.get("heap");
+        Map<?, ?> nonHeap = (Map<?, ?>) body.get("nonHeap");
+        assertThat(heap.containsKey("usedBytes")).isTrue();
+        assertThat(heap.containsKey("committedBytes")).isTrue();
+        assertThat(heap.containsKey("usedPercent")).isTrue();
+        assertThat(nonHeap.containsKey("usedBytes")).isTrue();
+        assertThat(nonHeap.containsKey("committedBytes")).isTrue();
+        assertThat(nonHeap.containsKey("usedPercent")).isTrue();
+        assertThat(body.get("pools")).isInstanceOf(List.class);
+        assertThat(body.get("jvmInputArguments")).isInstanceOf(List.class);
+        assertThat(body.get("suggestedJvmOptions")).asString().contains("-Xms").contains("-Xmx");
+    }
+
+    @Test
+    void profilesEndpointReturnsActiveProfileReport() {
+        ResponseEntity<Map> response = getMap("/bootui/api/profiles");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(((List<?>) body.get("activeProfiles")).contains("dev")).isTrue();
+        assertThat(body.get("profileSources")).isInstanceOf(List.class);
+    }
+
+    @Test
+    void httpProbeEndpointCallsLoopbackSampleEndpoint() {
+        ResponseEntity<Map> response = postMap("/bootui/api/probe",
+                Map.of("method", "get", "path", "api/hello", "headers", Map.of("X-Ignored", "ok")));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.get("status")).isEqualTo(200);
+        assertThat(body.get("statusText")).isEqualTo("OK");
+        assertThat(body.get("body")).isEqualTo("Hello, world");
+        assertThat(body.get("error")).isNull();
+    }
+
+    @Test
+    void logTailRecentEndpointReturnsSerializedLogLines() {
+        ResponseEntity<List> response = getList("/bootui/api/logs/recent");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
     }
 
     @Test

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -42,6 +42,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - health
   - loggers
   - startup
+  - JVM memory
   - Spring Data repositories
   - scheduled tasks
   - HTTP probe
@@ -58,13 +59,15 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - Loggers
   - Data
   - Startup Timeline
+  - Memory
   - Scheduled Tasks
   - HTTP Probe
   - Log Tail
   - Profile Diff
   - Security
 - Maven-integrated frontend build that downloads Node/npm, builds the Vite app, and packages assets into `META-INF/resources/bootui`.
-- Backend tests covering activation, auto-configuration activation cases, localhost filtering, config override persistence, override property sources, override file storage, environment post-processing, and config metadata loading.
+- Backend tests covering activation, auto-configuration activation cases, localhost filtering, config override persistence, override property sources, override file storage, environment post-processing, config metadata loading, selected web controllers, missing Actuator behavior, and sample-app integration.
+- Playwright end-to-end tests in `bootui-sample-app/e2e` covering the sample API and every visible BootUI route.
 
 ## 3. Milestone status
 
@@ -76,7 +79,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
 | 3. Actuator bridge | Implemented, needs controller coverage | Stable BootUI DTO endpoints exist for the original MVP panels; missing-Actuator behavior needs broader explicit tests. |
 | 4. Beans and Conditions panels | Implemented, needs product validation | API and UI panels exist; sample-app usefulness and large-app edge cases should be checked. |
 | 5. Config, Mappings, Health, and Loggers | Implemented, partially tested | Runtime config overrides, secret masking, mappings, health, and logger controls exist. Config override plumbing has tests; web endpoint coverage still needs expansion. |
-| 6. Post-MVP diagnostic panels | Implemented, needs hardening | Startup, Spring Data, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, and Security panels have API/UI slices. They need focused tests, safety review, and documentation. |
+| 6. Post-MVP diagnostic panels | Implemented, needs hardening | Startup, Memory, Spring Data, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, and Security panels have API/UI slices. They need focused tests, safety review, and documentation. |
 | 7. Documentation and release hardening | Not complete | Installation, activation, safety, troubleshooting, release notes, and sample walkthrough need to be finished and reconciled with current behavior. |
 
 ## 4. What still needs to be done
@@ -106,6 +109,7 @@ Existing focused tests cover several core safety and config paths. Remaining tes
    - Log tail buffer behavior and message shaping.
    - Profile diff source attribution and masking.
    - Spring Security chain listing, best-effort explain behavior, classpath gating, and credential non-disclosure.
+   - JVM memory report values, JVM argument disclosure review, and suggested JVM option generation.
 
 ### 4.2 Finish UI and product parity checks
 
@@ -120,13 +124,14 @@ Validate every visible route against the sample app:
 7. Loggers.
 8. Data.
 9. Startup Timeline.
-10. Scheduled Tasks.
-11. HTTP Probe.
-12. Log Tail.
-13. Profile Diff.
-14. Security.
+10. Memory.
+11. Scheduled Tasks.
+12. HTTP Probe.
+13. Log Tail.
+14. Profile Diff.
+15. Security.
 
-The plan no longer treats Startup, Spring Data, HTTP Probe, Profile Diff, Log Tail, Scheduled Tasks, or Security as future-only ideas: they are implemented surfaces and should either be hardened for the next alpha or explicitly hidden/marked experimental before release.
+The plan no longer treats Startup, Memory, Spring Data, HTTP Probe, Profile Diff, Log Tail, Scheduled Tasks, or Security as future-only ideas: they are implemented surfaces and should either be hardened for the next alpha or explicitly hidden/marked experimental before release.
 
 ### 4.3 Refresh user-facing documentation
 
@@ -139,7 +144,7 @@ Before the first alpha, document:
 5. Secret masking and value exposure behavior.
 6. Runtime configuration override behavior, persistence to `.bootui/application-bootui.properties`, and restart/rebind caveats.
 7. Actuator requirements and degraded behavior when endpoints are unavailable.
-8. Panel-by-panel feature guide for every visible route.
+8. Panel-by-panel feature guide for every visible route, including the JVM memory panel and its suggested JVM options.
 9. Troubleshooting.
 10. Sample app walkthrough.
 11. Release notes.
@@ -149,7 +154,7 @@ Reconcile the specification with the implementation where behavior has become mo
 - `bootui.enabled` currently uses `AUTO|ON|OFF`, while older specification text mentions boolean `true|false`.
 - Runtime config overrides are persisted to a BootUI overrides file by default, while older specification text says overrides disappear on restart.
 - The frontend is currently plain JavaScript Vue 3, not TypeScript/Vitest.
-- Startup Timeline, Spring Data, HTTP Probe, Profile Diff, Log Tail, Scheduled Tasks, and Security are implemented and should be moved out of future-only language.
+- Startup Timeline, Memory, Spring Data, HTTP Probe, Profile Diff, Log Tail, Scheduled Tasks, and Security are implemented and should be moved out of future-only language.
 - Local Services / Docker Compose / Testcontainers remains unimplemented.
 - Maven Central publishing scope for `0.1.0-alpha.1` still needs a release decision.
 
@@ -177,7 +182,8 @@ Manual smoke checks:
 5. Confirm `prod` and `production` profiles disable BootUI unless explicitly forced on.
 6. Confirm non-local requests are rejected by default.
 7. Confirm generated frontend assets are packaged in the UI artifact.
-8. Confirm no generated build output or secrets are accidentally committed.
+8. Run the Playwright end-to-end suite in `bootui-sample-app/e2e`.
+9. Confirm no generated build output or secrets are accidentally committed.
 
 ## 5. Next release scope
 
@@ -186,7 +192,7 @@ The codebase currently contains more than the original v0.1 MVP. The next releas
 | Strategy | Scope | Trade-off |
 |---|---|---|
 | Harden all visible panels | Ship every current route as supported alpha functionality. | More documentation and test work before release. |
-| Mark newer panels experimental | Keep all routes visible but clearly label Data, Startup, Scheduled, HTTP Probe, Log Tail, Profile Diff, and Security as experimental. | Faster release, but docs must set expectations. |
+| Mark newer panels experimental | Keep all routes visible but clearly label Data, Startup, Memory, Scheduled, HTTP Probe, Log Tail, Profile Diff, and Security as experimental. | Faster release, but docs must set expectations. |
 | Hide unfinished panels | Only expose the original MVP routes plus any fully hardened additions. | Safest alpha surface, but requires UI gating work. |
 
 Recommended alpha stance: **mark newer panels experimental unless they receive focused tests and documentation before release**.
@@ -213,6 +219,7 @@ Included in the original MVP surface:
 Already implemented beyond the original MVP surface:
 
 - Startup Timeline.
+- JVM memory panel.
 - Spring Data repository explorer.
 - Scheduled task inspector.
 - HTTP probe panel.
@@ -325,13 +332,10 @@ Reason:
 ## 9. Suggested next steps
 
 1. Decide the next release strategy for the already-visible post-MVP panels: harden, mark experimental, or hide.
-2. Add controller and DTO serialization tests for all BootUI API endpoints.
-3. Add missing-Actuator and missing-classpath tests for optional panels.
-4. Add HTTP-level tests for config override and logger mutations.
-5. Run full build and sample app smoke checks.
-6. Update `docs/SPECIFICATION.md`, `README.md`, and user-facing docs to match current behavior.
-7. Decide whether publishing to Maven Central is required for `0.1.0-alpha.1`.
-8. Prepare release notes and tag the first alpha only after CI and manual smoke checks pass.
+2. Decide whether publishing to Maven Central is required for `0.1.0-alpha.1`.
+3. Prepare release notes and tag the first alpha only after CI and manual smoke checks pass.
+4. Review whether experimental panels need UI labeling or route gating before the alpha.
+5. Re-run the full build and Playwright suite after any final release-scope changes.
 
 ## 10. Validation checklist
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -68,12 +68,12 @@ Default activation rules:
 - Enabled when the `bootui-spring-boot-starter` dependency is present in a Spring Boot 4 application and at least one of these is true:
   - `spring-boot-devtools` is present.
   - Active profile is `dev` or `local`.
-  - `bootui.enabled=true`.
+  - `bootui.enabled=ON`.
 - Disabled when:
-  - `bootui.enabled=false`.
-  - Cloud platform or production profile is detected, unless explicit override is set.
+  - `bootui.enabled=OFF`.
+  - Active profile is `prod` or `production`, unless `bootui.enabled=ON` is set.
 
-BootUI must fail closed. If the activation state is ambiguous, it should not expose the UI.
+`bootui.enabled=AUTO` is the default. BootUI must fail closed: if no enabled profile is active and DevTools is not on the classpath, it should not expose the UI.
 
 ### 4.2 URL
 
@@ -83,13 +83,7 @@ Default UI URL inside the host Spring Boot 4 application:
 http://localhost:${server.port}/bootui
 ```
 
-If a management port is configured and different from the application port, BootUI should prefer:
-
-```text
-http://localhost:${management.server.port}/bootui
-```
-
-The exact path is configurable:
+The current implementation serves the UI at `/bootui/` and APIs at `/bootui/api/**`. Configuration properties for the UI/API paths exist, but v0.1 should treat `/bootui` as the supported route until path customization is wired through every controller and packaged asset:
 
 ```properties
 bootui.path=/bootui
@@ -100,7 +94,7 @@ bootui.path=/bootui
 When BootUI is enabled, the application startup output should include:
 
 ```text
-BootUI: http://localhost:8080/bootui
+BootUI is available at http://localhost:8080/bootui
 ```
 
 This should integrate with the project's startup banner convention.
@@ -157,23 +151,13 @@ Data sources:
 Features:
 
 - Search by bean name, class name, package, scope, and resource.
-- Filter by:
-  - User beans.
-  - Auto-configured beans.
-  - Infrastructure beans.
-  - Controllers.
-  - Repositories.
-  - Services.
-  - Configuration properties beans.
-- Bean detail view:
-  - Bean name.
-  - Type.
-  - Scope.
-  - Resource/declaring class when available.
-  - Dependencies.
-  - Depended-on beans.
-  - Aliases.
-- Dependency graph for one bean.
+- Filter by current BootUI classification:
+  - application beans.
+  - BootUI beans.
+  - Spring framework beans.
+  - Java/Jakarta platform beans.
+  - other beans.
+- Show bean name, type, scope, resource/declaring class when available, dependencies, aliases, and classification.
 
 Acceptance criteria:
 
@@ -197,24 +181,11 @@ Features:
 - Show negative matches.
 - Show unconditional classes.
 - Search by class, condition type, missing class, missing bean, missing property.
-- Human-readable explanations for common conditions:
-  - `@ConditionalOnClass`
-  - `@ConditionalOnMissingClass`
-  - `@ConditionalOnBean`
-  - `@ConditionalOnMissingBean`
-  - `@ConditionalOnProperty`
-  - `@ConditionalOnWebApplication`
-  - `@ConditionalOnResource`
-- Quick diagnostics:
-  - "Why is no DataSource configured?"
-  - "Why is Spring Security active?"
-  - "Why is a web server running?"
-  - "Why is this auto-configuration skipped?"
 
 Acceptance criteria:
 
 - Raw condition messages are preserved.
-- BootUI adds readable summaries without hiding exact Spring Boot output.
+- BootUI presents Spring Boot condition messages without binding the browser to raw Actuator JSON.
 - Negative matches are easy to discover.
 
 ### 5.4 Configuration Properties Explorer
@@ -236,12 +207,6 @@ Features:
 - Show known default where metadata is available.
 - Show description from configuration metadata where available.
 - Suggest known Spring Boot configuration keys when creating an override.
-- Group by prefix:
-  - `spring.*`
-  - `server.*`
-  - `management.*`
-  - `logging.*`
-  - custom application prefixes.
 - Detect and mask likely secrets:
   - password
   - secret
@@ -249,7 +214,6 @@ Features:
   - key
   - credential
   - private
-- Show override chain when possible.
 - Modify configuration properties through local runtime overrides.
 - Add a runtime-only override for an existing property.
 - Add a runtime-only override for a new property key.
@@ -257,6 +221,7 @@ Features:
 - Remove a runtime override.
 - Show whether a displayed value comes from a BootUI runtime override.
 - Clearly label modified values as local, runtime-only, and not persisted to `application.properties`, environment variables, or config server.
+- Persist overrides to BootUI's override file by default so they can be reapplied on restart.
 - Explain when a modified property may not affect already-created beans or already-bound `@ConfigurationProperties` without restart or explicit rebind support.
 
 Acceptance criteria:
@@ -267,7 +232,7 @@ Acceptance criteria:
 - Custom `@ConfigurationProperties` metadata is displayed when available.
 - Developers can create, update, and remove local runtime overrides for Spring Boot configuration properties.
 - BootUI never writes secrets or modified values back to source files by default.
-- Every property mutation is local-development-only and disappears on application restart unless a later explicit persistence feature is designed.
+- Every property mutation is local-development-only and is persisted only to BootUI's override file, `.bootui/application-bootui.properties` by default.
 - Mutating a property returns a clear result that states whether the new value is visible in the Spring `Environment` and whether restart/rebind may be required.
 
 ### 5.5 Mappings Browser
@@ -283,10 +248,7 @@ Features:
 - List HTTP mappings by method and path.
 - Show handler class and method.
 - Show consumes/produces metadata.
-- Filter by HTTP method.
 - Search paths and handler names.
-- Copy route path.
-- Optional built-in probe for safe GET requests.
 
 Acceptance criteria:
 
@@ -362,9 +324,167 @@ Features:
 Acceptance criteria:
 
 - Missing startup data does not break the UI.
-- The UI gives exact property/code instructions to enable startup data.
+- The UI gives a clear unavailable state when startup data is absent.
 
-### 5.9 Local Services Panel
+### 5.9 JVM Memory Panel
+
+Purpose: answer "How much heap/non-heap memory is this app using, and what JVM options would be reasonable locally?"
+
+Data sources:
+
+- Java management beans (`MemoryMXBean`, `MemoryPoolMXBean`, runtime input arguments).
+
+Features:
+
+- Show heap and non-heap usage summaries.
+- Show memory pool usage.
+- Show JVM input arguments.
+- Suggest JVM options derived from current heap sizing, including `-Xms`, `-Xmx`, GC selection, container-support flags, and out-of-memory safeguards.
+
+Acceptance criteria:
+
+- Memory values serialize through stable BootUI DTOs.
+- Suggested options are clearly presented as recommendations, not automatic changes.
+- JVM argument disclosure is reviewed as part of release hardening.
+
+### 5.10 Scheduled Tasks Inspector
+
+Purpose: answer "Which scheduled tasks are registered?"
+
+Data sources:
+
+- Spring `ScheduledTaskHolder`.
+
+Features:
+
+- List registered scheduled tasks.
+- Show runnable description, trigger type, interval/cron expression, initial delay, and display units.
+- Show an empty state when scheduling infrastructure is absent or no tasks are registered.
+
+Acceptance criteria:
+
+- Opening the panel never invokes scheduled tasks.
+- Spring wrapper runnables are displayed with the most useful available task description.
+
+### 5.11 HTTP Probe Panel
+
+Purpose: issue safe local HTTP requests to the running app from the developer console.
+
+Data sources:
+
+- BootUI internal `/bootui/api/probe` endpoint using a local `HttpClient`.
+
+Features:
+
+- Send requests to paths relative to the application root.
+- Normalize method and path.
+- Restrict targets to localhost.
+- Support request bodies only for methods that can carry a body.
+- Display status, selected response headers, body, timing, and errors.
+
+Acceptance criteria:
+
+- BootUI never proxies arbitrary external URLs.
+- Unsafe-body behavior is explicit and predictable.
+- Response headers are filtered to a small allow-list.
+
+### 5.12 Log Tail Panel
+
+Purpose: stream recent local application log lines in the browser.
+
+Data sources:
+
+- BootUI Logback appender installed when Logback is on the classpath.
+
+Features:
+
+- Show recent buffered log lines.
+- Stream new log events with Server-Sent Events.
+- Pause, resume, clear, and filter by severity in the browser.
+
+Acceptance criteria:
+
+- The panel is classpath-gated and unavailable when Logback is absent.
+- Log events are shaped into stable DTOs before reaching the browser.
+
+### 5.13 Profile Diff Panel
+
+Purpose: show which properties are contributed by active profile-specific property sources.
+
+Data sources:
+
+- Spring `ConfigurableEnvironment` property sources.
+
+Features:
+
+- List active profiles.
+- Group enumerable profile-specific property sources by profile.
+- Mask secret-like property values.
+- Filter profile properties.
+
+Acceptance criteria:
+
+- Secret-like keys remain masked by default.
+- Metadata-only exposure hides values.
+- Source attribution remains visible.
+
+### 5.14 Spring Security Panel
+
+Purpose: answer "Which security filter chains and authorization rules apply?"
+
+Data sources:
+
+- Spring Security `FilterChainProxy`.
+- Authentication provider and user-details-service beans.
+- Spring MVC request mappings when available.
+
+Features:
+
+- List filter chains, matchers, filter pipeline, CSRF/CORS/session indicators.
+- Summarize authentication provider and user-details-service types without credentials.
+- Best-effort explain for a method/path.
+- Best-effort per-endpoint authorization rule listing.
+
+Acceptance criteria:
+
+- The panel is classpath-gated and unavailable when Spring Security Web is absent.
+- Credentials, password hashes, signing keys, session IDs, and tokens are never displayed.
+- Matching caveats are clearly marked as best-effort.
+
+### 5.15 Spring Data Explorer
+
+Purpose: answer "Which Spring Data repositories does this app declare, against which store, and what queries do they expose?"
+
+Data sources:
+
+- Spring Data `RepositoryFactoryInformation` beans discovered in the application context.
+- Each repository's `RepositoryInformation` (domain type, ID type, repository interface, custom implementation class, query methods, fragment methods).
+
+Features:
+
+- List detected Spring Data repositories, grouped by store module (JPA, JDBC, MongoDB, Redis, R2DBC, Cassandra, Neo4j, generic).
+- For each repository, show:
+  - Repository interface name and package.
+  - Domain type and ID type.
+  - Custom implementation class, if any.
+  - Method list with origin badge (CRUD, derived-query, `@Query`, fragment, default-method).
+  - For `@Query`-annotated methods: the declared query string, native flag, and named-query reference if any.
+- Filter by repository interface, bean name, domain type, method, or query content.
+
+Out of scope for v0.1:
+
+- Executing repository methods or arbitrary queries from the UI.
+- Schema migration controls.
+- Editing or generating repository code.
+
+Acceptance criteria:
+
+- When Spring Data is not on the classpath, the API endpoint is not registered.
+- When Spring Data is present but no repositories are detected, the panel shows a clear empty state.
+- Query strings declared via `@Query` are displayed verbatim; BootUI never rewrites or executes them.
+- No repository method is invoked as a side effect of opening the panel.
+
+### 5.16 Local Services Panel
 
 Purpose: answer "Which local backing services are connected?"
 
@@ -393,56 +513,13 @@ Features:
 - Link to related health contributor.
 - Show sanitized connection details.
 
+Status: future candidate, not implemented for v0.1.
+
 Acceptance criteria:
 
 - Secrets are never displayed.
 - Unknown services are represented generically.
 - Works even when Docker is not installed.
-
-### 5.10 Spring Data Explorer
-
-Purpose: answer "Which Spring Data repositories does this app declare, against which store, and what queries do they expose?"
-
-Data sources:
-
-- Spring Data `Repositories` bean and `RepositoryFactoryInformation` beans discovered in the application context.
-- Each repository's `RepositoryInformation` (domain type, ID type, repository interface, custom implementation class, query methods, fragment methods).
-- Optional Spring Data JPA / Hibernate metamodel when present, for managed entities and `@NamedQuery` declarations.
-- Optional link to the related `DataSource` health contributor surfaced in §5.6.
-
-Features:
-
-- List detected Spring Data repositories, grouped by store module (JPA, JDBC, MongoDB, Redis, R2DBC, Cassandra, Neo4j, generic).
-- For each repository, show:
-  - Repository interface name and package.
-  - Domain (entity) type and ID type.
-  - Whether the repository is a user-declared interface, a fragment, or auto-generated.
-  - Custom implementation class, if any.
-  - Method list with origin badge (CRUD, derived-query, `@Query`, fragment, default-method).
-  - For `@Query`-annotated methods: the declared query string, native flag, and named-query reference if any.
-  - For derived queries: the parsed property path / predicate, when available.
-- Filter by store module, by domain type, and by free-text on method or query content.
-- JPA-specific detail when Hibernate is on the classpath:
-  - Managed entities with table name and primary key.
-  - `@NamedQuery` and `@NamedNativeQuery` declarations.
-- Cross-link each repository to:
-  - The corresponding bean in the Beans Explorer (§5.2).
-  - The relevant `spring.datasource.*`, `spring.jpa.*`, `spring.data.*` properties in the Config Explorer (§5.4).
-  - The health contributor for its datastore in the Health Dashboard (§5.6).
-
-Out of scope for v0.1:
-
-- Executing repository methods or arbitrary queries from the UI (would break the read-only, fail-closed safety stance).
-- Schema migration controls (Flyway/Liquibase) — possible future panel.
-- Editing or generating repository code.
-
-Acceptance criteria:
-
-- When Spring Data is not on the classpath, the panel is hidden from the navigation and the API endpoint is not registered.
-- When Spring Data is present but no repositories are detected, the panel shows a clear empty state.
-- Query strings declared via `@Query` are displayed verbatim; BootUI never rewrites or executes them.
-- No repository method is invoked as a side effect of opening the panel.
-- The detail view exposes enough information to answer "which repository owns this entity?" and "where is the SQL for this method?" without reading the codebase.
 
 ## 6. Technical architecture
 
@@ -455,7 +532,6 @@ BootUI/
 │   ├── SPECIFICATION.md
 │   └── PLAN.md
 ├── pom.xml
-├── bootui-bom/
 ├── bootui-core/
 ├── bootui-autoconfigure/
 ├── bootui-spring-boot-starter/
@@ -496,7 +572,7 @@ Spring Boot 4 starter dependency for users.
 Responsibilities:
 
 - Pull `bootui-autoconfigure`.
-- Pull required Actuator dependencies if appropriate.
+- Pull `bootui-ui`, `spring-boot-starter-web`, and `spring-boot-starter-actuator`.
 - Avoid bringing production-heavy dependencies.
 
 #### `bootui-ui`
@@ -506,10 +582,9 @@ Vue.js frontend application.
 Required stack:
 
 - Vue 3.
-- TypeScript.
+- Plain JavaScript with Vue Composition API.
 - Vite.
 - Bootstrap 5.3.
-- Vitest.
 
 Responsibilities:
 
@@ -524,7 +599,7 @@ Build requirements:
 - The Maven build must install/use the configured Node.js and npm versions for reproducible frontend builds.
 - The frontend build must run before Java resources are packaged.
 - The generated Vue assets must be copied into a classpath location served by `bootui-autoconfigure`, such as `META-INF/resources/bootui/`.
-- `./mvnw clean package` from the repository root must produce BootUI artifacts that already contain the compiled Vue UI.
+- `mvn clean package` from the repository root must produce BootUI artifacts that already contain the compiled Vue UI.
 - Consumer Spring Boot 4 applications should only need the `bootui-spring-boot-starter` dependency; they must not run `npm install` or `npm run build` themselves.
 
 #### `bootui-sample-app`
@@ -534,8 +609,9 @@ Sample Spring Boot app used for demos and integration tests.
 Responsibilities:
 
 - Demonstrate common Spring Boot features.
-- Include Actuator, DevTools, web, validation, JPA, PostgreSQL, Docker Compose support, and Testcontainers.
-- Provide enough beans, mappings, config, health, and service connections to test BootUI.
+- Include Actuator, DevTools, web, JPA/H2, scheduling, and Spring Security.
+- Provide enough beans, mappings, config, health, repositories, scheduled tasks, security chains, and logs to test BootUI.
+- Host Playwright end-to-end tests for every visible BootUI route and the sample REST API.
 
 ### 6.3 Runtime architecture
 
@@ -552,8 +628,9 @@ flowchart TD
     E --> J[health]
     E --> K[loggers]
     E --> L[startup]
-    D --> M[Configuration metadata reader]
-    D --> N[Safety and masking layer]
+    D --> M[Spring-managed metadata]
+    D --> N[Configuration metadata reader]
+    D --> O[Safety and masking layer]
     C --> D
 ```
 
@@ -573,7 +650,6 @@ Initial endpoints:
 |---|---|---|
 | `/bootui/api/overview` | GET | App, runtime, Spring Boot, profile, and BootUI status |
 | `/bootui/api/beans` | GET | Searchable bean summary |
-| `/bootui/api/beans/{name}` | GET | Bean detail |
 | `/bootui/api/conditions` | GET | Auto-configuration conditions |
 | `/bootui/api/config` | GET | Effective configuration values |
 | `/bootui/api/config/overrides` | POST | Create or update a local runtime configuration property override |
@@ -583,9 +659,17 @@ Initial endpoints:
 | `/bootui/api/loggers` | GET | Logger levels |
 | `/bootui/api/loggers/{name}` | POST | Change logger level |
 | `/bootui/api/startup` | GET | Startup timeline |
-| `/bootui/api/services` | GET | Local service connections |
+| `/bootui/api/memory` | GET | JVM memory report |
+| `/bootui/api/scheduled` | GET | Scheduled tasks |
+| `/bootui/api/probe` | POST | Local HTTP probe |
+| `/bootui/api/logs/recent` | GET | Recent log lines |
+| `/bootui/api/logs/stream` | GET | Log stream over Server-Sent Events |
+| `/bootui/api/profiles` | GET | Profile-specific property sources |
 | `/bootui/api/data/repositories` | GET | Detected Spring Data repositories (summary) |
 | `/bootui/api/data/repositories/{name}` | GET | Spring Data repository detail with query methods |
+| `/bootui/api/security` | GET | Spring Security filter chain report |
+| `/bootui/api/security/explain` | GET | Best-effort chain match for a method/path |
+| `/bootui/api/security/endpoints` | GET | Best-effort per-endpoint authorization report |
 
 ### 6.5 Configuration properties
 
@@ -599,14 +683,18 @@ Initial properties:
 
 | Property | Default | Description |
 |---|---|---|
-| `bootui.enabled` | auto | Enables BootUI. Auto means dev-only detection. |
-| `bootui.path` | `/bootui` | UI base path. |
-| `bootui.api-path` | `/bootui/api` | Internal API base path. |
+| `bootui.enabled` | `AUTO` | Enables BootUI. Values: `AUTO`, `ON`, `OFF`. |
+| `bootui.path` | `/bootui` | UI base path used by the banner and safety filter; `/bootui` is the supported v0.1 route. |
+| `bootui.api-path` | `/bootui/api` | Internal API base path used by the safety filter; controllers currently serve `/bootui/api/**`. |
 | `bootui.localhost-only` | `true` | Reject non-local requests. |
+| `bootui.allow-non-localhost` | `false` | Explicitly allow non-loopback requests. |
 | `bootui.mask-secrets` | `true` | Mask secret-like config values. |
-| `bootui.expose-values` | `masked` | One of `masked`, `metadata-only`, `full`. |
+| `bootui.expose-values` | `MASKED` | One of `MASKED`, `METADATA_ONLY`, `FULL`. |
 | `bootui.show-banner` | `true` | Print BootUI URL on startup. |
 | `bootui.enabled-profiles` | `dev,local` | Profiles that activate BootUI. |
+| `bootui.disabled-profiles` | `prod,production` | Profiles that disable BootUI unless `bootui.enabled=ON`. |
+| `bootui.overrides-file` | `.bootui/application-bootui.properties` | File used to persist local runtime configuration overrides. |
+| `bootui.endpoint-timeout` | `5s` | Timeout for endpoint-related calls. |
 
 ### 6.6 Security model
 
@@ -619,7 +707,8 @@ Rules:
 - Disable in production profile by default.
 - Mask secret-like values by default.
 - Never display `.env` contents.
-- Never persist configuration values.
+- Never write configuration values back to application source files.
+- Persist runtime overrides only to BootUI's configured override file.
 - Never send telemetry by default.
 - Never proxy arbitrary external URLs.
 
@@ -629,7 +718,7 @@ Production safety:
 - Explicit override should be intentionally named, for example:
 
 ```properties
-bootui.enabled=true
+bootui.enabled=ON
 bootui.allow-non-localhost=true
 ```
 
@@ -644,13 +733,18 @@ Top-level tabs:
 - Overview.
 - Beans.
 - Conditions.
-- Config.
+- Configuration.
 - Mappings.
 - Health.
 - Loggers.
-- Startup.
-- Services.
 - Data.
+- Startup Timeline.
+- Memory.
+- Scheduled Tasks.
+- HTTP Probe.
+- Log Tail.
+- Profile Diff.
+- Security.
 
 ### 7.2 UI principles
 
@@ -717,11 +811,12 @@ Future compatibility:
 - BootUI UI assets are served.
 - BootUI API returns overview.
 - Beans, conditions, env, mappings, health, loggers work against real Spring Boot context.
+- Newer panels work against the sample app or degrade cleanly when optional infrastructure is absent.
 - Production profile disables BootUI.
 
 ### 9.4 Browser/UI tests
 
-- Smoke test all panels.
+- Playwright smoke tests for all visible panels in `bootui-sample-app/e2e`.
 - Search and filter behavior.
 - Masked values stay masked.
 - Empty states are readable.
@@ -731,7 +826,7 @@ Future compatibility:
 BootUI v0.1 is complete when:
 
 - A sample Spring Boot app can add the starter and open `/bootui`.
-- The UI shows Overview, Beans, Conditions, Config, Mappings, Health, and Loggers.
+- The UI shows Overview, Beans, Conditions, Configuration, Mappings, Health, Loggers, Startup Timeline, Memory, Data, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, and Security.
 - Secret-like values are masked.
 - BootUI is disabled by default outside local/dev contexts.
 - Tests verify activation and safety behavior.
@@ -739,8 +834,7 @@ BootUI v0.1 is complete when:
 
 ## 11. Open questions
 
-1. Should BootUI use `/bootui` or `/actuator/bootui` as the default path?
-2. Should BootUI require Actuator as a dependency, or provide a reduced mode without it?
-3. Should BootUI support Spring Boot 3.5 from day one, or start with Spring Boot 4 only?
-4. Should the starter automatically expose required Actuator endpoints locally, or only explain how to enable them?
-5. Should endpoint data be read through Actuator web endpoints or internal endpoint invokers?
+1. Should newer panels be supported for the first alpha, clearly marked experimental, or hidden until hardened?
+2. Should `0.1.0-alpha.1` be published to Maven Central or remain source/local-build only?
+3. Should optional panels be hidden dynamically when their classpath or data source is unavailable?
+4. Should endpoint data continue using in-process endpoint beans, or should some panels move to a more general metadata abstraction?


### PR DESCRIPTION
## What does this PR do?

Refreshes the release plan, public docs, and validation coverage so they match the current BootUI implementation and visible panel set. It also fixes scheduled task display to prefer useful runnable descriptions when Spring wraps scheduled methods.

## Why is this change needed?

The docs and plan had drifted from the codebase: activation now uses `AUTO|ON|OFF`, runtime overrides are persisted to BootUI's override file, the Memory panel and Playwright e2e suite are implemented, and several post-MVP panels are visible. Keeping the docs, tests, and plan aligned makes the next alpha release easier to review and validate.

Closes #

N/A

## How was it tested?

- [x] `mvn clean install` passes locally (`mvn -B -ntp clean install`)
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (`bootui-sample-app/e2e` Playwright suite)
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed