### PR TITLE
Add dependency vulnerability scanning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,34 +5,34 @@ BootUI is a **Spring Boot 4 starter** that adds a local-only developer console (
 ## Toolchain
 
 - Java 25, Spring Boot 4.0.x (`spring-boot.version` in root `pom.xml`).
-- Maven 3.9+ (no wrapper committed — use system Maven).
+- Maven Wrapper (`./mvnw`) using Maven 3.9.16; do not require a system Maven install.
 - Node.js / npm are downloaded automatically by the `frontend-maven-plugin`; do not add a manual Node install step.
 
 ## Build, run, test
 
 ```bash
 # Full multi-module build (downloads Node, builds Vue UI, packages all JARs).
-mvn clean install
+./mvnw clean install
 
 # Backend-only iteration loop (skips the Vue build).
-mvn -pl bootui-core,bootui-autoconfigure,bootui-spring-boot-starter,bootui-sample-app -am install
+./mvnw -pl bootui-core,bootui-autoconfigure,bootui-spring-boot-starter,bootui-sample-app -am install
 
 # Run the sample app (smoke-test path: http://localhost:8080/bootui).
-cd bootui-sample-app && mvn spring-boot:run -Dspring-boot.run.profiles=dev
+./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
 
 # Single test class / single test method.
-mvn -pl bootui-core test -Dtest=SecretMaskerTests
-mvn -pl bootui-core test -Dtest=SecretMaskerTests#detectsCommonSecretKeys
+./mvnw -pl bootui-core test -Dtest=SecretMaskerTests
+./mvnw -pl bootui-core test -Dtest=SecretMaskerTests#detectsCommonSecretKeys
 
 # Front-end inner loop (Vite dev server with HMR; proxies /bootui/api/* to a running sample app).
 cd bootui-ui/src/main/frontend
 npm install
 npm run dev
 # After changing UI code that needs to be re-bundled into the JAR:
-mvn -pl bootui-ui install
+./mvnw -pl bootui-ui install
 ```
 
-CI (`.github/workflows/build.yml`) runs `mvn -B -ntp clean install` on Java 25 — keep that command green.
+CI (`.github/workflows/build.yml`) runs `./mvnw -B -ntp clean install` on Java 25 — keep that command green.
 
 ## Module topology
 
@@ -85,5 +85,5 @@ Because already-bound `@ConfigurationProperties` beans won't auto-rebind, every 
 ## Contribution conventions (from `CONTRIBUTING.md`)
 
 - Branch names start with the GitHub username, e.g. `jdubois/improve-config-ui`.
-- Keep PRs small and update `docs/` whenever public behavior changes. The PR template's checklist (`mvn clean install`, sample-app smoke test, no committed secrets) is enforced in review.
+- Keep PRs small and update `docs/` whenever public behavior changes. The PR template's checklist (`./mvnw clean install`, sample-app smoke test, no committed secrets) is enforced in review.
 - Spring Boot 3.x compatibility is **out of scope** for v0.1 — don't add compatibility shims.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Closes #
 
 ## How was it tested?
 
-- [ ] `mvn clean install` passes locally
+- [ ] `./mvnw clean install` passes locally
 - [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
 - [ ] Added or updated tests where applicable
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           cache-dependency-path: bootui-sample-app/e2e/package-lock.json
 
       - name: Build all modules
-        run: mvn -B -ntp clean install
+        run: ./mvnw -B -ntp clean install
 
       - name: Install Playwright dependencies
         working-directory: bootui-sample-app/e2e

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build (Java)
         if: steps.code-scanning.outputs.enabled == 'true' && matrix.language == 'java-kotlin'
-        run: mvn -B -ntp -DskipTests package
+        run: ./mvnw -B -ntp -DskipTests package
 
       - name: Perform CodeQL Analysis
         if: steps.code-scanning.outputs.enabled == 'true'

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,2 @@
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,8 @@ participating you are expected to uphold this code.
 ## Prerequisites
 
 - **Java 25** (or newer). The reference toolchain is OpenJDK 25.
-- **Maven 3.9+**. The wrapper is not committed; use your system Maven.
+- **Maven Wrapper**. Use the committed `./mvnw` script; no system Maven
+  installation is required.
 - **Node.js 24+** and npm 11+ are downloaded automatically by the
   `frontend-maven-plugin` when you run the build. You do not need to install
   Node manually.
@@ -31,7 +32,7 @@ docs/                         Specification and roadmap
 ## Build
 
 ```bash
-mvn clean install
+./mvnw clean install
 ```
 
 This downloads Node + npm, runs `npm install`, builds the Vue UI with Vite, and
@@ -40,14 +41,13 @@ packages every module. A full clean build takes about a minute on a warm cache.
 To rebuild only the backend (useful while iterating on Java code):
 
 ```bash
-mvn -pl bootui-core,bootui-autoconfigure,bootui-spring-boot-starter,bootui-sample-app -am install
+./mvnw -pl bootui-core,bootui-autoconfigure,bootui-spring-boot-starter,bootui-sample-app -am install
 ```
 
 ## Run the sample app
 
 ```bash
-cd bootui-sample-app
-mvn spring-boot:run -Dspring-boot.run.profiles=dev
+./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 Then open <http://localhost:8080/bootui>.
@@ -78,7 +78,7 @@ npm run dev
 ```
 
 This starts Vite on a separate port and proxies `/bootui/api/*` to a locally
-running sample app. When you are done, run `mvn install -pl bootui-ui` once to
+running sample app. When you are done, run `./mvnw install -pl bootui-ui` once to
 re-bundle the assets into the JAR.
 
 ## Submitting a change
@@ -88,7 +88,7 @@ re-bundle the assets into the JAR.
    GitHub username (e.g. `jdubois/improve-config-ui`).
 3. Keep PRs small and focused. Update `docs/` whenever public behaviour
    changes.
-4. Run `mvn clean install` before pushing.
+4. Run `./mvnw clean install` before pushing.
 5. Run the Playwright end-to-end suite when you change the UI, browser-facing
    API responses, or sample-app behavior.
 6. Use the pull request template — it links to the verifications we expect.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ BootUI is served by the host application at `/bootui/` and uses internal `/bootu
 
 - Java 25
 - Spring Boot 4.x application
-- Maven
+- Maven or your application's Maven Wrapper
 
 ### 2) Add the starter dependency
 
@@ -57,7 +57,7 @@ BootUI is served by the host application at `/bootui/` and uses internal `/bootu
 ### 3) Run your app in development mode
 
 ```bash
-mvn spring-boot:run -Dspring-boot.run.profiles=dev
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 BootUI also activates automatically when `spring-boot-devtools` is on the classpath. To force it on or off:
@@ -79,21 +79,20 @@ Visit: <http://localhost:8080/bootui>
 ### 1) Prerequisites
 
 - Java 25
-- Maven
+- Maven Wrapper (`./mvnw`, included)
 
 Node.js and npm are downloaded automatically by Maven for the UI build.
 
 ### 2) Build everything
 
 ```bash
-mvn clean install
+./mvnw clean install
 ```
 
 ### 3) Run the sample app
 
 ```bash
-cd bootui-sample-app
-mvn spring-boot:run -Dspring-boot.run.profiles=dev
+./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 ### 4) Open BootUI
@@ -186,7 +185,7 @@ The release profile attaches source and Javadoc JARs, signs artifacts with GPG, 
 
 ```bash
 # CI-equivalent build
-mvn -B -ntp clean install
+./mvnw -B -ntp clean install
 
 # Browser end-to-end tests for the sample app
 cd bootui-sample-app/e2e

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -8,6 +8,7 @@ import io.github.jdubois.bootui.autoconfigure.web.ConditionsController;
 import io.github.jdubois.bootui.autoconfigure.web.ConfigController;
 import io.github.jdubois.bootui.autoconfigure.web.DataController;
 import io.github.jdubois.bootui.autoconfigure.web.DefaultDevToolsBridge;
+import io.github.jdubois.bootui.autoconfigure.web.DependenciesController;
 import io.github.jdubois.bootui.autoconfigure.web.DevToolsBridge;
 import io.github.jdubois.bootui.autoconfigure.web.DevToolsController;
 import io.github.jdubois.bootui.autoconfigure.web.DevServicesController;
@@ -62,6 +63,7 @@ import org.springframework.core.env.Environment;
         StartupController.class,
         DataController.class,
         DevServicesController.class,
+        DependenciesController.class,
         ScheduledController.class,
         HttpProbeController.class,
         LogTailController.class,

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -68,6 +68,9 @@ public class BootUiProperties {
     /** Dev Services panel settings. */
     private DevServices devServices = new DevServices();
 
+    /** Dependency inventory and vulnerability scanning settings. */
+    private Dependencies dependencies = new Dependencies();
+
     public static class DevServices {
 
         /** Allow BootUI to restart Testcontainers-backed services. */
@@ -90,6 +93,53 @@ public class BootUiProperties {
 
         public void setLogTailBytes(int logTailBytes) {
             this.logTailBytes = logTailBytes;
+        }
+    }
+
+    public static class Dependencies {
+
+        /** Allow on-demand vulnerability scans against OSV.dev. */
+        private boolean osvEnabled = true;
+
+        /** Timeout applied to each OSV request. */
+        private Duration requestTimeout = Duration.ofSeconds(10);
+
+        /** Maximum number of dependency packages included in one OSV batch query. */
+        private int maxPackages = 250;
+
+        /** Maximum number of advisory details fetched after the package query. */
+        private int maxAdvisories = 200;
+
+        public boolean isOsvEnabled() {
+            return osvEnabled;
+        }
+
+        public void setOsvEnabled(boolean osvEnabled) {
+            this.osvEnabled = osvEnabled;
+        }
+
+        public Duration getRequestTimeout() {
+            return requestTimeout;
+        }
+
+        public void setRequestTimeout(Duration requestTimeout) {
+            this.requestTimeout = requestTimeout;
+        }
+
+        public int getMaxPackages() {
+            return maxPackages;
+        }
+
+        public void setMaxPackages(int maxPackages) {
+            this.maxPackages = maxPackages;
+        }
+
+        public int getMaxAdvisories() {
+            return maxAdvisories;
+        }
+
+        public void setMaxAdvisories(int maxAdvisories) {
+            this.maxAdvisories = maxAdvisories;
         }
     }
 
@@ -195,5 +245,13 @@ public class BootUiProperties {
 
     public void setDevServices(DevServices devServices) {
         this.devServices = devServices;
+    }
+
+    public Dependencies getDependencies() {
+        return dependencies;
+    }
+
+    public void setDependencies(Dependencies dependencies) {
+        this.dependencies = dependencies;
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependenciesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependenciesController.java
@@ -1,0 +1,53 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.BootUiDtos.DependenciesReport;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/bootui/api/dependencies")
+public class DependenciesController {
+
+    private final BootUiProperties properties;
+
+    private final DependencyProvider dependencyProvider;
+
+    private final VulnerabilityScanner vulnerabilityScanner;
+
+    @Autowired
+    public DependenciesController(BootUiProperties properties) {
+        this(properties, new DependencyCatalog(), new OsvVulnerabilityScanner(properties.getDependencies()));
+    }
+
+    DependenciesController(BootUiProperties properties, DependencyProvider dependencyProvider,
+                           VulnerabilityScanner vulnerabilityScanner) {
+        this.properties = properties;
+        this.dependencyProvider = dependencyProvider;
+        this.vulnerabilityScanner = vulnerabilityScanner;
+    }
+
+    @GetMapping
+    public DependenciesReport dependencies() {
+        List<DependencyDto> dependencies = dependencyProvider.dependencies();
+        return OsvVulnerabilityScanner.report(properties.getDependencies().isOsvEnabled(), "NOT_SCANNED",
+                "Dependency inventory loaded. Click Scan with OSV.dev to check for known vulnerabilities.",
+                null, 0, dependencies);
+    }
+
+    @PostMapping("/scan")
+    public DependenciesReport scan() {
+        List<DependencyDto> dependencies = dependencyProvider.dependencies();
+        if (!properties.getDependencies().isOsvEnabled()) {
+            return OsvVulnerabilityScanner.report(false, "DISABLED",
+                    "OSV scanning is disabled. Set bootui.dependencies.osv-enabled=true to allow on-demand scans.",
+                    null, 0, dependencies);
+        }
+        return vulnerabilityScanner.scan(dependencies);
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
@@ -1,0 +1,140 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+final class DependencyCatalog implements DependencyProvider {
+
+    private static final String MAVEN_PROPERTIES_PATTERN = "classpath*:META-INF/maven/*/*/pom.properties";
+
+    private final ResourcePatternResolver resolver;
+
+    DependencyCatalog() {
+        this(new PathMatchingResourcePatternResolver());
+    }
+
+    DependencyCatalog(ResourcePatternResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public List<DependencyDto> dependencies() {
+        Map<String, DependencyDto> dependencies = new LinkedHashMap<>();
+        for (Resource resource : mavenPomProperties()) {
+            DependencyDto dependency = dependency(resource);
+            if (dependency != null) {
+                dependencies.putIfAbsent(dependency.packageName() + ":" + dependency.version(), dependency);
+            }
+        }
+        for (DependencyDto dependency : javaClassPathDependencies()) {
+            dependencies.putIfAbsent(dependency.packageName() + ":" + dependency.version(), dependency);
+        }
+        return dependencies.values().stream()
+                .sorted(Comparator.comparing(DependencyDto::packageName)
+                        .thenComparing(DependencyDto::version))
+                .toList();
+    }
+
+    private Resource[] mavenPomProperties() {
+        try {
+            return resolver.getResources(MAVEN_PROPERTIES_PATTERN);
+        }
+        catch (IOException ex) {
+            throw new IllegalStateException("Could not inspect classpath Maven metadata", ex);
+        }
+    }
+
+    private DependencyDto dependency(Resource resource) {
+        Properties properties = new Properties();
+        try (InputStream input = resource.getInputStream()) {
+            properties.load(input);
+        }
+        catch (IOException ex) {
+            throw new IllegalStateException("Could not read Maven metadata from " + resource.getDescription(), ex);
+        }
+        String groupId = blankToNull(properties.getProperty("groupId"));
+        String artifactId = blankToNull(properties.getProperty("artifactId"));
+        String version = blankToNull(properties.getProperty("version"));
+        if (groupId == null || artifactId == null || version == null) {
+            return null;
+        }
+        String packageName = groupId + ":" + artifactId;
+        return new DependencyDto(groupId, artifactId, version, packageName, "Maven metadata",
+                0, "NONE", List.of());
+    }
+
+    private List<DependencyDto> javaClassPathDependencies() {
+        String classPath = System.getProperty("java.class.path", "");
+        if (classPath.isBlank()) {
+            return List.of();
+        }
+        return List.of(classPath.split(java.util.regex.Pattern.quote(File.pathSeparator))).stream()
+                .map(this::dependencyFromClassPathEntry)
+                .filter(dependency -> dependency != null)
+                .toList();
+    }
+
+    private DependencyDto dependencyFromClassPathEntry(String entry) {
+        if (entry == null || !entry.endsWith(".jar")) {
+            return null;
+        }
+        Path jar = Path.of(entry).toAbsolutePath().normalize();
+        Path versionPath = jar.getParent();
+        Path artifactPath = versionPath == null ? null : versionPath.getParent();
+        if (artifactPath == null || artifactPath.getParent() == null) {
+            return null;
+        }
+        String artifactId = artifactPath.getFileName().toString();
+        String version = versionPath.getFileName().toString();
+        String fileName = jar.getFileName().toString();
+        if (!fileName.startsWith(artifactId + "-" + version) || !fileName.endsWith(".jar")) {
+            return null;
+        }
+        String groupId = groupId(artifactPath.getParent());
+        if (groupId == null) {
+            return null;
+        }
+        String packageName = groupId + ":" + artifactId;
+        return new DependencyDto(groupId, artifactId, version, packageName, "Java classpath",
+                0, "NONE", List.of());
+    }
+
+    private String groupId(Path groupPath) {
+        int repositoryIndex = -1;
+        for (int i = groupPath.getNameCount() - 1; i >= 0; i--) {
+            if ("repository".equals(groupPath.getName(i).toString())) {
+                repositoryIndex = i;
+                break;
+            }
+        }
+        if (repositoryIndex < 0 || repositoryIndex + 1 >= groupPath.getNameCount()) {
+            return null;
+        }
+        StringBuilder groupId = new StringBuilder();
+        for (int i = repositoryIndex + 1; i < groupPath.getNameCount(); i++) {
+            if (!groupId.isEmpty()) {
+                groupId.append('.');
+            }
+            groupId.append(groupPath.getName(i));
+        }
+        return groupId.toString();
+    }
+
+    private String blankToNull(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyProvider.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyProvider.java
@@ -1,0 +1,9 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.util.List;
+
+interface DependencyProvider {
+
+    List<DependencyDto> dependencies();
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -1,0 +1,370 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.BootUiDtos.DependenciesReport;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyScanStatusDto;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencySeverityCountDto;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyVulnerabilityDto;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+final class OsvVulnerabilityScanner implements VulnerabilityScanner {
+
+    private static final URI OSV_BASE_URI = URI.create("https://api.osv.dev");
+
+    private final BootUiProperties.Dependencies properties;
+
+    private final HttpClient httpClient;
+
+    private final ObjectMapper objectMapper;
+
+    private final URI baseUri;
+
+    OsvVulnerabilityScanner(BootUiProperties.Dependencies properties) {
+        this(properties, HttpClient.newBuilder()
+                .connectTimeout(properties.getRequestTimeout())
+                .build(), new ObjectMapper(), OSV_BASE_URI);
+    }
+
+    OsvVulnerabilityScanner(BootUiProperties.Dependencies properties, HttpClient httpClient,
+                            ObjectMapper objectMapper, URI baseUri) {
+        this.properties = properties;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.baseUri = baseUri;
+    }
+
+    @Override
+    public DependenciesReport scan(List<DependencyDto> dependencies) {
+        long scannedAt = Instant.now().toEpochMilli();
+        List<DependencyDto> packages = dependencies.stream()
+                .limit(Math.max(1, properties.getMaxPackages()))
+                .toList();
+        if (packages.isEmpty()) {
+            return report(true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
+        }
+        try {
+            Map<String, List<String>> vulnerabilityIds = queryBatch(packages);
+            Map<String, JsonNode> vulnerabilities = fetchVulnerabilities(vulnerabilityIds);
+            List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, vulnerabilities);
+            String status = packages.size() < dependencies.size() || vulnerabilities.size() < uniqueIds(vulnerabilityIds).size()
+                    ? "PARTIAL"
+                    : "SCANNED";
+            return report(true, status, scanMessage(status), scannedAt, packages.size(), enriched);
+        }
+        catch (IOException ex) {
+            return report(true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return report(true, "ERROR", "OSV scan was interrupted", scannedAt, packages.size(), dependencies);
+        }
+    }
+
+    private Map<String, List<String>> queryBatch(List<DependencyDto> dependencies)
+            throws IOException, InterruptedException {
+        List<Map<String, Object>> queries = new ArrayList<>();
+        for (DependencyDto dependency : dependencies) {
+            queries.add(Map.of(
+                    "package", Map.of("ecosystem", "Maven", "name", dependency.packageName()),
+                    "version", dependency.version()));
+        }
+        String body = objectMapper.writeValueAsString(Map.of("queries", queries));
+        HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("/v1/querybatch"))
+                .timeout(properties.getRequestTimeout())
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("OSV query returned HTTP " + response.statusCode());
+        }
+
+        JsonNode results = objectMapper.readTree(response.body()).path("results");
+        Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
+        for (int i = 0; i < dependencies.size(); i++) {
+            DependencyDto dependency = dependencies.get(i);
+            List<String> ids = new ArrayList<>();
+            JsonNode result = results.path(i).path("vulns");
+            if (result.isArray()) {
+                for (JsonNode vulnerability : result) {
+                    String id = text(vulnerability, "id");
+                    if (id != null) {
+                        ids.add(id);
+                    }
+                }
+            }
+            idsByPackage.put(key(dependency), ids);
+        }
+        return idsByPackage;
+    }
+
+    private Map<String, JsonNode> fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
+            throws IOException, InterruptedException {
+        Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
+        for (String id : uniqueIds(vulnerabilityIds).stream()
+                .limit(Math.max(1, properties.getMaxAdvisories()))
+                .toList()) {
+            HttpRequest request = HttpRequest.newBuilder(vulnerabilityUri(id))
+                    .timeout(properties.getRequestTimeout())
+                    .GET()
+                    .build();
+            HttpResponse<String> response = httpClient.send(request,
+                    HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IOException("OSV advisory " + id + " returned HTTP " + response.statusCode());
+            }
+            JsonNode vulnerability = objectMapper.readTree(response.body());
+            String vulnerabilityId = text(vulnerability, "id");
+            if (vulnerabilityId != null) {
+                vulnerabilities.put(vulnerabilityId, vulnerability);
+            }
+        }
+        return vulnerabilities;
+    }
+
+    private URI vulnerabilityUri(String id) {
+        String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8);
+        return baseUri.resolve("/v1/vulns/" + encoded);
+    }
+
+    private DependencyVulnerabilityDto vulnerability(JsonNode node, DependencyDto dependency) {
+        String id = text(node, "id");
+        Severity severity = severity(node);
+        return new DependencyVulnerabilityDto(
+                id,
+                text(node, "summary"),
+                text(node, "details"),
+                severity.label(),
+                severity.score(),
+                stringArray(node.path("aliases")),
+                references(node.path("references")),
+                fixedVersions(node.path("affected"), dependency.packageName()));
+    }
+
+    private List<DependencyDto> enrich(List<DependencyDto> dependencies,
+                                       Map<String, List<String>> vulnerabilityIds,
+                                       Map<String, JsonNode> vulnerabilities) {
+        List<DependencyDto> enriched = new ArrayList<>();
+        for (DependencyDto dependency : dependencies) {
+            List<DependencyVulnerabilityDto> dependencyVulnerabilities = vulnerabilityIds
+                    .getOrDefault(key(dependency), List.of()).stream()
+                    .map(vulnerabilities::get)
+                    .filter(vulnerability -> vulnerability != null)
+                    .map(vulnerability -> vulnerability(vulnerability, dependency))
+                    .sorted(Comparator.comparing(DependencyVulnerabilityDto::severity)
+                            .thenComparing(DependencyVulnerabilityDto::id))
+                    .toList();
+            enriched.add(new DependencyDto(
+                    dependency.groupId(),
+                    dependency.artifactId(),
+                    dependency.version(),
+                    dependency.packageName(),
+                    dependency.source(),
+                    dependencyVulnerabilities.size(),
+                    highestSeverity(dependencyVulnerabilities),
+                    dependencyVulnerabilities));
+        }
+        return enriched;
+    }
+
+    static DependenciesReport report(boolean scanningEnabled, String status, String message, Long scannedAt,
+                                     int packagesScanned, List<DependencyDto> dependencies) {
+        int vulnerabilitiesFound = dependencies.stream().mapToInt(DependencyDto::vulnerabilityCount).sum();
+        return new DependenciesReport(
+                scanningEnabled,
+                dependencies.size(),
+                (int) dependencies.stream().filter(dependency -> dependency.vulnerabilityCount() > 0).count(),
+                severityCounts(dependencies),
+                new DependencyScanStatusDto("OSV.dev", status, message, scannedAt, packagesScanned, vulnerabilitiesFound),
+                dependencies);
+    }
+
+    private static List<DependencySeverityCountDto> severityCounts(List<DependencyDto> dependencies) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (String severity : List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN")) {
+            counts.put(severity, 0);
+        }
+        for (DependencyDto dependency : dependencies) {
+            for (DependencyVulnerabilityDto vulnerability : dependency.vulnerabilities()) {
+                counts.computeIfPresent(vulnerability.severity(), (ignored, count) -> count + 1);
+            }
+        }
+        return counts.entrySet().stream()
+                .map(entry -> new DependencySeverityCountDto(entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    private static String highestSeverity(List<DependencyVulnerabilityDto> vulnerabilities) {
+        return vulnerabilities.stream()
+                .map(DependencyVulnerabilityDto::severity)
+                .min(Comparator.comparingInt(OsvVulnerabilityScanner::severityRank))
+                .orElse("NONE");
+    }
+
+    private static int severityRank(String severity) {
+        return switch (severity) {
+            case "CRITICAL" -> 0;
+            case "HIGH" -> 1;
+            case "MEDIUM" -> 2;
+            case "LOW" -> 3;
+            default -> 4;
+        };
+    }
+
+    private Severity severity(JsonNode node) {
+        String databaseSeverity = text(node.path("database_specific"), "severity");
+        String normalized = normalizeSeverity(databaseSeverity);
+        Double score = null;
+        JsonNode severities = node.path("severity");
+        if (severities.isArray()) {
+            for (JsonNode severityNode : severities) {
+                String value = text(severityNode, "score");
+                Double parsed = parseScore(value);
+                if (parsed != null) {
+                    score = parsed;
+                    normalized = normalizeSeverity(parsed);
+                    break;
+                }
+            }
+        }
+        return new Severity(normalized, score);
+    }
+
+    private static String normalizeSeverity(String value) {
+        if (value == null || value.isBlank()) {
+            return "UNKNOWN";
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        if (List.of("CRITICAL", "HIGH", "MEDIUM", "LOW").contains(normalized)) {
+            return normalized;
+        }
+        return "UNKNOWN";
+    }
+
+    private static String normalizeSeverity(double score) {
+        if (score >= 9.0d) {
+            return "CRITICAL";
+        }
+        if (score >= 7.0d) {
+            return "HIGH";
+        }
+        if (score >= 4.0d) {
+            return "MEDIUM";
+        }
+        return "LOW";
+    }
+
+    private static Double parseScore(String value) {
+        if (value == null || value.startsWith("CVSS:")) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value);
+        }
+        catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private static List<String> references(JsonNode references) {
+        List<String> values = new ArrayList<>();
+        if (!references.isArray()) {
+            return values;
+        }
+        for (JsonNode reference : references) {
+            String url = text(reference, "url");
+            if (url != null) {
+                values.add(url);
+            }
+        }
+        return values.stream().distinct().limit(20).toList();
+    }
+
+    private static List<String> fixedVersions(JsonNode affected, String packageName) {
+        Set<String> versions = new LinkedHashSet<>();
+        if (!affected.isArray()) {
+            return List.of();
+        }
+        for (JsonNode item : affected) {
+            JsonNode pkg = item.path("package");
+            if (!"Maven".equals(text(pkg, "ecosystem")) || !packageName.equals(text(pkg, "name"))) {
+                continue;
+            }
+            JsonNode ranges = item.path("ranges");
+            if (!ranges.isArray()) {
+                continue;
+            }
+            for (JsonNode range : ranges) {
+                JsonNode events = range.path("events");
+                if (!events.isArray()) {
+                    continue;
+                }
+                for (JsonNode event : events) {
+                    String fixed = text(event, "fixed");
+                    if (fixed != null) {
+                        versions.add(fixed);
+                    }
+                }
+            }
+        }
+        return versions.stream().limit(10).toList();
+    }
+
+    private static List<String> stringArray(JsonNode node) {
+        List<String> values = new ArrayList<>();
+        if (node.isArray()) {
+            for (JsonNode value : node) {
+                if (!value.isNull()) {
+                    values.add(value.asText());
+                }
+            }
+        }
+        return values;
+    }
+
+    private static Set<String> uniqueIds(Map<String, List<String>> vulnerabilityIds) {
+        Set<String> ids = new LinkedHashSet<>();
+        vulnerabilityIds.values().forEach(ids::addAll);
+        return ids;
+    }
+
+    private static String key(DependencyDto dependency) {
+        return dependency.packageName() + ":" + dependency.version();
+    }
+
+    private static String text(JsonNode node, String fieldName) {
+        JsonNode value = node.get(fieldName);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        String text = value.asText();
+        return text == null || text.isBlank() ? null : text;
+    }
+
+    private static String scanMessage(String status) {
+        return "PARTIAL".equals(status)
+                ? "Scan completed with configured package or advisory limits applied."
+                : "Scan completed against OSV.dev.";
+    }
+
+    private record Severity(String label, Double score) {
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilityScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilityScanner.java
@@ -1,0 +1,10 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.core.BootUiDtos.DependenciesReport;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.util.List;
+
+interface VulnerabilityScanner {
+
+    DependenciesReport scan(List<DependencyDto> dependencies);
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
 import io.github.jdubois.bootui.autoconfigure.safety.LocalhostOnlyFilter;
 import io.github.jdubois.bootui.autoconfigure.web.DataController;
+import io.github.jdubois.bootui.autoconfigure.web.DependenciesController;
 import io.github.jdubois.bootui.autoconfigure.web.DevToolsBridge;
 import io.github.jdubois.bootui.autoconfigure.web.DevToolsController;
 import io.github.jdubois.bootui.autoconfigure.web.DevServicesController;
@@ -41,6 +42,7 @@ class BootUiAutoConfigurationTests {
                         .hasSingleBean(DevToolsController.class)
                         .hasSingleBean(OverviewController.class)
                         .hasSingleBean(DevServicesController.class)
+                        .hasSingleBean(DependenciesController.class)
                         .hasSingleBean(BootUiActivation.class));
     }
 
@@ -112,7 +114,10 @@ class BootUiAutoConfigurationTests {
                         "bootui.overrides-file=/tmp/bootui.properties",
                         "bootui.endpoint-timeout=2s",
                         "bootui.dev-services.restart-enabled=true",
-                        "bootui.dev-services.log-tail-bytes=2048")
+                        "bootui.dev-services.log-tail-bytes=2048",
+                        "bootui.dependencies.osv-enabled=false",
+                        "bootui.dependencies.max-packages=42",
+                        "bootui.dependencies.max-advisories=24")
                 .run(context -> {
                     BootUiProperties properties = context.getBean(BootUiProperties.class);
                     assertThat(properties.getPath()).isEqualTo("/admin");
@@ -124,6 +129,9 @@ class BootUiAutoConfigurationTests {
                     assertThat(properties.getEndpointTimeout()).isEqualTo(Duration.ofSeconds(2));
                     assertThat(properties.getDevServices().isRestartEnabled()).isTrue();
                     assertThat(properties.getDevServices().getLogTailBytes()).isEqualTo(2048);
+                    assertThat(properties.getDependencies().isOsvEnabled()).isFalse();
+                    assertThat(properties.getDependencies().getMaxPackages()).isEqualTo(42);
+                    assertThat(properties.getDependencies().getMaxAdvisories()).isEqualTo(24);
                 });
     }
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependenciesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependenciesControllerTests.java
@@ -1,0 +1,71 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.hamcrest.Matchers.contains;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+
+class DependenciesControllerTests {
+
+    @Test
+    void dependenciesReturnsClasspathInventoryWithoutScanning() throws Exception {
+        MockMvc mvc = standaloneSetup(new DependenciesController(
+                new BootUiProperties(),
+                () -> List.of(dependency("org.example", "sample", "1.0.0")),
+                dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "unused", 1L, 1, dependencies)))
+                .build();
+
+        mvc.perform(get("/bootui/api/dependencies"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scanningEnabled").value(true))
+                .andExpect(jsonPath("$.scan.status").value("NOT_SCANNED"))
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.dependencies[0].packageName").value("org.example:sample"))
+                .andExpect(jsonPath("$.dependencies[0].vulnerabilityCount").value(0));
+    }
+
+    @Test
+    void scanUsesScannerWhenEnabled() throws Exception {
+        MockMvc mvc = standaloneSetup(new DependenciesController(
+                new BootUiProperties(),
+                () -> List.of(dependency("org.example", "sample", "1.0.0")),
+                dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "done", 1L, 1, dependencies)))
+                .build();
+
+        mvc.perform(post("/bootui/api/dependencies/scan"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scan.status").value("SCANNED"))
+                .andExpect(jsonPath("$.scan.message").value("done"))
+                .andExpect(jsonPath("$.scan.packagesScanned").value(1));
+    }
+
+    @Test
+    void scanReportsDisabledWhenOsvIsDisabled() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        properties.getDependencies().setOsvEnabled(false);
+        MockMvc mvc = standaloneSetup(new DependenciesController(
+                properties,
+                () -> List.of(dependency("org.example", "sample", "1.0.0")),
+                dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "unused", 1L, 1, dependencies)))
+                .build();
+
+        mvc.perform(post("/bootui/api/dependencies/scan"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scanningEnabled").value(false))
+                .andExpect(jsonPath("$.scan.status").value("DISABLED"))
+                .andExpect(jsonPath("$.dependencies[*].packageName", contains("org.example:sample")));
+    }
+
+    private static DependencyDto dependency(String groupId, String artifactId, String version) {
+        String packageName = groupId + ":" + artifactId;
+        return new DependencyDto(groupId, artifactId, version, packageName, "test", 0, "NONE", List.of());
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
@@ -1,0 +1,59 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.io.File;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+class DependencyCatalogTests {
+
+    @Test
+    void discoversMavenCoordinatesFromJavaClassPathJarsWithoutPomProperties() {
+        String previousClassPath = System.getProperty("java.class.path");
+        try {
+            System.setProperty("java.class.path", String.join(File.pathSeparator,
+                    "/home/user/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/11.0.21/tomcat-embed-core-11.0.21.jar",
+                    "/home/user/.m2/repository/org/postgresql/postgresql/42.7.10/postgresql-42.7.10.jar"));
+
+            List<DependencyDto> dependencies = new DependencyCatalog(emptyResolver()).dependencies();
+
+            assertThat(dependencies)
+                    .extracting(DependencyDto::packageName, DependencyDto::version)
+                    .contains(
+                            org.assertj.core.api.Assertions.tuple("org.apache.tomcat.embed:tomcat-embed-core", "11.0.21"),
+                            org.assertj.core.api.Assertions.tuple("org.postgresql:postgresql", "42.7.10"));
+        }
+        finally {
+            if (previousClassPath == null) {
+                System.clearProperty("java.class.path");
+            }
+            else {
+                System.setProperty("java.class.path", previousClassPath);
+            }
+        }
+    }
+
+    private static ResourcePatternResolver emptyResolver() {
+        return new ResourcePatternResolver() {
+            @Override
+            public Resource[] getResources(String locationPattern) {
+                return new Resource[0];
+            }
+
+            @Override
+            public Resource getResource(String location) {
+                return new ByteArrayResource(new byte[0]);
+            }
+
+            @Override
+            public ClassLoader getClassLoader() {
+                return DependencyCatalogTests.class.getClassLoader();
+            }
+        };
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -1,0 +1,115 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sun.net.httpserver.HttpServer;
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.BootUiDtos.DependenciesReport;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class OsvVulnerabilityScannerTests {
+
+    private HttpServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void enrichesDependenciesWithOsvAdvisories() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                    {"results":[{"vulns":[{"id":"GHSA-1234-5678-9012"}]}]}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-1234-5678-9012", exchange -> {
+            byte[] body = """
+                    {
+                      "id": "GHSA-1234-5678-9012",
+                      "summary": "Example vulnerability",
+                      "aliases": ["CVE-2026-0001"],
+                      "database_specific": { "severity": "HIGH" },
+                      "references": [{ "url": "https://example.com/advisory" }],
+                      "affected": [
+                        {
+                          "package": { "ecosystem": "Maven", "name": "org.example:sample" },
+                          "ranges": [{ "events": [{ "introduced": "0" }, { "fixed": "1.0.1" }] }]
+                        }
+                      ]
+                    }
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Dependencies properties = new BootUiProperties.Dependencies();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
+        assertThat(report.vulnerable()).isEqualTo(1);
+        assertThat(report.severityCounts())
+                .filteredOn(count -> count.severity().equals("HIGH"))
+                .singleElement()
+                .extracting("count")
+                .isEqualTo(1);
+        assertThat(report.dependencies().getFirst().highestSeverity()).isEqualTo("HIGH");
+        assertThat(report.dependencies().getFirst().vulnerabilities().getFirst().fixedVersions())
+                .containsExactly("1.0.1");
+    }
+
+    @Test
+    void reportsErrorWithoutDroppingDependencyInventory() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(500, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Dependencies properties = new BootUiProperties.Dependencies();
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("ERROR");
+        assertThat(report.dependencies()).hasSize(1);
+        assertThat(report.dependencies().getFirst().packageName()).isEqualTo("org.example:sample");
+    }
+
+    private static DependencyDto dependency(String groupId, String artifactId, String version) {
+        String packageName = groupId + ":" + artifactId;
+        return new DependencyDto(groupId, artifactId, version, packageName, "test", 0, "NONE", List.of());
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -377,6 +377,54 @@ public final class BootUiDtos {
             List<MetricSampleDto> samples) {
     }
 
+    /** One Maven dependency discovered on the running application's classpath. */
+    public record DependencyDto(
+            String groupId,
+            String artifactId,
+            String version,
+            String packageName,
+            String source,
+            int vulnerabilityCount,
+            String highestSeverity,
+            List<DependencyVulnerabilityDto> vulnerabilities) {
+    }
+
+    /** One vulnerability advisory affecting a dependency. */
+    public record DependencyVulnerabilityDto(
+            String id,
+            String summary,
+            String details,
+            String severity,
+            Double score,
+            List<String> aliases,
+            List<String> references,
+            List<String> fixedVersions) {
+    }
+
+    /** Count of vulnerability advisories by normalized severity. */
+    public record DependencySeverityCountDto(String severity, int count) {
+    }
+
+    /** Metadata about the dependency vulnerability scan. */
+    public record DependencyScanStatusDto(
+            String scanner,
+            String status,
+            String message,
+            Long scannedAt,
+            int packagesScanned,
+            int vulnerabilitiesFound) {
+    }
+
+    /** Top-level report for dependency inventory and vulnerability findings. */
+    public record DependenciesReport(
+            boolean scanningEnabled,
+            int total,
+            int vulnerable,
+            List<DependencySeverityCountDto> severityCounts,
+            DependencyScanStatusDto scan,
+            List<DependencyDto> dependencies) {
+    }
+
     /** A single JVM memory pool (heap, non-heap, or GC pool). */
     public record MemoryPoolDto(
             String name,

--- a/bootui-sample-app/e2e/README.md
+++ b/bootui-sample-app/e2e/README.md
@@ -36,13 +36,13 @@ flow) exposed by the sample app:
 ## Prerequisites
 
 * Node.js 20+
-* Java 25 and Maven (used to build & run the sample app)
+* Java 25 and the repository Maven Wrapper (used to build & run the sample app)
 * The BootUI parent build must be installed locally so the sample app can
   resolve its modules:
 
   ```bash
-  cd ..               # back to the repository root
-  mvn -DskipTests install
+  cd ../..            # back to the repository root
+  ./mvnw -DskipTests install
   ```
 
 ## Install
@@ -56,7 +56,7 @@ npx playwright install --with-deps chromium
 ## Run
 
 ```bash
-# Lets Playwright start the sample app for you (via mvn spring-boot:run)
+# Lets Playwright start the sample app for you (via ./mvnw spring-boot:run)
 npm test
 ```
 
@@ -65,8 +65,8 @@ launch the tests — Playwright will reuse the running server:
 
 ```bash
 # terminal 1
-cd ..
-mvn spring-boot:run
+cd ../..
+./mvnw -pl bootui-sample-app spring-boot:run
 # terminal 2
 cd bootui-sample-app/e2e
 npm test

--- a/bootui-sample-app/e2e/playwright.config.js
+++ b/bootui-sample-app/e2e/playwright.config.js
@@ -8,7 +8,7 @@ import { defineConfig, devices } from '@playwright/test'
  * by the `bootui-sample-app` Spring Boot module, using a real Chromium browser.
  *
  * By default Playwright will boot the sample app for you via
- * `mvn spring-boot:run` (requires `mvn install` of the parent build first so
+ * `./mvnw spring-boot:run` (requires `./mvnw install` of the parent build first so
  * the BootUI artefacts are available in the local Maven repository). If you
  * already have the app running on port 8080 it will be reused automatically.
  */
@@ -44,8 +44,8 @@ export default defineConfig({
   // Set BOOTUI_SKIP_WEBSERVER=1 to disable the auto-started Maven server when
   // running the tests against an already-deployed instance, listing tests, etc.
   webServer: process.env.BOOTUI_SKIP_WEBSERVER ? undefined : {
-    // Run from the sample-app module so `spring-boot:run` picks up the right pom.
-    command: 'mvn -f ../pom.xml -q spring-boot:run',
+    // Run from the e2e module through the root Maven Wrapper.
+    command: '../../mvnw -f ../pom.xml -q spring-boot:run',
     url: `${BASE_URL}/bootui/api/overview`,
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -16,23 +16,24 @@ test.describe('BootUI app shell', () => {
   test('sidebar links open every BootUI section', async ({ page }) => {
     const links = [
       { title: 'Overview',          heading: /^Overview/ },
-      { title: 'Beans',             heading: /^Beans/ },
-      { title: 'Conditions',        heading: /Auto-configuration conditions/ },
-      { title: 'Configuration',     heading: /^Configuration/ },
-      { title: 'Mappings',          heading: /HTTP mappings/ },
-      { title: 'Health',            heading: /^Health/ },
-      { title: 'Loggers',           heading: /^Loggers/ },
-      { title: 'Data',              heading: /Spring Data repositories/ },
       { title: 'Startup Timeline',  heading: /Startup timeline/ },
       { title: 'Memory',            heading: /^Memory/ },
+      { title: 'Health',            heading: /^Health/ },
       { title: 'Metrics',           heading: /^Metrics/ },
+      { title: 'Conditions',        heading: /Auto-configuration conditions/ },
+      { title: 'Beans',             heading: /^Beans/ },
+      { title: 'Mappings',          heading: /HTTP mappings/ },
+      { title: 'Configuration',     heading: /^Configuration/ },
+      { title: 'Profile Diff',      heading: /Profile Diff/ },
+      { title: 'Loggers',           heading: /^Loggers/ },
+      { title: 'Log Tail',          heading: /Log Tail/ },
+      { title: 'HTTP Probe',        heading: /HTTP Probe/ },
       { title: 'DevTools',          heading: /^DevTools/ },
       { title: 'Dev Services',      heading: /^Dev Services/ },
       { title: 'Scheduled Tasks',   heading: /Scheduled Tasks/ },
-      { title: 'HTTP Probe',        heading: /HTTP Probe/ },
-      { title: 'Log Tail',          heading: /Log Tail/ },
-      { title: 'Profile Diff',      heading: /Profile Diff/ },
-      { title: 'Security',          heading: /Spring Security/ }
+      { title: 'Data',              heading: /Spring Data repositories/ },
+      { title: 'Security',          heading: /Spring Security/ },
+      { title: 'Vulnerabilities',   heading: /^Vulnerabilities/ }
     ]
 
     await page.goto('/bootui/')

--- a/bootui-sample-app/e2e/tests/dependencies.spec.js
+++ b/bootui-sample-app/e2e/tests/dependencies.spec.js
@@ -1,0 +1,117 @@
+// @ts-check
+import { test, expect } from './fixtures.js'
+
+const inventoryReport = {
+  scanningEnabled: true,
+  total: 2,
+  vulnerable: 0,
+  severityCounts: [
+    { severity: 'CRITICAL', count: 0 },
+    { severity: 'HIGH', count: 0 },
+    { severity: 'MEDIUM', count: 0 },
+    { severity: 'LOW', count: 0 },
+    { severity: 'UNKNOWN', count: 0 }
+  ],
+  scan: {
+    scanner: 'OSV.dev',
+    status: 'NOT_SCANNED',
+    message: 'Dependency inventory loaded.',
+    scannedAt: null,
+    packagesScanned: 0,
+    vulnerabilitiesFound: 0
+  },
+  dependencies: [
+    dependency('org.springframework.boot', 'spring-boot', '4.0.6'),
+    dependency('org.example', 'vulnerable-lib', '1.0.0')
+  ]
+}
+
+const scannedReport = {
+  ...inventoryReport,
+  vulnerable: 1,
+  severityCounts: [
+    { severity: 'CRITICAL', count: 0 },
+    { severity: 'HIGH', count: 1 },
+    { severity: 'MEDIUM', count: 0 },
+    { severity: 'LOW', count: 0 },
+    { severity: 'UNKNOWN', count: 0 }
+  ],
+  scan: {
+    scanner: 'OSV.dev',
+    status: 'SCANNED',
+    message: 'Scan completed against OSV.dev.',
+    scannedAt: Date.now(),
+    packagesScanned: 2,
+    vulnerabilitiesFound: 1
+  },
+  dependencies: [
+    dependency('org.springframework.boot', 'spring-boot', '4.0.6'),
+    {
+      ...dependency('org.example', 'vulnerable-lib', '1.0.0'),
+      vulnerabilityCount: 1,
+      highestSeverity: 'HIGH',
+      vulnerabilities: [
+        {
+          id: 'GHSA-1234-5678-9012',
+          summary: 'Example vulnerability',
+          details: null,
+          severity: 'HIGH',
+          score: null,
+          aliases: ['CVE-2026-0001'],
+          references: ['https://example.com/advisory'],
+          fixedVersions: ['1.0.1']
+        }
+      ]
+    }
+  ]
+}
+
+test.describe('Vulnerabilities view', () => {
+
+  test('renders inventory and on-demand vulnerability scan results', async ({ page }) => {
+    await page.route(url => url.pathname === '/bootui/api/dependencies', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(inventoryReport)
+      })
+    })
+    await page.route(url => url.pathname === '/bootui/api/dependencies/scan', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(scannedReport)
+      })
+    })
+
+    await page.goto('/bootui/#/vulnerabilities')
+    await expect(page.locator('main h2').filter({ hasText: /^Vulnerabilities/ }).first()).toBeVisible()
+    await expect(page.getByText('2 of 2 dependencies')).toBeVisible()
+    await expect(page.getByText('NOT_SCANNED')).toBeVisible()
+    await expect(page.getByText('No vulnerability scan data yet')).toBeVisible()
+    await expect(page.getByText('Run Scan with OSV.dev to populate the severity breakdown.')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Scan with OSV.dev' }).click()
+    await expect(page.getByText('SCANNED')).toBeVisible()
+    await expect(page.getByText('No vulnerability scan data yet')).toHaveCount(0)
+    await expect(page.locator('#vulnerableOnly')).toBeChecked()
+    await expect(page.getByText('1 of 2 dependencies')).toBeVisible()
+    await expect(page.getByText('GHSA-1234-5678-9012')).toBeVisible()
+    await expect(page.getByText('fixed in 1.0.1')).toBeVisible()
+
+    await page.getByPlaceholder('Search group, artifact, or version').fill('vulnerable')
+    await expect(page.getByText('1 of 2 dependencies')).toBeVisible()
+    await expect(page.locator('tbody tr', { hasText: 'org.example:vulnerable-lib' })).toBeVisible()
+  })
+})
+
+function dependency(groupId, artifactId, version) {
+  return {
+    groupId,
+    artifactId,
+    version,
+    packageName: `${groupId}:${artifactId}`,
+    source: 'test',
+    vulnerabilityCount: 0,
+    highestSeverity: 'NONE',
+    vulnerabilities: []
+  }
+}

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -20,6 +20,7 @@ import ProfileDiff from './views/ProfileDiff.vue'
 import Security from './views/Security.vue'
 import Memory from './views/Memory.vue'
 import Metrics from './views/Metrics.vue'
+import Vulnerabilities from './views/Dependencies.vue'
 import DevServices from './views/DevServices.vue'
 import DevTools from './views/DevTools.vue'
 
@@ -28,23 +29,25 @@ const router = createRouter({
   routes: [
     { path: '/', redirect: '/overview' },
     { path: '/overview', name: 'overview', component: Overview, meta: { icon: 'bi-speedometer2', title: 'Overview' } },
-    { path: '/health', name: 'health', component: Health, meta: { icon: 'bi-heart-pulse', title: 'Health' } },
     { path: '/startup', name: 'startup', component: Startup, meta: { icon: 'bi-bar-chart-steps', title: 'Startup Timeline' } },
     { path: '/memory', name: 'memory', component: Memory, meta: { icon: 'bi-memory', title: 'Memory' } },
+    { path: '/health', name: 'health', component: Health, meta: { icon: 'bi-heart-pulse', title: 'Health' } },
     { path: '/metrics', name: 'metrics', component: Metrics, meta: { icon: 'bi-activity', title: 'Metrics' } },
-    { path: '/devtools', name: 'devtools', component: DevTools, meta: { icon: 'bi-lightning-charge', title: 'DevTools' } },
     { path: '/conditions', name: 'conditions', component: Conditions, meta: { icon: 'bi-check2-circle', title: 'Conditions' } },
     { path: '/beans', name: 'beans', component: Beans, meta: { icon: 'bi-diagram-3', title: 'Beans' } },
     { path: '/mappings', name: 'mappings', component: Mappings, meta: { icon: 'bi-signpost-2', title: 'Mappings' } },
     { path: '/config', name: 'config', component: Config, meta: { icon: 'bi-sliders', title: 'Configuration' } },
     { path: '/profiles', name: 'profiles', component: ProfileDiff, meta: { icon: 'bi-layers', title: 'Profile Diff' } },
-    { path: '/dev-services', name: 'dev-services', component: DevServices, meta: { icon: 'bi-box-seam', title: 'Dev Services' } },
-    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } },
-    { path: '/security', name: 'security', component: Security, meta: { icon: 'bi-shield-lock', title: 'Security' } },
-    { path: '/scheduled', name: 'scheduled', component: Scheduled, meta: { icon: 'bi-clock-history', title: 'Scheduled Tasks' } },
     { path: '/loggers', name: 'loggers', component: Loggers, meta: { icon: 'bi-journal-text', title: 'Loggers' } },
     { path: '/log-tail', name: 'log-tail', component: LogTail, meta: { icon: 'bi-terminal', title: 'Log Tail' } },
-    { path: '/http-probe', name: 'http-probe', component: HttpProbe, meta: { icon: 'bi-send', title: 'HTTP Probe' } }
+    { path: '/http-probe', name: 'http-probe', component: HttpProbe, meta: { icon: 'bi-send', title: 'HTTP Probe' } },
+    { path: '/devtools', name: 'devtools', component: DevTools, meta: { icon: 'bi-lightning-charge', title: 'DevTools' } },
+    { path: '/dev-services', name: 'dev-services', component: DevServices, meta: { icon: 'bi-box-seam', title: 'Dev Services' } },
+    { path: '/scheduled', name: 'scheduled', component: Scheduled, meta: { icon: 'bi-clock-history', title: 'Scheduled Tasks' } },
+    { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } },
+    { path: '/security', name: 'security', component: Security, meta: { icon: 'bi-person-lock', title: 'Security' } },
+    { path: '/vulnerabilities', name: 'vulnerabilities', component: Vulnerabilities, meta: { icon: 'bi-bug', title: 'Vulnerabilities' } },
+    { path: '/dependencies', redirect: '/vulnerabilities' }
   ]
 })
 

--- a/bootui-ui/src/main/frontend/src/views/Dependencies.vue
+++ b/bootui-ui/src/main/frontend/src/views/Dependencies.vue
@@ -1,0 +1,248 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+
+const data = ref(null)
+const error = ref(null)
+const loading = ref(false)
+const search = ref('')
+const vulnerableOnly = ref(false)
+
+const severityClasses = {
+  CRITICAL: 'text-bg-danger',
+  HIGH: 'text-bg-warning',
+  MEDIUM: 'text-bg-info',
+  LOW: 'text-bg-secondary',
+  UNKNOWN: 'text-bg-light',
+  NONE: 'text-bg-success'
+}
+
+const filteredDependencies = computed(() => {
+  if (!data.value) return []
+  const q = search.value.trim().toLowerCase()
+  return data.value.dependencies.filter((dependency) => {
+    const matchesSearch = !q ||
+      dependency.packageName.toLowerCase().includes(q) ||
+      dependency.version.toLowerCase().includes(q)
+    const matchesVulnerable = !vulnerableOnly.value || dependency.vulnerabilityCount > 0
+    return matchesSearch && matchesVulnerable
+  })
+})
+
+const maxSeverityCount = computed(() => {
+  if (!data.value?.severityCounts?.length) return 1
+  return Math.max(1, ...data.value.severityCounts.map((count) => count.count))
+})
+
+const hasScanData = computed(() => data.value?.scan?.status && data.value.scan.status !== 'NOT_SCANNED')
+
+function severityClass(severity) {
+  return severityClasses[severity] || 'text-bg-light'
+}
+
+function severityWidth(count) {
+  if (count === 0) return '0%'
+  return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
+}
+
+function scanTime() {
+  if (!data.value?.scan?.scannedAt) return ''
+  return new Date(data.value.scan.scannedAt).toLocaleTimeString([], {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  })
+}
+
+async function loadDependencies() {
+  try {
+    const res = await fetch('api/dependencies')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    data.value = await res.json()
+    error.value = null
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function scanDependencies() {
+  loading.value = true
+  try {
+    const res = await fetch('api/dependencies/scan', { method: 'POST' })
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    data.value = await res.json()
+    if (data.value.vulnerable > 0) {
+      vulnerableOnly.value = true
+    }
+    error.value = null
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(loadDependencies)
+</script>
+
+<template>
+  <div>
+    <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
+      <div>
+        <h2 class="h4 mb-1"><i class="bi bi-bug me-2"></i>Vulnerabilities</h2>
+        <p class="text-muted mb-0">Inspect runtime Maven JARs and scan them for known dependency vulnerabilities.</p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-primary"
+        :disabled="loading || data?.scanningEnabled === false"
+        @click="scanDependencies">
+        <span v-if="loading" class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+        Scan with OSV.dev
+      </button>
+    </div>
+
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+
+    <template v-if="data">
+      <div class="alert alert-info">
+        <strong>On-demand external scan.</strong>
+        BootUI only sends dependency package names and versions to OSV.dev when you click Scan.
+        <span v-if="data.scanningEnabled === false">Scanning is disabled by configuration.</span>
+      </div>
+
+      <div class="row g-3 mb-3">
+        <div class="col-md-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">Dependencies</div>
+              <div class="display-6">{{ data.total }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-3">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="text-muted small">Vulnerable</div>
+              <div class="display-6">{{ data.vulnerable }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6">
+          <div class="card h-100">
+            <div class="card-body">
+              <div class="d-flex justify-content-between align-items-start gap-2 mb-2">
+                <div>
+                  <div class="text-muted small">Scan status</div>
+                  <div class="fw-semibold">{{ data.scan.status }}</div>
+                </div>
+                <span class="badge text-bg-light">{{ data.scan.scanner }}</span>
+              </div>
+              <div class="small text-muted">{{ data.scan.message }}</div>
+              <div v-if="scanTime()" class="small text-muted mt-1">Scanned at {{ scanTime() }}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card mb-3">
+        <div class="card-header fw-semibold">Severity breakdown</div>
+        <div class="card-body">
+          <div v-if="!hasScanData" class="text-center text-muted py-4">
+            <i class="bi bi-search fs-2 d-block mb-2"></i>
+            <div class="fw-semibold text-body">No vulnerability scan data yet</div>
+            <div>Run <strong>Scan with OSV.dev</strong> to populate the severity breakdown.</div>
+          </div>
+          <div v-for="item in data.severityCounts" v-else :key="item.severity" class="row align-items-center g-2 mb-2">
+            <div class="col-3 col-md-2">
+              <span class="badge" :class="severityClass(item.severity)">{{ item.severity }}</span>
+            </div>
+            <div class="col">
+              <div class="progress" role="img" :aria-label="`${item.severity} vulnerabilities: ${item.count}`">
+                <div class="progress-bar" :class="severityClass(item.severity)" :style="{ width: severityWidth(item.count) }"></div>
+              </div>
+            </div>
+            <div class="col-auto small text-muted">{{ item.count }}</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header">
+          <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+            <div>
+              <div class="fw-semibold">Runtime JAR dependencies</div>
+              <div class="text-muted small">{{ filteredDependencies.length }} of {{ data.total }} dependencies</div>
+            </div>
+            <div class="d-flex flex-wrap gap-2">
+              <input v-model="search" class="form-control form-control-sm dependency-search" placeholder="Search group, artifact, or version">
+              <div class="form-check form-switch">
+                <input id="vulnerableOnly" v-model="vulnerableOnly" class="form-check-input" type="checkbox">
+                <label class="form-check-label small" for="vulnerableOnly">Vulnerable only</label>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Dependency</th>
+                <th>Version</th>
+                <th>Risk</th>
+                <th>Advisories</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="dependency in filteredDependencies" :key="`${dependency.packageName}:${dependency.version}`">
+                <td>
+                  <code>{{ dependency.packageName }}</code>
+                </td>
+                <td>{{ dependency.version }}</td>
+                <td>
+                  <span class="badge" :class="severityClass(dependency.highestSeverity)">
+                    {{ dependency.highestSeverity }}
+                  </span>
+                </td>
+                <td>
+                  <span v-if="dependency.vulnerabilityCount === 0" class="text-muted">None found</span>
+                  <div v-else class="vulnerability-list">
+                    <div v-for="vulnerability in dependency.vulnerabilities" :key="vulnerability.id" class="mb-2">
+                      <div class="d-flex flex-wrap align-items-center gap-2">
+                        <span class="badge" :class="severityClass(vulnerability.severity)">{{ vulnerability.severity }}</span>
+                        <a v-if="vulnerability.references.length" :href="vulnerability.references[0]" target="_blank" rel="noreferrer">
+                          {{ vulnerability.id }}
+                        </a>
+                        <span v-else class="fw-semibold">{{ vulnerability.id }}</span>
+                        <span v-if="vulnerability.fixedVersions.length" class="small text-muted">
+                          fixed in {{ vulnerability.fixedVersions.join(', ') }}
+                        </span>
+                      </div>
+                      <div class="small">{{ vulnerability.summary || vulnerability.details || 'No advisory summary available.' }}</div>
+                      <div v-if="vulnerability.aliases.length" class="small text-muted">
+                        {{ vulnerability.aliases.join(', ') }}
+                      </div>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+              <tr v-if="filteredDependencies.length === 0">
+                <td colspan="4" class="text-muted text-center py-4">No dependencies match the current filters.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.dependency-search {
+  min-width: 18rem;
+}
+
+.vulnerability-list {
+  max-width: 48rem;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -183,21 +183,21 @@ onMounted(load)
               </thead>
               <tbody>
                 <tr v-for="service in filtered" :key="service.id">
-                  <td>
+                  <td data-label="Service">
                     <div class="fw-semibold">{{ service.name }}</div>
                     <div class="small text-muted">
                       {{ service.type }}
                       <span v-if="service.image"> · <code>{{ service.image }}</code></span>
                     </div>
                   </td>
-                  <td><span class="badge" :class="sourceClass(service.source)">{{ service.source }}</span></td>
-                  <td><span class="badge" :class="statusClass(service.status)">{{ service.status }}</span></td>
-                  <td class="small">
+                  <td data-label="Source"><span class="badge" :class="sourceClass(service.source)">{{ service.source }}</span></td>
+                  <td data-label="Status"><span class="badge" :class="statusClass(service.status)">{{ service.status }}</span></td>
+                  <td data-label="Host / ports" class="small">
                     <div>{{ service.host || '—' }}</div>
                     <code>{{ formatPorts(service) }}</code>
                   </td>
-                  <td class="text-end">
-                    <div class="btn-group btn-group-sm">
+                  <td data-label="Actions" class="text-end">
+                    <div class="btn-group btn-group-sm service-actions">
                       <button class="btn btn-outline-secondary" @click="selected = service">
                         Details
                       </button>
@@ -281,5 +281,70 @@ onMounted(load)
   overflow: auto;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+td code {
+  white-space: normal;
+  word-break: break-word;
+}
+
+@media (max-width: 991.98px) {
+  .table-responsive {
+    overflow-x: visible;
+  }
+
+  table,
+  tbody,
+  tr,
+  td {
+    display: block;
+    width: 100%;
+  }
+
+  table {
+    border-collapse: separate;
+    border-spacing: 0 0.75rem;
+  }
+
+  thead {
+    display: none;
+  }
+
+  tr {
+    background: #fff;
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: 1rem;
+    box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.06);
+    padding: 0.75rem;
+  }
+
+  td {
+    border: 0;
+    padding: 0.35rem 0;
+  }
+
+  td::before {
+    color: #6c757d;
+    content: attr(data-label);
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    margin-bottom: 0.15rem;
+    text-transform: uppercase;
+  }
+
+  td.text-end {
+    text-align: start !important;
+  }
+
+  .service-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .service-actions > .btn {
+    border-radius: 0.75rem !important;
+  }
 }
 </style>

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -125,7 +125,7 @@ onMounted(() => {
 
 <template>
   <div>
-    <h2><i class="bi bi-shield-lock me-2"></i>Spring Security</h2>
+    <h2><i class="bi bi-person-lock me-2"></i>Spring Security</h2>
 
     <div v-if="!springSecurityPresent" class="alert alert-info">
       Spring Security is not on the classpath of this application. Add

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -50,6 +50,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - profile diff
   - Spring Security
   - Micrometer metrics
+  - dependency inventory and OSV vulnerability scan
   - DevTools reload/restart
 - Vue 3 UI shell with routes for:
   - Overview
@@ -68,11 +69,12 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - Profile Diff
   - Security
   - Metrics
+  - Vulnerabilities
   - DevTools
   - Dev Services
 - Maven-integrated frontend build that downloads Node/npm, builds the Vite app, and packages assets into `META-INF/resources/bootui`.
 - Backend tests covering activation, auto-configuration activation cases, localhost filtering, config override persistence, override property sources, override file storage, environment post-processing, config metadata loading, selected web controllers, missing Actuator behavior, and sample-app integration.
-- Playwright end-to-end tests in `bootui-sample-app/e2e` covering the sample API, every visible BootUI route, and focused flows for the current panel set, including Metrics, DevTools, and Dev Services.
+- Playwright end-to-end tests in `bootui-sample-app/e2e` covering the sample API, every visible BootUI route, and focused flows for the current panel set, including Metrics, Vulnerabilities, DevTools, and Dev Services.
 
 ## 3. Milestone status
 
@@ -84,7 +86,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
 | 3. Actuator bridge | Implemented, needs deeper backend coverage | Stable BootUI DTO endpoints exist for the original MVP panels; missing-Actuator behavior needs broader explicit tests. |
 | 4. Beans and Conditions panels | Implemented and covered by sample e2e | API and UI panels exist; large-app edge cases remain release-hardening work. |
 | 5. Config, Mappings, Health, and Loggers | Implemented and covered by sample e2e | Runtime config overrides, secret masking, mappings, health, and logger controls exist. Config override plumbing has focused backend tests. |
-| 6. Post-MVP diagnostic panels | Implemented and covered by sample e2e | Startup, Memory, Spring Data, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, Security, Metrics, DevTools, and Dev Services panels have API/UI slices plus route-level and focused Playwright coverage. Backend edge-case tests and safety review remain. |
+| 6. Post-MVP diagnostic panels | Implemented and covered by sample e2e | Startup, Memory, Spring Data, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, Security, Metrics, Vulnerabilities, DevTools, and Dev Services panels have API/UI slices plus route-level and focused Playwright coverage. Backend edge-case tests and safety review remain. |
 | 7. Documentation and release hardening | In progress | Installation, activation, safety, troubleshooting, release notes, screenshots, and sample walkthrough need to stay reconciled with current behavior. |
 
 ## 4. What still needs to be done
@@ -134,15 +136,16 @@ Validate every visible route against the sample app:
 9. Startup Timeline.
 10. Memory.
 11. Metrics.
-12. DevTools.
-13. Dev Services.
-14. Scheduled Tasks.
-15. HTTP Probe.
-16. Log Tail.
-17. Profile Diff.
-18. Security.
+12. Vulnerabilities.
+13. DevTools.
+14. Dev Services.
+15. Scheduled Tasks.
+16. HTTP Probe.
+17. Log Tail.
+18. Profile Diff.
+19. Security.
 
-The plan no longer treats Startup, Memory, Spring Data, HTTP Probe, Profile Diff, Log Tail, Scheduled Tasks, Security, Metrics, DevTools, or Dev Services as future-only ideas: they are implemented surfaces with sample-app Playwright coverage and should either be hardened for the next alpha or explicitly marked experimental before release.
+The plan no longer treats Startup, Memory, Spring Data, HTTP Probe, Profile Diff, Log Tail, Scheduled Tasks, Security, Metrics, Vulnerabilities, DevTools, or Dev Services as future-only ideas: they are implemented surfaces with sample-app Playwright coverage and should either be hardened for the next alpha or explicitly marked experimental before release.
 
 ### 4.3 Refresh user-facing documentation
 
@@ -176,14 +179,13 @@ Reconcile the specification with the implementation where behavior has become mo
 Run the CI-equivalent build:
 
 ```bash
-mvn -B -ntp clean install
+./mvnw -B -ntp clean install
 ```
 
 Run the sample app:
 
 ```bash
-cd bootui-sample-app
-mvn spring-boot:run -Dspring-boot.run.profiles=dev
+./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 Manual smoke checks:
@@ -356,7 +358,7 @@ Reason:
 
 Before considering the next alpha complete:
 
-- `mvn -B -ntp clean install` passes.
+- `./mvnw -B -ntp clean install` passes.
 - The UI build is executed automatically by Maven.
 - Sample app starts with the `dev` profile.
 - `/bootui` loads.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -411,7 +411,31 @@ Acceptance criteria:
 - Suggested options are clearly presented as recommendations, not automatic changes.
 - JVM argument disclosure is reviewed as part of release hardening.
 
-### 5.11 Scheduled Tasks Inspector
+### 5.11 Vulnerabilities Panel
+
+Purpose: answer "Which runtime JAR dependencies are present, and do any have known vulnerabilities?"
+
+Data sources:
+
+- Maven metadata (`META-INF/maven/*/*/pom.properties`) discovered from the running application's classpath.
+- OSV.dev Maven vulnerability data for explicit on-demand scans.
+
+Features:
+
+- List runtime Maven dependencies by group, artifact, and version.
+- Keep the initial inventory local-only; no external vulnerability lookup runs on page load.
+- Provide an explicit "Scan with OSV.dev" action that sends Maven package names and versions to OSV.dev.
+- Show scan status, vulnerable dependency count, advisory count, severity breakdown, advisory links, aliases, and fixed versions when available.
+- Support disabling OSV scans with `bootui.dependencies.osv-enabled=false`.
+
+Acceptance criteria:
+
+- Dependency and advisory data serialize through stable BootUI DTOs.
+- External scanning is user-initiated and clearly labeled in the UI.
+- OSV failures return a clear error status while preserving the local dependency inventory.
+- Scan size is bounded by configuration so large classpaths remain responsive.
+
+### 5.12 Scheduled Tasks Inspector
 
 Purpose: answer "Which scheduled tasks are registered?"
 
@@ -430,7 +454,7 @@ Acceptance criteria:
 - Opening the panel never invokes scheduled tasks.
 - Spring wrapper runnables are displayed with the most useful available task description.
 
-### 5.12 HTTP Probe Panel
+### 5.13 HTTP Probe Panel
 
 Purpose: issue safe local HTTP requests to the running app from the developer console.
 
@@ -452,7 +476,7 @@ Acceptance criteria:
 - Unsafe-body behavior is explicit and predictable.
 - Response headers are filtered to a small allow-list.
 
-### 5.13 Log Tail Panel
+### 5.14 Log Tail Panel
 
 Purpose: stream recent local application log lines in the browser.
 
@@ -471,7 +495,7 @@ Acceptance criteria:
 - The panel is classpath-gated and unavailable when Logback is absent.
 - Log events are shaped into stable DTOs before reaching the browser.
 
-### 5.14 Profile Diff Panel
+### 5.15 Profile Diff Panel
 
 Purpose: show which properties are contributed by active profile-specific property sources.
 
@@ -492,7 +516,7 @@ Acceptance criteria:
 - Metadata-only exposure hides values.
 - Source attribution remains visible.
 
-### 5.15 Spring Security Panel
+### 5.16 Spring Security Panel
 
 Purpose: answer "Which security filter chains and authorization rules apply?"
 
@@ -515,7 +539,7 @@ Acceptance criteria:
 - Credentials, password hashes, signing keys, session IDs, and tokens are never displayed.
 - Matching caveats are clearly marked as best-effort.
 
-### 5.16 Spring Data Explorer
+### 5.17 Spring Data Explorer
 
 Purpose: answer "Which Spring Data repositories does this app declare, against which store, and what queries do they expose?"
 
@@ -548,7 +572,7 @@ Acceptance criteria:
 - Query strings declared via `@Query` are displayed verbatim; BootUI never rewrites or executes them.
 - No repository method is invoked as a side effect of opening the panel.
 
-### 5.17 Dev Services Panel
+### 5.18 Dev Services Panel
 
 Purpose: answer "Which local backing services are connected?"
 
@@ -670,7 +694,7 @@ Build requirements:
 - The Maven build must install/use the configured Node.js and npm versions for reproducible frontend builds.
 - The frontend build must run before Java resources are packaged.
 - The generated Vue assets must be copied into a classpath location served by `bootui-autoconfigure`, such as `META-INF/resources/bootui/`.
-- `mvn clean package` from the repository root must produce BootUI artifacts that already contain the compiled Vue UI.
+- `./mvnw clean package` from the repository root must produce BootUI artifacts that already contain the compiled Vue UI.
 - Consumer Spring Boot 4 applications should only need the `bootui-spring-boot-starter` dependency; they must not run `npm install` or `npm run build` themselves.
 
 #### `bootui-sample-app`
@@ -732,6 +756,8 @@ Initial endpoints:
 | `/bootui/api/startup` | GET | Startup timeline |
 | `/bootui/api/metrics` | GET | Browseable Micrometer meter list |
 | `/bootui/api/metrics/detail` | GET | Micrometer meter detail and live measurements |
+| `/bootui/api/dependencies` | GET | Runtime Maven dependency inventory without external scanning |
+| `/bootui/api/dependencies/scan` | POST | Explicit on-demand OSV.dev vulnerability scan |
 | `/bootui/api/devtools` | GET | Spring Boot DevTools status |
 | `/bootui/api/devtools/livereload` | POST | Trigger a DevTools LiveReload notification when available |
 | `/bootui/api/devtools/restart` | POST | Schedule a DevTools restart after explicit confirmation |
@@ -774,6 +800,10 @@ Initial properties:
 | `bootui.disabled-profiles` | `prod,production` | Profiles that disable BootUI unless `bootui.enabled=ON`. |
 | `bootui.overrides-file` | `.bootui/application-bootui.properties` | File used to persist local runtime configuration overrides. |
 | `bootui.endpoint-timeout` | `5s` | Timeout for endpoint-related calls. |
+| `bootui.dependencies.osv-enabled` | `true` | Allow the user-initiated OSV.dev vulnerability scan action. |
+| `bootui.dependencies.request-timeout` | `10s` | Timeout applied to each OSV request. |
+| `bootui.dependencies.max-packages` | `250` | Maximum packages sent in one OSV batch query. |
+| `bootui.dependencies.max-advisories` | `200` | Maximum advisory detail documents fetched after a query. |
 | `bootui.dev-services.restart-enabled` | `false` | Enables restart controls for bean-backed Testcontainers services. |
 | `bootui.dev-services.log-tail-bytes` | `65536` | Maximum bytes returned by one Dev Services log request. |
 
@@ -792,6 +822,7 @@ Rules:
 - Persist runtime overrides only to BootUI's configured override file.
 - Never send telemetry by default.
 - Never proxy arbitrary external URLs.
+- Never perform dependency vulnerability lookups until the developer explicitly starts an OSV scan.
 
 Production safety:
 
@@ -822,6 +853,7 @@ Top-level tabs:
 - Startup Timeline.
 - Memory.
 - Metrics.
+- Vulnerabilities.
 - DevTools.
 - Dev Services.
 - Scheduled Tasks.

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,338 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version @@project.version@@
+#
+# Required ENV vars:
+# ------------------
+#   JAVA_HOME - location of a JDK home dir
+#
+# Optional ENV vars
+# -----------------
+#   MAVEN_OPTS - parameters passed to the Java VM when running Maven
+#     e.g. to debug Maven itself, use
+#       set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+#   MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+# ----------------------------------------------------------------------------
+
+if [ -z "$MAVEN_SKIP_RC" ]; then
+
+  if [ -f /usr/local/etc/mavenrc ]; then
+    . /usr/local/etc/mavenrc
+  fi
+
+  if [ -f /etc/mavenrc ]; then
+    . /etc/mavenrc
+  fi
+
+  if [ -f "$HOME/.mavenrc" ]; then
+    . "$HOME/.mavenrc"
+  fi
+
+fi
+
+# OS specific support.  $var _must_ be set to either true or false.
+cygwin=false
+darwin=false
+mingw=false
+case "$(uname)" in
+CYGWIN*) cygwin=true ;;
+MINGW*) mingw=true ;;
+Darwin*)
+  darwin=true
+  # Use /usr/libexec/java_home if available, otherwise fall back to /Library/Java/Home
+  # See https://developer.apple.com/library/mac/qa/qa1170/_index.html
+  if [ -z "$JAVA_HOME" ]; then
+    if [ -x "/usr/libexec/java_home" ]; then
+      JAVA_HOME="$(/usr/libexec/java_home)"
+      export JAVA_HOME
+    else
+      JAVA_HOME="/Library/Java/Home"
+      export JAVA_HOME
+    fi
+  fi
+  ;;
+esac
+
+if [ -z "$JAVA_HOME" ]; then
+  if [ -r /etc/gentoo-release ]; then
+    JAVA_HOME=$(java-config --jre-home)
+  fi
+fi
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] \
+    && JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] \
+    && CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
+fi
+
+# For Mingw, ensure paths are in UNIX format before anything is touched
+if $mingw; then
+  [ -n "$JAVA_HOME" ] && [ -d "$JAVA_HOME" ] \
+    && JAVA_HOME="$(
+      cd "$JAVA_HOME" || (
+        echo "cannot cd into $JAVA_HOME." >&2
+        exit 1
+      )
+      pwd
+    )"
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  javaExecutable="$(which javac)"
+  if [ -n "$javaExecutable" ] && ! [ "$(expr "$javaExecutable" : '\([^ ]*\)')" = "no" ]; then
+    # readlink(1) is not available as standard on Solaris 10.
+    readLink=$(which readlink)
+    if [ ! "$(expr "$readLink" : '\([^ ]*\)')" = "no" ]; then
+      if $darwin; then
+        javaHome="$(dirname "$javaExecutable")"
+        javaExecutable="$(cd "$javaHome" && pwd -P)/javac"
+      else
+        javaExecutable="$(readlink -f "$javaExecutable")"
+      fi
+      javaHome="$(dirname "$javaExecutable")"
+      javaHome=$(expr "$javaHome" : '\(.*\)/bin')
+      JAVA_HOME="$javaHome"
+      export JAVA_HOME
+    fi
+  fi
+fi
+
+if [ -z "$JAVACMD" ]; then
+  if [ -n "$JAVA_HOME" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD="$(
+      \unset -f command 2>/dev/null
+      \command -v java
+    )"
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ]; then
+  echo "Error: JAVA_HOME is not defined correctly." >&2
+  echo "  We cannot execute $JAVACMD" >&2
+  exit 1
+fi
+
+if [ -z "$JAVA_HOME" ]; then
+  echo "Warning: JAVA_HOME environment variable is not set." >&2
+fi
+
+# traverses directory structure from process work directory to filesystem root
+# first directory with .mvn subdirectory is considered project base directory
+find_maven_basedir() {
+  if [ -z "$1" ]; then
+    echo "Path not specified to find_maven_basedir" >&2
+    return 1
+  fi
+
+  basedir="$1"
+  wdir="$1"
+  while [ "$wdir" != '/' ]; do
+    if [ -d "$wdir"/.mvn ]; then
+      basedir=$wdir
+      break
+    fi
+    # workaround for JBEAP-8937 (on Solaris 10/Sparc)
+    if [ -d "${wdir}" ]; then
+      wdir=$(
+        cd "$wdir/.." || exit 1
+        pwd
+      )
+    fi
+    # end of workaround
+  done
+  printf '%s' "$(
+    cd "$basedir" || exit 1
+    pwd
+  )"
+}
+
+# concatenates all lines of a file
+concat_lines() {
+  if [ -f "$1" ]; then
+    # Remove \r in case we run on Windows within Git Bash
+    # and check out the repository with auto CRLF management
+    # enabled. Otherwise, we may read lines that are delimited with
+    # \r\n and produce $'-Xarg\r' rather than -Xarg due to word
+    # splitting rules.
+    tr -s '\r\n' ' ' <"$1"
+  fi
+}
+
+log() {
+  if [ "$MVNW_VERBOSE" = true ]; then
+    printf '%s\n' "$1"
+  fi
+}
+
+BASE_DIR=$(find_maven_basedir "$(dirname "$0")")
+if [ -z "$BASE_DIR" ]; then
+  exit 1
+fi
+
+MAVEN_PROJECTBASEDIR=${MAVEN_BASEDIR:-"$BASE_DIR"}
+export MAVEN_PROJECTBASEDIR
+log "$MAVEN_PROJECTBASEDIR"
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+##########################################################################################
+# Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+# This allows using the maven wrapper in projects that prohibit checking in binary data.
+##########################################################################################
+wrapperJarPath="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar"
+if [ -r "$wrapperJarPath" ]; then
+  log "Found $wrapperJarPath"
+else
+  log "Couldn't find $wrapperJarPath, downloading it ..."
+
+  if [ -n "$MVNW_REPOURL" ]; then
+    wrapperUrl="$MVNW_REPOURL/org/apache/maven/wrapper/maven-wrapper/@@project.version@@/maven-wrapper-@@project.version@@.jar"
+  else
+    wrapperUrl="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/@@project.version@@/maven-wrapper-@@project.version@@.jar"
+  fi
+  while IFS="=" read -r key value; do
+    case "$key" in wrapperUrl)
+      wrapperUrl=$(trim "${value-}")
+      break
+      ;;
+    esac
+  done <"$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+  log "Downloading from: $wrapperUrl"
+
+  if $cygwin; then
+    wrapperJarPath=$(cygpath --path --windows "$wrapperJarPath")
+  fi
+
+  if command -v wget >/dev/null; then
+    log "Found wget ... using wget"
+    [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--quiet"
+    if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+      wget ${QUIET:+"$QUIET"} "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+    else
+      wget ${QUIET:+"$QUIET"} --http-user="$MVNW_USERNAME" --http-password="$MVNW_PASSWORD" "$wrapperUrl" -O "$wrapperJarPath" || rm -f "$wrapperJarPath"
+    fi
+  elif command -v curl >/dev/null; then
+    log "Found curl ... using curl"
+    [ "$MVNW_VERBOSE" = true ] && QUIET="" || QUIET="--silent"
+    if [ -z "$MVNW_USERNAME" ] || [ -z "$MVNW_PASSWORD" ]; then
+      curl ${QUIET:+"$QUIET"} -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+    else
+      curl ${QUIET:+"$QUIET"} --user "$MVNW_USERNAME:$MVNW_PASSWORD" -o "$wrapperJarPath" "$wrapperUrl" -f -L || rm -f "$wrapperJarPath"
+    fi
+  else
+    log "Falling back to using Java to download"
+    javaSource="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.java"
+    javaClass="$MAVEN_PROJECTBASEDIR/.mvn/wrapper/MavenWrapperDownloader.class"
+    # For Cygwin, switch paths to Windows format before running javac
+    if $cygwin; then
+      javaSource=$(cygpath --path --windows "$javaSource")
+      javaClass=$(cygpath --path --windows "$javaClass")
+    fi
+    if [ -e "$javaSource" ]; then
+      if [ ! -e "$javaClass" ]; then
+        log " - Compiling MavenWrapperDownloader.java ..."
+        ("$JAVA_HOME/bin/javac" "$javaSource")
+      fi
+      if [ -e "$javaClass" ]; then
+        log " - Running MavenWrapperDownloader.java ..."
+        ("$JAVA_HOME/bin/java" -cp .mvn/wrapper MavenWrapperDownloader "$wrapperUrl" "$wrapperJarPath") || rm -f "$wrapperJarPath"
+      fi
+    fi
+  fi
+fi
+##########################################################################################
+# End of extension
+##########################################################################################
+
+# If specified, validate the SHA-256 sum of the Maven wrapper jar file
+wrapperSha256Sum=""
+while IFS="=" read -r key value; do
+  case "$key" in wrapperSha256Sum)
+    wrapperSha256Sum=$(trim "${value-}")
+    break
+    ;;
+  esac
+done <"$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.properties"
+if [ -n "$wrapperSha256Sum" ]; then
+  wrapperSha256Result=false
+  if command -v sha256sum >/dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | sha256sum -c - >/dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$wrapperSha256Sum  $wrapperJarPath" | shasum -a 256 -c >/dev/null 2>&1; then
+      wrapperSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'wrapperSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $wrapperSha256Result = false ]; then
+    echo "Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised." >&2
+    echo "Investigate or delete $wrapperJarPath to attempt a clean download." >&2
+    echo "If you updated your Maven version, you need to update the specified wrapperSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+MAVEN_OPTS="$(concat_lines "$MAVEN_PROJECTBASEDIR/.mvn/jvm.config") $MAVEN_OPTS"
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] \
+    && JAVA_HOME=$(cygpath --path --windows "$JAVA_HOME")
+  [ -n "$CLASSPATH" ] \
+    && CLASSPATH=$(cygpath --path --windows "$CLASSPATH")
+  [ -n "$MAVEN_PROJECTBASEDIR" ] \
+    && MAVEN_PROJECTBASEDIR=$(cygpath --path --windows "$MAVEN_PROJECTBASEDIR")
+fi
+
+# Provide a "standardized" way to retrieve the CLI args that will
+# work with both Windows and non-Windows executions.
+MAVEN_CMD_LINE_ARGS="$MAVEN_CONFIG $*"
+export MAVEN_CMD_LINE_ARGS
+
+WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+# shellcheck disable=SC2086 # safe args
+exec "$JAVACMD" \
+  $MAVEN_OPTS \
+  $MAVEN_DEBUG_OPTS \
+  -classpath "$MAVEN_PROJECTBASEDIR/.mvn/wrapper/maven-wrapper.jar" \
+  "-Dmaven.multiModuleProjectDirectory=${MAVEN_PROJECTBASEDIR}" \
+  ${WRAPPER_LAUNCHER} $MAVEN_CONFIG "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,206 @@
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version @@project.version@@
+@REM
+@REM Required ENV vars:
+@REM JAVA_HOME - location of a JDK home dir
+@REM
+@REM Optional ENV vars
+@REM MAVEN_BATCH_ECHO - set to 'on' to enable the echoing of the batch commands
+@REM MAVEN_BATCH_PAUSE - set to 'on' to wait for a keystroke before ending
+@REM MAVEN_OPTS - parameters passed to the Java VM when running Maven
+@REM     e.g. to debug Maven itself, use
+@REM set MAVEN_OPTS=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000
+@REM MAVEN_SKIP_RC - flag to disable loading of mavenrc files
+@REM ----------------------------------------------------------------------------
+
+@REM Begin all REM lines with '@' in case MAVEN_BATCH_ECHO is 'on'
+@echo off
+@REM set title of command window
+title %0
+@REM enable echoing by setting MAVEN_BATCH_ECHO to 'on'
+@if "%MAVEN_BATCH_ECHO%" == "on"  echo %MAVEN_BATCH_ECHO%
+
+@REM set %HOME% to equivalent of $HOME
+if "%HOME%" == "" (set "HOME=%HOMEDRIVE%%HOMEPATH%")
+
+@REM Execute a user defined script before this one
+if not "%MAVEN_SKIP_RC%" == "" goto skipRcPre
+@REM check for pre script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_pre.bat" call "%USERPROFILE%\mavenrc_pre.bat" %*
+if exist "%USERPROFILE%\mavenrc_pre.cmd" call "%USERPROFILE%\mavenrc_pre.cmd" %*
+:skipRcPre
+
+@setlocal
+
+set ERROR_CODE=0
+
+@REM To isolate internal variables from possible post scripts, we use another setlocal
+@setlocal
+
+@REM ==== START VALIDATION ====
+if not "%JAVA_HOME%" == "" goto OkJHome
+
+echo. >&2
+echo Error: JAVA_HOME not found in your environment. >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo. >&2
+goto error
+
+:OkJHome
+if exist "%JAVA_HOME%\bin\java.exe" goto init
+
+echo. >&2
+echo Error: JAVA_HOME is set to an invalid directory. >&2
+echo JAVA_HOME = "%JAVA_HOME%" >&2
+echo Please set the JAVA_HOME variable in your environment to match the >&2
+echo location of your Java installation. >&2
+echo. >&2
+goto error
+
+@REM ==== END VALIDATION ====
+
+:init
+
+@REM Find the project base dir, i.e. the directory that contains the folder ".mvn".
+@REM Fallback to current working directory if not found.
+
+set MAVEN_PROJECTBASEDIR=%MAVEN_BASEDIR%
+IF NOT "%MAVEN_PROJECTBASEDIR%"=="" goto endDetectBaseDir
+
+set EXEC_DIR=%CD%
+set WDIR=%EXEC_DIR%
+:findBaseDir
+IF EXIST "%WDIR%"\.mvn goto baseDirFound
+cd ..
+IF "%WDIR%"=="%CD%" goto baseDirNotFound
+set WDIR=%CD%
+goto findBaseDir
+
+:baseDirFound
+set MAVEN_PROJECTBASEDIR=%WDIR%
+cd "%EXEC_DIR%"
+goto endDetectBaseDir
+
+:baseDirNotFound
+set MAVEN_PROJECTBASEDIR=%EXEC_DIR%
+cd "%EXEC_DIR%"
+
+:endDetectBaseDir
+
+IF NOT EXIST "%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config" goto endReadAdditionalConfig
+
+@setlocal EnableExtensions EnableDelayedExpansion
+for /F "usebackq delims=" %%a in ("%MAVEN_PROJECTBASEDIR%\.mvn\jvm.config") do set JVM_CONFIG_MAVEN_PROPS=!JVM_CONFIG_MAVEN_PROPS! %%a
+@endlocal & set JVM_CONFIG_MAVEN_PROPS=%JVM_CONFIG_MAVEN_PROPS%
+
+:endReadAdditionalConfig
+
+SET MAVEN_JAVA_EXE="%JAVA_HOME%\bin\java.exe"
+set WRAPPER_JAR="%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.jar"
+set WRAPPER_LAUNCHER=org.apache.maven.wrapper.MavenWrapperMain
+
+set WRAPPER_URL="https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/@@project.version@@/maven-wrapper-@@project.version@@.jar"
+
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperUrl" SET WRAPPER_URL=%%B
+)
+
+@REM Extension to allow automatically downloading the maven-wrapper.jar from Maven-central
+@REM This allows using the maven wrapper in projects that prohibit checking in binary data.
+if exist %WRAPPER_JAR% (
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Found %WRAPPER_JAR%
+    )
+) else (
+    if not "%MVNW_REPOURL%" == "" (
+        SET WRAPPER_URL="%MVNW_REPOURL%/org/apache/maven/wrapper/maven-wrapper/@@project.version@@/maven-wrapper-@@project.version@@.jar"
+    )
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Couldn't find %WRAPPER_JAR%, downloading it ...
+        echo Downloading from: %WRAPPER_URL%
+    )
+
+    powershell -Command "&{"^
+		"$webclient = new-object System.Net.WebClient;"^
+		"if (-not ([string]::IsNullOrEmpty('%MVNW_USERNAME%') -and [string]::IsNullOrEmpty('%MVNW_PASSWORD%'))) {"^
+		"$webclient.Credentials = new-object System.Net.NetworkCredential('%MVNW_USERNAME%', '%MVNW_PASSWORD%');"^
+		"}"^
+		"[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $webclient.DownloadFile('%WRAPPER_URL%', '%WRAPPER_JAR%')"^
+		"}"
+    if "%MVNW_VERBOSE%" == "true" (
+        echo Finished downloading %WRAPPER_JAR%
+    )
+)
+@REM End of extension
+
+@REM If specified, validate the SHA-256 sum of the Maven wrapper jar file
+SET WRAPPER_SHA_256_SUM=""
+FOR /F "usebackq tokens=1,2 delims==" %%A IN ("%MAVEN_PROJECTBASEDIR%\.mvn\wrapper\maven-wrapper.properties") DO (
+    IF "%%A"=="wrapperSha256Sum" SET WRAPPER_SHA_256_SUM=%%B
+)
+IF NOT %WRAPPER_SHA_256_SUM%=="" (
+    powershell -Command "&{"^
+       "Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash;"^
+       "$hash = (Get-FileHash \"%WRAPPER_JAR%\" -Algorithm SHA256).Hash.ToLower();"^
+       "If('%WRAPPER_SHA_256_SUM%' -ne $hash){"^
+       "  Write-Error 'Error: Failed to validate Maven wrapper SHA-256, your Maven wrapper might be compromised.';"^
+       "  Write-Error 'Investigate or delete %WRAPPER_JAR% to attempt a clean download.';"^
+       "  Write-Error 'If you updated your Maven version, you need to update the specified wrapperSha256Sum property.';"^
+       "  exit 1;"^
+       "}"^
+       "}"
+    if ERRORLEVEL 1 goto error
+)
+
+@REM Provide a "standardized" way to retrieve the CLI args that will
+@REM work with both Windows and non-Windows executions.
+set MAVEN_CMD_LINE_ARGS=%*
+
+%MAVEN_JAVA_EXE% ^
+  %JVM_CONFIG_MAVEN_PROPS% ^
+  %MAVEN_OPTS% ^
+  %MAVEN_DEBUG_OPTS% ^
+  -classpath %WRAPPER_JAR% ^
+  "-Dmaven.multiModuleProjectDirectory=%MAVEN_PROJECTBASEDIR%" ^
+  %WRAPPER_LAUNCHER% %MAVEN_CONFIG% %*
+if ERRORLEVEL 1 goto error
+goto end
+
+:error
+set ERROR_CODE=1
+
+:end
+@endlocal & set ERROR_CODE=%ERROR_CODE%
+
+if not "%MAVEN_SKIP_RC%"=="" goto skipRcPost
+@REM check for post script, once with legacy .bat ending and once with .cmd ending
+if exist "%USERPROFILE%\mavenrc_post.bat" call "%USERPROFILE%\mavenrc_post.bat"
+if exist "%USERPROFILE%\mavenrc_post.cmd" call "%USERPROFILE%\mavenrc_post.cmd"
+:skipRcPost
+
+@REM pause the script if MAVEN_BATCH_PAUSE is set to 'on'
+if "%MAVEN_BATCH_PAUSE%"=="on" pause
+
+if "%MAVEN_TERMINATE_CMD%"=="on" exit %ERROR_CODE%
+
+cmd /C exit /B %ERROR_CODE%


### PR DESCRIPTION
## What does this PR do?

Adds a local Vulnerabilities panel that inventories runtime Maven dependencies and runs an explicit OSV.dev scan on demand. It also adds the Maven Wrapper and updates repository docs and CI commands to use `./mvnw`.

## Why is this change needed?

BootUI can show a lot of runtime state, but it did not help developers understand whether their local application dependency set includes known vulnerable JARs. This adds a dev-console workflow for reviewing dependency advisories without making an external request until the developer starts a scan.

The scanner first discovers Maven metadata from the runtime classpath, then falls back to Maven-repository paths for JARs that do not include `META-INF/maven/**/pom.properties`, such as Tomcat and PostgreSQL. The UI makes the pre-scan state explicit, filters vulnerable dependencies automatically when findings exist, and keeps `/dependencies` as a redirect to the new `/vulnerabilities` route.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional validation run:

```bash
./mvnw -pl bootui-autoconfigure -am test -Dtest=DependencyCatalogTests,DependenciesControllerTests,OsvVulnerabilityScannerTests,BootUiAutoConfigurationTests -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
./mvnw -B -ntp -DskipTests package
```

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed