### PR TITLE
Improve Dev Services panel

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesController.java
@@ -8,6 +8,7 @@ import io.github.jdubois.bootui.core.BootUiDtos.DevServicePortDto;
 import io.github.jdubois.bootui.core.BootUiDtos.DevServiceRestartResult;
 import io.github.jdubois.bootui.core.BootUiDtos.DevServicesReport;
 import io.github.jdubois.bootui.core.SecretMasker;
+import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -109,10 +110,14 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
     @GetMapping("/{id}/logs")
     public DevServiceLogReport logs(@PathVariable String id) {
         Object bean = findBeanBackedService(id);
-        if (bean == null || findNoArgMethod(bean.getClass(), "getLogs") == null) {
+        if (bean == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Service not found");
+        }
+        Method logsMethod = findLogsMethod(bean.getClass());
+        if (logsMethod == null) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Logs are not available for this service");
         }
-        Object logs = invoke(bean, "getLogs");
+        Object logs = invokeLogs(bean, logsMethod);
         String text = logs == null ? "" : String.valueOf(logs);
         int maxBytes = Math.max(1024, properties.getDevServices().getLogTailBytes());
         boolean truncated = text.getBytes(java.nio.charset.StandardCharsets.UTF_8).length > maxBytes;
@@ -237,7 +242,7 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
                 testcontainersPorts(bean),
                 sanitizeDetails(details),
                 restartable,
-                findNoArgMethod(bean.getClass(), "getLogs") != null,
+                findLogsMethod(bean.getClass()) != null,
                 properties.getDevServices().isRestartEnabled()
                         ? "Restart may require application clients to reconnect."
                         : "Restart disabled by default; set bootui.dev-services.restart-enabled=true to allow it.");
@@ -569,6 +574,39 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
 
     private Method findNoArgMethod(Class<?> type, String methodName) {
         return findMethod(type, methodName);
+    }
+
+    private Method findLogsMethod(Class<?> type) {
+        for (Method method : type.getMethods()) {
+            if (!method.getName().equals("getLogs") || method.getReturnType() == Void.TYPE) {
+                continue;
+            }
+            if (method.getParameterCount() == 0) {
+                return method;
+            }
+            if (method.isVarArgs() && method.getParameterCount() == 1 && method.getParameterTypes()[0].isArray()) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    private Object invokeLogs(Object bean, Method logsMethod) {
+        try {
+            if (logsMethod.getParameterCount() == 0) {
+                return logsMethod.invoke(bean);
+            }
+            Object emptySelection = Array.newInstance(logsMethod.getParameterTypes()[0].getComponentType(), 0);
+            return logsMethod.invoke(bean, emptySelection);
+        }
+        catch (IllegalAccessException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Unable to read service logs", ex);
+        }
+        catch (InvocationTargetException ex) {
+            Throwable cause = ex.getCause() == null ? ex : ex.getCause();
+            String message = cause.getMessage() == null ? "Unable to read service logs" : cause.getMessage();
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, message, cause);
+        }
     }
 
     private Method findMethod(Class<?> type, String methodName, Object... args) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesControllerTests.java
@@ -85,6 +85,20 @@ class DevServicesControllerTests {
     }
 
     @Test
+    void logsSupportsTestcontainersVarargsLogMethod() throws Exception {
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean("redisTestcontainer", FakeVarargsLogTestcontainer.class);
+        context.refresh();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties())).build();
+
+        mvc.perform(get("/bootui/api/dev-services/bean:redisTestcontainer/logs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.logs").value("Redis container started"));
+
+        context.close();
+    }
+
+    @Test
     void restartIsDisabledByDefault() throws Exception {
         GenericApplicationContext context = new GenericApplicationContext();
         context.registerBean("postgresTestcontainer", FakeTestcontainer.class);
@@ -159,6 +173,25 @@ class DevServicesControllerTests {
 
         String restartCalls() {
             return restartCalls.toString();
+        }
+    }
+
+    static class FakeVarargsLogTestcontainer {
+
+        public String getDockerImageName() {
+            return "redis:7";
+        }
+
+        public String getContainerName() {
+            return "redis";
+        }
+
+        public boolean isRunning() {
+            return true;
+        }
+
+        public String getLogs(String... outputTypes) {
+            return "Redis container started";
         }
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -486,6 +486,10 @@ public final class BootUiDtos {
             List<DependencySeverityCountDto> severityCounts,
             DependencyScanStatusDto scan,
             List<DependencyDto> dependencies) {
+
+        public String status() {
+            return scan == null ? null : scan.status();
+        }
     }
 
     /** A single JVM memory pool (heap, non-heap, or GC pool). */

--- a/bootui-sample-app/e2e/tests/dev-services.spec.js
+++ b/bootui-sample-app/e2e/tests/dev-services.spec.js
@@ -38,12 +38,23 @@ const devServicesReport = {
   ]
 }
 
+const restartableDevServicesReport = {
+  ...devServicesReport,
+  services: devServicesReport.services.map(service => service.id === 'bean:redisContainer'
+    ? {
+        ...service,
+        restartable: true,
+        note: 'Restart may require application clients to reconnect.'
+      }
+    : service)
+}
+
 test.describe('Dev Services view', () => {
 
   test('renders the live Dev Services report or the empty state', async ({ openView, page }) => {
     await openView('dev-services', 'Dev Services')
 
-    await expect(page.locator('.alert-info')).toContainText('Restart is intentionally disabled by default')
+    await expect(page.locator('.alert-info')).toContainText('Restart controls appear only')
 
     const emptyState = page.locator('.alert-secondary', {
       hasText: 'No Docker Compose, Testcontainers, or Spring Boot service connection beans were detected.'
@@ -52,7 +63,7 @@ test.describe('Dev Services view', () => {
     await expect.poll(async () => (await emptyState.count()) + (await tableRows.count())).toBeGreaterThan(0)
   })
 
-  test('filters services, opens details, and keeps restart disabled by default', async ({ page }) => {
+  test('filters services, opens details, loads logs, and hides unavailable restart', async ({ page }) => {
     await page.route(url => url.pathname === '/bootui/api/dev-services', async route => {
       await route.fulfill({
         contentType: 'application/json',
@@ -74,22 +85,52 @@ test.describe('Dev Services view', () => {
     await page.goto('/bootui/#/dev-services')
     await expect(page.locator('main h2').filter({ hasText: /^Dev Services/ }).first()).toBeVisible()
     await expect(page.getByText('2 / 2 services')).toBeVisible()
+    await expect(page.getByRole('columnheader', { name: 'Source' })).toHaveCount(0)
 
-    await page.getByPlaceholder('Filter by name, type, source, or image').fill('redis')
+    await page.getByPlaceholder('Filter by name, type, status, or image').fill('redis')
     await expect(page.getByText('1 / 2 services')).toBeVisible()
 
     const redisRow = page.locator('tbody tr', { hasText: 'redis' })
     await expect(redisRow).toBeVisible()
-    await expect(redisRow.locator('.badge', { hasText: 'Testcontainers' })).toBeVisible()
-    await expect(redisRow.getByRole('button', { name: 'Restart' })).toBeDisabled()
+    await expect(redisRow.getByRole('button', { name: 'Restart' })).toHaveCount(0)
 
-    await redisRow.getByRole('button', { name: 'Details' }).click()
+    await redisRow.getByRole('button', { name: 'View details' }).click()
     const details = page.locator('.card', { hasText: 'redis' }).last()
     await expect(details).toContainText('Connection details')
     await expect(details).toContainText('containerId')
+    await expect(details).toContainText('Testcontainers')
 
-    await redisRow.getByRole('button', { name: 'Logs' }).click()
+    await redisRow.getByRole('button', { name: 'View logs' }).click()
     await expect(details.locator('pre')).toContainText('Ready to accept connections')
   })
-})
 
+  test('posts restart for restartable services', async ({ page }) => {
+    let restartCalled = false
+    await page.route(url => url.pathname === '/bootui/api/dev-services', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify(restartableDevServicesReport)
+      })
+    })
+    await page.route(url => url.pathname === '/bootui/api/dev-services/bean%3AredisContainer/restart', async route => {
+      expect(route.request().method()).toBe('POST')
+      restartCalled = true
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'bean:redisContainer',
+          status: 'restarted',
+          message: 'Service restarted. Already-created client beans may need an application restart to reconnect.'
+        })
+      })
+    })
+
+    await page.goto('/bootui/#/dev-services')
+    const redisRow = page.locator('tbody tr', { hasText: 'redis' })
+    await expect(redisRow.getByRole('button', { name: 'Restart' })).toBeVisible()
+
+    await redisRow.getByRole('button', { name: 'Restart' }).click()
+    await expect(page.locator('.alert-success')).toContainText('Service restarted')
+    await expect.poll(async () => restartCalled).toBe(true)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -10,14 +10,17 @@ const logs = ref(null)
 const actionMessage = ref(null)
 const busyService = ref(null)
 
-async function load() {
+async function load(options = {}) {
   loading.value = true
   error.value = null
-  actionMessage.value = null
+  if (!options.preserveActionMessage) {
+    actionMessage.value = null
+  }
   try {
     const res = await fetch('api/dev-services')
     if (!res.ok) throw new Error('HTTP ' + res.status)
     report.value = await res.json()
+    syncSelectedService()
   } catch (e) {
     error.value = e.message
   } finally {
@@ -32,7 +35,7 @@ const filtered = computed(() => {
   return report.value.services.filter(service =>
     (service.name || '').toLowerCase().includes(value)
     || (service.type || '').toLowerCase().includes(value)
-    || (service.source || '').toLowerCase().includes(value)
+    || (service.status || '').toLowerCase().includes(value)
     || (service.image || '').toLowerCase().includes(value)
   )
 })
@@ -79,13 +82,53 @@ function detailEntries(service) {
   return Object.entries(service.connectionDetails || {})
 }
 
+function syncSelectedService() {
+  const services = report.value?.services || []
+  if (services.length === 0) {
+    selected.value = null
+    logs.value = null
+    return
+  }
+  if (!selected.value) {
+    selected.value = services[0]
+    logs.value = null
+    return
+  }
+  const updated = services.find(service => service.id === selected.value.id)
+  if (updated) {
+    selected.value = updated
+    return
+  }
+  selected.value = services[0]
+  logs.value = null
+}
+
+function selectService(service) {
+  if (selected.value?.id !== service.id) {
+    logs.value = null
+  }
+  selected.value = service
+  actionMessage.value = null
+}
+
+function isSelected(service) {
+  return selected.value?.id === service.id
+}
+
+function serviceActionUrl(service, action) {
+  return `api/dev-services/${encodeURIComponent(service.id)}/${action}`
+}
+
 async function openLogs(service) {
+  if (selected.value?.id !== service.id) {
+    logs.value = null
+  }
   selected.value = service
   logs.value = null
   actionMessage.value = null
   busyService.value = service.id
   try {
-    const res = await fetch(`api/dev-services/${encodeURIComponent(service.id)}/logs`)
+    const res = await fetch(serviceActionUrl(service, 'logs'))
     if (!res.ok) throw new Error(await responseMessage(res))
     logs.value = await res.json()
   } catch (e) {
@@ -96,15 +139,19 @@ async function openLogs(service) {
 }
 
 async function restart(service) {
+  if (selected.value?.id !== service.id) {
+    logs.value = null
+  }
   selected.value = service
+  logs.value = null
   actionMessage.value = null
   busyService.value = service.id
   try {
-    const res = await fetch(`api/dev-services/${encodeURIComponent(service.id)}/restart`, { method: 'POST' })
+    const res = await fetch(serviceActionUrl(service, 'restart'), { method: 'POST' })
     if (!res.ok) throw new Error(await responseMessage(res))
     const result = await res.json()
+    await load({ preserveActionMessage: true })
     actionMessage.value = { type: 'success', text: result.message }
-    await load()
   } catch (e) {
     actionMessage.value = { type: 'danger', text: e.message }
   } finally {
@@ -141,8 +188,8 @@ onMounted(load)
     </div>
 
     <div class="alert alert-info">
-      Docker Compose services are shown from Spring Boot's startup snapshot. Restart is intentionally disabled by default
-      because service ports can change and already-created client beans may not reconnect.
+      Docker Compose services are shown from Spring Boot's startup snapshot. Restart controls appear only for
+      bean-backed Testcontainers services when <code>bootui.dev-services.restart-enabled=true</code>.
     </div>
 
     <div v-if="loading" class="text-muted">Loading…</div>
@@ -157,7 +204,7 @@ onMounted(load)
           <input
             v-model="filter"
             class="form-control"
-            placeholder="Filter by name, type, source, or image…" />
+            placeholder="Filter by name, type, status, or image…" />
         </div>
         <div class="col-md-4 text-end small text-muted align-self-center">
           {{ filtered.length }} / {{ report.total }} services
@@ -175,14 +222,13 @@ onMounted(load)
               <thead>
                 <tr>
                   <th>Service</th>
-                  <th>Source</th>
                   <th>Status</th>
                   <th>Host / ports</th>
                   <th class="text-end">Actions</th>
                 </tr>
               </thead>
               <tbody>
-                <tr v-for="service in filtered" :key="service.id">
+                <tr v-for="service in filtered" :key="service.id" :class="{ 'selected-row': isSelected(service) }">
                   <td data-label="Service">
                     <div class="fw-semibold">{{ service.name }}</div>
                     <div class="small text-muted">
@@ -190,27 +236,35 @@ onMounted(load)
                       <span v-if="service.image"> · <code>{{ service.image }}</code></span>
                     </div>
                   </td>
-                  <td data-label="Source"><span class="badge" :class="sourceClass(service.source)">{{ service.source }}</span></td>
                   <td data-label="Status"><span class="badge" :class="statusClass(service.status)">{{ service.status }}</span></td>
                   <td data-label="Host / ports" class="small">
                     <div>{{ service.host || '—' }}</div>
                     <code>{{ formatPorts(service) }}</code>
                   </td>
                   <td data-label="Actions" class="text-end">
-                    <div class="btn-group btn-group-sm service-actions">
-                      <button class="btn btn-outline-secondary" @click="selected = service">
-                        Details
+                    <div class="d-flex flex-wrap justify-content-end gap-1 service-actions">
+                      <button
+                        class="btn btn-sm"
+                        :class="isSelected(service) ? 'btn-primary' : 'btn-outline-primary'"
+                        :aria-pressed="isSelected(service)"
+                        @click="selectService(service)">
+                        <i class="bi bi-info-circle me-1"></i>
+                        {{ isSelected(service) ? 'Details shown' : 'View details' }}
                       </button>
                       <button
-                        class="btn btn-outline-secondary"
-                        :disabled="!service.logsAvailable || busyService === service.id"
+                        v-if="service.logsAvailable"
+                        class="btn btn-sm btn-outline-secondary"
+                        :disabled="busyService === service.id"
                         @click="openLogs(service)">
-                        Logs
+                        <i class="bi bi-card-text me-1"></i>
+                        View logs
                       </button>
                       <button
-                        class="btn btn-outline-danger"
-                        :disabled="!service.restartable || busyService === service.id"
+                        v-if="service.restartable"
+                        class="btn btn-sm btn-outline-danger"
+                        :disabled="busyService === service.id"
                         @click="restart(service)">
+                        <i class="bi bi-arrow-repeat me-1"></i>
                         Restart
                       </button>
                     </div>
@@ -263,7 +317,12 @@ onMounted(load)
                   <h6 class="mb-0">Logs</h6>
                   <span v-if="logs.truncated" class="badge text-bg-warning">Tail {{ logs.maxBytes }} bytes</span>
                 </div>
-                <pre class="logs rounded border p-2 mt-2 mb-0"><code>{{ logs.logs || 'No logs returned.' }}</code></pre>
+                <pre class="logs rounded border p-2 mt-2 mb-0"><code>{{ logs.logs || 'No log output yet.' }}</code></pre>
+              </template>
+              <template v-else-if="selected.logsAvailable">
+                <div class="text-muted small mt-3">
+                  Use <strong>View logs</strong> to load the bounded log tail for this service.
+                </div>
               </template>
             </div>
           </div>
@@ -286,6 +345,10 @@ onMounted(load)
 td code {
   white-space: normal;
   word-break: break-word;
+}
+
+.selected-row > td {
+  --bs-table-bg: rgba(13, 110, 253, 0.08);
 }
 
 @media (max-width: 991.98px) {
@@ -341,6 +404,7 @@ td code {
     display: flex;
     flex-wrap: wrap;
     gap: 0.35rem;
+    justify-content: flex-start !important;
   }
 
   .service-actions > .btn {

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -88,7 +88,7 @@ The DevTools panel reports Spring Boot DevTools availability, LiveReload status,
 
 ## Dev Services
 
-The Dev Services panel surfaces local development services discovered from Docker Compose snapshots, Testcontainers beans, and service connection metadata. It masks sensitive connection information, can show bounded logs for supported services, and keeps restart controls disabled unless `bootui.dev-services.restart-enabled=true`.
+The Dev Services panel surfaces local development services discovered from Docker Compose snapshots, Testcontainers beans, and service connection metadata. It masks sensitive connection information, can show bounded logs for supported services, and shows restart controls only for supported Testcontainers services when `bootui.dev-services.restart-enabled=true`.
 
 ![BootUI Dev Services panel](images/bootui-dev-services.png)
 


### PR DESCRIPTION
## What does this PR do?

Improves the Dev Services panel by removing the low-value Source column, making service details easier to discover, fixing log retrieval for Testcontainers services, and showing restart only when it can actually run.

## Why is this change needed?

The existing panel spent table space on source metadata, made the details action easy to miss, and did not handle Testcontainers' common varargs `getLogs(...)` API, so the Logs action could appear unavailable or fail to return logs. Restart support already exists for bean-backed Testcontainers services behind `bootui.dev-services.restart-enabled=true`; this keeps that behavior but hides the button when a service is not restartable.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks run:

- `./mvnw -pl bootui-ui install -q`
- `./mvnw -pl bootui-autoconfigure -Dtest=DevServicesControllerTests test -q`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed