### PR TITLE
Run Playwright tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,36 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
 
-      - name: Set up Node.js (used by the bootui-ui module)
+      - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: npm
+          cache-dependency-path: bootui-sample-app/e2e/package-lock.json
 
       - name: Build all modules
         run: mvn -B -ntp clean install
+
+      - name: Install Playwright dependencies
+        working-directory: bootui-sample-app/e2e
+        run: |
+          npm ci
+          npx playwright install --with-deps chromium
+
+      - name: Run Playwright end-to-end tests
+        working-directory: bootui-sample-app/e2e
+        run: npm test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: |
+            bootui-sample-app/e2e/playwright-report/
+            bootui-sample-app/e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload sample-app jar
         if: success()


### PR DESCRIPTION
## What does this PR do?

Adds the existing sample-app Playwright end-to-end suite to the main build workflow after the Maven build completes.

## Why is this change needed?

The Playwright tests were already present and documented, but CI only ran the Maven build. Running them in GitHub Actions gives browser-facing BootUI behavior the same automated coverage as the Java modules.

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Validated the workflow YAML and confirmed the Playwright suite installs and discovers all tests with `npm ci --ignore-scripts` and `BOOTUI_SKIP_WEBSERVER=1 npx playwright test --list`.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed