### PR TITLE
Add release preparation workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,103 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version, for example 0.1.0-alpha.2
+        required: true
+        type: string
+      skip_build:
+        description: Skip the verification build before creating the tag
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  prepare-release:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Configure Git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Prepare release commit and tag
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          SKIP_BUILD: ${{ inputs.skip_build }}
+        run: |
+          set -euo pipefail
+
+          VERSION="${RELEASE_VERSION#v}"
+          TAG="v$VERSION"
+
+          if [[ -z "$VERSION" || "$VERSION" == *[[:space:]]* || "$VERSION" == */* ]]; then
+            echo "::error::Invalid release version: $RELEASE_VERSION"
+            exit 2
+          fi
+
+          if [[ "$VERSION" == *-SNAPSHOT ]]; then
+            echo "::error::Refusing to prepare a snapshot release: $VERSION"
+            exit 2
+          fi
+
+          if [[ "$GITHUB_REF_TYPE" != "branch" ]]; then
+            echo "::error::Prepare Release must run from a branch, not $GITHUB_REF_TYPE"
+            exit 1
+          fi
+
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG already exists locally"
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists on origin"
+            exit 1
+          fi
+
+          CURRENT_VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=project.version)"
+          echo "Preparing release $TAG from $CURRENT_VERSION"
+
+          ./mvnw -B -ntp versions:set \
+            -DnewVersion="$VERSION" \
+            -DprocessAllModules=true \
+            -DgenerateBackupPoms=false
+
+          export CURRENT_VERSION VERSION
+          perl -0pi -e 's/\Q$ENV{CURRENT_VERSION}\E/$ENV{VERSION}/g' README.md
+
+          if [[ "$SKIP_BUILD" != "true" ]]; then
+            ./mvnw -B -ntp clean verify
+          fi
+
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add pom.xml */pom.xml README.md
+            git commit -m "Release $TAG"
+          else
+            echo "Project files already declare version $VERSION; tagging current HEAD."
+          fi
+
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "HEAD:$GITHUB_REF_NAME"
+          git push origin "$TAG"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,13 @@ server from `~/.m2/settings.xml`. The sample app is not deployed. By default,
 Central uploads are published automatically; set `-Dcentral.autoPublish=false`
 to stage for manual publishing instead.
 
+To prepare a release, run the **Prepare Release** GitHub Actions workflow from
+the branch you want to release, usually `main`, and enter the target version
+without the leading `v`, for example `0.1.0-alpha.2`. The workflow updates all
+Maven module versions, refreshes the README dependency example, commits the
+release, creates an annotated `v0.1.0-alpha.2` tag, and pushes the branch plus
+tag. Pushing the tag starts the release workflow below.
+
 The GitHub Actions release workflow (`.github/workflows/release.yml`) runs on
 `v*` tags or manually through `workflow_dispatch`. Configure these repository or
 environment secrets before running it:


### PR DESCRIPTION
## What does this PR do?

Adds a manually triggered Prepare Release workflow that updates Maven module versions, refreshes the README dependency example, commits the release version, creates an annotated version tag, and pushes the branch and tag so the existing release workflow can publish.

## Why is this change needed?

Release preparation currently requires manually updating `pom.xml` files and tagging the branch. Moving that preparation into GitHub Actions makes the release process repeatable without running local scripts.

Closes N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Validated the workflow shell syntax and Maven project version lookup locally.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed