### PR TITLE
Add sample app welcome page

### DIFF
--- a/bootui-sample-app/e2e/tests/sample-api.spec.js
+++ b/bootui-sample-app/e2e/tests/sample-api.spec.js
@@ -8,6 +8,15 @@ import { test, expect } from '@playwright/test'
  */
 test.describe('Sample application REST API', () => {
 
+  test('GET / serves a welcome page that links to BootUI', async ({ request }) => {
+    const response = await request.get('/')
+    expect(response.status()).toBe(200)
+    const body = await response.text()
+    expect(body).toContain('Welcome to the BootUI sample app')
+    expect(body).toContain('href="/bootui/"')
+    expect(body).toContain('GET /api/sample/products')
+  })
+
   test('GET /api/hello returns a simple HTTP probe greeting', async ({ request }) => {
     const response = await request.get('/api/hello')
     expect(response.status()).toBe(200)

--- a/bootui-sample-app/src/main/resources/static/index.html
+++ b/bootui-sample-app/src/main/resources/static/index.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>BootUI Sample App</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.5;
+        color: #172033;
+        background: #f5f7fb;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      main {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 56px 24px;
+      }
+
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 24px;
+        padding: 40px;
+        border-radius: 28px;
+        background: linear-gradient(135deg, #ffffff 0%, #eef4ff 100%);
+        box-shadow: 0 24px 70px rgba(23, 32, 51, 0.12);
+      }
+
+      .eyebrow {
+        margin: 0;
+        font-size: 0.78rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: #3451b2;
+      }
+
+      h1 {
+        margin: 0;
+        max-width: 760px;
+        font-size: clamp(2.25rem, 6vw, 4.5rem);
+        line-height: 1;
+        letter-spacing: -0.05em;
+      }
+
+      .lead {
+        max-width: 760px;
+        margin: 0;
+        font-size: 1.2rem;
+        color: #4a5568;
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+      }
+
+      a {
+        color: #3451b2;
+        font-weight: 650;
+        text-decoration: none;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 44px;
+        padding: 0 18px;
+        border-radius: 999px;
+        background: #3451b2;
+        color: #ffffff;
+        box-shadow: 0 10px 24px rgba(52, 81, 178, 0.25);
+      }
+
+      .button:hover {
+        text-decoration: none;
+        background: #2b459f;
+      }
+
+      .button.secondary {
+        background: #ffffff;
+        color: #3451b2;
+        box-shadow: inset 0 0 0 1px rgba(52, 81, 178, 0.22);
+      }
+
+      .content-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 20px;
+        margin-top: 28px;
+      }
+
+      section {
+        padding: 24px;
+        border-radius: 20px;
+        background: #ffffff;
+        box-shadow: 0 12px 36px rgba(23, 32, 51, 0.08);
+      }
+
+      h2 {
+        margin: 0 0 12px;
+        font-size: 1.1rem;
+      }
+
+      ul {
+        margin: 0;
+        padding-left: 1.2rem;
+      }
+
+      li + li {
+        margin-top: 8px;
+      }
+
+      code {
+        padding: 0.15rem 0.35rem;
+        border-radius: 0.4rem;
+        background: #eef2f7;
+        color: #263245;
+      }
+
+      @media (min-width: 860px) {
+        .hero {
+          grid-template-columns: minmax(0, 1fr) 280px;
+          align-items: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="hero">
+        <div>
+          <p class="eyebrow">Spring Boot 4 demo</p>
+          <h1>Welcome to the BootUI sample app</h1>
+          <p class="lead">
+            This app demonstrates a small Spring Boot service with public endpoints,
+            secured admin routes, scheduled work, JPA data, and enough runtime state
+            for BootUI to inspect.
+          </p>
+          <div class="actions" aria-label="Primary links">
+            <a class="button" href="/bootui/">Open BootUI</a>
+            <a class="button secondary" href="/api/sample/products">View sample products</a>
+          </div>
+        </div>
+        <section aria-labelledby="bootui-heading">
+          <h2 id="bootui-heading">BootUI console</h2>
+          <p>
+            Open <a href="/bootui/">BootUI</a> to explore the running application,
+            including beans, conditions, configuration, mappings, health, loggers,
+            data repositories, scheduled tasks, log tailing, profiles, security, and JVM memory.
+          </p>
+        </section>
+      </div>
+
+      <div class="content-grid">
+        <section aria-labelledby="api-heading">
+          <h2 id="api-heading">Try the sample API</h2>
+          <ul>
+            <li><a href="/api/hello"><code>GET /api/hello</code></a> returns a basic greeting.</li>
+            <li><a href="/api/sample/hello"><code>GET /api/sample/hello</code></a> uses live configuration properties.</li>
+            <li><a href="/api/sample/products"><code>GET /api/sample/products</code></a> returns active JPA-backed products.</li>
+          </ul>
+        </section>
+
+        <section aria-labelledby="security-heading">
+          <h2 id="security-heading">See security rules in action</h2>
+          <p>
+            The sample keeps <code>/admin</code> and <code>/api/secure</code>
+            protected with HTTP Basic authentication. Use <code>admin/admin</code>
+            for the admin role or <code>developer/developer</code> to see a forbidden user.
+          </p>
+        </section>
+
+        <section aria-labelledby="probe-heading">
+          <h2 id="probe-heading">Use BootUI to inspect it</h2>
+          <p>
+            The BootUI panels can probe these endpoints, explain Spring Security
+            matching, inspect repository methods, edit local configuration overrides,
+            and show how the app was auto-configured.
+          </p>
+        </section>
+      </div>
+    </main>
+  </body>
+</html>

--- a/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -339,6 +339,18 @@ class BootUiSampleApplicationIntegrationTests {
     }
 
     @Test
+    void rootIndexPageIntroducesTheSampleApp() {
+        ResponseEntity<String> response = getString("/");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody())
+                .contains("Welcome to the BootUI sample app")
+                .contains("Open BootUI")
+                .contains("href=\"/bootui/\"")
+                .contains("GET /api/sample/products");
+    }
+
+    @Test
     void secureApiEndpointRequiresAdminRole() {
         ResponseEntity<String> secureWithoutCredentials = getString("/api/secure");
         assertThat(secureWithoutCredentials.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
## What does this PR do?

Adds a root welcome page to the sample app that explains the available demo endpoints and links users directly to the BootUI console.

## Why is this change needed?

The sample app previously opened without a guided landing page, so developers had to already know where BootUI and the demo endpoints lived. The new page makes the sample app self-explanatory and provides a clear path to `/bootui/`.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed