### PR TITLE
Update overview hero homepage link

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -78,16 +78,22 @@ onMounted(load)
           <i class="bi bi-stars me-1"></i>
           Runtime command center
         </span>
-        <h2>Understand this Spring Boot app in minutes.</h2>
+        <h2>Understand your Spring Boot app in minutes</h2>
         <p>
           BootUI turns the local runtime into a guided map of profiles, ports,
           safety status, Actuator-backed diagnostics, and the panels that explain how the app is wired.
         </p>
       </div>
-      <button class="btn btn-light hero-refresh" @click="load" :disabled="loading">
-        <i class="bi bi-arrow-clockwise me-1" :class="{ 'spin': loading }"></i>
-        Refresh snapshot
-      </button>
+      <div class="hero-actions">
+        <a class="btn btn-outline-light" href="/">
+          <i class="bi bi-house-door me-1"></i>
+          Back to homepage
+        </a>
+        <button class="btn btn-light hero-refresh" @click="load" :disabled="loading">
+          <i class="bi bi-arrow-clockwise me-1" :class="{ 'spin': loading }"></i>
+          Refresh snapshot
+        </button>
+      </div>
     </div>
 
     <div v-if="loading" class="overview-skeleton">
@@ -297,12 +303,20 @@ onMounted(load)
   margin-bottom: 0;
 }
 
-.hero-refresh {
-  box-shadow: 0 0.8rem 1.8rem rgba(0, 0, 0, 0.14);
+.hero-actions {
+  display: flex;
   flex-shrink: 0;
-  font-weight: 700;
+  gap: 0.75rem;
   position: relative;
   z-index: 1;
+}
+
+.hero-actions .btn {
+  font-weight: 700;
+}
+
+.hero-refresh {
+  box-shadow: 0 0.8rem 1.8rem rgba(0, 0, 0, 0.14);
 }
 
 .spin {
@@ -611,6 +625,10 @@ onMounted(load)
   .overview-hero,
   .openapi-card {
     flex-direction: column;
+  }
+
+  .hero-actions {
+    flex-wrap: wrap;
   }
 
   .overview-skeleton {


### PR DESCRIPTION
## What does this PR do?

Updates the overview hero headline and adds a prominent link back to the host app homepage.

## Why is this change needed?

The main BootUI screen should use user-facing copy that speaks to the developer's own Spring Boot app, and provide a clear way to return to `/` from the BootUI console.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Ran `npm run build` in `bootui-ui/src/main/frontend`.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed