### PR TITLE
Add Paketo-style JVM memory calculator to the Memory panel

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/MemoryCalculator.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/MemoryCalculator.java
@@ -1,0 +1,263 @@
+package io.github.bootui.autoconfigure.web;
+
+import io.github.bootui.core.BootUiDtos.MemoryCalculationDto;
+
+/**
+ * Paketo {@code libjvm}-style JVM memory calculator.
+ *
+ * <p>Partitions a target container-memory budget into JVM regions using:
+ * <pre>
+ *   heap = totalMemory − headRoom − directMemory − metaspace
+ *          − reservedCodeCache − (stack × threadCount)
+ * </pre>
+ *
+ * <p>The formula and the default region sizes mirror
+ * {@code paketo-buildpacks/libjvm/calc/calculator.go}. We deviate from the
+ * buildpack on two points because BootUI has access to a live JVM:
+ *
+ * <ul>
+ *   <li><b>Loaded class count</b> comes from
+ *       {@link java.lang.management.ClassLoadingMXBean#getLoadedClassCount()}
+ *       instead of counting JAR entries at build time, so the buildpack's
+ *       {@code ClassLoadFactor = 0.35} (a build-time → runtime estimator) is
+ *       not applied. We do apply a {@link #META_SAFETY_FACTOR} on top of the
+ *       observed count to account for lazy class loading after the user
+ *       opens the panel.</li>
+ *   <li><b>Default thread count</b> is {@code max(liveThreads, 250)} so a
+ *       freshly-started small app doesn't under-reserve stack memory.</li>
+ * </ul>
+ *
+ * <p>This class is pure (no Spring, no JMX); the controller resolves all
+ * inputs and passes them in. That makes the formula trivial to unit-test.
+ */
+final class MemoryCalculator {
+
+    /** libjvm: {@code DefaultDirectMemory = 10 * Mebi}. */
+    static final long DIRECT_MEMORY_BYTES = 10L * 1024 * 1024;
+
+    /** libjvm: {@code DefaultReservedCodeCache = 240 * Mebi}. */
+    static final long CODE_CACHE_BYTES = 240L * 1024 * 1024;
+
+    /** libjvm: {@code DefaultStack = 1 * Mebi}. */
+    static final long STACK_BYTES_PER_THREAD = 1L * 1024 * 1024;
+
+    /** libjvm: {@code ClassOverhead = 14_000_000} (decimal MB, not MiB). */
+    static final long META_BASE_BYTES = 14_000_000L;
+
+    /** libjvm: {@code ClassSize = 5_800} bytes per loaded class. */
+    static final long META_PER_CLASS_BYTES = 5_800L;
+
+    /**
+     * Safety factor on observed loaded-class count, used to size metaspace.
+     * The live count is a snapshot; Spring lazily loads many classes
+     * (devtools, JDBC drivers, error paths, JSON serializers …) after the
+     * panel is first opened. 1.25× gives a forgiving but not wasteful cap.
+     */
+    static final double META_SAFETY_FACTOR = 1.25;
+
+    /** Floor for the default thread count, matching libjvm's value. */
+    static final int DEFAULT_THREAD_COUNT_FLOOR = 250;
+
+    static final int MIN_THREAD_COUNT = 1;
+    static final int MAX_THREAD_COUNT = 10_000;
+    static final int MIN_HEAD_ROOM_PERCENT = 0;
+    static final int MAX_HEAD_ROOM_PERCENT = 90;
+    static final long MIN_TOTAL_MEMORY_BYTES = 128L * 1024 * 1024;
+    static final long MAX_TOTAL_MEMORY_BYTES = 64L * 1024 * 1024 * 1024;
+
+    private static final long GC_FLIP_HEAP_BYTES = 4L * 1024 * 1024 * 1024;
+
+    private final JdkVersion jdkVersion;
+
+    MemoryCalculator() {
+        this(JdkVersion.current());
+    }
+
+    MemoryCalculator(JdkVersion jdkVersion) {
+        this.jdkVersion = jdkVersion;
+    }
+
+    /**
+     * Compute a memory plan for the given inputs.
+     *
+     * @param totalMemoryBytes target container memory budget
+     * @param threadCount      thread count to reserve stack memory for
+     * @param loadedClasses    live class count from {@code ClassLoadingMXBean}
+     * @param headRoomPercent  percentage of total memory to leave unallocated
+     * @param liveThreadCount  current live thread count (reported for UI context)
+     * @param liveLoadedClassCount currently loaded classes (reported for UI context)
+     * @return calculation DTO; if inputs leave no room for any heap, the
+     *         returned DTO has {@code valid = false} and a non-null
+     *         {@code error} — no exception is thrown so the panel can keep
+     *         polling without an HTTP error
+     */
+    MemoryCalculationDto calculate(
+            long totalMemoryBytes,
+            int threadCount,
+            int loadedClasses,
+            int headRoomPercent,
+            int liveThreadCount,
+            int liveLoadedClassCount) {
+
+        long clampedTotal = clamp(totalMemoryBytes, MIN_TOTAL_MEMORY_BYTES, MAX_TOTAL_MEMORY_BYTES);
+        int clampedThreads = (int) clamp(threadCount, MIN_THREAD_COUNT, MAX_THREAD_COUNT);
+        int clampedHeadRoom = (int) clamp(headRoomPercent, MIN_HEAD_ROOM_PERCENT, MAX_HEAD_ROOM_PERCENT);
+        int clampedClasses = Math.max(loadedClasses, 0);
+
+        long metaspaceBytes = computeMetaspaceBytes(clampedClasses);
+        long stackBytesTotal = STACK_BYTES_PER_THREAD * (long) clampedThreads;
+        long fixedRegionsBytes = DIRECT_MEMORY_BYTES + metaspaceBytes + CODE_CACHE_BYTES + stackBytesTotal;
+        long headRoomBytes = (long) ((clampedHeadRoom / 100.0) * clampedTotal);
+        long heapBytes = clampedTotal - headRoomBytes - fixedRegionsBytes;
+
+        if (heapBytes <= 0) {
+            String message = String.format(
+                    "No room for heap: fixed regions (%d MB) + headroom (%d MB) >= total (%d MB). "
+                            + "Try a larger total memory, fewer threads, or lower headroom.",
+                    bytesToMb(fixedRegionsBytes),
+                    bytesToMb(headRoomBytes),
+                    bytesToMb(clampedTotal));
+            return new MemoryCalculationDto(
+                    clampedTotal,
+                    0,
+                    metaspaceBytes,
+                    CODE_CACHE_BYTES,
+                    DIRECT_MEMORY_BYTES,
+                    STACK_BYTES_PER_THREAD,
+                    stackBytesTotal,
+                    headRoomBytes,
+                    fixedRegionsBytes,
+                    clampedThreads,
+                    clampedClasses,
+                    liveThreadCount,
+                    liveLoadedClassCount,
+                    clampedHeadRoom,
+                    "",
+                    false,
+                    message);
+        }
+
+        String jvmOptions = buildJvmOptions(
+                heapBytes, metaspaceBytes, CODE_CACHE_BYTES, DIRECT_MEMORY_BYTES, STACK_BYTES_PER_THREAD);
+
+        return new MemoryCalculationDto(
+                clampedTotal,
+                heapBytes,
+                metaspaceBytes,
+                CODE_CACHE_BYTES,
+                DIRECT_MEMORY_BYTES,
+                STACK_BYTES_PER_THREAD,
+                stackBytesTotal,
+                headRoomBytes,
+                fixedRegionsBytes,
+                clampedThreads,
+                clampedClasses,
+                liveThreadCount,
+                liveLoadedClassCount,
+                clampedHeadRoom,
+                jvmOptions,
+                true,
+                null);
+    }
+
+    /**
+     * Pick a sensible default {@code totalMemoryBytes} that is independent of
+     * the host machine's RAM. We size to roughly 1.5× the app's observed
+     * footprint, with a floor sized to fit all fixed regions plus 128 MB of
+     * heap, and a hard upper clamp of 2 GiB so a 32 GB Mac doesn't poison
+     * the recommendation. The user can move the value freely afterwards.
+     */
+    long defaultTotalMemoryBytes(
+            long heapCommittedBytes,
+            long nonHeapCommittedBytes,
+            int threadCount,
+            int loadedClasses) {
+
+        int safeThreads = Math.max(threadCount, DEFAULT_THREAD_COUNT_FLOOR);
+        long fixed = DIRECT_MEMORY_BYTES
+                + computeMetaspaceBytes(loadedClasses)
+                + CODE_CACHE_BYTES
+                + STACK_BYTES_PER_THREAD * (long) safeThreads;
+        long floor = fixed + 128L * 1024 * 1024;
+
+        long useful = heapCommittedBytes + Math.max(0, nonHeapCommittedBytes);
+        useful = useful + (useful / 2); // ×1.5 footprint
+
+        long picked = Math.max(floor, useful);
+        picked = roundUpTo(picked, 64L * 1024 * 1024);
+
+        long min = 384L * 1024 * 1024;
+        long max = 2048L * 1024 * 1024;
+        return clamp(picked, min, max);
+    }
+
+    static int defaultThreadCount(int liveThreadCount) {
+        return Math.max(liveThreadCount, DEFAULT_THREAD_COUNT_FLOOR);
+    }
+
+    private long computeMetaspaceBytes(int loadedClasses) {
+        double withFactor = (META_BASE_BYTES + META_PER_CLASS_BYTES * (double) loadedClasses) * META_SAFETY_FACTOR;
+        return (long) Math.ceil(withFactor);
+    }
+
+    private String buildJvmOptions(
+            long heapBytes,
+            long metaspaceBytes,
+            long codeCacheBytes,
+            long directMemoryBytes,
+            long stackBytesPerThread) {
+
+        long heapMb = bytesToMb(heapBytes);
+        long metaMb = bytesToMb(metaspaceBytes);
+        long ccMb = bytesToMb(codeCacheBytes);
+        long dmMb = bytesToMb(directMemoryBytes);
+        long stackKb = stackBytesPerThread / 1024;
+
+        String gcFlag = heapBytes >= GC_FLIP_HEAP_BYTES ? "-XX:+UseZGC" : "-XX:+UseG1GC";
+
+        StringBuilder sb = new StringBuilder(256);
+        sb.append("-Xms").append(heapMb).append("m");
+        sb.append(" -Xmx").append(heapMb).append("m");
+        sb.append(" -XX:MaxMetaspaceSize=").append(metaMb).append("m");
+        sb.append(" -XX:ReservedCodeCacheSize=").append(ccMb).append("m");
+        sb.append(" -XX:MaxDirectMemorySize=").append(dmMb).append("m");
+        sb.append(" -Xss").append(stackKb).append("k");
+        sb.append(" ").append(gcFlag);
+        sb.append(" -XX:+UseStringDeduplication");
+        if (jdkVersion.feature() >= 25) {
+            sb.append(" -XX:+UseCompactObjectHeaders");
+        }
+        sb.append(" -XX:+ExitOnOutOfMemoryError");
+        sb.append(" -XX:+HeapDumpOnOutOfMemoryError");
+        sb.append(" -XX:HeapDumpPath=/tmp");
+        return sb.toString();
+    }
+
+    private static long bytesToMb(long bytes) {
+        return Math.max(0, Math.round(bytes / (1024.0 * 1024.0)));
+    }
+
+    private static long roundUpTo(long value, long multiple) {
+        if (value <= 0) return multiple;
+        return ((value + multiple - 1) / multiple) * multiple;
+    }
+
+    private static long clamp(long value, long min, long max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    /**
+     * Indirection over {@link Runtime#version()} so tests can pin the feature
+     * version and verify JDK-gated options (e.g. {@code UseCompactObjectHeaders}
+     * which became a product flag in JDK 25 / JEP 519 and is rejected on
+     * earlier JDKs).
+     */
+    @FunctionalInterface
+    interface JdkVersion {
+        int feature();
+
+        static JdkVersion current() {
+            return () -> Runtime.version().feature();
+        }
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/MemoryController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/MemoryController.java
@@ -1,28 +1,49 @@
 package io.github.bootui.autoconfigure.web;
 
+import io.github.bootui.core.BootUiDtos.MemoryCalculationDto;
 import io.github.bootui.core.BootUiDtos.MemoryPoolDto;
 import io.github.bootui.core.BootUiDtos.MemoryReport;
-import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ClassLoadingMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
+import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/bootui/api/memory")
 public class MemoryController {
 
-    @GetMapping
-    public MemoryReport memory() {
-        MemoryMXBean memBean = ManagementFactory.getMemoryMXBean();
+    private final MemoryCalculator calculator;
 
-        MemoryPoolDto heap = toDto("Heap", memBean.getHeapMemoryUsage());
-        MemoryPoolDto nonHeap = toDto("Non-Heap", memBean.getNonHeapMemoryUsage());
+    public MemoryController() {
+        this(new MemoryCalculator());
+    }
+
+    MemoryController(MemoryCalculator calculator) {
+        this.calculator = calculator;
+    }
+
+    @GetMapping
+    public MemoryReport memory(
+            @RequestParam(name = "totalMemoryMb", required = false) Long totalMemoryMb,
+            @RequestParam(name = "threadCount", required = false) Integer threadCount,
+            @RequestParam(name = "headRoomPercent", required = false) Integer headRoomPercent) {
+        MemoryMXBean memBean = ManagementFactory.getMemoryMXBean();
+        ClassLoadingMXBean classBean = ManagementFactory.getClassLoadingMXBean();
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+
+        MemoryUsage heapUsage = memBean.getHeapMemoryUsage();
+        MemoryUsage nonHeapUsage = memBean.getNonHeapMemoryUsage();
+
+        MemoryPoolDto heap = toDto("Heap", heapUsage);
+        MemoryPoolDto nonHeap = toDto("Non-Heap", nonHeapUsage);
 
         List<MemoryPoolDto> pools = new ArrayList<>();
         for (MemoryPoolMXBean pool : ManagementFactory.getMemoryPoolMXBeans()) {
@@ -34,9 +55,30 @@ public class MemoryController {
 
         List<String> inputArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
 
-        String suggested = buildSuggestedOptions(memBean.getHeapMemoryUsage());
+        int liveThreads = threadBean.getThreadCount();
+        int liveClasses = classBean.getLoadedClassCount();
 
-        return new MemoryReport(heap, nonHeap, pools, inputArgs, suggested);
+        long resolvedTotalBytes = totalMemoryMb != null
+                ? totalMemoryMb * 1024L * 1024L
+                : calculator.defaultTotalMemoryBytes(
+                        heapUsage.getCommitted(),
+                        nonHeapUsage.getCommitted(),
+                        MemoryCalculator.defaultThreadCount(liveThreads),
+                        liveClasses);
+        int resolvedThreads = threadCount != null
+                ? threadCount
+                : MemoryCalculator.defaultThreadCount(liveThreads);
+        int resolvedHeadRoom = headRoomPercent != null ? headRoomPercent : 0;
+
+        MemoryCalculationDto calculation = calculator.calculate(
+                resolvedTotalBytes,
+                resolvedThreads,
+                liveClasses,
+                resolvedHeadRoom,
+                liveThreads,
+                liveClasses);
+
+        return new MemoryReport(heap, nonHeap, pools, inputArgs, calculation.jvmOptions(), calculation);
     }
 
     private MemoryPoolDto toDto(String name, MemoryUsage usage) {
@@ -46,67 +88,5 @@ public class MemoryController {
         int pct = (max > 0) ? (int) (used * 100L / max) : (committed > 0 ? (int) (used * 100L / committed) : 0);
         return new MemoryPoolDto(name, used, committed, max, pct);
     }
-
-    /**
-     * Calculates recommended JVM startup options based on current heap usage.
-     *
-     * <p>Targets Spring Boot 4 on Java 25.
-     *
-     * <p>The strategy:
-     * <ul>
-     *   <li>-Xms: next multiple of 128 MB above current heap committed (minimum 64 MB)</li>
-     *   <li>-Xmx: next multiple of 256 MB above current heap max (or committed when max is -1)</li>
-     *   <li>G1GC for heaps &lt; 4 GB; ZGC (generational by default on JDK 24+) for larger heaps</li>
-     *   <li>{@code -XX:+UseStringDeduplication}: Spring apps allocate many duplicate strings
-     *       (bean names, config keys, JSON property names, log templates); deduplication
-     *       typically saves 5–15% of heap on G1 and ZGC (since JDK 18)</li>
-     *   <li>{@code -XX:+UseCompactObjectHeaders}: JEP 519 graduated this to a product flag
-     *       in JDK 25 — shrinks every object header from 12 to 8 bytes on 64-bit JVMs with
-     *       compressed oops, saving roughly 10–20% of heap on Spring's small-object-heavy
-     *       allocation pattern</li>
-     *   <li>OOM safety flags with a writable HeapDumpPath suitable for containers</li>
-     * </ul>
-     *
-     * <p>Notes on flags intentionally <em>not</em> emitted:
-     * <ul>
-     *   <li>{@code -XX:+UseContainerSupport} is enabled by default since JDK 10.</li>
-     *   <li>{@code -XX:+ZGenerational} was removed in JDK 24 (JEP 490); generational
-     *       mode is now the default for ZGC and the flag is rejected as unrecognized.</li>
-     *   <li>{@code -XX:MaxRAMPercentage} / {@code -XX:InitialRAMPercentage} are only
-     *       honored when {@code -Xmx} / {@code -Xms} are <em>not</em> set, so mixing
-     *       them with explicit heap sizes is a no-op and misleading.</li>
-     *   <li>{@code -Djava.security.egd=file:/dev/./urandom} has been obsolete since
-     *       JDK 9 — {@code SecureRandom} already uses {@code NativePRNGNonBlocking}
-     *       (which reads {@code /dev/urandom}) by default on Linux.</li>
-     *   <li>AOT cache ({@code -XX:AOTCache=...}, JEP 514 stable in JDK 25) is Spring
-     *       Boot 4's biggest startup-time win but requires a multi-step training
-     *       workflow, so it belongs in documentation, not a copy-paste options string.</li>
-     * </ul>
-     */
-    private String buildSuggestedOptions(MemoryUsage heapUsage) {
-        long committed = heapUsage.getCommitted();
-        long max = heapUsage.getMax() > 0 ? heapUsage.getMax() : committed;
-
-        long xmsMb = roundUpTo(committed / (1024 * 1024), 128);
-        if (xmsMb < 64) xmsMb = 64;
-
-        long xmxMb = roundUpTo(max / (1024 * 1024), 256);
-        if (xmxMb < 256) xmxMb = 256;
-
-        String gcFlag = xmxMb >= 4096 ? "-XX:+UseZGC" : "-XX:+UseG1GC";
-
-        return "-Xms" + xmsMb + "m" +
-               " -Xmx" + xmxMb + "m" +
-               " " + gcFlag +
-               " -XX:+UseStringDeduplication" +
-               " -XX:+UseCompactObjectHeaders" +
-               " -XX:+ExitOnOutOfMemoryError" +
-               " -XX:+HeapDumpOnOutOfMemoryError" +
-               " -XX:HeapDumpPath=/tmp";
-    }
-
-    private long roundUpTo(long value, long multiple) {
-        if (value <= 0) return multiple;
-        return ((value + multiple - 1) / multiple) * multiple;
-    }
 }
+

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/MemoryCalculatorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/MemoryCalculatorTests.java
@@ -1,0 +1,246 @@
+package io.github.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.bootui.autoconfigure.web.MemoryCalculator.JdkVersion;
+import io.github.bootui.core.BootUiDtos.MemoryCalculationDto;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the Paketo {@code libjvm}-style {@link MemoryCalculator}.
+ *
+ * <p>Verifies the partition formula, libjvm-equivalent constants, and the JDK
+ * version gating that controls {@code -XX:+UseCompactObjectHeaders}.
+ */
+class MemoryCalculatorTests {
+
+    private static final long MB = 1024L * 1024L;
+
+    private static final JdkVersion JDK_25 = () -> 25;
+    private static final JdkVersion JDK_24 = () -> 24;
+
+    @Test
+    void heapIsTotalMinusFixedRegionsAndHeadroom() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        MemoryCalculationDto result = calc.calculate(
+                1024 * MB,
+                250,
+                10_000,
+                0,
+                42,
+                10_000);
+
+        long expectedMetaspace = (long) Math.ceil(
+                (14_000_000L + 5_800L * 10_000L) * MemoryCalculator.META_SAFETY_FACTOR);
+        long expectedFixed = MemoryCalculator.DIRECT_MEMORY_BYTES
+                + expectedMetaspace
+                + MemoryCalculator.CODE_CACHE_BYTES
+                + MemoryCalculator.STACK_BYTES_PER_THREAD * 250L;
+        long expectedHeap = 1024 * MB - 0 - expectedFixed;
+
+        assertThat(result.valid()).isTrue();
+        assertThat(result.error()).isNull();
+        assertThat(result.totalMemoryBytes()).isEqualTo(1024 * MB);
+        assertThat(result.metaspaceBytes()).isEqualTo(expectedMetaspace);
+        assertThat(result.codeCacheBytes()).isEqualTo(MemoryCalculator.CODE_CACHE_BYTES);
+        assertThat(result.directMemoryBytes()).isEqualTo(MemoryCalculator.DIRECT_MEMORY_BYTES);
+        assertThat(result.stackBytesPerThread()).isEqualTo(MemoryCalculator.STACK_BYTES_PER_THREAD);
+        assertThat(result.stackBytesTotal()).isEqualTo(MemoryCalculator.STACK_BYTES_PER_THREAD * 250L);
+        assertThat(result.fixedRegionsBytes()).isEqualTo(expectedFixed);
+        assertThat(result.headRoomBytes()).isZero();
+        assertThat(result.heapBytes()).isEqualTo(expectedHeap);
+        assertThat(result.threadCount()).isEqualTo(250);
+        assertThat(result.loadedClasses()).isEqualTo(10_000);
+        assertThat(result.liveThreadCount()).isEqualTo(42);
+        assertThat(result.liveLoadedClassCount()).isEqualTo(10_000);
+    }
+
+    @Test
+    void metaspaceAppliesSafetyFactorOnLiveClassCount() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        MemoryCalculationDto a = calc.calculate(1024 * MB, 250, 0, 0, 1, 0);
+        long expectedBaseline = (long) Math.ceil(14_000_000L * MemoryCalculator.META_SAFETY_FACTOR);
+        assertThat(a.metaspaceBytes()).isEqualTo(expectedBaseline);
+
+        MemoryCalculationDto b = calc.calculate(1024 * MB, 250, 1_000, 0, 1, 1_000);
+        long expected1k = (long) Math.ceil(
+                (14_000_000L + 5_800L * 1_000L) * MemoryCalculator.META_SAFETY_FACTOR);
+        assertThat(b.metaspaceBytes()).isEqualTo(expected1k);
+    }
+
+    @Test
+    void headRoomReducesAvailableHeap() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        MemoryCalculationDto noHeadroom = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+        MemoryCalculationDto withHeadroom = calc.calculate(1024 * MB, 250, 5_000, 10, 1, 5_000);
+
+        long expectedHeadroom = (long) ((10 / 100.0) * (1024 * MB));
+        assertThat(withHeadroom.headRoomBytes()).isEqualTo(expectedHeadroom);
+        assertThat(withHeadroom.heapBytes()).isEqualTo(noHeadroom.heapBytes() - expectedHeadroom);
+        assertThat(withHeadroom.headRoomPercent()).isEqualTo(10);
+    }
+
+    @Test
+    void gcFlagFlipsToZgcAt4GiBHeap() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        MemoryCalculationDto small = calc.calculate(1024 * MB, 250, 1_000, 0, 1, 1_000);
+        MemoryCalculationDto large = calc.calculate(8L * 1024 * MB, 250, 1_000, 0, 1, 1_000);
+
+        assertThat(small.jvmOptions()).contains("-XX:+UseG1GC").doesNotContain("-XX:+UseZGC");
+        assertThat(large.jvmOptions()).contains("-XX:+UseZGC").doesNotContain("-XX:+UseG1GC");
+    }
+
+    @Test
+    void jvmOptionsSetXmsEqualToXmx() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+
+        long heapMb = Math.round(result.heapBytes() / (double) MB);
+        assertThat(result.jvmOptions())
+                .contains("-Xms" + heapMb + "m")
+                .contains("-Xmx" + heapMb + "m");
+    }
+
+    @Test
+    void jvmOptionsExpressStackInKilobytes() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+
+        assertThat(result.jvmOptions()).contains("-Xss1024k");
+    }
+
+    @Test
+    void jvmOptionsExpressFixedRegionsInMegabytes() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+
+        long metaMb = Math.round(result.metaspaceBytes() / (double) MB);
+        assertThat(result.jvmOptions())
+                .contains("-XX:ReservedCodeCacheSize=240m")
+                .contains("-XX:MaxDirectMemorySize=10m")
+                .contains("-XX:MaxMetaspaceSize=" + metaMb + "m");
+    }
+
+    @Test
+    void compactObjectHeadersOnlyOnJdk25OrNewer() {
+        MemoryCalculator on25 = new MemoryCalculator(JDK_25);
+        MemoryCalculator on24 = new MemoryCalculator(JDK_24);
+
+        MemoryCalculationDto result25 = on25.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+        MemoryCalculationDto result24 = on24.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+
+        assertThat(result25.jvmOptions()).contains("-XX:+UseCompactObjectHeaders");
+        assertThat(result24.jvmOptions()).doesNotContain("-XX:+UseCompactObjectHeaders");
+    }
+
+    @Test
+    void invalidWhenTotalMemoryLeavesNoRoomForHeap() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        MemoryCalculationDto result = calc.calculate(
+                256 * MB,
+                5_000,
+                100_000,
+                0,
+                10,
+                100_000);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.error()).isNotNull().contains("No room for heap");
+        assertThat(result.heapBytes()).isZero();
+        assertThat(result.jvmOptions()).isEmpty();
+    }
+
+    @Test
+    void clampsOutOfRangeInputs() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        MemoryCalculationDto result = calc.calculate(
+                -1,
+                -1,
+                -1,
+                -50,
+                10,
+                0);
+
+        assertThat(result.totalMemoryBytes()).isGreaterThanOrEqualTo(MemoryCalculator.MIN_TOTAL_MEMORY_BYTES);
+        assertThat(result.threadCount()).isGreaterThanOrEqualTo(MemoryCalculator.MIN_THREAD_COUNT);
+        assertThat(result.headRoomPercent()).isGreaterThanOrEqualTo(MemoryCalculator.MIN_HEAD_ROOM_PERCENT);
+        assertThat(result.loadedClasses()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    void clampsOversizedInputs() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        MemoryCalculationDto result = calc.calculate(
+                Long.MAX_VALUE,
+                Integer.MAX_VALUE,
+                10_000,
+                1_000,
+                10,
+                10_000);
+
+        assertThat(result.totalMemoryBytes()).isLessThanOrEqualTo(MemoryCalculator.MAX_TOTAL_MEMORY_BYTES);
+        assertThat(result.threadCount()).isLessThanOrEqualTo(MemoryCalculator.MAX_THREAD_COUNT);
+        assertThat(result.headRoomPercent()).isLessThanOrEqualTo(MemoryCalculator.MAX_HEAD_ROOM_PERCENT);
+    }
+
+    @Test
+    void defaultTotalMemoryIsClampedRegardlessOfHostFootprint() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        long onLargeMac = calc.defaultTotalMemoryBytes(
+                2L * 1024 * MB,
+                300L * MB,
+                40,
+                15_000);
+
+        long onTinyApp = calc.defaultTotalMemoryBytes(
+                32L * MB,
+                16L * MB,
+                10,
+                500);
+
+        assertThat(onLargeMac).isLessThanOrEqualTo(2048L * MB);
+        assertThat(onLargeMac).isGreaterThanOrEqualTo(384L * MB);
+        assertThat(onTinyApp).isGreaterThanOrEqualTo(384L * MB);
+        assertThat(onTinyApp).isLessThanOrEqualTo(2048L * MB);
+    }
+
+    @Test
+    void defaultTotalMemoryIsAlignedTo64MbBoundary() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+
+        long result = calc.defaultTotalMemoryBytes(
+                200L * MB,
+                100L * MB,
+                40,
+                10_000);
+
+        assertThat(result % (64L * MB)).isZero();
+    }
+
+    @Test
+    void defaultThreadCountFloorsAt250() {
+        assertThat(MemoryCalculator.defaultThreadCount(10)).isEqualTo(250);
+        assertThat(MemoryCalculator.defaultThreadCount(250)).isEqualTo(250);
+        assertThat(MemoryCalculator.defaultThreadCount(500)).isEqualTo(500);
+    }
+
+    @Test
+    void jvmOptionsAlwaysIncludeOomSafetyAndStringDeduplication() {
+        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+
+        assertThat(result.jvmOptions())
+                .contains("-XX:+UseStringDeduplication")
+                .contains("-XX:+ExitOnOutOfMemoryError")
+                .contains("-XX:+HeapDumpOnOutOfMemoryError")
+                .contains("-XX:HeapDumpPath=/tmp");
+    }
+}

--- a/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/bootui/core/BootUiDtos.java
@@ -351,7 +351,37 @@ public final class BootUiDtos {
             MemoryPoolDto nonHeap,
             List<MemoryPoolDto> pools,
             List<String> jvmInputArguments,
-            String suggestedJvmOptions) {
+            String suggestedJvmOptions,
+            MemoryCalculationDto calculation) {
+    }
+
+    /**
+     * Result of the Paketo-style memory calculator.
+     *
+     * <p>Computed by partitioning a target container memory budget into JVM regions:
+     * {@code heap = totalMemory − headRoom − directMemory − metaspace − codeCache − stack×threads}.
+     * Mirrors the formula in {@code paketo-buildpacks/libjvm/calc/calculator.go} with one
+     * adaptation: we use the live loaded-class count from {@link java.lang.management.ClassLoadingMXBean}
+     * with a safety factor instead of the buildpack's build-time JAR-entry estimate.
+     */
+    public record MemoryCalculationDto(
+            long totalMemoryBytes,
+            long heapBytes,
+            long metaspaceBytes,
+            long codeCacheBytes,
+            long directMemoryBytes,
+            long stackBytesPerThread,
+            long stackBytesTotal,
+            long headRoomBytes,
+            long fixedRegionsBytes,
+            int threadCount,
+            int loadedClasses,
+            int liveThreadCount,
+            int liveLoadedClassCount,
+            int headRoomPercent,
+            String jvmOptions,
+            boolean valid,
+            String error) {
     }
 
     /** A host/container port mapping exposed by a local development service. */

--- a/bootui-sample-app/e2e/tests/memory.spec.js
+++ b/bootui-sample-app/e2e/tests/memory.spec.js
@@ -40,4 +40,35 @@ test.describe('Memory view', () => {
     await expect(rows.first().locator('td').nth(0)).not.toBeEmpty()
     await expect(rows.first().locator('td').nth(4)).toContainText(/%/)
   })
+
+  test('editing total memory updates the recommended -Xmx', async ({ openView, page }) => {
+    await openView('memory', 'Memory')
+
+    const calculatorCard = page.locator('.card', { hasText: 'JVM memory calculator' })
+    await expect(calculatorCard).toBeVisible()
+
+    const totalInput = calculatorCard.locator('input[type="number"]').first()
+    await expect(totalInput).toBeVisible()
+    await expect(totalInput).not.toHaveValue('')
+
+    const optionsBlock = page.locator('.options-box code')
+    // Capture the current -Xmx value before editing
+    const before = await optionsBlock.innerText()
+    const beforeMatch = before.match(/-Xmx(\d+)m/)
+    expect(beforeMatch).not.toBeNull()
+    const beforeXmx = parseInt(beforeMatch[1], 10)
+
+    // Pick a clearly different total: jump by 256 MB up or down to dodge clamping.
+    const currentTotal = parseInt(await totalInput.inputValue(), 10)
+    const newTotal = currentTotal > 1024 ? 512 : currentTotal + 512
+    await totalInput.fill(String(newTotal))
+    await totalInput.blur()
+
+    // Debounced re-fetch is 300 ms; allow up to 5 s.
+    await expect.poll(async () => {
+      const text = await optionsBlock.innerText()
+      const m = text.match(/-Xmx(\d+)m/)
+      return m ? parseInt(m[1], 10) : 0
+    }, { timeout: 5_000 }).not.toBe(beforeXmx)
+  })
 })

--- a/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -290,6 +290,23 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(body.get("pools")).isInstanceOf(List.class);
         assertThat(body.get("jvmInputArguments")).isInstanceOf(List.class);
         assertThat(body.get("suggestedJvmOptions")).asString().contains("-Xms").contains("-Xmx");
+
+        Map<?, ?> calculation = (Map<?, ?>) body.get("calculation");
+        assertThat(calculation).isNotNull();
+        assertThat(calculation.get("valid")).isEqualTo(Boolean.TRUE);
+        assertThat(calculation.containsKey("totalMemoryBytes")).isTrue();
+        assertThat(calculation.containsKey("heapBytes")).isTrue();
+        assertThat(calculation.containsKey("metaspaceBytes")).isTrue();
+        assertThat(calculation.containsKey("codeCacheBytes")).isTrue();
+        assertThat(calculation.containsKey("directMemoryBytes")).isTrue();
+        assertThat(calculation.containsKey("stackBytesTotal")).isTrue();
+        assertThat(calculation.containsKey("headRoomBytes")).isTrue();
+        assertThat(calculation.containsKey("threadCount")).isTrue();
+        assertThat(calculation.containsKey("loadedClasses")).isTrue();
+        assertThat(calculation.get("jvmOptions")).asString()
+                .contains("-Xmx")
+                .contains("-XX:MaxMetaspaceSize=")
+                .contains("-XX:ReservedCodeCacheSize=");
     }
 
     @Test

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -1,26 +1,61 @@
 <script setup>
-import { ref, onMounted, onBeforeUnmount, computed } from 'vue'
+import { ref, onMounted, onBeforeUnmount, computed, watch } from 'vue'
 
 const data = ref(null)
 const error = ref(null)
 const lastUpdated = ref(null)
 const copied = ref(false)
 let timer = null
+let debounceHandle = null
+
+const totalMemoryMb = ref(null)
+const threadCount = ref(null)
+const headRoomPercent = ref(null)
+const inputsInitialized = ref(false)
+
+const MB = 1024 * 1024
+
+function bytesToMb(bytes) {
+  return Math.round(bytes / MB)
+}
+
+function buildQuery() {
+  if (!inputsInitialized.value) return ''
+  const parts = []
+  if (totalMemoryMb.value != null) parts.push('totalMemoryMb=' + totalMemoryMb.value)
+  if (threadCount.value != null) parts.push('threadCount=' + threadCount.value)
+  if (headRoomPercent.value != null) parts.push('headRoomPercent=' + headRoomPercent.value)
+  return parts.length ? '?' + parts.join('&') : ''
+}
 
 async function load() {
   try {
-    const res = await fetch('api/memory')
+    const res = await fetch('api/memory' + buildQuery())
     if (!res.ok) throw new Error('HTTP ' + res.status)
-    data.value = await res.json()
+    const payload = await res.json()
+    data.value = payload
     lastUpdated.value = new Date()
     error.value = null
+    if (!inputsInitialized.value && payload.calculation) {
+      totalMemoryMb.value = bytesToMb(payload.calculation.totalMemoryBytes)
+      threadCount.value = payload.calculation.threadCount
+      headRoomPercent.value = payload.calculation.headRoomPercent
+      inputsInitialized.value = true
+    }
   } catch (e) {
     error.value = e.message
   }
 }
 
+function scheduleReload() {
+  if (debounceHandle) clearTimeout(debounceHandle)
+  debounceHandle = setTimeout(() => {
+    load()
+  }, 300)
+}
+
 function formatBytes(bytes) {
-  if (bytes < 0) return 'N/A'
+  if (bytes == null || bytes < 0) return 'N/A'
   if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
   if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + ' MB'
   return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB'
@@ -44,7 +79,6 @@ async function copyOptions() {
     copied.value = true
     setTimeout(() => { copied.value = false }, 2000)
   } catch {
-    // fallback for older browsers
     const ta = document.createElement('textarea')
     ta.value = data.value.suggestedJvmOptions
     document.body.appendChild(ta)
@@ -56,6 +90,34 @@ async function copyOptions() {
   }
 }
 
+const breakdown = computed(() => {
+  const c = data.value?.calculation
+  if (!c) return []
+  const segments = [
+    { key: 'heap', label: 'Heap', bytes: c.heapBytes, color: '#198754' },
+    { key: 'metaspace', label: 'Metaspace', bytes: c.metaspaceBytes, color: '#0d6efd' },
+    { key: 'codeCache', label: 'Code cache', bytes: c.codeCacheBytes, color: '#6610f2' },
+    { key: 'directMemory', label: 'Direct', bytes: c.directMemoryBytes, color: '#fd7e14' },
+    { key: 'stacks', label: 'Thread stacks', bytes: c.stackBytesTotal, color: '#ffc107' },
+    { key: 'headroom', label: 'Headroom', bytes: c.headRoomBytes, color: '#6c757d' }
+  ]
+  const total = segments.reduce((sum, s) => sum + Math.max(0, s.bytes || 0), 0)
+  return segments.map(s => ({
+    ...s,
+    bytes: Math.max(0, s.bytes || 0),
+    percent: total > 0 ? (Math.max(0, s.bytes || 0) / total) * 100 : 0
+  }))
+})
+
+function stepTotal(delta) {
+  const next = Math.max(128, Math.min(8192, (totalMemoryMb.value || 0) + delta))
+  totalMemoryMb.value = next
+}
+
+watch([totalMemoryMb, threadCount, headRoomPercent], () => {
+  if (inputsInitialized.value) scheduleReload()
+})
+
 onMounted(() => {
   load()
   timer = setInterval(load, 5000)
@@ -63,6 +125,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   if (timer) clearInterval(timer)
+  if (debounceHandle) clearTimeout(debounceHandle)
 })
 </script>
 
@@ -78,20 +141,120 @@ onBeforeUnmount(() => {
     <div v-if="error" class="alert alert-danger">{{ error }}</div>
 
     <template v-if="data">
-      <!-- JVM Options Panel -->
+      <!-- Memory Calculator Panel -->
+      <div class="card mb-4 border-primary" v-if="data.calculation">
+        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+          <span><i class="bi bi-calculator me-2"></i>JVM memory calculator</span>
+          <small class="text-white-50">Plan a container memory limit</small>
+        </div>
+        <div class="card-body">
+          <p class="text-muted small mb-3">
+            Inspired by the Paketo <code>libjvm</code> memory calculator.
+            Heap is whatever is left after subtracting metaspace (sized from
+            currently loaded classes × 1.25 safety factor), code cache, direct
+            memory, thread stacks, and headroom from your target memory.
+          </p>
+
+          <div class="row g-3 mb-3">
+            <div class="col-md-5">
+              <label class="form-label small fw-semibold">Total container memory (MB)</label>
+              <div class="input-group input-group-sm">
+                <button type="button" class="btn btn-outline-secondary" @click="stepTotal(-64)" aria-label="Decrease">−</button>
+                <input
+                  type="number"
+                  class="form-control text-center"
+                  v-model.number="totalMemoryMb"
+                  min="128"
+                  max="8192"
+                  step="64"
+                />
+                <button type="button" class="btn btn-outline-secondary" @click="stepTotal(64)" aria-label="Increase">+</button>
+                <span class="input-group-text">MB</span>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label small fw-semibold">
+                Thread count
+                <span class="text-muted fw-normal">
+                  (currently {{ data.calculation.liveThreadCount }})
+                </span>
+              </label>
+              <input
+                type="number"
+                class="form-control form-control-sm"
+                v-model.number="threadCount"
+                min="1"
+                max="10000"
+                step="10"
+              />
+            </div>
+            <div class="col-md-3">
+              <label class="form-label small fw-semibold">Headroom (%)</label>
+              <input
+                type="number"
+                class="form-control form-control-sm"
+                v-model.number="headRoomPercent"
+                min="0"
+                max="30"
+                step="1"
+              />
+            </div>
+          </div>
+
+          <div v-if="!data.calculation.valid" class="alert alert-warning small mb-3">
+            <i class="bi bi-exclamation-triangle me-1"></i>{{ data.calculation.error }}
+          </div>
+
+          <template v-else>
+            <div class="progress breakdown-bar mb-2" style="height: 24px;" role="img" aria-label="Memory breakdown">
+              <div
+                v-for="seg in breakdown"
+                :key="seg.key"
+                class="progress-bar"
+                :style="{ width: seg.percent + '%', backgroundColor: seg.color }"
+                :title="seg.label + ': ' + formatBytes(seg.bytes)"
+              >
+                <span v-if="seg.percent >= 8" class="small">{{ seg.label }}</span>
+              </div>
+            </div>
+            <div class="d-flex flex-wrap gap-3 small mb-2">
+              <div v-for="seg in breakdown" :key="'leg-' + seg.key" class="d-flex align-items-center">
+                <span class="legend-swatch me-1" :style="{ backgroundColor: seg.color }"></span>
+                <span class="text-muted me-1">{{ seg.label }}:</span>
+                <span class="fw-semibold">{{ formatBytes(seg.bytes) }}</span>
+              </div>
+            </div>
+            <div class="small text-muted">
+              Currently {{ data.calculation.liveLoadedClassCount.toLocaleString() }} classes loaded ·
+              metaspace sized for {{ data.calculation.loadedClasses.toLocaleString() }} classes × 1.25 safety factor
+            </div>
+          </template>
+        </div>
+      </div>
+
+      <!-- Recommended JVM Options -->
       <div class="card mb-4 border-primary">
         <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
           <span><i class="bi bi-rocket-takeoff me-2"></i>Recommended JVM Options</span>
-          <button class="btn btn-sm btn-light" @click="copyOptions" :class="{ 'btn-success': copied }">
+          <button
+            class="btn btn-sm btn-light"
+            @click="copyOptions"
+            :class="{ 'btn-success': copied }"
+            :disabled="!data.calculation || !data.calculation.valid"
+          >
             <i :class="['bi', copied ? 'bi-check-lg' : 'bi-clipboard', 'me-1']"></i>
             {{ copied ? 'Copied!' : 'Copy' }}
           </button>
         </div>
         <div class="card-body">
           <p class="text-muted small mb-2">
-            Calculated from current heap usage. Tuned for Java 24+ (generational ZGC is the default; container support is built in).
+            Generated from your calculator inputs. <code>-Xms == -Xmx</code> for predictable container startup;
+            GC picked automatically (G1 below 4 GB, ZGC above).
           </p>
-          <pre class="bg-dark text-light rounded p-3 mb-0 options-box"><code>{{ data.suggestedJvmOptions }}</code></pre>
+          <pre
+            class="bg-dark text-light rounded p-3 mb-0 options-box"
+            :class="{ 'opacity-50': data.calculation && !data.calculation.valid }"
+          ><code>{{ data.suggestedJvmOptions || '—' }}</code></pre>
           <div class="mt-2">
             <span class="badge text-bg-secondary me-1"><i class="bi bi-shield-check me-1"></i>OOM protection</span>
             <span class="badge text-bg-secondary me-1"><i class="bi bi-gear me-1"></i>GC tuned</span>
@@ -239,4 +402,18 @@ onBeforeUnmount(() => {
   white-space: pre-wrap;
   word-break: break-all;
 }
+.breakdown-bar .progress-bar {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #fff;
+  font-weight: 500;
+}
+.legend-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
 </style>
+

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -357,14 +357,23 @@ Purpose: answer "How much heap/non-heap memory is this app using, and what JVM o
 
 Data sources:
 
-- Java management beans (`MemoryMXBean`, `MemoryPoolMXBean`, runtime input arguments).
+- Java management beans (`MemoryMXBean`, `MemoryPoolMXBean`, `ClassLoadingMXBean`, `ThreadMXBean`, runtime input arguments).
 
 Features:
 
 - Show heap and non-heap usage summaries.
 - Show memory pool usage.
 - Show JVM input arguments.
-- Suggest JVM options derived from current heap sizing, including `-Xms`, `-Xmx`, GC selection, container-support flags, and out-of-memory safeguards.
+- A Paketo `libjvm`-style memory calculator that partitions a user-chosen
+  target container memory into JVM regions
+  (`heap = total − headRoom − directMemory − metaspace − codeCache − stack×threads`),
+  using the live loaded-class count from `ClassLoadingMXBean` (with a 1.25× safety
+  factor) and a live-or-floored thread count, so the recommendation is independent
+  of the host machine's RAM rather than inheriting the JVM's `~25% of host RAM` heap-max default.
+- Suggest JVM options derived from the calculator output, including `-Xms`/`-Xmx`
+  (equal for predictable startup), `-XX:MaxMetaspaceSize`, `-XX:ReservedCodeCacheSize`,
+  `-XX:MaxDirectMemorySize`, `-Xss`, GC selection (G1 below 4 GB, ZGC above), and
+  out-of-memory safeguards.
 
 Acceptance criteria:
 


### PR DESCRIPTION
## What does this PR do?

Replaces the Memory panel's naive "round up current heap max" recommendation with a Paketo `libjvm`-style memory calculator that partitions a user-chosen total container memory into JVM regions.

## Why is this change needed?

The previous logic derived `-Xmx` from `MemoryMXBean.getHeapMemoryUsage().getMax()` rounded up to 256 MB. Without an explicit `-Xmx`, the JVM defaults that value to ~25% of host RAM — so a 32 GB Mac silently produced `-Xmx8192m`. That isn't a recommendation, it's the JVM's host-derived default leaking into the UI. The old calculation also ignored metaspace, code cache, direct memory, and thread stacks entirely, so it couldn't help a user pick a real container memory limit.

The Paketo `libjvm` calculator (referenced in the original feedback) solves exactly this problem in Go. This PR ports the same algorithm to Java and wires it into the panel.

## Approach

- **New `MemoryCalculator`** in `bootui-autoconfigure` implements `heap = total − headRoom − directMem − metaspace − codeCache − stack × threads`. Constants mirror libjvm exactly (10 MiB direct, 240 MiB code cache, 1 MiB stack, 250-thread floor, metaspace = `14_000_000 + 5_800 × classes`). Pure Java, no Spring deps, fully unit-tested.
- **BootUI improves on the buildpack** by reading the loaded-class count from `ClassLoadingMXBean` directly (so the buildpack's 0.35 `ClassLoadFactor` is not needed) and applying a **1.25× safety factor** on top to account for lazy class loading after the panel opens. The default thread count is `max(liveThreads, 250)` so a freshly-started small app doesn't under-reserve stack memory.
- **Default `totalMemoryMb`** is derived from the app's observed footprint and clamped to **384 MB – 2 GB**, so a 32 GB host no longer poisons the recommendation. On the sample app the default drops from 8192 MB to 1152 MB and the recommended `-Xmx` drops from `8192m` to `502m`.
- **API**: the existing `GET /bootui/api/memory` endpoint now accepts optional `totalMemoryMb`, `threadCount`, and `headRoomPercent` query parameters. Recomputation happens server-side so the live class/thread counts stay authoritative.
- **UI**: a new "JVM memory calculator" card with total / threads / headroom inputs, a stacked breakdown bar (heap | metaspace | code cache | direct | stacks | headroom), and a debounced re-fetch. The 5 s auto-refresh updates live JMX numbers without clobbering user-edited inputs.
- `Xms == Xmx` for predictable container startup, `UseCompactObjectHeaders` is gated to JDK 25+ (JEP 519 is rejected on earlier JDKs), and the GC flag flips from G1 to ZGC at the 4 GiB heap boundary.

## Notable trade-offs

- The calculator emits `-XX:MaxDirectMemorySize=10m` (matching libjvm). That is intentionally tight; NIO/Netty-heavy apps will want to raise it. Surfacing it as a UI input is a reasonable follow-up.
- The 1.25× metaspace safety factor was chosen as a forgiving-but-not-wasteful middle ground; the rubber-duck pass flagged the risk of capping metaspace at the live snapshot, so it would be useful to revisit this number once real apps run against the panel.

## How was it tested?

- [x] `mvn clean install` passes locally (25 integration tests + 15 new `MemoryCalculatorTests` green)
- [x] Started `bootui-sample-app` and verified `/bootui/api/memory` returns the expected breakdown for default inputs, custom inputs (`totalMemoryMb=512&threadCount=50&headRoomPercent=10`), the GC flip case (`totalMemoryMb=6144` → ZGC), and the impossible-input case (`totalMemoryMb=200` → `valid: false` with a clear error)
- [x] Added or updated tests: new `MemoryCalculatorTests` covers the formula, safety factor, validation, clamping, GC flip, JDK gating, and `Xms == Xmx`. Extended the sample-app integration test to assert the new `calculation` field shape. Extended `memory.spec.js` with a test that editing the total-memory input changes the recommended `-Xmx`.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (SPECIFICATION.md §5.9)
- [x] Public API kept backward compatible, or a migration note added: the existing `MemoryReport.suggestedJvmOptions` field is retained and now sourced from `calculation.jvmOptions`. The new `calculation` field is purely additive.
- [x] No secrets, tokens, or local paths committed