### PR TITLE
Fix sample app Docker Compose startup and data

### DIFF
--- a/bootui-sample-app/src/main/java/io/github/bootui/sample/BootUiSampleApplication.java
+++ b/bootui-sample-app/src/main/java/io/github/bootui/sample/BootUiSampleApplication.java
@@ -1,6 +1,10 @@
 package io.github.bootui.sample;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -16,7 +20,22 @@ import org.springframework.web.bind.annotation.RestController;
 public class BootUiSampleApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(BootUiSampleApplication.class, args);
+        SpringApplication application = new SpringApplication(BootUiSampleApplication.class);
+        composeFileDefault().ifPresent(composeFile -> application.setDefaultProperties(
+                Map.of("spring.docker.compose.file", composeFile.toString())));
+        application.run(args);
+    }
+
+    static Optional<Path> composeFileDefault() {
+        return composeFileDefault(Path.of("").toAbsolutePath());
+    }
+
+    static Optional<Path> composeFileDefault(Path workingDirectory) {
+        if (Files.isRegularFile(workingDirectory.resolve("compose.yaml"))) {
+            return Optional.empty();
+        }
+        Path moduleComposeFile = workingDirectory.resolve(Path.of("bootui-sample-app", "compose.yaml"));
+        return Files.isRegularFile(moduleComposeFile) ? Optional.of(moduleComposeFile) : Optional.empty();
     }
 
     @ConfigurationProperties(prefix = "sample")

--- a/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/bootui/sample/BootUiSampleApplicationTests.java
@@ -1,0 +1,34 @@
+package io.github.bootui.sample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BootUiSampleApplicationTests {
+
+    @Test
+    void leavesDockerComposeDiscoveryAloneWhenRunningFromSampleModule(@TempDir Path workingDirectory)
+            throws Exception {
+        Files.createFile(workingDirectory.resolve("compose.yaml"));
+
+        assertThat(BootUiSampleApplication.composeFileDefault(workingDirectory)).isEmpty();
+    }
+
+    @Test
+    void pointsDockerComposeToSampleModuleWhenRunningFromRepositoryRoot(@TempDir Path workingDirectory)
+            throws Exception {
+        Path composeFile = Files.createDirectories(workingDirectory.resolve("bootui-sample-app"))
+                .resolve("compose.yaml");
+        Files.createFile(composeFile);
+
+        assertThat(BootUiSampleApplication.composeFileDefault(workingDirectory)).contains(composeFile);
+    }
+
+    @Test
+    void leavesDockerComposeDiscoveryAloneWhenNoSampleComposeFileExists(@TempDir Path workingDirectory) {
+        assertThat(BootUiSampleApplication.composeFileDefault(workingDirectory)).isEmpty();
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes sample app startup when launched from the repository root by defaulting Spring Boot Docker Compose to `bootui-sample-app/compose.yaml` when no compose file exists in the current working directory. It also moves sample product seeding to Spring Boot's default `data.sql` initialization so the Docker Compose PostgreSQL database is populated on startup.

## Why is this change needed?

The sample app includes its Docker Compose file inside the sample module, but Spring Boot searches the application working directory by default. Launching the sample app from the repository root could fail with `No Docker Compose file found` even though the module has a valid compose file.

After switching the sample app to PostgreSQL, sample product data also needs to be initialized through the standard Spring Boot SQL initializer instead of a custom runner.

N/A

## How was it tested?

- [ ] `mvn clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
