### PR TITLE
Add Traces and AI Usage panels backed by an embedded OTLP receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ BootUI exposes these panels in the same order as the application menu. See the [
 | [Scheduled Tasks](docs/FEATURES.md#scheduled-tasks) | View registered scheduled tasks and their trigger metadata. |
 | [Data](docs/FEATURES.md#data) | Explore Spring Data repositories, domain types, IDs, and query methods. |
 | [Cache](docs/FEATURES.md#cache) | Inspect Spring Cache managers, caches, metrics, annotations, and confirmed clear actions. |
+| [Traces](docs/FEATURES.md#traces) | Inspect distributed tracing spans collected by the embedded OTLP receiver with a per-trace waterfall view. |
+| [AI Usage](docs/FEATURES.md#ai-usage) | Summarize Spring AI chat conversations, token usage, latency, and model details from OpenTelemetry spans. |
 | [Security](docs/FEATURES.md#security) | Inspect Spring Security filter chains and best-effort endpoint rule explanations. |
 | [Vulnerabilities](docs/FEATURES.md#vulnerabilities) | Review dependency inventory and local OSV vulnerability scan results. |
 

--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -71,6 +71,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.opentelemetry.proto</groupId>
+            <artifactId>opentelemetry-proto</artifactId>
+            <version>${opentelemetry-proto.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -1,7 +1,10 @@
 package io.github.jdubois.bootui.autoconfigure;
 
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
+import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
 import io.github.jdubois.bootui.autoconfigure.safety.LocalhostOnlyFilter;
+import io.github.jdubois.bootui.autoconfigure.web.AiController;
 import io.github.jdubois.bootui.autoconfigure.web.BeansController;
 import io.github.jdubois.bootui.autoconfigure.web.BootUiIndexController;
 import io.github.jdubois.bootui.autoconfigure.web.CacheController;
@@ -20,11 +23,13 @@ import io.github.jdubois.bootui.autoconfigure.web.LogTailController;
 import io.github.jdubois.bootui.autoconfigure.web.MappingsController;
 import io.github.jdubois.bootui.autoconfigure.web.MemoryController;
 import io.github.jdubois.bootui.autoconfigure.web.MetricsController;
+import io.github.jdubois.bootui.autoconfigure.web.OtlpReceiverController;
 import io.github.jdubois.bootui.autoconfigure.web.OverviewController;
 import io.github.jdubois.bootui.autoconfigure.web.ProfileController;
 import io.github.jdubois.bootui.autoconfigure.web.ScheduledController;
 import io.github.jdubois.bootui.autoconfigure.web.SecurityController;
 import io.github.jdubois.bootui.autoconfigure.web.StartupController;
+import io.github.jdubois.bootui.autoconfigure.web.TracesController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
@@ -74,6 +79,9 @@ import org.springframework.core.env.Environment;
         MemoryController.class,
         MetricsController.class,
         DevToolsController.class,
+        TracesController.class,
+        AiController.class,
+        OtlpReceiverController.class,
         BootUiIndexController.class
 })
 public class BootUiAutoConfiguration {
@@ -104,6 +112,16 @@ public class BootUiAutoConfiguration {
     @Bean
     public LocalhostOnlyFilter bootUiLocalhostOnlyFilter(BootUiProperties properties) {
         return new LocalhostOnlyFilter(properties);
+    }
+
+    @Bean
+    public TelemetryStore bootUiTelemetryStore(BootUiProperties properties) {
+        return new TelemetryStore(properties.getTelemetry());
+    }
+
+    @Bean
+    public OtlpSpanDecoder bootUiOtlpSpanDecoder(BootUiProperties properties) {
+        return new OtlpSpanDecoder(properties.getTelemetry());
     }
 
     @Bean

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -74,6 +74,12 @@ public class BootUiProperties {
     /** Dependency inventory and vulnerability scanning settings. */
     private Dependencies dependencies = new Dependencies();
 
+    /** OTLP-based telemetry receiver and trace store settings. */
+    private Telemetry telemetry = new Telemetry();
+
+    /** AI Usage panel settings. */
+    private Ai ai = new Ai();
+
     public static class DevServices {
 
         /** Allow BootUI to restart Testcontainers-backed services. */
@@ -157,6 +163,111 @@ public class BootUiProperties {
 
         public void setMaxAdvisories(int maxAdvisories) {
             this.maxAdvisories = maxAdvisories;
+        }
+    }
+
+    public static class Telemetry {
+
+        /** Accept OTLP/HTTP trace payloads at the BootUI OTLP endpoint. */
+        private boolean enabled = true;
+
+        /** Maximum number of distinct traces retained in memory. Oldest are evicted. */
+        private int maxTraces = 500;
+
+        /** Maximum number of spans retained per trace. */
+        private int maxSpansPerTrace = 500;
+
+        /** Maximum length of a single attribute string value before truncation. */
+        private int maxAttributeValueBytes = 4 * 1024;
+
+        /** Drop spans whose route/path attribute starts with the BootUI API path. */
+        private boolean excludeSelfSpans = true;
+
+        /** Maximum payload size (bytes) accepted by the OTLP receiver. */
+        private int maxRequestBytes = 8 * 1024 * 1024;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getMaxTraces() {
+            return maxTraces;
+        }
+
+        public void setMaxTraces(int maxTraces) {
+            this.maxTraces = maxTraces;
+        }
+
+        public int getMaxSpansPerTrace() {
+            return maxSpansPerTrace;
+        }
+
+        public void setMaxSpansPerTrace(int maxSpansPerTrace) {
+            this.maxSpansPerTrace = maxSpansPerTrace;
+        }
+
+        public int getMaxAttributeValueBytes() {
+            return maxAttributeValueBytes;
+        }
+
+        public void setMaxAttributeValueBytes(int maxAttributeValueBytes) {
+            this.maxAttributeValueBytes = maxAttributeValueBytes;
+        }
+
+        public boolean isExcludeSelfSpans() {
+            return excludeSelfSpans;
+        }
+
+        public void setExcludeSelfSpans(boolean excludeSelfSpans) {
+            this.excludeSelfSpans = excludeSelfSpans;
+        }
+
+        public int getMaxRequestBytes() {
+            return maxRequestBytes;
+        }
+
+        public void setMaxRequestBytes(int maxRequestBytes) {
+            this.maxRequestBytes = maxRequestBytes;
+        }
+    }
+
+    public static class Ai {
+
+        /** Number of minutes retained in the per-minute token-usage series. */
+        private int tokenSeriesMinutes = 60;
+
+        /** Maximum number of recent chat completions surfaced by the AI panel. */
+        private int maxRecentChats = 100;
+
+        /** When true, BootUI surfaces a banner explaining that prompt/completion content is not captured by default. */
+        private boolean showContentCaptureBanner = true;
+
+        public int getTokenSeriesMinutes() {
+            return tokenSeriesMinutes;
+        }
+
+        public void setTokenSeriesMinutes(int tokenSeriesMinutes) {
+            this.tokenSeriesMinutes = tokenSeriesMinutes;
+        }
+
+        public int getMaxRecentChats() {
+            return maxRecentChats;
+        }
+
+        public void setMaxRecentChats(int maxRecentChats) {
+            this.maxRecentChats = maxRecentChats;
+        }
+
+        public boolean isShowContentCaptureBanner() {
+            return showContentCaptureBanner;
+        }
+
+        public void setShowContentCaptureBanner(boolean showContentCaptureBanner) {
+            this.showContentCaptureBanner = showContentCaptureBanner;
         }
     }
 
@@ -278,5 +389,21 @@ public class BootUiProperties {
 
     public void setDependencies(Dependencies dependencies) {
         this.dependencies = dependencies;
+    }
+
+    public Telemetry getTelemetry() {
+        return telemetry;
+    }
+
+    public void setTelemetry(Telemetry telemetry) {
+        this.telemetry = telemetry;
+    }
+
+    public Ai getAi() {
+        return ai;
+    }
+
+    public void setAi(Ai ai) {
+        this.ai = ai;
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/AttributeValue.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/AttributeValue.java
@@ -1,0 +1,49 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+/**
+ * Normalized representation of an OTLP attribute value.
+ *
+ * <p>The {@code type} field uses one of {@code string}, {@code number}, {@code boolean},
+ * or {@code list}. The {@code value} is the JSON-friendly Java representation
+ * ({@link String}, {@link Number}, {@link Boolean}, or a {@link java.util.List} of
+ * those).</p>
+ */
+public record AttributeValue(String type, Object value) {
+
+    public static AttributeValue ofString(String s) {
+        return new AttributeValue("string", s);
+    }
+
+    public static AttributeValue ofNumber(Number n) {
+        return new AttributeValue("number", n);
+    }
+
+    public static AttributeValue ofBoolean(boolean b) {
+        return new AttributeValue("boolean", b);
+    }
+
+    public static AttributeValue ofList(java.util.List<?> list) {
+        return new AttributeValue("list", list);
+    }
+
+    public String asString() {
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
+    }
+
+    public Long asLong() {
+        if (value instanceof Number n) {
+            return n.longValue();
+        }
+        if (value instanceof String s) {
+            try {
+                return Long.parseLong(s);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/NormalizedEvent.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/NormalizedEvent.java
@@ -1,0 +1,13 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+import java.util.Map;
+
+/**
+ * Normalized span event with a time offset relative to its parent span and
+ * attribute map coerced to JSON-friendly types.
+ */
+public record NormalizedEvent(
+        String name,
+        long timeOffsetNanos,
+        Map<String, AttributeValue> attributes) {
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/NormalizedSpan.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/NormalizedSpan.java
@@ -1,0 +1,36 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Normalized representation of an OTLP span used internally by the BootUI
+ * telemetry store and panels.
+ *
+ * <p>Attribute values are coerced to JSON-friendly types so the controllers
+ * can serialize them with the default Jackson configuration shipped by
+ * Spring Boot.</p>
+ */
+public record NormalizedSpan(
+        String traceId,
+        String spanId,
+        String parentSpanId,
+        String name,
+        String kind,
+        String serviceName,
+        String scope,
+        long startEpochNanos,
+        long endEpochNanos,
+        String statusCode,
+        String statusMessage,
+        Map<String, AttributeValue> attributes,
+        List<NormalizedEvent> events) {
+
+    public long durationNanos() {
+        return Math.max(0L, endEpochNanos - startEpochNanos);
+    }
+
+    public boolean isError() {
+        return "ERROR".equals(statusCode);
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/OtlpSpanDecoder.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/OtlpSpanDecoder.java
@@ -1,0 +1,183 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Decodes OTLP/HTTP protobuf trace payloads into a flat list of
+ * {@link NormalizedSpan} instances suitable for the BootUI telemetry store.
+ */
+public final class OtlpSpanDecoder {
+
+    private final BootUiProperties.Telemetry config;
+
+    public OtlpSpanDecoder(BootUiProperties.Telemetry config) {
+        this.config = config;
+    }
+
+    public List<NormalizedSpan> decode(byte[] body) throws InvalidProtocolBufferException {
+        ExportTraceServiceRequest request = ExportTraceServiceRequest.parseFrom(body);
+        List<NormalizedSpan> out = new ArrayList<>();
+        for (ResourceSpans rs : request.getResourceSpansList()) {
+            Resource resource = rs.getResource();
+            String serviceName = extractServiceName(resource);
+            for (ScopeSpans ss : rs.getScopeSpansList()) {
+                InstrumentationScope scope = ss.getScope();
+                String scopeName = scope != null ? scope.getName() : "";
+                for (Span span : ss.getSpansList()) {
+                    out.add(toNormalized(span, serviceName, scopeName));
+                }
+            }
+        }
+        return out;
+    }
+
+    private NormalizedSpan toNormalized(Span span, String serviceName, String scopeName) {
+        Map<String, AttributeValue> attrs = toAttributeMap(span.getAttributesList());
+        List<NormalizedEvent> events = new ArrayList<>(span.getEventsCount());
+        long startNs = span.getStartTimeUnixNano();
+        for (Span.Event event : span.getEventsList()) {
+            events.add(new NormalizedEvent(
+                    event.getName(),
+                    Math.max(0L, event.getTimeUnixNano() - startNs),
+                    toAttributeMap(event.getAttributesList())));
+        }
+        Status status = span.getStatus();
+        String statusCode = switch (status.getCode()) {
+            case STATUS_CODE_OK -> "OK";
+            case STATUS_CODE_ERROR -> "ERROR";
+            default -> "UNSET";
+        };
+        return new NormalizedSpan(
+                hex(span.getTraceId()),
+                hex(span.getSpanId()),
+                emptyToNull(hex(span.getParentSpanId())),
+                span.getName(),
+                spanKindToString(span.getKind()),
+                serviceName,
+                scopeName,
+                startNs,
+                span.getEndTimeUnixNano(),
+                statusCode,
+                status.getMessage(),
+                attrs,
+                events);
+    }
+
+    private Map<String, AttributeValue> toAttributeMap(List<KeyValue> keyValues) {
+        Map<String, AttributeValue> map = new LinkedHashMap<>(keyValues.size());
+        for (KeyValue kv : keyValues) {
+            AttributeValue value = toAttributeValue(kv.getValue());
+            if (value != null) {
+                map.put(kv.getKey(), value);
+            }
+        }
+        return map;
+    }
+
+    private AttributeValue toAttributeValue(AnyValue value) {
+        if (value == null) {
+            return null;
+        }
+        return switch (value.getValueCase()) {
+            case STRING_VALUE -> AttributeValue.ofString(truncate(value.getStringValue()));
+            case BOOL_VALUE -> AttributeValue.ofBoolean(value.getBoolValue());
+            case INT_VALUE -> AttributeValue.ofNumber(value.getIntValue());
+            case DOUBLE_VALUE -> AttributeValue.ofNumber(value.getDoubleValue());
+            case BYTES_VALUE -> AttributeValue.ofString(
+                    truncate("0x" + bytesToHex(value.getBytesValue())));
+            case ARRAY_VALUE -> {
+                List<Object> arr = new ArrayList<>(value.getArrayValue().getValuesCount());
+                for (AnyValue v : value.getArrayValue().getValuesList()) {
+                    AttributeValue av = toAttributeValue(v);
+                    arr.add(av != null ? av.value() : null);
+                }
+                yield AttributeValue.ofList(arr);
+            }
+            case KVLIST_VALUE -> {
+                Map<String, Object> nested = new LinkedHashMap<>();
+                for (KeyValue inner : value.getKvlistValue().getValuesList()) {
+                    AttributeValue av = toAttributeValue(inner.getValue());
+                    nested.put(inner.getKey(), av != null ? av.value() : null);
+                }
+                yield new AttributeValue("map", nested);
+            }
+            default -> null;
+        };
+    }
+
+    private String truncate(String value) {
+        if (value == null) {
+            return null;
+        }
+        int max = Math.max(64, config.getMaxAttributeValueBytes());
+        if (value.length() <= max) {
+            return value;
+        }
+        return value.substring(0, max) + "…[truncated " + (value.length() - max) + " chars]";
+    }
+
+    private String extractServiceName(Resource resource) {
+        if (resource == null) {
+            return "unknown_service";
+        }
+        for (KeyValue kv : resource.getAttributesList()) {
+            if ("service.name".equals(kv.getKey()) && kv.getValue().hasStringValue()) {
+                String name = kv.getValue().getStringValue();
+                if (name != null && !name.isBlank()) {
+                    return name;
+                }
+            }
+        }
+        return "unknown_service";
+    }
+
+    private static String spanKindToString(Span.SpanKind kind) {
+        if (kind == null) {
+            return "INTERNAL";
+        }
+        return switch (kind) {
+            case SPAN_KIND_SERVER -> "SERVER";
+            case SPAN_KIND_CLIENT -> "CLIENT";
+            case SPAN_KIND_PRODUCER -> "PRODUCER";
+            case SPAN_KIND_CONSUMER -> "CONSUMER";
+            case SPAN_KIND_INTERNAL -> "INTERNAL";
+            default -> "UNSPECIFIED";
+        };
+    }
+
+    private static String hex(ByteString bytes) {
+        if (bytes == null || bytes.isEmpty()) {
+            return "";
+        }
+        return bytesToHex(bytes);
+    }
+
+    private static String bytesToHex(ByteString bytes) {
+        StringBuilder sb = new StringBuilder(bytes.size() * 2);
+        for (int i = 0; i < bytes.size(); i++) {
+            int b = bytes.byteAt(i) & 0xFF;
+            sb.append(Character.forDigit(b >>> 4, 16));
+            sb.append(Character.forDigit(b & 0x0F, 16));
+        }
+        return sb.toString();
+    }
+
+    private static String emptyToNull(String s) {
+        return (s == null || s.isEmpty()) ? null : s;
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryStore.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryStore.java
@@ -1,0 +1,121 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bounded in-memory store for OTLP spans received over the BootUI OTLP receiver.
+ *
+ * <p>Spans are grouped by trace id. When the configured trace capacity is
+ * exceeded the oldest trace bucket is dropped. Each trace also caps its span
+ * list to avoid unbounded growth from misbehaving exporters.</p>
+ *
+ * <p>The store is intentionally simple: a synchronized {@link LinkedHashMap}
+ * ordered by last update time. BootUI is a developer-only console and is
+ * never expected to ingest production trace volumes.</p>
+ */
+public class TelemetryStore {
+
+    /** Holder for a single trace; the spans list is mutated under the store's monitor. */
+    public static final class TraceBucket {
+
+        private final String traceId;
+
+        private final List<NormalizedSpan> spans;
+
+        private long lastUpdateEpochNanos;
+
+        TraceBucket(String traceId) {
+            this.traceId = traceId;
+            this.spans = new ArrayList<>();
+        }
+
+        public String traceId() {
+            return traceId;
+        }
+
+        public List<NormalizedSpan> spans() {
+            return spans;
+        }
+
+        public long lastUpdateEpochNanos() {
+            return lastUpdateEpochNanos;
+        }
+    }
+
+    private final BootUiProperties.Telemetry config;
+
+    private final LinkedHashMap<String, TraceBucket> tracesById;
+
+    public TelemetryStore(BootUiProperties.Telemetry config) {
+        this.config = config;
+        this.tracesById = new LinkedHashMap<>(256, 0.75f, false);
+    }
+
+    /**
+     * Append a span to its trace, evicting the eldest trace when capacity is reached.
+     */
+    public synchronized void add(NormalizedSpan span) {
+        if (span == null || span.traceId() == null || span.traceId().isEmpty()) {
+            return;
+        }
+        TraceBucket bucket = tracesById.remove(span.traceId());
+        if (bucket == null) {
+            bucket = new TraceBucket(span.traceId());
+            while (tracesById.size() >= Math.max(1, config.getMaxTraces())) {
+                Iterator<Map.Entry<String, TraceBucket>> it = tracesById.entrySet().iterator();
+                if (!it.hasNext()) {
+                    break;
+                }
+                it.next();
+                it.remove();
+            }
+        }
+        if (bucket.spans.size() < Math.max(1, config.getMaxSpansPerTrace())) {
+            bucket.spans.add(span);
+        }
+        bucket.lastUpdateEpochNanos = Math.max(bucket.lastUpdateEpochNanos, span.endEpochNanos());
+        tracesById.put(span.traceId(), bucket);
+    }
+
+    /**
+     * @return the most recently updated traces first.
+     */
+    public synchronized List<TraceBucket> recentTraces(int limit) {
+        List<TraceBucket> ordered = new ArrayList<>(tracesById.values());
+        java.util.Collections.reverse(ordered);
+        if (limit > 0 && ordered.size() > limit) {
+            return new ArrayList<>(ordered.subList(0, limit));
+        }
+        return ordered;
+    }
+
+    public synchronized TraceBucket findTrace(String traceId) {
+        return tracesById.get(traceId);
+    }
+
+    public synchronized int retainedTraceCount() {
+        return tracesById.size();
+    }
+
+    public int capacity() {
+        return config.getMaxTraces();
+    }
+
+    /** Snapshot of all spans for read-only iteration. */
+    public synchronized List<NormalizedSpan> allSpansSnapshot() {
+        List<NormalizedSpan> out = new ArrayList<>();
+        for (TraceBucket bucket : tracesById.values()) {
+            out.addAll(bucket.spans);
+        }
+        return out;
+    }
+
+    public synchronized void clear() {
+        tracesById.clear();
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiController.java
@@ -83,7 +83,7 @@ public class AiController {
                 embeddingCount++;
             }
         }
-        int recentLimit = Math.max(1, Math.min(aiConfig.getMaxRecentChats(), chats.size()));
+        int recentLimit = Math.min(aiConfig.getMaxRecentChats(), chats.size());
         List<AiChatSummaryDto> recent = new ArrayList<>(recentLimit);
         for (int i = 0; i < recentLimit; i++) {
             recent.add(toSummary(chats.get(i)));

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiController.java
@@ -1,0 +1,282 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
+import io.github.jdubois.bootui.core.BootUiDtos.AiChatDetailDto;
+import io.github.jdubois.bootui.core.BootUiDtos.AiChatSummaryDto;
+import io.github.jdubois.bootui.core.BootUiDtos.AiOverviewDto;
+import io.github.jdubois.bootui.core.BootUiDtos.AiTokenBucketDto;
+import io.github.jdubois.bootui.core.BootUiDtos.AiTokenSeriesDto;
+import io.github.jdubois.bootui.core.BootUiDtos.AiToolCallDto;
+import io.github.jdubois.bootui.core.BootUiDtos.AiVectorOpDto;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Read-only API for the BootUI AI Usage panel.
+ *
+ * <p>The data is derived from the OTLP spans accumulated in
+ * {@link TelemetryStore}. Spring AI emits the OTel GenAI semantic-conventions
+ * spans needed here automatically; no additional configuration is required.</p>
+ */
+@RestController
+@RequestMapping("/bootui/api/ai")
+public class AiController {
+
+    private static final String SPRING_AI_CLASS = "org.springframework.ai.chat.client.ChatClient";
+
+    private static final long NANOS_PER_MS = 1_000_000L;
+
+    private static final long NANOS_PER_SECOND = 1_000_000_000L;
+
+    private final TelemetryStore store;
+
+    private final BootUiProperties properties;
+
+    public AiController(TelemetryStore store, BootUiProperties properties) {
+        this.store = store;
+        this.properties = properties;
+    }
+
+    @GetMapping("/overview")
+    public AiOverviewDto overview() {
+        BootUiProperties.Ai aiConfig = properties.getAi();
+        List<NormalizedSpan> chats = chatSpansSorted();
+        long totalIn = 0;
+        long totalOut = 0;
+        Map<String, Long> tokensByModel = new LinkedHashMap<>();
+        Map<String, Integer> callsByModel = new LinkedHashMap<>();
+        for (NormalizedSpan chat : chats) {
+            Long in = AiSpanRecognizer.inputTokens(chat);
+            Long out = AiSpanRecognizer.outputTokens(chat);
+            totalIn += in == null ? 0 : in;
+            totalOut += out == null ? 0 : out;
+            String model = preferredModel(chat);
+            long modelTokens = (in == null ? 0 : in) + (out == null ? 0 : out);
+            tokensByModel.merge(model, modelTokens, Long::sum);
+            callsByModel.merge(model, 1, Integer::sum);
+        }
+        int toolCount = 0;
+        int vectorCount = 0;
+        int embeddingCount = 0;
+        for (NormalizedSpan span : store.allSpansSnapshot()) {
+            if (AiSpanRecognizer.isToolCall(span)) {
+                toolCount++;
+            }
+            if (AiSpanRecognizer.isVectorOperation(span)) {
+                vectorCount++;
+            }
+            if (AiSpanRecognizer.isEmbedding(span)) {
+                embeddingCount++;
+            }
+        }
+        int recentLimit = Math.max(1, Math.min(aiConfig.getMaxRecentChats(), chats.size()));
+        List<AiChatSummaryDto> recent = new ArrayList<>(recentLimit);
+        for (int i = 0; i < recentLimit; i++) {
+            recent.add(toSummary(chats.get(i)));
+        }
+        boolean springAi = isSpringAiOnClasspath();
+        String banner = aiConfig.isShowContentCaptureBanner()
+                ? "Prompt and completion text is not captured by default. Enable Spring AI's "
+                  + "include-prompt / include-completion observation options (or attach a custom "
+                  + "ObservationFilter) to see message content in the conversation drawer."
+                : null;
+        return new AiOverviewDto(
+                properties.getTelemetry().isEnabled(),
+                springAi,
+                chats.size(),
+                totalIn,
+                totalOut,
+                tokensByModel,
+                callsByModel,
+                toolCount,
+                vectorCount,
+                embeddingCount,
+                recent,
+                banner);
+    }
+
+    @GetMapping("/chats")
+    public List<AiChatSummaryDto> chats(@RequestParam(name = "limit", required = false, defaultValue = "100") int limit) {
+        int safeLimit = Math.max(1, Math.min(500, limit));
+        List<NormalizedSpan> chats = chatSpansSorted();
+        List<AiChatSummaryDto> out = new ArrayList<>(Math.min(safeLimit, chats.size()));
+        for (int i = 0; i < chats.size() && i < safeLimit; i++) {
+            out.add(toSummary(chats.get(i)));
+        }
+        return out;
+    }
+
+    @GetMapping("/chats/{spanId}")
+    public AiChatDetailDto chatDetail(@PathVariable String spanId) {
+        for (NormalizedSpan span : store.allSpansSnapshot()) {
+            if (AiSpanRecognizer.isChat(span) && spanId.equals(span.spanId())) {
+                return buildDetail(span);
+            }
+        }
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "chat span " + spanId + " not found");
+    }
+
+    @GetMapping("/tokens")
+    public AiTokenSeriesDto tokens(@RequestParam(name = "minutes", required = false, defaultValue = "60") int minutes) {
+        int window = Math.max(1, Math.min(240, minutes));
+        long nowMillis = System.currentTimeMillis();
+        long endMinute = nowMillis / 60_000L;
+        long startMinute = endMinute - window + 1;
+        TreeMap<Long, long[]> buckets = new TreeMap<>(); // [in, out, calls]
+        for (long m = startMinute; m <= endMinute; m++) {
+            buckets.put(m, new long[3]);
+        }
+        for (NormalizedSpan span : store.allSpansSnapshot()) {
+            if (!AiSpanRecognizer.isChat(span)) {
+                continue;
+            }
+            long minute = (span.startEpochNanos() / NANOS_PER_SECOND) / 60L;
+            if (minute < startMinute || minute > endMinute) {
+                continue;
+            }
+            long[] bucket = buckets.get(minute);
+            if (bucket == null) {
+                continue;
+            }
+            Long in = AiSpanRecognizer.inputTokens(span);
+            Long out = AiSpanRecognizer.outputTokens(span);
+            bucket[0] += in == null ? 0 : in;
+            bucket[1] += out == null ? 0 : out;
+            bucket[2] += 1;
+        }
+        List<AiTokenBucketDto> out = new ArrayList<>(buckets.size());
+        for (Map.Entry<Long, long[]> entry : buckets.entrySet()) {
+            long[] v = entry.getValue();
+            out.add(new AiTokenBucketDto(entry.getKey(), v[0], v[1], (int) v[2]));
+        }
+        return new AiTokenSeriesDto(window, out);
+    }
+
+    private List<NormalizedSpan> chatSpansSorted() {
+        List<NormalizedSpan> chats = new ArrayList<>();
+        for (NormalizedSpan span : store.allSpansSnapshot()) {
+            if (AiSpanRecognizer.isChat(span)) {
+                chats.add(span);
+            }
+        }
+        chats.sort(Comparator.comparingLong(NormalizedSpan::startEpochNanos).reversed());
+        return chats;
+    }
+
+    private AiChatSummaryDto toSummary(NormalizedSpan chat) {
+        int toolCalls = 0;
+        int vectorOps = 0;
+        TelemetryStore.TraceBucket bucket = store.findTrace(chat.traceId());
+        if (bucket != null) {
+            for (NormalizedSpan sibling : bucket.spans()) {
+                if (AiSpanRecognizer.isToolCall(sibling)) {
+                    toolCalls++;
+                }
+                if (AiSpanRecognizer.isVectorOperation(sibling)) {
+                    vectorOps++;
+                }
+            }
+        }
+        Long in = AiSpanRecognizer.inputTokens(chat);
+        Long out = AiSpanRecognizer.outputTokens(chat);
+        Long total = AiSpanRecognizer.totalTokens(chat);
+        return new AiChatSummaryDto(
+                chat.traceId(),
+                chat.spanId(),
+                chat.startEpochNanos(),
+                chat.durationNanos(),
+                AiSpanRecognizer.provider(chat),
+                AiSpanRecognizer.requestModel(chat),
+                AiSpanRecognizer.responseModel(chat),
+                in,
+                out,
+                total,
+                AiSpanRecognizer.finishReason(chat),
+                chat.statusCode(),
+                "chat",
+                toolCalls,
+                vectorOps);
+    }
+
+    private AiChatDetailDto buildDetail(NormalizedSpan chat) {
+        TelemetryStore.TraceBucket bucket = store.findTrace(chat.traceId());
+        List<AiToolCallDto> tools = new ArrayList<>();
+        List<AiVectorOpDto> vectors = new ArrayList<>();
+        if (bucket != null) {
+            for (NormalizedSpan sibling : bucket.spans()) {
+                if (AiSpanRecognizer.isToolCall(sibling)) {
+                    tools.add(new AiToolCallDto(
+                            sibling.spanId(),
+                            AiSpanRecognizer.toolName(sibling),
+                            sibling.startEpochNanos(),
+                            sibling.durationNanos(),
+                            sibling.statusCode()));
+                }
+                if (AiSpanRecognizer.isVectorOperation(sibling)) {
+                    vectors.add(new AiVectorOpDto(
+                            sibling.spanId(),
+                            AiSpanRecognizer.vectorOperation(sibling),
+                            AiSpanRecognizer.vectorCollection(sibling),
+                            sibling.startEpochNanos(),
+                            sibling.durationNanos(),
+                            sibling.statusCode()));
+                }
+            }
+        }
+        tools.sort(Comparator.comparingLong(AiToolCallDto::startEpochNanos));
+        vectors.sort(Comparator.comparingLong(AiVectorOpDto::startEpochNanos));
+        boolean contentCaptured = chat.attributes() != null
+                && (chat.attributes().containsKey("gen_ai.prompt")
+                    || chat.attributes().containsKey("gen_ai.completion")
+                    || chat.attributes().containsKey("gen_ai.input.messages")
+                    || chat.attributes().containsKey("gen_ai.output.messages"));
+        String banner = !contentCaptured && properties.getAi().isShowContentCaptureBanner()
+                ? "Message content is not on this span. Enable Spring AI's include-prompt / include-completion "
+                  + "observation options to capture prompt and completion text."
+                : null;
+        return new AiChatDetailDto(
+                toSummary(chat),
+                tools,
+                vectors,
+                TracesController.toAttributeList(chat.attributes()),
+                TracesController.toEventList(chat.events()),
+                contentCaptured,
+                banner);
+    }
+
+    private static String preferredModel(NormalizedSpan chat) {
+        String model = AiSpanRecognizer.responseModel(chat);
+        if (model == null || model.isBlank()) {
+            model = AiSpanRecognizer.requestModel(chat);
+        }
+        return model == null || model.isBlank() ? "unknown" : model;
+    }
+
+    private static boolean isSpringAiOnClasspath() {
+        try {
+            Class.forName(SPRING_AI_CLASS, false, AiController.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException ex) {
+            return false;
+        }
+    }
+
+    // helper used by unit tests
+    static long nanosPerMs() {
+        return NANOS_PER_MS;
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiSpanRecognizer.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiSpanRecognizer.java
@@ -1,0 +1,184 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.autoconfigure.otlp.AttributeValue;
+import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
+
+/**
+ * Heuristics for recognizing Spring AI / OTel GenAI spans inside the BootUI
+ * telemetry store. Centralized so the Traces and AI controllers stay in sync.
+ *
+ * <p>Spring AI emits spans following the OTel GenAI semantic conventions:</p>
+ * <ul>
+ *   <li>Chat: {@code gen_ai.operation.name=chat} and {@code gen_ai.system=<provider>}.</li>
+ *   <li>Embeddings: {@code gen_ai.operation.name=embeddings}.</li>
+ *   <li>Tool execution: {@code gen_ai.operation.name=execute_tool} or {@code spring.ai.tool}.</li>
+ *   <li>Vector store: {@code db.system=spring_ai_vector_store} or scope contains "vectorstore".</li>
+ * </ul>
+ */
+public final class AiSpanRecognizer {
+
+    private AiSpanRecognizer() {
+    }
+
+    public static boolean isAi(NormalizedSpan span) {
+        return isChat(span) || isEmbedding(span) || isToolCall(span) || isVectorOperation(span);
+    }
+
+    public static boolean isChat(NormalizedSpan span) {
+        String op = stringAttr(span, "gen_ai.operation.name");
+        if (op == null) {
+            return false;
+        }
+        return "chat".equalsIgnoreCase(op) || "text_completion".equalsIgnoreCase(op);
+    }
+
+    public static boolean isEmbedding(NormalizedSpan span) {
+        String op = stringAttr(span, "gen_ai.operation.name");
+        return op != null && "embeddings".equalsIgnoreCase(op);
+    }
+
+    public static boolean isToolCall(NormalizedSpan span) {
+        String op = stringAttr(span, "gen_ai.operation.name");
+        if (op != null && ("execute_tool".equalsIgnoreCase(op) || "tool".equalsIgnoreCase(op))) {
+            return true;
+        }
+        String name = span.name();
+        if (name == null) {
+            return false;
+        }
+        return name.startsWith("spring.ai.tool") || name.startsWith("execute_tool");
+    }
+
+    public static boolean isVectorOperation(NormalizedSpan span) {
+        String dbSystem = stringAttr(span, "db.system");
+        if (dbSystem != null && (dbSystem.startsWith("spring_ai") || dbSystem.contains("vector"))) {
+            return true;
+        }
+        String op = stringAttr(span, "db.operation.name");
+        String collection = stringAttr(span, "db.collection.name");
+        if (op != null && collection != null) {
+            // covers spring-ai vector store spans regardless of db.system naming
+            String scope = span.scope();
+            if (scope != null && scope.toLowerCase().contains("vectorstore")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String provider(NormalizedSpan span) {
+        String provider = stringAttr(span, "gen_ai.provider.name");
+        if (provider != null && !provider.isBlank()) {
+            return provider;
+        }
+        return stringAttr(span, "gen_ai.system");
+    }
+
+    public static String requestModel(NormalizedSpan span) {
+        String model = stringAttr(span, "gen_ai.request.model");
+        if (model == null) {
+            model = stringAttr(span, "gen_ai.request.model_name");
+        }
+        return model;
+    }
+
+    public static String responseModel(NormalizedSpan span) {
+        String model = stringAttr(span, "gen_ai.response.model");
+        if (model == null) {
+            model = stringAttr(span, "gen_ai.response.model_name");
+        }
+        return model;
+    }
+
+    public static Long inputTokens(NormalizedSpan span) {
+        Long v = longAttr(span, "gen_ai.usage.input_tokens");
+        if (v == null) {
+            v = longAttr(span, "gen_ai.usage.prompt_tokens");
+        }
+        return v;
+    }
+
+    public static Long outputTokens(NormalizedSpan span) {
+        Long v = longAttr(span, "gen_ai.usage.output_tokens");
+        if (v == null) {
+            v = longAttr(span, "gen_ai.usage.completion_tokens");
+        }
+        return v;
+    }
+
+    public static Long totalTokens(NormalizedSpan span) {
+        Long v = longAttr(span, "gen_ai.usage.total_tokens");
+        if (v != null) {
+            return v;
+        }
+        Long in = inputTokens(span);
+        Long out = outputTokens(span);
+        if (in == null && out == null) {
+            return null;
+        }
+        return (in == null ? 0L : in) + (out == null ? 0L : out);
+    }
+
+    public static String finishReason(NormalizedSpan span) {
+        AttributeValue av = span.attributes() != null
+                ? span.attributes().get("gen_ai.response.finish_reasons") : null;
+        if (av == null) {
+            return stringAttr(span, "gen_ai.response.finish_reason");
+        }
+        Object value = av.value();
+        if (value instanceof java.util.List<?> list) {
+            if (list.isEmpty()) {
+                return null;
+            }
+            return String.valueOf(list.get(0));
+        }
+        return av.asString();
+    }
+
+    public static String toolName(NormalizedSpan span) {
+        String name = stringAttr(span, "gen_ai.tool.name");
+        if (name == null) {
+            name = stringAttr(span, "spring.ai.tool.name");
+        }
+        if (name == null && span.name() != null) {
+            String n = span.name();
+            int sep = n.indexOf(' ');
+            if (sep > 0 && sep < n.length() - 1) {
+                return n.substring(sep + 1).trim();
+            }
+        }
+        return name;
+    }
+
+    public static String vectorCollection(NormalizedSpan span) {
+        String c = stringAttr(span, "db.collection.name");
+        if (c == null) {
+            c = stringAttr(span, "spring.ai.vectorstore.collection.name");
+        }
+        return c;
+    }
+
+    public static String vectorOperation(NormalizedSpan span) {
+        String op = stringAttr(span, "db.operation.name");
+        if (op == null) {
+            op = stringAttr(span, "spring.ai.vectorstore.operation");
+        }
+        return op;
+    }
+
+    private static String stringAttr(NormalizedSpan span, String key) {
+        if (span.attributes() == null) {
+            return null;
+        }
+        AttributeValue av = span.attributes().get(key);
+        return av != null ? av.asString() : null;
+    }
+
+    private static Long longAttr(NormalizedSpan span, String key) {
+        if (span.attributes() == null) {
+            return null;
+        }
+        AttributeValue av = span.attributes().get(key);
+        return av != null ? av.asLong() : null;
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
@@ -1,0 +1,127 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
+import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * OTLP/HTTP receiver mounted under {@code /bootui/api/otlp}.
+ *
+ * <p>Accepts protobuf-encoded {@code ExportTraceServiceRequest} payloads from
+ * the host JVM (or any cooperating local process) and stores normalized spans
+ * in the {@link TelemetryStore}. Returns an empty {@code ExportTraceServiceResponse}
+ * with HTTP 200 on success per the OTLP spec.</p>
+ *
+ * <p>This receiver is reached through {@code LocalhostOnlyFilter}, so non-loopback
+ * callers are rejected unless {@code bootui.allow-non-localhost=true}.</p>
+ */
+@RestController
+@RequestMapping("/bootui/api/otlp")
+public class OtlpReceiverController {
+
+    private static final Logger log = LoggerFactory.getLogger(OtlpReceiverController.class);
+
+    private static final byte[] EMPTY_RESPONSE = ExportTraceServiceResponse.getDefaultInstance().toByteArray();
+
+    private final TelemetryStore store;
+
+    private final OtlpSpanDecoder decoder;
+
+    private final BootUiProperties properties;
+
+    public OtlpReceiverController(TelemetryStore store,
+                                  OtlpSpanDecoder decoder,
+                                  BootUiProperties properties) {
+        this.store = store;
+        this.decoder = decoder;
+        this.properties = properties;
+    }
+
+    @PostMapping(path = "/v1/traces",
+            consumes = { "application/x-protobuf", "application/octet-stream" })
+    public ResponseEntity<byte[]> receiveTraces(@RequestBody byte[] body,
+                                                HttpServletRequest request) {
+        BootUiProperties.Telemetry telemetry = properties.getTelemetry();
+        if (!telemetry.isEnabled()) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+        }
+        if (body == null || body.length == 0) {
+            return okResponse();
+        }
+        if (body.length > telemetry.getMaxRequestBytes()) {
+            log.warn("Rejecting OTLP payload exceeding bootui.telemetry.max-request-bytes ({} > {})",
+                    body.length, telemetry.getMaxRequestBytes());
+            return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).build();
+        }
+        try {
+            List<NormalizedSpan> spans = decoder.decode(body);
+            String apiPath = properties.getApiPath();
+            int kept = 0;
+            for (NormalizedSpan span : spans) {
+                if (telemetry.isExcludeSelfSpans() && isSelfSpan(span, apiPath)) {
+                    continue;
+                }
+                store.add(span);
+                kept++;
+            }
+            if (log.isDebugEnabled()) {
+                log.debug("OTLP receiver stored {} spans (of {} received)", kept, spans.size());
+            }
+            return okResponse();
+        } catch (InvalidProtocolBufferException ex) {
+            log.warn("Rejecting invalid OTLP protobuf payload from {}: {}",
+                    request.getRemoteAddr(), ex.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        } catch (RuntimeException ex) {
+            log.warn("OTLP receiver failed to handle payload", ex);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    private static boolean isSelfSpan(NormalizedSpan span, String apiPath) {
+        if (apiPath == null || apiPath.isEmpty()) {
+            return false;
+        }
+        if (span.attributes() == null) {
+            return false;
+        }
+        String route = stringAttribute(span, "http.route");
+        if (route != null && (route.startsWith(apiPath) || route.startsWith("/bootui"))) {
+            return true;
+        }
+        String urlPath = stringAttribute(span, "url.path");
+        if (urlPath != null && (urlPath.startsWith(apiPath) || urlPath.startsWith("/bootui"))) {
+            return true;
+        }
+        String target = stringAttribute(span, "http.target");
+        return target != null && (target.startsWith(apiPath) || target.startsWith("/bootui"));
+    }
+
+    private static String stringAttribute(NormalizedSpan span, String key) {
+        if (span.attributes() == null) {
+            return null;
+        }
+        var av = span.attributes().get(key);
+        return av != null ? av.asString() : null;
+    }
+
+    private static ResponseEntity<byte[]> okResponse() {
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("application/x-protobuf"))
+                .body(EMPTY_RESPONSE);
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/TracesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/TracesController.java
@@ -1,0 +1,167 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.autoconfigure.otlp.AttributeValue;
+import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedEvent;
+import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
+import io.github.jdubois.bootui.core.BootUiDtos.SpanAttributeDto;
+import io.github.jdubois.bootui.core.BootUiDtos.SpanDto;
+import io.github.jdubois.bootui.core.BootUiDtos.SpanEventDto;
+import io.github.jdubois.bootui.core.BootUiDtos.TraceDetailDto;
+import io.github.jdubois.bootui.core.BootUiDtos.TraceSummaryDto;
+import io.github.jdubois.bootui.core.BootUiDtos.TracesReport;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Read-only API for the BootUI Traces panel.
+ */
+@RestController
+@RequestMapping("/bootui/api/traces")
+public class TracesController {
+
+    private final TelemetryStore store;
+
+    public TracesController(TelemetryStore store) {
+        this.store = store;
+    }
+
+    @GetMapping
+    public TracesReport list(@RequestParam(name = "limit", required = false, defaultValue = "100") int limit) {
+        int safeLimit = Math.max(1, Math.min(500, limit));
+        List<TraceSummaryDto> summaries = new ArrayList<>();
+        for (TelemetryStore.TraceBucket bucket : store.recentTraces(safeLimit)) {
+            summaries.add(toSummary(bucket));
+        }
+        return new TracesReport(true, store.retainedTraceCount(), store.capacity(), summaries);
+    }
+
+    @GetMapping("/{traceId}")
+    public TraceDetailDto detail(@PathVariable String traceId) {
+        TelemetryStore.TraceBucket bucket = store.findTrace(traceId);
+        if (bucket == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "trace " + traceId + " not found");
+        }
+        List<SpanDto> spans = new ArrayList<>(bucket.spans().size());
+        for (NormalizedSpan span : bucket.spans()) {
+            spans.add(toSpanDto(span));
+        }
+        spans.sort(Comparator.comparingLong(SpanDto::startEpochNanos));
+        return new TraceDetailDto(bucket.traceId(), spans);
+    }
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void clear() {
+        store.clear();
+    }
+
+    static TraceSummaryDto toSummary(TelemetryStore.TraceBucket bucket) {
+        long minStart = Long.MAX_VALUE;
+        long maxEnd = Long.MIN_VALUE;
+        Set<String> services = new LinkedHashSet<>();
+        boolean hasError = false;
+        boolean hasAi = false;
+        String rootSpanName = null;
+        NormalizedSpan earliest = null;
+        for (NormalizedSpan span : bucket.spans()) {
+            if (span.startEpochNanos() < minStart) {
+                minStart = span.startEpochNanos();
+            }
+            if (span.endEpochNanos() > maxEnd) {
+                maxEnd = span.endEpochNanos();
+            }
+            if (span.serviceName() != null) {
+                services.add(span.serviceName());
+            }
+            if (span.isError()) {
+                hasError = true;
+            }
+            if (AiSpanRecognizer.isAi(span)) {
+                hasAi = true;
+            }
+            if (span.parentSpanId() == null) {
+                if (earliest == null || span.startEpochNanos() < earliest.startEpochNanos()) {
+                    earliest = span;
+                }
+            }
+        }
+        if (earliest != null) {
+            rootSpanName = earliest.name();
+        } else if (!bucket.spans().isEmpty()) {
+            NormalizedSpan first = bucket.spans().stream()
+                    .min(Comparator.comparingLong(NormalizedSpan::startEpochNanos))
+                    .orElse(bucket.spans().get(0));
+            rootSpanName = first.name();
+        }
+        if (minStart == Long.MAX_VALUE) {
+            minStart = 0L;
+            maxEnd = 0L;
+        }
+        return new TraceSummaryDto(
+                bucket.traceId(),
+                rootSpanName,
+                new ArrayList<>(services),
+                minStart,
+                maxEnd,
+                Math.max(0L, maxEnd - minStart),
+                bucket.spans().size(),
+                hasError,
+                hasAi);
+    }
+
+    static SpanDto toSpanDto(NormalizedSpan span) {
+        return new SpanDto(
+                span.traceId(),
+                span.spanId(),
+                span.parentSpanId(),
+                span.name(),
+                span.kind(),
+                span.serviceName(),
+                span.scope(),
+                span.startEpochNanos(),
+                span.endEpochNanos(),
+                span.durationNanos(),
+                span.statusCode(),
+                span.statusMessage(),
+                toAttributeList(span.attributes()),
+                toEventList(span.events()));
+    }
+
+    static List<SpanAttributeDto> toAttributeList(Map<String, AttributeValue> attrs) {
+        if (attrs == null || attrs.isEmpty()) {
+            return List.of();
+        }
+        List<SpanAttributeDto> out = new ArrayList<>(attrs.size());
+        for (Map.Entry<String, AttributeValue> entry : attrs.entrySet()) {
+            AttributeValue v = entry.getValue();
+            out.add(new SpanAttributeDto(entry.getKey(), v.type(), v.value()));
+        }
+        return out;
+    }
+
+    static List<SpanEventDto> toEventList(List<NormalizedEvent> events) {
+        if (events == null || events.isEmpty()) {
+            return List.of();
+        }
+        List<SpanEventDto> out = new ArrayList<>(events.size());
+        for (NormalizedEvent event : events) {
+            out.add(new SpanEventDto(event.name(), event.timeOffsetNanos(),
+                    toAttributeList(event.attributes())));
+        }
+        return out;
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverEndToEndTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverEndToEndTests.java
@@ -1,0 +1,233 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import com.google.protobuf.ByteString;
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.ArrayValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+
+class OtlpReceiverEndToEndTests {
+
+    private static final String TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+    private static final String CHAT_SPAN_ID = "1111111111111111";
+
+    private static final String TOOL_SPAN_ID = "2222222222222222";
+
+    private static final String VECTOR_SPAN_ID = "3333333333333333";
+
+    private TelemetryStore store;
+
+    private MockMvc mvc;
+
+    @BeforeEach
+    void setUp() {
+        BootUiProperties properties = new BootUiProperties();
+        properties.getTelemetry().setEnabled(true);
+        store = new TelemetryStore(properties.getTelemetry());
+        OtlpSpanDecoder decoder = new OtlpSpanDecoder(properties.getTelemetry());
+        OtlpReceiverController receiver = new OtlpReceiverController(store, decoder, properties);
+        TracesController traces = new TracesController(store);
+        AiController ai = new AiController(store, properties);
+        mvc = standaloneSetup(receiver, traces, ai).build();
+    }
+
+    @Test
+    void receivesProtobufPayloadAndExposesTraceAndAiViews() throws Exception {
+        byte[] payload = sampleRequest().toByteArray();
+
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                .contentType("application/x-protobuf")
+                .content(payload))
+                .andExpect(status().isOk());
+
+        mvc.perform(get("/bootui/api/traces"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.retained").value(1))
+                .andExpect(jsonPath("$.traces[0].traceId").value(TRACE_ID))
+                .andExpect(jsonPath("$.traces[0].spanCount").value(3))
+                .andExpect(jsonPath("$.traces[0].hasAi").value(true))
+                .andExpect(jsonPath("$.traces[0].services[0]").value("sample"));
+
+        mvc.perform(get("/bootui/api/traces/" + TRACE_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.spans.length()").value(3));
+
+        mvc.perform(get("/bootui/api/ai/overview"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalChats").value(1))
+                .andExpect(jsonPath("$.totalInputTokens").value(42))
+                .andExpect(jsonPath("$.totalOutputTokens").value(7))
+                .andExpect(jsonPath("$.toolCallCount").value(1))
+                .andExpect(jsonPath("$.vectorOperationCount").value(1))
+                .andExpect(jsonPath("$.recent[0].requestModel").value("qwen3:0.6b"))
+                .andExpect(jsonPath("$.recent[0].provider").value("ollama"));
+
+        mvc.perform(get("/bootui/api/ai/chats/" + CHAT_SPAN_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.summary.toolCallCount").value(1))
+                .andExpect(jsonPath("$.summary.vectorOperationCount").value(1))
+                .andExpect(jsonPath("$.toolCalls[0].name").value("getWeather"))
+                .andExpect(jsonPath("$.vectorOperations[0].collectionName").value("docs"));
+
+        mvc.perform(get("/bootui/api/ai/tokens?minutes=5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.minutes").value(5));
+    }
+
+    @Test
+    void receiverRejectsInvalidProtobuf() throws Exception {
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                .contentType("application/x-protobuf")
+                .content(new byte[] { 0x7F, 0x7F, 0x7F }))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void receiverRejectsOversizePayload() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        properties.getTelemetry().setMaxRequestBytes(10);
+        TelemetryStore tinyStore = new TelemetryStore(properties.getTelemetry());
+        OtlpSpanDecoder decoder = new OtlpSpanDecoder(properties.getTelemetry());
+        OtlpReceiverController smallReceiver = new OtlpReceiverController(tinyStore, decoder, properties);
+        MockMvc tinyMvc = standaloneSetup(smallReceiver).build();
+        tinyMvc.perform(post("/bootui/api/otlp/v1/traces")
+                .contentType("application/x-protobuf")
+                .content(new byte[256]))
+                .andExpect(status().isPayloadTooLarge());
+    }
+
+    @Test
+    void clearEndpointEmptiesStore() throws Exception {
+        store.add(decode(sampleRequest()).get(0));
+        assertThat(store.retainedTraceCount()).isEqualTo(1);
+        mvc.perform(delete("/bootui/api/traces"))
+                .andExpect(status().isNoContent());
+        assertThat(store.retainedTraceCount()).isZero();
+    }
+
+    private java.util.List<io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan> decode(ExportTraceServiceRequest req)
+            throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        return new OtlpSpanDecoder(properties.getTelemetry()).decode(req.toByteArray());
+    }
+
+    private ExportTraceServiceRequest sampleRequest() {
+        long now = System.currentTimeMillis() * 1_000_000L;
+        ByteString traceId = ByteString.copyFrom(hexToBytes(TRACE_ID));
+
+        Span chat = Span.newBuilder()
+                .setTraceId(traceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
+                .setName("chat qwen3:0.6b")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now)
+                .setEndTimeUnixNano(now + 250_000_000L)
+                .setStatus(Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "chat"))
+                .addAttributes(stringAttr("gen_ai.system", "ollama"))
+                .addAttributes(stringAttr("gen_ai.request.model", "qwen3:0.6b"))
+                .addAttributes(stringAttr("gen_ai.response.model", "qwen3:0.6b"))
+                .addAttributes(intAttr("gen_ai.usage.input_tokens", 42L))
+                .addAttributes(intAttr("gen_ai.usage.output_tokens", 7L))
+                .addAttributes(arrayStringAttr("gen_ai.response.finish_reasons", "stop"))
+                .build();
+
+        Span tool = Span.newBuilder()
+                .setTraceId(traceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes(TOOL_SPAN_ID)))
+                .setParentSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
+                .setName("execute_tool getWeather")
+                .setKind(Span.SpanKind.SPAN_KIND_INTERNAL)
+                .setStartTimeUnixNano(now + 10_000_000L)
+                .setEndTimeUnixNano(now + 30_000_000L)
+                .setStatus(Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "execute_tool"))
+                .addAttributes(stringAttr("gen_ai.tool.name", "getWeather"))
+                .build();
+
+        Span vector = Span.newBuilder()
+                .setTraceId(traceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes(VECTOR_SPAN_ID)))
+                .setParentSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
+                .setName("db query docs")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now + 5_000_000L)
+                .setEndTimeUnixNano(now + 15_000_000L)
+                .setStatus(Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
+                .addAttributes(stringAttr("db.system", "spring_ai_vector_store"))
+                .addAttributes(stringAttr("db.operation.name", "query"))
+                .addAttributes(stringAttr("db.collection.name", "docs"))
+                .build();
+
+        ScopeSpans scopeSpans = ScopeSpans.newBuilder()
+                .setScope(InstrumentationScope.newBuilder().setName("io.micrometer.observation").build())
+                .addSpans(chat)
+                .addSpans(tool)
+                .addSpans(vector)
+                .build();
+
+        ResourceSpans resourceSpans = ResourceSpans.newBuilder()
+                .setResource(Resource.newBuilder().addAttributes(stringAttr("service.name", "sample")).build())
+                .addScopeSpans(scopeSpans)
+                .build();
+
+        return ExportTraceServiceRequest.newBuilder().addResourceSpans(resourceSpans).build();
+    }
+
+    private static KeyValue stringAttr(String key, String value) {
+        return KeyValue.newBuilder().setKey(key)
+                .setValue(AnyValue.newBuilder().setStringValue(value).build())
+                .build();
+    }
+
+    private static KeyValue intAttr(String key, long value) {
+        return KeyValue.newBuilder().setKey(key)
+                .setValue(AnyValue.newBuilder().setIntValue(value).build())
+                .build();
+    }
+
+    private static KeyValue arrayStringAttr(String key, String... values) {
+        ArrayValue.Builder arr = ArrayValue.newBuilder();
+        for (String v : values) {
+            arr.addValues(AnyValue.newBuilder().setStringValue(v).build());
+        }
+        return KeyValue.newBuilder().setKey(key)
+                .setValue(AnyValue.newBuilder().setArrayValue(arr.build()).build())
+                .build();
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        byte[] out = new byte[hex.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unused")
+    private static String s(String value) {
+        return new String(value.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -486,6 +486,10 @@ public final class BootUiDtos {
             List<DependencySeverityCountDto> severityCounts,
             DependencyScanStatusDto scan,
             List<DependencyDto> dependencies) {
+
+        public String status() {
+            return scan == null ? null : scan.status();
+        }
     }
 
     /** A single JVM memory pool (heap, non-heap, or GC pool). */

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -582,4 +582,144 @@ public final class BootUiDtos {
             String status,
             String message) {
     }
+
+    // ----- OTLP traces + AI panel ----------------------------------------------------------
+
+    /** Summary describing a span attribute, normalized to a JSON-friendly value type. */
+    public record SpanAttributeDto(
+            String key,
+            String type,
+            Object value) {
+    }
+
+    /** Discrete event recorded inside a span. */
+    public record SpanEventDto(
+            String name,
+            long timeOffsetNanos,
+            List<SpanAttributeDto> attributes) {
+    }
+
+    /** Detailed span record returned by the Traces detail endpoint. */
+    public record SpanDto(
+            String traceId,
+            String spanId,
+            String parentSpanId,
+            String name,
+            String kind,
+            String serviceName,
+            String scope,
+            long startEpochNanos,
+            long endEpochNanos,
+            long durationNanos,
+            String statusCode,
+            String statusMessage,
+            List<SpanAttributeDto> attributes,
+            List<SpanEventDto> events) {
+    }
+
+    /** Summary used by the Traces list view. */
+    public record TraceSummaryDto(
+            String traceId,
+            String rootSpanName,
+            List<String> services,
+            long startEpochNanos,
+            long endEpochNanos,
+            long durationNanos,
+            int spanCount,
+            boolean hasError,
+            boolean hasAi) {
+    }
+
+    /** Top-level Traces list payload. */
+    public record TracesReport(
+            boolean enabled,
+            int retained,
+            int capacity,
+            List<TraceSummaryDto> traces) {
+    }
+
+    /** Top-level Trace detail payload. */
+    public record TraceDetailDto(
+            String traceId,
+            List<SpanDto> spans) {
+    }
+
+    /** Summary of a single AI chat completion span. */
+    public record AiChatSummaryDto(
+            String traceId,
+            String spanId,
+            long startEpochNanos,
+            long durationNanos,
+            String provider,
+            String requestModel,
+            String responseModel,
+            Long inputTokens,
+            Long outputTokens,
+            Long totalTokens,
+            String finishReason,
+            String statusCode,
+            String operation,
+            int toolCallCount,
+            int vectorOperationCount) {
+    }
+
+    /** Tool call (function call) emitted by Spring AI advisors. */
+    public record AiToolCallDto(
+            String spanId,
+            String name,
+            long startEpochNanos,
+            long durationNanos,
+            String statusCode) {
+    }
+
+    /** Vector store operation linked to the same trace. */
+    public record AiVectorOpDto(
+            String spanId,
+            String operation,
+            String collectionName,
+            long startEpochNanos,
+            long durationNanos,
+            String statusCode) {
+    }
+
+    /** Detail of a single AI chat span, including linked tool calls and vector operations from the same trace. */
+    public record AiChatDetailDto(
+            AiChatSummaryDto summary,
+            List<AiToolCallDto> toolCalls,
+            List<AiVectorOpDto> vectorOperations,
+            List<SpanAttributeDto> attributes,
+            List<SpanEventDto> events,
+            boolean contentCaptured,
+            String contentBanner) {
+    }
+
+    /** Per-minute token usage bucket. */
+    public record AiTokenBucketDto(
+            long epochMinute,
+            long inputTokens,
+            long outputTokens,
+            int callCount) {
+    }
+
+    /** Token usage time series payload. */
+    public record AiTokenSeriesDto(
+            int minutes,
+            List<AiTokenBucketDto> buckets) {
+    }
+
+    /** AI Usage overview payload. */
+    public record AiOverviewDto(
+            boolean enabled,
+            boolean springAiDetected,
+            int totalChats,
+            long totalInputTokens,
+            long totalOutputTokens,
+            Map<String, Long> tokensByModel,
+            Map<String, Integer> callsByModel,
+            int toolCallCount,
+            int vectorOperationCount,
+            int embeddingCount,
+            List<AiChatSummaryDto> recent,
+            String contentBanner) {
+    }
 }

--- a/bootui-sample-app/compose.yaml
+++ b/bootui-sample-app/compose.yaml
@@ -11,3 +11,14 @@ services:
     image: redis:8-alpine
     ports:
       - "6379:6379"
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    healthcheck:
+      test: ["CMD", "ollama", "--version"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    labels:
+      org.springframework.boot.service-connection: ollama

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -41,6 +41,8 @@ test.describe('BootUI app shell', () => {
       { title: 'Scheduled Tasks',   heading: /Scheduled Tasks/ },
       { title: 'Data',              heading: /Spring Data repositories/ },
       { title: 'Cache',             heading: /Spring Cache/ },
+      { title: 'Traces',            heading: /^Traces/ },
+      { title: 'AI Usage',          heading: /AI Usage/ },
       { title: 'Security',          heading: /Spring Security/ },
       { title: 'Vulnerabilities',   heading: /^Vulnerabilities/ }
     ]

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -16,7 +16,20 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <spring-ai.version>2.0.0-M7</spring-ai.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.ai</groupId>
+                <artifactId>spring-ai-bom</artifactId>
+                <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -45,6 +58,21 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-ollama</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -65,6 +65,10 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-tracing-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-tracing-bridge-otel</artifactId>
         </dependency>

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/ChatController.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/ChatController.java
@@ -1,0 +1,36 @@
+package io.github.jdubois.bootui.sample;
+
+import java.util.Map;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/chat")
+@ConditionalOnBean(ChatModel.class)
+public class ChatController {
+
+    private final ChatClient chatClient;
+
+    public ChatController(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder
+                .defaultSystem("You are a concise assistant. Reply in two sentences or less.")
+                .build();
+    }
+
+    @PostMapping
+    public Map<String, String> chat(@RequestBody ChatRequest request) {
+        String reply = chatClient.prompt()
+                .user(request.message())
+                .call()
+                .content();
+        return Map.of("reply", reply);
+    }
+
+    public record ChatRequest(String message) {
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/ChatController.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/ChatController.java
@@ -2,8 +2,8 @@ package io.github.jdubois.bootui.sample;
 
 import java.util.Map;
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.model.ChatModel;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,24 +11,29 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/chat")
-@ConditionalOnBean(ChatModel.class)
 public class ChatController {
 
     private final ChatClient chatClient;
 
-    public ChatController(ChatClient.Builder chatClientBuilder) {
-        this.chatClient = chatClientBuilder
-                .defaultSystem("You are a concise assistant. Reply in two sentences or less.")
-                .build();
+    public ChatController(ObjectProvider<ChatClient.Builder> builderProvider) {
+        ChatClient.Builder builder = builderProvider.getIfAvailable();
+        this.chatClient = (builder != null)
+                ? builder.defaultSystem("You are a concise assistant. Reply in two sentences or less.").build()
+                : null;
     }
 
     @PostMapping
-    public Map<String, String> chat(@RequestBody ChatRequest request) {
+    public ResponseEntity<Map<String, String>> chat(@RequestBody ChatRequest request) {
+        if (chatClient == null) {
+            return ResponseEntity.status(503)
+                    .body(Map.of("error",
+                            "Spring AI ChatClient is not configured. Ensure Ollama auto-configuration is enabled and a model is reachable."));
+        }
         String reply = chatClient.prompt()
                 .user(request.message())
                 .call()
                 .content();
-        return Map.of("reply", reply);
+        return ResponseEntity.ok(Map.of("reply", reply));
     }
 
     public record ChatRequest(String message) {

--- a/bootui-sample-app/src/main/resources/application.properties
+++ b/bootui-sample-app/src/main/resources/application.properties
@@ -5,8 +5,8 @@ management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always
 
 management.tracing.sampling.probability=1.0
-management.otlp.tracing.endpoint=http://localhost:8080/bootui/api/otlp/v1/traces
-management.otlp.tracing.compression=none
+management.opentelemetry.tracing.export.otlp.endpoint=http://localhost:8080/bootui/api/otlp/v1/traces
+management.opentelemetry.tracing.export.otlp.compression=none
 
 spring.ai.ollama.base-url=http://localhost:11434
 spring.ai.ollama.chat.options.model=qwen2.5:0.5b

--- a/bootui-sample-app/src/main/resources/application.properties
+++ b/bootui-sample-app/src/main/resources/application.properties
@@ -4,6 +4,17 @@ server.port=8080
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always
 
+management.tracing.sampling.probability=1.0
+management.otlp.tracing.endpoint=http://localhost:8080/bootui/api/otlp/v1/traces
+management.otlp.tracing.compression=none
+
+spring.ai.ollama.base-url=http://localhost:11434
+spring.ai.ollama.chat.options.model=qwen2.5:0.5b
+spring.ai.ollama.init.pull-model-strategy=when_missing
+spring.ai.ollama.init.chat.additional-models=qwen2.5:0.5b
+spring.ai.chat.client.observations.log-prompt=false
+spring.ai.chat.client.observations.log-completion=false
+
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.open-in-view=false
 spring.jpa.defer-datasource-initialization=true

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -46,7 +46,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
                         + "org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration,"
                         + "org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration,"
                         + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisHealthContributorAutoConfiguration,"
-                        + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisReactiveHealthContributorAutoConfiguration",
+                        + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisReactiveHealthContributorAutoConfiguration,"
+                        + "org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration,"
+                        + "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration",
                 "bootui.show-banner=false",
                 "bootui.overrides-file=target/bootui-test-overrides.properties"
         })

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -48,7 +48,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
                         + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisHealthContributorAutoConfiguration,"
                         + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisReactiveHealthContributorAutoConfiguration,"
                         + "org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration,"
-                        + "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration",
+                        + "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration,"
+                        + "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration",
                 "bootui.show-banner=false",
                 "bootui.overrides-file=target/bootui-test-overrides.properties"
         })

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -24,6 +24,8 @@ import Metrics from './views/Metrics.vue'
 import Vulnerabilities from './views/Dependencies.vue'
 import DevServices from './views/DevServices.vue'
 import DevTools from './views/DevTools.vue'
+import Traces from './views/Traces.vue'
+import Ai from './views/Ai.vue'
 
 const router = createRouter({
   history: createWebHashHistory(),
@@ -47,6 +49,8 @@ const router = createRouter({
     { path: '/scheduled', name: 'scheduled', component: Scheduled, meta: { icon: 'bi-clock-history', title: 'Scheduled Tasks' } },
     { path: '/data', name: 'data', component: Data, meta: { icon: 'bi-database', title: 'Data' } },
     { path: '/cache', name: 'cache', component: Cache, meta: { icon: 'bi-hdd-stack', title: 'Cache' } },
+    { path: '/traces', name: 'traces', component: Traces, meta: { icon: 'bi-bezier2', title: 'Traces' } },
+    { path: '/ai', name: 'ai', component: Ai, meta: { icon: 'bi-stars', title: 'AI Usage' } },
     { path: '/security', name: 'security', component: Security, meta: { icon: 'bi-person-lock', title: 'Security' } },
     { path: '/vulnerabilities', name: 'vulnerabilities', component: Vulnerabilities, meta: { icon: 'bi-bug', title: 'Vulnerabilities' } },
     { path: '/dependencies', redirect: '/vulnerabilities' }

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -1,0 +1,303 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+
+const overview = ref(null)
+const series = ref(null)
+const detail = ref(null)
+const loading = ref(true)
+const error = ref(null)
+const selectedSpanId = ref(null)
+const detailLoading = ref(false)
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const [ovRes, tsRes] = await Promise.all([
+      fetch('api/ai/overview'),
+      fetch('api/ai/tokens?minutes=60')
+    ])
+    if (!ovRes.ok) throw new Error('HTTP ' + ovRes.status)
+    overview.value = await ovRes.json()
+    if (tsRes.ok) {
+      series.value = await tsRes.json()
+    }
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+async function openChat(spanId) {
+  selectedSpanId.value = spanId
+  detail.value = null
+  detailLoading.value = true
+  try {
+    const res = await fetch('api/ai/chats/' + spanId)
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    detail.value = await res.json()
+  } catch (e) {
+    detail.value = { error: e.message }
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+function closeDrawer() {
+  selectedSpanId.value = null
+  detail.value = null
+}
+
+function formatDuration(nanos) {
+  if (nanos == null) return '—'
+  const ms = nanos / 1_000_000
+  if (ms < 1) return (nanos / 1000).toFixed(1) + ' µs'
+  if (ms < 1000) return ms.toFixed(1) + ' ms'
+  return (ms / 1000).toFixed(2) + ' s'
+}
+
+function formatTime(epochNanos) {
+  if (!epochNanos) return '—'
+  return new Date(Math.floor(epochNanos / 1_000_000)).toLocaleTimeString()
+}
+
+function formatNumber(n) {
+  if (n == null) return '—'
+  return Number(n).toLocaleString()
+}
+
+const tokensByModelEntries = computed(() => {
+  if (!overview.value || !overview.value.tokensByModel) return []
+  return Object.entries(overview.value.tokensByModel)
+    .sort((a, b) => b[1] - a[1])
+})
+
+const callsByModelEntries = computed(() => {
+  if (!overview.value || !overview.value.callsByModel) return []
+  return Object.entries(overview.value.callsByModel)
+    .sort((a, b) => b[1] - a[1])
+})
+
+const sparkline = computed(() => {
+  if (!series.value || !series.value.buckets || series.value.buckets.length === 0) return null
+  const buckets = series.value.buckets
+  const maxTokens = buckets.reduce((m, b) => {
+    const t = (b.inputTokens || 0) + (b.outputTokens || 0)
+    return t > m ? t : m
+  }, 1)
+  const width = 600
+  const height = 80
+  const step = width / Math.max(buckets.length - 1, 1)
+  const points = buckets.map((b, i) => {
+    const t = (b.inputTokens || 0) + (b.outputTokens || 0)
+    const x = i * step
+    const y = height - (t / maxTokens) * height
+    return `${x},${y}`
+  })
+  return { width, height, polyline: points.join(' '), maxTokens, buckets }
+})
+
+const hasAnyData = computed(() => overview.value && overview.value.totalChats > 0)
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
+      <div>
+        <h2 class="mb-1"><i class="bi bi-stars me-2"></i>AI Usage</h2>
+        <div v-if="overview" class="text-muted small">
+          <span v-if="overview.springAiDetected" class="badge text-bg-success me-1">Spring AI detected</span>
+          <span v-else class="badge text-bg-secondary me-1">Spring AI not on classpath</span>
+          <span v-if="!overview.enabled" class="badge text-bg-warning me-1">Telemetry disabled</span>
+        </div>
+      </div>
+      <button class="btn btn-sm btn-outline-secondary" :disabled="loading" @click="load">
+        <i class="bi bi-arrow-clockwise"></i> Refresh
+      </button>
+    </div>
+
+    <div v-if="loading" class="text-muted">Loading AI usage…</div>
+    <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
+
+    <template v-else-if="overview">
+      <div v-if="overview.contentBanner" class="alert alert-info small">
+        <i class="bi bi-info-circle me-1"></i>{{ overview.contentBanner }}
+      </div>
+
+      <div v-if="!hasAnyData" class="alert alert-secondary">
+        No AI chat completions recorded yet. Make sure your application uses Spring AI with OpenTelemetry tracing enabled
+        and exports OTLP to <code>/bootui/api/otlp/v1/traces</code>, then exercise a chat endpoint to populate this panel.
+      </div>
+
+      <template v-else>
+        <div class="row g-3 mb-3">
+          <div class="col-md-3 col-6">
+            <div class="card h-100"><div class="card-body">
+              <div class="text-muted small">Chats</div>
+              <div class="fs-3 fw-semibold">{{ formatNumber(overview.totalChats) }}</div>
+            </div></div>
+          </div>
+          <div class="col-md-3 col-6">
+            <div class="card h-100"><div class="card-body">
+              <div class="text-muted small">Input tokens</div>
+              <div class="fs-3 fw-semibold">{{ formatNumber(overview.totalInputTokens) }}</div>
+            </div></div>
+          </div>
+          <div class="col-md-3 col-6">
+            <div class="card h-100"><div class="card-body">
+              <div class="text-muted small">Output tokens</div>
+              <div class="fs-3 fw-semibold">{{ formatNumber(overview.totalOutputTokens) }}</div>
+            </div></div>
+          </div>
+          <div class="col-md-3 col-6">
+            <div class="card h-100"><div class="card-body">
+              <div class="text-muted small">Tool calls · Vector ops · Embeddings</div>
+              <div class="fs-5 fw-semibold">
+                {{ formatNumber(overview.toolCallCount) }} ·
+                {{ formatNumber(overview.vectorOperationCount) }} ·
+                {{ formatNumber(overview.embeddingCount) }}
+              </div>
+            </div></div>
+          </div>
+        </div>
+
+        <div v-if="sparkline" class="card mb-3">
+          <div class="card-body">
+            <h6 class="mb-2">Token usage (last {{ series.minutes }} min)</h6>
+            <svg :viewBox="'0 0 ' + sparkline.width + ' ' + sparkline.height" class="w-100" style="max-height: 100px;">
+              <polyline :points="sparkline.polyline" fill="none" stroke="#0d6efd" stroke-width="2"/>
+            </svg>
+            <div class="text-muted small">Peak {{ formatNumber(sparkline.maxTokens) }} tokens/min</div>
+          </div>
+        </div>
+
+        <div class="row g-3 mb-3">
+          <div class="col-md-6">
+            <div class="card h-100"><div class="card-body">
+              <h6>Tokens by model</h6>
+              <table class="table table-sm mb-0">
+                <tbody>
+                  <tr v-for="[model, tokens] in tokensByModelEntries" :key="model">
+                    <td><code>{{ model }}</code></td>
+                    <td class="text-end">{{ formatNumber(tokens) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div></div>
+          </div>
+          <div class="col-md-6">
+            <div class="card h-100"><div class="card-body">
+              <h6>Calls by model</h6>
+              <table class="table table-sm mb-0">
+                <tbody>
+                  <tr v-for="[model, calls] in callsByModelEntries" :key="model">
+                    <td><code>{{ model }}</code></td>
+                    <td class="text-end">{{ formatNumber(calls) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div></div>
+          </div>
+        </div>
+
+        <h5>Recent chats</h5>
+        <div class="table-responsive">
+          <table class="table table-sm table-hover align-middle">
+            <thead>
+              <tr>
+                <th>Started</th>
+                <th>Provider</th>
+                <th>Model</th>
+                <th>Tokens in/out</th>
+                <th>Duration</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="chat in overview.recent" :key="chat.spanId"
+                  :class="{ 'table-active': chat.spanId === selectedSpanId }">
+                <td class="text-muted small">{{ formatTime(chat.startEpochNanos) }}</td>
+                <td>{{ chat.provider || '—' }}</td>
+                <td><code>{{ chat.requestModel || '—' }}</code></td>
+                <td>{{ formatNumber(chat.inputTokens) }} / {{ formatNumber(chat.outputTokens) }}</td>
+                <td>{{ formatDuration(chat.durationNanos) }}</td>
+                <td>
+                  <span v-if="chat.statusCode === 'ERROR'" class="badge text-bg-danger">error</span>
+                  <span v-else class="badge text-bg-success">{{ chat.finishReason || 'ok' }}</span>
+                </td>
+                <td class="text-end">
+                  <button class="btn btn-sm btn-outline-primary" @click="openChat(chat.spanId)">Open</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </template>
+    </template>
+
+    <div v-if="selectedSpanId" class="card mt-3">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <div><i class="bi bi-stars me-2"></i>Chat <code>{{ selectedSpanId }}</code></div>
+        <button class="btn btn-sm btn-outline-secondary" @click="closeDrawer">Close</button>
+      </div>
+      <div class="card-body">
+        <div v-if="detailLoading" class="text-muted">Loading…</div>
+        <template v-else-if="detail && detail.summary">
+          <div v-if="detail.contentBanner && !detail.contentCaptured" class="alert alert-info small">
+            <i class="bi bi-info-circle me-1"></i>{{ detail.contentBanner }}
+          </div>
+          <dl class="row mb-3">
+            <dt class="col-sm-3">Provider</dt><dd class="col-sm-9">{{ detail.summary.provider || '—' }}</dd>
+            <dt class="col-sm-3">Request model</dt><dd class="col-sm-9"><code>{{ detail.summary.requestModel || '—' }}</code></dd>
+            <dt class="col-sm-3">Response model</dt><dd class="col-sm-9"><code>{{ detail.summary.responseModel || '—' }}</code></dd>
+            <dt class="col-sm-3">Tokens</dt><dd class="col-sm-9">
+              in {{ formatNumber(detail.summary.inputTokens) }} ·
+              out {{ formatNumber(detail.summary.outputTokens) }} ·
+              total {{ formatNumber(detail.summary.totalTokens) }}
+            </dd>
+            <dt class="col-sm-3">Duration</dt><dd class="col-sm-9">{{ formatDuration(detail.summary.durationNanos) }}</dd>
+            <dt class="col-sm-3">Finish reason</dt><dd class="col-sm-9">{{ detail.summary.finishReason || '—' }}</dd>
+          </dl>
+
+          <div v-if="detail.toolCalls && detail.toolCalls.length" class="mb-3">
+            <h6>Tool calls</h6>
+            <ul class="list-group">
+              <li v-for="tc in detail.toolCalls" :key="tc.spanId" class="list-group-item d-flex justify-content-between">
+                <span><i class="bi bi-tools me-1"></i><code>{{ tc.name || '(unnamed)' }}</code></span>
+                <span class="text-muted small">{{ formatDuration(tc.durationNanos) }}</span>
+              </li>
+            </ul>
+          </div>
+
+          <div v-if="detail.vectorOperations && detail.vectorOperations.length" class="mb-3">
+            <h6>Vector operations</h6>
+            <ul class="list-group">
+              <li v-for="vo in detail.vectorOperations" :key="vo.spanId" class="list-group-item d-flex justify-content-between">
+                <span><i class="bi bi-database me-1"></i><code>{{ vo.collectionName || '?' }}</code> · {{ vo.operation || '—' }}</span>
+                <span class="text-muted small">{{ formatDuration(vo.durationNanos) }}</span>
+              </li>
+            </ul>
+          </div>
+
+          <details v-if="detail.attributes && detail.attributes.length">
+            <summary class="text-muted">Span attributes ({{ detail.attributes.length }})</summary>
+            <table class="table table-sm mt-2">
+              <tbody>
+                <tr v-for="a in detail.attributes" :key="a.key">
+                  <td><code>{{ a.key }}</code></td>
+                  <td><code>{{ a.value }}</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </details>
+        </template>
+        <div v-else-if="detail && detail.error" class="alert alert-danger small">{{ detail.error }}</div>
+        <div v-else class="text-muted small">No detail available.</div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -1,0 +1,253 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+
+const report = ref(null)
+const detail = ref(null)
+const loading = ref(true)
+const error = ref(null)
+const banner = ref(null)
+const filter = ref('')
+const selectedTraceId = ref(null)
+const detailLoading = ref(false)
+const busy = ref(false)
+
+async function load() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await fetch('api/traces')
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    report.value = await res.json()
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+async function openTrace(traceId) {
+  selectedTraceId.value = traceId
+  detail.value = null
+  detailLoading.value = true
+  try {
+    const res = await fetch('api/traces/' + traceId)
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    detail.value = await res.json()
+  } catch (e) {
+    banner.value = { type: 'danger', text: 'Could not load trace: ' + e.message }
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+function closeDrawer() {
+  selectedTraceId.value = null
+  detail.value = null
+}
+
+async function clearAll() {
+  if (!confirm('Clear all retained traces? This cannot be undone.')) return
+  busy.value = true
+  try {
+    const res = await fetch('api/traces', { method: 'DELETE' })
+    if (!res.ok && res.status !== 204) throw new Error('HTTP ' + res.status)
+    closeDrawer()
+    await load()
+    banner.value = { type: 'success', text: 'Cleared retained traces.' }
+    setTimeout(() => { banner.value = null }, 4000)
+  } catch (e) {
+    banner.value = { type: 'danger', text: 'Could not clear: ' + e.message }
+  } finally {
+    busy.value = false
+  }
+}
+
+const filteredTraces = computed(() => {
+  if (!report.value) return []
+  const v = filter.value.trim().toLowerCase()
+  if (!v) return report.value.traces
+  return report.value.traces.filter(t =>
+    (t.traceId || '').toLowerCase().includes(v)
+    || (t.rootSpanName || '').toLowerCase().includes(v)
+    || (t.services || []).join(' ').toLowerCase().includes(v))
+})
+
+const waterfall = computed(() => {
+  if (!detail.value || !detail.value.spans || detail.value.spans.length === 0) return null
+  const spans = [...detail.value.spans]
+  const minStart = spans.reduce((m, s) => s.startEpochNanos < m ? s.startEpochNanos : m, spans[0].startEpochNanos)
+  const maxEnd = spans.reduce((m, s) => s.endEpochNanos > m ? s.endEpochNanos : m, spans[0].endEpochNanos)
+  const totalNanos = Math.max(maxEnd - minStart, 1)
+  const sorted = spans
+    .map(s => ({
+      ...s,
+      offsetPct: ((s.startEpochNanos - minStart) / totalNanos) * 100,
+      widthPct: Math.max((s.durationNanos / totalNanos) * 100, 0.5)
+    }))
+    .sort((a, b) => a.startEpochNanos - b.startEpochNanos)
+  return { spans: sorted, totalNanos }
+})
+
+function formatDuration(nanos) {
+  if (nanos == null) return '—'
+  const ms = nanos / 1_000_000
+  if (ms < 1) return (nanos / 1000).toFixed(1) + ' µs'
+  if (ms < 1000) return ms.toFixed(1) + ' ms'
+  return (ms / 1000).toFixed(2) + ' s'
+}
+
+function formatTime(epochNanos) {
+  if (!epochNanos) return '—'
+  const ms = Math.floor(epochNanos / 1_000_000)
+  return new Date(ms).toLocaleTimeString()
+}
+
+function spanColor(span) {
+  if (span.statusCode === 'ERROR') return 'bg-danger'
+  if ((span.kind || '').includes('SERVER')) return 'bg-primary'
+  if ((span.kind || '').includes('CLIENT')) return 'bg-info'
+  if ((span.kind || '').includes('PRODUCER') || (span.kind || '').includes('CONSUMER')) return 'bg-warning'
+  return 'bg-secondary'
+}
+
+function shortId(id) {
+  if (!id) return '—'
+  return id.length > 8 ? id.substring(0, 8) : id
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div>
+    <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
+      <div>
+        <h2 class="mb-1"><i class="bi bi-bezier2 me-2"></i>Traces</h2>
+        <div v-if="report" class="text-muted small">
+          {{ report.retained }} / {{ report.capacity }} retained trace{{ report.retained === 1 ? '' : 's' }}
+          <span v-if="!report.enabled" class="badge text-bg-secondary ms-1">Disabled</span>
+        </div>
+      </div>
+      <div class="d-flex gap-2">
+        <button class="btn btn-sm btn-outline-danger" :disabled="!report || report.retained === 0 || busy" @click="clearAll">
+          <span v-if="busy" class="spinner-border spinner-border-sm me-1"></span>
+          <i v-else class="bi bi-trash me-1"></i>Clear
+        </button>
+        <button class="btn btn-sm btn-outline-secondary" :disabled="loading" @click="load">
+          <i class="bi bi-arrow-clockwise"></i> Refresh
+        </button>
+      </div>
+    </div>
+
+    <div v-if="banner" class="alert d-flex justify-content-between align-items-center" :class="'alert-' + banner.type">
+      <div>{{ banner.text }}</div>
+      <button class="btn-close" @click="banner = null"></button>
+    </div>
+
+    <div v-if="loading" class="text-muted">Loading traces…</div>
+    <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
+
+    <template v-else-if="report">
+      <div v-if="!report.enabled" class="alert alert-info small">
+        Telemetry receiver is disabled. Set <code>bootui.telemetry.enabled=true</code> and configure your application
+        to export OTLP to <code>http://localhost:8080/bootui/api/otlp/v1/traces</code>.
+      </div>
+
+      <div v-else-if="report.retained === 0" class="alert alert-secondary">
+        No traces received yet. Add an OTLP exporter pointed at
+        <code>/bootui/api/otlp/v1/traces</code> and exercise your application to populate this panel.
+      </div>
+
+      <template v-else>
+        <div class="mb-3">
+          <input v-model="filter" class="form-control form-control-sm"
+                 placeholder="Filter by trace id, root span, or service…" />
+        </div>
+
+        <div class="table-responsive">
+          <table class="table table-sm table-hover align-middle">
+            <thead>
+              <tr>
+                <th>Started</th>
+                <th>Root span</th>
+                <th>Services</th>
+                <th>Spans</th>
+                <th>Duration</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="t in filteredTraces" :key="t.traceId"
+                  :class="{ 'table-active': t.traceId === selectedTraceId }">
+                <td class="text-muted small">{{ formatTime(t.startEpochNanos) }}</td>
+                <td>
+                  <code class="me-2">{{ shortId(t.traceId) }}</code>
+                  <span class="fw-semibold">{{ t.rootSpanName || '—' }}</span>
+                  <span v-if="t.hasAi" class="badge text-bg-info ms-1"><i class="bi bi-stars"></i> AI</span>
+                </td>
+                <td>
+                  <span v-for="s in t.services" :key="s" class="badge text-bg-secondary me-1">{{ s }}</span>
+                </td>
+                <td>{{ t.spanCount }}</td>
+                <td>{{ formatDuration(t.durationNanos) }}</td>
+                <td>
+                  <span v-if="t.hasError" class="badge text-bg-danger">error</span>
+                  <span v-else class="badge text-bg-success">ok</span>
+                </td>
+                <td class="text-end">
+                  <button class="btn btn-sm btn-outline-primary" @click="openTrace(t.traceId)">Open</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </template>
+    </template>
+
+    <div v-if="selectedTraceId" class="trace-drawer card mt-3">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <div>
+          <i class="bi bi-bezier2 me-2"></i>
+          <code>{{ selectedTraceId }}</code>
+        </div>
+        <button class="btn btn-sm btn-outline-secondary" @click="closeDrawer">Close</button>
+      </div>
+      <div class="card-body">
+        <div v-if="detailLoading" class="text-muted small">Loading spans…</div>
+        <template v-else-if="waterfall">
+          <div class="text-muted small mb-2">
+            {{ waterfall.spans.length }} span{{ waterfall.spans.length === 1 ? '' : 's' }} ·
+            total {{ formatDuration(waterfall.totalNanos) }}
+          </div>
+          <div class="waterfall">
+            <div v-for="(s, i) in waterfall.spans" :key="s.spanId + '-' + i" class="waterfall-row">
+              <div class="waterfall-label" :title="s.name">
+                <span class="text-muted small">{{ s.serviceName || '—' }}</span>
+                <div class="text-truncate">{{ s.name }}</div>
+              </div>
+              <div class="waterfall-track">
+                <div class="waterfall-bar" :class="spanColor(s)"
+                     :style="{ marginLeft: s.offsetPct + '%', width: s.widthPct + '%' }"
+                     :title="formatDuration(s.durationNanos)">
+                </div>
+              </div>
+              <div class="waterfall-duration small text-muted">{{ formatDuration(s.durationNanos) }}</div>
+            </div>
+          </div>
+        </template>
+        <div v-else class="text-muted">No spans in this trace.</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.waterfall { display: flex; flex-direction: column; gap: 4px; }
+.waterfall-row { display: grid; grid-template-columns: 220px 1fr 80px; align-items: center; gap: 8px; }
+.waterfall-label { overflow: hidden; }
+.waterfall-track { position: relative; height: 16px; background: rgba(0,0,0,0.05); border-radius: 4px; }
+.waterfall-bar { height: 100%; border-radius: 4px; }
+.waterfall-duration { text-align: right; }
+.trace-drawer { border: 1px solid rgba(0,0,0,0.08); }
+</style>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -110,6 +110,18 @@ The Cache panel inspects Spring Cache infrastructure. It lists cache manager bea
 
 ![BootUI Cache panel](images/bootui-cache.png)
 
+## Traces
+
+The Traces panel shows distributed tracing spans collected by BootUI's embedded OTLP/HTTP receiver at `/bootui/api/otlp/v1/traces`. Any Spring Boot service that uses Micrometer Tracing with the OpenTelemetry bridge — including the host application itself when self-tracing is enabled — can export to this endpoint and have its traces appear here. The list shows the most recent traces with service name, root span name, status, duration, and span count; opening a trace renders a waterfall view of its spans so you can see latency contributions, errors, and parent/child relationships across services. Spans emitted by BootUI's own API are filtered out by default to keep the view focused on application traffic; this can be tuned with `bootui.telemetry.exclude-self-spans=false`. The in-memory trace buffer is bounded by `bootui.telemetry.max-traces` and is reset on application restart or via the panel's clear action.
+
+![BootUI Traces panel](images/bootui-traces.png)
+
+## AI Usage
+
+The AI Usage panel summarizes Spring AI activity collected from OpenTelemetry spans emitted by Spring AI's built-in observability. It groups chat client and chat model spans by conversation so you can see request count, token usage (prompt, completion, total), latency, model, and the prompt/response snippet when Spring AI is configured to capture content (`spring.ai.chat.client.observations.log-prompt`, `spring.ai.chat.observations.log-prompt`, `spring.ai.chat.observations.log-completion`). A small inline chart shows total token usage over recent calls so you can spot expensive interactions during local development. Vector store and embedding spans appear alongside chat spans when present. As with the Traces panel, data is sourced from the embedded OTLP receiver, is in-memory only, and is cleared on restart.
+
+![BootUI AI Usage panel](images/bootui-ai.png)
+
 ## Security
 
 The Security panel inspects Spring Security filter chains and provides best-effort endpoint rule explanations. It is meant to explain local security wiring without exposing credentials or replacing a full security audit.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -53,6 +53,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - Micrometer metrics
   - dependency inventory and OSV vulnerability scan
   - DevTools reload/restart
+  - OTLP traces receiver (`/bootui/api/otlp/v1/traces`), Traces panel API, and AI Usage panel API
 - Vue 3 UI shell with routes for:
   - Overview
   - Beans
@@ -74,6 +75,8 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - Vulnerabilities
   - DevTools
   - Dev Services
+  - Traces
+  - AI Usage
 - Maven-integrated frontend build that downloads Node/npm, builds the Vite app, and packages assets into `META-INF/resources/bootui`.
 - Backend tests covering activation, auto-configuration activation cases, localhost filtering, config override persistence, override property sources, override file storage, environment post-processing, config metadata loading, selected web controllers, missing Actuator behavior, and sample-app integration.
 - Playwright end-to-end tests in `bootui-sample-app/e2e` covering the sample API, every visible BootUI route, and focused flows for the current panel set, including Metrics, Redis-backed Cache, Vulnerabilities, DevTools, and Dev Services.
@@ -90,6 +93,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
 | 5. Config, Mappings, Health, and Loggers | Implemented and covered by sample e2e | Runtime config overrides, secret masking, mappings, health, and logger controls exist. Config override plumbing has focused backend tests. |
 | 6. Post-MVP diagnostic panels | Implemented and covered | Startup, Memory, Spring Data, Spring Cache, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, Security, Metrics, Vulnerabilities, DevTools, and Dev Services panels have API/UI slices plus backend edge-case tests and focused Playwright coverage. |
 | 7. Documentation and release hardening | Validated for the current alpha; ongoing | User-facing docs are reconciled with current behavior, and the CI-equivalent build plus sample-app Playwright suite passed on 2026-05-27. Keep release checks current as v0.2 work lands. |
+| 8. In-app OTLP sink + Traces + AI Usage | In progress | Adds an OTLP/HTTP receiver on `/bootui/api/otlp/v1/traces`, a Traces waterfall panel, an AI Usage panel for Spring AI observations, and a sample-app Ollama service started via `compose.yaml`. |
 
 ## 4. Current status and next work
 
@@ -237,13 +241,20 @@ Already implemented beyond the original MVP surface:
 - Spring Security panel.
 - Micrometer metrics browser with live values.
 - DevTools reload/restart controls.
+- In-app OTLP/HTTP traces receiver, Traces panel, and AI Usage panel.
+
+Newly in scope (added 2026-06):
+
+- **In-app OTLP/HTTP receiver**. BootUI exposes `POST /bootui/api/otlp/v1/traces` and accepts protobuf-encoded `ExportTraceServiceRequest` payloads from the host JVM (and from any cooperating local service that points its OTLP exporter there). Traces are buffered in memory only; nothing is forwarded.
+- **Traces panel**. Lists recent traces with a service swim-lane chip strip and per-trace waterfall, including span attributes and events.
+- **AI Usage panel**. Aggregates Spring AI's `gen_ai.client.operation`, `spring.ai.tool`, `db.vector.client.operation`, and embedding spans. Shows recent completions, token usage, tool calls, and (when content capture is enabled) a conversation drawer with messages.
+- **Multi-service dev orchestration (sink-only)**. Multiple cooperating local processes can each export OTLP to BootUI and their spans show up in the same waterfall. This is the dev-time equivalent of Aspire's distributed-tracing view; BootUI does not run, schedule, or restart the other services.
 
 Still excluded:
 
-- Multi-service orchestration.
-- Live Docker Compose lifecycle control.
+- Live Docker Compose lifecycle control beyond the existing snapshot view.
+- Production-grade tracing or APM replacement. The OTLP receiver is dev-only and bounded in memory.
 - Request history.
-- Distributed tracing.
 - Extension SPI.
 - CLI.
 - Gradle plugin.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -39,11 +39,11 @@ Make a running Spring Boot application understandable in minutes.
 ### 2.3 Non-goals for MVP
 
 - Production monitoring.
-- Multi-application orchestration.
+- Multi-application *runtime* orchestration. BootUI accepts OTLP traces from cooperating local services as a dev-time sink, but it does not run, schedule, restart, or supervise other processes the way .NET Aspire's AppHost does.
 - Kubernetes workflow management.
 - Hosted dashboards.
 - Authentication and user management.
-- Full APM/tracing replacement.
+- Full APM/tracing replacement. The OTLP receiver is dev-only, bounded in memory, and never forwards data anywhere.
 - Upgrade automation.
 - Code editing.
 - Replacing Spring Boot Admin.

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <spring-boot.version>4.0.6</spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
+        <opentelemetry-proto.version>1.10.0-alpha</opentelemetry-proto.version>
         <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <central.autoPublish>true</central.autoPublish>


### PR DESCRIPTION
## Summary

Brings two Aspire-inspired panels to BootUI, served entirely from the host JVM — no external collector required:

- **Traces** — distributed-tracing waterfall view. BootUI now embeds a tiny OTLP/HTTP receiver at `POST /bootui/api/otlp/v1/traces` that decodes the official OpenTelemetry protobuf payload, retains the most recent spans in a bounded in-memory store, and exposes them to the UI as trace summaries + per-trace timelines. Works for a single Boot app *and* for multi-service setups where peer services point their OTLP exporter at the dev-only BootUI endpoint.
- **AI Usage** — Spring AI dashboard. Recognises Spring AI's OpenTelemetry semantic-conventions spans (`gen_ai.*`) and surfaces per-chat input/output tokens, model, provider, finish reason, tool calls and vector operations, plus per-model rollups.

## Sample-app changes

The sample app now demonstrates the new panels end-to-end:

- **Spring AI + Ollama**: a `ChatController` exposes `POST /api/chat` backed by Spring AI; the embedded Ollama service (`compose.yaml`) is brought up by Spring Boot's Docker Compose support and the `qwen2.5:0.5b` model is auto-pulled the same way the existing cache panel relies on Redis.
- **OTLP wiring for Spring Boot 4**: depends on `spring-boot-micrometer-tracing-opentelemetry` + `micrometer-tracing-bridge-otel` + `opentelemetry-exporter-otlp`, with the new Boot 4 property prefix `management.opentelemetry.tracing.export.otlp.*` (the old `management.otlp.tracing.*` is no longer recognised).
- **`ChatController` hardening**: uses `ObjectProvider<ChatClient.Builder>` rather than `@ConditionalOnBean` on a component-scanned controller (which races with auto-configuration), and returns HTTP 503 when no `ChatModel` is configured.

## Documentation

`docs/FEATURES.md` and the README feature table both grew Traces + AI Usage sections, and the Playwright `app-shell` nav test enumerates the new sidebar entries.

## Validation

- `./mvnw -B -ntp clean install` — green, 30/30 module tests pass
- Playwright `bootui-sample-app/e2e` — green, 46/46 tests pass against the running sample app
- Manual smoke: `POST /api/chat` returns real LLM replies; `/bootui/api/traces` shows `/api/chat` spans flagged `hasAi:true`; `/bootui/api/ai/overview` reports chats, tokens-by-model, provider, and finish reason.

## Notes for reviewers

- The OTLP receiver itself produces a (small) trace per ingestion request, so the Traces panel shows a few `POST /bootui/api/otlp/v1/traces` entries alongside application traces. That's expected and matches what other dev dashboards (e.g. Aspire) surface.
- Prompt/completion *content* is intentionally not captured by default; the AI panel surfaces a banner explaining how to enable Spring AI's `include-prompt` / `include-completion` observation options if you want to inspect message bodies.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>