### PR TITLE
Add DevTools reload controls

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -7,6 +7,9 @@ import io.github.bootui.autoconfigure.web.BootUiIndexController;
 import io.github.bootui.autoconfigure.web.ConditionsController;
 import io.github.bootui.autoconfigure.web.ConfigController;
 import io.github.bootui.autoconfigure.web.DataController;
+import io.github.bootui.autoconfigure.web.DefaultDevToolsBridge;
+import io.github.bootui.autoconfigure.web.DevToolsBridge;
+import io.github.bootui.autoconfigure.web.DevToolsController;
 import io.github.bootui.autoconfigure.web.HealthController;
 import io.github.bootui.autoconfigure.web.HttpProbeController;
 import io.github.bootui.autoconfigure.web.LoggersController;
@@ -28,6 +31,7 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
@@ -61,6 +65,7 @@ import org.springframework.core.env.Environment;
         ProfileController.class,
         SecurityController.class,
         MemoryController.class,
+        DevToolsController.class,
         BootUiIndexController.class
 })
 public class BootUiAutoConfiguration {
@@ -81,6 +86,11 @@ public class BootUiAutoConfiguration {
     public ConfigOverrideService bootUiConfigOverrideService(ConfigurableEnvironment environment,
                                                               BootUiProperties properties) {
         return new ConfigOverrideService(environment, properties);
+    }
+
+    @Bean
+    public DevToolsBridge bootUiDevToolsBridge(ApplicationContext applicationContext) {
+        return new DefaultDevToolsBridge(applicationContext);
     }
 
     @Bean

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DefaultDevToolsBridge.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DefaultDevToolsBridge.java
@@ -1,0 +1,225 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.DevToolsActionResult;
+import io.github.bootui.core.BootUiDtos.DevToolsStatus;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.util.ClassUtils;
+
+public class DefaultDevToolsBridge implements DevToolsBridge {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultDevToolsBridge.class);
+
+    private static final String RESTARTER_CLASS = "org.springframework.boot.devtools.restart.Restarter";
+
+    private static final String LIVE_RELOAD_SERVER_CLASS =
+            "org.springframework.boot.devtools.livereload.LiveReloadServer";
+
+    private static final String OPTIONAL_LIVE_RELOAD_SERVER_CLASS =
+            "org.springframework.boot.devtools.autoconfigure.OptionalLiveReloadServer";
+
+    private final ApplicationContext applicationContext;
+
+    private final ClassLoader classLoader;
+
+    private final AtomicBoolean restartPending = new AtomicBoolean(false);
+
+    public DefaultDevToolsBridge(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+        this.classLoader = applicationContext.getClassLoader() == null
+                ? ClassUtils.getDefaultClassLoader()
+                : applicationContext.getClassLoader();
+    }
+
+    @Override
+    public DevToolsStatus status() {
+        Availability restart = restartAvailability();
+        LiveReloadHandle liveReload = liveReloadHandle();
+        return new DevToolsStatus(
+                restart.available(),
+                restart.reason(),
+                restartPending.get(),
+                liveReload.available(),
+                liveReload.port(),
+                liveReload.reason());
+    }
+
+    @Override
+    public DevToolsActionResult triggerLiveReload() {
+        LiveReloadHandle liveReload = liveReloadHandle();
+        if (!liveReload.available()) {
+            return new DevToolsActionResult("livereload", "unavailable", liveReload.reason());
+        }
+        try {
+            Method triggerReload = liveReload.target().getClass().getMethod("triggerReload");
+            triggerReload.invoke(liveReload.target());
+            return new DevToolsActionResult("livereload", "triggered",
+                    "LiveReload notification sent to connected browsers.");
+        }
+        catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException("Could not trigger Spring Boot DevTools LiveReload", unwrap(ex));
+        }
+    }
+
+    @Override
+    public DevToolsActionResult scheduleRestart() {
+        Availability restart = restartAvailability();
+        if (!restart.available()) {
+            return new DevToolsActionResult("restart", "unavailable", restart.reason());
+        }
+        if (!restartPending.compareAndSet(false, true)) {
+            return new DevToolsActionResult("restart", "already_pending",
+                    "A DevTools restart is already pending.");
+        }
+
+        Object restarter = restarter();
+        Thread restartThread = new Thread(() -> restartAfterResponse(restarter), "bootui-devtools-restart");
+        restartThread.setDaemon(false);
+        restartThread.start();
+        return new DevToolsActionResult("restart", "scheduled",
+                "Restart scheduled. BootUI will reconnect when the application is available again.");
+    }
+
+    private void restartAfterResponse(Object restarter) {
+        try {
+            Thread.sleep(250);
+            Method restart = restarter.getClass().getMethod("restart");
+            restart.invoke(restarter);
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            restartPending.set(false);
+            log.warn("Spring Boot DevTools restart was interrupted", ex);
+        }
+        catch (ReflectiveOperationException ex) {
+            restartPending.set(false);
+            log.warn("Spring Boot DevTools restart failed", unwrap(ex));
+        }
+    }
+
+    private Availability restartAvailability() {
+        if (!ClassUtils.isPresent(RESTARTER_CLASS, classLoader)) {
+            return Availability.unavailable("spring-boot-devtools is not on the classpath.");
+        }
+        try {
+            restarter();
+            return Availability.ready();
+        }
+        catch (IllegalStateException ex) {
+            return Availability.unavailable(ex.getMessage());
+        }
+    }
+
+    private Object restarter() {
+        try {
+            Class<?> restarterClass = ClassUtils.forName(RESTARTER_CLASS, classLoader);
+            Method getInstance = restarterClass.getMethod("getInstance");
+            return getInstance.invoke(null);
+        }
+        catch (InvocationTargetException ex) {
+            Throwable cause = ex.getTargetException();
+            throw new IllegalStateException(cause.getMessage() == null
+                    ? "Spring Boot DevTools Restarter is not initialized."
+                    : cause.getMessage(), cause);
+        }
+        catch (ReflectiveOperationException | LinkageError ex) {
+            throw new IllegalStateException("Spring Boot DevTools Restarter is not available.", ex);
+        }
+    }
+
+    private LiveReloadHandle liveReloadHandle() {
+        if (!ClassUtils.isPresent(OPTIONAL_LIVE_RELOAD_SERVER_CLASS, classLoader)
+                && !ClassUtils.isPresent(LIVE_RELOAD_SERVER_CLASS, classLoader)) {
+            return LiveReloadHandle.unavailable("Spring Boot DevTools LiveReload is not on the classpath.");
+        }
+        LiveReloadHandle optional = beanHandle(OPTIONAL_LIVE_RELOAD_SERVER_CLASS);
+        if (optional.available()) {
+            return optional;
+        }
+        LiveReloadHandle server = beanHandle(LIVE_RELOAD_SERVER_CLASS);
+        if (server.available()) {
+            return server;
+        }
+        return LiveReloadHandle.unavailable("Spring Boot DevTools LiveReload server is not available.");
+    }
+
+    private LiveReloadHandle beanHandle(String className) {
+        if (!ClassUtils.isPresent(className, classLoader)) {
+            return LiveReloadHandle.unavailable(null);
+        }
+        try {
+            Class<?> type = ClassUtils.forName(className, classLoader);
+            Map<String, ?> beans = applicationContext.getBeansOfType(type, false, false);
+            if (beans.isEmpty()) {
+                return LiveReloadHandle.unavailable(null);
+            }
+            Object bean = beans.values().iterator().next();
+            return new LiveReloadHandle(bean, liveReloadPort(bean), null);
+        }
+        catch (ReflectiveOperationException | LinkageError ex) {
+            return LiveReloadHandle.unavailable("Spring Boot DevTools LiveReload server is not available.");
+        }
+    }
+
+    private Integer liveReloadPort(Object bean) {
+        Object target = liveReloadServer(bean);
+        if (target == null) {
+            return null;
+        }
+        try {
+            Method getPort = target.getClass().getMethod("getPort");
+            return (Integer) getPort.invoke(target);
+        }
+        catch (ReflectiveOperationException ex) {
+            return null;
+        }
+    }
+
+    private Object liveReloadServer(Object bean) {
+        if (bean.getClass().getName().equals(LIVE_RELOAD_SERVER_CLASS)) {
+            return bean;
+        }
+        try {
+            Field server = bean.getClass().getDeclaredField("server");
+            server.setAccessible(true);
+            return server.get(bean);
+        }
+        catch (ReflectiveOperationException ex) {
+            return null;
+        }
+    }
+
+    private Throwable unwrap(ReflectiveOperationException ex) {
+        return ex instanceof InvocationTargetException invocation && invocation.getTargetException() != null
+                ? invocation.getTargetException()
+                : ex;
+    }
+
+    private record Availability(boolean available, String reason) {
+
+        static Availability ready() {
+            return new Availability(true, null);
+        }
+
+        static Availability unavailable(String reason) {
+            return new Availability(false, reason);
+        }
+    }
+
+    private record LiveReloadHandle(Object target, Integer port, String reason) {
+
+        boolean available() {
+            return target != null;
+        }
+
+        static LiveReloadHandle unavailable(String reason) {
+            return new LiveReloadHandle(null, null, reason);
+        }
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DevToolsBridge.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DevToolsBridge.java
@@ -1,0 +1,16 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.DevToolsActionResult;
+import io.github.bootui.core.BootUiDtos.DevToolsStatus;
+
+/**
+ * Bridge to optional Spring Boot DevTools APIs.
+ */
+public interface DevToolsBridge {
+
+    DevToolsStatus status();
+
+    DevToolsActionResult triggerLiveReload();
+
+    DevToolsActionResult scheduleRestart();
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DevToolsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DevToolsController.java
@@ -1,0 +1,60 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.DevToolsActionResult;
+import io.github.bootui.core.BootUiDtos.DevToolsRestartRequest;
+import io.github.bootui.core.BootUiDtos.DevToolsStatus;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/bootui/api/devtools")
+public class DevToolsController {
+
+    private final DevToolsBridge devTools;
+
+    public DevToolsController(DevToolsBridge devTools) {
+        this.devTools = devTools;
+    }
+
+    @GetMapping
+    public DevToolsStatus status() {
+        return devTools.status();
+    }
+
+    @PostMapping("/livereload")
+    public ResponseEntity<DevToolsActionResult> triggerLiveReload() {
+        DevToolsActionResult result = devTools.triggerLiveReload();
+        return ResponseEntity.status(statusFor(result)).body(result);
+    }
+
+    @PostMapping("/restart")
+    public ResponseEntity<DevToolsActionResult> restart(@RequestBody(required = false) DevToolsRestartRequest request) {
+        if (request == null || !Boolean.TRUE.equals(request.confirm())) {
+            return ResponseEntity.badRequest().body(new DevToolsActionResult("restart", "confirmation_required",
+                    "Restart requires explicit confirmation."));
+        }
+        DevToolsActionResult result = devTools.scheduleRestart();
+        return ResponseEntity.status(statusFor(result)).body(result);
+    }
+
+    private HttpStatus statusFor(DevToolsActionResult result) {
+        return switch (result.status()) {
+            case "scheduled" -> HttpStatus.ACCEPTED;
+            case "unavailable", "already_pending" -> HttpStatus.CONFLICT;
+            default -> HttpStatus.OK;
+        };
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalState(IllegalStateException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Map.of("error", ex.getMessage() == null ? "DevTools action failed" : ex.getMessage()));
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.bootui.autoconfigure.config.ConfigOverrideService;
 import io.github.bootui.autoconfigure.safety.LocalhostOnlyFilter;
+import io.github.bootui.autoconfigure.web.DevToolsBridge;
+import io.github.bootui.autoconfigure.web.DevToolsController;
 import io.github.bootui.autoconfigure.web.OverviewController;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -28,6 +30,8 @@ class BootUiAutoConfigurationTests {
                         .hasSingleBean(BootUiAutoConfiguration.class)
                         .hasSingleBean(LocalhostOnlyFilter.class)
                         .hasSingleBean(ConfigOverrideService.class)
+                        .hasSingleBean(DevToolsBridge.class)
+                        .hasSingleBean(DevToolsController.class)
                         .hasSingleBean(OverviewController.class)
                         .hasSingleBean(BootUiActivation.class));
     }

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/DevToolsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/DevToolsControllerTests.java
@@ -1,0 +1,102 @@
+package io.github.bootui.autoconfigure.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.bootui.core.BootUiDtos.DevToolsActionResult;
+import io.github.bootui.core.BootUiDtos.DevToolsStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+class DevToolsControllerTests {
+
+    @Test
+    void reportsDevToolsStatus() throws Exception {
+        MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
+                new DevToolsStatus(true, null, false, true, 35729, null),
+                new DevToolsActionResult("livereload", "triggered", "ok"),
+                new DevToolsActionResult("restart", "scheduled", "ok")))).build();
+
+        mvc.perform(get("/bootui/api/devtools"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.restartAvailable").value(true))
+                .andExpect(jsonPath("$.restartPending").value(false))
+                .andExpect(jsonPath("$.liveReloadAvailable").value(true))
+                .andExpect(jsonPath("$.liveReloadPort").value(35729));
+    }
+
+    @Test
+    void triggersLiveReloadWhenAvailable() throws Exception {
+        MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
+                new DevToolsStatus(true, null, false, true, 35729, null),
+                new DevToolsActionResult("livereload", "triggered", "LiveReload notification sent."),
+                new DevToolsActionResult("restart", "scheduled", "ok")))).build();
+
+        mvc.perform(post("/bootui/api/devtools/livereload"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.action").value("livereload"))
+                .andExpect(jsonPath("$.status").value("triggered"));
+    }
+
+    @Test
+    void returnsConflictWhenLiveReloadUnavailable() throws Exception {
+        MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
+                new DevToolsStatus(false, "no restart", false, false, null, "no livereload"),
+                new DevToolsActionResult("livereload", "unavailable", "no livereload"),
+                new DevToolsActionResult("restart", "unavailable", "no restart")))).build();
+
+        mvc.perform(post("/bootui/api/devtools/livereload"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value("unavailable"))
+                .andExpect(jsonPath("$.message").value("no livereload"));
+    }
+
+    @Test
+    void restartRequiresConfirmation() throws Exception {
+        MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
+                new DevToolsStatus(true, null, false, true, 35729, null),
+                new DevToolsActionResult("livereload", "triggered", "ok"),
+                new DevToolsActionResult("restart", "scheduled", "ok")))).build();
+
+        mvc.perform(post("/bootui/api/devtools/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"confirm\":false}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("confirmation_required"));
+    }
+
+    @Test
+    void schedulesRestartWhenConfirmed() throws Exception {
+        MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
+                new DevToolsStatus(true, null, false, true, 35729, null),
+                new DevToolsActionResult("livereload", "triggered", "ok"),
+                new DevToolsActionResult("restart", "scheduled", "Restart scheduled.")))).build();
+
+        mvc.perform(post("/bootui/api/devtools/restart")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"confirm\":true}"))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.action").value("restart"))
+                .andExpect(jsonPath("$.status").value("scheduled"));
+    }
+
+    private record StubDevToolsBridge(
+            DevToolsStatus status,
+            DevToolsActionResult liveReloadResult,
+            DevToolsActionResult restartResult) implements DevToolsBridge {
+
+        @Override
+        public DevToolsActionResult triggerLiveReload() {
+            return liveReloadResult;
+        }
+
+        @Override
+        public DevToolsActionResult scheduleRestart() {
+            return restartResult;
+        }
+    }
+}

--- a/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
@@ -160,6 +160,24 @@ public final class BootUiDtos {
     public record LogLineDto(long timestamp, String level, String logger, String message, String thread) {
     }
 
+    /** DevTools-backed reload and restart status. */
+    public record DevToolsStatus(
+            boolean restartAvailable,
+            String restartUnavailableReason,
+            boolean restartPending,
+            boolean liveReloadAvailable,
+            Integer liveReloadPort,
+            String liveReloadUnavailableReason) {
+    }
+
+    /** Request to restart the application through Spring Boot DevTools. */
+    public record DevToolsRestartRequest(Boolean confirm) {
+    }
+
+    /** Result of a DevTools reload or restart action. */
+    public record DevToolsActionResult(String action, String status, String message) {
+    }
+
     public record StartupStepDto(
             long id,
             Long parentId,

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -19,6 +19,7 @@ import LogTail from './views/LogTail.vue'
 import ProfileDiff from './views/ProfileDiff.vue'
 import Security from './views/Security.vue'
 import Memory from './views/Memory.vue'
+import DevTools from './views/DevTools.vue'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -28,6 +29,7 @@ const router = createRouter({
     { path: '/health', name: 'health', component: Health, meta: { icon: 'bi-heart-pulse', title: 'Health' } },
     { path: '/startup', name: 'startup', component: Startup, meta: { icon: 'bi-bar-chart-steps', title: 'Startup Timeline' } },
     { path: '/memory', name: 'memory', component: Memory, meta: { icon: 'bi-memory', title: 'Memory' } },
+    { path: '/devtools', name: 'devtools', component: DevTools, meta: { icon: 'bi-lightning-charge', title: 'DevTools' } },
     { path: '/conditions', name: 'conditions', component: Conditions, meta: { icon: 'bi-check2-circle', title: 'Conditions' } },
     { path: '/beans', name: 'beans', component: Beans, meta: { icon: 'bi-diagram-3', title: 'Beans' } },
     { path: '/mappings', name: 'mappings', component: Mappings, meta: { icon: 'bi-signpost-2', title: 'Mappings' } },

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -1,0 +1,239 @@
+<script setup>
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+
+const status = ref(null)
+const loading = ref(true)
+const actionLoading = ref(null)
+const banner = ref(null)
+const restarting = ref(false)
+let reconnectTimer = null
+
+const restartReady = computed(() => status.value?.restartAvailable && !status.value?.restartPending)
+const liveReloadReady = computed(() => status.value?.liveReloadAvailable)
+
+async function load() {
+  loading.value = true
+  try {
+    const res = await fetch('api/devtools')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    status.value = await res.json()
+  } catch (e) {
+    flash('Could not load DevTools status: ' + e.message, 'danger')
+  } finally {
+    loading.value = false
+  }
+}
+
+async function triggerLiveReload() {
+  actionLoading.value = 'livereload'
+  try {
+    const res = await fetch('api/devtools/livereload', { method: 'POST' })
+    const result = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      flash(result.message || result.error || ('HTTP ' + res.status), 'warning')
+      await load()
+      return
+    }
+    flash(result.message || 'LiveReload triggered.', 'success')
+    await load()
+  } catch (e) {
+    flash('Could not trigger LiveReload: ' + e.message, 'danger')
+  } finally {
+    actionLoading.value = null
+  }
+}
+
+async function restart() {
+  if (!confirm('Restart this Spring Boot application now? In-memory state and in-flight requests will be interrupted.')) return
+
+  actionLoading.value = 'restart'
+  try {
+    const res = await fetch('api/devtools/restart', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirm: true })
+    })
+    const result = await res.json().catch(() => ({}))
+    if (!res.ok) {
+      flash(result.message || result.error || ('HTTP ' + res.status), 'warning')
+      await load()
+      return
+    }
+    restarting.value = true
+    flash(result.message || 'Restart scheduled.', 'success')
+    pollUntilOnline()
+  } catch (e) {
+    flash('Could not schedule restart: ' + e.message, 'danger')
+  } finally {
+    actionLoading.value = null
+  }
+}
+
+function pollUntilOnline() {
+  clearReconnectTimer()
+  reconnectTimer = setTimeout(async () => {
+    try {
+      const res = await fetch('api/devtools', { cache: 'no-store' })
+      if (res.ok) {
+        status.value = await res.json()
+        restarting.value = false
+        flash('Application is available again.', 'success')
+        return
+      }
+    } catch {
+      // Expected while DevTools is restarting the application.
+    }
+    pollUntilOnline()
+  }, 1500)
+}
+
+function clearReconnectTimer() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+}
+
+function flash(text, type) {
+  banner.value = { text, type }
+  setTimeout(() => { banner.value = null }, 8000)
+}
+
+onMounted(load)
+onUnmounted(clearReconnectTimer)
+</script>
+
+<template>
+  <div>
+    <div class="d-flex justify-content-between align-items-start mb-3">
+      <div>
+        <h2 class="mb-1"><i class="bi bi-lightning-charge me-2"></i>DevTools</h2>
+        <p class="text-muted mb-0 small">
+          Trigger Spring Boot DevTools LiveReload notifications or restart the local application.
+        </p>
+      </div>
+      <button class="btn btn-outline-secondary" @click="load" :disabled="loading || restarting" title="Refresh">
+        <i class="bi bi-arrow-clockwise" :class="{ 'spin': loading }"></i>
+      </button>
+    </div>
+
+    <div v-if="banner" class="alert d-flex justify-content-between align-items-center" :class="'alert-' + banner.type">
+      <div>
+        <i class="bi" :class="banner.type === 'danger' ? 'bi-exclamation-triangle-fill' : 'bi-info-circle-fill'"></i>
+        <span class="ms-2">{{ banner.text }}</span>
+      </div>
+      <button class="btn-close" @click="banner = null"></button>
+    </div>
+
+    <div v-if="restarting" class="alert alert-primary d-flex align-items-start gap-3">
+      <div class="spinner-border spinner-border-sm mt-1" role="status"></div>
+      <div>
+        <strong>Restarting application…</strong>
+        <div class="small">BootUI is polling until the local server responds again.</div>
+      </div>
+    </div>
+
+    <div v-if="loading" class="card">
+      <div class="card-body text-muted">Loading DevTools status…</div>
+    </div>
+
+    <div v-else-if="status" class="row g-4">
+      <div class="col-lg-6">
+        <div class="card h-100 action-card">
+          <div class="card-body p-4">
+            <div class="d-flex align-items-start justify-content-between gap-3 mb-3">
+              <div>
+                <div class="action-icon bg-primary-subtle text-primary">
+                  <i class="bi bi-broadcast"></i>
+                </div>
+                <h3 class="h5 fw-bold mt-3 mb-1">Trigger LiveReload</h3>
+                <p class="text-muted small mb-0">
+                  Sends a LiveReload event to browsers connected to Spring Boot DevTools.
+                </p>
+              </div>
+              <span class="badge" :class="liveReloadReady ? 'text-bg-success' : 'text-bg-secondary'">
+                {{ liveReloadReady ? 'Available' : 'Unavailable' }}
+              </span>
+            </div>
+
+            <div class="small text-muted mb-3">
+              <span v-if="status.liveReloadPort">LiveReload port: <code>{{ status.liveReloadPort }}</code></span>
+              <span v-else>{{ status.liveReloadUnavailableReason || 'No LiveReload port reported.' }}</span>
+            </div>
+
+            <button class="btn btn-primary" @click="triggerLiveReload" :disabled="!liveReloadReady || actionLoading">
+              <span v-if="actionLoading === 'livereload'" class="spinner-border spinner-border-sm me-2"></span>
+              <i v-else class="bi bi-broadcast me-1"></i>
+              Trigger LiveReload
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-lg-6">
+        <div class="card h-100 action-card border-warning-subtle">
+          <div class="card-body p-4">
+            <div class="d-flex align-items-start justify-content-between gap-3 mb-3">
+              <div>
+                <div class="action-icon bg-warning-subtle text-warning-emphasis">
+                  <i class="bi bi-arrow-clockwise"></i>
+                </div>
+                <h3 class="h5 fw-bold mt-3 mb-1">Restart application</h3>
+                <p class="text-muted small mb-0">
+                  Schedules a DevTools restart after the API response is sent.
+                </p>
+              </div>
+              <span class="badge" :class="restartReady ? 'text-bg-success' : 'text-bg-secondary'">
+                {{ status.restartPending ? 'Pending' : (restartReady ? 'Available' : 'Unavailable') }}
+              </span>
+            </div>
+
+            <div class="small text-muted mb-3">
+              {{ status.restartUnavailableReason || 'Spring Boot DevTools restart is initialized.' }}
+            </div>
+
+            <button class="btn btn-warning" @click="restart" :disabled="!restartReady || actionLoading || restarting">
+              <span v-if="actionLoading === 'restart'" class="spinner-border spinner-border-sm me-2"></span>
+              <i v-else class="bi bi-arrow-clockwise me-1"></i>
+              Restart app
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-12">
+        <div class="alert alert-info small mb-0">
+          <strong>Note:</strong>
+          LiveReload notifies connected browser tooling; it does not force this BootUI tab to reload.
+          Restart interrupts the current JVM context and is intended for local development only.
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.action-card {
+  min-height: 17rem;
+}
+
+.action-icon {
+  align-items: center;
+  border-radius: 1rem;
+  display: inline-flex;
+  font-size: 1.5rem;
+  height: 3rem;
+  justify-content: center;
+  width: 3rem;
+}
+
+.spin {
+  animation: spin 900ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -48,6 +48,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - log tail
   - profile diff
   - Spring Security
+  - DevTools reload/restart
 - Vue 3 UI shell with routes for:
   - Overview
   - Beans
@@ -63,6 +64,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - Log Tail
   - Profile Diff
   - Security
+  - DevTools
 - Maven-integrated frontend build that downloads Node/npm, builds the Vite app, and packages assets into `META-INF/resources/bootui`.
 - Backend tests covering activation, auto-configuration activation cases, localhost filtering, config override persistence, override property sources, override file storage, environment post-processing, and config metadata loading.
 
@@ -219,6 +221,7 @@ Already implemented beyond the original MVP surface:
 - Live log tail.
 - Profile diff.
 - Spring Security panel.
+- DevTools reload/restart controls.
 
 Still excluded:
 
@@ -346,6 +349,7 @@ Before considering the next alpha complete:
 - Configuration panel works and masks secrets.
 - Runtime config overrides persist through the BootUI overrides file and warn about restart/rebind caveats.
 - Logger changes work.
+- DevTools controls show unavailable states when Spring Boot DevTools is absent.
 - Newer diagnostic panels either have release-grade coverage/docs or are clearly marked experimental/hidden.
 - BootUI is disabled with `prod` and `production` profiles unless `bootui.enabled=ON`.
 - Non-local requests are rejected by default.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -342,6 +342,31 @@ Acceptance criteria:
 - Runtime level changes work when Actuator supports them.
 - UI clearly states changes are runtime-only and not persisted.
 
+### 5.7.1 DevTools Controls
+
+Purpose: answer "Can I trigger local LiveReload or restart this app from the console?"
+
+Data sources:
+
+- Spring Boot DevTools restart APIs when present and initialized.
+- Spring Boot DevTools LiveReload server when present.
+
+Features:
+
+- Show whether DevTools restart is available.
+- Show whether LiveReload is available and which port it uses when reported.
+- Trigger a LiveReload notification for connected browsers.
+- Restart the local application through DevTools after explicit confirmation.
+- Poll for the application to return after a restart is scheduled.
+- Explain unavailable states instead of hiding the panel.
+
+Acceptance criteria:
+
+- DevTools is optional; BootUI must still start when DevTools is absent.
+- Restart actions require explicit confirmation and are intended for local development only.
+- Restart scheduling returns an API response before DevTools tears down the running context.
+- LiveReload is clearly described as a notification to connected browser tooling, not a forced BootUI page reload.
+
 ### 5.8 Startup Timeline
 
 Purpose: answer "What made startup slow?"


### PR DESCRIPTION
## What does this PR do?

Adds a DevTools panel and API that let local BootUI users trigger Spring Boot DevTools LiveReload notifications or schedule a DevTools application restart from the UI.

## Why is this change needed?

Developers using BootUI during the local inner loop need a quick way to nudge connected browsers or restart the app after runtime configuration changes without leaving the console. The implementation keeps DevTools optional, reports clear unavailable states, requires explicit restart confirmation, and schedules restart after the API response is sent so the UI can enter a reconnecting state cleanly.

## How was it tested?

- [x] `mvn clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed