### PR TITLE
Use PostgreSQL for the sample app database

### DIFF
--- a/bootui-sample-app/compose.yaml
+++ b/bootui-sample-app/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  postgres:
+    image: postgres:18-alpine
+    environment:
+      POSTGRES_DB: bootui_sample
+      POSTGRES_USER: bootui
+      POSTGRES_PASSWORD: bootui
+    ports:
+      - "5432"

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -39,14 +39,36 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-docker-compose</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/bootui-sample-app/src/main/resources/application.properties
+++ b/bootui-sample-app/src/main/resources/application.properties
@@ -4,9 +4,6 @@ server.port=8080
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always
 
-spring.datasource.url=jdbc:h2:mem:bootui-sample;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.username=sa
-spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.open-in-view=false
 

--- a/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -24,6 +25,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.web.client.RestClient;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * End-to-end tests that boot the sample app on a random port and call BootUI's
@@ -35,12 +39,18 @@ import org.springframework.web.client.RestClient;
         webEnvironment = WebEnvironment.RANDOM_PORT,
         properties = {
                 "spring.profiles.active=dev",
+                "spring.docker.compose.enabled=false",
                 "bootui.show-banner=false",
                 "bootui.overrides-file=target/bootui-test-overrides.properties"
         })
+@Testcontainers
 class BootUiSampleApplicationIntegrationTests {
 
     private static final Path OVERRIDES_FILE = Paths.get("target/bootui-test-overrides.properties");
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:18-alpine");
 
     @LocalServerPort
     int port;

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -669,7 +669,7 @@ Sample Spring Boot app used for demos and integration tests.
 Responsibilities:
 
 - Demonstrate common Spring Boot features.
-- Include Actuator, DevTools, web, JPA/H2, scheduling, and Spring Security.
+- Include Actuator, DevTools, web, JPA/PostgreSQL through Docker Compose, scheduling, and Spring Security.
 - Provide enough beans, mappings, config, health, repositories, scheduled tasks, security chains, and logs to test BootUI.
 - Host Playwright end-to-end tests for every visible BootUI route and the sample REST API.
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <spring-boot.version>4.0.6</spring-boot.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <node.version>v24.16.0</node.version>


### PR DESCRIPTION
## What does this PR do?

Switches the sample app from embedded H2 to PostgreSQL: Docker Compose supplies the runtime database, and Testcontainers supplies the integration-test database.

## Why is this change needed?

The sample app should exercise BootUI against a realistic external database and Spring Boot's native service connection support instead of relying on an in-memory H2 datasource.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Also ran `mvn -pl bootui-sample-app -am test -Dskip.frontend=true`.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed