### PR TITLE
Expose BootUI Actuator defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ BootUI is intended for local development only. By default it:
 - activates in `AUTO` mode only for `dev` / `local` profiles or DevTools
 - rejects non-loopback requests
 - masks secret-like configuration values
+- exposes the local Actuator endpoints used by BootUI panels when BootUI is active
 - disables itself for `prod` / `production` profiles
 - stores runtime configuration overrides in `.bootui/application-bootui.properties`, not in your source config files
 

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
@@ -1,0 +1,46 @@
+package io.github.bootui.autoconfigure.config;
+
+import io.github.bootui.autoconfigure.BootUiActivationCondition;
+import java.util.Map;
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+
+/**
+ * Contributes the Actuator endpoint exposure defaults BootUI needs for its
+ * local developer panels.
+ */
+public class BootUiActuatorDefaultsEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+    public static final int ORDER = BootUiOverridesEnvironmentPostProcessor.ORDER + 5;
+
+    static final String PROPERTY_SOURCE_NAME = "bootUiActuatorEndpointDefaults";
+
+    static final String REQUIRED_ENDPOINTS = "health,info,beans,conditions,configprops,env,loggers,mappings,"
+            + "metrics,startup,scheduledtasks";
+
+    private static final Map<String, Object> DEFAULTS = Map.of(
+            "management.endpoints.web.exposure.include", REQUIRED_ENDPOINTS,
+            "management.endpoint.health.show-details", "always");
+
+    @Override
+    public int getOrder() {
+        return ORDER;
+    }
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        if (!BootUiActivationCondition.resolve(environment, application.getClassLoader()).enabled()) {
+            return;
+        }
+
+        MutablePropertySources sources = environment.getPropertySources();
+        if (sources.contains(PROPERTY_SOURCE_NAME)) {
+            sources.remove(PROPERTY_SOURCE_NAME);
+        }
+        sources.addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, DEFAULTS));
+    }
+}

--- a/bootui-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/bootui-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,4 @@
 org.springframework.boot.EnvironmentPostProcessor=\
 io.github.bootui.autoconfigure.config.BootUiOverridesEnvironmentPostProcessor,\
+io.github.bootui.autoconfigure.config.BootUiActuatorDefaultsEnvironmentPostProcessor,\
 io.github.bootui.autoconfigure.config.BootUiStartupEnvironmentPostProcessor

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
@@ -1,0 +1,55 @@
+package io.github.bootui.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.mock.env.MockEnvironment;
+
+class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
+
+    private final BootUiActuatorDefaultsEnvironmentPostProcessor processor =
+            new BootUiActuatorDefaultsEnvironmentPostProcessor();
+
+    @Test
+    void contributesActuatorDefaultsWhenBootUiIsEnabled() {
+        MockEnvironment env = new MockEnvironment()
+                .withProperty("bootui.enabled", "ON");
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getProperty("management.endpoints.web.exposure.include"))
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.REQUIRED_ENDPOINTS);
+        assertThat(env.getProperty("management.endpoint.health.show-details")).isEqualTo("always");
+    }
+
+    @Test
+    void keepsUserConfiguredActuatorExposure() {
+        MockEnvironment env = new MockEnvironment()
+                .withProperty("bootui.enabled", "ON")
+                .withProperty("management.endpoints.web.exposure.include", "health,info")
+                .withProperty("management.endpoint.health.show-details", "never");
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getProperty("management.endpoints.web.exposure.include")).isEqualTo("health,info");
+        assertThat(env.getProperty("management.endpoint.health.show-details")).isEqualTo("never");
+    }
+
+    @Test
+    void doesNotContributeDefaultsWhenBootUiIsDisabled() {
+        MockEnvironment env = new MockEnvironment();
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getPropertySources()
+                .contains(BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME)).isFalse();
+    }
+
+    @Test
+    void orderIsBetweenOverridesAndStartupProcessors() {
+        assertThat(processor.getOrder())
+                .isGreaterThan(BootUiOverridesEnvironmentPostProcessor.ORDER)
+                .isLessThan(BootUiStartupEnvironmentPostProcessor.ORDER);
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -75,6 +75,8 @@ Default activation rules:
 
 `bootui.enabled=AUTO` is the default. BootUI must fail closed: if no enabled profile is active and DevTools is not on the classpath, it should not expose the UI.
 
+When BootUI is active, the starter should contribute low-precedence Actuator defaults for the local panels, including `beans`, `conditions`, `configprops`, `env`, `loggers`, `mappings`, `metrics`, `startup`, and `scheduledtasks`. Host applications can override those `management.*` settings explicitly.
+
 ### 4.2 URL
 
 Default UI URL inside the host Spring Boot 4 application:


### PR DESCRIPTION
BootUI panels depend on local Actuator endpoint beans, but host apps only expose the default Actuator web endpoints unless they add their own `management.*` configuration. That made panels like beans, conditions, mappings, metrics, and startup appear empty after installing the starter.

This adds a BootUI environment post-processor that contributes low-precedence Actuator defaults when BootUI is active. It exposes the endpoints used by BootUI panels and enables health details, while preserving any explicit host application `management.*` settings.

Tests cover default contribution, user override precedence, disabled BootUI behavior, and processor ordering. The README and specification now document that BootUI provides these local Actuator defaults.