### PR TITLE
Update PostgreSQL JDBC driver to 42.7.11

### DIFF
--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -90,6 +90,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
+            <version>42.7.11</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
## Summary
- update the sample app PostgreSQL JDBC runtime dependency to 42.7.11
- addresses Dependabot alert #22 / GHSA-98qh-xjc8-98pq

## Validation
- ./mvnw -B -ntp -pl bootui-sample-app dependency:tree -Dincludes=org.postgresql:postgresql -Dscope=runtime
- ./mvnw -B -ntp -pl bootui-sample-app test