### PR TITLE
Add GitHub project links to BootUI

### DIFF
--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -13,6 +13,14 @@ test.describe('BootUI app shell', () => {
     await expect(subtitle).toContainText(/Java /)
   })
 
+  test('sidebar links to the BootUI GitHub project', async ({ page }) => {
+    await page.goto('/bootui/')
+
+    const contributeLink = page.getByRole('link', { name: /Contribute to the project/ })
+    await expect(contributeLink).toHaveAttribute('href', 'https://github.com/jdubois/boot-ui')
+    await expect(contributeLink.locator('.bi-github')).toBeVisible()
+  })
+
   test('sidebar links open every BootUI section', async ({ page }) => {
     const links = [
       { title: 'Overview',          heading: /^Overview/ },

--- a/bootui-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-sample-app/e2e/tests/overview.spec.js
@@ -29,4 +29,11 @@ test.describe('Overview view', () => {
     const response = await requestPromise
     expect(response.ok()).toBeTruthy()
   })
+
+  test('hero links to the BootUI GitHub project', async ({ openView }) => {
+    const page = await openView('overview', 'Overview')
+
+    await expect(page.getByRole('link', { name: /BootUI GitHub project/ }))
+      .toHaveAttribute('href', 'https://github.com/jdubois/boot-ui')
+  })
 })

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -20,6 +20,7 @@ const activationLabel = computed(() => {
   if (!overview.value?.activation) return 'Loading'
   return overview.value.activation.enabled ? 'Active' : 'Disabled'
 })
+const githubProjectUrl = 'https://github.com/jdubois/boot-ui'
 
 async function loadOverview() {
   try {
@@ -60,16 +61,19 @@ onMounted(loadOverview)
         </router-link>
       </nav>
 
-      <div class="safety-card mt-auto">
-        <div class="d-flex align-items-center gap-2">
-          <span class="safety-icon">
-            <i class="bi bi-shield-lock"></i>
+      <div class="sidebar-bottom mt-auto">
+        <a
+          class="contribute-card text-decoration-none"
+          :href="githubProjectUrl"
+          target="_blank"
+          rel="noopener noreferrer">
+          <span class="contribute-icon">
+            <i class="bi bi-github"></i>
           </span>
-          <div>
-            <strong>Loopback first</strong>
-            <div class="small text-muted">Local-only by default</div>
-          </div>
-        </div>
+          <span>
+            <strong>Contribute to the project</strong>
+          </span>
+        </a>
         <div v-if="overview?.activation && !overview.activation.enabled" class="alert alert-warning mt-3 mb-0 small">
           BootUI is disabled: {{ overview.activation.reason }}
         </div>
@@ -226,7 +230,7 @@ onMounted(loadOverview)
 
 .brand-mark,
 .page-icon,
-.safety-icon {
+.contribute-icon {
   align-items: center;
   border-radius: 1rem;
   display: inline-flex;
@@ -296,16 +300,36 @@ onMounted(loadOverview)
   font-size: 1.05rem;
 }
 
-.safety-card {
+.sidebar-bottom {
+  display: flex;
+  flex-direction: column;
+}
+
+.contribute-card {
+  align-items: center;
   background: rgba(255, 255, 255, 0.84);
   border: 1px solid rgba(15, 23, 42, 0.08);
   border-radius: 1.1rem;
+  color: inherit;
+  display: flex;
+  gap: 0.75rem;
   padding: 0.9rem;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
 
-.safety-icon {
-  background: rgba(25, 135, 84, 0.12);
-  color: #198754;
+.contribute-card:hover {
+  border-color: rgba(13, 110, 253, 0.25);
+  box-shadow: 0 0.9rem 1.8rem rgba(15, 23, 42, 0.09);
+  transform: translateY(-2px);
+}
+
+.contribute-card strong {
+  display: block;
+}
+
+.contribute-icon {
+  background: #24292f;
+  color: #fff;
   height: 2.25rem;
   width: 2.25rem;
 }

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -8,6 +8,7 @@ const error = ref(null)
 const activeProfiles = computed(() => data.value?.activeProfiles ?? [])
 const defaultProfiles = computed(() => data.value?.defaultProfiles ?? [])
 const warningCount = computed(() => data.value?.activation?.warnings?.length ?? 0)
+const githubProjectUrl = 'https://github.com/jdubois/boot-ui'
 const stats = computed(() => {
   if (!data.value) return []
   return [
@@ -88,6 +89,10 @@ onMounted(load)
         <a class="btn btn-outline-light" href="/">
           <i class="bi bi-house-door me-1"></i>
           Back to homepage
+        </a>
+        <a class="btn btn-outline-light" :href="githubProjectUrl" target="_blank" rel="noopener noreferrer">
+          <i class="bi bi-github me-1"></i>
+          BootUI GitHub project
         </a>
         <button class="btn btn-light hero-refresh" @click="load" :disabled="loading">
           <i class="bi bi-arrow-clockwise me-1" :class="{ 'spin': loading }"></i>


### PR DESCRIPTION
BootUI did not expose an obvious path from the local console back to the project repository. This adds visible GitHub entry points so users can contribute to the project or inspect the repository from the UI.

## Summary
- Replace the sidebar's loopback note with a GitHub contribution card linking to `jdubois/boot-ui`.
- Add a `BootUI GitHub project` link next to `Back to homepage` in the overview hero.
- Cover both GitHub links in the app shell and overview Playwright specs.

## Validation
- `./mvnw -B -ntp -pl bootui-ui install -DskipTests`
- `cd bootui-sample-app/e2e && export PATH="$PWD/../../bootui-ui/target/node/node:$PATH" && MAVEN_ARGS=--offline BOOTUI_SAMPLE_PORT=18083 SERVER_PORT=18083 npm test -- tests/app-shell.spec.js tests/overview.spec.js`

Full e2e was also attempted; it passed these new checks but hit an unrelated existing strict-locator issue in the Vulnerabilities scan test for `SCANNED`.