### PR TITLE
Harden BootUI alpha release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         java: ['25']
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ BootUI is served by the host application at `/bootui/` and uses internal `/bootu
 <dependency>
   <groupId>io.github.bootui</groupId>
   <artifactId>bootui-spring-boot-starter</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.0-alpha.1</version>
 </dependency>
 ```
 
@@ -63,11 +63,12 @@ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 BootUI also activates automatically when `spring-boot-devtools` is on the classpath. To force it on or off:
 
 ```properties
+bootui.enabled=AUTO
 bootui.enabled=ON
 bootui.enabled=OFF
 ```
 
-`prod` and `production` profiles disable BootUI unless `bootui.enabled=ON` is set.
+`prod` and `production` profiles disable BootUI unless `bootui.enabled=ON` is set. Invalid `bootui.enabled` values fail closed and keep BootUI disabled.
 
 ### 4) Open BootUI
 
@@ -118,7 +119,7 @@ Common properties:
 | `bootui.enabled-profiles` | `dev,local` | Profiles that activate BootUI in auto mode. |
 | `bootui.disabled-profiles` | `prod,production` | Profiles that disable BootUI unless forced on. |
 | `bootui.allow-non-localhost` | `false` | Explicit opt-out of loopback-only protection. |
-| `bootui.expose-values` | `MASKED` | `MASKED`, `METADATA_ONLY`, or `FULL`. |
+| `bootui.expose-values` | `MASKED` | `MASKED`, `METADATA_ONLY`, or `FULL`; `FULL` can disclose secrets and should stay local. |
 | `bootui.overrides-file` | `.bootui/application-bootui.properties` | Runtime override persistence file. |
 | `bootui.dev-services.restart-enabled` | `false` | Enables restart controls for bean-backed Testcontainers services. Disabled by default. |
 | `bootui.dev-services.log-tail-bytes` | `65536` | Maximum bytes returned by one Dev Services log request. |
@@ -149,6 +150,37 @@ Current visible panels:
 | Security | Spring Security filter chains and best-effort endpoint rules. |
 
 Some panels depend on optional Spring or Actuator infrastructure. When data is unavailable, BootUI returns stable empty responses or shows an explanatory empty state.
+
+## Runtime overrides
+
+The Configuration panel can create, update, and delete local runtime overrides. Overrides are stored in `.bootui/application-bootui.properties` by default, are loaded at high precedence on the next startup, and never modify your application source configuration. Already-bound `@ConfigurationProperties` beans may keep their previous value until the app restarts; BootUI returns that warning with every override mutation.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| `/bootui` returns 404 | Use the `dev` or `local` profile, add DevTools, or set `bootui.enabled=ON`. |
+| BootUI is disabled in `prod` | This is intentional; only `bootui.enabled=ON` can force activation with a disabled profile. |
+| Browser is rejected | BootUI accepts loopback callers by default. Use `bootui.allow-non-localhost=true` only for a trusted local network. |
+| A panel is empty | Enable the relevant Actuator endpoint or optional Spring module; BootUI degrades to stable empty DTOs when data is unavailable. |
+| Startup Timeline is empty | Configure `BufferingApplicationStartup` in the host app. |
+| Secrets are hidden | Default exposure is `MASKED`; use `METADATA_ONLY` to hide all values or `FULL` only in trusted local sessions. |
+
+## Release notes: 0.1.0-alpha.1
+
+`0.1.0-alpha.1` is scoped to harden every visible panel as supported alpha functionality: Overview, Beans, Conditions, Configuration, Mappings, Health, Loggers, Data, Startup Timeline, Memory, Metrics, DevTools, Dev Services, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, and Security.
+
+The alpha targets Java 25 and Spring Boot 4.x only, publishes Maven artifacts for the starter modules, and keeps the sample app as a local validation/demo module.
+
+## Publishing
+
+Maven Central publication uses the `release` Maven profile:
+
+```bash
+mvn -B -ntp -Prelease clean deploy
+```
+
+The release profile attaches source and Javadoc JARs, signs artifacts with GPG, and stages through the Sonatype Central Publishing plugin using the `central` server from `~/.m2/settings.xml`. The sample app is not deployed.
 
 ## Testing
 

--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-alpha.1</version>
     </parent>
 
     <artifactId>bootui-autoconfigure</artifactId>

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiActivationCondition.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/BootUiActivationCondition.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.env.Environment;
@@ -35,12 +36,18 @@ public class BootUiActivationCondition implements Condition {
     }
 
     public static BootUiActivation resolve(Environment environment, ClassLoader classLoader) {
-        String mode = environment.getProperty("bootui.enabled", "AUTO").toUpperCase();
+        String mode = environment.getProperty("bootui.enabled", "AUTO").trim().toUpperCase(Locale.ROOT);
         List<String> warnings = new ArrayList<>();
         Collection<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
 
         List<String> disabledProfiles = listProperty(environment, "bootui.disabled-profiles", List.of("prod", "production"));
         List<String> enabledProfiles = listProperty(environment, "bootui.enabled-profiles", List.of("dev", "local"));
+
+        if (!List.of("AUTO", "ON", "OFF").contains(mode)) {
+            return new BootUiActivation(false,
+                    "Disabled: invalid bootui.enabled value '" + mode + "'",
+                    warnings);
+        }
 
         for (String profile : disabledProfiles) {
             if (activeProfiles.contains(profile)) {

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/config/ConfigOverrideService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/config/ConfigOverrideService.java
@@ -1,6 +1,7 @@
 package io.github.bootui.autoconfigure.config;
 
 import io.github.bootui.autoconfigure.BootUiProperties;
+import io.github.bootui.autoconfigure.BootUiProperties.ValueExposure;
 import io.github.bootui.core.BootUiDtos.ConfigOverrideResult;
 import io.github.bootui.core.SecretMasker;
 import java.nio.file.Path;
@@ -100,7 +101,12 @@ public class ConfigOverrideService {
     }
 
     private String displayValue(String name, Object value) {
-        if (properties.isMaskSecrets() && masker.isSecret(name)) {
+        if (properties.getExposeValues() == ValueExposure.METADATA_ONLY) {
+            return null;
+        }
+        if (properties.getExposeValues() == ValueExposure.MASKED
+                && properties.isMaskSecrets()
+                && masker.isSecret(name)) {
             return SecretMasker.MASKED_VALUE;
         }
         return value == null ? null : String.valueOf(value);

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ConfigController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ConfigController.java
@@ -107,7 +107,9 @@ public class ConfigController {
         boolean masked = false;
         if (properties.getExposeValues() == ValueExposure.METADATA_ONLY) {
             displayValue = null;
-        } else if (properties.isMaskSecrets() && masker.isSecret(name)) {
+        } else if (properties.getExposeValues() == ValueExposure.MASKED
+                && properties.isMaskSecrets()
+                && masker.isSecret(name)) {
             displayValue = SecretMasker.MASKED_VALUE;
             masked = true;
         }

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DevServicesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/DevServicesController.java
@@ -317,7 +317,9 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         if (properties.getExposeValues() == ValueExposure.METADATA_ONLY) {
             return null;
         }
-        if (value == null || !properties.isMaskSecrets()) {
+        if (value == null
+                || properties.getExposeValues() == ValueExposure.FULL
+                || !properties.isMaskSecrets()) {
             return value;
         }
         if (masker.isSecret(key)) {

--- a/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ProfileController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/bootui/autoconfigure/web/ProfileController.java
@@ -58,8 +58,8 @@ public class ProfileController {
             for (String key : enumerable.getPropertyNames()) {
                 Object rawValue = enumerable.getProperty(key);
                 String strValue = rawValue == null ? null : rawValue.toString();
-                boolean masked = masker.isSecret(key);
-                String displayValue = masked ? SecretMasker.MASKED_VALUE : displayValue(strValue);
+            boolean masked = shouldMask(key);
+            String displayValue = displayValue(key, strValue);
                 props.add(new ConfigPropertyDto(key, displayValue, source.getName(), null, masked, false, null, null));
             }
             props.sort(Comparator.comparing(ConfigPropertyDto::name, Comparator.nullsLast(String::compareTo)));
@@ -79,12 +79,21 @@ public class ProfileController {
         return matcher.find() ? matcher.group(1) : null;
     }
 
-    private String displayValue(String value) {
+    private boolean shouldMask(String key) {
+        return properties.getExposeValues() == ValueExposure.MASKED
+                && properties.isMaskSecrets()
+                && masker.isSecret(key);
+    }
+
+    private String displayValue(String key, String value) {
         if (value == null) {
             return null;
         }
         if (properties.getExposeValues() == ValueExposure.METADATA_ONLY) {
             return null;
+        }
+        if (shouldMask(key)) {
+            return SecretMasker.MASKED_VALUE;
         }
         return value;
     }

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/BootUiActivationConditionTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/BootUiActivationConditionTests.java
@@ -2,7 +2,12 @@ package io.github.bootui.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.tools.ToolProvider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.mock.env.MockEnvironment;
 
 class BootUiActivationConditionTests {
@@ -68,9 +73,21 @@ class BootUiActivationConditionTests {
     }
 
     @Test
+    void invalidEnabledModeFailsClosedEvenWithEnabledProfile() {
+        MockEnvironment env = new MockEnvironment();
+        env.setActiveProfiles("dev");
+        env.setProperty("bootui.enabled", "maybe");
+
+        BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
+
+        assertThat(activation.enabled()).isFalse();
+        assertThat(activation.reason()).contains("invalid bootui.enabled");
+    }
+
+    @Test
     void modeIsCaseInsensitive() {
         MockEnvironment env = new MockEnvironment();
-        env.setProperty("bootui.enabled", "on");
+        env.setProperty("bootui.enabled", " on ");
 
         BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
 
@@ -90,6 +107,18 @@ class BootUiActivationConditionTests {
     }
 
     @Test
+    void customDisabledProfilesAreHonored() {
+        MockEnvironment env = new MockEnvironment();
+        env.setActiveProfiles("sandbox");
+        env.setProperty("bootui.disabled-profiles", "sandbox");
+
+        BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
+
+        assertThat(activation.enabled()).isFalse();
+        assertThat(activation.reason()).contains("sandbox");
+    }
+
+    @Test
     void blankEnabledProfilesPropertyFallsBackToDefaults() {
         MockEnvironment env = new MockEnvironment();
         env.setActiveProfiles("local");
@@ -99,5 +128,27 @@ class BootUiActivationConditionTests {
 
         assertThat(activation.enabled()).isTrue();
         assertThat(activation.reason()).contains("local");
+    }
+
+    @Test
+    void autoEnablesWhenDevtoolsIsPresent(@TempDir Path tempDir) throws Exception {
+        Path source = tempDir.resolve("org/springframework/boot/devtools/restart/RestartScope.java");
+        Files.createDirectories(source.getParent());
+        Files.writeString(source, """
+                package org.springframework.boot.devtools.restart;
+
+                public class RestartScope {
+                }
+                """);
+        int result = ToolProvider.getSystemJavaCompiler()
+                .run(null, null, null, "-d", tempDir.toString(), source.toString());
+        assertThat(result).isZero();
+
+        try (URLClassLoader devtoolsClassLoader = new URLClassLoader(new java.net.URL[] { tempDir.toUri().toURL() }, null)) {
+            BootUiActivation activation = BootUiActivationCondition.resolve(new MockEnvironment(), devtoolsClassLoader);
+
+            assertThat(activation.enabled()).isTrue();
+            assertThat(activation.reason()).contains("devtools");
+        }
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -12,6 +12,7 @@ import io.github.bootui.autoconfigure.web.LogTailController;
 import io.github.bootui.autoconfigure.web.OverviewController;
 import io.github.bootui.autoconfigure.web.ScheduledController;
 import io.github.bootui.autoconfigure.web.SecurityController;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
@@ -73,6 +74,34 @@ class BootUiAutoConfigurationTests {
     }
 
     @Test
+    void invalidEnabledValueFailsClosed() {
+        runner.withPropertyValues("spring.profiles.active=dev", "bootui.enabled=maybe")
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiAutoConfiguration.class));
+    }
+
+    @Test
+    void bindsDefaultProperties() {
+        runner.withPropertyValues("bootui.enabled=ON")
+                .run(context -> {
+                    BootUiProperties properties = context.getBean(BootUiProperties.class);
+                    assertThat(properties.getEnabled()).isEqualTo(BootUiProperties.Mode.ON);
+                    assertThat(properties.getPath()).isEqualTo("/bootui");
+                    assertThat(properties.getApiPath()).isEqualTo("/bootui/api");
+                    assertThat(properties.isLocalhostOnly()).isTrue();
+                    assertThat(properties.isAllowNonLocalhost()).isFalse();
+                    assertThat(properties.isMaskSecrets()).isTrue();
+                    assertThat(properties.getExposeValues()).isEqualTo(BootUiProperties.ValueExposure.MASKED);
+                    assertThat(properties.isShowBanner()).isTrue();
+                    assertThat(properties.getEnabledProfiles()).containsExactly("dev", "local");
+                    assertThat(properties.getDisabledProfiles()).containsExactly("prod", "production");
+                    assertThat(properties.getOverridesFile()).isEqualTo(".bootui/application-bootui.properties");
+                    assertThat(properties.getEndpointTimeout()).isEqualTo(Duration.ofSeconds(5));
+                    assertThat(properties.getDevServices().isRestartEnabled()).isFalse();
+                    assertThat(properties.getDevServices().getLogTailBytes()).isEqualTo(64 * 1024);
+                });
+    }
+
+    @Test
     void bindsCustomProperties() {
         runner.withPropertyValues(
                         "bootui.enabled=ON",
@@ -80,6 +109,8 @@ class BootUiAutoConfigurationTests {
                         "bootui.api-path=/admin/api",
                         "bootui.mask-secrets=false",
                         "bootui.expose-values=FULL",
+                        "bootui.overrides-file=/tmp/bootui.properties",
+                        "bootui.endpoint-timeout=2s",
                         "bootui.dev-services.restart-enabled=true",
                         "bootui.dev-services.log-tail-bytes=2048")
                 .run(context -> {
@@ -89,6 +120,8 @@ class BootUiAutoConfigurationTests {
                     assertThat(properties.isMaskSecrets()).isFalse();
                     assertThat(properties.getExposeValues())
                             .isEqualTo(BootUiProperties.ValueExposure.FULL);
+                    assertThat(properties.getOverridesFile()).isEqualTo("/tmp/bootui.properties");
+                    assertThat(properties.getEndpointTimeout()).isEqualTo(Duration.ofSeconds(2));
                     assertThat(properties.getDevServices().isRestartEnabled()).isTrue();
                     assertThat(properties.getDevServices().getLogTailBytes()).isEqualTo(2048);
                 });

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/config/ConfigOverrideServiceTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/config/ConfigOverrideServiceTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.bootui.autoconfigure.BootUiProperties;
+import io.github.bootui.autoconfigure.BootUiProperties.ValueExposure;
 import io.github.bootui.core.BootUiDtos.ConfigOverrideResult;
 import io.github.bootui.core.SecretMasker;
 import java.nio.file.Files;
@@ -69,6 +70,24 @@ class ConfigOverrideServiceTests {
     @Test
     void putDoesNotMaskWhenMaskingDisabled() {
         properties.setMaskSecrets(false);
+
+        ConfigOverrideResult result = service.put("api.token", "abc");
+
+        assertThat(result.value()).isEqualTo("abc");
+    }
+
+    @Test
+    void putHidesValuesUnderMetadataOnlyExposure() {
+        properties.setExposeValues(ValueExposure.METADATA_ONLY);
+
+        ConfigOverrideResult result = service.put("server.port", "9090");
+
+        assertThat(result.value()).isNull();
+    }
+
+    @Test
+    void putExposesSecretValuesUnderFullExposure() {
+        properties.setExposeValues(ValueExposure.FULL);
 
         ConfigOverrideResult result = service.put("api.token", "abc");
 

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/ConfigControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/ConfigControllerTests.java
@@ -80,6 +80,18 @@ class ConfigControllerTests {
     }
 
     @Test
+    void listExposesSecretValuesUnderFullExposure() throws Exception {
+        properties.setExposeValues(ValueExposure.FULL);
+
+        mvc.perform(get("/bootui/api/config"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].value")
+                        .value("s3cret"));
+    }
+
+    @Test
     void postCreatesOverrideAndDeleteRemovesIt() throws Exception {
         // First write to establish a previous override value.
         mvc.perform(post("/bootui/api/config/overrides")
@@ -88,7 +100,8 @@ class ConfigControllerTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("server.port"))
                 .andExpect(jsonPath("$.value").value("9090"))
-                .andExpect(jsonPath("$.persisted").value(true));
+                .andExpect(jsonPath("$.persisted").value(true))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("until restart")));
 
         // Second write should report the previous override value.
         mvc.perform(post("/bootui/api/config/overrides")

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/DevServicesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/DevServicesControllerTests.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 import io.github.bootui.autoconfigure.BootUiProperties;
+import io.github.bootui.autoconfigure.BootUiProperties.ValueExposure;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
 import org.springframework.context.support.GenericApplicationContext;
@@ -44,6 +45,24 @@ class DevServicesControllerTests {
                 .andExpect(jsonPath("$.services[0].connectionDetails.jdbcUrl")
                         .value("jdbc:postgresql://******@localhost:5432/app"))
                 .andExpect(jsonPath("$.services[0].connectionDetails.password").value("******"));
+
+        context.close();
+    }
+
+    @Test
+    void listExposesConnectionDetailsUnderFullExposure() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        properties.setExposeValues(ValueExposure.FULL);
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean("postgresConnectionDetails", SampleConnectionDetails.class);
+        context.refresh();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, properties)).build();
+
+        mvc.perform(get("/bootui/api/dev-services"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.services[0].connectionDetails.jdbcUrl")
+                        .value("jdbc:postgresql://dbuser:secret@localhost:5432/app"))
+                .andExpect(jsonPath("$.services[0].connectionDetails.password").value("secret"));
 
         context.close();
     }

--- a/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/ProfileControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/bootui/autoconfigure/web/ProfileControllerTests.java
@@ -1,0 +1,70 @@
+package io.github.bootui.autoconfigure.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.bootui.autoconfigure.BootUiProperties;
+import io.github.bootui.autoconfigure.BootUiProperties.ValueExposure;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.web.servlet.MockMvc;
+
+class ProfileControllerTests {
+
+    private BootUiProperties properties;
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("dev");
+        environment.getPropertySources().addFirst(new MapPropertySource(
+                "application-dev.properties",
+                Map.of(
+                        "sample.name", "demo",
+                        "sample.password", "secret")));
+        properties = new BootUiProperties();
+        mvc = standaloneSetup(new ProfileController(environment, properties)).build();
+    }
+
+    @Test
+    void profilesMaskSecretValuesByDefault() throws Exception {
+        mvc.perform(get("/bootui/api/profiles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeProfiles[0]").value("dev"))
+                .andExpect(jsonPath("$.profileSources[0].profile").value("dev"))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
+                        .value(true))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].value")
+                        .value("******"));
+    }
+
+    @Test
+    void profilesHideValuesUnderMetadataOnlyExposure() throws Exception {
+        properties.setExposeValues(ValueExposure.METADATA_ONLY);
+
+        mvc.perform(get("/bootui/api/profiles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.name')].value[0]")
+                        .doesNotExist())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
+                        .value(false));
+    }
+
+    @Test
+    void profilesExposeSecretValuesUnderFullExposure() throws Exception {
+        properties.setExposeValues(ValueExposure.FULL);
+
+        mvc.perform(get("/bootui/api/profiles"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].value")
+                        .value("secret"));
+    }
+}

--- a/bootui-core/pom.xml
+++ b/bootui-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-alpha.1</version>
     </parent>
 
     <artifactId>bootui-core</artifactId>

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -7,12 +7,16 @@
     <parent>
         <groupId>io.github.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-alpha.1</version>
     </parent>
 
     <artifactId>bootui-sample-app</artifactId>
     <name>BootUI :: Sample App</name>
     <description>Reference Spring Boot 4 application that demonstrates the BootUI developer console.</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/bootui-spring-boot-starter/pom.xml
+++ b/bootui-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-alpha.1</version>
     </parent>
 
     <artifactId>bootui-spring-boot-starter</artifactId>
@@ -33,4 +33,45 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-empty-javadocs</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/empty-javadocs"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-empty-javadocs</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${project.build.directory}/empty-javadocs</classesDirectory>
+                            <skipIfEmpty>false</skipIfEmpty>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/bootui-ui/pom.xml
+++ b/bootui-ui/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-alpha.1</version>
     </parent>
 
     <artifactId>bootui-ui</artifactId>
@@ -85,6 +85,42 @@
                                     <filtering>false</filtering>
                                 </resource>
                             </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-empty-javadocs</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${project.build.directory}/empty-javadocs"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-empty-javadocs</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>javadoc</classifier>
+                            <classesDirectory>${project.build.directory}/empty-javadocs</classesDirectory>
+                            <skipIfEmpty>false</skipIfEmpty>
                         </configuration>
                     </execution>
                 </executions>

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -166,10 +166,10 @@ Reconcile the specification with the implementation where behavior has become mo
 - Runtime config overrides are persisted to a BootUI overrides file by default, while older specification text says overrides disappear on restart.
 - The frontend is currently plain JavaScript Vue 3, not TypeScript/Vitest.
 - Startup Timeline, Memory, Spring Data, HTTP Probe, Profile Diff, Log Tail, Scheduled Tasks, Security, Metrics, DevTools, and Dev Services are implemented and should be moved out of future-only language.
-- Dev Services / Docker Compose / Testcontainers is implemented as a best-effort experimental panel.
+- Dev Services / Docker Compose / Testcontainers is implemented and included in the harden-all-visible-panels alpha scope.
   Docker Compose entries are startup snapshots; bean-backed Testcontainers services can expose bounded logs,
   and restart is disabled unless `bootui.dev-services.restart-enabled=true`.
-- Maven Central publishing scope for `0.1.0-alpha.1` still needs a release decision.
+- Maven Central publishing is required for `0.1.0-alpha.1`; the release profile signs and stages artifacts through the Sonatype Central Publishing plugin.
 
 ### 4.4 Validate release readiness
 
@@ -200,15 +200,15 @@ Manual smoke checks:
 
 ## 5. Next release scope
 
-The codebase currently contains more than the original v0.1 MVP. The next release should use one of these release strategies:
+The codebase currently contains more than the original v0.1 MVP. The next release uses this release strategy:
 
 | Strategy | Scope | Trade-off |
 |---|---|---|
-| Harden all visible panels | Ship every current route as supported alpha functionality. | More documentation and test work before release. |
+| Harden all visible panels | Ship every current route as supported alpha functionality. | Selected for `0.1.0-alpha.1`; requires focused backend tests, docs, and release validation. |
 | Mark newer panels experimental | Keep all routes visible but clearly label Data, Startup, Memory, Scheduled, HTTP Probe, Log Tail, Profile Diff, and Security as experimental. | Faster release, but docs must set expectations. |
 | Hide unfinished panels | Only expose the original MVP routes plus any fully hardened additions. | Safest alpha surface, but requires UI gating work. |
 
-Recommended alpha stance: **mark newer panels experimental unless they receive focused tests and documentation before release**.
+Selected alpha stance: **harden all visible panels**.
 
 Included in the original MVP surface:
 
@@ -347,11 +347,10 @@ Reason:
 
 ## 9. Suggested next steps
 
-1. Decide the next release strategy for the already-visible post-MVP panels: harden, mark experimental, or hide.
-2. Decide whether publishing to Maven Central is required for `0.1.0-alpha.1`.
+1. Finish focused backend tests for the harden-all-visible-panels scope.
+2. Verify Maven Central publishing prerequisites: `central` server credentials, GPG signing key, and release-profile deploy configuration.
 3. Prepare release notes and tag the first alpha only after CI and manual smoke checks pass.
-4. Review whether experimental panels need UI labeling or route gating before the alpha.
-5. Re-run the full build and Playwright suite after any final release-scope changes.
+4. Re-run the full build and Playwright suite after any final release-scope changes.
 
 ## 10. Validation checklist
 
@@ -367,7 +366,7 @@ Before considering the next alpha complete:
 - Runtime config overrides persist through the BootUI overrides file and warn about restart/rebind caveats.
 - Logger changes work.
 - DevTools controls show unavailable states when Spring Boot DevTools is absent.
-- Newer diagnostic panels either have release-grade coverage/docs or are clearly marked experimental/hidden.
+- Newer diagnostic panels have release-grade coverage/docs for the alpha.
 - BootUI is disabled with `prod` and `production` profiles unless `bootui.enabled=ON`.
 - Non-local requests are rejected by default.
 - Documentation matches actual behavior.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -579,11 +579,12 @@ Features:
 - Show a restart action for bean-backed services only when explicitly enabled with
   `bootui.dev-services.restart-enabled=true`.
 
-Status: implemented as an experimental panel for v0.1.
+Status: implemented and supported for `0.1.0-alpha.1` as part of the harden-all-visible-panels release scope.
 
 Acceptance criteria:
 
 - Secrets are never displayed.
+- `bootui.expose-values=FULL` is the only mode that may reveal secret-like service connection values, and should be used only in trusted local sessions.
 - Unknown services are represented generically.
 - Works even when Docker is not installed.
 - Docker Compose services are clearly identified as startup snapshots because
@@ -915,9 +916,11 @@ BootUI v0.1 is complete when:
 - Tests verify activation and safety behavior.
 - Documentation explains installation, activation, safety model, and limitations.
 
-## 11. Open questions
+## 11. Release decisions
 
-1. Should newer panels be supported for the first alpha, clearly marked experimental, or hidden until hardened?
-2. Should `0.1.0-alpha.1` be published to Maven Central or remain source/local-build only?
-3. Should optional panels be hidden dynamically when their classpath or data source is unavailable?
-4. Should endpoint data continue using in-process endpoint beans, or should some panels move to a more general metadata abstraction?
+Resolved for `0.1.0-alpha.1`:
+
+1. Harden every visible panel and ship the full current route set as supported alpha functionality.
+2. Publish the alpha artifacts to Maven Central.
+3. Keep optional panels visible and show clear unavailable/empty states when their classpath or data source is absent.
+4. Continue using in-process Actuator endpoint beans and Spring-managed metadata for v0.1; revisit broader metadata abstractions after the alpha.

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,35 @@
 
     <groupId>io.github.bootui</groupId>
     <artifactId>bootui-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0-alpha.1</version>
     <packaging>pom</packaging>
 
     <name>BootUI Parent</name>
     <description>BootUI: local developer console starter for Spring Boot 4 applications</description>
+    <url>https://github.com/jdubois/boot-ui</url>
+
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>jdubois</id>
+            <name>Julien Dubois</name>
+            <url>https://github.com/jdubois</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/jdubois/boot-ui.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jdubois/boot-ui.git</developerConnection>
+        <url>https://github.com/jdubois/boot-ui</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <modules>
         <module>bootui-core</module>
@@ -30,7 +54,13 @@
         <spring-boot.version>4.0.6</spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
+        <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+        <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+        <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <node.version>v24.16.0</node.version>
         <npm.version>11.15.0</npm.version>
     </properties>
@@ -99,7 +129,104 @@
                     <artifactId>frontend-maven-plugin</artifactId>
                     <version>${frontend-maven-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>${maven-antrun-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>${maven-jar-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
+                    <configuration>
+                        <forceCreation>true</forceCreation>
+                        <includePom>true</includePom>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.version}</version>
+                    <configuration>
+                        <doclint>none</doclint>
+                        <failOnError>false</failOnError>
+                        <quiet>true</quiet>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>${maven-gpg-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>${central-publishing-maven-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <publishingServerId>central</publishingServerId>
+                        <autoPublish>false</autoPublish>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## What does this PR do?

Prepares `0.1.0-alpha.1` as a harden-all-visible-panels alpha release. It adds Maven Central release metadata/profile wiring, tightens fail-closed activation and value exposure behavior, expands backend coverage, and updates release documentation.

## Why is this change needed?

The release plan now calls for shipping every current BootUI route as supported alpha functionality and publishing the alpha to Maven Central. This makes the runtime safety behavior, release packaging, and user-facing docs consistent with that scope.

N/A

## How was it tested?

- [x] `mvn clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional validation: focused backend hardening tests passed, the release profile dry run passed with signing skipped, all visible BootUI sample APIs returned 200, config masking was smoke-checked, and the Playwright e2e suite passed.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed