### PR TITLE
Use logger in EchoScheduler

### DIFF
--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/EchoScheduler.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/EchoScheduler.java
@@ -1,13 +1,17 @@
 package io.github.bootui.sample;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 public class EchoScheduler {
 
+    private static final Logger logger = LoggerFactory.getLogger(EchoScheduler.class);
+
     @Scheduled(fixedRate = 30_000)
     public void echo() {
-        System.out.println("echo");
+        logger.info("echo");
     }
 }


### PR DESCRIPTION
EchoScheduler was writing directly to standard output, which bypasses the application logging configuration used by the sample app.

This replaces the direct console write with an SLF4J logger so scheduled echo messages flow through normal logging infrastructure.

Validation:
- `mvn -pl bootui-sample-app -am test -Dtest=BootUiSampleApplicationIntegrationTests#scheduledEndpointFindsSampleTask -Dskip.npm -Dsurefire.failIfNoSpecifiedTests=false`