### PR TITLE
Remove unavailable sidebar tag

### DIFF
--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -21,6 +21,24 @@ test.describe('BootUI app shell', () => {
     await expect(contributeLink.locator('.bi-github')).toBeVisible()
   })
 
+  test('sidebar does not label unavailable panels', async ({ page }) => {
+    await page.route(url => url.pathname === '/bootui/api/panels', async route => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          panels: [
+            { id: 'overview', available: false }
+          ]
+        })
+      })
+    })
+    await page.goto('/bootui/')
+
+    const overviewLink = page.locator('aside .nav-link', { hasText: 'Overview' })
+    await expect(overviewLink).toHaveClass(/bootui-nav-link--unavailable/)
+    await expect(overviewLink).not.toContainText('Unavailable')
+  })
+
   test('sidebar links open every BootUI section', async ({ page }) => {
     const links = [
       { title: 'Overview',          heading: /^Overview/ },

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -77,7 +77,6 @@ onMounted(loadShellData)
           }">
           <i :class="['bi', r.meta.icon]"></i>
           <span class="bootui-nav-link__label">{{ r.meta.title }}</span>
-          <small v-if="panelLookup.get(r.name)?.available === false" class="bootui-nav-link__status">Unavailable</small>
         </router-link>
       </nav>
 
@@ -322,10 +321,6 @@ onMounted(loadShellData)
 
 .bootui-nav-link__label {
   flex: 1;
-}
-
-.bootui-nav-link__status {
-  font-size: 0.72rem;
 }
 
 .bootui-nav-link--unavailable {


### PR DESCRIPTION
## What does this PR do?

Removes the "Unavailable" text label from unavailable panels in the left sidebar while keeping the existing dimmed unavailable styling.

## Why is this change needed?

Unavailable panels were visually noisy in the navigation because each unavailable item repeated an "Unavailable" tag next to the title. The sidebar now communicates unavailable state through styling only.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `./mvnw -pl bootui-ui install`
- [x] `./mvnw -B -ntp -DskipTests install`
- [x] `(cd bootui-sample-app/e2e && CI=1 <local npm> test)`
- [x] `(cd bootui-sample-app/e2e && CI=1 <local npm> test -- tests/app-shell.spec.js)`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: this sidebar tag was not documented)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed