### PR TITLE
Add repository formatting checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,14 +40,27 @@ jobs:
           cache: npm
           cache-dependency-path: bootui-sample-app/e2e/package-lock.json
 
+      - name: Check Maven formatting
+        run: ./mvnw -B -ntp spotless:check
+
       - name: Build all modules
         run: ./mvnw -B -ntp clean install
 
+      - name: Check frontend formatting
+        working-directory: bootui-ui/src/main/frontend
+        run: npm run format:check
+
       - name: Install Playwright dependencies
         working-directory: bootui-sample-app/e2e
-        run: |
-          npm ci
-          npx playwright install --with-deps chromium
+        run: npm ci
+
+      - name: Check Playwright formatting
+        working-directory: bootui-sample-app/e2e
+        run: npm run format:check
+
+      - name: Install Playwright browsers
+        working-directory: bootui-sample-app/e2e
+        run: npx playwright install --with-deps chromium
 
       - name: Run Playwright end-to-end tests
         working-directory: bootui-sample-app/e2e

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+playwright-report/
+target/
+test-results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,22 @@ npm test
 Playwright can start the sample app automatically. If you already have the sample app running on port 8080, it will
 reuse that server.
 
+## Formatting
+
+Use Spotless for Java and repository whitespace checks:
+
+```bash
+./mvnw spotless:apply
+./mvnw spotless:check
+```
+
+Use Prettier for the Vue app and Playwright tests:
+
+```bash
+(cd bootui-ui/src/main/frontend && npm run format)
+(cd bootui-sample-app/e2e && npm run format)
+```
+
 ## Run the sample app
 
 ```bash

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiActivation.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiActivation.java
@@ -5,5 +5,4 @@ import java.util.List;
 /**
  * Resolved BootUI activation state at startup time.
  */
-public record BootUiActivation(boolean enabled, String reason, List<String> warnings) {
-}
+public record BootUiActivation(boolean enabled, String reason, List<String> warnings) {}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationCondition.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationCondition.java
@@ -1,12 +1,11 @@
 package io.github.jdubois.bootui.autoconfigure;
 
+import java.util.*;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.util.ClassUtils;
-
-import java.util.*;
 
 /**
  * Custom condition that controls when {@link BootUiAutoConfiguration} activates.
@@ -32,26 +31,28 @@ public class BootUiActivationCondition implements Condition {
         List<String> warnings = new ArrayList<>();
         Collection<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
 
-        List<String> disabledProfiles = listProperty(environment, "bootui.disabled-profiles", List.of("prod", "production"));
+        List<String> disabledProfiles =
+                listProperty(environment, "bootui.disabled-profiles", List.of("prod", "production"));
         List<String> enabledProfiles = listProperty(environment, "bootui.enabled-profiles", List.of("dev", "local"));
 
         if (!List.of("AUTO", "ON", "OFF").contains(mode)) {
-            return new BootUiActivation(false,
-                "Disabled: invalid bootui.enabled value '" + mode + "'",
-                warnings);
+            return new BootUiActivation(false, "Disabled: invalid bootui.enabled value '" + mode + "'", warnings);
         }
 
         for (String profile : disabledProfiles) {
             if (activeProfiles.contains(profile)) {
                 if ("ON".equals(mode)) {
-                    warnings.add("Profile '" + profile + "' is in bootui.disabled-profiles but bootui.enabled=ON forces it on.");
-                    return new BootUiActivation(true,
-                        "Explicitly enabled (bootui.enabled=ON) despite disabled profile '" + profile + "'",
-                        warnings);
+                    warnings.add("Profile '" + profile
+                            + "' is in bootui.disabled-profiles but bootui.enabled=ON forces it on.");
+                    return new BootUiActivation(
+                            true,
+                            "Explicitly enabled (bootui.enabled=ON) despite disabled profile '" + profile + "'",
+                            warnings);
                 }
-                return new BootUiActivation(false,
-                    "Disabled because active profile '" + profile + "' is in bootui.disabled-profiles",
-                    warnings);
+                return new BootUiActivation(
+                        false,
+                        "Disabled because active profile '" + profile + "' is in bootui.disabled-profiles",
+                        warnings);
             }
         }
 
@@ -64,21 +65,16 @@ public class BootUiActivationCondition implements Condition {
 
         for (String profile : enabledProfiles) {
             if (activeProfiles.contains(profile)) {
-                return new BootUiActivation(true,
-                    "Enabled by active profile '" + profile + "'",
-                    warnings);
+                return new BootUiActivation(true, "Enabled by active profile '" + profile + "'", warnings);
             }
         }
 
         if (ClassUtils.isPresent(DEVTOOLS_CLASS, classLoader)) {
-            return new BootUiActivation(true,
-                "Enabled because spring-boot-devtools is on the classpath",
-                warnings);
+            return new BootUiActivation(true, "Enabled because spring-boot-devtools is on the classpath", warnings);
         }
 
-        return new BootUiActivation(false,
-            "Disabled: no enabled profile and devtools is not on the classpath",
-            warnings);
+        return new BootUiActivation(
+                false, "Disabled: no enabled profile and devtools is not on the classpath", warnings);
     }
 
     private static List<String> listProperty(Environment env, String key, List<String> defaults) {
@@ -87,9 +83,9 @@ public class BootUiActivationCondition implements Condition {
             return defaults;
         }
         return Arrays.stream(raw.split(","))
-            .map(String::trim)
-            .filter(s -> !s.isBlank())
-            .toList();
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
     }
 
     @Override

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -65,7 +65,8 @@ public class BootUiAutoConfiguration {
 
     @Bean
     public BootUiActivation bootUiActivation(Environment environment) {
-        BootUiActivation activation = BootUiActivationCondition.resolve(environment, getClass().getClassLoader());
+        BootUiActivation activation =
+                BootUiActivationCondition.resolve(environment, getClass().getClassLoader());
         log.info("BootUI activation: {}", activation.reason());
         for (String warning : activation.warnings()) {
             log.warn("BootUI activation warning: {}", warning);
@@ -74,8 +75,8 @@ public class BootUiAutoConfiguration {
     }
 
     @Bean
-    public ConfigOverrideService bootUiConfigOverrideService(ConfigurableEnvironment environment,
-                                                             BootUiProperties properties) {
+    public ConfigOverrideService bootUiConfigOverrideService(
+            ConfigurableEnvironment environment, BootUiProperties properties) {
         return new ConfigOverrideService(environment, properties);
     }
 
@@ -101,7 +102,7 @@ public class BootUiAutoConfiguration {
 
     @Bean
     public FilterRegistrationBean<LocalhostOnlyFilter> bootUiLocalhostOnlyFilterRegistration(
-        LocalhostOnlyFilter filter, BootUiProperties properties) {
+            LocalhostOnlyFilter filter, BootUiProperties properties) {
         FilterRegistrationBean<LocalhostOnlyFilter> registration = new FilterRegistrationBean<>(filter);
         registration.addUrlPatterns(properties.getPath() + "/*", properties.getApiPath() + "/*");
         registration.setOrder(Integer.MIN_VALUE);
@@ -110,14 +111,13 @@ public class BootUiAutoConfiguration {
     }
 
     @Bean
-    public ApplicationListener<ApplicationReadyEvent> bootUiStartupBanner(BootUiProperties properties,
-                                                                          Environment environment) {
+    public ApplicationListener<ApplicationReadyEvent> bootUiStartupBanner(
+            BootUiProperties properties, Environment environment) {
         return event -> {
             if (!properties.isShowBanner()) {
                 return;
             }
-            String port = environment.getProperty("local.server.port",
-                environment.getProperty("server.port", "8080"));
+            String port = environment.getProperty("local.server.port", environment.getProperty("server.port", "8080"));
             String contextPath = environment.getProperty("server.servlet.context-path", "");
             String url = "http://localhost:" + port + contextPath + properties.getPath();
             log.info("BootUI is available at {}", url);

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -1,8 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
 import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Configuration properties bound under the {@code bootui.*} prefix.

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
@@ -1,14 +1,13 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiActivationCondition;
+import java.util.Map;
 import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
-
-import java.util.Map;
 
 /**
  * Contributes the Actuator endpoint exposure defaults BootUI needs for its
@@ -20,12 +19,14 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
 
     static final String PROPERTY_SOURCE_NAME = "bootUiActuatorEndpointDefaults";
 
-    static final String REQUIRED_ENDPOINTS = "health,info,beans,conditions,configprops,env,loggers,mappings,"
-        + "metrics,startup,scheduledtasks";
+    static final String REQUIRED_ENDPOINTS =
+            "health,info,beans,conditions,configprops,env,loggers,mappings," + "metrics,startup,scheduledtasks";
 
     private static final Map<String, Object> DEFAULTS = Map.of(
-        "management.endpoints.web.exposure.include", REQUIRED_ENDPOINTS,
-        "management.endpoint.health.show-details", "always");
+            "management.endpoints.web.exposure.include",
+            REQUIRED_ENDPOINTS,
+            "management.endpoint.health.show-details",
+            "always");
 
     @Override
     public int getOrder() {
@@ -34,7 +35,8 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
 
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
-        if (!BootUiActivationCondition.resolve(environment, application.getClassLoader()).enabled()) {
+        if (!BootUiActivationCondition.resolve(environment, application.getClassLoader())
+                .enabled()) {
             return;
         }
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesEnvironmentPostProcessor.java
@@ -1,14 +1,13 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
 import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MutablePropertySources;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Map;
 
 /**
  * Registers the {@link BootUiOverridesPropertySource} as the highest-precedence
@@ -31,9 +30,8 @@ public class BootUiOverridesEnvironmentPostProcessor implements EnvironmentPostP
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
         String configured = environment.getProperty("bootui.overrides-file");
-        Path file = Paths.get(configured != null && !configured.isBlank()
-            ? configured
-            : ".bootui/application-bootui.properties");
+        Path file = Paths.get(
+                configured != null && !configured.isBlank() ? configured : ".bootui/application-bootui.properties");
 
         ConfigOverridesFileStore store = new ConfigOverridesFileStore(file);
         Map<String, Object> existing = store.load();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesPropertySource.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesPropertySource.java
@@ -1,9 +1,8 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
-import org.springframework.core.env.MapPropertySource;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.springframework.core.env.MapPropertySource;
 
 /**
  * Mutable Spring property source that holds BootUI runtime overrides.

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiStartupEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiStartupEnvironmentPostProcessor.java
@@ -43,7 +43,8 @@ public class BootUiStartupEnvironmentPostProcessor implements EnvironmentPostPro
         if (!environment.getProperty("bootui.startup.enabled", Boolean.class, true)) {
             return;
         }
-        if (!BootUiActivationCondition.resolve(environment, application.getClassLoader()).enabled()) {
+        if (!BootUiActivationCondition.resolve(environment, application.getClassLoader())
+                .enabled()) {
             return;
         }
         ApplicationStartup current = application.getApplicationStartup();
@@ -64,7 +65,7 @@ public class BootUiStartupEnvironmentPostProcessor implements EnvironmentPostPro
      * Spring Boot's auto-configured {@code StartupEndpoint} can be exposed.
      */
     static final class BufferingApplicationStartupRegistrar
-        implements ApplicationContextInitializer<ConfigurableApplicationContext>, Ordered {
+            implements ApplicationContextInitializer<ConfigurableApplicationContext>, Ordered {
 
         private final BufferingApplicationStartup startup;
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/ConfigOverrideService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/ConfigOverrideService.java
@@ -4,13 +4,12 @@ import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
 import io.github.jdubois.bootui.core.BootUiDtos.ConfigOverrideResult;
 import io.github.jdubois.bootui.core.SecretMasker;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MutablePropertySources;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MutablePropertySources;
 
 /**
  * Reads, writes, and persists BootUI runtime configuration overrides.
@@ -62,17 +61,11 @@ public class ConfigOverrideService {
         validateName(name);
         BootUiOverridesPropertySource src = source();
         Object previous = src.getProperty(name);
-        String previousDisplay = previous == null
-            ? null
-            : displayValue(name, previous);
+        String previousDisplay = previous == null ? null : displayValue(name, previous);
         src.put(name, value);
         store.save(src.mutableSource());
         String message = describeRebindCaveat(name);
-        return new ConfigOverrideResult(name,
-            displayValue(name, value),
-            previousDisplay,
-            true,
-            message);
+        return new ConfigOverrideResult(name, displayValue(name, value), previousDisplay, true, message);
     }
 
     public ConfigOverrideResult remove(String name) {
@@ -81,8 +74,7 @@ public class ConfigOverrideService {
         Object previous = src.remove(name);
         store.save(src.mutableSource());
         String previousDisplay = previous == null ? null : displayValue(name, previous);
-        return new ConfigOverrideResult(name, null, previousDisplay, true,
-            describeRebindCaveat(name));
+        return new ConfigOverrideResult(name, null, previousDisplay, true, describeRebindCaveat(name));
     }
 
     private BootUiOverridesPropertySource source() {
@@ -106,8 +98,8 @@ public class ConfigOverrideService {
             return null;
         }
         if (properties.getExposeValues() == ValueExposure.MASKED
-            && properties.isMaskSecrets()
-            && masker.isSecret(name)) {
+                && properties.isMaskSecrets()
+                && masker.isSecret(name)) {
             return SecretMasker.MASKED_VALUE;
         }
         return value == null ? null : String.valueOf(value);
@@ -115,6 +107,6 @@ public class ConfigOverrideService {
 
     private String describeRebindCaveat(String name) {
         return "Override stored at " + store.file()
-            + ". Already-bound @ConfigurationProperties beans may keep their previous value until restart.";
+                + ". Already-bound @ConfigurationProperties beans may keep their previous value until restart.";
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/NormalizedEvent.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/NormalizedEvent.java
@@ -6,8 +6,4 @@ import java.util.Map;
  * Normalized span event with a time offset relative to its parent span and
  * attribute map coerced to JSON-friendly types.
  */
-public record NormalizedEvent(
-    String name,
-    long timeOffsetNanos,
-    Map<String, AttributeValue> attributes) {
-}
+public record NormalizedEvent(String name, long timeOffsetNanos, Map<String, AttributeValue> attributes) {}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/NormalizedSpan.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/NormalizedSpan.java
@@ -12,19 +12,19 @@ import java.util.Map;
  * Spring Boot.</p>
  */
 public record NormalizedSpan(
-    String traceId,
-    String spanId,
-    String parentSpanId,
-    String name,
-    String kind,
-    String serviceName,
-    String scope,
-    long startEpochNanos,
-    long endEpochNanos,
-    String statusCode,
-    String statusMessage,
-    Map<String, AttributeValue> attributes,
-    List<NormalizedEvent> events) {
+        String traceId,
+        String spanId,
+        String parentSpanId,
+        String name,
+        String kind,
+        String serviceName,
+        String scope,
+        long startEpochNanos,
+        long endEpochNanos,
+        String statusCode,
+        String statusMessage,
+        Map<String, AttributeValue> attributes,
+        List<NormalizedEvent> events) {
 
     public long durationNanos() {
         return Math.max(0L, endEpochNanos - startEpochNanos);

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/OtlpSpanDecoder.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/OtlpSpanDecoder.java
@@ -12,7 +12,6 @@ import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Span;
 import io.opentelemetry.proto.trace.v1.Status;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -90,30 +89,31 @@ public final class OtlpSpanDecoder {
         long startNs = span.getStartTimeUnixNano();
         for (Span.Event event : span.getEventsList()) {
             events.add(new NormalizedEvent(
-                event.getName(),
-                Math.max(0L, event.getTimeUnixNano() - startNs),
-                toAttributeMap(event.getAttributesList())));
+                    event.getName(),
+                    Math.max(0L, event.getTimeUnixNano() - startNs),
+                    toAttributeMap(event.getAttributesList())));
         }
         Status status = span.getStatus();
-        String statusCode = switch (status.getCode()) {
-            case STATUS_CODE_OK -> "OK";
-            case STATUS_CODE_ERROR -> "ERROR";
-            default -> "UNSET";
-        };
+        String statusCode =
+                switch (status.getCode()) {
+                    case STATUS_CODE_OK -> "OK";
+                    case STATUS_CODE_ERROR -> "ERROR";
+                    default -> "UNSET";
+                };
         return new NormalizedSpan(
-            hex(span.getTraceId()),
-            hex(span.getSpanId()),
-            emptyToNull(hex(span.getParentSpanId())),
-            truncate(span.getName()),
-            spanKindToString(span.getKind()),
-            truncate(serviceName),
-            truncate(scopeName),
-            startNs,
-            span.getEndTimeUnixNano(),
-            statusCode,
-            truncate(status.getMessage()),
-            attrs,
-            events);
+                hex(span.getTraceId()),
+                hex(span.getSpanId()),
+                emptyToNull(hex(span.getParentSpanId())),
+                truncate(span.getName()),
+                spanKindToString(span.getKind()),
+                truncate(serviceName),
+                truncate(scopeName),
+                startNs,
+                span.getEndTimeUnixNano(),
+                statusCode,
+                truncate(status.getMessage()),
+                attrs,
+                events);
     }
 
     private Map<String, AttributeValue> toAttributeMap(List<KeyValue> keyValues) {
@@ -136,8 +136,7 @@ public final class OtlpSpanDecoder {
             case BOOL_VALUE -> AttributeValue.ofBoolean(value.getBoolValue());
             case INT_VALUE -> AttributeValue.ofNumber(value.getIntValue());
             case DOUBLE_VALUE -> AttributeValue.ofNumber(value.getDoubleValue());
-            case BYTES_VALUE -> AttributeValue.ofString(
-                truncate("0x" + bytesToHex(value.getBytesValue())));
+            case BYTES_VALUE -> AttributeValue.ofString(truncate("0x" + bytesToHex(value.getBytesValue())));
             case ARRAY_VALUE -> {
                 List<Object> arr = new ArrayList<>(value.getArrayValue().getValuesCount());
                 for (AnyValue v : value.getArrayValue().getValuesList()) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryStore.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryStore.java
@@ -1,7 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.otlp;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
-
 import java.util.*;
 
 /**
@@ -51,7 +50,8 @@ public class TelemetryStore {
         if (bucket == null) {
             bucket = new TraceBucket(span.traceId());
             while (tracesById.size() >= effectiveMaxTraces(config)) {
-                Iterator<Map.Entry<String, TraceBucket>> it = tracesById.entrySet().iterator();
+                Iterator<Map.Entry<String, TraceBucket>> it =
+                        tracesById.entrySet().iterator();
                 if (!it.hasNext()) {
                     break;
                 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilter.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilter.java
@@ -5,13 +5,12 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * Rejects any BootUI request that does not originate from a loopback address.
@@ -40,7 +39,7 @@ public class LocalhostOnlyFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
-        throws ServletException, IOException {
+            throws ServletException, IOException {
 
         if (properties.isAllowNonLocalhost() || !properties.isLocalhostOnly()) {
             chain.doFilter(request, response);
@@ -56,8 +55,9 @@ public class LocalhostOnlyFilter extends OncePerRequestFilter {
         log.warn("BootUI rejected non-loopback request from {} to {}", remote, request.getRequestURI());
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json");
-        response.getWriter().write("{\"error\":\"BootUI is restricted to loopback requests. " +
-            "Set bootui.allow-non-localhost=true to override.\"}");
+        response.getWriter()
+                .write("{\"error\":\"BootUI is restricted to loopback requests. "
+                        + "Set bootui.allow-non-localhost=true to override.\"}");
     }
 
     private boolean isLoopback(String remoteAddr) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiController.java
@@ -4,11 +4,10 @@ import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
 import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
 import io.github.jdubois.bootui.core.BootUiDtos.*;
+import java.util.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.*;
 
 /**
  * Read-only API for the BootUI AI Usage panel.
@@ -66,20 +65,22 @@ public class AiController {
 
     private static Map<String, Long> topLongEntries(Map<String, Long> input) {
         return input.entrySet().stream()
-            .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
-            .limit(MAX_MODEL_BREAKDOWN_ENTRIES)
-            .collect(LinkedHashMap::new,
-                (map, entry) -> map.put(entry.getKey(), entry.getValue()),
-                LinkedHashMap::putAll);
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(MAX_MODEL_BREAKDOWN_ENTRIES)
+                .collect(
+                        LinkedHashMap::new,
+                        (map, entry) -> map.put(entry.getKey(), entry.getValue()),
+                        LinkedHashMap::putAll);
     }
 
     private static Map<String, Integer> topIntegerEntries(Map<String, Integer> input) {
         return input.entrySet().stream()
-            .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
-            .limit(MAX_MODEL_BREAKDOWN_ENTRIES)
-            .collect(LinkedHashMap::new,
-                (map, entry) -> map.put(entry.getKey(), entry.getValue()),
-                LinkedHashMap::putAll);
+                .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+                .limit(MAX_MODEL_BREAKDOWN_ENTRIES)
+                .collect(
+                        LinkedHashMap::new,
+                        (map, entry) -> map.put(entry.getKey(), entry.getValue()),
+                        LinkedHashMap::putAll);
     }
 
     private static int clamp(int value, int min, int max) {
@@ -126,27 +127,28 @@ public class AiController {
         boolean telemetryEnabled = properties.getTelemetry().isEnabled();
         boolean springAi = isSpringAiOnClasspath();
         String banner = telemetryEnabled && springAi && aiConfig.isShowContentCaptureBanner()
-            ? "Prompt and completion text is not captured by default. Enable Spring AI's "
-              + "include-prompt / include-completion observation options (or attach a custom "
-              + "ObservationFilter) to see message content in the conversation drawer."
-            : null;
+                ? "Prompt and completion text is not captured by default. Enable Spring AI's "
+                        + "include-prompt / include-completion observation options (or attach a custom "
+                        + "ObservationFilter) to see message content in the conversation drawer."
+                : null;
         return new AiOverviewDto(
-            telemetryEnabled,
-            springAi,
-            chats.size(),
-            totalIn,
-            totalOut,
-            topLongEntries(tokensByModel),
-            topIntegerEntries(callsByModel),
-            toolCount,
-            vectorCount,
-            embeddingCount,
-            recent,
-            banner);
+                telemetryEnabled,
+                springAi,
+                chats.size(),
+                totalIn,
+                totalOut,
+                topLongEntries(tokensByModel),
+                topIntegerEntries(callsByModel),
+                toolCount,
+                vectorCount,
+                embeddingCount,
+                recent,
+                banner);
     }
 
     @GetMapping("/chats")
-    public List<AiChatSummaryDto> chats(@RequestParam(name = "limit", required = false, defaultValue = "100") int limit) {
+    public List<AiChatSummaryDto> chats(
+            @RequestParam(name = "limit", required = false, defaultValue = "100") int limit) {
         int safeLimit = Math.max(1, Math.min(500, limit));
         List<NormalizedSpan> chats = chatSpansSorted();
         List<AiChatSummaryDto> out = new ArrayList<>(Math.min(safeLimit, chats.size()));
@@ -232,21 +234,21 @@ public class AiController {
         Long out = AiSpanRecognizer.outputTokens(chat);
         Long total = AiSpanRecognizer.totalTokens(chat);
         return new AiChatSummaryDto(
-            chat.traceId(),
-            chat.spanId(),
-            chat.startEpochNanos(),
-            chat.durationNanos(),
-            AiSpanRecognizer.provider(chat),
-            AiSpanRecognizer.requestModel(chat),
-            AiSpanRecognizer.responseModel(chat),
-            in,
-            out,
-            total,
-            AiSpanRecognizer.finishReason(chat),
-            chat.statusCode(),
-            "chat",
-            toolCalls,
-            vectorOps);
+                chat.traceId(),
+                chat.spanId(),
+                chat.startEpochNanos(),
+                chat.durationNanos(),
+                AiSpanRecognizer.provider(chat),
+                AiSpanRecognizer.requestModel(chat),
+                AiSpanRecognizer.responseModel(chat),
+                in,
+                out,
+                total,
+                AiSpanRecognizer.finishReason(chat),
+                chat.statusCode(),
+                "chat",
+                toolCalls,
+                vectorOps);
     }
 
     private AiChatDetailDto buildDetail(NormalizedSpan chat) {
@@ -257,41 +259,41 @@ public class AiController {
             for (NormalizedSpan sibling : bucket.spans()) {
                 if (AiSpanRecognizer.isToolCall(sibling)) {
                     tools.add(new AiToolCallDto(
-                        sibling.spanId(),
-                        AiSpanRecognizer.toolName(sibling),
-                        sibling.startEpochNanos(),
-                        sibling.durationNanos(),
-                        sibling.statusCode()));
+                            sibling.spanId(),
+                            AiSpanRecognizer.toolName(sibling),
+                            sibling.startEpochNanos(),
+                            sibling.durationNanos(),
+                            sibling.statusCode()));
                 }
                 if (AiSpanRecognizer.isVectorOperation(sibling)) {
                     vectors.add(new AiVectorOpDto(
-                        sibling.spanId(),
-                        AiSpanRecognizer.vectorOperation(sibling),
-                        AiSpanRecognizer.vectorCollection(sibling),
-                        sibling.startEpochNanos(),
-                        sibling.durationNanos(),
-                        sibling.statusCode()));
+                            sibling.spanId(),
+                            AiSpanRecognizer.vectorOperation(sibling),
+                            AiSpanRecognizer.vectorCollection(sibling),
+                            sibling.startEpochNanos(),
+                            sibling.durationNanos(),
+                            sibling.statusCode()));
                 }
             }
         }
         tools.sort(Comparator.comparingLong(AiToolCallDto::startEpochNanos));
         vectors.sort(Comparator.comparingLong(AiVectorOpDto::startEpochNanos));
         boolean contentCaptured = chat.attributes() != null
-            && (chat.attributes().containsKey("gen_ai.prompt")
-            || chat.attributes().containsKey("gen_ai.completion")
-            || chat.attributes().containsKey("gen_ai.input.messages")
-            || chat.attributes().containsKey("gen_ai.output.messages"));
+                && (chat.attributes().containsKey("gen_ai.prompt")
+                        || chat.attributes().containsKey("gen_ai.completion")
+                        || chat.attributes().containsKey("gen_ai.input.messages")
+                        || chat.attributes().containsKey("gen_ai.output.messages"));
         String banner = !contentCaptured && properties.getAi().isShowContentCaptureBanner()
-            ? "Message content is not on this span. Enable Spring AI's include-prompt / include-completion "
-              + "observation options to capture prompt and completion text."
-            : null;
+                ? "Message content is not on this span. Enable Spring AI's include-prompt / include-completion "
+                        + "observation options to capture prompt and completion text."
+                : null;
         return new AiChatDetailDto(
-            toSummary(chat),
-            tools,
-            vectors,
-            TracesController.toAttributeList(chat.attributes()),
-            TracesController.toEventList(chat.events()),
-            contentCaptured,
-            banner);
+                toSummary(chat),
+                tools,
+                vectors,
+                TracesController.toAttributeList(chat.attributes()),
+                TracesController.toEventList(chat.events()),
+                contentCaptured,
+                banner);
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiSpanRecognizer.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiSpanRecognizer.java
@@ -17,8 +17,7 @@ import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
  */
 public final class AiSpanRecognizer {
 
-    private AiSpanRecognizer() {
-    }
+    private AiSpanRecognizer() {}
 
     public static boolean isAi(NormalizedSpan span) {
         return isChat(span) || isEmbedding(span) || isToolCall(span) || isVectorOperation(span);
@@ -120,8 +119,7 @@ public final class AiSpanRecognizer {
     }
 
     public static String finishReason(NormalizedSpan span) {
-        AttributeValue av = span.attributes() != null
-            ? span.attributes().get("gen_ai.response.finish_reasons") : null;
+        AttributeValue av = span.attributes() != null ? span.attributes().get("gen_ai.response.finish_reasons") : null;
         if (av == null) {
             return stringAttr(span, "gen_ai.response.finish_reason");
         }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BeansController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BeansController.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.BeanList;
 import io.github.jdubois.bootui.core.BootUiDtos.BeanSummary;
+import java.util.*;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.beans.BeansEndpoint;
 import org.springframework.boot.actuate.beans.BeansEndpoint.BeanDescriptor;
@@ -10,8 +11,6 @@ import org.springframework.boot.actuate.beans.BeansEndpoint.ContextBeansDescript
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.*;
 
 @RestController
 @RequestMapping("/bootui/api/beans")
@@ -31,8 +30,10 @@ public class BeansController {
         }
         BeansDescriptor descriptor = be.beans();
         List<BeanSummary> summaries = new ArrayList<>();
-        for (Map.Entry<String, ContextBeansDescriptor> ctxEntry : descriptor.getContexts().entrySet()) {
-            for (Map.Entry<String, BeanDescriptor> beanEntry : ctxEntry.getValue().getBeans().entrySet()) {
+        for (Map.Entry<String, ContextBeansDescriptor> ctxEntry :
+                descriptor.getContexts().entrySet()) {
+            for (Map.Entry<String, BeanDescriptor> beanEntry :
+                    ctxEntry.getValue().getBeans().entrySet()) {
                 summaries.add(toSummary(beanEntry.getKey(), beanEntry.getValue()));
             }
         }
@@ -43,13 +44,13 @@ public class BeansController {
     private BeanSummary toSummary(String name, BeanDescriptor descriptor) {
         String type = descriptor.getType() == null ? null : descriptor.getType().getName();
         return new BeanSummary(
-            name,
-            type,
-            descriptor.getScope(),
-            descriptor.getResource(),
-            descriptor.getDependencies() == null ? List.of() : Arrays.asList(descriptor.getDependencies()),
-            descriptor.getAliases() == null ? List.of() : Arrays.asList(descriptor.getAliases()),
-            classify(name, type));
+                name,
+                type,
+                descriptor.getScope(),
+                descriptor.getResource(),
+                descriptor.getDependencies() == null ? List.of() : Arrays.asList(descriptor.getDependencies()),
+                descriptor.getAliases() == null ? List.of() : Arrays.asList(descriptor.getAliases()),
+                classify(name, type));
     }
 
     private String classify(String name, String type) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiIndexController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiIndexController.java
@@ -2,11 +2,10 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-
-import java.io.IOException;
 
 /**
  * Serves the BootUI single-page application root and convenience aliases.

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiLogAppender.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiLogAppender.java
@@ -5,14 +5,13 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
 import ch.qos.logback.core.AppenderBase;
-import org.slf4j.ILoggerFactory;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
 
 public class BootUiLogAppender extends AppenderBase<ILoggingEvent> {
 
@@ -56,11 +55,11 @@ public class BootUiLogAppender extends AppenderBase<ILoggingEvent> {
     @Override
     protected void append(ILoggingEvent event) {
         LogLineDto line = new LogLineDto(
-            event.getTimeStamp(),
-            event.getLevel().toString(),
-            event.getLoggerName(),
-            event.getFormattedMessage(),
-            event.getThreadName());
+                event.getTimeStamp(),
+                event.getLevel().toString(),
+                event.getLoggerName(),
+                event.getFormattedMessage(),
+                event.getThreadName());
         synchronized (lines) {
             if (lines.size() >= MAX_LINES) {
                 lines.removeFirst();
@@ -83,6 +82,5 @@ public class BootUiLogAppender extends AppenderBase<ILoggingEvent> {
         return () -> subscribers.remove(consumer);
     }
 
-    public record LogLineDto(long timestamp, String level, String logger, String message, String thread) {
-    }
+    public record LogLineDto(long timestamp, String level, String logger, String message, String thread) {}
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CacheController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CacheController.java
@@ -5,6 +5,10 @@ import io.github.jdubois.bootui.core.BootUiDtos.*;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
@@ -19,11 +23,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.ClassUtils;
 import org.springframework.web.bind.annotation.*;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.*;
 
 @RestController
 @RequestMapping("/bootui/api/cache")
@@ -43,10 +42,11 @@ public class CacheController {
 
     private final BootUiProperties properties;
 
-    public CacheController(ObjectProvider<ListableBeanFactory> beanFactoryProvider,
-                           ObjectProvider<CacheOperationSource> cacheOperationSources,
-                           ObjectProvider<MeterRegistry> meterRegistries,
-                           BootUiProperties properties) {
+    public CacheController(
+            ObjectProvider<ListableBeanFactory> beanFactoryProvider,
+            ObjectProvider<CacheOperationSource> cacheOperationSources,
+            ObjectProvider<MeterRegistry> meterRegistries,
+            BootUiProperties properties) {
         this.beanFactoryProvider = beanFactoryProvider;
         this.cacheOperationSources = cacheOperationSources;
         this.meterRegistries = meterRegistries;
@@ -56,60 +56,77 @@ public class CacheController {
     @GetMapping
     public CacheReport cache() {
         ListableBeanFactory factory = beanFactoryProvider.getIfAvailable();
-        OperationDiscovery operationDiscovery = factory == null
-            ? new OperationDiscovery(List.of(), List.of())
-            : discoverOperations(factory);
+        OperationDiscovery operationDiscovery =
+                factory == null ? new OperationDiscovery(List.of(), List.of()) : discoverOperations(factory);
         if (factory == null) {
-            return new CacheReport(false, clearEnabled(), 0, 0, operationDiscovery.operations().size(),
-                List.of(), operationDiscovery.operations(), operationDiscovery.warnings());
+            return new CacheReport(
+                    false,
+                    clearEnabled(),
+                    0,
+                    0,
+                    operationDiscovery.operations().size(),
+                    List.of(),
+                    operationDiscovery.operations(),
+                    operationDiscovery.warnings());
         }
 
         List<CacheManagerEntry> managers = discoverManagers(factory);
         Map<MetricKey, CacheMetricsAccumulator> metrics = cacheMetrics();
-        List<CacheManagerDto> managerDtos = managers.stream()
-            .map(manager -> toManagerDto(manager, metrics))
-            .toList();
-        int cacheCount = managerDtos.stream().mapToInt(manager -> manager.caches().size()).sum();
+        List<CacheManagerDto> managerDtos =
+                managers.stream().map(manager -> toManagerDto(manager, metrics)).toList();
+        int cacheCount = managerDtos.stream()
+                .mapToInt(manager -> manager.caches().size())
+                .sum();
         return new CacheReport(
-            !managers.isEmpty(),
-            clearEnabled(),
-            managers.size(),
-            cacheCount,
-            operationDiscovery.operations().size(),
-            managerDtos,
-            operationDiscovery.operations(),
-            operationDiscovery.warnings());
+                !managers.isEmpty(),
+                clearEnabled(),
+                managers.size(),
+                cacheCount,
+                operationDiscovery.operations().size(),
+                managerDtos,
+                operationDiscovery.operations(),
+                operationDiscovery.warnings());
     }
 
     @PostMapping("/clear")
     public ResponseEntity<CacheClearResult> clear(@RequestBody(required = false) CacheClearRequest request) {
         if (!clearEnabled()) {
-            return result(HttpStatus.CONFLICT, "disabled",
-                "Cache clearing is disabled. Set bootui.cache.clear-enabled=true to allow it.",
-                List.of());
+            return result(
+                    HttpStatus.CONFLICT,
+                    "disabled",
+                    "Cache clearing is disabled. Set bootui.cache.clear-enabled=true to allow it.",
+                    List.of());
         }
         if (request == null || !Boolean.TRUE.equals(request.confirm())) {
-            return result(HttpStatus.BAD_REQUEST, "confirmation_required",
-                "Cache clearing requires explicit confirmation.", List.of());
+            return result(
+                    HttpStatus.BAD_REQUEST,
+                    "confirmation_required",
+                    "Cache clearing requires explicit confirmation.",
+                    List.of());
         }
 
         ListableBeanFactory factory = beanFactoryProvider.getIfAvailable();
         if (factory == null) {
-            return result(HttpStatus.CONFLICT, "unavailable",
-                "No bean factory is available to discover cache managers.", List.of());
+            return result(
+                    HttpStatus.CONFLICT,
+                    "unavailable",
+                    "No bean factory is available to discover cache managers.",
+                    List.of());
         }
         List<CacheManagerEntry> managers = discoverManagers(factory);
         if (managers.isEmpty()) {
-            return result(HttpStatus.CONFLICT, "unavailable",
-                "No CacheManager beans are available.", List.of());
+            return result(HttpStatus.CONFLICT, "unavailable", "No CacheManager beans are available.", List.of());
         }
 
         if (Boolean.TRUE.equals(request.all())) {
             return clearAll(managers);
         }
         if (isBlank(request.managerName()) || isBlank(request.cacheName())) {
-            return result(HttpStatus.BAD_REQUEST, "invalid_request",
-                "managerName and cacheName are required when clearing one cache.", List.of());
+            return result(
+                    HttpStatus.BAD_REQUEST,
+                    "invalid_request",
+                    "managerName and cacheName are required when clearing one cache.",
+                    List.of());
         }
         return clearOne(managers, request.managerName(), request.cacheName());
     }
@@ -129,30 +146,37 @@ public class CacheController {
             }
         }
         log.warn("BootUI cleared {} caches across all Spring Cache managers: {}", cleared.size(), cleared);
-        return result(HttpStatus.OK, "cleared",
-            "Cleared " + cleared.size() + " cache" + (cleared.size() == 1 ? "." : "s."),
-            cleared);
+        return result(
+                HttpStatus.OK,
+                "cleared",
+                "Cleared " + cleared.size() + " cache" + (cleared.size() == 1 ? "." : "s."),
+                cleared);
     }
 
-    private ResponseEntity<CacheClearResult> clearOne(List<CacheManagerEntry> managers,
-                                                      String managerName,
-                                                      String cacheName) {
+    private ResponseEntity<CacheClearResult> clearOne(
+            List<CacheManagerEntry> managers, String managerName, String cacheName) {
         CacheManagerEntry manager = managers.stream()
-            .filter(entry -> entry.name().equals(managerName))
-            .findFirst()
-            .orElse(null);
+                .filter(entry -> entry.name().equals(managerName))
+                .findFirst()
+                .orElse(null);
         if (manager == null) {
-            return result(HttpStatus.NOT_FOUND, "not_found",
-                "Cache manager '" + managerName + "' was not found.", List.of());
+            return result(
+                    HttpStatus.NOT_FOUND, "not_found", "Cache manager '" + managerName + "' was not found.", List.of());
         }
         if (!cacheNames(manager.manager()).contains(cacheName)) {
-            return result(HttpStatus.NOT_FOUND, "not_found",
-                "Cache '" + cacheName + "' was not found in manager '" + managerName + "'.", List.of());
+            return result(
+                    HttpStatus.NOT_FOUND,
+                    "not_found",
+                    "Cache '" + cacheName + "' was not found in manager '" + managerName + "'.",
+                    List.of());
         }
         Cache cache = manager.manager().getCache(cacheName);
         if (cache == null) {
-            return result(HttpStatus.NOT_FOUND, "not_found",
-                "Cache '" + cacheName + "' was not returned by manager '" + managerName + "'.", List.of());
+            return result(
+                    HttpStatus.NOT_FOUND,
+                    "not_found",
+                    "Cache '" + cacheName + "' was not returned by manager '" + managerName + "'.",
+                    List.of());
         }
 
         List<String> cleared = new ArrayList<>();
@@ -161,29 +185,32 @@ public class CacheController {
             return failure;
         }
         log.warn("BootUI cleared Spring Cache entry {} / {}", manager.name(), cacheName);
-        return result(HttpStatus.OK, "cleared",
-            "Cleared cache '" + cacheName + "' from manager '" + manager.name() + "'.",
-            cleared);
+        return result(
+                HttpStatus.OK,
+                "cleared",
+                "Cleared cache '" + cacheName + "' from manager '" + manager.name() + "'.",
+                cleared);
     }
 
-    private ResponseEntity<CacheClearResult> clearCache(String managerName, String cacheName, Cache cache,
-                                                        List<String> cleared) {
+    private ResponseEntity<CacheClearResult> clearCache(
+            String managerName, String cacheName, Cache cache, List<String> cleared) {
         try {
             cache.clear();
             cleared.add(managerName + "/" + cacheName);
             return null;
         } catch (RuntimeException ex) {
-            return result(HttpStatus.INTERNAL_SERVER_ERROR, "failed",
-                "Failed to clear cache '" + cacheName + "' from manager '" + managerName
-                    + "' (" + ex.getClass().getSimpleName() + ").",
-                cleared);
+            return result(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "failed",
+                    "Failed to clear cache '" + cacheName + "' from manager '" + managerName + "' ("
+                            + ex.getClass().getSimpleName() + ").",
+                    cleared);
         }
     }
 
-    private ResponseEntity<CacheClearResult> result(HttpStatus status, String resultStatus, String message,
-                                                    List<String> caches) {
-        return ResponseEntity.status(status)
-            .body(new CacheClearResult(resultStatus, message, caches.size(), caches));
+    private ResponseEntity<CacheClearResult> result(
+            HttpStatus status, String resultStatus, String message, List<String> caches) {
+        return ResponseEntity.status(status).body(new CacheClearResult(resultStatus, message, caches.size(), caches));
     }
 
     private List<CacheManagerEntry> discoverManagers(ListableBeanFactory factory) {
@@ -197,8 +224,7 @@ public class CacheController {
         return managers;
     }
 
-    private CacheManagerDto toManagerDto(CacheManagerEntry entry,
-                                         Map<MetricKey, CacheMetricsAccumulator> metrics) {
+    private CacheManagerDto toManagerDto(CacheManagerEntry entry, Map<MetricKey, CacheMetricsAccumulator> metrics) {
         List<CacheDto> caches = new ArrayList<>();
         for (String cacheName : cacheNames(entry.manager())) {
             Cache cache = entry.manager().getCache(cacheName);
@@ -211,25 +237,23 @@ public class CacheController {
         return new CacheManagerDto(entry.name(), entry.manager().getClass().getName(), isNoOp(entry.manager()), caches);
     }
 
-    private CacheDto toCacheDto(String managerName, String cacheName, Cache cache,
-                                Map<MetricKey, CacheMetricsAccumulator> metrics) {
+    private CacheDto toCacheDto(
+            String managerName, String cacheName, Cache cache, Map<MetricKey, CacheMetricsAccumulator> metrics) {
         Object nativeCache = nativeCache(cache);
         CacheMetricsAccumulator metric = metrics.get(new MetricKey(managerName, cacheName));
         if (metric == null) {
             metric = metrics.get(new MetricKey("*", cacheName));
         }
         return new CacheDto(
-            managerName,
-            cacheName,
-            nativeCache == null ? null : nativeCache.getClass().getName(),
-            estimateSize(nativeCache),
-            metric == null ? new CacheMetricsDto(false, null, null, null, null, null, null, null) : metric.toDto());
+                managerName,
+                cacheName,
+                nativeCache == null ? null : nativeCache.getClass().getName(),
+                estimateSize(nativeCache),
+                metric == null ? new CacheMetricsDto(false, null, null, null, null, null, null, null) : metric.toDto());
     }
 
     private List<String> cacheNames(CacheManager manager) {
-        return manager.getCacheNames().stream()
-            .sorted()
-            .toList();
+        return manager.getCacheNames().stream().sorted().toList();
     }
 
     private Object nativeCache(Cache cache) {
@@ -288,11 +312,12 @@ public class CacheController {
                 continue;
             }
             String managerName = firstNonBlank(
-                meter.getId().getTag("name"),
-                meter.getId().getTag("cacheManager"),
-                meter.getId().getTag("cache.manager"));
+                    meter.getId().getTag("name"),
+                    meter.getId().getTag("cacheManager"),
+                    meter.getId().getTag("cache.manager"));
             MetricKey key = new MetricKey(isBlank(managerName) ? "*" : managerName, cacheName);
-            CacheMetricsAccumulator accumulator = metrics.computeIfAbsent(key, ignored -> new CacheMetricsAccumulator());
+            CacheMetricsAccumulator accumulator =
+                    metrics.computeIfAbsent(key, ignored -> new CacheMetricsAccumulator());
             addMetric(accumulator, meterName, meter);
         }
         return metrics;
@@ -324,8 +349,7 @@ public class CacheController {
             case "cache.evictions" -> accumulator.addEvictions(value.getAsDouble());
             case "cache.removals" -> accumulator.addRemovals(value.getAsDouble());
             case "cache.size" -> accumulator.setSize(value.getAsDouble());
-            default -> {
-            }
+            default -> {}
         }
     }
 
@@ -343,14 +367,15 @@ public class CacheController {
     }
 
     private OperationDiscovery discoverOperations(ListableBeanFactory factory) {
-        List<CacheOperationSource> sources = cacheOperationSources.orderedStream().toList();
+        List<CacheOperationSource> sources =
+                cacheOperationSources.orderedStream().toList();
         if (sources.isEmpty()) {
             return new OperationDiscovery(List.of(), List.of());
         }
 
         List<String> beanNames = Arrays.stream(BeanFactoryUtils.beanNamesIncludingAncestors(factory))
-            .sorted()
-            .toList();
+                .sorted()
+                .toList();
         List<CacheOperationDto> operations = new ArrayList<>();
         List<String> warnings = new ArrayList<>();
         int scannedMethods = 0;
@@ -370,7 +395,7 @@ public class CacheController {
                 scannedMethods++;
                 if (scannedMethods > MAX_SCANNED_METHODS) {
                     warnings.add("Cache annotation scan stopped after " + MAX_SCANNED_METHODS
-                        + " methods to avoid slowing the application.");
+                            + " methods to avoid slowing the application.");
                     break scan;
                 }
                 Method bridged = BridgeMethodResolver.findBridgedMethod(method);
@@ -383,7 +408,7 @@ public class CacheController {
                         cacheOperations = source.getCacheOperations(bridged, userType);
                     } catch (RuntimeException ex) {
                         warnings.add("Could not inspect cache annotations on " + userType.getName() + "#"
-                            + bridged.getName() + " (" + ex.getClass().getSimpleName() + ").");
+                                + bridged.getName() + " (" + ex.getClass().getSimpleName() + ").");
                         continue;
                     }
                     if (cacheOperations == null || cacheOperations.isEmpty()) {
@@ -393,7 +418,7 @@ public class CacheController {
                         operations.add(toOperationDto(beanName, userType, bridged, operation));
                         if (operations.size() >= MAX_CACHE_OPERATIONS) {
                             warnings.add("Cache annotation report was truncated after " + MAX_CACHE_OPERATIONS
-                                + " operations.");
+                                    + " operations.");
                             break scan;
                         }
                     }
@@ -401,8 +426,8 @@ public class CacheController {
             }
         }
         operations.sort(Comparator.comparing(CacheOperationDto::beanName)
-            .thenComparing(CacheOperationDto::method)
-            .thenComparing(CacheOperationDto::operation));
+                .thenComparing(CacheOperationDto::method)
+                .thenComparing(CacheOperationDto::operation));
         return new OperationDiscovery(operations, warnings);
     }
 
@@ -416,17 +441,17 @@ public class CacheController {
 
     private boolean skipMethod(Method method) {
         return method.getDeclaringClass() == Object.class
-            || method.isBridge()
-            || method.isSynthetic()
-            || Modifier.isStatic(method.getModifiers());
+                || method.isBridge()
+                || method.isSynthetic()
+                || Modifier.isStatic(method.getModifiers());
     }
 
     private String methodKey(Method method) {
         return method.getName() + Arrays.toString(method.getParameterTypes());
     }
 
-    private CacheOperationDto toOperationDto(String beanName, Class<?> targetType, Method method,
-                                             CacheOperation operation) {
+    private CacheOperationDto toOperationDto(
+            String beanName, Class<?> targetType, Method method, CacheOperation operation) {
         String unless = null;
         boolean allEntries = false;
         boolean beforeInvocation = false;
@@ -440,16 +465,16 @@ public class CacheController {
         }
 
         return new CacheOperationDto(
-            beanName,
-            targetType.getName(),
-            signatureOf(method),
-            operationName(operation),
-            operation.getCacheNames().stream().sorted().toList(),
-            blankToNull(operation.getKey()),
-            blankToNull(operation.getCondition()),
-            unless,
-            allEntries,
-            beforeInvocation);
+                beanName,
+                targetType.getName(),
+                signatureOf(method),
+                operationName(operation),
+                operation.getCacheNames().stream().sorted().toList(),
+                blankToNull(operation.getKey()),
+                blankToNull(operation.getCondition()),
+                unless,
+                allEntries,
+                beforeInvocation);
     }
 
     private String operationName(CacheOperation operation) {
@@ -467,9 +492,9 @@ public class CacheController {
 
     private String signatureOf(Method method) {
         String params = Arrays.stream(method.getParameterTypes())
-            .map(Class::getSimpleName)
-            .reduce((left, right) -> left + ", " + right)
-            .orElse("");
+                .map(Class::getSimpleName)
+                .reduce((left, right) -> left + ", " + right)
+                .orElse("");
         return method.getReturnType().getSimpleName() + " " + method.getName() + "(" + params + ")";
     }
 
@@ -494,14 +519,11 @@ public class CacheController {
         return isBlank(value) ? null : value;
     }
 
-    private record CacheManagerEntry(String name, CacheManager manager) {
-    }
+    private record CacheManagerEntry(String name, CacheManager manager) {}
 
-    private record MetricKey(String managerName, String cacheName) {
-    }
+    private record MetricKey(String managerName, String cacheName) {}
 
-    private record OperationDiscovery(List<CacheOperationDto> operations, List<String> warnings) {
-    }
+    private record OperationDiscovery(List<CacheOperationDto> operations, List<String> warnings) {}
 
     private static final class CacheMetricsAccumulator {
 
@@ -567,14 +589,14 @@ public class CacheController {
                 hitRatio = total == 0.0 ? 0.0 : hits / total;
             }
             return new CacheMetricsDto(
-                available,
-                hitsSeen ? hits : null,
-                missesSeen ? misses : null,
-                hitRatio,
-                putsSeen ? puts : null,
-                evictionsSeen ? evictions : null,
-                removalsSeen ? removals : null,
-                sizeSeen ? size : null);
+                    available,
+                    hitsSeen ? hits : null,
+                    missesSeen ? misses : null,
+                    hitRatio,
+                    putsSeen ? puts : null,
+                    evictionsSeen ? evictions : null,
+                    removalsSeen ? removals : null,
+                    sizeSeen ? size : null);
         }
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConditionsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConditionsController.java
@@ -2,6 +2,10 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.ConditionEntry;
 import io.github.jdubois.bootui.core.BootUiDtos.ConditionsReport;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint;
 import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint.ConditionsDescriptor;
@@ -11,11 +15,6 @@ import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReport
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @RestController
 @RequestMapping("/bootui/api/conditions")
@@ -39,14 +38,17 @@ public class ConditionsController {
         List<String> unconditional = new ArrayList<>();
         List<String> exclusions = new ArrayList<>();
 
-        for (Map.Entry<String, ContextConditionsDescriptor> ctx : descriptor.getContexts().entrySet()) {
+        for (Map.Entry<String, ContextConditionsDescriptor> ctx :
+                descriptor.getContexts().entrySet()) {
             ContextConditionsDescriptor ccd = ctx.getValue();
-            for (Map.Entry<String, List<MessageAndConditionDescriptor>> e : ccd.getPositiveMatches().entrySet()) {
+            for (Map.Entry<String, List<MessageAndConditionDescriptor>> e :
+                    ccd.getPositiveMatches().entrySet()) {
                 for (MessageAndConditionDescriptor m : e.getValue()) {
                     positive.add(new ConditionEntry(e.getKey(), m.getCondition(), m.getMessage(), "MATCH"));
                 }
             }
-            for (Map.Entry<String, MessageAndConditionsDescriptor> e : ccd.getNegativeMatches().entrySet()) {
+            for (Map.Entry<String, MessageAndConditionsDescriptor> e :
+                    ccd.getNegativeMatches().entrySet()) {
                 MessageAndConditionsDescriptor v = e.getValue();
                 if (v.getNotMatched() != null) {
                     for (MessageAndConditionDescriptor m : v.getNotMatched()) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigController.java
@@ -6,13 +6,12 @@ import io.github.jdubois.bootui.autoconfigure.config.BootUiOverridesPropertySour
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
 import io.github.jdubois.bootui.core.BootUiDtos.*;
 import io.github.jdubois.bootui.core.SecretMasker;
+import java.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.PropertySource;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.*;
 
 @RestController
 @RequestMapping("/bootui/api/config")
@@ -29,16 +28,20 @@ public class ConfigController {
     private final SecretMasker masker = new SecretMasker();
 
     @Autowired
-    public ConfigController(ConfigurableEnvironment environment,
-                            ConfigOverrideService overrideService,
-                            BootUiProperties properties) {
-        this(environment, overrideService, properties, new ConfigMetadataCatalog(ConfigController.class.getClassLoader()));
+    public ConfigController(
+            ConfigurableEnvironment environment, ConfigOverrideService overrideService, BootUiProperties properties) {
+        this(
+                environment,
+                overrideService,
+                properties,
+                new ConfigMetadataCatalog(ConfigController.class.getClassLoader()));
     }
 
-    ConfigController(ConfigurableEnvironment environment,
-                     ConfigOverrideService overrideService,
-                     BootUiProperties properties,
-                     ConfigMetadataCatalog metadataCatalog) {
+    ConfigController(
+            ConfigurableEnvironment environment,
+            ConfigOverrideService overrideService,
+            BootUiProperties properties,
+            ConfigMetadataCatalog metadataCatalog) {
         this.environment = environment;
         this.overrideService = overrideService;
         this.properties = properties;
@@ -67,10 +70,7 @@ public class ConfigController {
         List<ConfigPropertyDto> sorted = new ArrayList<>(merged.values());
         sorted.sort(Comparator.comparing(ConfigPropertyDto::name));
         return new ConfigReport(
-            Arrays.asList(environment.getActiveProfiles()),
-            sources,
-            sorted,
-            metadataCatalog.suggestions());
+                Arrays.asList(environment.getActiveProfiles()), sources, sorted, metadataCatalog.suggestions());
     }
 
     @PostMapping("/overrides")
@@ -94,19 +94,19 @@ public class ConfigController {
         if (properties.getExposeValues() == ValueExposure.METADATA_ONLY) {
             displayValue = null;
         } else if (properties.getExposeValues() == ValueExposure.MASKED
-            && properties.isMaskSecrets()
-            && masker.isSecret(name)) {
+                && properties.isMaskSecrets()
+                && masker.isSecret(name)) {
             displayValue = SecretMasker.MASKED_VALUE;
             masked = true;
         }
         return new ConfigPropertyDto(
-            name,
-            displayValue,
-            sourceName,
-            null,
-            masked,
-            isOverride,
-            metadata == null ? null : metadata.description(),
-            metadata == null ? null : metadata.defaultValue());
+                name,
+                displayValue,
+                sourceName,
+                null,
+                masked,
+                isOverride,
+                metadata == null ? null : metadata.description(),
+                metadata == null ? null : metadata.defaultValue());
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigMetadataCatalog.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigMetadataCatalog.java
@@ -1,13 +1,12 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.ConfigPropertySuggestionDto;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.*;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 final class ConfigMetadataCatalog {
 
@@ -24,9 +23,8 @@ final class ConfigMetadataCatalog {
     }
 
     private static Map<String, ConfigPropertySuggestionDto> load(ClassLoader classLoader, ObjectMapper objectMapper) {
-        ClassLoader effectiveClassLoader = classLoader != null
-            ? classLoader
-            : Thread.currentThread().getContextClassLoader();
+        ClassLoader effectiveClassLoader =
+                classLoader != null ? classLoader : Thread.currentThread().getContextClassLoader();
         if (effectiveClassLoader == null) {
             effectiveClassLoader = ConfigMetadataCatalog.class.getClassLoader();
         }
@@ -50,18 +48,17 @@ final class ConfigMetadataCatalog {
         return sortByName(result);
     }
 
-    private static void addProperty(Map<String, ConfigPropertySuggestionDto> result,
-                                    JsonNode propertyNode,
-                                    ObjectMapper objectMapper) {
+    private static void addProperty(
+            Map<String, ConfigPropertySuggestionDto> result, JsonNode propertyNode, ObjectMapper objectMapper) {
         String name = text(propertyNode, "name");
         if (name == null || propertyNode.has("deprecation")) {
             return;
         }
         ConfigPropertySuggestionDto candidate = new ConfigPropertySuggestionDto(
-            name,
-            text(propertyNode, "type"),
-            text(propertyNode, "description"),
-            toObject(propertyNode.get("defaultValue"), objectMapper));
+                name,
+                text(propertyNode, "type"),
+                text(propertyNode, "description"),
+                toObject(propertyNode.get("defaultValue"), objectMapper));
         ConfigPropertySuggestionDto current = result.get(name);
         if (current == null || isRicher(candidate, current)) {
             result.put(name, candidate);
@@ -87,11 +84,11 @@ final class ConfigMetadataCatalog {
     }
 
     private static Map<String, ConfigPropertySuggestionDto> sortByName(
-        Map<String, ConfigPropertySuggestionDto> unsorted) {
+            Map<String, ConfigPropertySuggestionDto> unsorted) {
         Map<String, ConfigPropertySuggestionDto> sorted = new LinkedHashMap<>();
         unsorted.values().stream()
-            .sorted(Comparator.comparing(ConfigPropertySuggestionDto::name))
-            .forEach(suggestion -> sorted.put(suggestion.name(), suggestion));
+                .sorted(Comparator.comparing(ConfigPropertySuggestionDto::name))
+                .forEach(suggestion -> sorted.put(suggestion.name(), suggestion));
         return sorted;
     }
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DataController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DataController.java
@@ -5,6 +5,10 @@ import io.github.jdubois.bootui.core.BootUiDtos.RepositoryDetailDto;
 import io.github.jdubois.bootui.core.BootUiDtos.RepositoryDto;
 import io.github.jdubois.bootui.core.BootUiDtos.RepositoryMethodDto;
 import jakarta.annotation.Nullable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.*;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,11 +19,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Exposes Spring Data repositories declared in the current application context.
@@ -43,10 +42,10 @@ public class DataController {
     public RepositoriesReport repositories() {
         List<RepositoryEntry> entries = discover();
         List<RepositoryDto> summaries = entries.stream()
-            .map(this::toSummary)
-            .sorted(Comparator.comparing(RepositoryDto::repositoryInterface,
-                Comparator.nullsLast(String::compareTo)))
-            .collect(Collectors.toList());
+                .map(this::toSummary)
+                .sorted(Comparator.comparing(
+                        RepositoryDto::repositoryInterface, Comparator.nullsLast(String::compareTo)))
+                .collect(Collectors.toList());
         return new RepositoriesReport(true, summaries.size(), summaries);
     }
 
@@ -105,14 +104,14 @@ public class DataController {
         int fragments = fragmentCount(entry);
         int queryMethods = queryMethodCount(info);
         return new RepositoryDto(
-            entry.beanName(),
-            iface == null ? null : iface.getName(),
-            domainType == null ? null : domainType.getName(),
-            idType == null ? null : idType.getName(),
-            detectStoreModule(iface),
-            custom == null ? null : custom.getName(),
-            queryMethods,
-            fragments);
+                entry.beanName(),
+                iface == null ? null : iface.getName(),
+                domainType == null ? null : domainType.getName(),
+                idType == null ? null : idType.getName(),
+                detectStoreModule(iface),
+                custom == null ? null : custom.getName(),
+                queryMethods,
+                fragments);
     }
 
     private RepositoryDetailDto toDetail(RepositoryEntry entry) {
@@ -133,14 +132,14 @@ public class DataController {
             }
         }
         return new RepositoryDetailDto(
-            entry.beanName(),
-            iface == null ? null : iface.getName(),
-            domainType == null ? null : domainType.getName(),
-            idType == null ? null : idType.getName(),
-            detectStoreModule(iface),
-            custom == null ? null : custom.getName(),
-            methods,
-            Collections.emptyList());
+                entry.beanName(),
+                iface == null ? null : iface.getName(),
+                domainType == null ? null : domainType.getName(),
+                idType == null ? null : idType.getName(),
+                detectStoreModule(iface),
+                custom == null ? null : custom.getName(),
+                methods,
+                Collections.emptyList());
     }
 
     private RepositoryMethodDto toMethodDto(RepositoryInformation info, Method method) {
@@ -161,12 +160,12 @@ public class DataController {
             origin = "ANNOTATED";
         }
         return new RepositoryMethodDto(
-            method.getName(),
-            signatureOf(method),
-            origin,
-            queryAnnotation == null ? null : queryAnnotation.value,
-            queryAnnotation != null && queryAnnotation.nativeQuery,
-            queryAnnotation == null ? null : queryAnnotation.name);
+                method.getName(),
+                signatureOf(method),
+                origin,
+                queryAnnotation == null ? null : queryAnnotation.value,
+                queryAnnotation != null && queryAnnotation.nativeQuery,
+                queryAnnotation == null ? null : queryAnnotation.name);
     }
 
     private int queryMethodCount(RepositoryInformation info) {
@@ -202,8 +201,8 @@ public class DataController {
 
     private String signatureOf(Method method) {
         String params = Arrays.stream(method.getParameterTypes())
-            .map(Class::getSimpleName)
-            .collect(Collectors.joining(", "));
+                .map(Class::getSimpleName)
+                .collect(Collectors.joining(", "));
         String returnType = method.getReturnType().getSimpleName();
         return returnType + " " + method.getName() + "(" + params + ")";
     }
@@ -285,10 +284,10 @@ public class DataController {
             String name = readAttribute(annotation, "name");
             Boolean nativeQuery = readBooleanAttribute(annotation, "nativeQuery");
             return new QueryAnnotation(
-                value == null || value.isBlank() ? null : value,
-                name == null || name.isBlank() ? null : name,
-                Boolean.TRUE.equals(nativeQuery),
-                value != null && !value.isBlank());
+                    value == null || value.isBlank() ? null : value,
+                    name == null || name.isBlank() ? null : name,
+                    Boolean.TRUE.equals(nativeQuery),
+                    value != null && !value.isBlank());
         }
         return null;
     }
@@ -319,14 +318,11 @@ public class DataController {
         return beanName.startsWith("&") ? beanName.substring(1) : beanName;
     }
 
-    private record RepositoryEntry(String beanName,
-                                   RepositoryFactoryInformation<?, ?> factoryInformation,
-                                   RepositoryInformation information) {
-    }
+    private record RepositoryEntry(
+            String beanName,
+            RepositoryFactoryInformation<?, ?> factoryInformation,
+            RepositoryInformation information) {}
 
-    private record QueryAnnotation(@Nullable String value,
-                                   @Nullable String name,
-                                   boolean nativeQuery,
-                                   boolean hasValue) {
-    }
+    private record QueryAnnotation(
+            @Nullable String value, @Nullable String name, boolean nativeQuery, boolean hasValue) {}
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DefaultDevToolsBridge.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DefaultDevToolsBridge.java
@@ -2,16 +2,15 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.DevToolsActionResult;
 import io.github.jdubois.bootui.core.BootUiDtos.DevToolsStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
-import org.springframework.util.ClassUtils;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.util.ClassUtils;
 
 public class DefaultDevToolsBridge implements DevToolsBridge {
 
@@ -20,10 +19,10 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
     private static final String RESTARTER_CLASS = "org.springframework.boot.devtools.restart.Restarter";
 
     private static final String LIVE_RELOAD_SERVER_CLASS =
-        "org.springframework.boot.devtools.livereload.LiveReloadServer";
+            "org.springframework.boot.devtools.livereload.LiveReloadServer";
 
     private static final String OPTIONAL_LIVE_RELOAD_SERVER_CLASS =
-        "org.springframework.boot.devtools.autoconfigure.OptionalLiveReloadServer";
+            "org.springframework.boot.devtools.autoconfigure.OptionalLiveReloadServer";
 
     private final ApplicationContext applicationContext;
 
@@ -34,8 +33,8 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
     public DefaultDevToolsBridge(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
         this.classLoader = applicationContext.getClassLoader() == null
-            ? ClassUtils.getDefaultClassLoader()
-            : applicationContext.getClassLoader();
+                ? ClassUtils.getDefaultClassLoader()
+                : applicationContext.getClassLoader();
     }
 
     @Override
@@ -43,12 +42,12 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
         Availability restart = restartAvailability();
         LiveReloadHandle liveReload = liveReloadHandle();
         return new DevToolsStatus(
-            restart.available(),
-            restart.reason(),
-            restartPending.get(),
-            liveReload.available(),
-            liveReload.port(),
-            liveReload.reason());
+                restart.available(),
+                restart.reason(),
+                restartPending.get(),
+                liveReload.available(),
+                liveReload.port(),
+                liveReload.reason());
     }
 
     @Override
@@ -60,8 +59,8 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
         try {
             Method triggerReload = liveReload.target().getClass().getMethod("triggerReload");
             triggerReload.invoke(liveReload.target());
-            return new DevToolsActionResult("livereload", "triggered",
-                "LiveReload notification sent to connected browsers.");
+            return new DevToolsActionResult(
+                    "livereload", "triggered", "LiveReload notification sent to connected browsers.");
         } catch (ReflectiveOperationException ex) {
             throw new IllegalStateException("Could not trigger Spring Boot DevTools LiveReload", unwrap(ex));
         }
@@ -74,16 +73,17 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
             return new DevToolsActionResult("restart", "unavailable", restart.reason());
         }
         if (!restartPending.compareAndSet(false, true)) {
-            return new DevToolsActionResult("restart", "already_pending",
-                "A DevTools restart is already pending.");
+            return new DevToolsActionResult("restart", "already_pending", "A DevTools restart is already pending.");
         }
 
         Object restarter = restarter();
         Thread restartThread = new Thread(() -> restartAfterResponse(restarter), "bootui-devtools-restart");
         restartThread.setDaemon(false);
         restartThread.start();
-        return new DevToolsActionResult("restart", "scheduled",
-            "Restart scheduled. BootUI will reconnect when the application is available again.");
+        return new DevToolsActionResult(
+                "restart",
+                "scheduled",
+                "Restart scheduled. BootUI will reconnect when the application is available again.");
     }
 
     private void restartAfterResponse(Object restarter) {
@@ -120,9 +120,11 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
             return getInstance.invoke(null);
         } catch (InvocationTargetException ex) {
             Throwable cause = ex.getTargetException();
-            throw new IllegalStateException(cause.getMessage() == null
-                ? "Spring Boot DevTools Restarter is not initialized."
-                : cause.getMessage(), cause);
+            throw new IllegalStateException(
+                    cause.getMessage() == null
+                            ? "Spring Boot DevTools Restarter is not initialized."
+                            : cause.getMessage(),
+                    cause);
         } catch (ReflectiveOperationException | LinkageError ex) {
             throw new IllegalStateException("Spring Boot DevTools Restarter is not available.", ex);
         }
@@ -130,7 +132,7 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
 
     private LiveReloadHandle liveReloadHandle() {
         if (!ClassUtils.isPresent(OPTIONAL_LIVE_RELOAD_SERVER_CLASS, classLoader)
-            && !ClassUtils.isPresent(LIVE_RELOAD_SERVER_CLASS, classLoader)) {
+                && !ClassUtils.isPresent(LIVE_RELOAD_SERVER_CLASS, classLoader)) {
             return LiveReloadHandle.unavailable("Spring Boot DevTools LiveReload is not on the classpath.");
         }
         LiveReloadHandle optional = beanHandle(OPTIONAL_LIVE_RELOAD_SERVER_CLASS);
@@ -189,8 +191,8 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
 
     private Throwable unwrap(ReflectiveOperationException ex) {
         return ex instanceof InvocationTargetException invocation && invocation.getTargetException() != null
-            ? invocation.getTargetException()
-            : ex;
+                ? invocation.getTargetException()
+                : ex;
     }
 
     private record Availability(boolean available, String reason) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependenciesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependenciesController.java
@@ -3,13 +3,12 @@ package io.github.jdubois.bootui.autoconfigure.web;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.BootUiDtos.DependenciesReport;
 import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/bootui/api/dependencies")
@@ -28,8 +27,10 @@ public class DependenciesController {
         this(properties, new DependencyCatalog(), new OsvVulnerabilityScanner(properties.getDependencies()));
     }
 
-    DependenciesController(BootUiProperties properties, DependencyProvider dependencyProvider,
-                           VulnerabilityScanner vulnerabilityScanner) {
+    DependenciesController(
+            BootUiProperties properties,
+            DependencyProvider dependencyProvider,
+            VulnerabilityScanner vulnerabilityScanner) {
         this.properties = properties;
         this.dependencyProvider = dependencyProvider;
         this.vulnerabilityScanner = vulnerabilityScanner;
@@ -42,9 +43,13 @@ public class DependenciesController {
             return cached;
         }
         List<DependencyDto> dependencies = dependencyProvider.dependencies();
-        return OsvVulnerabilityScanner.report(properties.getDependencies().isOsvEnabled(), "NOT_SCANNED",
-            "Dependency inventory loaded. Click Scan with OSV.dev to check for known vulnerabilities.",
-            null, 0, dependencies);
+        return OsvVulnerabilityScanner.report(
+                properties.getDependencies().isOsvEnabled(),
+                "NOT_SCANNED",
+                "Dependency inventory loaded. Click Scan with OSV.dev to check for known vulnerabilities.",
+                null,
+                0,
+                dependencies);
     }
 
     @PostMapping("/scan")
@@ -52,9 +57,13 @@ public class DependenciesController {
         List<DependencyDto> dependencies = dependencyProvider.dependencies();
         DependenciesReport report;
         if (!properties.getDependencies().isOsvEnabled()) {
-            report = OsvVulnerabilityScanner.report(false, "DISABLED",
-                "OSV scanning is disabled. Set bootui.dependencies.osv-enabled=true to allow on-demand scans.",
-                null, 0, dependencies);
+            report = OsvVulnerabilityScanner.report(
+                    false,
+                    "DISABLED",
+                    "OSV scanning is disabled. Set bootui.dependencies.osv-enabled=true to allow on-demand scans.",
+                    null,
+                    0,
+                    dependencies);
         } else {
             report = vulnerabilityScanner.scan(dependencies);
         }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
@@ -1,15 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.springframework.core.io.support.ResourcePatternResolver;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.*;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
 
 final class DependencyCatalog implements DependencyProvider {
 
@@ -38,9 +37,8 @@ final class DependencyCatalog implements DependencyProvider {
             dependencies.putIfAbsent(dependency.packageName() + ":" + dependency.version(), dependency);
         }
         return dependencies.values().stream()
-            .sorted(Comparator.comparing(DependencyDto::packageName)
-                .thenComparing(DependencyDto::version))
-            .toList();
+                .sorted(Comparator.comparing(DependencyDto::packageName).thenComparing(DependencyDto::version))
+                .toList();
     }
 
     private Resource[] mavenPomProperties() {
@@ -65,8 +63,7 @@ final class DependencyCatalog implements DependencyProvider {
             return null;
         }
         String packageName = groupId + ":" + artifactId;
-        return new DependencyDto(groupId, artifactId, version, packageName, "Maven metadata",
-            0, "NONE", List.of());
+        return new DependencyDto(groupId, artifactId, version, packageName, "Maven metadata", 0, "NONE", List.of());
     }
 
     private List<DependencyDto> javaClassPathDependencies() {
@@ -75,9 +72,9 @@ final class DependencyCatalog implements DependencyProvider {
             return List.of();
         }
         return List.of(classPath.split(java.util.regex.Pattern.quote(File.pathSeparator))).stream()
-            .map(this::dependencyFromClassPathEntry)
-            .filter(dependency -> dependency != null)
-            .toList();
+                .map(this::dependencyFromClassPathEntry)
+                .filter(dependency -> dependency != null)
+                .toList();
     }
 
     private DependencyDto dependencyFromClassPathEntry(String entry) {
@@ -101,8 +98,7 @@ final class DependencyCatalog implements DependencyProvider {
             return null;
         }
         String packageName = groupId + ":" + artifactId;
-        return new DependencyDto(groupId, artifactId, version, packageName, "Java classpath",
-            0, "NONE", List.of());
+        return new DependencyDto(groupId, artifactId, version, packageName, "Java classpath", 0, "NONE", List.of());
     }
 
     private String groupId(Path groupPath) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyProvider.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyProvider.java
@@ -1,7 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
-
 import java.util.List;
 
 interface DependencyProvider {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesController.java
@@ -4,6 +4,15 @@ import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
 import io.github.jdubois.bootui.core.BootUiDtos.*;
 import io.github.jdubois.bootui.core.SecretMasker;
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.ListableBeanFactory;
@@ -19,30 +28,17 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.net.URI;
-import java.time.Instant;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
-
 @RestController
 @RequestMapping("/bootui/api/dev-services")
 public class DevServicesController implements ApplicationListener<ApplicationEvent> {
 
     private static final String DOCKER_COMPOSE_EVENT =
-        "org.springframework.boot.docker.compose.lifecycle.DockerComposeServicesReadyEvent";
+            "org.springframework.boot.docker.compose.lifecycle.DockerComposeServicesReadyEvent";
 
-    private static final Set<String> SKIPPED_DETAIL_PROPERTIES = Set.of(
-        "class",
-        "origin",
-        "sslBundle");
+    private static final Set<String> SKIPPED_DETAIL_PROPERTIES = Set.of("class", "origin", "sslBundle");
 
-    private static final Pattern URL_CREDENTIALS = Pattern.compile("([a-z][a-z0-9+.-]*://)([^:/@\\s]+):([^@\\s]+)@",
-        Pattern.CASE_INSENSITIVE);
+    private static final Pattern URL_CREDENTIALS =
+            Pattern.compile("([a-z][a-z0-9+.-]*://)([^:/@\\s]+):([^@\\s]+)@", Pattern.CASE_INSENSITIVE);
 
     private final ConfigurableApplicationContext applicationContext;
 
@@ -79,19 +75,19 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
     public DevServicesReport list() {
         Map<String, DevServiceDto> services = new LinkedHashMap<>();
         this.dockerComposeServices.values().stream()
-            .sorted(Comparator.comparing(DevServiceDto::name))
-            .forEach(service -> services.put(service.id(), service));
+                .sorted(Comparator.comparing(DevServiceDto::name))
+                .forEach(service -> services.put(service.id(), service));
         discoverTestcontainers(services);
         discoverConnectionDetails(services);
         List<DevServiceDto> sorted = services.values().stream()
-            .sorted(Comparator.comparing(DevServiceDto::source).thenComparing(DevServiceDto::name))
-            .toList();
+                .sorted(Comparator.comparing(DevServiceDto::source).thenComparing(DevServiceDto::name))
+                .toList();
         return new DevServicesReport(
-            isPresent("org.springframework.boot.docker.compose.lifecycle.DockerComposeServicesReadyEvent"),
-            isPresent("org.testcontainers.lifecycle.Startable"),
-            resolveSnapshotTimestamp(),
-            sorted.size(),
-            sorted);
+                isPresent("org.springframework.boot.docker.compose.lifecycle.DockerComposeServicesReadyEvent"),
+                isPresent("org.testcontainers.lifecycle.Startable"),
+                resolveSnapshotTimestamp(),
+                sorted.size(),
+                sorted);
     }
 
     @GetMapping("/{id}/logs")
@@ -121,8 +117,9 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Service not found");
         }
         if (!properties.getDevServices().isRestartEnabled()) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                "Restart is disabled. Set bootui.dev-services.restart-enabled=true to allow it.");
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Restart is disabled. Set bootui.dev-services.restart-enabled=true to allow it.");
         }
         Method start = findNoArgMethod(bean.getClass(), "start");
         Method stop = findNoArgMethod(bean.getClass(), "stop");
@@ -132,12 +129,13 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         try {
             stop.invoke(bean);
             start.invoke(bean);
-            return new DevServiceRestartResult(id, "restarted",
-                "Service restarted. Already-created client beans may need an application restart to reconnect.");
+            return new DevServiceRestartResult(
+                    id,
+                    "restarted",
+                    "Service restarted. Already-created client beans may need an application restart to reconnect.");
         } catch (IllegalAccessException | InvocationTargetException ex) {
-            Throwable cause = ex instanceof InvocationTargetException ite && ite.getCause() != null
-                ? ite.getCause()
-                : ex;
+            Throwable cause =
+                    ex instanceof InvocationTargetException ite && ite.getCause() != null ? ite.getCause() : ex;
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, cause.getMessage(), cause);
         }
     }
@@ -190,24 +188,24 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         Map<?, ?> labels = asMap(invoke(runningService, "labels"));
         String type = inferType(name, image, labels);
         return new DevServiceDto(
-            "compose:" + slug(name),
-            name,
-            type,
-            "Docker Compose",
-            image,
-            "READY_AT_STARTUP",
-            host,
-            composePorts(invoke(runningService, "ports")),
-            sanitizeDetails(details),
-            false,
-            false,
-            "Docker Compose status is a startup snapshot; Spring Boot does not expose live per-service restart.");
+                "compose:" + slug(name),
+                name,
+                type,
+                "Docker Compose",
+                image,
+                "READY_AT_STARTUP",
+                host,
+                composePorts(invoke(runningService, "ports")),
+                sanitizeDetails(details),
+                false,
+                false,
+                "Docker Compose status is a startup snapshot; Spring Boot does not expose live per-service restart.");
     }
 
     private DevServiceDto testcontainersDto(String beanName, Object bean) {
         String image = stringValue(invoke(bean, "getDockerImageName"));
-        String host = firstNonBlank(stringValue(invoke(bean, "getHost")),
-            stringValue(invoke(bean, "getTestHostIpAddress")));
+        String host =
+                firstNonBlank(stringValue(invoke(bean, "getHost")), stringValue(invoke(bean, "getTestHostIpAddress")));
         boolean running = Boolean.TRUE.equals(invoke(bean, "isRunning"));
         String name = firstNonBlank(stringValue(invoke(bean, "getContainerName")), beanName);
         Map<String, Object> details = new LinkedHashMap<>();
@@ -215,44 +213,44 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         addIfPresent(details, "networkMode", invoke(bean, "getNetworkMode"));
         addIfPresent(details, "reuse", invoke(bean, "isShouldBeReused"));
         boolean restartable = properties.getDevServices().isRestartEnabled()
-            && findNoArgMethod(bean.getClass(), "start") != null
-            && findNoArgMethod(bean.getClass(), "stop") != null;
+                && findNoArgMethod(bean.getClass(), "start") != null
+                && findNoArgMethod(bean.getClass(), "stop") != null;
         return new DevServiceDto(
-            "bean:" + beanName,
-            name,
-            inferType(name, image, Map.of()),
-            "Testcontainers",
-            image,
-            running ? "RUNNING" : "STOPPED",
-            host,
-            testcontainersPorts(bean),
-            sanitizeDetails(details),
-            restartable,
-            findLogsMethod(bean.getClass()) != null,
-            properties.getDevServices().isRestartEnabled()
-                ? "Restart may require application clients to reconnect."
-                : "Restart disabled by default; set bootui.dev-services.restart-enabled=true to allow it.");
+                "bean:" + beanName,
+                name,
+                inferType(name, image, Map.of()),
+                "Testcontainers",
+                image,
+                running ? "RUNNING" : "STOPPED",
+                host,
+                testcontainersPorts(bean),
+                sanitizeDetails(details),
+                restartable,
+                findLogsMethod(bean.getClass()) != null,
+                properties.getDevServices().isRestartEnabled()
+                        ? "Restart may require application clients to reconnect."
+                        : "Restart disabled by default; set bootui.dev-services.restart-enabled=true to allow it.");
     }
 
-    private DevServiceDto connectionDetailsDto(ListableBeanFactory beanFactory, String beanName,
-                                               ConnectionDetails details) {
+    private DevServiceDto connectionDetailsDto(
+            ListableBeanFactory beanFactory, String beanName, ConnectionDetails details) {
         ContainerImageMetadata metadata = containerImageMetadata(beanFactory, beanName);
         String image = metadata == null ? null : metadata.imageName();
         Map<String, Object> connectionDetails = new LinkedHashMap<>();
         collectDetails("", details, connectionDetails, 0);
         return new DevServiceDto(
-            "connection:" + beanName,
-            readableName(beanName),
-            inferType(beanName, image, Map.of()),
-            "Connection details",
-            image,
-            "AVAILABLE",
-            null,
-            List.of(),
-            sanitizeDetails(connectionDetails),
-            false,
-            false,
-            "Spring Boot connection details bean; lifecycle is managed by Docker Compose or Testcontainers.");
+                "connection:" + beanName,
+                readableName(beanName),
+                inferType(beanName, image, Map.of()),
+                "Connection details",
+                image,
+                "AVAILABLE",
+                null,
+                List.of(),
+                sanitizeDetails(connectionDetails),
+                false,
+                false,
+                "Spring Boot connection details bean; lifecycle is managed by Docker Compose or Testcontainers.");
     }
 
     private ContainerImageMetadata containerImageMetadata(ListableBeanFactory beanFactory, String beanName) {
@@ -306,9 +304,7 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         if (properties.getExposeValues() == ValueExposure.METADATA_ONLY) {
             return null;
         }
-        if (value == null
-            || properties.getExposeValues() == ValueExposure.FULL
-            || !properties.isMaskSecrets()) {
+        if (value == null || properties.getExposeValues() == ValueExposure.FULL || !properties.isMaskSecrets()) {
             return value;
         }
         if (masker.isSecret(key)) {
@@ -352,8 +348,9 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
     private Object findBeanBackedService(String id) {
         if (id == null || !id.startsWith("bean:")) {
             if (this.dockerComposeServices.containsKey(id)) {
-                throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Docker Compose services are snapshots and cannot be controlled by BootUI");
+                throw new ResponseStatusException(
+                        HttpStatus.CONFLICT,
+                        "Docker Compose services are snapshots and cannot be controlled by BootUI");
             }
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Service not found");
         }
@@ -385,23 +382,21 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
     private boolean isSimpleValue(Object value) {
         Class<?> type = value.getClass();
         return value instanceof CharSequence
-            || value instanceof Number
-            || value instanceof Boolean
-            || value instanceof Character
-            || type.isEnum()
-            || value instanceof URI;
+                || value instanceof Number
+                || value instanceof Boolean
+                || value instanceof Character
+                || type.isEnum()
+                || value instanceof URI;
     }
 
     private boolean shouldRecurseInto(Object value) {
         String packageName = value.getClass().getPackageName();
-        return !packageName.startsWith("java.")
-            && !packageName.startsWith("jdk.")
-            && !packageName.startsWith("sun.");
+        return !packageName.startsWith("java.") && !packageName.startsWith("jdk.") && !packageName.startsWith("sun.");
     }
 
     private boolean isTestcontainerType(Class<?> type) {
         if (hasTypeName(type, "org.testcontainers.lifecycle.Startable")
-            || hasTypeName(type, "org.testcontainers.containers.Container")) {
+                || hasTypeName(type, "org.testcontainers.containers.Container")) {
             return true;
         }
         String name = type.getName();
@@ -457,9 +452,11 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
     }
 
     private String slug(String value) {
-        String normalized = value == null ? "service" : value.toLowerCase(Locale.ROOT)
-            .replaceAll("[^a-z0-9._-]+", "-")
-            .replaceAll("(^-+|-+$)", "");
+        String normalized = value == null
+                ? "service"
+                : value.toLowerCase(Locale.ROOT)
+                        .replaceAll("[^a-z0-9._-]+", "-")
+                        .replaceAll("(^-+|-+$)", "");
         return normalized.isBlank() ? "service" : normalized;
     }
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevToolsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevToolsController.java
@@ -3,11 +3,10 @@ package io.github.jdubois.bootui.autoconfigure.web;
 import io.github.jdubois.bootui.core.BootUiDtos.DevToolsActionResult;
 import io.github.jdubois.bootui.core.BootUiDtos.DevToolsRestartRequest;
 import io.github.jdubois.bootui.core.BootUiDtos.DevToolsStatus;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/bootui/api/devtools")
@@ -33,8 +32,9 @@ public class DevToolsController {
     @PostMapping("/restart")
     public ResponseEntity<DevToolsActionResult> restart(@RequestBody(required = false) DevToolsRestartRequest request) {
         if (request == null || !Boolean.TRUE.equals(request.confirm())) {
-            return ResponseEntity.badRequest().body(new DevToolsActionResult("restart", "confirmation_required",
-                "Restart requires explicit confirmation."));
+            return ResponseEntity.badRequest()
+                    .body(new DevToolsActionResult(
+                            "restart", "confirmation_required", "Restart requires explicit confirmation."));
         }
         DevToolsActionResult result = devTools.scheduleRestart();
         return ResponseEntity.status(statusFor(result)).body(result);
@@ -51,6 +51,6 @@ public class DevToolsController {
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<Map<String, String>> handleIllegalState(IllegalStateException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
-            .body(Map.of("error", ex.getMessage() == null ? "DevTools action failed" : ex.getMessage()));
+                .body(Map.of("error", ex.getMessage() == null ? "DevTools action failed" : ex.getMessage()));
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HealthController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HealthController.java
@@ -1,6 +1,9 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.HealthNodeDto;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.health.actuate.endpoint.CompositeHealthDescriptor;
 import org.springframework.boot.health.actuate.endpoint.HealthDescriptor;
@@ -9,10 +12,6 @@ import org.springframework.boot.health.actuate.endpoint.IndicatedHealthDescripto
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/bootui/api/health")
@@ -37,7 +36,9 @@ public class HealthController {
         if (descriptor == null) {
             return new HealthNodeDto(name, "UNKNOWN", null, List.of());
         }
-        String status = descriptor.getStatus() == null ? "UNKNOWN" : descriptor.getStatus().getCode();
+        String status = descriptor.getStatus() == null
+                ? "UNKNOWN"
+                : descriptor.getStatus().getCode();
         if (descriptor instanceof CompositeHealthDescriptor composite) {
             List<HealthNodeDto> children = new ArrayList<>();
             Map<String, HealthDescriptor> components = composite.getComponents();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeController.java
@@ -2,12 +2,6 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.HttpProbeRequest;
 import io.github.jdubois.bootui.core.BootUiDtos.HttpProbeResponse;
-import org.springframework.core.env.Environment;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -18,6 +12,11 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/bootui/api/probe")
@@ -31,9 +30,8 @@ public class HttpProbeController {
 
     public HttpProbeController(Environment environment) {
         this.environment = environment;
-        this.httpClient = HttpClient.newBuilder()
-            .connectTimeout(REQUEST_TIMEOUT)
-            .build();
+        this.httpClient =
+                HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build();
     }
 
     @PostMapping
@@ -47,22 +45,21 @@ public class HttpProbeController {
         }
 
         try {
-            HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(url))
-                .timeout(REQUEST_TIMEOUT);
+            HttpRequest.Builder builder =
+                    HttpRequest.newBuilder(URI.create(url)).timeout(REQUEST_TIMEOUT);
             applyHeaders(builder, request == null ? null : request.headers());
             builder.method(method, requestBodyPublisher(method, request == null ? null : request.body()));
 
-            HttpResponse<String> response = httpClient.send(
-                builder.build(),
-                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            HttpResponse<String> response =
+                    httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
             long durationMs = System.currentTimeMillis() - start;
             return new HttpProbeResponse(
-                response.statusCode(),
-                statusText(response.statusCode()),
-                filterHeaders(response.headers().map()),
-                response.body(),
-                durationMs,
-                null);
+                    response.statusCode(),
+                    statusText(response.statusCode()),
+                    filterHeaders(response.headers().map()),
+                    response.body(),
+                    durationMs,
+                    null);
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
@@ -102,8 +99,7 @@ public class HttpProbeController {
     }
 
     private String resolveServerPort() {
-        return environment.getProperty("local.server.port",
-            environment.getProperty("server.port", "8080"));
+        return environment.getProperty("local.server.port", environment.getProperty("server.port", "8080"));
     }
 
     private String normalizeMethod(String method) {
@@ -128,8 +124,8 @@ public class HttpProbeController {
             }
             String normalized = name.toLowerCase(Locale.ROOT);
             if (!"content-type".equals(normalized)
-                && !"content-length".equals(normalized)
-                && !"location".equals(normalized)) {
+                    && !"content-length".equals(normalized)
+                    && !"location".equals(normalized)) {
                 return;
             }
             filtered.put(normalized, String.join(", ", values));

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
@@ -1,17 +1,16 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.LogLineDto;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
 
 @RestController
 @RequestMapping("/bootui/api/logs")
@@ -31,9 +30,7 @@ public class LogTailController {
 
     @GetMapping("/recent")
     public List<LogLineDto> recent() {
-        return appender.getRecentLines().stream()
-            .map(LogTailController::toDto)
-            .toList();
+        return appender.getRecentLines().stream().map(LogTailController::toDto).toList();
     }
 
     @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
@@ -41,8 +38,7 @@ public class LogTailController {
         SseEmitter emitter = new SseEmitter(0L);
         emitters.add(emitter);
 
-        AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {
-        });
+        AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {});
         emitter.onCompletion(() -> cleanup(emitter, unsubscribeRef.get()));
         emitter.onTimeout(() -> cleanup(emitter, unsubscribeRef.get()));
         emitter.onError(error -> cleanup(emitter, unsubscribeRef.get()));
@@ -76,8 +72,6 @@ public class LogTailController {
     }
 
     private void sendLog(SseEmitter emitter, LogLineDto line) throws IOException {
-        emitter.send(SseEmitter.event()
-            .name("log")
-            .data(line, MediaType.APPLICATION_JSON));
+        emitter.send(SseEmitter.event().name("log").data(line, MediaType.APPLICATION_JSON));
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LoggersController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LoggersController.java
@@ -2,6 +2,10 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.LoggerDto;
 import io.github.jdubois.bootui.core.BootUiDtos.LoggersReport;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
 import org.springframework.boot.actuate.logging.LoggersEndpoint.LoggerLevelsDescriptor;
@@ -11,11 +15,6 @@ import org.springframework.boot.logging.LogLevel;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/bootui/api/loggers")
@@ -62,9 +61,10 @@ public class LoggersController {
         if (le == null) {
             throw new IllegalStateException("LoggersEndpoint is not available");
         }
-        LogLevel level = request == null || request.level() == null || request.level().isBlank()
-            ? null
-            : LogLevel.valueOf(request.level().toUpperCase());
+        LogLevel level =
+                request == null || request.level() == null || request.level().isBlank()
+                        ? null
+                        : LogLevel.valueOf(request.level().toUpperCase());
         le.configureLogLevel(name, level);
         LoggerLevelsDescriptor descriptor = le.loggerLevels(name);
         String configured = descriptor.getConfiguredLevel();
@@ -78,9 +78,8 @@ public class LoggersController {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()));
+                .body(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()));
     }
 
-    public record LevelUpdateRequest(String level) {
-    }
+    public record LevelUpdateRequest(String level) {}
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MemoryCalculator.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MemoryCalculator.java
@@ -121,12 +121,12 @@ final class MemoryCalculator {
      * polling without an HTTP error
      */
     MemoryCalculationDto calculate(
-        long totalMemoryBytes,
-        int threadCount,
-        int loadedClasses,
-        int headRoomPercent,
-        int liveThreadCount,
-        int liveLoadedClassCount) {
+            long totalMemoryBytes,
+            int threadCount,
+            int loadedClasses,
+            int headRoomPercent,
+            int liveThreadCount,
+            int liveLoadedClassCount) {
 
         long clampedTotal = clamp(totalMemoryBytes, MIN_TOTAL_MEMORY_BYTES, MAX_TOTAL_MEMORY_BYTES);
         int clampedThreads = (int) clamp(threadCount, MIN_THREAD_COUNT, MAX_THREAD_COUNT);
@@ -141,14 +141,35 @@ final class MemoryCalculator {
 
         if (heapBytes <= 0) {
             String message = String.format(
-                "No room for heap: fixed regions (%d MB) + headroom (%d MB) >= total (%d MB). "
-                    + "Try a larger total memory, fewer threads, or lower headroom.",
-                bytesToMb(fixedRegionsBytes),
-                bytesToMb(headRoomBytes),
-                bytesToMb(clampedTotal));
+                    "No room for heap: fixed regions (%d MB) + headroom (%d MB) >= total (%d MB). "
+                            + "Try a larger total memory, fewer threads, or lower headroom.",
+                    bytesToMb(fixedRegionsBytes), bytesToMb(headRoomBytes), bytesToMb(clampedTotal));
             return new MemoryCalculationDto(
+                    clampedTotal,
+                    0,
+                    metaspaceBytes,
+                    CODE_CACHE_BYTES,
+                    DIRECT_MEMORY_BYTES,
+                    STACK_BYTES_PER_THREAD,
+                    stackBytesTotal,
+                    headRoomBytes,
+                    fixedRegionsBytes,
+                    clampedThreads,
+                    clampedClasses,
+                    liveThreadCount,
+                    liveLoadedClassCount,
+                    clampedHeadRoom,
+                    "",
+                    false,
+                    message);
+        }
+
+        String jvmOptions = buildJvmOptions(
+                heapBytes, metaspaceBytes, CODE_CACHE_BYTES, DIRECT_MEMORY_BYTES, STACK_BYTES_PER_THREAD);
+
+        return new MemoryCalculationDto(
                 clampedTotal,
-                0,
+                heapBytes,
                 metaspaceBytes,
                 CODE_CACHE_BYTES,
                 DIRECT_MEMORY_BYTES,
@@ -161,32 +182,9 @@ final class MemoryCalculator {
                 liveThreadCount,
                 liveLoadedClassCount,
                 clampedHeadRoom,
-                "",
-                false,
-                message);
-        }
-
-        String jvmOptions = buildJvmOptions(
-            heapBytes, metaspaceBytes, CODE_CACHE_BYTES, DIRECT_MEMORY_BYTES, STACK_BYTES_PER_THREAD);
-
-        return new MemoryCalculationDto(
-            clampedTotal,
-            heapBytes,
-            metaspaceBytes,
-            CODE_CACHE_BYTES,
-            DIRECT_MEMORY_BYTES,
-            STACK_BYTES_PER_THREAD,
-            stackBytesTotal,
-            headRoomBytes,
-            fixedRegionsBytes,
-            clampedThreads,
-            clampedClasses,
-            liveThreadCount,
-            liveLoadedClassCount,
-            clampedHeadRoom,
-            jvmOptions,
-            true,
-            null);
+                jvmOptions,
+                true,
+                null);
     }
 
     /**
@@ -197,16 +195,13 @@ final class MemoryCalculator {
      * the recommendation. The user can move the value freely afterwards.
      */
     long defaultTotalMemoryBytes(
-        long heapCommittedBytes,
-        long nonHeapCommittedBytes,
-        int threadCount,
-        int loadedClasses) {
+            long heapCommittedBytes, long nonHeapCommittedBytes, int threadCount, int loadedClasses) {
 
         int safeThreads = Math.max(threadCount, DEFAULT_THREAD_COUNT_FLOOR);
         long fixed = DIRECT_MEMORY_BYTES
-            + computeMetaspaceBytes(loadedClasses)
-            + CODE_CACHE_BYTES
-            + STACK_BYTES_PER_THREAD * (long) safeThreads;
+                + computeMetaspaceBytes(loadedClasses)
+                + CODE_CACHE_BYTES
+                + STACK_BYTES_PER_THREAD * (long) safeThreads;
         long floor = fixed + 128L * 1024 * 1024;
 
         long useful = heapCommittedBytes + Math.max(0, nonHeapCommittedBytes);
@@ -226,11 +221,11 @@ final class MemoryCalculator {
     }
 
     private String buildJvmOptions(
-        long heapBytes,
-        long metaspaceBytes,
-        long codeCacheBytes,
-        long directMemoryBytes,
-        long stackBytesPerThread) {
+            long heapBytes,
+            long metaspaceBytes,
+            long codeCacheBytes,
+            long directMemoryBytes,
+            long stackBytesPerThread) {
 
         long heapMb = bytesToMb(heapBytes);
         long metaMb = bytesToMb(metaspaceBytes);

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MemoryController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MemoryController.java
@@ -3,14 +3,13 @@ package io.github.jdubois.bootui.autoconfigure.web;
 import io.github.jdubois.bootui.core.BootUiDtos.MemoryCalculationDto;
 import io.github.jdubois.bootui.core.BootUiDtos.MemoryPoolDto;
 import io.github.jdubois.bootui.core.BootUiDtos.MemoryReport;
+import java.lang.management.*;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.lang.management.*;
-import java.util.ArrayList;
-import java.util.List;
 
 @RestController
 @RequestMapping("/bootui/api/memory")
@@ -28,9 +27,9 @@ public class MemoryController {
 
     @GetMapping
     public MemoryReport memory(
-        @RequestParam(name = "totalMemoryMb", required = false) Long totalMemoryMb,
-        @RequestParam(name = "threadCount", required = false) Integer threadCount,
-        @RequestParam(name = "headRoomPercent", required = false) Integer headRoomPercent) {
+            @RequestParam(name = "totalMemoryMb", required = false) Long totalMemoryMb,
+            @RequestParam(name = "threadCount", required = false) Integer threadCount,
+            @RequestParam(name = "headRoomPercent", required = false) Integer headRoomPercent) {
         MemoryMXBean memBean = ManagementFactory.getMemoryMXBean();
         ClassLoadingMXBean classBean = ManagementFactory.getClassLoadingMXBean();
         ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
@@ -55,24 +54,17 @@ public class MemoryController {
         int liveClasses = classBean.getLoadedClassCount();
 
         long resolvedTotalBytes = totalMemoryMb != null
-            ? totalMemoryMb * 1024L * 1024L
-            : calculator.defaultTotalMemoryBytes(
-            heapUsage.getCommitted(),
-            nonHeapUsage.getCommitted(),
-            MemoryCalculator.defaultThreadCount(liveThreads),
-            liveClasses);
-        int resolvedThreads = threadCount != null
-            ? threadCount
-            : MemoryCalculator.defaultThreadCount(liveThreads);
+                ? totalMemoryMb * 1024L * 1024L
+                : calculator.defaultTotalMemoryBytes(
+                        heapUsage.getCommitted(),
+                        nonHeapUsage.getCommitted(),
+                        MemoryCalculator.defaultThreadCount(liveThreads),
+                        liveClasses);
+        int resolvedThreads = threadCount != null ? threadCount : MemoryCalculator.defaultThreadCount(liveThreads);
         int resolvedHeadRoom = headRoomPercent != null ? headRoomPercent : 0;
 
         MemoryCalculationDto calculation = calculator.calculate(
-            resolvedTotalBytes,
-            resolvedThreads,
-            liveClasses,
-            resolvedHeadRoom,
-            liveThreads,
-            liveClasses);
+                resolvedTotalBytes, resolvedThreads, liveClasses, resolvedHeadRoom, liveThreads, liveClasses);
 
         return new MemoryReport(heap, nonHeap, pools, inputArgs, calculation.jvmOptions(), calculation);
     }
@@ -85,4 +77,3 @@ public class MemoryController {
         return new MemoryPoolDto(name, used, committed, max, pct);
     }
 }
-

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MetricsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MetricsController.java
@@ -2,13 +2,12 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.*;
 import io.micrometer.core.instrument.*;
+import java.util.*;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.*;
 
 @RestController
 @RequestMapping("/bootui/api/metrics")
@@ -31,44 +30,43 @@ public class MetricsController {
 
         Map<String, List<Meter>> metersByName = metersByName(registry.getMeters());
         List<MetricMeterDto> meters = metersByName.entrySet().stream()
-            .map(entry -> toMeterDto(entry.getKey(), entry.getValue()))
-            .toList();
+                .map(entry -> toMeterDto(entry.getKey(), entry.getValue()))
+                .toList();
         return new MetricsReport(true, meters.size(), meters);
     }
 
     @GetMapping("/detail")
-    public MetricDetailDto metric(@RequestParam String name,
-                                  @RequestParam(name = "tag", required = false) List<String> tagFilters) {
+    public MetricDetailDto metric(
+            @RequestParam String name, @RequestParam(name = "tag", required = false) List<String> tagFilters) {
         MeterRegistry registry = registry();
         if (registry == null) {
             return emptyDetail(false, name);
         }
 
         List<Meter> meters = registry.getMeters().stream()
-            .filter(meter -> meter.getId().getName().equals(name))
-            .toList();
+                .filter(meter -> meter.getId().getName().equals(name))
+                .toList();
         if (meters.isEmpty()) {
             return emptyDetail(true, name);
         }
 
         Map<String, String> requiredTags = parseTagFilters(tagFilters);
-        List<Meter> matchingMeters = meters.stream()
-            .filter(meter -> hasTags(meter, requiredTags))
-            .toList();
+        List<Meter> matchingMeters =
+                meters.stream().filter(meter -> hasTags(meter, requiredTags)).toList();
         List<MetricSampleDto> samples = matchingMeters.stream()
-            .map(this::toSample)
-            .sorted(Comparator.comparing(sample -> sample.tags().toString()))
-            .toList();
+                .map(this::toSample)
+                .sorted(Comparator.comparing(sample -> sample.tags().toString()))
+                .toList();
 
         return new MetricDetailDto(
-            true,
-            name,
-            firstDescription(meters),
-            firstBaseUnit(meters),
-            firstType(meters),
-            aggregateMeasurements(matchingMeters),
-            availableTags(meters),
-            samples);
+                true,
+                name,
+                firstDescription(meters),
+                firstBaseUnit(meters),
+                firstType(meters),
+                aggregateMeasurements(matchingMeters),
+                availableTags(meters),
+                samples);
     }
 
     private MeterRegistry registry() {
@@ -82,18 +80,15 @@ public class MetricsController {
     private Map<String, List<Meter>> metersByName(List<Meter> meters) {
         Map<String, List<Meter>> grouped = new TreeMap<>();
         for (Meter meter : meters) {
-            grouped.computeIfAbsent(meter.getId().getName(), name -> new ArrayList<>()).add(meter);
+            grouped.computeIfAbsent(meter.getId().getName(), name -> new ArrayList<>())
+                    .add(meter);
         }
         return grouped;
     }
 
     private MetricMeterDto toMeterDto(String name, List<Meter> meters) {
         return new MetricMeterDto(
-            name,
-            firstDescription(meters),
-            firstBaseUnit(meters),
-            firstType(meters),
-            availableTags(meters));
+                name, firstDescription(meters), firstBaseUnit(meters), firstType(meters), availableTags(meters));
     }
 
     private MetricDetailDto emptyDetail(boolean metricsAvailable, String name) {
@@ -102,27 +97,27 @@ public class MetricsController {
 
     private String firstDescription(List<Meter> meters) {
         return meters.stream()
-            .map(meter -> meter.getId().getDescription())
-            .filter(value -> value != null && !value.isBlank())
-            .findFirst()
-            .orElse(null);
+                .map(meter -> meter.getId().getDescription())
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst()
+                .orElse(null);
     }
 
     private String firstBaseUnit(List<Meter> meters) {
         return meters.stream()
-            .map(meter -> meter.getId().getBaseUnit())
-            .filter(value -> value != null && !value.isBlank())
-            .findFirst()
-            .orElse(null);
+                .map(meter -> meter.getId().getBaseUnit())
+                .filter(value -> value != null && !value.isBlank())
+                .findFirst()
+                .orElse(null);
     }
 
     private String firstType(List<Meter> meters) {
         return meters.stream()
-            .map(meter -> meter.getId().getType())
-            .filter(type -> type != null)
-            .map(Enum::name)
-            .findFirst()
-            .orElse(null);
+                .map(meter -> meter.getId().getType())
+                .filter(type -> type != null)
+                .map(Enum::name)
+                .findFirst()
+                .orElse(null);
     }
 
     private Map<String, String> parseTagFilters(List<String> tagFilters) {
@@ -153,25 +148,27 @@ public class MetricsController {
         Map<String, TreeSet<String>> valuesByKey = new TreeMap<>();
         for (Meter meter : meters) {
             for (Tag tag : meter.getId().getTags()) {
-                valuesByKey.computeIfAbsent(tag.getKey(), key -> new TreeSet<>()).add(tag.getValue());
+                valuesByKey
+                        .computeIfAbsent(tag.getKey(), key -> new TreeSet<>())
+                        .add(tag.getValue());
             }
         }
 
         List<MetricAvailableTagDto> tags = new ArrayList<>();
         for (Map.Entry<String, TreeSet<String>> entry : valuesByKey.entrySet()) {
-            List<String> values = entry.getValue().stream()
-                .limit(MAX_TAG_VALUES)
-                .toList();
-            tags.add(new MetricAvailableTagDto(entry.getKey(), values, entry.getValue().size() > MAX_TAG_VALUES));
+            List<String> values =
+                    entry.getValue().stream().limit(MAX_TAG_VALUES).toList();
+            tags.add(new MetricAvailableTagDto(
+                    entry.getKey(), values, entry.getValue().size() > MAX_TAG_VALUES));
         }
         return tags;
     }
 
     private MetricSampleDto toSample(Meter meter) {
         List<MetricTagDto> tags = meter.getId().getTags().stream()
-            .sorted(Comparator.comparing(Tag::getKey).thenComparing(Tag::getValue))
-            .map(tag -> new MetricTagDto(tag.getKey(), tag.getValue()))
-            .toList();
+                .sorted(Comparator.comparing(Tag::getKey).thenComparing(Tag::getValue))
+                .map(tag -> new MetricTagDto(tag.getKey(), tag.getValue()))
+                .toList();
         return new MetricSampleDto(tags, measurements(meter));
     }
 
@@ -212,6 +209,6 @@ public class MetricsController {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-            .body(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()));
+                .body(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()));
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -2,9 +2,6 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.BootUiDtos.*;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -14,6 +11,8 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
@@ -28,29 +27,43 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private final URI baseUri;
 
     OsvVulnerabilityScanner(BootUiProperties.Dependencies properties) {
-        this(properties, HttpClient.newBuilder()
-            .connectTimeout(properties.getRequestTimeout())
-            .build(), new ObjectMapper(), OSV_BASE_URI);
+        this(
+                properties,
+                HttpClient.newBuilder()
+                        .connectTimeout(properties.getRequestTimeout())
+                        .build(),
+                new ObjectMapper(),
+                OSV_BASE_URI);
     }
 
-    OsvVulnerabilityScanner(BootUiProperties.Dependencies properties, HttpClient httpClient,
-                            ObjectMapper objectMapper, URI baseUri) {
+    OsvVulnerabilityScanner(
+            BootUiProperties.Dependencies properties, HttpClient httpClient, ObjectMapper objectMapper, URI baseUri) {
         this.properties = properties;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
         this.baseUri = baseUri;
     }
 
-    static DependenciesReport report(boolean scanningEnabled, String status, String message, Long scannedAt,
-                                     int packagesScanned, List<DependencyDto> dependencies) {
-        int vulnerabilitiesFound = dependencies.stream().mapToInt(DependencyDto::vulnerabilityCount).sum();
+    static DependenciesReport report(
+            boolean scanningEnabled,
+            String status,
+            String message,
+            Long scannedAt,
+            int packagesScanned,
+            List<DependencyDto> dependencies) {
+        int vulnerabilitiesFound = dependencies.stream()
+                .mapToInt(DependencyDto::vulnerabilityCount)
+                .sum();
         return new DependenciesReport(
-            scanningEnabled,
-            dependencies.size(),
-            (int) dependencies.stream().filter(dependency -> dependency.vulnerabilityCount() > 0).count(),
-            severityCounts(dependencies),
-            new DependencyScanStatusDto("OSV.dev", status, message, scannedAt, packagesScanned, vulnerabilitiesFound),
-            dependencies);
+                scanningEnabled,
+                dependencies.size(),
+                (int) dependencies.stream()
+                        .filter(dependency -> dependency.vulnerabilityCount() > 0)
+                        .count(),
+                severityCounts(dependencies),
+                new DependencyScanStatusDto(
+                        "OSV.dev", status, message, scannedAt, packagesScanned, vulnerabilitiesFound),
+                dependencies);
     }
 
     private static List<DependencySeverityCountDto> severityCounts(List<DependencyDto> dependencies) {
@@ -64,15 +77,15 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             }
         }
         return counts.entrySet().stream()
-            .map(entry -> new DependencySeverityCountDto(entry.getKey(), entry.getValue()))
-            .toList();
+                .map(entry -> new DependencySeverityCountDto(entry.getKey(), entry.getValue()))
+                .toList();
     }
 
     private static String highestSeverity(List<DependencyVulnerabilityDto> vulnerabilities) {
         return vulnerabilities.stream()
-            .map(DependencyVulnerabilityDto::severity)
-            .min(Comparator.comparingInt(OsvVulnerabilityScanner::severityRank))
-            .orElse("NONE");
+                .map(DependencyVulnerabilityDto::severity)
+                .min(Comparator.comparingInt(OsvVulnerabilityScanner::severityRank))
+                .orElse("NONE");
     }
 
     private static int severityRank(String severity) {
@@ -197,29 +210,33 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
     private static String scanMessage(String status) {
         return "PARTIAL".equals(status)
-            ? "Scan completed with configured package or advisory limits applied."
-            : "Scan completed against OSV.dev.";
+                ? "Scan completed with configured package or advisory limits applied."
+                : "Scan completed against OSV.dev.";
     }
 
     @Override
     public DependenciesReport scan(List<DependencyDto> dependencies) {
         long scannedAt = Instant.now().toEpochMilli();
         List<DependencyDto> packages = dependencies.stream()
-            .limit(Math.max(1, properties.getMaxPackages()))
-            .toList();
+                .limit(Math.max(1, properties.getMaxPackages()))
+                .toList();
         if (packages.isEmpty()) {
-            return report(true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
+            return report(
+                    true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
         }
         try {
             Map<String, List<String>> vulnerabilityIds = queryBatch(packages);
             Map<String, JsonNode> vulnerabilities = fetchVulnerabilities(vulnerabilityIds);
             List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, vulnerabilities);
-            String status = packages.size() < dependencies.size() || vulnerabilities.size() < uniqueIds(vulnerabilityIds).size()
-                ? "PARTIAL"
-                : "SCANNED";
+            String status = packages.size() < dependencies.size()
+                            || vulnerabilities.size()
+                                    < uniqueIds(vulnerabilityIds).size()
+                    ? "PARTIAL"
+                    : "SCANNED";
             return report(true, status, scanMessage(status), scannedAt, packages.size(), enriched);
         } catch (IOException ex) {
-            return report(true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
+            return report(
+                    true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             return report(true, "ERROR", "OSV scan was interrupted", scannedAt, packages.size(), dependencies);
@@ -227,20 +244,21 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     }
 
     private Map<String, List<String>> queryBatch(List<DependencyDto> dependencies)
-        throws IOException, InterruptedException {
+            throws IOException, InterruptedException {
         List<Map<String, Object>> queries = new ArrayList<>();
         for (DependencyDto dependency : dependencies) {
             queries.add(Map.of(
-                "package", Map.of("ecosystem", "Maven", "name", dependency.packageName()),
-                "version", dependency.version()));
+                    "package", Map.of("ecosystem", "Maven", "name", dependency.packageName()),
+                    "version", dependency.version()));
         }
         String body = objectMapper.writeValueAsString(Map.of("queries", queries));
         HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("/v1/querybatch"))
-            .timeout(properties.getRequestTimeout())
-            .header("Content-Type", "application/json")
-            .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
-            .build();
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                .timeout(properties.getRequestTimeout())
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+                .build();
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             throw new IOException("OSV query returned HTTP " + response.statusCode());
         }
@@ -265,17 +283,17 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     }
 
     private Map<String, JsonNode> fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
-        throws IOException, InterruptedException {
+            throws IOException, InterruptedException {
         Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
         for (String id : uniqueIds(vulnerabilityIds).stream()
-            .limit(Math.max(1, properties.getMaxAdvisories()))
-            .toList()) {
+                .limit(Math.max(1, properties.getMaxAdvisories()))
+                .toList()) {
             HttpRequest request = HttpRequest.newBuilder(vulnerabilityUri(id))
-                .timeout(properties.getRequestTimeout())
-                .GET()
-                .build();
-            HttpResponse<String> response = httpClient.send(request,
-                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                    .timeout(properties.getRequestTimeout())
+                    .GET()
+                    .build();
+            HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
             if (response.statusCode() < 200 || response.statusCode() >= 300) {
                 throw new IOException("OSV advisory " + id + " returned HTTP " + response.statusCode());
             }
@@ -297,38 +315,39 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         String id = text(node, "id");
         Severity severity = severity(node);
         return new DependencyVulnerabilityDto(
-            id,
-            text(node, "summary"),
-            text(node, "details"),
-            severity.label(),
-            severity.score(),
-            stringArray(node.path("aliases")),
-            references(node.path("references")),
-            fixedVersions(node.path("affected"), dependency.packageName()));
+                id,
+                text(node, "summary"),
+                text(node, "details"),
+                severity.label(),
+                severity.score(),
+                stringArray(node.path("aliases")),
+                references(node.path("references")),
+                fixedVersions(node.path("affected"), dependency.packageName()));
     }
 
-    private List<DependencyDto> enrich(List<DependencyDto> dependencies,
-                                       Map<String, List<String>> vulnerabilityIds,
-                                       Map<String, JsonNode> vulnerabilities) {
+    private List<DependencyDto> enrich(
+            List<DependencyDto> dependencies,
+            Map<String, List<String>> vulnerabilityIds,
+            Map<String, JsonNode> vulnerabilities) {
         List<DependencyDto> enriched = new ArrayList<>();
         for (DependencyDto dependency : dependencies) {
-            List<DependencyVulnerabilityDto> dependencyVulnerabilities = vulnerabilityIds
-                .getOrDefault(key(dependency), List.of()).stream()
-                .map(vulnerabilities::get)
-                .filter(vulnerability -> vulnerability != null)
-                .map(vulnerability -> vulnerability(vulnerability, dependency))
-                .sorted(Comparator.comparing(DependencyVulnerabilityDto::severity)
-                    .thenComparing(DependencyVulnerabilityDto::id))
-                .toList();
+            List<DependencyVulnerabilityDto> dependencyVulnerabilities =
+                    vulnerabilityIds.getOrDefault(key(dependency), List.of()).stream()
+                            .map(vulnerabilities::get)
+                            .filter(vulnerability -> vulnerability != null)
+                            .map(vulnerability -> vulnerability(vulnerability, dependency))
+                            .sorted(Comparator.comparing(DependencyVulnerabilityDto::severity)
+                                    .thenComparing(DependencyVulnerabilityDto::id))
+                            .toList();
             enriched.add(new DependencyDto(
-                dependency.groupId(),
-                dependency.artifactId(),
-                dependency.version(),
-                dependency.packageName(),
-                dependency.source(),
-                dependencyVulnerabilities.size(),
-                highestSeverity(dependencyVulnerabilities),
-                dependencyVulnerabilities));
+                    dependency.groupId(),
+                    dependency.artifactId(),
+                    dependency.version(),
+                    dependency.packageName(),
+                    dependency.source(),
+                    dependencyVulnerabilities.size(),
+                    highestSeverity(dependencyVulnerabilities),
+                    dependencyVulnerabilities));
         }
         return enriched;
     }
@@ -352,6 +371,5 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return new Severity(normalized, score);
     }
 
-    private record Severity(String label, Double score) {
-    }
+    private record Severity(String label, Double score) {}
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
@@ -7,6 +7,7 @@ import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
 import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -16,8 +17,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 /**
  * OTLP/HTTP receiver mounted under {@code /bootui/api/otlp}.
@@ -36,7 +35,8 @@ public class OtlpReceiverController {
 
     private static final Logger log = LoggerFactory.getLogger(OtlpReceiverController.class);
 
-    private static final byte[] EMPTY_RESPONSE = ExportTraceServiceResponse.getDefaultInstance().toByteArray();
+    private static final byte[] EMPTY_RESPONSE =
+            ExportTraceServiceResponse.getDefaultInstance().toByteArray();
 
     private final TelemetryStore store;
 
@@ -44,9 +44,7 @@ public class OtlpReceiverController {
 
     private final BootUiProperties properties;
 
-    public OtlpReceiverController(TelemetryStore store,
-                                  OtlpSpanDecoder decoder,
-                                  BootUiProperties properties) {
+    public OtlpReceiverController(TelemetryStore store, OtlpSpanDecoder decoder, BootUiProperties properties) {
         this.store = store;
         this.decoder = decoder;
         this.properties = properties;
@@ -81,14 +79,14 @@ public class OtlpReceiverController {
 
     private static ResponseEntity<byte[]> okResponse() {
         return ResponseEntity.ok()
-            .contentType(MediaType.parseMediaType("application/x-protobuf"))
-            .body(EMPTY_RESPONSE);
+                .contentType(MediaType.parseMediaType("application/x-protobuf"))
+                .body(EMPTY_RESPONSE);
     }
 
-    @PostMapping(path = "/v1/traces",
-        consumes = {"application/x-protobuf", "application/octet-stream"})
-    public ResponseEntity<byte[]> receiveTraces(@RequestBody byte[] body,
-                                                HttpServletRequest request) {
+    @PostMapping(
+            path = "/v1/traces",
+            consumes = {"application/x-protobuf", "application/octet-stream"})
+    public ResponseEntity<byte[]> receiveTraces(@RequestBody byte[] body, HttpServletRequest request) {
         BootUiProperties.Telemetry telemetry = properties.getTelemetry();
         if (!telemetry.isEnabled()) {
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
@@ -97,8 +95,10 @@ public class OtlpReceiverController {
             return okResponse();
         }
         if (body.length > telemetry.getMaxRequestBytes()) {
-            log.warn("Rejecting OTLP payload exceeding bootui.telemetry.max-request-bytes ({} > {})",
-                body.length, telemetry.getMaxRequestBytes());
+            log.warn(
+                    "Rejecting OTLP payload exceeding bootui.telemetry.max-request-bytes ({} > {})",
+                    body.length,
+                    telemetry.getMaxRequestBytes());
             return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).build();
         }
         try {
@@ -117,8 +117,7 @@ public class OtlpReceiverController {
             }
             return okResponse();
         } catch (InvalidProtocolBufferException ex) {
-            log.warn("Rejecting invalid OTLP protobuf payload from {}: {}",
-                request.getRemoteAddr(), ex.getMessage());
+            log.warn("Rejecting invalid OTLP protobuf payload from {}: {}", request.getRemoteAddr(), ex.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         } catch (RuntimeException ex) {
             log.warn("OTLP receiver failed to handle payload", ex);

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OverviewController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OverviewController.java
@@ -5,14 +5,13 @@ import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.BootUiDtos.ActivationStatus;
 import io.github.jdubois.bootui.core.BootUiDtos.OverviewDto;
 import io.github.jdubois.bootui.core.BootUiInfo;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.boot.SpringBootVersion;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Arrays;
-import java.util.List;
 
 @RestController
 @RequestMapping("/bootui/api/overview")
@@ -24,8 +23,7 @@ public class OverviewController {
 
     private final BootUiProperties properties;
 
-    public OverviewController(Environment environment, BootUiActivation activation,
-                              BootUiProperties properties) {
+    public OverviewController(Environment environment, BootUiActivation activation, BootUiProperties properties) {
         this.environment = environment;
         this.activation = activation;
         this.properties = properties;
@@ -35,30 +33,30 @@ public class OverviewController {
     public OverviewDto overview() {
         String name = environment.getProperty("spring.application.name", "application");
         String webType = detectWebType();
-        Integer port = parseInt(environment.getProperty("local.server.port",
-            environment.getProperty("server.port", "8080")));
+        Integer port =
+                parseInt(environment.getProperty("local.server.port", environment.getProperty("server.port", "8080")));
         Integer managementPort = parseInt(environment.getProperty("management.server.port"));
         Long startupMs = parseLong(environment.getProperty("spring.boot.application.startup.time"));
 
         return new OverviewDto(
-            BootUiInfo.VERSION,
-            name,
-            SpringBootVersion.getVersion(),
-            System.getProperty("java.version"),
-            System.getProperty("java.vendor"),
-            Arrays.asList(environment.getActiveProfiles()),
-            Arrays.asList(environment.getDefaultProfiles()),
-            webType,
-            port,
-            managementPort,
-            environment.getProperty("server.servlet.context-path", ""),
-            startupMs,
-            new ActivationStatus(
-                activation.enabled(),
-                properties.isLocalhostOnly() && !properties.isAllowNonLocalhost(),
-                activation.reason(),
-                activation.warnings() == null ? List.of() : activation.warnings()),
-            detectOpenApiUrl());
+                BootUiInfo.VERSION,
+                name,
+                SpringBootVersion.getVersion(),
+                System.getProperty("java.version"),
+                System.getProperty("java.vendor"),
+                Arrays.asList(environment.getActiveProfiles()),
+                Arrays.asList(environment.getDefaultProfiles()),
+                webType,
+                port,
+                managementPort,
+                environment.getProperty("server.servlet.context-path", ""),
+                startupMs,
+                new ActivationStatus(
+                        activation.enabled(),
+                        properties.isLocalhostOnly() && !properties.isAllowNonLocalhost(),
+                        activation.reason(),
+                        activation.warnings() == null ? List.of() : activation.warnings()),
+                detectOpenApiUrl());
     }
 
     private String detectOpenApiUrl() {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PanelsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PanelsController.java
@@ -3,6 +3,8 @@ package io.github.jdubois.bootui.autoconfigure.web;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.BootUiDtos.PanelDto;
 import io.github.jdubois.bootui.core.BootUiDtos.PanelsReport;
+import java.util.List;
+import java.util.regex.Pattern;
 import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint;
 import org.springframework.boot.actuate.beans.BeansEndpoint;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
@@ -22,23 +24,21 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-import java.util.regex.Pattern;
-
 @RestController
 @RequestMapping("/bootui/api/panels")
 public class PanelsController {
 
     // Matches both plain application-<profile>.{properties,yml,yaml} names and
     // Spring Boot's "Config resource 'file ... application-<profile>.yml'" source names.
-    private static final Pattern PROFILE_SOURCE_PATTERN =
-        Pattern.compile("(?:application-|Config resource 'file [^']*application-)([\\w-]+)(?:\\.properties|\\.ya?ml)");
+    private static final Pattern PROFILE_SOURCE_PATTERN = Pattern.compile(
+            "(?:application-|Config resource 'file [^']*application-)([\\w-]+)(?:\\.properties|\\.ya?ml)");
 
     private final ApplicationContext applicationContext;
     private final Environment environment;
     private final BootUiProperties properties;
 
-    public PanelsController(ApplicationContext applicationContext, Environment environment, BootUiProperties properties) {
+    public PanelsController(
+            ApplicationContext applicationContext, Environment environment, BootUiProperties properties) {
         this.applicationContext = applicationContext;
         this.environment = environment;
         this.properties = properties;
@@ -47,44 +47,69 @@ public class PanelsController {
     @GetMapping
     public PanelsReport panels() {
         return new PanelsReport(List.of(
-            panel("overview", "Overview", true, null),
-            panel("startup", "Startup Timeline", beanPresent(StartupEndpoint.class),
-                "Actuator startup endpoint not available"),
-            panel("memory", "Memory", true, null),
-            panel("health", "Health", beanPresent(HealthEndpoint.class),
-                "Actuator health endpoint not available"),
-            panel("metrics", "Metrics", classPresent("io.micrometer.core.instrument.MeterRegistry") && beanPresent(MetricsEndpoint.class),
-                "Actuator metrics endpoint or MeterRegistry not available"),
-            panel("conditions", "Conditions", beanPresent(ConditionsReportEndpoint.class),
-                "Actuator conditions endpoint not available"),
-            panel("beans", "Beans", beanPresent(BeansEndpoint.class),
-                "Actuator beans endpoint not available"),
-            panel("mappings", "Mappings", beanPresent(MappingsEndpoint.class),
-                "Actuator mappings endpoint not available"),
-            panel("config", "Configuration", true, null),
-            panel("profiles", "Profile Diff", profilesAvailable(),
-                "No active profiles or profile-specific config sources available"),
-            panel("loggers", "Loggers", beanPresent(LoggersEndpoint.class),
-                "Actuator loggers endpoint not available"),
-            panel("log-tail", "Log Tail", classPresent("ch.qos.logback.classic.Logger"),
-                "Logback not on the classpath"),
-            panel("http-probe", "HTTP Probe", true, null),
-            panel("devtools", "DevTools", devToolsPresent(),
-                "Spring Boot DevTools not on the classpath"),
-            panel("dev-services", "Dev Services", devServicesPresent(),
-                "Docker Compose or Testcontainers not on the classpath"),
-            panel("scheduled", "Scheduled Tasks", scheduledAvailable(),
-                "Scheduling is not enabled"),
-            panel("data", "Data", classPresent("org.springframework.data.repository.Repository"),
-                "Spring Data not on the classpath"),
-            panel("cache", "Cache", beanPresent(CacheManager.class),
-                "No CacheManager beans are available"),
-            panel("traces", "Traces", properties.getTelemetry().isEnabled(),
-                "Telemetry receiver is disabled"),
-            panel("ai", "AI Usage", aiAvailable(), aiUnavailableReason()),
-            panel("security", "Security", classPresent("org.springframework.security.web.SecurityFilterChain"),
-                "Spring Security not on the classpath"),
-            panel("vulnerabilities", "Vulnerabilities", true, null)));
+                panel("overview", "Overview", true, null),
+                panel(
+                        "startup",
+                        "Startup Timeline",
+                        beanPresent(StartupEndpoint.class),
+                        "Actuator startup endpoint not available"),
+                panel("memory", "Memory", true, null),
+                panel("health", "Health", beanPresent(HealthEndpoint.class), "Actuator health endpoint not available"),
+                panel(
+                        "metrics",
+                        "Metrics",
+                        classPresent("io.micrometer.core.instrument.MeterRegistry")
+                                && beanPresent(MetricsEndpoint.class),
+                        "Actuator metrics endpoint or MeterRegistry not available"),
+                panel(
+                        "conditions",
+                        "Conditions",
+                        beanPresent(ConditionsReportEndpoint.class),
+                        "Actuator conditions endpoint not available"),
+                panel("beans", "Beans", beanPresent(BeansEndpoint.class), "Actuator beans endpoint not available"),
+                panel(
+                        "mappings",
+                        "Mappings",
+                        beanPresent(MappingsEndpoint.class),
+                        "Actuator mappings endpoint not available"),
+                panel("config", "Configuration", true, null),
+                panel(
+                        "profiles",
+                        "Profile Diff",
+                        profilesAvailable(),
+                        "No active profiles or profile-specific config sources available"),
+                panel(
+                        "loggers",
+                        "Loggers",
+                        beanPresent(LoggersEndpoint.class),
+                        "Actuator loggers endpoint not available"),
+                panel(
+                        "log-tail",
+                        "Log Tail",
+                        classPresent("ch.qos.logback.classic.Logger"),
+                        "Logback not on the classpath"),
+                panel("http-probe", "HTTP Probe", true, null),
+                panel("devtools", "DevTools", devToolsPresent(), "Spring Boot DevTools not on the classpath"),
+                panel(
+                        "dev-services",
+                        "Dev Services",
+                        devServicesPresent(),
+                        "Docker Compose or Testcontainers not on the classpath"),
+                panel("scheduled", "Scheduled Tasks", scheduledAvailable(), "Scheduling is not enabled"),
+                panel(
+                        "data",
+                        "Data",
+                        classPresent("org.springframework.data.repository.Repository"),
+                        "Spring Data not on the classpath"),
+                panel("cache", "Cache", beanPresent(CacheManager.class), "No CacheManager beans are available"),
+                panel("traces", "Traces", properties.getTelemetry().isEnabled(), "Telemetry receiver is disabled"),
+                panel("ai", "AI Usage", aiAvailable(), aiUnavailableReason()),
+                panel(
+                        "security",
+                        "Security",
+                        classPresent("org.springframework.security.web.SecurityFilterChain"),
+                        "Spring Security not on the classpath"),
+                panel("vulnerabilities", "Vulnerabilities", true, null)));
     }
 
     private PanelDto panel(String id, String title, boolean available, String unavailableReason) {
@@ -118,22 +143,20 @@ public class PanelsController {
 
     private boolean devToolsPresent() {
         return classPresent("org.springframework.boot.devtools.RemoteSpringApplication")
-            || classPresent("org.springframework.boot.devtools.restart.Restarter");
+                || classPresent("org.springframework.boot.devtools.restart.Restarter");
     }
 
     private boolean devServicesPresent() {
         return classPresent("org.springframework.boot.docker.compose.core.DockerCompose")
-            || classPresent("org.testcontainers.containers.GenericContainer");
+                || classPresent("org.testcontainers.containers.GenericContainer");
     }
 
     private boolean scheduledAvailable() {
-        return beanPresent(ScheduledTaskHolder.class)
-            || beanPresent(ScheduledAnnotationBeanPostProcessor.class);
+        return beanPresent(ScheduledTaskHolder.class) || beanPresent(ScheduledAnnotationBeanPostProcessor.class);
     }
 
     private boolean aiAvailable() {
-        return properties.getTelemetry().isEnabled()
-            && classPresent("org.springframework.ai.chat.client.ChatClient");
+        return properties.getTelemetry().isEnabled() && classPresent("org.springframework.ai.chat.client.ChatClient");
     }
 
     private String aiUnavailableReason() {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ProfileController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ProfileController.java
@@ -6,19 +6,18 @@ import io.github.jdubois.bootui.core.BootUiDtos.ConfigPropertyDto;
 import io.github.jdubois.bootui.core.BootUiDtos.ProfileSourceDto;
 import io.github.jdubois.bootui.core.BootUiDtos.ProfilesReport;
 import io.github.jdubois.bootui.core.SecretMasker;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.EnumerablePropertySource;
-import org.springframework.core.env.PropertySource;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.PropertySource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Exposes a profile-aware view of the current configuration.
@@ -30,8 +29,8 @@ import java.util.regex.Pattern;
 @RequestMapping("/bootui/api/profiles")
 public class ProfileController {
 
-    private static final Pattern PROFILE_SOURCE_PATTERN =
-        Pattern.compile("(?:application-|Config resource 'file [^']*application-)([\\w-]+)(?:\\.properties|\\.ya?ml)");
+    private static final Pattern PROFILE_SOURCE_PATTERN = Pattern.compile(
+            "(?:application-|Config resource 'file [^']*application-)([\\w-]+)(?:\\.properties|\\.ya?ml)");
 
     private final ConfigurableEnvironment environment;
     private final BootUiProperties properties;
@@ -82,8 +81,8 @@ public class ProfileController {
 
     private boolean shouldMask(String key) {
         return properties.getExposeValues() == ValueExposure.MASKED
-            && properties.isMaskSecrets()
-            && masker.isSecret(key);
+                && properties.isMaskSecrets()
+                && masker.isSecret(key);
     }
 
     private String displayValue(String key, String value) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ScheduledController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ScheduledController.java
@@ -2,17 +2,16 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.ScheduledReport;
 import io.github.jdubois.bootui.core.BootUiDtos.ScheduledTaskDto;
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.scheduling.config.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.Duration;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
 
 @RestController
 @ConditionalOnClass(name = "org.springframework.scheduling.config.ScheduledTaskHolder")
@@ -32,10 +31,13 @@ public class ScheduledController {
             return new ScheduledReport(false, 0, List.of());
         }
         Set<ScheduledTask> scheduledTasks = holder.getScheduledTasks();
-        List<ScheduledTaskDto> tasks = scheduledTasks == null ? List.of() : scheduledTasks.stream()
-            .map(this::toDto)
-            .sorted(Comparator.comparing(ScheduledTaskDto::runnable, Comparator.nullsLast(String::compareTo)))
-            .toList();
+        List<ScheduledTaskDto> tasks = scheduledTasks == null
+                ? List.of()
+                : scheduledTasks.stream()
+                        .map(this::toDto)
+                        .sorted(Comparator.comparing(
+                                ScheduledTaskDto::runnable, Comparator.nullsLast(String::compareTo)))
+                        .toList();
         return new ScheduledReport(true, tasks.size(), tasks);
     }
 
@@ -49,19 +51,27 @@ public class ScheduledController {
         if (task instanceof FixedRateTask fixedRateTask) {
             long intervalMs = fixedRateTask.getIntervalDuration().toMillis();
             Long initialDelayMs = toMillis(fixedRateTask.getInitialDelayDuration());
-            return new ScheduledTaskDto(runnableName, "FIXED_RATE", Long.toString(intervalMs), initialDelayMs,
-                intervalUnit(intervalMs, initialDelayMs));
+            return new ScheduledTaskDto(
+                    runnableName,
+                    "FIXED_RATE",
+                    Long.toString(intervalMs),
+                    initialDelayMs,
+                    intervalUnit(intervalMs, initialDelayMs));
         }
         if (task instanceof FixedDelayTask fixedDelayTask) {
             long intervalMs = fixedDelayTask.getIntervalDuration().toMillis();
             Long initialDelayMs = toMillis(fixedDelayTask.getInitialDelayDuration());
-            return new ScheduledTaskDto(runnableName, "FIXED_DELAY", Long.toString(intervalMs), initialDelayMs,
-                intervalUnit(intervalMs, initialDelayMs));
+            return new ScheduledTaskDto(
+                    runnableName,
+                    "FIXED_DELAY",
+                    Long.toString(intervalMs),
+                    initialDelayMs,
+                    intervalUnit(intervalMs, initialDelayMs));
         }
         if (task instanceof OneTimeTask oneTimeTask) {
             Long initialDelayMs = toMillis(oneTimeTask.getInitialDelayDuration());
-            return new ScheduledTaskDto(runnableName, "ONE_SHOT", null, initialDelayMs,
-                intervalUnit(null, initialDelayMs));
+            return new ScheduledTaskDto(
+                    runnableName, "ONE_SHOT", null, initialDelayMs, intervalUnit(null, initialDelayMs));
         }
         if (task instanceof TriggerTask triggerTask) {
             return new ScheduledTaskDto(runnableName, "ONE_SHOT", String.valueOf(triggerTask.getTrigger()), null, null);
@@ -75,9 +85,10 @@ public class ScheduledController {
         }
         String typeName = runnable.getClass().getName();
         String description = runnable.toString();
-        if (description != null && !description.isBlank()
-            && !description.equals(typeName)
-            && !description.startsWith(typeName + "@")) {
+        if (description != null
+                && !description.isBlank()
+                && !description.equals(typeName)
+                && !description.startsWith(typeName + "@")) {
             return description;
         }
         return typeName;

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityController.java
@@ -4,6 +4,13 @@ import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.BootUiDtos.*;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
+import java.io.BufferedReader;
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.core.env.Environment;
@@ -27,14 +34,6 @@ import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
 
-import java.io.BufferedReader;
-import java.lang.reflect.Method;
-import java.security.Principal;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 /**
  * Exposes Spring Security filter chain configuration for the BootUI developer console.
  *
@@ -54,12 +53,13 @@ public class SecurityController {
     private final Environment environment;
     private final BootUiProperties properties;
 
-    public SecurityController(ObjectProvider<FilterChainProxy> filterChainProxyProvider,
-                              ObjectProvider<AuthenticationProvider> authenticationProviderProvider,
-                              ObjectProvider<UserDetailsService> userDetailsServiceProvider,
-                              ObjectProvider<RequestMappingInfoHandlerMapping> handlerMappingProvider,
-                              Environment environment,
-                              BootUiProperties properties) {
+    public SecurityController(
+            ObjectProvider<FilterChainProxy> filterChainProxyProvider,
+            ObjectProvider<AuthenticationProvider> authenticationProviderProvider,
+            ObjectProvider<UserDetailsService> userDetailsServiceProvider,
+            ObjectProvider<RequestMappingInfoHandlerMapping> handlerMappingProvider,
+            Environment environment,
+            BootUiProperties properties) {
         this.filterChainProxyProvider = filterChainProxyProvider;
         this.authenticationProviderProvider = authenticationProviderProvider;
         this.userDetailsServiceProvider = userDetailsServiceProvider;
@@ -91,8 +91,8 @@ public class SecurityController {
      * {@code true} when the stub detected that such matchers were consulted.</p>
      */
     @GetMapping("/explain")
-    public SecurityExplainDto explain(@RequestParam(defaultValue = "GET") String method,
-                                      @RequestParam(defaultValue = "/") String path) {
+    public SecurityExplainDto explain(
+            @RequestParam(defaultValue = "GET") String method, @RequestParam(defaultValue = "/") String path) {
         FilterChainProxy proxy = filterChainProxyProvider.getIfAvailable();
         if (proxy == null) {
             return new SecurityExplainDto(false, false, null, null, List.of());
@@ -105,18 +105,17 @@ public class SecurityController {
             try {
                 matches = chain.matches(request);
             } catch (Exception ex) {
-                return new SecurityExplainDto(false, true, null,
-                    "Chain " + i + " matcher threw " + ex.getClass().getSimpleName()
-                        + " — requires more request context than available",
-                    List.of());
+                return new SecurityExplainDto(
+                        false,
+                        true,
+                        null,
+                        "Chain " + i + " matcher threw " + ex.getClass().getSimpleName()
+                                + " — requires more request context than available",
+                        List.of());
             }
             if (matches) {
                 return new SecurityExplainDto(
-                    true,
-                    request.isBestEffort(),
-                    i,
-                    matcherDescription(chain),
-                    filterNames(chain.getFilters()));
+                        true, request.isBestEffort(), i, matcherDescription(chain), filterNames(chain.getFilters()));
             }
         }
         return new SecurityExplainDto(false, request.isBestEffort(), null, "No chain matched", List.of());
@@ -138,8 +137,8 @@ public class SecurityController {
     public SecurityEndpointsReport endpoints() {
         FilterChainProxy proxy = filterChainProxyProvider.getIfAvailable();
         boolean springSecurityPresent = proxy != null;
-        List<RequestMappingInfoHandlerMapping> handlerMappings = handlerMappingProvider.stream()
-            .collect(Collectors.toList());
+        List<RequestMappingInfoHandlerMapping> handlerMappings =
+                handlerMappingProvider.stream().collect(Collectors.toList());
         if (handlerMappings.isEmpty()) {
             return new SecurityEndpointsReport(springSecurityPresent, false, 0, List.of());
         }
@@ -158,22 +157,21 @@ public class SecurityController {
             }
         }
 
-        endpoints.sort(Comparator.comparing(SecurityEndpointDto::pattern)
-            .thenComparing(SecurityEndpointDto::method));
+        endpoints.sort(Comparator.comparing(SecurityEndpointDto::pattern).thenComparing(SecurityEndpointDto::method));
         return new SecurityEndpointsReport(springSecurityPresent, true, endpoints.size(), endpoints);
     }
 
-    private List<SecurityEndpointDto> describeEndpoint(RequestMappingInfo info,
-                                                       HandlerMethod handlerMethod,
-                                                       List<SecurityFilterChain> chains) {
+    private List<SecurityEndpointDto> describeEndpoint(
+            RequestMappingInfo info, HandlerMethod handlerMethod, List<SecurityFilterChain> chains) {
         Set<String> patterns = extractPatterns(info);
         Set<String> methods = info.getMethodsCondition().getMethods().stream()
-            .map(Enum::name)
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+                .map(Enum::name)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
         if (methods.isEmpty()) {
             methods.add("ANY");
         }
-        String handler = handlerMethod.getBeanType().getSimpleName() + "#" + handlerMethod.getMethod().getName();
+        String handler = handlerMethod.getBeanType().getSimpleName() + "#"
+                + handlerMethod.getMethod().getName();
 
         List<SecurityEndpointDto> result = new ArrayList<>();
         for (String pattern : patterns) {
@@ -187,8 +185,7 @@ public class SecurityController {
     private Set<String> extractPatterns(RequestMappingInfo info) {
         Set<String> patterns = new LinkedHashSet<>();
         if (info.getPathPatternsCondition() != null) {
-            info.getPathPatternsCondition().getPatterns()
-                .forEach(p -> patterns.add(p.getPatternString()));
+            info.getPathPatternsCondition().getPatterns().forEach(p -> patterns.add(p.getPatternString()));
         }
         if (patterns.isEmpty()) {
             patterns.add("/**");
@@ -196,11 +193,20 @@ public class SecurityController {
         return patterns;
     }
 
-    private SecurityEndpointDto resolveEndpoint(String method, String pattern, String handler,
-                                                List<SecurityFilterChain> chains) {
+    private SecurityEndpointDto resolveEndpoint(
+            String method, String pattern, String handler, List<SecurityFilterChain> chains) {
         if (chains.isEmpty()) {
-            return new SecurityEndpointDto(method, pattern, handler, false, "unsecured",
-                List.of(), null, null, "No Spring Security filter chains configured", false);
+            return new SecurityEndpointDto(
+                    method,
+                    pattern,
+                    handler,
+                    false,
+                    "unsecured",
+                    List.of(),
+                    null,
+                    null,
+                    "No Spring Security filter chains configured",
+                    false);
         }
         ExplainRequest request = new ExplainRequest(method, pattern);
         for (int i = 0; i < chains.size(); i++) {
@@ -209,22 +215,47 @@ public class SecurityController {
             try {
                 matches = chain.matches(request);
             } catch (Exception ex) {
-                return new SecurityEndpointDto(method, pattern, handler, true, "unknown",
-                    List.of(), i, matcherDescription(chain),
-                    "Chain matcher threw " + ex.getClass().getSimpleName(), true);
+                return new SecurityEndpointDto(
+                        method,
+                        pattern,
+                        handler,
+                        true,
+                        "unknown",
+                        List.of(),
+                        i,
+                        matcherDescription(chain),
+                        "Chain matcher threw " + ex.getClass().getSimpleName(),
+                        true);
             }
             if (matches) {
                 AuthorizationFilter authFilter = findAuthorizationFilter(chain);
                 if (authFilter == null) {
-                    return new SecurityEndpointDto(method, pattern, handler, true, "unknown",
-                        List.of(), i, matcherDescription(chain),
-                        "Chain has no AuthorizationFilter", request.isBestEffort());
+                    return new SecurityEndpointDto(
+                            method,
+                            pattern,
+                            handler,
+                            true,
+                            "unknown",
+                            List.of(),
+                            i,
+                            matcherDescription(chain),
+                            "Chain has no AuthorizationFilter",
+                            request.isBestEffort());
                 }
                 return classifyRule(method, pattern, handler, i, chain, authFilter, request);
             }
         }
-        return new SecurityEndpointDto(method, pattern, handler, false, "unsecured",
-            List.of(), null, null, "No Spring Security filter chain matched", request.isBestEffort());
+        return new SecurityEndpointDto(
+                method,
+                pattern,
+                handler,
+                false,
+                "unsecured",
+                List.of(),
+                null,
+                null,
+                "No Spring Security filter chain matched",
+                request.isBestEffort());
     }
 
     private AuthorizationFilter findAuthorizationFilter(SecurityFilterChain chain) {
@@ -244,22 +275,45 @@ public class SecurityController {
      * and authority names can be reported.
      */
     @SuppressWarnings("unchecked")
-    private SecurityEndpointDto classifyRule(String method, String pattern, String handler,
-                                             int chainIndex, SecurityFilterChain chain,
-                                             AuthorizationFilter authFilter, ExplainRequest request) {
+    private SecurityEndpointDto classifyRule(
+            String method,
+            String pattern,
+            String handler,
+            int chainIndex,
+            SecurityFilterChain chain,
+            AuthorizationFilter authFilter,
+            ExplainRequest request) {
         AuthorizationManager<HttpServletRequest> manager =
-            (AuthorizationManager<HttpServletRequest>) authFilter.getAuthorizationManager();
+                (AuthorizationManager<HttpServletRequest>) authFilter.getAuthorizationManager();
 
         boolean anonymousGranted = simulate(manager, anonymousAuth(), request);
         if (anonymousGranted) {
-            return new SecurityEndpointDto(method, pattern, handler, true, "permitAll",
-                List.of(), chainIndex, matcherDescription(chain), null, request.isBestEffort());
+            return new SecurityEndpointDto(
+                    method,
+                    pattern,
+                    handler,
+                    true,
+                    "permitAll",
+                    List.of(),
+                    chainIndex,
+                    matcherDescription(chain),
+                    null,
+                    request.isBestEffort());
         }
 
         boolean authenticatedGranted = simulate(manager, authenticatedAuth(List.of()), request);
         if (authenticatedGranted) {
-            return new SecurityEndpointDto(method, pattern, handler, true, "authenticated",
-                List.of(), chainIndex, matcherDescription(chain), null, request.isBestEffort());
+            return new SecurityEndpointDto(
+                    method,
+                    pattern,
+                    handler,
+                    true,
+                    "authenticated",
+                    List.of(),
+                    chainIndex,
+                    matcherDescription(chain),
+                    null,
+                    request.isBestEffort());
         }
 
         // Try to extract role/authority names from the AuthorizationManager's toString().
@@ -272,24 +326,46 @@ public class SecurityController {
                 List<String> exposed = new ArrayList<>(spec.authorities.size());
                 String rule = spec.allRolePrefixed ? "hasRole" : "hasAuthority";
                 for (String authority : spec.authorities) {
-                    exposed.add(spec.allRolePrefixed && authority.startsWith("ROLE_")
-                        ? authority.substring("ROLE_".length()) : authority);
+                    exposed.add(
+                            spec.allRolePrefixed && authority.startsWith("ROLE_")
+                                    ? authority.substring("ROLE_".length())
+                                    : authority);
                 }
-                return new SecurityEndpointDto(method, pattern, handler, true, rule,
-                    exposed, chainIndex, matcherDescription(chain), null, request.isBestEffort());
+                return new SecurityEndpointDto(
+                        method,
+                        pattern,
+                        handler,
+                        true,
+                        rule,
+                        exposed,
+                        chainIndex,
+                        matcherDescription(chain),
+                        null,
+                        request.isBestEffort());
             }
         }
 
         // No synthetic principal could obtain access — most likely denyAll, or a custom manager.
-        boolean superGranted = simulate(manager, authenticatedAuth(List.of("ROLE_ADMIN", "ROLE_USER", "SCOPE_ADMIN")), request);
+        boolean superGranted =
+                simulate(manager, authenticatedAuth(List.of("ROLE_ADMIN", "ROLE_USER", "SCOPE_ADMIN")), request);
         String rule = superGranted ? "custom" : "denyAll";
-        return new SecurityEndpointDto(method, pattern, handler, true, rule,
-            List.of(), chainIndex, matcherDescription(chain),
-            "Managed by " + manager.getClass().getSimpleName(), request.isBestEffort());
+        return new SecurityEndpointDto(
+                method,
+                pattern,
+                handler,
+                true,
+                rule,
+                List.of(),
+                chainIndex,
+                matcherDescription(chain),
+                "Managed by " + manager.getClass().getSimpleName(),
+                request.isBestEffort());
     }
 
-    private boolean simulate(AuthorizationManager<HttpServletRequest> manager,
-                             Authentication authentication, HttpServletRequest request) {
+    private boolean simulate(
+            AuthorizationManager<HttpServletRequest> manager,
+            Authentication authentication,
+            HttpServletRequest request) {
         try {
             AuthorizationResult result = manager.authorize(() -> authentication, request);
             return result != null && result.isGranted();
@@ -299,20 +375,19 @@ public class SecurityController {
     }
 
     private Authentication anonymousAuth() {
-        return new AnonymousAuthenticationToken("bootui-explain", "anonymousUser",
-            List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+        return new AnonymousAuthenticationToken(
+                "bootui-explain", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
     }
 
     private Authentication authenticatedAuth(List<String> authorities) {
-        List<SimpleGrantedAuthority> granted = authorities.stream()
-            .map(SimpleGrantedAuthority::new)
-            .collect(Collectors.toList());
+        List<SimpleGrantedAuthority> granted =
+                authorities.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
         return UsernamePasswordAuthenticationToken.authenticated("bootui-explain", "n/a", granted);
     }
 
     private AuthoritySpec extractAuthorities(AuthorizationManager<?> manager) {
         // Try a public getter first, in case future versions expose one.
-        for (String getterName : new String[]{"getAuthorities"}) {
+        for (String getterName : new String[] {"getAuthorities"}) {
             try {
                 Method m = manager.getClass().getMethod(getterName);
                 Object value = m.invoke(manager);
@@ -371,13 +446,13 @@ public class SecurityController {
 
     private SecurityFilterChainDto toChainDto(int order, SecurityFilterChain chain) {
         return new SecurityFilterChainDto(
-            order,
-            matcherDescription(chain),
-            matcherTypeName(chain),
-            filterNames(chain.getFilters()),
-            hasFilter(chain, "CsrfFilter"),
-            hasFilter(chain, "CorsFilter"),
-            hasFilter(chain, "SessionManagementFilter"));
+                order,
+                matcherDescription(chain),
+                matcherTypeName(chain),
+                filterNames(chain.getFilters()),
+                hasFilter(chain, "CsrfFilter"),
+                hasFilter(chain, "CorsFilter"),
+                hasFilter(chain, "SessionManagementFilter"));
     }
 
     private String matcherDescription(SecurityFilterChain chain) {
@@ -395,25 +470,23 @@ public class SecurityController {
     }
 
     private List<String> filterNames(List<? extends jakarta.servlet.Filter> filters) {
-        return filters.stream()
-            .map(f -> f.getClass().getSimpleName())
-            .collect(Collectors.toList());
+        return filters.stream().map(f -> f.getClass().getSimpleName()).collect(Collectors.toList());
     }
 
     private boolean hasFilter(SecurityFilterChain chain, String simpleClassName) {
         return chain.getFilters().stream()
-            .anyMatch(f -> f.getClass().getSimpleName().equals(simpleClassName));
+                .anyMatch(f -> f.getClass().getSimpleName().equals(simpleClassName));
     }
 
     private SecurityAuthDto buildAuth() {
         List<String> providerTypes = authenticationProviderProvider.stream()
-            .map(p -> p.getClass().getName())
-            .sorted()
-            .collect(Collectors.toList());
+                .map(p -> p.getClass().getName())
+                .sorted()
+                .collect(Collectors.toList());
         List<String> udsTypes = userDetailsServiceProvider.stream()
-            .map(u -> u.getClass().getName())
-            .sorted()
-            .collect(Collectors.toList());
+                .map(u -> u.getClass().getName())
+                .sorted()
+                .collect(Collectors.toList());
         // spring.security.user.name is a username, not a secret; expose it to help
         // developers identify the auto-generated user when no custom UserDetailsService
         // is configured. Never read spring.security.user.password.
@@ -424,8 +497,7 @@ public class SecurityController {
         return new SecurityAuthDto(providerTypes, udsTypes, configuredUsername);
     }
 
-    private record AuthoritySpec(List<String> authorities, boolean allRolePrefixed) {
-    }
+    private record AuthoritySpec(List<String> authorities, boolean allRolePrefixed) {}
 
     /**
      * Minimal {@link HttpServletRequest} stub used for best-effort chain matching in the
@@ -651,10 +723,14 @@ public class SecurityController {
         }
 
         @Override
-        public void setAttribute(String name, Object o) { /* no-op */ }
+        public void setAttribute(String name, Object o) {
+            /* no-op */
+        }
 
         @Override
-        public void removeAttribute(String name) { /* no-op */ }
+        public void removeAttribute(String name) {
+            /* no-op */
+        }
 
         // ── Parameters ────────────────────────────────────────────────────────────
 
@@ -686,7 +762,9 @@ public class SecurityController {
         }
 
         @Override
-        public void setCharacterEncoding(String env) { /* no-op */ }
+        public void setCharacterEncoding(String env) {
+            /* no-op */
+        }
 
         @Override
         public int getContentLength() {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/StartupController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/StartupController.java
@@ -3,6 +3,9 @@ package io.github.jdubois.bootui.autoconfigure.web;
 import io.github.jdubois.bootui.core.BootUiDtos.StartupReport;
 import io.github.jdubois.bootui.core.BootUiDtos.StartupStepDto;
 import io.github.jdubois.bootui.core.BootUiDtos.TagDto;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.StreamSupport;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.startup.StartupEndpoint;
 import org.springframework.boot.actuate.startup.StartupEndpoint.StartupDescriptor;
@@ -11,10 +14,6 @@ import org.springframework.core.metrics.StartupStep;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.Duration;
-import java.util.List;
-import java.util.stream.StreamSupport;
 
 @RestController
 @RequestMapping("/bootui/api/startup")
@@ -36,27 +35,30 @@ public class StartupController {
     }
 
     private StartupReport toReport(StartupDescriptor descriptor) {
-        if (descriptor == null || descriptor.getTimeline() == null || descriptor.getTimeline().getEvents() == null) {
+        if (descriptor == null
+                || descriptor.getTimeline() == null
+                || descriptor.getTimeline().getEvents() == null) {
             return new StartupReport(List.of());
         }
-        return new StartupReport(descriptor.getTimeline().getEvents().stream()
-            .map(this::toStep)
-            .toList());
+        return new StartupReport(
+                descriptor.getTimeline().getEvents().stream().map(this::toStep).toList());
     }
 
     private StartupStepDto toStep(TimelineEvent event) {
         StartupStep step = event.getStartupStep();
         return new StartupStepDto(
-            step.getId(),
-            step.getParentId(),
-            step.getName(),
-            durationMs(event),
-            StreamSupport.stream(step.getTags().spliterator(), false)
-                .map(tag -> new TagDto(tag.getKey(), tag.getValue()))
-                .toList());
+                step.getId(),
+                step.getParentId(),
+                step.getName(),
+                durationMs(event),
+                StreamSupport.stream(step.getTags().spliterator(), false)
+                        .map(tag -> new TagDto(tag.getKey(), tag.getValue()))
+                        .toList());
     }
 
     private long durationMs(TimelineEvent event) {
-        return event.getDuration() == null ? 0L : Duration.parse(event.getDuration().toString()).toMillis();
+        return event.getDuration() == null
+                ? 0L
+                : Duration.parse(event.getDuration().toString()).toMillis();
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/TracesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/TracesController.java
@@ -6,11 +6,10 @@ import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedEvent;
 import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
 import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
 import io.github.jdubois.bootui.core.BootUiDtos.*;
+import java.util.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.util.*;
 
 /**
  * Read-only API for the BootUI Traces panel.
@@ -64,8 +63,8 @@ public class TracesController {
             rootSpanName = earliest.name();
         } else if (!bucket.spans().isEmpty()) {
             NormalizedSpan first = bucket.spans().stream()
-                .min(Comparator.comparingLong(NormalizedSpan::startEpochNanos))
-                .orElse(bucket.spans().get(0));
+                    .min(Comparator.comparingLong(NormalizedSpan::startEpochNanos))
+                    .orElse(bucket.spans().get(0));
             rootSpanName = first.name();
         }
         if (minStart == Long.MAX_VALUE) {
@@ -73,33 +72,33 @@ public class TracesController {
             maxEnd = 0L;
         }
         return new TraceSummaryDto(
-            bucket.traceId(),
-            rootSpanName,
-            firstServices(services),
-            minStart,
-            maxEnd,
-            Math.max(0L, maxEnd - minStart),
-            bucket.spans().size(),
-            hasError,
-            hasAi);
+                bucket.traceId(),
+                rootSpanName,
+                firstServices(services),
+                minStart,
+                maxEnd,
+                Math.max(0L, maxEnd - minStart),
+                bucket.spans().size(),
+                hasError,
+                hasAi);
     }
 
     static SpanDto toSpanDto(NormalizedSpan span) {
         return new SpanDto(
-            span.traceId(),
-            span.spanId(),
-            span.parentSpanId(),
-            span.name(),
-            span.kind(),
-            span.serviceName(),
-            span.scope(),
-            span.startEpochNanos(),
-            span.endEpochNanos(),
-            span.durationNanos(),
-            span.statusCode(),
-            span.statusMessage(),
-            toAttributeList(span.attributes()),
-            toEventList(span.events()));
+                span.traceId(),
+                span.spanId(),
+                span.parentSpanId(),
+                span.name(),
+                span.kind(),
+                span.serviceName(),
+                span.scope(),
+                span.startEpochNanos(),
+                span.endEpochNanos(),
+                span.durationNanos(),
+                span.statusCode(),
+                span.statusMessage(),
+                toAttributeList(span.attributes()),
+                toEventList(span.events()));
     }
 
     static List<SpanAttributeDto> toAttributeList(Map<String, AttributeValue> attrs) {
@@ -120,8 +119,7 @@ public class TracesController {
         }
         List<SpanEventDto> out = new ArrayList<>(events.size());
         for (NormalizedEvent event : events) {
-            out.add(new SpanEventDto(event.name(), event.timeOffsetNanos(),
-                toAttributeList(event.attributes())));
+            out.add(new SpanEventDto(event.name(), event.timeOffsetNanos(), toAttributeList(event.attributes())));
         }
         return out;
     }
@@ -149,7 +147,8 @@ public class TracesController {
         for (TelemetryStore.TraceBucket bucket : store.recentTraces(safeLimit)) {
             summaries.add(toSummary(bucket));
         }
-        return new TracesReport(properties.getTelemetry().isEnabled(), store.retainedTraceCount(), store.capacity(), summaries);
+        return new TracesReport(
+                properties.getTelemetry().isEnabled(), store.retainedTraceCount(), store.capacity(), summaries);
     }
 
     @GetMapping("/{traceId}")

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilityScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilityScanner.java
@@ -2,7 +2,6 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.DependenciesReport;
 import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
-
 import java.util.List;
 
 interface VulnerabilityScanner {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationConditionAdditionalTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationConditionAdditionalTests.java
@@ -1,15 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.springframework.mock.env.MockEnvironment;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.tools.ToolProvider;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.env.MockEnvironment;
 
 /**
  * Additional coverage for {@link BootUiActivationCondition} targeting scenarios not
@@ -43,12 +42,12 @@ class BootUiActivationConditionAdditionalTests {
             public class RestartScope {
             }
             """);
-        int result = ToolProvider.getSystemJavaCompiler()
-            .run(null, null, null, "-d", tempDir.toString(), source.toString());
+        int result =
+                ToolProvider.getSystemJavaCompiler().run(null, null, null, "-d", tempDir.toString(), source.toString());
         if (result != 0) {
             throw new IllegalStateException("Failed to compile stub RestartScope");
         }
-        return new URLClassLoader(new java.net.URL[]{tempDir.toUri().toURL()}, null);
+        return new URLClassLoader(new java.net.URL[] {tempDir.toUri().toURL()}, null);
     }
 
     @Test
@@ -118,7 +117,7 @@ class BootUiActivationConditionAdditionalTests {
     @Test
     void devtoolsClassNameConstantIsCorrect() {
         assertThat(BootUiActivationCondition.DEVTOOLS_CLASS)
-            .isEqualTo("org.springframework.boot.devtools.restart.RestartScope");
+                .isEqualTo("org.springframework.boot.devtools.restart.RestartScope");
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationConditionTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationConditionTests.java
@@ -1,15 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.springframework.mock.env.MockEnvironment;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.tools.ToolProvider;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.tools.ToolProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.env.MockEnvironment;
 
 class BootUiActivationConditionTests {
 
@@ -141,11 +140,12 @@ class BootUiActivationConditionTests {
             public class RestartScope {
             }
             """);
-        int result = ToolProvider.getSystemJavaCompiler()
-            .run(null, null, null, "-d", tempDir.toString(), source.toString());
+        int result =
+                ToolProvider.getSystemJavaCompiler().run(null, null, null, "-d", tempDir.toString(), source.toString());
         assertThat(result).isZero();
 
-        try (URLClassLoader devtoolsClassLoader = new URLClassLoader(new java.net.URL[]{tempDir.toUri().toURL()}, null)) {
+        try (URLClassLoader devtoolsClassLoader =
+                new URLClassLoader(new java.net.URL[] {tempDir.toUri().toURL()}, null)) {
             BootUiActivation activation = BootUiActivationCondition.resolve(new MockEnvironment(), devtoolsClassLoader);
 
             assertThat(activation.enabled()).isTrue();

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -1,172 +1,169 @@
 package io.github.jdubois.bootui.autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
 import io.github.jdubois.bootui.autoconfigure.safety.LocalhostOnlyFilter;
 import io.github.jdubois.bootui.autoconfigure.web.*;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 class BootUiAutoConfigurationTests {
 
-    private final WebApplicationContextRunner runner = new WebApplicationContextRunner()
-        .withConfiguration(AutoConfigurations.of(BootUiAutoConfiguration.class));
+    private final WebApplicationContextRunner runner =
+            new WebApplicationContextRunner().withConfiguration(AutoConfigurations.of(BootUiAutoConfiguration.class));
 
     @Test
     void doesNotActivateInAutoModeWithoutEnablingProfile() {
         runner.run(context -> assertThat(context)
-            .doesNotHaveBean(BootUiAutoConfiguration.class)
-            .doesNotHaveBean(LocalhostOnlyFilter.class));
+                .doesNotHaveBean(BootUiAutoConfiguration.class)
+                .doesNotHaveBean(LocalhostOnlyFilter.class));
     }
 
     @Test
     void activatesWhenEnabledOn() {
         runner.withPropertyValues("bootui.enabled=ON")
-            .run(context -> assertThat(context)
-                .hasSingleBean(BootUiAutoConfiguration.class)
-                .hasSingleBean(LocalhostOnlyFilter.class)
-                .hasSingleBean(ConfigOverrideService.class)
-                .hasSingleBean(DevToolsBridge.class)
-                .hasSingleBean(DevToolsController.class)
-                .hasSingleBean(OverviewController.class)
-                .hasSingleBean(DevServicesController.class)
-                .hasSingleBean(DependenciesController.class)
-                .hasSingleBean(BootUiActivation.class));
+                .run(context -> assertThat(context)
+                        .hasSingleBean(BootUiAutoConfiguration.class)
+                        .hasSingleBean(LocalhostOnlyFilter.class)
+                        .hasSingleBean(ConfigOverrideService.class)
+                        .hasSingleBean(DevToolsBridge.class)
+                        .hasSingleBean(DevToolsController.class)
+                        .hasSingleBean(OverviewController.class)
+                        .hasSingleBean(DevServicesController.class)
+                        .hasSingleBean(DependenciesController.class)
+                        .hasSingleBean(BootUiActivation.class));
     }
 
     @Test
     void activatesOnEnabledProfile() {
         runner.withPropertyValues("spring.profiles.active=dev")
-            .run(context -> assertThat(context).hasSingleBean(BootUiAutoConfiguration.class));
+                .run(context -> assertThat(context).hasSingleBean(BootUiAutoConfiguration.class));
     }
 
     @Test
     void disabledByProductionProfileEvenWithEnabledProfile() {
         runner.withPropertyValues("spring.profiles.active=prod,dev")
-            .run(context -> assertThat(context).doesNotHaveBean(BootUiAutoConfiguration.class));
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiAutoConfiguration.class));
     }
 
     @Test
     void enabledOnOverridesProductionProfile() {
         runner.withPropertyValues("spring.profiles.active=prod", "bootui.enabled=ON")
-            .run(context -> {
-                assertThat(context).hasSingleBean(BootUiAutoConfiguration.class);
-                BootUiActivation activation = context.getBean(BootUiActivation.class);
-                assertThat(activation.enabled()).isTrue();
-                assertThat(activation.warnings()).isNotEmpty();
-            });
+                .run(context -> {
+                    assertThat(context).hasSingleBean(BootUiAutoConfiguration.class);
+                    BootUiActivation activation = context.getBean(BootUiActivation.class);
+                    assertThat(activation.enabled()).isTrue();
+                    assertThat(activation.warnings()).isNotEmpty();
+                });
     }
 
     @Test
     void enabledOffForcesDisabledEvenWithDevProfile() {
         runner.withPropertyValues("spring.profiles.active=dev", "bootui.enabled=OFF")
-            .run(context -> assertThat(context).doesNotHaveBean(BootUiAutoConfiguration.class));
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiAutoConfiguration.class));
     }
 
     @Test
     void invalidEnabledValueFailsClosed() {
         runner.withPropertyValues("spring.profiles.active=dev", "bootui.enabled=maybe")
-            .run(context -> assertThat(context).doesNotHaveBean(BootUiAutoConfiguration.class));
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiAutoConfiguration.class));
     }
 
     @Test
     void bindsDefaultProperties() {
-        runner.withPropertyValues("bootui.enabled=ON")
-            .run(context -> {
-                BootUiProperties properties = context.getBean(BootUiProperties.class);
-                assertThat(properties.getEnabled()).isEqualTo(BootUiProperties.Mode.ON);
-                assertThat(properties.getPath()).isEqualTo("/bootui");
-                assertThat(properties.getApiPath()).isEqualTo("/bootui/api");
-                assertThat(properties.isLocalhostOnly()).isTrue();
-                assertThat(properties.isAllowNonLocalhost()).isFalse();
-                assertThat(properties.isMaskSecrets()).isTrue();
-                assertThat(properties.getExposeValues()).isEqualTo(BootUiProperties.ValueExposure.MASKED);
-                assertThat(properties.isShowBanner()).isTrue();
-                assertThat(properties.getEnabledProfiles()).containsExactly("dev", "local");
-                assertThat(properties.getDisabledProfiles()).containsExactly("prod", "production");
-                assertThat(properties.getOverridesFile()).isEqualTo(".bootui/application-bootui.properties");
-                assertThat(properties.getEndpointTimeout()).isEqualTo(Duration.ofSeconds(5));
-                assertThat(properties.getDevServices().isRestartEnabled()).isFalse();
-                assertThat(properties.getDevServices().getLogTailBytes()).isEqualTo(64 * 1024);
-                assertThat(properties.getCache().isClearEnabled()).isTrue();
-            });
+        runner.withPropertyValues("bootui.enabled=ON").run(context -> {
+            BootUiProperties properties = context.getBean(BootUiProperties.class);
+            assertThat(properties.getEnabled()).isEqualTo(BootUiProperties.Mode.ON);
+            assertThat(properties.getPath()).isEqualTo("/bootui");
+            assertThat(properties.getApiPath()).isEqualTo("/bootui/api");
+            assertThat(properties.isLocalhostOnly()).isTrue();
+            assertThat(properties.isAllowNonLocalhost()).isFalse();
+            assertThat(properties.isMaskSecrets()).isTrue();
+            assertThat(properties.getExposeValues()).isEqualTo(BootUiProperties.ValueExposure.MASKED);
+            assertThat(properties.isShowBanner()).isTrue();
+            assertThat(properties.getEnabledProfiles()).containsExactly("dev", "local");
+            assertThat(properties.getDisabledProfiles()).containsExactly("prod", "production");
+            assertThat(properties.getOverridesFile()).isEqualTo(".bootui/application-bootui.properties");
+            assertThat(properties.getEndpointTimeout()).isEqualTo(Duration.ofSeconds(5));
+            assertThat(properties.getDevServices().isRestartEnabled()).isFalse();
+            assertThat(properties.getDevServices().getLogTailBytes()).isEqualTo(64 * 1024);
+            assertThat(properties.getCache().isClearEnabled()).isTrue();
+        });
     }
 
     @Test
     void bindsCustomProperties() {
         runner.withPropertyValues(
-                "bootui.enabled=ON",
-                "bootui.path=/admin",
-                "bootui.api-path=/admin/api",
-                "bootui.mask-secrets=false",
-                "bootui.expose-values=FULL",
-                "bootui.overrides-file=/tmp/bootui.properties",
-                "bootui.endpoint-timeout=2s",
-                "bootui.dev-services.restart-enabled=true",
-                "bootui.dev-services.log-tail-bytes=2048",
-                "bootui.cache.clear-enabled=false",
-                "bootui.dependencies.osv-enabled=false",
-                "bootui.dependencies.max-packages=42",
-                "bootui.dependencies.max-advisories=24")
-            .run(context -> {
-                BootUiProperties properties = context.getBean(BootUiProperties.class);
-                assertThat(properties.getPath()).isEqualTo("/admin");
-                assertThat(properties.getApiPath()).isEqualTo("/admin/api");
-                assertThat(properties.isMaskSecrets()).isFalse();
-                assertThat(properties.getExposeValues())
-                    .isEqualTo(BootUiProperties.ValueExposure.FULL);
-                assertThat(properties.getOverridesFile()).isEqualTo("/tmp/bootui.properties");
-                assertThat(properties.getEndpointTimeout()).isEqualTo(Duration.ofSeconds(2));
-                assertThat(properties.getDevServices().isRestartEnabled()).isTrue();
-                assertThat(properties.getDevServices().getLogTailBytes()).isEqualTo(2048);
-                assertThat(properties.getCache().isClearEnabled()).isFalse();
-                assertThat(properties.getDependencies().isOsvEnabled()).isFalse();
-                assertThat(properties.getDependencies().getMaxPackages()).isEqualTo(42);
-                assertThat(properties.getDependencies().getMaxAdvisories()).isEqualTo(24);
-            });
+                        "bootui.enabled=ON",
+                        "bootui.path=/admin",
+                        "bootui.api-path=/admin/api",
+                        "bootui.mask-secrets=false",
+                        "bootui.expose-values=FULL",
+                        "bootui.overrides-file=/tmp/bootui.properties",
+                        "bootui.endpoint-timeout=2s",
+                        "bootui.dev-services.restart-enabled=true",
+                        "bootui.dev-services.log-tail-bytes=2048",
+                        "bootui.cache.clear-enabled=false",
+                        "bootui.dependencies.osv-enabled=false",
+                        "bootui.dependencies.max-packages=42",
+                        "bootui.dependencies.max-advisories=24")
+                .run(context -> {
+                    BootUiProperties properties = context.getBean(BootUiProperties.class);
+                    assertThat(properties.getPath()).isEqualTo("/admin");
+                    assertThat(properties.getApiPath()).isEqualTo("/admin/api");
+                    assertThat(properties.isMaskSecrets()).isFalse();
+                    assertThat(properties.getExposeValues()).isEqualTo(BootUiProperties.ValueExposure.FULL);
+                    assertThat(properties.getOverridesFile()).isEqualTo("/tmp/bootui.properties");
+                    assertThat(properties.getEndpointTimeout()).isEqualTo(Duration.ofSeconds(2));
+                    assertThat(properties.getDevServices().isRestartEnabled()).isTrue();
+                    assertThat(properties.getDevServices().getLogTailBytes()).isEqualTo(2048);
+                    assertThat(properties.getCache().isClearEnabled()).isFalse();
+                    assertThat(properties.getDependencies().isOsvEnabled()).isFalse();
+                    assertThat(properties.getDependencies().getMaxPackages()).isEqualTo(42);
+                    assertThat(properties.getDependencies().getMaxAdvisories()).isEqualTo(24);
+                });
     }
 
     @Test
     void optionalClasspathPanelsAreRegisteredWhenDependenciesArePresent() {
         runner.withPropertyValues("bootui.enabled=ON")
-            .run(context -> assertThat(context)
-                .hasSingleBean(CacheController.class)
-                .hasSingleBean(DataController.class)
-                .hasSingleBean(LogTailController.class)
-                .hasSingleBean(ScheduledController.class)
-                .hasSingleBean(SecurityController.class));
+                .run(context -> assertThat(context)
+                        .hasSingleBean(CacheController.class)
+                        .hasSingleBean(DataController.class)
+                        .hasSingleBean(LogTailController.class)
+                        .hasSingleBean(ScheduledController.class)
+                        .hasSingleBean(SecurityController.class));
     }
 
     @Test
     void skipsSpringDataPanelWhenSpringDataRepositoryMetadataIsMissing() {
         runner.withPropertyValues("bootui.enabled=ON")
-            .withClassLoader(new FilteredClassLoader("org.springframework.data.repository.core.support"))
-            .run(context -> assertThat(context).doesNotHaveBean(DataController.class));
+                .withClassLoader(new FilteredClassLoader("org.springframework.data.repository.core.support"))
+                .run(context -> assertThat(context).doesNotHaveBean(DataController.class));
     }
 
     @Test
     void skipsLogTailPanelWhenLogbackIsMissing() {
         runner.withPropertyValues("bootui.enabled=ON")
-            .withClassLoader(new FilteredClassLoader("ch.qos.logback.classic"))
-            .run(context -> assertThat(context).doesNotHaveBean(LogTailController.class));
+                .withClassLoader(new FilteredClassLoader("ch.qos.logback.classic"))
+                .run(context -> assertThat(context).doesNotHaveBean(LogTailController.class));
     }
 
     @Test
     void skipsScheduledPanelWhenSchedulingInfrastructureIsMissing() {
         runner.withPropertyValues("bootui.enabled=ON")
-            .withClassLoader(new FilteredClassLoader("org.springframework.scheduling.config.ScheduledTaskHolder"))
-            .run(context -> assertThat(context).doesNotHaveBean(ScheduledController.class));
+                .withClassLoader(new FilteredClassLoader("org.springframework.scheduling.config.ScheduledTaskHolder"))
+                .run(context -> assertThat(context).doesNotHaveBean(ScheduledController.class));
     }
 
     @Test
     void skipsSecurityPanelWhenSpringSecurityWebIsMissing() {
         runner.withPropertyValues("bootui.enabled=ON")
-            .withClassLoader(new FilteredClassLoader("org.springframework.security.web.FilterChainProxy"))
-            .run(context -> assertThat(context).doesNotHaveBean(SecurityController.class));
+                .withClassLoader(new FilteredClassLoader("org.springframework.security.web.FilterChainProxy"))
+                .run(context -> assertThat(context).doesNotHaveBean(SecurityController.class));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiPropertiesTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiPropertiesTests.java
@@ -1,13 +1,12 @@
 package io.github.jdubois.bootui.autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.bind.BindResult;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.mock.env.MockEnvironment;
-
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Verifies {@link BootUiProperties} default values and binding from environment

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
@@ -1,34 +1,33 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
 import org.springframework.mock.env.MockEnvironment;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
 
     private final BootUiActuatorDefaultsEnvironmentPostProcessor processor =
-        new BootUiActuatorDefaultsEnvironmentPostProcessor();
+            new BootUiActuatorDefaultsEnvironmentPostProcessor();
 
     @Test
     void contributesActuatorDefaultsWhenBootUiIsEnabled() {
-        MockEnvironment env = new MockEnvironment()
-            .withProperty("bootui.enabled", "ON");
+        MockEnvironment env = new MockEnvironment().withProperty("bootui.enabled", "ON");
 
         processor.postProcessEnvironment(env, new SpringApplication());
 
         assertThat(env.getProperty("management.endpoints.web.exposure.include"))
-            .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.REQUIRED_ENDPOINTS);
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.REQUIRED_ENDPOINTS);
         assertThat(env.getProperty("management.endpoint.health.show-details")).isEqualTo("always");
     }
 
     @Test
     void keepsUserConfiguredActuatorExposure() {
         MockEnvironment env = new MockEnvironment()
-            .withProperty("bootui.enabled", "ON")
-            .withProperty("management.endpoints.web.exposure.include", "health,info")
-            .withProperty("management.endpoint.health.show-details", "never");
+                .withProperty("bootui.enabled", "ON")
+                .withProperty("management.endpoints.web.exposure.include", "health,info")
+                .withProperty("management.endpoint.health.show-details", "never");
 
         processor.postProcessEnvironment(env, new SpringApplication());
 
@@ -43,13 +42,14 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         processor.postProcessEnvironment(env, new SpringApplication());
 
         assertThat(env.getPropertySources()
-            .contains(BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME)).isFalse();
+                        .contains(BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME))
+                .isFalse();
     }
 
     @Test
     void orderIsBetweenOverridesAndStartupProcessors() {
         assertThat(processor.getOrder())
-            .isGreaterThan(BootUiOverridesEnvironmentPostProcessor.ORDER)
-            .isLessThan(BootUiStartupEnvironmentPostProcessor.ORDER);
+                .isGreaterThan(BootUiOverridesEnvironmentPostProcessor.ORDER)
+                .isLessThan(BootUiStartupEnvironmentPostProcessor.ORDER);
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesEnvironmentPostProcessorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesEnvironmentPostProcessorTests.java
@@ -1,20 +1,18 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.SpringApplication;
 import org.springframework.core.env.StandardEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 class BootUiOverridesEnvironmentPostProcessorTests {
 
-    private final BootUiOverridesEnvironmentPostProcessor processor =
-        new BootUiOverridesEnvironmentPostProcessor();
+    private final BootUiOverridesEnvironmentPostProcessor processor = new BootUiOverridesEnvironmentPostProcessor();
 
     @Test
     void registersHighestPrecedencePropertySource(@TempDir Path tmp) throws Exception {
@@ -27,10 +25,10 @@ class BootUiOverridesEnvironmentPostProcessorTests {
 
         processor.postProcessEnvironment(env, new SpringApplication());
 
-        assertThat(env.getPropertySources().contains(BootUiOverridesPropertySource.NAME)).isTrue();
+        assertThat(env.getPropertySources().contains(BootUiOverridesPropertySource.NAME))
+                .isTrue();
         assertThat(env.getProperty("server.port")).isEqualTo("9090");
-        assertThat(env.getPropertySources().iterator().next().getName())
-            .isEqualTo(BootUiOverridesPropertySource.NAME);
+        assertThat(env.getPropertySources().iterator().next().getName()).isEqualTo(BootUiOverridesPropertySource.NAME);
     }
 
     @Test
@@ -48,8 +46,8 @@ class BootUiOverridesEnvironmentPostProcessorTests {
 
         assertThat(env.getProperty("k")).isEqualTo("second");
         long count = env.getPropertySources().stream()
-            .filter(s -> BootUiOverridesPropertySource.NAME.equals(s.getName()))
-            .count();
+                .filter(s -> BootUiOverridesPropertySource.NAME.equals(s.getName()))
+                .count();
         assertThat(count).isEqualTo(1);
     }
 
@@ -61,8 +59,8 @@ class BootUiOverridesEnvironmentPostProcessorTests {
 
         processor.postProcessEnvironment(env, new SpringApplication());
 
-        BootUiOverridesPropertySource src = (BootUiOverridesPropertySource)
-            env.getPropertySources().get(BootUiOverridesPropertySource.NAME);
+        BootUiOverridesPropertySource src =
+                (BootUiOverridesPropertySource) env.getPropertySources().get(BootUiOverridesPropertySource.NAME);
         assertThat(src).isNotNull();
         assertThat(src.mutableSource()).isEmpty();
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesPropertySourceTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesPropertySourceTests.java
@@ -1,18 +1,16 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class BootUiOverridesPropertySourceTests {
 
     @Test
     void hasStableName() {
-        assertThat(new BootUiOverridesPropertySource().getName())
-            .isEqualTo(BootUiOverridesPropertySource.NAME);
+        assertThat(new BootUiOverridesPropertySource().getName()).isEqualTo(BootUiOverridesPropertySource.NAME);
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/ConfigOverrideServiceTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/ConfigOverrideServiceTests.java
@@ -1,19 +1,18 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
 import io.github.jdubois.bootui.core.BootUiDtos.ConfigOverrideResult;
 import io.github.jdubois.bootui.core.SecretMasker;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.mock.env.MockEnvironment;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConfigOverrideServiceTests {
 
@@ -97,10 +96,8 @@ class ConfigOverrideServiceTests {
 
     @Test
     void putBlankNameThrows() {
-        assertThatThrownBy(() -> service.put("  ", "x"))
-            .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> service.put(null, "x"))
-            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> service.put("  ", "x")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> service.put(null, "x")).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -137,7 +134,6 @@ class ConfigOverrideServiceTests {
         properties.setOverridesFile("   ");
         ConfigOverrideService fallback = new ConfigOverrideService(new MockEnvironment(), properties);
 
-        assertThat(fallback.overridesFile().toString())
-            .endsWith("application-bootui.properties");
+        assertThat(fallback.overridesFile().toString()).endsWith("application-bootui.properties");
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/ConfigOverridesFileStoreTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/ConfigOverridesFileStoreTests.java
@@ -1,15 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class ConfigOverridesFileStoreTests {
 
@@ -32,9 +31,7 @@ class ConfigOverridesFileStoreTests {
 
         assertThat(Files.exists(file)).isTrue();
         Map<String, Object> reloaded = new ConfigOverridesFileStore(file).load();
-        assertThat(reloaded)
-            .containsEntry("server.port", "9090")
-            .containsEntry("sample.greeting", "Bonjour");
+        assertThat(reloaded).containsEntry("server.port", "9090").containsEntry("sample.greeting", "Bonjour");
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryLimitsTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryLimitsTests.java
@@ -1,5 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.otlp;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.protobuf.ByteString;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
@@ -9,49 +11,48 @@ import io.opentelemetry.proto.resource.v1.Resource;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Span;
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 class TelemetryLimitsTests {
 
     private static NormalizedSpan span(String traceId, String spanId) {
         return new NormalizedSpan(
-            traceId,
-            spanId,
-            null,
-            "GET /sample",
-            "SERVER",
-            "sample",
-            "test",
-            1L,
-            2L,
-            "OK",
-            null,
-            Map.of(),
-            List.of());
+                traceId,
+                spanId,
+                null,
+                "GET /sample",
+                "SERVER",
+                "sample",
+                "test",
+                1L,
+                2L,
+                "OK",
+                null,
+                Map.of(),
+                List.of());
     }
 
     private static ExportTraceServiceRequest requestWithAttribute(String value) {
         Span span = Span.newBuilder()
-            .setTraceId(ByteString.copyFrom(hexToBytes("0123456789abcdef0123456789abcdef")))
-            .setSpanId(ByteString.copyFrom(hexToBytes("1111111111111111")))
-            .setName("large span")
-            .setStartTimeUnixNano(1L)
-            .setEndTimeUnixNano(2L)
-            .addAttributes(KeyValue.newBuilder()
-                .setKey("large")
-                .setValue(AnyValue.newBuilder().setStringValue(value).build())
-                .build())
-            .build();
+                .setTraceId(ByteString.copyFrom(hexToBytes("0123456789abcdef0123456789abcdef")))
+                .setSpanId(ByteString.copyFrom(hexToBytes("1111111111111111")))
+                .setName("large span")
+                .setStartTimeUnixNano(1L)
+                .setEndTimeUnixNano(2L)
+                .addAttributes(KeyValue.newBuilder()
+                        .setKey("large")
+                        .setValue(AnyValue.newBuilder().setStringValue(value).build())
+                        .build())
+                .build();
         ResourceSpans resourceSpans = ResourceSpans.newBuilder()
-            .setResource(Resource.newBuilder().build())
-            .addScopeSpans(ScopeSpans.newBuilder().addSpans(span).build())
-            .build();
-        return ExportTraceServiceRequest.newBuilder().addResourceSpans(resourceSpans).build();
+                .setResource(Resource.newBuilder().build())
+                .addScopeSpans(ScopeSpans.newBuilder().addSpans(span).build())
+                .build();
+        return ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(resourceSpans)
+                .build();
     }
 
     private static byte[] hexToBytes(String hex) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilterTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilterTests.java
@@ -1,5 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.safety;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import jakarta.servlet.FilterChain;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,8 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class LocalhostOnlyFilterTests {
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/AdditionalMissingActuatorEndpointsTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/AdditionalMissingActuatorEndpointsTests.java
@@ -1,14 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.test.web.servlet.MockMvc;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.test.web.servlet.MockMvc;
 
 /**
  * Extends missing-actuator/framework endpoint coverage beyond what
@@ -86,11 +86,11 @@ class AdditionalMissingActuatorEndpointsTests {
         MockMvc mvc = standaloneSetup(new DataController(emptyProvider())).build();
 
         mvc.perform(get("/bootui/api/data/repositories"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.springDataPresent").value(true))
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.repositories").isArray())
-            .andExpect(jsonPath("$.repositories").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.springDataPresent").value(true))
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.repositories").isArray())
+                .andExpect(jsonPath("$.repositories").isEmpty());
     }
 
     /**
@@ -101,7 +101,6 @@ class AdditionalMissingActuatorEndpointsTests {
     void dataControllerReturnsNotFoundForSpecificRepositoryWhenBeanFactoryMissing() throws Exception {
         MockMvc mvc = standaloneSetup(new DataController(emptyProvider())).build();
 
-        mvc.perform(get("/bootui/api/data/repositories/MyRepository"))
-            .andExpect(status().isNotFound());
+        mvc.perform(get("/bootui/api/data/repositories/MyRepository")).andExpect(status().isNotFound());
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/BeansControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/BeansControllerTests.java
@@ -1,5 +1,12 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
 import org.springframework.beans.factory.ObjectProvider;
@@ -9,14 +16,6 @@ import org.springframework.boot.actuate.beans.BeansEndpoint.BeansDescriptor;
 import org.springframework.boot.actuate.beans.BeansEndpoint.ContextBeansDescriptor;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Map;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Controller-level tests for {@link BeansController}.
@@ -52,10 +51,10 @@ class BeansControllerTests {
         MockMvc mvc = standaloneSetup(new BeansController(emptyProvider())).build();
 
         mvc.perform(get("/bootui/api/beans").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.beans").isArray())
-            .andExpect(jsonPath("$.beans").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.beans").isArray())
+                .andExpect(jsonPath("$.beans").isEmpty());
     }
 
     @Test
@@ -70,8 +69,8 @@ class BeansControllerTests {
         BeanDescriptor bd2 = inlineMock(BeanDescriptor.class);
         doReturn(java.util.ArrayList.class).when(bd2).getType();
         when(bd2.getScope()).thenReturn("prototype");
-        when(bd2.getDependencies()).thenReturn(new String[]{"dep1"});
-        when(bd2.getAliases()).thenReturn(new String[]{"listAlias"});
+        when(bd2.getDependencies()).thenReturn(new String[] {"dep1"});
+        when(bd2.getAliases()).thenReturn(new String[] {"listAlias"});
 
         ContextBeansDescriptor ctx = inlineMock(ContextBeansDescriptor.class);
         when(ctx.getBeans()).thenReturn(Map.of("alphaBean", bd1, "betaBean", bd2));
@@ -85,22 +84,24 @@ class BeansControllerTests {
         MockMvc mvc = standaloneSetup(new BeansController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/beans").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.total").value(2))
-            // results are sorted by name, so alphaBean comes before betaBean
-            .andExpect(jsonPath("$.beans[0].name").value("alphaBean"))
-            .andExpect(jsonPath("$.beans[0].type").value(String.class.getName()))
-            .andExpect(jsonPath("$.beans[0].scope").value("singleton"))
-            .andExpect(jsonPath("$.beans[0].classification").value("PLATFORM"))
-            .andExpect(jsonPath("$.beans[1].name").value("betaBean"))
-            .andExpect(jsonPath("$.beans[1].dependencies[0]").value("dep1"))
-            .andExpect(jsonPath("$.beans[1].aliases[0]").value("listAlias"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(2))
+                // results are sorted by name, so alphaBean comes before betaBean
+                .andExpect(jsonPath("$.beans[0].name").value("alphaBean"))
+                .andExpect(jsonPath("$.beans[0].type").value(String.class.getName()))
+                .andExpect(jsonPath("$.beans[0].scope").value("singleton"))
+                .andExpect(jsonPath("$.beans[0].classification").value("PLATFORM"))
+                .andExpect(jsonPath("$.beans[1].name").value("betaBean"))
+                .andExpect(jsonPath("$.beans[1].dependencies[0]").value("dep1"))
+                .andExpect(jsonPath("$.beans[1].aliases[0]").value("listAlias"));
     }
 
     @Test
     void beansClassifiesTypesCorrectly() throws Exception {
         BeanDescriptor frameworkBean = inlineMock(BeanDescriptor.class);
-        doReturn(org.springframework.context.ApplicationContext.class).when(frameworkBean).getType();
+        doReturn(org.springframework.context.ApplicationContext.class)
+                .when(frameworkBean)
+                .getType();
         when(frameworkBean.getDependencies()).thenReturn(new String[0]);
         when(frameworkBean.getAliases()).thenReturn(new String[0]);
 
@@ -115,10 +116,11 @@ class BeansControllerTests {
         when(platformBean.getAliases()).thenReturn(new String[0]);
 
         ContextBeansDescriptor ctx = inlineMock(ContextBeansDescriptor.class);
-        when(ctx.getBeans()).thenReturn(Map.of(
-            "aFrameworkBean", frameworkBean,
-            "bPlatformBean", platformBean,
-            "zNullBean", nullTypeBean));
+        when(ctx.getBeans())
+                .thenReturn(Map.of(
+                        "aFrameworkBean", frameworkBean,
+                        "bPlatformBean", platformBean,
+                        "zNullBean", nullTypeBean));
 
         BeansDescriptor descriptor = inlineMock(BeansDescriptor.class);
         when(descriptor.getContexts()).thenReturn(Map.of("root", ctx));
@@ -129,13 +131,13 @@ class BeansControllerTests {
         MockMvc mvc = standaloneSetup(new BeansController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/beans").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.beans[0].name").value("aFrameworkBean"))
-            .andExpect(jsonPath("$.beans[0].classification").value("FRAMEWORK"))
-            .andExpect(jsonPath("$.beans[1].name").value("bPlatformBean"))
-            .andExpect(jsonPath("$.beans[1].classification").value("PLATFORM"))
-            .andExpect(jsonPath("$.beans[2].name").value("zNullBean"))
-            .andExpect(jsonPath("$.beans[2].classification").value("OTHER"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.beans[0].name").value("aFrameworkBean"))
+                .andExpect(jsonPath("$.beans[0].classification").value("FRAMEWORK"))
+                .andExpect(jsonPath("$.beans[1].name").value("bPlatformBean"))
+                .andExpect(jsonPath("$.beans[1].classification").value("PLATFORM"))
+                .andExpect(jsonPath("$.beans[2].name").value("zNullBean"))
+                .andExpect(jsonPath("$.beans[2].classification").value("OTHER"));
     }
 
     @Test
@@ -162,8 +164,8 @@ class BeansControllerTests {
         MockMvc mvc = standaloneSetup(new BeansController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/beans").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.beans[0].name").value("apple"))
-            .andExpect(jsonPath("$.beans[1].name").value("zebra"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.beans[0].name").value("apple"))
+                .andExpect(jsonPath("$.beans[1].name").value("zebra"));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/BootUiIndexControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/BootUiIndexControllerTests.java
@@ -1,13 +1,13 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Tests for {@link BootUiIndexController}.
@@ -24,17 +24,15 @@ class BootUiIndexControllerTests {
 
     private static MockMvc buildMvc(BootUiProperties properties) {
         return standaloneSetup(new BootUiIndexController(properties))
-            .setViewResolvers(new InternalResourceViewResolver())
-            .build();
+                .setViewResolvers(new InternalResourceViewResolver())
+                .build();
     }
 
     @Test
     void rootPathRedirectsToTrailingSlash() throws Exception {
         MockMvc mvc = buildMvc(new BootUiProperties());
 
-        mvc.perform(get("/bootui"))
-            .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl("/bootui/"));
+        mvc.perform(get("/bootui")).andExpect(status().is3xxRedirection()).andExpect(redirectedUrl("/bootui/"));
     }
 
     // ── /bootui/ → forward ────────────────────────────────────────────────────
@@ -45,9 +43,7 @@ class BootUiIndexControllerTests {
         properties.setPath("/devtools");
         MockMvc mvc = buildMvc(properties);
 
-        mvc.perform(get("/bootui"))
-            .andExpect(status().is3xxRedirection())
-            .andExpect(redirectedUrl("/devtools/"));
+        mvc.perform(get("/bootui")).andExpect(status().is3xxRedirection()).andExpect(redirectedUrl("/devtools/"));
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
@@ -56,8 +52,6 @@ class BootUiIndexControllerTests {
     void indexPathForwardsToIndexHtml() throws Exception {
         MockMvc mvc = buildMvc(new BootUiProperties());
 
-        mvc.perform(get("/bootui/"))
-            .andExpect(status().isOk())
-            .andExpect(forwardedUrl("/bootui/index.html"));
+        mvc.perform(get("/bootui/")).andExpect(status().isOk()).andExpect(forwardedUrl("/bootui/index.html"));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/CacheControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/CacheControllerTests.java
@@ -1,8 +1,18 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
@@ -16,35 +26,25 @@ import org.springframework.cache.interceptor.CacheOperationSource;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
-
 class CacheControllerTests {
 
     @SuppressWarnings("unchecked")
-    private static CacheController controller(ListableBeanFactory factory,
-                                              CacheOperationSource operationSource,
-                                              MeterRegistry meterRegistry,
-                                              BootUiProperties properties) {
+    private static CacheController controller(
+            ListableBeanFactory factory,
+            CacheOperationSource operationSource,
+            MeterRegistry meterRegistry,
+            BootUiProperties properties) {
         ObjectProvider<ListableBeanFactory> factoryProvider = mock(ObjectProvider.class);
         when(factoryProvider.getIfAvailable()).thenReturn(factory);
 
         ObjectProvider<CacheOperationSource> operationSourceProvider = mock(ObjectProvider.class);
-        when(operationSourceProvider.orderedStream()).thenReturn(
-            operationSource == null ? Stream.empty() : Stream.of(operationSource));
+        when(operationSourceProvider.orderedStream())
+                .thenReturn(operationSource == null ? Stream.empty() : Stream.of(operationSource));
 
         ObjectProvider<MeterRegistry> meterRegistryProvider = mock(ObjectProvider.class);
         when(meterRegistryProvider.getIfUnique()).thenReturn(meterRegistry);
-        when(meterRegistryProvider.orderedStream()).thenReturn(
-            meterRegistry == null ? Stream.empty() : Stream.of(meterRegistry));
+        when(meterRegistryProvider.orderedStream())
+                .thenReturn(meterRegistry == null ? Stream.empty() : Stream.of(meterRegistry));
 
         return new CacheController(factoryProvider, operationSourceProvider, meterRegistryProvider, properties);
     }
@@ -64,16 +64,16 @@ class CacheControllerTests {
     @Test
     void cacheReportIsStableWhenNoCacheManagersArePresent() throws Exception {
         MockMvc mvc = standaloneSetup(controller(new StaticListableBeanFactory(), null, null, new BootUiProperties()))
-            .build();
+                .build();
 
         mvc.perform(get("/bootui/api/cache"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.cacheAvailable").value(false))
-            .andExpect(jsonPath("$.clearEnabled").value(true))
-            .andExpect(jsonPath("$.managerCount").value(0))
-            .andExpect(jsonPath("$.cacheCount").value(0))
-            .andExpect(jsonPath("$.managers").isEmpty())
-            .andExpect(jsonPath("$.operations").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cacheAvailable").value(false))
+                .andExpect(jsonPath("$.clearEnabled").value(true))
+                .andExpect(jsonPath("$.managerCount").value(0))
+                .andExpect(jsonPath("$.cacheCount").value(0))
+                .andExpect(jsonPath("$.managers").isEmpty())
+                .andExpect(jsonPath("$.operations").isEmpty());
     }
 
     @Test
@@ -87,28 +87,35 @@ class CacheControllerTests {
 
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         registry.counter("cache.gets", "cache", "sample-products", "name", "cacheManager", "result", "hit")
-            .increment(3);
+                .increment(3);
         registry.counter("cache.gets", "cache", "sample-products", "name", "cacheManager", "result", "miss")
-            .increment(1);
+                .increment(1);
         registry.counter("cache.puts", "cache", "sample-products", "name", "cacheManager")
-            .increment(2);
+                .increment(2);
 
-        MockMvc mvc = standaloneSetup(controller(factory, new AnnotationCacheOperationSource(), registry,
-            new BootUiProperties())).build();
+        MockMvc mvc = standaloneSetup(
+                        controller(factory, new AnnotationCacheOperationSource(), registry, new BootUiProperties()))
+                .build();
 
         mvc.perform(get("/bootui/api/cache"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.cacheAvailable").value(true))
-            .andExpect(jsonPath("$.managerCount").value(1))
-            .andExpect(jsonPath("$.cacheCount").value(2))
-            .andExpect(jsonPath("$.managers[0].name").value("cacheManager"))
-            .andExpect(jsonPath("$.managers[0].caches[?(@.name=='sample-products')].size").value(1))
-            .andExpect(jsonPath("$.managers[0].caches[?(@.name=='sample-products')].metrics.hits").value(3.0))
-            .andExpect(jsonPath("$.managers[0].caches[?(@.name=='sample-products')].metrics.misses").value(1.0))
-            .andExpect(jsonPath("$.managers[0].caches[?(@.name=='sample-products')].metrics.hitRatio").value(0.75))
-            .andExpect(jsonPath("$.operationCount").value(2))
-            .andExpect(jsonPath("$.operations[?(@.operation=='@Cacheable')]").exists())
-            .andExpect(jsonPath("$.operations[?(@.operation=='@CacheEvict')]").exists());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cacheAvailable").value(true))
+                .andExpect(jsonPath("$.managerCount").value(1))
+                .andExpect(jsonPath("$.cacheCount").value(2))
+                .andExpect(jsonPath("$.managers[0].name").value("cacheManager"))
+                .andExpect(jsonPath("$.managers[0].caches[?(@.name=='sample-products')].size")
+                        .value(1))
+                .andExpect(jsonPath("$.managers[0].caches[?(@.name=='sample-products')].metrics.hits")
+                        .value(3.0))
+                .andExpect(jsonPath("$.managers[0].caches[?(@.name=='sample-products')].metrics.misses")
+                        .value(1.0))
+                .andExpect(jsonPath("$.managers[0].caches[?(@.name=='sample-products')].metrics.hitRatio")
+                        .value(0.75))
+                .andExpect(jsonPath("$.operationCount").value(2))
+                .andExpect(
+                        jsonPath("$.operations[?(@.operation=='@Cacheable')]").exists())
+                .andExpect(
+                        jsonPath("$.operations[?(@.operation=='@CacheEvict')]").exists());
     }
 
     @Test
@@ -119,15 +126,16 @@ class CacheControllerTests {
 
         StaticListableBeanFactory factory = new StaticListableBeanFactory();
         factory.addBean("cacheManager", manager);
-        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearDisabledProperties())).build();
+        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearDisabledProperties()))
+                .build();
 
         mvc.perform(post("/bootui/api/cache/clear")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
                     {"managerName":"cacheManager","cacheName":"sample-products","confirm":true}
                     """))
-            .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.status").value("disabled"));
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value("disabled"));
         assertThat(cache.get("library")).isNotNull();
     }
 
@@ -139,15 +147,16 @@ class CacheControllerTests {
 
         StaticListableBeanFactory factory = new StaticListableBeanFactory();
         factory.addBean("cacheManager", manager);
-        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearEnabledProperties())).build();
+        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearEnabledProperties()))
+                .build();
 
         mvc.perform(post("/bootui/api/cache/clear")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
                     {"managerName":"cacheManager","cacheName":"sample-products"}
                     """))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.status").value("confirmation_required"));
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("confirmation_required"));
         assertThat(cache.get("library")).isNotNull();
     }
 
@@ -159,17 +168,18 @@ class CacheControllerTests {
 
         StaticListableBeanFactory factory = new StaticListableBeanFactory();
         factory.addBean("cacheManager", manager);
-        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearEnabledProperties())).build();
+        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearEnabledProperties()))
+                .build();
 
         mvc.perform(post("/bootui/api/cache/clear")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
                     {"managerName":"cacheManager","cacheName":"sample-products","confirm":true}
                     """))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value("cleared"))
-            .andExpect(jsonPath("$.clearedCaches").value(1))
-            .andExpect(jsonPath("$.caches[0]").value("cacheManager/sample-products"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("cleared"))
+                .andExpect(jsonPath("$.clearedCaches").value(1))
+                .andExpect(jsonPath("$.caches[0]").value("cacheManager/sample-products"));
         assertThat(cache.get("library")).isNull();
     }
 
@@ -183,16 +193,17 @@ class CacheControllerTests {
         StaticListableBeanFactory factory = new StaticListableBeanFactory();
         factory.addBean("primaryCacheManager", primary);
         factory.addBean("secondaryCacheManager", secondary);
-        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearEnabledProperties())).build();
+        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearEnabledProperties()))
+                .build();
 
         mvc.perform(post("/bootui/api/cache/clear")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
                     {"all":true,"confirm":true}
                     """))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value("cleared"))
-            .andExpect(jsonPath("$.clearedCaches").value(2));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("cleared"))
+                .andExpect(jsonPath("$.clearedCaches").value(2));
         assertThat(primary.getCache("sample-products").get("library")).isNull();
         assertThat(secondary.getCache("sample-greetings").get("hello")).isNull();
     }
@@ -202,15 +213,16 @@ class CacheControllerTests {
         ConcurrentMapCacheManager manager = new ConcurrentMapCacheManager("sample-products");
         StaticListableBeanFactory factory = new StaticListableBeanFactory();
         factory.addBean("cacheManager", manager);
-        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearEnabledProperties())).build();
+        MockMvc mvc = standaloneSetup(controller(factory, null, null, clearEnabledProperties()))
+                .build();
 
         mvc.perform(post("/bootui/api/cache/clear")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
                     {"managerName":"cacheManager","cacheName":"missing","confirm":true}
                     """))
-            .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.status").value("not_found"));
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value("not_found"));
     }
 
     public static class CachedService {
@@ -221,7 +233,6 @@ class CacheControllerTests {
         }
 
         @CacheEvict(cacheNames = "sample-products", allEntries = true, beforeInvocation = true)
-        public void resetProducts() {
-        }
+        public void resetProducts() {}
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConditionsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConditionsControllerTests.java
@@ -1,5 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
 import org.springframework.beans.factory.ObjectProvider;
@@ -10,16 +19,6 @@ import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReport
 import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint.MessageAndConditionsDescriptor;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Controller-level tests for {@link ConditionsController}.
@@ -56,15 +55,15 @@ class ConditionsControllerTests {
         MockMvc mvc = standaloneSetup(new ConditionsController(emptyProvider())).build();
 
         mvc.perform(get("/bootui/api/conditions").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.positiveMatches").isArray())
-            .andExpect(jsonPath("$.positiveMatches").isEmpty())
-            .andExpect(jsonPath("$.negativeMatches").isArray())
-            .andExpect(jsonPath("$.negativeMatches").isEmpty())
-            .andExpect(jsonPath("$.unconditionalClasses").isArray())
-            .andExpect(jsonPath("$.unconditionalClasses").isEmpty())
-            .andExpect(jsonPath("$.exclusions").isArray())
-            .andExpect(jsonPath("$.exclusions").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.positiveMatches").isArray())
+                .andExpect(jsonPath("$.positiveMatches").isEmpty())
+                .andExpect(jsonPath("$.negativeMatches").isArray())
+                .andExpect(jsonPath("$.negativeMatches").isEmpty())
+                .andExpect(jsonPath("$.unconditionalClasses").isArray())
+                .andExpect(jsonPath("$.unconditionalClasses").isEmpty())
+                .andExpect(jsonPath("$.exclusions").isArray())
+                .andExpect(jsonPath("$.exclusions").isEmpty());
     }
 
     @Test
@@ -74,8 +73,7 @@ class ConditionsControllerTests {
         when(matchDesc.getMessage()).thenReturn("@ConditionalOnClass found required class 'javax.servlet.Servlet'");
 
         ContextConditionsDescriptor ccd = inlineMock(ContextConditionsDescriptor.class);
-        when(ccd.getPositiveMatches()).thenReturn(
-            Map.of("org.example.WebConfig", List.of(matchDesc)));
+        when(ccd.getPositiveMatches()).thenReturn(Map.of("org.example.WebConfig", List.of(matchDesc)));
         when(ccd.getNegativeMatches()).thenReturn(Map.of());
         when(ccd.getUnconditionalClasses()).thenReturn(Set.of());
         when(ccd.getExclusions()).thenReturn(List.of());
@@ -86,14 +84,16 @@ class ConditionsControllerTests {
         ConditionsReportEndpoint endpoint = mock(ConditionsReportEndpoint.class);
         when(endpoint.conditions()).thenReturn(descriptor);
 
-        MockMvc mvc = standaloneSetup(new ConditionsController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new ConditionsController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/conditions").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.positiveMatches[0].autoConfigurationClass").value("org.example.WebConfig"))
-            .andExpect(jsonPath("$.positiveMatches[0].condition").value("OnClassCondition"))
-            .andExpect(jsonPath("$.positiveMatches[0].outcome").value("MATCH"))
-            .andExpect(jsonPath("$.negativeMatches").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.positiveMatches[0].autoConfigurationClass").value("org.example.WebConfig"))
+                .andExpect(jsonPath("$.positiveMatches[0].condition").value("OnClassCondition"))
+                .andExpect(jsonPath("$.positiveMatches[0].outcome").value("MATCH"))
+                .andExpect(jsonPath("$.negativeMatches").isEmpty());
     }
 
     @Test
@@ -122,18 +122,21 @@ class ConditionsControllerTests {
         ConditionsReportEndpoint endpoint = mock(ConditionsReportEndpoint.class);
         when(endpoint.conditions()).thenReturn(descriptor);
 
-        MockMvc mvc = standaloneSetup(new ConditionsController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new ConditionsController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/conditions").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            // noMatchDesc → negativeMatches with outcome NO_MATCH
-            .andExpect(jsonPath("$.negativeMatches[0].autoConfigurationClass").value("org.example.JpaConfig"))
-            .andExpect(jsonPath("$.negativeMatches[0].condition").value("OnBeanCondition"))
-            .andExpect(jsonPath("$.negativeMatches[0].outcome").value("NO_MATCH"))
-            // partialDesc → positiveMatches with outcome PARTIAL
-            .andExpect(jsonPath("$.positiveMatches[0].autoConfigurationClass").value("org.example.JpaConfig"))
-            .andExpect(jsonPath("$.positiveMatches[0].condition").value("OnPropertyCondition"))
-            .andExpect(jsonPath("$.positiveMatches[0].outcome").value("PARTIAL"));
+                .andExpect(status().isOk())
+                // noMatchDesc → negativeMatches with outcome NO_MATCH
+                .andExpect(
+                        jsonPath("$.negativeMatches[0].autoConfigurationClass").value("org.example.JpaConfig"))
+                .andExpect(jsonPath("$.negativeMatches[0].condition").value("OnBeanCondition"))
+                .andExpect(jsonPath("$.negativeMatches[0].outcome").value("NO_MATCH"))
+                // partialDesc → positiveMatches with outcome PARTIAL
+                .andExpect(
+                        jsonPath("$.positiveMatches[0].autoConfigurationClass").value("org.example.JpaConfig"))
+                .andExpect(jsonPath("$.positiveMatches[0].condition").value("OnPropertyCondition"))
+                .andExpect(jsonPath("$.positiveMatches[0].outcome").value("PARTIAL"));
     }
 
     @Test
@@ -150,11 +153,12 @@ class ConditionsControllerTests {
         ConditionsReportEndpoint endpoint = mock(ConditionsReportEndpoint.class);
         when(endpoint.conditions()).thenReturn(descriptor);
 
-        MockMvc mvc = standaloneSetup(new ConditionsController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new ConditionsController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/conditions").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.unconditionalClasses[0]").value("org.example.UnconditionalConfig"))
-            .andExpect(jsonPath("$.exclusions[0]").value("org.example.ExcludedAutoConfig"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.unconditionalClasses[0]").value("org.example.UnconditionalConfig"))
+                .andExpect(jsonPath("$.exclusions[0]").value("org.example.ExcludedAutoConfig"));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigControllerHttpCrudTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigControllerHttpCrudTests.java
@@ -1,21 +1,20 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.http.MediaType;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.nio.file.Path;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * HTTP-level CRUD tests for {@link ConfigController} override endpoints.
@@ -50,20 +49,23 @@ class ConfigControllerHttpCrudTests {
      */
     private MockMvc buildMvc() {
         ConfigController controller = new ConfigController(
-            environment, overrideService, properties,
-            new ConfigMetadataCatalog(getClass().getClassLoader()));
+                environment,
+                overrideService,
+                properties,
+                new ConfigMetadataCatalog(getClass().getClassLoader()));
         return standaloneSetup(controller).build();
     }
 
     @Test
     void postCreatesNewOverrideAndReturnsCorrectDto() throws Exception {
-        buildMvc().perform(post("/bootui/api/config/overrides")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"app.name\",\"value\":\"overridden-app\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("app.name"))
-            .andExpect(jsonPath("$.value").value("overridden-app"))
-            .andExpect(jsonPath("$.persisted").value(true));
+        buildMvc()
+                .perform(post("/bootui/api/config/overrides")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"app.name\",\"value\":\"overridden-app\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("app.name"))
+                .andExpect(jsonPath("$.value").value("overridden-app"))
+                .andExpect(jsonPath("$.persisted").value(true));
     }
 
     @Test
@@ -72,19 +74,19 @@ class ConfigControllerHttpCrudTests {
 
         // First write
         mvc.perform(post("/bootui/api/config/overrides")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"server.port\",\"value\":\"9090\"}"))
-            .andExpect(status().isOk());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"server.port\",\"value\":\"9090\"}"))
+                .andExpect(status().isOk());
 
         // Second write with a different value must report the previous one
         mvc.perform(post("/bootui/api/config/overrides")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"server.port\",\"value\":\"9191\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("server.port"))
-            .andExpect(jsonPath("$.value").value("9191"))
-            .andExpect(jsonPath("$.previousValue").value("9090"))
-            .andExpect(jsonPath("$.persisted").value(true));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"server.port\",\"value\":\"9191\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("server.port"))
+                .andExpect(jsonPath("$.value").value("9191"))
+                .andExpect(jsonPath("$.previousValue").value("9090"))
+                .andExpect(jsonPath("$.persisted").value(true));
     }
 
     @Test
@@ -92,51 +94,57 @@ class ConfigControllerHttpCrudTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/config/overrides")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"app.name\",\"value\":\"to-delete\"}"))
-            .andExpect(status().isOk());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"app.name\",\"value\":\"to-delete\"}"))
+                .andExpect(status().isOk());
 
         mvc.perform(delete("/bootui/api/config/overrides/app.name"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("app.name"))
-            .andExpect(jsonPath("$.value").doesNotExist())
-            .andExpect(jsonPath("$.previousValue").value("to-delete"))
-            .andExpect(jsonPath("$.persisted").value(true));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("app.name"))
+                .andExpect(jsonPath("$.value").doesNotExist())
+                .andExpect(jsonPath("$.previousValue").value("to-delete"))
+                .andExpect(jsonPath("$.persisted").value(true));
     }
 
     @Test
     void deleteNonExistingOverrideIsIdempotentAndReturns200() throws Exception {
         // No prior POST — controller must return a stable 200 result, not an error
-        buildMvc().perform(delete("/bootui/api/config/overrides/does.not.exist"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("does.not.exist"))
-            .andExpect(jsonPath("$.value").doesNotExist())
-            .andExpect(jsonPath("$.persisted").value(true));
+        buildMvc()
+                .perform(delete("/bootui/api/config/overrides/does.not.exist"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("does.not.exist"))
+                .andExpect(jsonPath("$.value").doesNotExist())
+                .andExpect(jsonPath("$.persisted").value(true));
     }
 
     @Test
     void persistedStateSurvivesAcrossControllerInstances() throws Exception {
         // Write through one controller instance
-        buildMvc().perform(post("/bootui/api/config/overrides")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"server.port\",\"value\":\"7777\"}"))
-            .andExpect(status().isOk());
+        buildMvc()
+                .perform(post("/bootui/api/config/overrides")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"server.port\",\"value\":\"7777\"}"))
+                .andExpect(status().isOk());
 
         // A second, independently constructed controller sharing the same service
         // must see the override in the GET response
-        buildMvc().perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='server.port')].value").value("7777"))
-            .andExpect(jsonPath("$.properties[?(@.name=='server.port')].override").value(true));
+        buildMvc()
+                .perform(get("/bootui/api/config"))
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.properties[?(@.name=='server.port')].value").value("7777"))
+                .andExpect(jsonPath("$.properties[?(@.name=='server.port')].override")
+                        .value(true));
     }
 
     @Test
     void restartWarningMessageIsPresentForOverriddenProperty() throws Exception {
         // The service always warns that already-bound beans may need a restart
-        buildMvc().perform(post("/bootui/api/config/overrides")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"server.port\",\"value\":\"9090\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.message").value(containsString("restart")));
+        buildMvc()
+                .perform(post("/bootui/api/config/overrides")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"server.port\",\"value\":\"9090\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(containsString("restart")));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigControllerMaskingTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigControllerMaskingTests.java
@@ -1,20 +1,19 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.nio.file.Path;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Verifies that {@link ConfigController} applies the three {@link ValueExposure} modes
@@ -50,8 +49,10 @@ class ConfigControllerMaskingTests {
 
         ConfigOverrideService overrideService = new ConfigOverrideService(environment, properties);
         ConfigController controller = new ConfigController(
-            environment, overrideService, properties,
-            new ConfigMetadataCatalog(getClass().getClassLoader()));
+                environment,
+                overrideService,
+                properties,
+                new ConfigMetadataCatalog(getClass().getClassLoader()));
         mvc = standaloneSetup(controller).build();
     }
 
@@ -62,10 +63,11 @@ class ConfigControllerMaskingTests {
         properties.setExposeValues(ValueExposure.MASKED);
 
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].masked").value(true))
-            .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].value")
-                .value("******"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].masked")
+                        .value(true))
+                .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].value")
+                        .value("******"));
     }
 
     @Test
@@ -73,10 +75,11 @@ class ConfigControllerMaskingTests {
         properties.setExposeValues(ValueExposure.MASKED);
 
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].masked").value(false))
-            .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].value")
-                .value(PLAIN_VALUE));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].value")
+                        .value(PLAIN_VALUE));
     }
 
     // ── METADATA_ONLY mode ────────────────────────────────────────────────────
@@ -86,9 +89,9 @@ class ConfigControllerMaskingTests {
         properties.setExposeValues(ValueExposure.METADATA_ONLY);
 
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].value[0]")
-                .doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].value[0]")
+                        .doesNotExist());
     }
 
     @Test
@@ -96,9 +99,9 @@ class ConfigControllerMaskingTests {
         properties.setExposeValues(ValueExposure.METADATA_ONLY);
 
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].value[0]")
-                .doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].value[0]")
+                        .doesNotExist());
     }
 
     // ── FULL mode ─────────────────────────────────────────────────────────────
@@ -108,10 +111,11 @@ class ConfigControllerMaskingTests {
         properties.setExposeValues(ValueExposure.FULL);
 
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].masked").value(false))
-            .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].value")
-                .value(SECRET_VALUE));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.properties[?(@.name=='" + SECRET_KEY + "')].value")
+                        .value(SECRET_VALUE));
     }
 
     @Test
@@ -119,9 +123,10 @@ class ConfigControllerMaskingTests {
         properties.setExposeValues(ValueExposure.FULL);
 
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].masked").value(false))
-            .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].value")
-                .value(PLAIN_VALUE));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.properties[?(@.name=='" + PLAIN_KEY + "')].value")
+                        .value(PLAIN_VALUE));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigControllerTests.java
@@ -1,21 +1,20 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.http.MediaType;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.nio.file.Path;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * HTTP-level tests for {@link ConfigController}.
@@ -45,28 +44,32 @@ class ConfigControllerTests {
 
         overrideService = new ConfigOverrideService(environment, properties);
 
-        ConfigController controller = new ConfigController(environment, overrideService, properties,
-            new ConfigMetadataCatalog(getClass().getClassLoader()));
+        ConfigController controller = new ConfigController(
+                environment,
+                overrideService,
+                properties,
+                new ConfigMetadataCatalog(getClass().getClassLoader()));
         mvc = standaloneSetup(controller).build();
     }
 
     @Test
     void listReturnsActiveProfilesPropertiesAndSources() throws Exception {
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.activeProfiles[0]").value("dev"))
-            .andExpect(jsonPath("$.sources").isArray())
-            .andExpect(jsonPath("$.properties[?(@.name=='server.port')].value").value("8080"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeProfiles[0]").value("dev"))
+                .andExpect(jsonPath("$.sources").isArray())
+                .andExpect(
+                        jsonPath("$.properties[?(@.name=='server.port')].value").value("8080"));
     }
 
     @Test
     void listMasksSecretValuesByDefault() throws Exception {
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].masked")
-                .value(true))
-            .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].value")
-                .value("******"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].masked")
+                        .value(true))
+                .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].value")
+                        .value("******"));
     }
 
     @Test
@@ -74,8 +77,9 @@ class ConfigControllerTests {
         properties.setExposeValues(ValueExposure.METADATA_ONLY);
 
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='server.port')].value[0]").doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='server.port')].value[0]")
+                        .doesNotExist());
     }
 
     @Test
@@ -83,36 +87,36 @@ class ConfigControllerTests {
         properties.setExposeValues(ValueExposure.FULL);
 
         mvc.perform(get("/bootui/api/config"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].masked")
-                .value(false))
-            .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].value")
-                .value("s3cret"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.properties[?(@.name=='spring.datasource.password')].value")
+                        .value("s3cret"));
     }
 
     @Test
     void postCreatesOverrideAndDeleteRemovesIt() throws Exception {
         // First write to establish a previous override value.
         mvc.perform(post("/bootui/api/config/overrides")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"server.port\",\"value\":\"9090\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("server.port"))
-            .andExpect(jsonPath("$.value").value("9090"))
-            .andExpect(jsonPath("$.persisted").value(true))
-            .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("until restart")));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"server.port\",\"value\":\"9090\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("server.port"))
+                .andExpect(jsonPath("$.value").value("9090"))
+                .andExpect(jsonPath("$.persisted").value(true))
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("until restart")));
 
         // Second write should report the previous override value.
         mvc.perform(post("/bootui/api/config/overrides")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\":\"server.port\",\"value\":\"9191\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.previousValue").value("9090"))
-            .andExpect(jsonPath("$.value").value("9191"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"server.port\",\"value\":\"9191\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.previousValue").value("9090"))
+                .andExpect(jsonPath("$.value").value("9191"));
 
         mvc.perform(delete("/bootui/api/config/overrides/server.port"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("server.port"))
-            .andExpect(jsonPath("$.value").doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("server.port"))
+                .andExpect(jsonPath("$.value").doesNotExist());
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigMetadataCatalogTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigMetadataCatalogTests.java
@@ -1,15 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.github.jdubois.bootui.core.BootUiDtos.ConfigPropertySuggestionDto;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.jdubois.bootui.core.BootUiDtos.ConfigPropertySuggestionDto;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class ConfigMetadataCatalogTests {
 
@@ -45,14 +44,15 @@ class ConfigMetadataCatalogTests {
             }
             """);
 
-        try (URLClassLoader classLoader = new URLClassLoader(new java.net.URL[]{tempDir.toUri().toURL()}, null)) {
+        try (URLClassLoader classLoader =
+                new URLClassLoader(new java.net.URL[] {tempDir.toUri().toURL()}, null)) {
             ConfigMetadataCatalog catalog = new ConfigMetadataCatalog(classLoader);
 
             List<ConfigPropertySuggestionDto> suggestions = catalog.suggestions();
 
             assertThat(suggestions)
-                .extracting(ConfigPropertySuggestionDto::name)
-                .containsExactly("server.port", "spring.main.banner-mode");
+                    .extracting(ConfigPropertySuggestionDto::name)
+                    .containsExactly("server.port", "spring.main.banner-mode");
             assertThat(catalog.get("server.port").defaultValue()).isEqualTo(8080);
             assertThat(catalog.get("spring.main.banner-mode").defaultValue()).isEqualTo("console");
             assertThat(catalog.get("spring.old")).isNull();

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DataControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DataControllerTests.java
@@ -1,16 +1,5 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ListableBeanFactory;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.core.RepositoryInformation;
-import org.springframework.data.repository.core.support.RepositoryFactoryInformation;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.io.Serializable;
-import java.lang.reflect.Method;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -19,6 +8,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryInformation;
+import org.springframework.data.repository.core.support.RepositoryFactoryInformation;
+import org.springframework.test.web.servlet.MockMvc;
 
 /**
  * HTTP-level tests for {@link DataController}.
@@ -35,10 +34,9 @@ class DataControllerTests {
         RepositoryFactoryInformation<?, ?> info = mock(RepositoryFactoryInformation.class);
         RepositoryInformation information = mock(RepositoryInformation.class);
 
-        when(factory.getBeanNamesForType(RepositoryFactoryInformation.class))
-            .thenReturn(new String[]{beanName});
+        when(factory.getBeanNamesForType(RepositoryFactoryInformation.class)).thenReturn(new String[] {beanName});
         when(factory.getBean(eq(beanName), eq(RepositoryFactoryInformation.class)))
-            .thenAnswer(invocation -> info);
+                .thenAnswer(invocation -> info);
         when(info.getRepositoryInformation()).thenReturn(information);
 
         // Mockito cannot return Class<?> from raw-typed getters without an unchecked
@@ -83,26 +81,25 @@ class DataControllerTests {
         MockMvc mvc = standaloneSetup(new DataController(provider)).build();
 
         mvc.perform(get("/bootui/api/data/repositories"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.springDataPresent").value(true))
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.repositories").isArray())
-            .andExpect(jsonPath("$.repositories").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.springDataPresent").value(true))
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.repositories").isArray())
+                .andExpect(jsonPath("$.repositories").isEmpty());
     }
 
     @Test
     void repositoriesReturnsEmptyReportWhenNoRepositoryBeans() throws Exception {
         ListableBeanFactory factory = mock(ListableBeanFactory.class);
-        when(factory.getBeanNamesForType(RepositoryFactoryInformation.class))
-            .thenReturn(new String[0]);
+        when(factory.getBeanNamesForType(RepositoryFactoryInformation.class)).thenReturn(new String[0]);
 
         MockMvc mvc = standaloneSetup(new DataController(providerOf(factory))).build();
 
         mvc.perform(get("/bootui/api/data/repositories"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.springDataPresent").value(true))
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.repositories").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.springDataPresent").value(true))
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.repositories").isEmpty());
     }
 
     @Test
@@ -112,18 +109,17 @@ class DataControllerTests {
         MockMvc mvc = standaloneSetup(new DataController(providerOf(factory))).build();
 
         mvc.perform(get("/bootui/api/data/repositories"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.total").value(1))
-            .andExpect(jsonPath("$.repositories[0].beanName").value("widgetRepository"))
-            .andExpect(jsonPath("$.repositories[0].repositoryInterface")
-                .value(WidgetRepository.class.getName()))
-            .andExpect(jsonPath("$.repositories[0].domainType").value(Widget.class.getName()))
-            .andExpect(jsonPath("$.repositories[0].idType").value(Long.class.getName()))
-            // WidgetRepository lives outside the spring-data package tree, so it
-            // resolves to the generic store module marker.
-            .andExpect(jsonPath("$.repositories[0].storeModule").value("GENERIC"))
-            .andExpect(jsonPath("$.repositories[0].queryMethodCount").value(1))
-            .andExpect(jsonPath("$.repositories[0].fragmentCount").value(0));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.repositories[0].beanName").value("widgetRepository"))
+                .andExpect(jsonPath("$.repositories[0].repositoryInterface").value(WidgetRepository.class.getName()))
+                .andExpect(jsonPath("$.repositories[0].domainType").value(Widget.class.getName()))
+                .andExpect(jsonPath("$.repositories[0].idType").value(Long.class.getName()))
+                // WidgetRepository lives outside the spring-data package tree, so it
+                // resolves to the generic store module marker.
+                .andExpect(jsonPath("$.repositories[0].storeModule").value("GENERIC"))
+                .andExpect(jsonPath("$.repositories[0].queryMethodCount").value(1))
+                .andExpect(jsonPath("$.repositories[0].fragmentCount").value(0));
     }
 
     @Test
@@ -132,12 +128,12 @@ class DataControllerTests {
         MockMvc mvc = standaloneSetup(new DataController(providerOf(factory))).build();
 
         mvc.perform(get("/bootui/api/data/repositories/widgetRepository"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.beanName").value("widgetRepository"))
-            .andExpect(jsonPath("$.repositoryInterface").value(WidgetRepository.class.getName()))
-            .andExpect(jsonPath("$.methods").isArray())
-            .andExpect(jsonPath("$.methods[?(@.name=='findByName')]").exists())
-            .andExpect(jsonPath("$.methods[?(@.name=='findByName')].origin").value("QUERY"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.beanName").value("widgetRepository"))
+                .andExpect(jsonPath("$.repositoryInterface").value(WidgetRepository.class.getName()))
+                .andExpect(jsonPath("$.methods").isArray())
+                .andExpect(jsonPath("$.methods[?(@.name=='findByName')]").exists())
+                .andExpect(jsonPath("$.methods[?(@.name=='findByName')].origin").value("QUERY"));
     }
 
     @Test
@@ -146,8 +142,8 @@ class DataControllerTests {
         MockMvc mvc = standaloneSetup(new DataController(providerOf(factory))).build();
 
         mvc.perform(get("/bootui/api/data/repositories/" + WidgetRepository.class.getName()))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.repositoryInterface").value(WidgetRepository.class.getName()));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.repositoryInterface").value(WidgetRepository.class.getName()));
     }
 
     @Test
@@ -156,8 +152,8 @@ class DataControllerTests {
         MockMvc mvc = standaloneSetup(new DataController(providerOf(factory))).build();
 
         mvc.perform(get("/bootui/api/data/repositories/WidgetRepository"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.repositoryInterface").value(WidgetRepository.class.getName()));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.repositoryInterface").value(WidgetRepository.class.getName()));
     }
 
     @Test
@@ -165,8 +161,7 @@ class DataControllerTests {
         ListableBeanFactory factory = beanFactoryWithRepository("widgetRepository", WidgetRepository.class);
         MockMvc mvc = standaloneSetup(new DataController(providerOf(factory))).build();
 
-        mvc.perform(get("/bootui/api/data/repositories/UnknownRepository"))
-            .andExpect(status().isNotFound());
+        mvc.perform(get("/bootui/api/data/repositories/UnknownRepository")).andExpect(status().isNotFound());
     }
 
     /**

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependenciesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependenciesControllerTests.java
@@ -1,18 +1,17 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
-import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
-import org.junit.jupiter.api.Test;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-
 import static org.hamcrest.Matchers.contains;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
 
 class DependenciesControllerTests {
 
@@ -24,33 +23,33 @@ class DependenciesControllerTests {
     @Test
     void dependenciesReturnsClasspathInventoryWithoutScanning() throws Exception {
         MockMvc mvc = standaloneSetup(new DependenciesController(
-            new BootUiProperties(),
-            () -> List.of(dependency("org.example", "sample", "1.0.0")),
-            dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "unused", 1L, 1, dependencies)))
-            .build();
+                        new BootUiProperties(),
+                        () -> List.of(dependency("org.example", "sample", "1.0.0")),
+                        dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "unused", 1L, 1, dependencies)))
+                .build();
 
         mvc.perform(get("/bootui/api/dependencies"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.scanningEnabled").value(true))
-            .andExpect(jsonPath("$.scan.status").value("NOT_SCANNED"))
-            .andExpect(jsonPath("$.total").value(1))
-            .andExpect(jsonPath("$.dependencies[0].packageName").value("org.example:sample"))
-            .andExpect(jsonPath("$.dependencies[0].vulnerabilityCount").value(0));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scanningEnabled").value(true))
+                .andExpect(jsonPath("$.scan.status").value("NOT_SCANNED"))
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.dependencies[0].packageName").value("org.example:sample"))
+                .andExpect(jsonPath("$.dependencies[0].vulnerabilityCount").value(0));
     }
 
     @Test
     void scanUsesScannerWhenEnabled() throws Exception {
         MockMvc mvc = standaloneSetup(new DependenciesController(
-            new BootUiProperties(),
-            () -> List.of(dependency("org.example", "sample", "1.0.0")),
-            dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "done", 1L, 1, dependencies)))
-            .build();
+                        new BootUiProperties(),
+                        () -> List.of(dependency("org.example", "sample", "1.0.0")),
+                        dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "done", 1L, 1, dependencies)))
+                .build();
 
         mvc.perform(post("/bootui/api/dependencies/scan"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.scan.status").value("SCANNED"))
-            .andExpect(jsonPath("$.scan.message").value("done"))
-            .andExpect(jsonPath("$.scan.packagesScanned").value(1));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scan.status").value("SCANNED"))
+                .andExpect(jsonPath("$.scan.message").value("done"))
+                .andExpect(jsonPath("$.scan.packagesScanned").value(1));
     }
 
     @Test
@@ -58,33 +57,33 @@ class DependenciesControllerTests {
         BootUiProperties properties = new BootUiProperties();
         properties.getDependencies().setOsvEnabled(false);
         MockMvc mvc = standaloneSetup(new DependenciesController(
-            properties,
-            () -> List.of(dependency("org.example", "sample", "1.0.0")),
-            dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "unused", 1L, 1, dependencies)))
-            .build();
+                        properties,
+                        () -> List.of(dependency("org.example", "sample", "1.0.0")),
+                        dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "unused", 1L, 1, dependencies)))
+                .build();
 
         mvc.perform(post("/bootui/api/dependencies/scan"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.scanningEnabled").value(false))
-            .andExpect(jsonPath("$.scan.status").value("DISABLED"))
-            .andExpect(jsonPath("$.dependencies[*].packageName", contains("org.example:sample")));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scanningEnabled").value(false))
+                .andExpect(jsonPath("$.scan.status").value("DISABLED"))
+                .andExpect(jsonPath("$.dependencies[*].packageName", contains("org.example:sample")));
     }
 
     @Test
     void dependenciesReturnsLastScanReportAfterScan() throws Exception {
         MockMvc mvc = standaloneSetup(new DependenciesController(
-            new BootUiProperties(),
-            () -> List.of(dependency("org.example", "sample", "1.0.0")),
-            dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "done", 1L, 1, dependencies)))
-            .build();
+                        new BootUiProperties(),
+                        () -> List.of(dependency("org.example", "sample", "1.0.0")),
+                        dependencies -> OsvVulnerabilityScanner.report(true, "SCANNED", "done", 1L, 1, dependencies)))
+                .build();
 
         mvc.perform(post("/bootui/api/dependencies/scan"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.scan.status").value("SCANNED"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scan.status").value("SCANNED"));
 
         mvc.perform(get("/bootui/api/dependencies"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.scan.status").value("SCANNED"))
-            .andExpect(jsonPath("$.scan.message").value("done"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scan.status").value("SCANNED"))
+                .andExpect(jsonPath("$.scan.message").value("done"));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
@@ -1,15 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
+import java.io.File;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
-
-import java.io.File;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class DependencyCatalogTests {
 
@@ -36,17 +35,21 @@ class DependencyCatalogTests {
     void discoversMavenCoordinatesFromJavaClassPathJarsWithoutPomProperties() {
         String previousClassPath = System.getProperty("java.class.path");
         try {
-            System.setProperty("java.class.path", String.join(File.pathSeparator,
-                "/home/user/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/11.0.21/tomcat-embed-core-11.0.21.jar",
-                "/home/user/.m2/repository/org/postgresql/postgresql/42.7.10/postgresql-42.7.10.jar"));
+            System.setProperty(
+                    "java.class.path",
+                    String.join(
+                            File.pathSeparator,
+                            "/home/user/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/11.0.21/tomcat-embed-core-11.0.21.jar",
+                            "/home/user/.m2/repository/org/postgresql/postgresql/42.7.10/postgresql-42.7.10.jar"));
 
             List<DependencyDto> dependencies = new DependencyCatalog(emptyResolver()).dependencies();
 
             assertThat(dependencies)
-                .extracting(DependencyDto::packageName, DependencyDto::version)
-                .contains(
-                    org.assertj.core.api.Assertions.tuple("org.apache.tomcat.embed:tomcat-embed-core", "11.0.21"),
-                    org.assertj.core.api.Assertions.tuple("org.postgresql:postgresql", "42.7.10"));
+                    .extracting(DependencyDto::packageName, DependencyDto::version)
+                    .contains(
+                            org.assertj.core.api.Assertions.tuple(
+                                    "org.apache.tomcat.embed:tomcat-embed-core", "11.0.21"),
+                            org.assertj.core.api.Assertions.tuple("org.postgresql:postgresql", "42.7.10"));
         } finally {
             if (previousClassPath == null) {
                 System.clearProperty("java.class.path");

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesControllerTests.java
@@ -1,12 +1,5 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
-import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
-import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.test.web.servlet.MockMvc;
-
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -14,18 +7,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.web.servlet.MockMvc;
+
 class DevServicesControllerTests {
 
     @Test
     void listReturnsEmptyReportWhenNoDevServicesArePresent() throws Exception {
         GenericApplicationContext context = new GenericApplicationContext();
         context.refresh();
-        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties())).build();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
 
         mvc.perform(get("/bootui/api/dev-services"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.services").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.services").isEmpty());
 
         context.close();
     }
@@ -35,16 +36,17 @@ class DevServicesControllerTests {
         GenericApplicationContext context = new GenericApplicationContext();
         context.registerBean("postgresConnectionDetails", SampleConnectionDetails.class);
         context.refresh();
-        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties())).build();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
 
         mvc.perform(get("/bootui/api/dev-services"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.total").value(1))
-            .andExpect(jsonPath("$.services[0].id").value("connection:postgresConnectionDetails"))
-            .andExpect(jsonPath("$.services[0].type").value("PostgreSQL"))
-            .andExpect(jsonPath("$.services[0].connectionDetails.jdbcUrl")
-                .value("jdbc:postgresql://******@localhost:5432/app"))
-            .andExpect(jsonPath("$.services[0].connectionDetails.password").value("******"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.services[0].id").value("connection:postgresConnectionDetails"))
+                .andExpect(jsonPath("$.services[0].type").value("PostgreSQL"))
+                .andExpect(jsonPath("$.services[0].connectionDetails.jdbcUrl")
+                        .value("jdbc:postgresql://******@localhost:5432/app"))
+                .andExpect(jsonPath("$.services[0].connectionDetails.password").value("******"));
 
         context.close();
     }
@@ -56,13 +58,14 @@ class DevServicesControllerTests {
         GenericApplicationContext context = new GenericApplicationContext();
         context.registerBean("postgresConnectionDetails", SampleConnectionDetails.class);
         context.refresh();
-        MockMvc mvc = standaloneSetup(new DevServicesController(context, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new DevServicesController(context, properties)).build();
 
         mvc.perform(get("/bootui/api/dev-services"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.services[0].connectionDetails.jdbcUrl")
-                .value("jdbc:postgresql://dbuser:secret@localhost:5432/app"))
-            .andExpect(jsonPath("$.services[0].connectionDetails.password").value("secret"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.services[0].connectionDetails.jdbcUrl")
+                        .value("jdbc:postgresql://dbuser:secret@localhost:5432/app"))
+                .andExpect(jsonPath("$.services[0].connectionDetails.password").value("secret"));
 
         context.close();
     }
@@ -74,12 +77,13 @@ class DevServicesControllerTests {
         GenericApplicationContext context = new GenericApplicationContext();
         context.registerBean("postgresTestcontainer", FakeTestcontainer.class);
         context.refresh();
-        MockMvc mvc = standaloneSetup(new DevServicesController(context, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new DevServicesController(context, properties)).build();
 
         mvc.perform(get("/bootui/api/dev-services/bean:postgresTestcontainer/logs"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.truncated").value(true))
-            .andExpect(jsonPath("$.logs").value(containsString("3456789-end")));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.truncated").value(true))
+                .andExpect(jsonPath("$.logs").value(containsString("3456789-end")));
 
         context.close();
     }
@@ -89,11 +93,12 @@ class DevServicesControllerTests {
         GenericApplicationContext context = new GenericApplicationContext();
         context.registerBean("redisTestcontainer", FakeVarargsLogTestcontainer.class);
         context.refresh();
-        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties())).build();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
 
         mvc.perform(get("/bootui/api/dev-services/bean:redisTestcontainer/logs"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.logs").value("Redis container started"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.logs").value("Redis container started"));
 
         context.close();
     }
@@ -103,10 +108,11 @@ class DevServicesControllerTests {
         GenericApplicationContext context = new GenericApplicationContext();
         context.registerBean("postgresTestcontainer", FakeTestcontainer.class);
         context.refresh();
-        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties())).build();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
 
         mvc.perform(post("/bootui/api/dev-services/bean:postgresTestcontainer/restart"))
-            .andExpect(status().isConflict());
+                .andExpect(status().isConflict());
 
         context.close();
     }
@@ -118,11 +124,12 @@ class DevServicesControllerTests {
         GenericApplicationContext context = new GenericApplicationContext();
         context.registerBean("postgresTestcontainer", FakeTestcontainer.class);
         context.refresh();
-        MockMvc mvc = standaloneSetup(new DevServicesController(context, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new DevServicesController(context, properties)).build();
 
         mvc.perform(post("/bootui/api/dev-services/bean:postgresTestcontainer/restart"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value("restarted"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("restarted"));
 
         FakeTestcontainer container = context.getBean(FakeTestcontainer.class);
         org.assertj.core.api.Assertions.assertThat(container.restartCalls()).isEqualTo("stop,start");

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevToolsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevToolsControllerTests.java
@@ -1,93 +1,97 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.github.jdubois.bootui.core.BootUiDtos.DevToolsActionResult;
-import io.github.jdubois.bootui.core.BootUiDtos.DevToolsStatus;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
+import io.github.jdubois.bootui.core.BootUiDtos.DevToolsActionResult;
+import io.github.jdubois.bootui.core.BootUiDtos.DevToolsStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
 class DevToolsControllerTests {
 
     @Test
     void reportsDevToolsStatus() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-            new DevToolsStatus(true, null, false, true, 35729, null),
-            new DevToolsActionResult("livereload", "triggered", "ok"),
-            new DevToolsActionResult("restart", "scheduled", "ok")))).build();
+                        new DevToolsStatus(true, null, false, true, 35729, null),
+                        new DevToolsActionResult("livereload", "triggered", "ok"),
+                        new DevToolsActionResult("restart", "scheduled", "ok"))))
+                .build();
 
         mvc.perform(get("/bootui/api/devtools"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.restartAvailable").value(true))
-            .andExpect(jsonPath("$.restartPending").value(false))
-            .andExpect(jsonPath("$.liveReloadAvailable").value(true))
-            .andExpect(jsonPath("$.liveReloadPort").value(35729));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.restartAvailable").value(true))
+                .andExpect(jsonPath("$.restartPending").value(false))
+                .andExpect(jsonPath("$.liveReloadAvailable").value(true))
+                .andExpect(jsonPath("$.liveReloadPort").value(35729));
     }
 
     @Test
     void triggersLiveReloadWhenAvailable() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-            new DevToolsStatus(true, null, false, true, 35729, null),
-            new DevToolsActionResult("livereload", "triggered", "LiveReload notification sent."),
-            new DevToolsActionResult("restart", "scheduled", "ok")))).build();
+                        new DevToolsStatus(true, null, false, true, 35729, null),
+                        new DevToolsActionResult("livereload", "triggered", "LiveReload notification sent."),
+                        new DevToolsActionResult("restart", "scheduled", "ok"))))
+                .build();
 
         mvc.perform(post("/bootui/api/devtools/livereload"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.action").value("livereload"))
-            .andExpect(jsonPath("$.status").value("triggered"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.action").value("livereload"))
+                .andExpect(jsonPath("$.status").value("triggered"));
     }
 
     @Test
     void returnsConflictWhenLiveReloadUnavailable() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-            new DevToolsStatus(false, "no restart", false, false, null, "no livereload"),
-            new DevToolsActionResult("livereload", "unavailable", "no livereload"),
-            new DevToolsActionResult("restart", "unavailable", "no restart")))).build();
+                        new DevToolsStatus(false, "no restart", false, false, null, "no livereload"),
+                        new DevToolsActionResult("livereload", "unavailable", "no livereload"),
+                        new DevToolsActionResult("restart", "unavailable", "no restart"))))
+                .build();
 
         mvc.perform(post("/bootui/api/devtools/livereload"))
-            .andExpect(status().isConflict())
-            .andExpect(jsonPath("$.status").value("unavailable"))
-            .andExpect(jsonPath("$.message").value("no livereload"));
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value("unavailable"))
+                .andExpect(jsonPath("$.message").value("no livereload"));
     }
 
     @Test
     void restartRequiresConfirmation() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-            new DevToolsStatus(true, null, false, true, 35729, null),
-            new DevToolsActionResult("livereload", "triggered", "ok"),
-            new DevToolsActionResult("restart", "scheduled", "ok")))).build();
+                        new DevToolsStatus(true, null, false, true, 35729, null),
+                        new DevToolsActionResult("livereload", "triggered", "ok"),
+                        new DevToolsActionResult("restart", "scheduled", "ok"))))
+                .build();
 
         mvc.perform(post("/bootui/api/devtools/restart")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"confirm\":false}"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.status").value("confirmation_required"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"confirm\":false}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("confirmation_required"));
     }
 
     @Test
     void schedulesRestartWhenConfirmed() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-            new DevToolsStatus(true, null, false, true, 35729, null),
-            new DevToolsActionResult("livereload", "triggered", "ok"),
-            new DevToolsActionResult("restart", "scheduled", "Restart scheduled.")))).build();
+                        new DevToolsStatus(true, null, false, true, 35729, null),
+                        new DevToolsActionResult("livereload", "triggered", "ok"),
+                        new DevToolsActionResult("restart", "scheduled", "Restart scheduled."))))
+                .build();
 
         mvc.perform(post("/bootui/api/devtools/restart")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"confirm\":true}"))
-            .andExpect(status().isAccepted())
-            .andExpect(jsonPath("$.action").value("restart"))
-            .andExpect(jsonPath("$.status").value("scheduled"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"confirm\":true}"))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.action").value("restart"))
+                .andExpect(jsonPath("$.status").value("scheduled"));
     }
 
     private record StubDevToolsBridge(
-        DevToolsStatus status,
-        DevToolsActionResult liveReloadResult,
-        DevToolsActionResult restartResult) implements DevToolsBridge {
+            DevToolsStatus status, DevToolsActionResult liveReloadResult, DevToolsActionResult restartResult)
+            implements DevToolsBridge {
 
         @Override
         public DevToolsActionResult triggerLiveReload() {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HealthControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HealthControllerTests.java
@@ -1,5 +1,12 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
 import org.springframework.beans.factory.ObjectProvider;
@@ -10,14 +17,6 @@ import org.springframework.boot.health.actuate.endpoint.IndicatedHealthDescripto
 import org.springframework.boot.health.contributor.Status;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Map;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Controller-level tests for {@link HealthController}.
@@ -49,65 +48,67 @@ class HealthControllerTests {
         MockMvc mvc = standaloneSetup(new HealthController(emptyProvider())).build();
 
         mvc.perform(get("/bootui/api/health"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("application"))
-            .andExpect(jsonPath("$.status").value("UNKNOWN"))
-            .andExpect(jsonPath("$.components").isArray())
-            .andExpect(jsonPath("$.components").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("application"))
+                .andExpect(jsonPath("$.status").value("UNKNOWN"))
+                .andExpect(jsonPath("$.components").isArray())
+                .andExpect(jsonPath("$.components").isEmpty());
     }
 
     @Test
     void healthReturnsSimpleUpStatus() throws Exception {
-        IndicatedHealthDescriptor indicated = mock(IndicatedHealthDescriptor.class,
-            withSettings().mockMaker(MockMakers.INLINE));
+        IndicatedHealthDescriptor indicated =
+                mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(indicated.getStatus()).thenReturn(Status.UP);
         when(indicated.getDetails()).thenReturn(Map.of("ping", "pong"));
 
         HealthEndpoint endpoint = mock(HealthEndpoint.class);
         when(endpoint.health()).thenReturn(indicated);
 
-        MockMvc mvc = standaloneSetup(new HealthController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new HealthController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/health").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("application"))
-            .andExpect(jsonPath("$.status").value("UP"))
-            .andExpect(jsonPath("$.components").isArray())
-            .andExpect(jsonPath("$.components").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("application"))
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.components").isArray())
+                .andExpect(jsonPath("$.components").isEmpty());
     }
 
     @Test
     void healthReturnsDownStatus() throws Exception {
-        IndicatedHealthDescriptor downDescriptor = mock(IndicatedHealthDescriptor.class,
-            withSettings().mockMaker(MockMakers.INLINE));
+        IndicatedHealthDescriptor downDescriptor =
+                mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(downDescriptor.getStatus()).thenReturn(Status.DOWN);
         when(downDescriptor.getDetails()).thenReturn(Map.of("error", "Connection refused"));
 
         HealthEndpoint endpoint = mock(HealthEndpoint.class);
         when(endpoint.health()).thenReturn(downDescriptor);
 
-        MockMvc mvc = standaloneSetup(new HealthController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new HealthController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/health").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value("DOWN"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DOWN"));
     }
 
     @Test
     void healthReturnsCompositeWithComponents() throws Exception {
-        IndicatedHealthDescriptor dbDescriptor = mock(IndicatedHealthDescriptor.class,
-            withSettings().mockMaker(MockMakers.INLINE));
+        IndicatedHealthDescriptor dbDescriptor =
+                mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(dbDescriptor.getStatus()).thenReturn(Status.UP);
         when(dbDescriptor.getDetails()).thenReturn(Map.of("database", "H2"));
 
-        IndicatedHealthDescriptor diskDescriptor = mock(IndicatedHealthDescriptor.class,
-            withSettings().mockMaker(MockMakers.INLINE));
+        IndicatedHealthDescriptor diskDescriptor =
+                mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(diskDescriptor.getStatus()).thenReturn(new Status("DOWN"));
         when(diskDescriptor.getDetails()).thenReturn(Map.of("free", 1024L));
 
         Map<String, HealthDescriptor> components = Map.of(
-            "db", dbDescriptor,
-            "diskSpace", diskDescriptor);
+                "db", dbDescriptor,
+                "diskSpace", diskDescriptor);
 
         CompositeHealthDescriptor composite = mock(CompositeHealthDescriptor.class);
         when(composite.getStatus()).thenReturn(new Status("DOWN"));
@@ -116,15 +117,17 @@ class HealthControllerTests {
         HealthEndpoint endpoint = mock(HealthEndpoint.class);
         when(endpoint.health()).thenReturn(composite);
 
-        MockMvc mvc = standaloneSetup(new HealthController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new HealthController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/health").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("application"))
-            .andExpect(jsonPath("$.status").value("DOWN"))
-            .andExpect(jsonPath("$.components").isArray())
-            .andExpect(jsonPath("$.components.length()").value(2))
-            .andExpect(jsonPath("$.components[?(@.name=='db')].status").value("UP"))
-            .andExpect(jsonPath("$.components[?(@.name=='diskSpace')].status").value("DOWN"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("application"))
+                .andExpect(jsonPath("$.status").value("DOWN"))
+                .andExpect(jsonPath("$.components").isArray())
+                .andExpect(jsonPath("$.components.length()").value(2))
+                .andExpect(jsonPath("$.components[?(@.name=='db')].status").value("UP"))
+                .andExpect(
+                        jsonPath("$.components[?(@.name=='diskSpace')].status").value("DOWN"));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeControllerTests.java
@@ -1,7 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import com.sun.net.httpserver.HttpServer;
 import io.github.jdubois.bootui.core.BootUiDtos.HttpProbeRequest;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,14 +16,6 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
 import tools.jackson.databind.ObjectMapper;
-
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Standalone MockMvc tests for {@link HttpProbeController}.
@@ -56,11 +55,11 @@ class HttpProbeControllerTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("get", "/api/ping", null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.error").isEmpty());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("get", "/api/ping", null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.error").isEmpty());
     }
 
     @Test
@@ -74,10 +73,10 @@ class HttpProbeControllerTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest(null, "/default-method", null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(200));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest(null, "/default-method", null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
     }
 
     // ── path normalization ────────────────────────────────────────────────────
@@ -94,10 +93,10 @@ class HttpProbeControllerTests {
 
         // path "hello" (no leading slash) should be normalized to "/hello"
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("GET", "hello", null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(200));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", "hello", null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
     }
 
     @Test
@@ -111,10 +110,10 @@ class HttpProbeControllerTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("GET", null, null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(200));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", null, null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
     }
 
     // ── loopback enforcement ──────────────────────────────────────────────────
@@ -134,10 +133,10 @@ class HttpProbeControllerTests {
 
         // Normal loopback probe succeeds
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("GET", "/safe", null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(200));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", "/safe", null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
     }
 
     // ── response header filtering ─────────────────────────────────────────────
@@ -157,14 +156,14 @@ class HttpProbeControllerTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("GET", "/headers", null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.headers['content-type']").exists())
-            // sensitive / non-allow-listed headers must not appear
-            .andExpect(jsonPath("$.headers['x-custom-header']").doesNotExist())
-            .andExpect(jsonPath("$.headers['authorization']").doesNotExist())
-            .andExpect(jsonPath("$.headers['set-cookie']").doesNotExist());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", "/headers", null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.headers['content-type']").exists())
+                // sensitive / non-allow-listed headers must not appear
+                .andExpect(jsonPath("$.headers['x-custom-header']").doesNotExist())
+                .andExpect(jsonPath("$.headers['authorization']").doesNotExist())
+                .andExpect(jsonPath("$.headers['set-cookie']").doesNotExist());
     }
 
     @Test
@@ -177,10 +176,10 @@ class HttpProbeControllerTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("GET", "/redirect-me", null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.headers['location']").value("/new-location"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", "/redirect-me", null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.headers['location']").value("/new-location"));
     }
 
     // ── timeout / error responses ─────────────────────────────────────────────
@@ -198,13 +197,13 @@ class HttpProbeControllerTests {
         MockMvc mvc = standaloneSetup(new HttpProbeController(env)).build();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("GET", "/", null, null))))
-            // The controller returns HTTP 200; error details are in the DTO
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(0))
-            .andExpect(jsonPath("$.statusText").value("Error"))
-            .andExpect(jsonPath("$.durationMs").isNumber());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", "/", null, null))))
+                // The controller returns HTTP 200; error details are in the DTO
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(0))
+                .andExpect(jsonPath("$.statusText").value("Error"))
+                .andExpect(jsonPath("$.durationMs").isNumber());
     }
 
     @Test
@@ -220,10 +219,10 @@ class HttpProbeControllerTests {
         MockMvc mvc = standaloneSetup(new HttpProbeController(env)).build();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest(null, null, null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(0));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest(null, null, null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(0));
     }
 
     // ── body handling ─────────────────────────────────────────────────────────
@@ -239,10 +238,10 @@ class HttpProbeControllerTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("GET", "/body", null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.body").value("hello-body"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", "/body", null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.body").value("hello-body"));
     }
 
     @Test
@@ -256,11 +255,11 @@ class HttpProbeControllerTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("POST", "/echo", "request-payload", null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status").value(200))
-            .andExpect(jsonPath("$.body").value("request-payload"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("POST", "/echo", "request-payload", null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.body").value("request-payload"));
     }
 
     @Test
@@ -274,10 +273,10 @@ class HttpProbeControllerTests {
         MockMvc mvc = buildMvc();
 
         mvc.perform(post("/bootui/api/probe")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(toJson(new HttpProbeRequest("GET", "/fast", null, null))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.durationMs").isNumber());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", "/fast", null, null))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.durationMs").isNumber());
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LogTailControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LogTailControllerTests.java
@@ -1,16 +1,5 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.slf4j.ILoggerFactory;
-import org.slf4j.LoggerFactory;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,6 +7,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.web.servlet.MockMvc;
 
 /**
  * Tests for {@link LogTailController} and {@link BootUiLogAppender}.
@@ -136,13 +135,13 @@ class LogTailControllerTests {
     void levelStringMatchesLogbackLevelToString() {
         BootUiLogAppender appender = freshAppender();
 
-        for (Level level : new Level[]{Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR}) {
+        for (Level level : new Level[] {Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR}) {
             appender.doAppend(event(level, "l", "m"));
         }
 
         List<String> levels = appender.getRecentLines().stream()
-            .map(BootUiLogAppender.LogLineDto::level)
-            .toList();
+                .map(BootUiLogAppender.LogLineDto::level)
+                .toList();
         assertThat(levels).containsExactly("TRACE", "DEBUG", "INFO", "WARN", "ERROR");
     }
 
@@ -176,10 +175,11 @@ class LogTailControllerTests {
         MockMvc mvc = standaloneSetup(new LogTailController()).build();
 
         mvc.perform(get("/bootui/api/logs/recent"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].level").value("ERROR"))
-            .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].logger")
-                .value("io.github.jdubois.Test"));
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$[?(@.message == '" + uniqueMsg + "')].level").value("ERROR"))
+                .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].logger")
+                        .value("io.github.jdubois.Test"));
     }
 
     @Test
@@ -199,10 +199,14 @@ class LogTailControllerTests {
         MockMvc mvc = standaloneSetup(new LogTailController()).build();
 
         mvc.perform(get("/bootui/api/logs/recent"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].timestamp").value(ts))
-            .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].level").value("DEBUG"))
-            .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].logger").value("shape.Logger"))
-            .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].thread").value("shape-thread"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].timestamp")
+                        .value(ts))
+                .andExpect(
+                        jsonPath("$[?(@.message == '" + uniqueMsg + "')].level").value("DEBUG"))
+                .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].logger")
+                        .value("shape.Logger"))
+                .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].thread")
+                        .value("shape-thread"));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LoggersControllerMutationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LoggersControllerMutationTests.java
@@ -1,5 +1,17 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
@@ -10,19 +22,6 @@ import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggerConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.TreeSet;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Mutation-focused tests for {@link LoggersController}.
@@ -82,33 +81,43 @@ class LoggersControllerMutationTests {
 
         // POST: setting DEBUG should return the refreshed DTO
         when(endpoint.loggerLevels("com.example"))
-            .thenReturn(new SingleLoggerLevelsDescriptor(
-                new LoggerConfiguration("com.example", LogLevel.DEBUG, LogLevel.DEBUG)));
+                .thenReturn(new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("com.example", LogLevel.DEBUG, LogLevel.DEBUG)));
 
         // GET all: build a LoggersDescriptor that includes the newly-configured logger
         Map<String, LoggerLevelsDescriptor> loggersMap = new LinkedHashMap<>();
-        loggersMap.put("com.example", new SingleLoggerLevelsDescriptor(
-            new LoggerConfiguration("com.example", LogLevel.DEBUG, LogLevel.DEBUG)));
+        loggersMap.put(
+                "com.example",
+                new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("com.example", LogLevel.DEBUG, LogLevel.DEBUG)));
         TreeSet<LogLevel> levels = new TreeSet<>();
-        levels.addAll(java.util.List.of(LogLevel.TRACE, LogLevel.DEBUG, LogLevel.INFO,
-            LogLevel.WARN, LogLevel.ERROR, LogLevel.FATAL, LogLevel.OFF));
+        levels.addAll(java.util.List.of(
+                LogLevel.TRACE,
+                LogLevel.DEBUG,
+                LogLevel.INFO,
+                LogLevel.WARN,
+                LogLevel.ERROR,
+                LogLevel.FATAL,
+                LogLevel.OFF));
         when(endpoint.loggers()).thenReturn(new LoggersDescriptor(levels, loggersMap, Map.of()));
 
-        MockMvc mvc = standaloneSetup(new LoggersController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new LoggersController(providerOf(endpoint))).build();
 
         // POST to configure the level
         mvc.perform(post("/bootui/api/loggers/com.example")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"level\":\"DEBUG\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("com.example"))
-            .andExpect(jsonPath("$.configuredLevel").value("DEBUG"))
-            .andExpect(jsonPath("$.effectiveLevel").value("DEBUG"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":\"DEBUG\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("com.example"))
+                .andExpect(jsonPath("$.configuredLevel").value("DEBUG"))
+                .andExpect(jsonPath("$.effectiveLevel").value("DEBUG"));
 
         // GET: the full list must contain the updated entry
         mvc.perform(get("/bootui/api/loggers"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.loggers[?(@.name=='com.example')].configuredLevel").value("DEBUG"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.loggers[?(@.name=='com.example')].configuredLevel")
+                        .value("DEBUG"));
 
         verify(endpoint, times(1)).configureLogLevel(eq("com.example"), eq(LogLevel.DEBUG));
     }
@@ -120,18 +129,19 @@ class LoggersControllerMutationTests {
         LoggersEndpoint endpoint = mock(LoggersEndpoint.class);
         // After clearing, the logger has no configured level but inherits INFO
         when(endpoint.loggerLevels("com.example"))
-            .thenReturn(new SingleLoggerLevelsDescriptor(
-                new LoggerConfiguration("com.example", (LogLevel) null, LogLevel.INFO)));
+                .thenReturn(new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("com.example", (LogLevel) null, LogLevel.INFO)));
 
-        MockMvc mvc = standaloneSetup(new LoggersController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new LoggersController(providerOf(endpoint))).build();
 
         mvc.perform(post("/bootui/api/loggers/com.example")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"level\":null}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("com.example"))
-            .andExpect(jsonPath("$.configuredLevel").doesNotExist())
-            .andExpect(jsonPath("$.effectiveLevel").value("INFO"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":null}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("com.example"))
+                .andExpect(jsonPath("$.configuredLevel").doesNotExist())
+                .andExpect(jsonPath("$.effectiveLevel").value("INFO"));
 
         verify(endpoint, times(1)).configureLogLevel(eq("com.example"), eq((LogLevel) null));
     }
@@ -144,46 +154,51 @@ class LoggersControllerMutationTests {
 
         // POST clear (blank level): returns the logger without a configured level
         when(endpoint.loggerLevels("com.example"))
-            .thenReturn(new SingleLoggerLevelsDescriptor(
-                new LoggerConfiguration("com.example", (LogLevel) null, LogLevel.WARN)));
+                .thenReturn(new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("com.example", (LogLevel) null, LogLevel.WARN)));
 
         // GET all: the descriptor also shows null configured, WARN effective
         Map<String, LoggerLevelsDescriptor> loggersMap = new LinkedHashMap<>();
-        loggersMap.put("com.example", new SingleLoggerLevelsDescriptor(
-            new LoggerConfiguration("com.example", (LogLevel) null, LogLevel.WARN)));
-        when(endpoint.loggers())
-            .thenReturn(new LoggersDescriptor(new TreeSet<>(), loggersMap, Map.of()));
+        loggersMap.put(
+                "com.example",
+                new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("com.example", (LogLevel) null, LogLevel.WARN)));
+        when(endpoint.loggers()).thenReturn(new LoggersDescriptor(new TreeSet<>(), loggersMap, Map.of()));
 
-        MockMvc mvc = standaloneSetup(new LoggersController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new LoggersController(providerOf(endpoint))).build();
 
         // Clearing the level
         mvc.perform(post("/bootui/api/loggers/com.example")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"level\":\"\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.configuredLevel").doesNotExist())
-            .andExpect(jsonPath("$.effectiveLevel").value("WARN"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":\"\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.configuredLevel").doesNotExist())
+                .andExpect(jsonPath("$.effectiveLevel").value("WARN"));
 
         // The GET list must reflect null configured and WARN effective.
         // The filter expression returns [null] for a null configuredLevel, so we use
         // a Hamcrest matcher rather than isEmpty() (which would reject [null]).
         mvc.perform(get("/bootui/api/loggers"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.loggers[?(@.name=='com.example')].configuredLevel",
-                org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.nullValue())))
-            .andExpect(jsonPath("$.loggers[?(@.name=='com.example')].effectiveLevel").value("WARN"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(
+                        "$.loggers[?(@.name=='com.example')].configuredLevel",
+                        org.hamcrest.Matchers.hasItem(org.hamcrest.Matchers.nullValue())))
+                .andExpect(jsonPath("$.loggers[?(@.name=='com.example')].effectiveLevel")
+                        .value("WARN"));
     }
 
     @Test
     void postWithUnrecognisedLevel_returnsBadRequestAndErrorBody() throws Exception {
         LoggersEndpoint endpoint = mock(LoggersEndpoint.class);
-        MockMvc mvc = standaloneSetup(new LoggersController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new LoggersController(providerOf(endpoint))).build();
 
         mvc.perform(post("/bootui/api/loggers/com.example")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"level\":\"VERBOSE\"}"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").isString());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":\"VERBOSE\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").isString());
     }
 
     @Test
@@ -192,10 +207,11 @@ class LoggersControllerMutationTests {
 
         // When LoggersEndpoint is absent the controller throws IllegalStateException.
         // Spring MVC propagates it out of perform() as a wrapped servlet exception.
-        Exception ex = org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () ->
-            mvc.perform(post("/bootui/api/loggers/com.example")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"level\":\"INFO\"}")));
+        Exception ex = org.junit.jupiter.api.Assertions.assertThrows(
+                Exception.class,
+                () -> mvc.perform(post("/bootui/api/loggers/com.example")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":\"INFO\"}")));
 
         Throwable cause = ex;
         while (cause.getCause() != null) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LoggersControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LoggersControllerTests.java
@@ -1,5 +1,12 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
@@ -8,13 +15,6 @@ import org.springframework.boot.logging.LogLevel;
 import org.springframework.boot.logging.LoggerConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * HTTP-level tests for {@link LoggersController} mutation behavior.
@@ -35,18 +35,19 @@ class LoggersControllerTests {
     void postUpdatesLogLevelAndReturnsRefreshedDto() throws Exception {
         LoggersEndpoint endpoint = mock(LoggersEndpoint.class);
         when(endpoint.loggerLevels("com.example"))
-            .thenReturn(new SingleLoggerLevelsDescriptor(
-                new LoggerConfiguration("com.example", LogLevel.DEBUG, LogLevel.DEBUG)));
+                .thenReturn(new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("com.example", LogLevel.DEBUG, LogLevel.DEBUG)));
 
-        MockMvc mvc = standaloneSetup(new LoggersController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new LoggersController(providerOf(endpoint))).build();
 
         mvc.perform(post("/bootui/api/loggers/com.example")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"level\":\"DEBUG\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("com.example"))
-            .andExpect(jsonPath("$.configuredLevel").value("DEBUG"))
-            .andExpect(jsonPath("$.effectiveLevel").value("DEBUG"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":\"DEBUG\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("com.example"))
+                .andExpect(jsonPath("$.configuredLevel").value("DEBUG"))
+                .andExpect(jsonPath("$.effectiveLevel").value("DEBUG"));
 
         verify(endpoint, times(1)).configureLogLevel(eq("com.example"), eq(LogLevel.DEBUG));
     }
@@ -55,18 +56,19 @@ class LoggersControllerTests {
     void postWithBlankLevelClearsConfiguredLevel() throws Exception {
         LoggersEndpoint endpoint = mock(LoggersEndpoint.class);
         when(endpoint.loggerLevels("com.example"))
-            .thenReturn(new SingleLoggerLevelsDescriptor(
-                new LoggerConfiguration("com.example", null, LogLevel.INFO)));
+                .thenReturn(
+                        new SingleLoggerLevelsDescriptor(new LoggerConfiguration("com.example", null, LogLevel.INFO)));
 
-        MockMvc mvc = standaloneSetup(new LoggersController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new LoggersController(providerOf(endpoint))).build();
 
         mvc.perform(post("/bootui/api/loggers/com.example")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"level\":\"\"}"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("com.example"))
-            .andExpect(jsonPath("$.configuredLevel").doesNotExist())
-            .andExpect(jsonPath("$.effectiveLevel").value("INFO"));
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":\"\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("com.example"))
+                .andExpect(jsonPath("$.configuredLevel").doesNotExist())
+                .andExpect(jsonPath("$.effectiveLevel").value("INFO"));
 
         verify(endpoint, times(1)).configureLogLevel(eq("com.example"), eq((LogLevel) null));
     }
@@ -74,13 +76,14 @@ class LoggersControllerTests {
     @Test
     void postWithInvalidLevelReturnsBadRequest() throws Exception {
         LoggersEndpoint endpoint = mock(LoggersEndpoint.class);
-        MockMvc mvc = standaloneSetup(new LoggersController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new LoggersController(providerOf(endpoint))).build();
 
         mvc.perform(post("/bootui/api/loggers/com.example")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"level\":\"NOT_A_LEVEL\"}"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").exists());
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"level\":\"NOT_A_LEVEL\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
 
         verify(endpoint, never()).configureLogLevel(eq("com.example"), org.mockito.ArgumentMatchers.any());
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MappingsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MappingsControllerTests.java
@@ -1,5 +1,12 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
 import org.springframework.beans.factory.ObjectProvider;
@@ -7,14 +14,6 @@ import org.springframework.boot.actuate.web.mappings.MappingsEndpoint;
 import org.springframework.boot.actuate.web.mappings.MappingsEndpoint.ApplicationMappingsDescriptor;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Map;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Controller-level tests for {@link MappingsController}.
@@ -44,23 +43,23 @@ class MappingsControllerTests {
     void mappingsReturnsNoContentWhenActuatorUnavailable() throws Exception {
         MockMvc mvc = standaloneSetup(new MappingsController(emptyProvider())).build();
 
-        mvc.perform(get("/bootui/api/mappings"))
-            .andExpect(status().isNoContent());
+        mvc.perform(get("/bootui/api/mappings")).andExpect(status().isNoContent());
     }
 
     @Test
     void mappingsReturnsOkWithDescriptorWhenActuatorPresent() throws Exception {
-        ApplicationMappingsDescriptor descriptor = mock(ApplicationMappingsDescriptor.class,
-            withSettings().mockMaker(MockMakers.INLINE));
+        ApplicationMappingsDescriptor descriptor =
+                mock(ApplicationMappingsDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(descriptor.getContexts()).thenReturn(Map.of());
 
         MappingsEndpoint endpoint = mock(MappingsEndpoint.class);
         when(endpoint.mappings()).thenReturn(descriptor);
 
-        MockMvc mvc = standaloneSetup(new MappingsController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new MappingsController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/mappings").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MemoryCalculatorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MemoryCalculatorTests.java
@@ -1,10 +1,10 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.github.jdubois.bootui.autoconfigure.web.MemoryCalculator.JdkVersion;
 import io.github.jdubois.bootui.core.BootUiDtos.MemoryCalculationDto;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit tests for the Paketo {@code libjvm}-style {@link MemoryCalculator}.
@@ -23,20 +23,14 @@ class MemoryCalculatorTests {
     void heapIsTotalMinusFixedRegionsAndHeadroom() {
         MemoryCalculator calc = new MemoryCalculator(JDK_25);
 
-        MemoryCalculationDto result = calc.calculate(
-            1024 * MB,
-            250,
-            10_000,
-            0,
-            42,
-            10_000);
+        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 10_000, 0, 42, 10_000);
 
-        long expectedMetaspace = (long) Math.ceil(
-            (14_000_000L + 5_800L * 10_000L) * MemoryCalculator.META_SAFETY_FACTOR);
+        long expectedMetaspace =
+                (long) Math.ceil((14_000_000L + 5_800L * 10_000L) * MemoryCalculator.META_SAFETY_FACTOR);
         long expectedFixed = MemoryCalculator.DIRECT_MEMORY_BYTES
-            + expectedMetaspace
-            + MemoryCalculator.CODE_CACHE_BYTES
-            + MemoryCalculator.STACK_BYTES_PER_THREAD * 250L;
+                + expectedMetaspace
+                + MemoryCalculator.CODE_CACHE_BYTES
+                + MemoryCalculator.STACK_BYTES_PER_THREAD * 250L;
         long expectedHeap = 1024 * MB - 0 - expectedFixed;
 
         assertThat(result.valid()).isTrue();
@@ -65,8 +59,7 @@ class MemoryCalculatorTests {
         assertThat(a.metaspaceBytes()).isEqualTo(expectedBaseline);
 
         MemoryCalculationDto b = calc.calculate(1024 * MB, 250, 1_000, 0, 1, 1_000);
-        long expected1k = (long) Math.ceil(
-            (14_000_000L + 5_800L * 1_000L) * MemoryCalculator.META_SAFETY_FACTOR);
+        long expected1k = (long) Math.ceil((14_000_000L + 5_800L * 1_000L) * MemoryCalculator.META_SAFETY_FACTOR);
         assertThat(b.metaspaceBytes()).isEqualTo(expected1k);
     }
 
@@ -100,9 +93,7 @@ class MemoryCalculatorTests {
         MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
 
         long heapMb = Math.round(result.heapBytes() / (double) MB);
-        assertThat(result.jvmOptions())
-            .contains("-Xms" + heapMb + "m")
-            .contains("-Xmx" + heapMb + "m");
+        assertThat(result.jvmOptions()).contains("-Xms" + heapMb + "m").contains("-Xmx" + heapMb + "m");
     }
 
     @Test
@@ -120,9 +111,9 @@ class MemoryCalculatorTests {
 
         long metaMb = Math.round(result.metaspaceBytes() / (double) MB);
         assertThat(result.jvmOptions())
-            .contains("-XX:ReservedCodeCacheSize=240m")
-            .contains("-XX:MaxDirectMemorySize=10m")
-            .contains("-XX:MaxMetaspaceSize=" + metaMb + "m");
+                .contains("-XX:ReservedCodeCacheSize=240m")
+                .contains("-XX:MaxDirectMemorySize=10m")
+                .contains("-XX:MaxMetaspaceSize=" + metaMb + "m");
     }
 
     @Test
@@ -141,13 +132,7 @@ class MemoryCalculatorTests {
     void invalidWhenTotalMemoryLeavesNoRoomForHeap() {
         MemoryCalculator calc = new MemoryCalculator(JDK_25);
 
-        MemoryCalculationDto result = calc.calculate(
-            256 * MB,
-            5_000,
-            100_000,
-            0,
-            10,
-            100_000);
+        MemoryCalculationDto result = calc.calculate(256 * MB, 5_000, 100_000, 0, 10, 100_000);
 
         assertThat(result.valid()).isFalse();
         assertThat(result.error()).isNotNull().contains("No room for heap");
@@ -159,13 +144,7 @@ class MemoryCalculatorTests {
     void clampsOutOfRangeInputs() {
         MemoryCalculator calc = new MemoryCalculator(JDK_25);
 
-        MemoryCalculationDto result = calc.calculate(
-            -1,
-            -1,
-            -1,
-            -50,
-            10,
-            0);
+        MemoryCalculationDto result = calc.calculate(-1, -1, -1, -50, 10, 0);
 
         assertThat(result.totalMemoryBytes()).isGreaterThanOrEqualTo(MemoryCalculator.MIN_TOTAL_MEMORY_BYTES);
         assertThat(result.threadCount()).isGreaterThanOrEqualTo(MemoryCalculator.MIN_THREAD_COUNT);
@@ -177,13 +156,7 @@ class MemoryCalculatorTests {
     void clampsOversizedInputs() {
         MemoryCalculator calc = new MemoryCalculator(JDK_25);
 
-        MemoryCalculationDto result = calc.calculate(
-            Long.MAX_VALUE,
-            Integer.MAX_VALUE,
-            10_000,
-            1_000,
-            10,
-            10_000);
+        MemoryCalculationDto result = calc.calculate(Long.MAX_VALUE, Integer.MAX_VALUE, 10_000, 1_000, 10, 10_000);
 
         assertThat(result.totalMemoryBytes()).isLessThanOrEqualTo(MemoryCalculator.MAX_TOTAL_MEMORY_BYTES);
         assertThat(result.threadCount()).isLessThanOrEqualTo(MemoryCalculator.MAX_THREAD_COUNT);
@@ -194,17 +167,9 @@ class MemoryCalculatorTests {
     void defaultTotalMemoryIsClampedRegardlessOfHostFootprint() {
         MemoryCalculator calc = new MemoryCalculator(JDK_25);
 
-        long onLargeMac = calc.defaultTotalMemoryBytes(
-            2L * 1024 * MB,
-            300L * MB,
-            40,
-            15_000);
+        long onLargeMac = calc.defaultTotalMemoryBytes(2L * 1024 * MB, 300L * MB, 40, 15_000);
 
-        long onTinyApp = calc.defaultTotalMemoryBytes(
-            32L * MB,
-            16L * MB,
-            10,
-            500);
+        long onTinyApp = calc.defaultTotalMemoryBytes(32L * MB, 16L * MB, 10, 500);
 
         assertThat(onLargeMac).isLessThanOrEqualTo(2048L * MB);
         assertThat(onLargeMac).isGreaterThanOrEqualTo(384L * MB);
@@ -216,11 +181,7 @@ class MemoryCalculatorTests {
     void defaultTotalMemoryIsAlignedTo64MbBoundary() {
         MemoryCalculator calc = new MemoryCalculator(JDK_25);
 
-        long result = calc.defaultTotalMemoryBytes(
-            200L * MB,
-            100L * MB,
-            40,
-            10_000);
+        long result = calc.defaultTotalMemoryBytes(200L * MB, 100L * MB, 40, 10_000);
 
         assertThat(result % (64L * MB)).isZero();
     }
@@ -238,9 +199,9 @@ class MemoryCalculatorTests {
         MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
 
         assertThat(result.jvmOptions())
-            .contains("-XX:+UseStringDeduplication")
-            .contains("-XX:+ExitOnOutOfMemoryError")
-            .contains("-XX:+HeapDumpOnOutOfMemoryError")
-            .contains("-XX:HeapDumpPath=/tmp");
+                .contains("-XX:+UseStringDeduplication")
+                .contains("-XX:+ExitOnOutOfMemoryError")
+                .contains("-XX:+HeapDumpOnOutOfMemoryError")
+                .contains("-XX:HeapDumpPath=/tmp");
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MemoryControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MemoryControllerTests.java
@@ -1,14 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.github.jdubois.bootui.autoconfigure.web.MemoryCalculator.JdkVersion;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.jdubois.bootui.autoconfigure.web.MemoryCalculator.JdkVersion;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 
 /**
  * Controller-level tests for {@link MemoryController}.
@@ -29,100 +29,99 @@ class MemoryControllerTests {
 
     @Test
     void memoryReturnsExpectedTopLevelShape() throws Exception {
-        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25))).build();
+        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25)))
+                .build();
 
         mvc.perform(get("/bootui/api/memory").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.heap").isMap())
-            .andExpect(jsonPath("$.heap.name").value("Heap"))
-            .andExpect(jsonPath("$.nonHeap").isMap())
-            .andExpect(jsonPath("$.nonHeap.name").value("Non-Heap"))
-            .andExpect(jsonPath("$.pools").isArray())
-            .andExpect(jsonPath("$.jvmInputArguments").isArray())
-            .andExpect(jsonPath("$.suggestedJvmOptions").isString())
-            .andExpect(jsonPath("$.calculation").isMap());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.heap").isMap())
+                .andExpect(jsonPath("$.heap.name").value("Heap"))
+                .andExpect(jsonPath("$.nonHeap").isMap())
+                .andExpect(jsonPath("$.nonHeap.name").value("Non-Heap"))
+                .andExpect(jsonPath("$.pools").isArray())
+                .andExpect(jsonPath("$.jvmInputArguments").isArray())
+                .andExpect(jsonPath("$.suggestedJvmOptions").isString())
+                .andExpect(jsonPath("$.calculation").isMap());
     }
 
     @Test
     void memoryPoolDtoHasRequiredFields() throws Exception {
-        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25))).build();
+        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25)))
+                .build();
 
         mvc.perform(get("/bootui/api/memory").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.heap.usedBytes").isNumber())
-            .andExpect(jsonPath("$.heap.committedBytes").isNumber())
-            .andExpect(jsonPath("$.heap.maxBytes").isNumber())
-            .andExpect(jsonPath("$.heap.usedPercent").isNumber())
-            .andExpect(jsonPath("$.nonHeap.usedBytes").isNumber());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.heap.usedBytes").isNumber())
+                .andExpect(jsonPath("$.heap.committedBytes").isNumber())
+                .andExpect(jsonPath("$.heap.maxBytes").isNumber())
+                .andExpect(jsonPath("$.heap.usedPercent").isNumber())
+                .andExpect(jsonPath("$.nonHeap.usedBytes").isNumber());
     }
 
     @Test
     void memoryHonorsTotalMemoryMbOverrideParam() throws Exception {
-        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25))).build();
+        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25)))
+                .build();
 
         // With 512 MB total, calculation.totalMemoryBytes must reflect exactly 512 * 1024 * 1024
         long expectedBytes = 512L * 1024L * 1024L;
-        mvc.perform(get("/bootui/api/memory")
-                .param("totalMemoryMb", "512")
-                .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.calculation.totalMemoryBytes").value(expectedBytes));
+        mvc.perform(get("/bootui/api/memory").param("totalMemoryMb", "512").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.calculation.totalMemoryBytes").value(expectedBytes));
     }
 
     @Test
     void memoryHonorsThreadCountOverrideParam() throws Exception {
-        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25))).build();
+        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25)))
+                .build();
 
         mvc.perform(get("/bootui/api/memory")
-                .param("totalMemoryMb", "1024")
-                .param("threadCount", "50")
-                .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            // 50 < MIN_THREAD_COUNT (1) floor is fine, but also < DEFAULT_THREAD_COUNT_FLOOR (250)
-            // The clamp keeps it at max(1, min(10000, 50)) = 50
-            .andExpect(jsonPath("$.calculation.threadCount").value(50));
+                        .param("totalMemoryMb", "1024")
+                        .param("threadCount", "50")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                // 50 < MIN_THREAD_COUNT (1) floor is fine, but also < DEFAULT_THREAD_COUNT_FLOOR (250)
+                // The clamp keeps it at max(1, min(10000, 50)) = 50
+                .andExpect(jsonPath("$.calculation.threadCount").value(50));
     }
 
     @Test
     void suggestedJvmOptionsContainsRequiredFlags() throws Exception {
-        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25))).build();
+        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25)))
+                .build();
 
-        mvc.perform(get("/bootui/api/memory")
-                .param("totalMemoryMb", "1024")
-                .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.suggestedJvmOptions").value(
-                org.hamcrest.Matchers.containsString("-Xmx")))
-            .andExpect(jsonPath("$.suggestedJvmOptions").value(
-                org.hamcrest.Matchers.containsString("-Xms")))
-            .andExpect(jsonPath("$.suggestedJvmOptions").value(
-                org.hamcrest.Matchers.containsString("-XX:MaxMetaspaceSize=")))
-            .andExpect(jsonPath("$.suggestedJvmOptions").value(
-                org.hamcrest.Matchers.containsString("-XX:+UseCompactObjectHeaders")));
+        mvc.perform(get("/bootui/api/memory").param("totalMemoryMb", "1024").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.suggestedJvmOptions").value(org.hamcrest.Matchers.containsString("-Xmx")))
+                .andExpect(jsonPath("$.suggestedJvmOptions").value(org.hamcrest.Matchers.containsString("-Xms")))
+                .andExpect(jsonPath("$.suggestedJvmOptions")
+                        .value(org.hamcrest.Matchers.containsString("-XX:MaxMetaspaceSize=")))
+                .andExpect(jsonPath("$.suggestedJvmOptions")
+                        .value(org.hamcrest.Matchers.containsString("-XX:+UseCompactObjectHeaders")));
     }
 
     @Test
     void jvmInputArgumentsAreExposedAsArray() throws Exception {
-        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25))).build();
+        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25)))
+                .build();
 
         // The endpoint always returns the live JVM input args list;
         // in a test JVM it may be empty, but the field must be a JSON array.
         mvc.perform(get("/bootui/api/memory").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.jvmInputArguments").isArray());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.jvmInputArguments").isArray());
     }
 
     @Test
     void calculationReportsLiveContextValues() throws Exception {
-        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25))).build();
+        MockMvc mvc = standaloneSetup(new MemoryController(new MemoryCalculator(JDK_25)))
+                .build();
 
         mvc.perform(get("/bootui/api/memory").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            // liveThreadCount must be at least 1 (the test thread itself)
-            .andExpect(jsonPath("$.calculation.liveThreadCount").value(
-                org.hamcrest.Matchers.greaterThan(0)))
-            // liveLoadedClassCount must be at least 1
-            .andExpect(jsonPath("$.calculation.liveLoadedClassCount").value(
-                org.hamcrest.Matchers.greaterThan(0)));
+                .andExpect(status().isOk())
+                // liveThreadCount must be at least 1 (the test thread itself)
+                .andExpect(jsonPath("$.calculation.liveThreadCount").value(org.hamcrest.Matchers.greaterThan(0)))
+                // liveLoadedClassCount must be at least 1
+                .andExpect(jsonPath("$.calculation.liveLoadedClassCount").value(org.hamcrest.Matchers.greaterThan(0)));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MetricsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MetricsControllerTests.java
@@ -1,14 +1,5 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.micrometer.core.instrument.*;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.mockito.Mockito.mock;
@@ -17,6 +8,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.micrometer.core.instrument.*;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.test.web.servlet.MockMvc;
 
 class MetricsControllerTests {
 
@@ -31,76 +30,79 @@ class MetricsControllerTests {
     void listGroupsMetersByNameAndAggregatesTagValues() throws Exception {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         Counter.builder("bootui.sample.requests")
-            .description("Sample requests")
-            .baseUnit("requests")
-            .tag("outcome", "success")
-            .register(registry)
-            .increment(2);
+                .description("Sample requests")
+                .baseUnit("requests")
+                .tag("outcome", "success")
+                .register(registry)
+                .increment(2);
         Counter.builder("bootui.sample.requests")
-            .description("Sample requests")
-            .baseUnit("requests")
-            .tag("outcome", "failure")
-            .register(registry)
-            .increment();
+                .description("Sample requests")
+                .baseUnit("requests")
+                .tag("outcome", "failure")
+                .register(registry)
+                .increment();
 
-        MockMvc mvc = standaloneSetup(new MetricsController(providerOf(registry))).build();
+        MockMvc mvc =
+                standaloneSetup(new MetricsController(providerOf(registry))).build();
 
         mvc.perform(get("/bootui/api/metrics"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.metricsAvailable").value(true))
-            .andExpect(jsonPath("$.total").value(greaterThan(0)))
-            .andExpect(jsonPath("$.meters[0].name").value("bootui.sample.requests"))
-            .andExpect(jsonPath("$.meters[0].description").value("Sample requests"))
-            .andExpect(jsonPath("$.meters[0].baseUnit").value("requests"))
-            .andExpect(jsonPath("$.meters[0].type").value("COUNTER"))
-            .andExpect(jsonPath("$.meters[0].availableTags[0].key").value("outcome"))
-            .andExpect(jsonPath("$.meters[0].availableTags[0].values", contains("failure", "success")));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.metricsAvailable").value(true))
+                .andExpect(jsonPath("$.total").value(greaterThan(0)))
+                .andExpect(jsonPath("$.meters[0].name").value("bootui.sample.requests"))
+                .andExpect(jsonPath("$.meters[0].description").value("Sample requests"))
+                .andExpect(jsonPath("$.meters[0].baseUnit").value("requests"))
+                .andExpect(jsonPath("$.meters[0].type").value("COUNTER"))
+                .andExpect(jsonPath("$.meters[0].availableTags[0].key").value("outcome"))
+                .andExpect(jsonPath("$.meters[0].availableTags[0].values", contains("failure", "success")));
     }
 
     @Test
     void detailFiltersByTagsAndAggregatesFiniteMeasurements() throws Exception {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         Counter.builder("bootui.sample.requests")
-            .tag("outcome", "success")
-            .register(registry)
-            .increment(2);
+                .tag("outcome", "success")
+                .register(registry)
+                .increment(2);
         Counter.builder("bootui.sample.requests")
-            .tag("outcome", "failure")
-            .register(registry)
-            .increment(3);
+                .tag("outcome", "failure")
+                .register(registry)
+                .increment(3);
 
-        MockMvc mvc = standaloneSetup(new MetricsController(providerOf(registry))).build();
+        MockMvc mvc =
+                standaloneSetup(new MetricsController(providerOf(registry))).build();
 
         mvc.perform(get("/bootui/api/metrics/detail")
-                .param("name", "bootui.sample.requests")
-                .param("tag", "outcome:success"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.metricsAvailable").value(true))
-            .andExpect(jsonPath("$.name").value("bootui.sample.requests"))
-            .andExpect(jsonPath("$.measurements[0].statistic").value("count"))
-            .andExpect(jsonPath("$.measurements[0].value").value(2.0))
-            .andExpect(jsonPath("$.samples.length()").value(1))
-            .andExpect(jsonPath("$.samples[0].tags[0].key").value("outcome"))
-            .andExpect(jsonPath("$.samples[0].tags[0].value").value("success"));
+                        .param("name", "bootui.sample.requests")
+                        .param("tag", "outcome:success"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.metricsAvailable").value(true))
+                .andExpect(jsonPath("$.name").value("bootui.sample.requests"))
+                .andExpect(jsonPath("$.measurements[0].statistic").value("count"))
+                .andExpect(jsonPath("$.measurements[0].value").value(2.0))
+                .andExpect(jsonPath("$.samples.length()").value(1))
+                .andExpect(jsonPath("$.samples[0].tags[0].key").value("outcome"))
+                .andExpect(jsonPath("$.samples[0].tags[0].value").value("success"));
     }
 
     @Test
     void detailUsesMaximumWhenAggregatingMaxStatistic() throws Exception {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         Timer.builder("bootui.sample.latency")
-            .tag("node", "one")
-            .register(registry)
-            .record(10, TimeUnit.MILLISECONDS);
+                .tag("node", "one")
+                .register(registry)
+                .record(10, TimeUnit.MILLISECONDS);
         Timer.builder("bootui.sample.latency")
-            .tag("node", "two")
-            .register(registry)
-            .record(25, TimeUnit.MILLISECONDS);
+                .tag("node", "two")
+                .register(registry)
+                .record(25, TimeUnit.MILLISECONDS);
 
-        MockMvc mvc = standaloneSetup(new MetricsController(providerOf(registry))).build();
+        MockMvc mvc =
+                standaloneSetup(new MetricsController(providerOf(registry))).build();
 
         mvc.perform(get("/bootui/api/metrics/detail").param("name", "bootui.sample.latency"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.measurements[?(@.statistic == 'max')].value", contains(0.025)));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.measurements[?(@.statistic == 'max')].value", contains(0.025)));
     }
 
     @Test
@@ -108,17 +110,18 @@ class MetricsControllerTests {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         AtomicInteger value = new AtomicInteger(7);
         Gauge.builder("bootui.sample.gauge", value, AtomicInteger::get)
-            .tags(Tags.of("uri", "http://localhost:8080/api"))
-            .register(registry);
+                .tags(Tags.of("uri", "http://localhost:8080/api"))
+                .register(registry);
 
-        MockMvc mvc = standaloneSetup(new MetricsController(providerOf(registry))).build();
+        MockMvc mvc =
+                standaloneSetup(new MetricsController(providerOf(registry))).build();
 
         mvc.perform(get("/bootui/api/metrics/detail")
-                .param("name", "bootui.sample.gauge")
-                .param("tag", "uri:http://localhost:8080/api"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.samples.length()").value(1))
-            .andExpect(jsonPath("$.measurements[0].value").value(7.0));
+                        .param("name", "bootui.sample.gauge")
+                        .param("tag", "uri:http://localhost:8080/api"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.samples.length()").value(1))
+                .andExpect(jsonPath("$.measurements[0].value").value(7.0));
     }
 
     @Test
@@ -126,12 +129,13 @@ class MetricsControllerTests {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         registry.counter("bootui.sample.requests").increment();
 
-        MockMvc mvc = standaloneSetup(new MetricsController(providerOf(registry))).build();
+        MockMvc mvc =
+                standaloneSetup(new MetricsController(providerOf(registry))).build();
 
         mvc.perform(get("/bootui/api/metrics/detail")
-                .param("name", "bootui.sample.requests")
-                .param("tag", "malformed"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").exists());
+                        .param("name", "bootui.sample.requests")
+                        .param("tag", "malformed"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MissingActuatorEndpointsTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MissingActuatorEndpointsTests.java
@@ -1,5 +1,10 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -16,11 +21,6 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.web.servlet.MockMvc;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Verifies that every BootUI controller backed by an optional Actuator or
@@ -68,10 +68,10 @@ class MissingActuatorEndpointsTests {
         MockMvc mvc = standaloneSetup(new BeansController(provider)).build();
 
         mvc.perform(get("/bootui/api/beans"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.beans").isArray())
-            .andExpect(jsonPath("$.beans").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.beans").isArray())
+                .andExpect(jsonPath("$.beans").isEmpty());
     }
 
     @Test
@@ -80,11 +80,11 @@ class MissingActuatorEndpointsTests {
         MockMvc mvc = standaloneSetup(new ConditionsController(provider)).build();
 
         mvc.perform(get("/bootui/api/conditions"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.positiveMatches").isEmpty())
-            .andExpect(jsonPath("$.negativeMatches").isEmpty())
-            .andExpect(jsonPath("$.unconditionalClasses").isEmpty())
-            .andExpect(jsonPath("$.exclusions").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.positiveMatches").isEmpty())
+                .andExpect(jsonPath("$.negativeMatches").isEmpty())
+                .andExpect(jsonPath("$.unconditionalClasses").isEmpty())
+                .andExpect(jsonPath("$.exclusions").isEmpty());
     }
 
     @Test
@@ -93,10 +93,10 @@ class MissingActuatorEndpointsTests {
         MockMvc mvc = standaloneSetup(new HealthController(provider)).build();
 
         mvc.perform(get("/bootui/api/health"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.name").value("application"))
-            .andExpect(jsonPath("$.status").value("UNKNOWN"))
-            .andExpect(jsonPath("$.components").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("application"))
+                .andExpect(jsonPath("$.status").value("UNKNOWN"))
+                .andExpect(jsonPath("$.components").isEmpty());
     }
 
     @Test
@@ -105,9 +105,9 @@ class MissingActuatorEndpointsTests {
         MockMvc mvc = standaloneSetup(new LoggersController(provider)).build();
 
         mvc.perform(get("/bootui/api/loggers"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.availableLevels").isEmpty())
-            .andExpect(jsonPath("$.loggers").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.availableLevels").isEmpty())
+                .andExpect(jsonPath("$.loggers").isEmpty());
     }
 
     @Test
@@ -116,10 +116,10 @@ class MissingActuatorEndpointsTests {
         MockMvc mvc = standaloneSetup(new MetricsController(provider)).build();
 
         mvc.perform(get("/bootui/api/metrics"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.metricsAvailable").value(false))
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.meters").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.metricsAvailable").value(false))
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.meters").isEmpty());
     }
 
     @Test
@@ -127,8 +127,7 @@ class MissingActuatorEndpointsTests {
         ObjectProvider<MappingsEndpoint> provider = emptyProvider();
         MockMvc mvc = standaloneSetup(new MappingsController(provider)).build();
 
-        mvc.perform(get("/bootui/api/mappings"))
-            .andExpect(status().isNoContent());
+        mvc.perform(get("/bootui/api/mappings")).andExpect(status().isNoContent());
     }
 
     @Test
@@ -137,8 +136,8 @@ class MissingActuatorEndpointsTests {
         MockMvc mvc = standaloneSetup(new StartupController(provider)).build();
 
         mvc.perform(get("/bootui/api/startup"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.steps").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.steps").isEmpty());
     }
 
     @Test
@@ -147,27 +146,27 @@ class MissingActuatorEndpointsTests {
         MockMvc mvc = standaloneSetup(new ScheduledController(provider)).build();
 
         mvc.perform(get("/bootui/api/scheduled"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.schedulingPresent").value(false))
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.tasks").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.schedulingPresent").value(false))
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.tasks").isEmpty());
     }
 
     @Test
     void securityControllerReturnsAbsentReportWhenFilterChainProxyMissing() throws Exception {
         SecurityController controller = new SecurityController(
-            emptyProvider(),
-            emptyProvider(),
-            emptyProvider(),
-            emptyProvider(),
-            new MockEnvironment(),
-            new BootUiProperties());
+                emptyProvider(),
+                emptyProvider(),
+                emptyProvider(),
+                emptyProvider(),
+                new MockEnvironment(),
+                new BootUiProperties());
         MockMvc mvc = standaloneSetup(controller).build();
 
         mvc.perform(get("/bootui/api/security"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.springSecurityPresent").value(false))
-            .andExpect(jsonPath("$.chains").isEmpty())
-            .andExpect(jsonPath("$.auth").doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.springSecurityPresent").value(false))
+                .andExpect(jsonPath("$.chains").isEmpty())
+                .andExpect(jsonPath("$.auth").doesNotExist());
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -1,13 +1,11 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.sun.net.httpserver.HttpServer;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.BootUiDtos.DependenciesReport;
 import io.github.jdubois.bootui.core.BootUiDtos.DependencyDto;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import tools.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -15,8 +13,9 @@ import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
 
 class OsvVulnerabilityScannerTests {
 
@@ -71,23 +70,24 @@ class OsvVulnerabilityScannerTests {
 
         BootUiProperties.Dependencies properties = new BootUiProperties.Dependencies();
         properties.setRequestTimeout(Duration.ofSeconds(2));
-        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(properties,
-            HttpClient.newHttpClient(),
-            new ObjectMapper(),
-            URI.create("http://localhost:" + server.getAddress().getPort()));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
 
         DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
 
         assertThat(report.scan().status()).isEqualTo("SCANNED");
         assertThat(report.vulnerable()).isEqualTo(1);
         assertThat(report.severityCounts())
-            .filteredOn(count -> count.severity().equals("HIGH"))
-            .singleElement()
-            .extracting("count")
-            .isEqualTo(1);
+                .filteredOn(count -> count.severity().equals("HIGH"))
+                .singleElement()
+                .extracting("count")
+                .isEqualTo(1);
         assertThat(report.dependencies().getFirst().highestSeverity()).isEqualTo("HIGH");
         assertThat(report.dependencies().getFirst().vulnerabilities().getFirst().fixedVersions())
-            .containsExactly("1.0.1");
+                .containsExactly("1.0.1");
     }
 
     @Test
@@ -102,10 +102,11 @@ class OsvVulnerabilityScannerTests {
         server.start();
 
         BootUiProperties.Dependencies properties = new BootUiProperties.Dependencies();
-        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(properties,
-            HttpClient.newHttpClient(),
-            new ObjectMapper(),
-            URI.create("http://localhost:" + server.getAddress().getPort()));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
 
         DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverEndToEndTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverEndToEndTests.java
@@ -1,5 +1,11 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import com.google.protobuf.ByteString;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
@@ -14,17 +20,10 @@ import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import io.opentelemetry.proto.trace.v1.ScopeSpans;
 import io.opentelemetry.proto.trace.v1.Span;
 import io.opentelemetry.proto.trace.v1.Status;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.nio.charset.StandardCharsets;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 class OtlpReceiverEndToEndTests {
 
@@ -43,15 +42,17 @@ class OtlpReceiverEndToEndTests {
     private MockMvc mvc;
 
     private static KeyValue stringAttr(String key, String value) {
-        return KeyValue.newBuilder().setKey(key)
-            .setValue(AnyValue.newBuilder().setStringValue(value).build())
-            .build();
+        return KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setStringValue(value).build())
+                .build();
     }
 
     private static KeyValue intAttr(String key, long value) {
-        return KeyValue.newBuilder().setKey(key)
-            .setValue(AnyValue.newBuilder().setIntValue(value).build())
-            .build();
+        return KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setIntValue(value).build())
+                .build();
     }
 
     private static KeyValue arrayStringAttr(String key, String... values) {
@@ -59,9 +60,10 @@ class OtlpReceiverEndToEndTests {
         for (String v : values) {
             arr.addValues(AnyValue.newBuilder().setStringValue(v).build());
         }
-        return KeyValue.newBuilder().setKey(key)
-            .setValue(AnyValue.newBuilder().setArrayValue(arr.build()).build())
-            .build();
+        return KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setArrayValue(arr.build()).build())
+                .build();
     }
 
     private static byte[] hexToBytes(String hex) {
@@ -94,50 +96,50 @@ class OtlpReceiverEndToEndTests {
         byte[] payload = sampleRequest().toByteArray();
 
         mvc.perform(post("/bootui/api/otlp/v1/traces")
-                .contentType("application/x-protobuf")
-                .content(payload))
-            .andExpect(status().isOk());
+                        .contentType("application/x-protobuf")
+                        .content(payload))
+                .andExpect(status().isOk());
 
         mvc.perform(get("/bootui/api/traces"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.retained").value(1))
-            .andExpect(jsonPath("$.traces[0].traceId").value(TRACE_ID))
-            .andExpect(jsonPath("$.traces[0].spanCount").value(3))
-            .andExpect(jsonPath("$.traces[0].hasAi").value(true))
-            .andExpect(jsonPath("$.traces[0].services[0]").value("sample"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.retained").value(1))
+                .andExpect(jsonPath("$.traces[0].traceId").value(TRACE_ID))
+                .andExpect(jsonPath("$.traces[0].spanCount").value(3))
+                .andExpect(jsonPath("$.traces[0].hasAi").value(true))
+                .andExpect(jsonPath("$.traces[0].services[0]").value("sample"));
 
         mvc.perform(get("/bootui/api/traces/" + TRACE_ID))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.spans.length()").value(3));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.spans.length()").value(3));
 
         mvc.perform(get("/bootui/api/ai/overview"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.totalChats").value(1))
-            .andExpect(jsonPath("$.totalInputTokens").value(42))
-            .andExpect(jsonPath("$.totalOutputTokens").value(7))
-            .andExpect(jsonPath("$.toolCallCount").value(1))
-            .andExpect(jsonPath("$.vectorOperationCount").value(1))
-            .andExpect(jsonPath("$.recent[0].requestModel").value("qwen3:0.6b"))
-            .andExpect(jsonPath("$.recent[0].provider").value("ollama"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalChats").value(1))
+                .andExpect(jsonPath("$.totalInputTokens").value(42))
+                .andExpect(jsonPath("$.totalOutputTokens").value(7))
+                .andExpect(jsonPath("$.toolCallCount").value(1))
+                .andExpect(jsonPath("$.vectorOperationCount").value(1))
+                .andExpect(jsonPath("$.recent[0].requestModel").value("qwen3:0.6b"))
+                .andExpect(jsonPath("$.recent[0].provider").value("ollama"));
 
         mvc.perform(get("/bootui/api/ai/chats/" + CHAT_SPAN_ID))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.summary.toolCallCount").value(1))
-            .andExpect(jsonPath("$.summary.vectorOperationCount").value(1))
-            .andExpect(jsonPath("$.toolCalls[0].name").value("getWeather"))
-            .andExpect(jsonPath("$.vectorOperations[0].collectionName").value("docs"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.summary.toolCallCount").value(1))
+                .andExpect(jsonPath("$.summary.vectorOperationCount").value(1))
+                .andExpect(jsonPath("$.toolCalls[0].name").value("getWeather"))
+                .andExpect(jsonPath("$.vectorOperations[0].collectionName").value("docs"));
 
         mvc.perform(get("/bootui/api/ai/tokens?minutes=5"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.minutes").value(5));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.minutes").value(5));
     }
 
     @Test
     void receiverRejectsInvalidProtobuf() throws Exception {
         mvc.perform(post("/bootui/api/otlp/v1/traces")
-                .contentType("application/x-protobuf")
-                .content(new byte[]{0x7F, 0x7F, 0x7F}))
-            .andExpect(status().isBadRequest());
+                        .contentType("application/x-protobuf")
+                        .content(new byte[] {0x7F, 0x7F, 0x7F}))
+                .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -149,9 +151,9 @@ class OtlpReceiverEndToEndTests {
         OtlpReceiverController smallReceiver = new OtlpReceiverController(tinyStore, decoder, properties);
         MockMvc tinyMvc = standaloneSetup(smallReceiver).build();
         tinyMvc.perform(post("/bootui/api/otlp/v1/traces")
-                .contentType("application/x-protobuf")
-                .content(new byte[256]))
-            .andExpect(status().isPayloadTooLarge());
+                        .contentType("application/x-protobuf")
+                        .content(new byte[256]))
+                .andExpect(status().isPayloadTooLarge());
     }
 
     @Test
@@ -159,17 +161,17 @@ class OtlpReceiverEndToEndTests {
         properties.getTelemetry().setEnabled(false);
 
         mvc.perform(get("/bootui/api/traces"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.enabled").value(false));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(false));
 
         mvc.perform(get("/bootui/api/ai/overview"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.enabled").value(false));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(false));
 
         mvc.perform(post("/bootui/api/otlp/v1/traces")
-                .contentType("application/x-protobuf")
-                .content(new byte[]{0x01}))
-            .andExpect(status().isServiceUnavailable());
+                        .contentType("application/x-protobuf")
+                        .content(new byte[] {0x01}))
+                .andExpect(status().isServiceUnavailable());
     }
 
     @Test
@@ -178,22 +180,21 @@ class OtlpReceiverEndToEndTests {
         store.add(decode(sampleRequest()).get(0));
 
         mvc.perform(get("/bootui/api/ai/overview"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.totalChats").value(1))
-            .andExpect(jsonPath("$.recent.length()").value(0));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalChats").value(1))
+                .andExpect(jsonPath("$.recent.length()").value(0));
     }
 
     @Test
     void clearEndpointEmptiesStore() throws Exception {
         store.add(decode(sampleRequest()).get(0));
         assertThat(store.retainedTraceCount()).isEqualTo(1);
-        mvc.perform(delete("/bootui/api/traces"))
-            .andExpect(status().isNoContent());
+        mvc.perform(delete("/bootui/api/traces")).andExpect(status().isNoContent());
         assertThat(store.retainedTraceCount()).isZero();
     }
 
-    private java.util.List<io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan> decode(ExportTraceServiceRequest req)
-        throws Exception {
+    private java.util.List<io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan> decode(
+            ExportTraceServiceRequest req) throws Exception {
         BootUiProperties properties = new BootUiProperties();
         return new OtlpSpanDecoder(properties.getTelemetry()).decode(req.toByteArray());
     }
@@ -203,61 +204,73 @@ class OtlpReceiverEndToEndTests {
         ByteString traceId = ByteString.copyFrom(hexToBytes(TRACE_ID));
 
         Span chat = Span.newBuilder()
-            .setTraceId(traceId)
-            .setSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
-            .setName("chat qwen3:0.6b")
-            .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
-            .setStartTimeUnixNano(now)
-            .setEndTimeUnixNano(now + 250_000_000L)
-            .setStatus(Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
-            .addAttributes(stringAttr("gen_ai.operation.name", "chat"))
-            .addAttributes(stringAttr("gen_ai.system", "ollama"))
-            .addAttributes(stringAttr("gen_ai.request.model", "qwen3:0.6b"))
-            .addAttributes(stringAttr("gen_ai.response.model", "qwen3:0.6b"))
-            .addAttributes(intAttr("gen_ai.usage.input_tokens", 42L))
-            .addAttributes(intAttr("gen_ai.usage.output_tokens", 7L))
-            .addAttributes(arrayStringAttr("gen_ai.response.finish_reasons", "stop"))
-            .build();
+                .setTraceId(traceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
+                .setName("chat qwen3:0.6b")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now)
+                .setEndTimeUnixNano(now + 250_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "chat"))
+                .addAttributes(stringAttr("gen_ai.system", "ollama"))
+                .addAttributes(stringAttr("gen_ai.request.model", "qwen3:0.6b"))
+                .addAttributes(stringAttr("gen_ai.response.model", "qwen3:0.6b"))
+                .addAttributes(intAttr("gen_ai.usage.input_tokens", 42L))
+                .addAttributes(intAttr("gen_ai.usage.output_tokens", 7L))
+                .addAttributes(arrayStringAttr("gen_ai.response.finish_reasons", "stop"))
+                .build();
 
         Span tool = Span.newBuilder()
-            .setTraceId(traceId)
-            .setSpanId(ByteString.copyFrom(hexToBytes(TOOL_SPAN_ID)))
-            .setParentSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
-            .setName("execute_tool getWeather")
-            .setKind(Span.SpanKind.SPAN_KIND_INTERNAL)
-            .setStartTimeUnixNano(now + 10_000_000L)
-            .setEndTimeUnixNano(now + 30_000_000L)
-            .setStatus(Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
-            .addAttributes(stringAttr("gen_ai.operation.name", "execute_tool"))
-            .addAttributes(stringAttr("gen_ai.tool.name", "getWeather"))
-            .build();
+                .setTraceId(traceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes(TOOL_SPAN_ID)))
+                .setParentSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
+                .setName("execute_tool getWeather")
+                .setKind(Span.SpanKind.SPAN_KIND_INTERNAL)
+                .setStartTimeUnixNano(now + 10_000_000L)
+                .setEndTimeUnixNano(now + 30_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "execute_tool"))
+                .addAttributes(stringAttr("gen_ai.tool.name", "getWeather"))
+                .build();
 
         Span vector = Span.newBuilder()
-            .setTraceId(traceId)
-            .setSpanId(ByteString.copyFrom(hexToBytes(VECTOR_SPAN_ID)))
-            .setParentSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
-            .setName("db query docs")
-            .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
-            .setStartTimeUnixNano(now + 5_000_000L)
-            .setEndTimeUnixNano(now + 15_000_000L)
-            .setStatus(Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_OK).build())
-            .addAttributes(stringAttr("db.system", "spring_ai_vector_store"))
-            .addAttributes(stringAttr("db.operation.name", "query"))
-            .addAttributes(stringAttr("db.collection.name", "docs"))
-            .build();
+                .setTraceId(traceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes(VECTOR_SPAN_ID)))
+                .setParentSpanId(ByteString.copyFrom(hexToBytes(CHAT_SPAN_ID)))
+                .setName("db query docs")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now + 5_000_000L)
+                .setEndTimeUnixNano(now + 15_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("db.system", "spring_ai_vector_store"))
+                .addAttributes(stringAttr("db.operation.name", "query"))
+                .addAttributes(stringAttr("db.collection.name", "docs"))
+                .build();
 
         ScopeSpans scopeSpans = ScopeSpans.newBuilder()
-            .setScope(InstrumentationScope.newBuilder().setName("io.micrometer.observation").build())
-            .addSpans(chat)
-            .addSpans(tool)
-            .addSpans(vector)
-            .build();
+                .setScope(InstrumentationScope.newBuilder()
+                        .setName("io.micrometer.observation")
+                        .build())
+                .addSpans(chat)
+                .addSpans(tool)
+                .addSpans(vector)
+                .build();
 
         ResourceSpans resourceSpans = ResourceSpans.newBuilder()
-            .setResource(Resource.newBuilder().addAttributes(stringAttr("service.name", "sample")).build())
-            .addScopeSpans(scopeSpans)
-            .build();
+                .setResource(Resource.newBuilder()
+                        .addAttributes(stringAttr("service.name", "sample"))
+                        .build())
+                .addScopeSpans(scopeSpans)
+                .build();
 
-        return ExportTraceServiceRequest.newBuilder().addResourceSpans(resourceSpans).build();
+        return ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(resourceSpans)
+                .build();
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OverviewControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OverviewControllerTests.java
@@ -1,18 +1,17 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.github.jdubois.bootui.autoconfigure.BootUiActivation;
-import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
-import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-import org.springframework.mock.env.MockEnvironment;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-
 import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiActivation;
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.web.servlet.MockMvc;
 
 /**
  * Controller-level tests for {@link OverviewController}.
@@ -32,29 +31,26 @@ class OverviewControllerTests {
         environment.setActiveProfiles("dev");
         environment.setDefaultProfiles("default");
 
-        BootUiActivation activation = new BootUiActivation(true,
-            "activated by spring.profiles.active=dev",
-            List.of());
+        BootUiActivation activation = new BootUiActivation(true, "activated by spring.profiles.active=dev", List.of());
         BootUiProperties properties = new BootUiProperties();
 
         OverviewController controller = new OverviewController(environment, activation, properties);
         MockMvc mockMvc = standaloneSetup(controller).build();
 
         mockMvc.perform(get("/bootui/api/overview").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.applicationName").value("sample-app"))
-            .andExpect(jsonPath("$.serverPort").value(8080))
-            .andExpect(jsonPath("$.contextPath").value("/app"))
-            .andExpect(jsonPath("$.activeProfiles", hasItem("dev")))
-            .andExpect(jsonPath("$.defaultProfiles", hasItem("default")))
-            .andExpect(jsonPath("$.activation.enabled").value(true))
-            .andExpect(jsonPath("$.activation.localhostOnly").value(true))
-            .andExpect(jsonPath("$.activation.reason")
-                .value("activated by spring.profiles.active=dev"))
-            .andExpect(jsonPath("$.springBootVersion").exists())
-            .andExpect(jsonPath("$.javaVersion").exists())
-            .andExpect(jsonPath("$.bootUiVersion").exists());
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.applicationName").value("sample-app"))
+                .andExpect(jsonPath("$.serverPort").value(8080))
+                .andExpect(jsonPath("$.contextPath").value("/app"))
+                .andExpect(jsonPath("$.activeProfiles", hasItem("dev")))
+                .andExpect(jsonPath("$.defaultProfiles", hasItem("default")))
+                .andExpect(jsonPath("$.activation.enabled").value(true))
+                .andExpect(jsonPath("$.activation.localhostOnly").value(true))
+                .andExpect(jsonPath("$.activation.reason").value("activated by spring.profiles.active=dev"))
+                .andExpect(jsonPath("$.springBootVersion").exists())
+                .andExpect(jsonPath("$.javaVersion").exists())
+                .andExpect(jsonPath("$.bootUiVersion").exists());
     }
 
     @Test
@@ -68,8 +64,8 @@ class OverviewControllerTests {
         MockMvc mockMvc = standaloneSetup(controller).build();
 
         mockMvc.perform(get("/bootui/api/overview"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.activation.localhostOnly").value(false));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activation.localhostOnly").value(false));
     }
 
     @Test
@@ -86,9 +82,9 @@ class OverviewControllerTests {
         MockMvc mockMvc = standaloneSetup(controller).build();
 
         mockMvc.perform(get("/bootui/api/overview"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.serverPort").doesNotExist())
-            .andExpect(jsonPath("$.managementPort").doesNotExist())
-            .andExpect(jsonPath("$.startupTimeMillis").doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.serverPort").doesNotExist())
+                .andExpect(jsonPath("$.managementPort").doesNotExist())
+                .andExpect(jsonPath("$.startupTimeMillis").doesNotExist());
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
@@ -1,14 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
-import org.junit.jupiter.api.Test;
-import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.test.web.servlet.MockMvc;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.test.web.servlet.MockMvc;
 
 class PanelsControllerTests {
 
@@ -16,15 +16,17 @@ class PanelsControllerTests {
     void panelsListsEverySidebarPanel() throws Exception {
         try (GenericApplicationContext context = new GenericApplicationContext()) {
             context.refresh();
-            MockMvc mvc = standaloneSetup(new PanelsController(context, context.getEnvironment(), new BootUiProperties())).build();
+            MockMvc mvc = standaloneSetup(
+                            new PanelsController(context, context.getEnvironment(), new BootUiProperties()))
+                    .build();
 
             mvc.perform(get("/bootui/api/panels"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.panels.length()").value(22))
-                .andExpect(jsonPath("$.panels[0].id").value("overview"))
-                .andExpect(jsonPath("$.panels[18].id").value("traces"))
-                .andExpect(jsonPath("$.panels[19].id").value("ai"))
-                .andExpect(jsonPath("$.panels[21].id").value("vulnerabilities"));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.panels.length()").value(22))
+                    .andExpect(jsonPath("$.panels[0].id").value("overview"))
+                    .andExpect(jsonPath("$.panels[18].id").value("traces"))
+                    .andExpect(jsonPath("$.panels[19].id").value("ai"))
+                    .andExpect(jsonPath("$.panels[21].id").value("vulnerabilities"));
         }
     }
 
@@ -32,22 +34,24 @@ class PanelsControllerTests {
     void panelsMarksAlwaysAvailablePanelsAsAvailable() throws Exception {
         try (GenericApplicationContext context = new GenericApplicationContext()) {
             context.refresh();
-            MockMvc mvc = standaloneSetup(new PanelsController(context, context.getEnvironment(), new BootUiProperties())).build();
+            MockMvc mvc = standaloneSetup(
+                            new PanelsController(context, context.getEnvironment(), new BootUiProperties()))
+                    .build();
 
             mvc.perform(get("/bootui/api/panels"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.panels[0].id").value("overview"))
-                .andExpect(jsonPath("$.panels[0].available").value(true))
-                .andExpect(jsonPath("$.panels[2].id").value("memory"))
-                .andExpect(jsonPath("$.panels[2].available").value(true))
-                .andExpect(jsonPath("$.panels[8].id").value("config"))
-                .andExpect(jsonPath("$.panels[8].available").value(true))
-                .andExpect(jsonPath("$.panels[12].id").value("http-probe"))
-                .andExpect(jsonPath("$.panels[12].available").value(true))
-                .andExpect(jsonPath("$.panels[18].id").value("traces"))
-                .andExpect(jsonPath("$.panels[18].available").value(true))
-                .andExpect(jsonPath("$.panels[21].id").value("vulnerabilities"))
-                .andExpect(jsonPath("$.panels[21].available").value(true));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.panels[0].id").value("overview"))
+                    .andExpect(jsonPath("$.panels[0].available").value(true))
+                    .andExpect(jsonPath("$.panels[2].id").value("memory"))
+                    .andExpect(jsonPath("$.panels[2].available").value(true))
+                    .andExpect(jsonPath("$.panels[8].id").value("config"))
+                    .andExpect(jsonPath("$.panels[8].available").value(true))
+                    .andExpect(jsonPath("$.panels[12].id").value("http-probe"))
+                    .andExpect(jsonPath("$.panels[12].available").value(true))
+                    .andExpect(jsonPath("$.panels[18].id").value("traces"))
+                    .andExpect(jsonPath("$.panels[18].available").value(true))
+                    .andExpect(jsonPath("$.panels[21].id").value("vulnerabilities"))
+                    .andExpect(jsonPath("$.panels[21].available").value(true));
         }
     }
 
@@ -55,24 +59,26 @@ class PanelsControllerTests {
     void panelsMarksActuatorBackedPanelsUnavailableWhenEndpointsAreAbsent() throws Exception {
         try (GenericApplicationContext context = new GenericApplicationContext()) {
             context.refresh();
-            MockMvc mvc = standaloneSetup(new PanelsController(context, context.getEnvironment(), new BootUiProperties())).build();
+            MockMvc mvc = standaloneSetup(
+                            new PanelsController(context, context.getEnvironment(), new BootUiProperties()))
+                    .build();
 
             mvc.perform(get("/bootui/api/panels"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.panels[1].id").value("startup"))
-                .andExpect(jsonPath("$.panels[1].available").value(false))
-                .andExpect(jsonPath("$.panels[3].id").value("health"))
-                .andExpect(jsonPath("$.panels[3].available").value(false))
-                .andExpect(jsonPath("$.panels[4].id").value("metrics"))
-                .andExpect(jsonPath("$.panels[4].available").value(false))
-                .andExpect(jsonPath("$.panels[5].id").value("conditions"))
-                .andExpect(jsonPath("$.panels[5].available").value(false))
-                .andExpect(jsonPath("$.panels[6].id").value("beans"))
-                .andExpect(jsonPath("$.panels[6].available").value(false))
-                .andExpect(jsonPath("$.panels[7].id").value("mappings"))
-                .andExpect(jsonPath("$.panels[7].available").value(false))
-                .andExpect(jsonPath("$.panels[10].id").value("loggers"))
-                .andExpect(jsonPath("$.panels[10].available").value(false));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.panels[1].id").value("startup"))
+                    .andExpect(jsonPath("$.panels[1].available").value(false))
+                    .andExpect(jsonPath("$.panels[3].id").value("health"))
+                    .andExpect(jsonPath("$.panels[3].available").value(false))
+                    .andExpect(jsonPath("$.panels[4].id").value("metrics"))
+                    .andExpect(jsonPath("$.panels[4].available").value(false))
+                    .andExpect(jsonPath("$.panels[5].id").value("conditions"))
+                    .andExpect(jsonPath("$.panels[5].available").value(false))
+                    .andExpect(jsonPath("$.panels[6].id").value("beans"))
+                    .andExpect(jsonPath("$.panels[6].available").value(false))
+                    .andExpect(jsonPath("$.panels[7].id").value("mappings"))
+                    .andExpect(jsonPath("$.panels[7].available").value(false))
+                    .andExpect(jsonPath("$.panels[10].id").value("loggers"))
+                    .andExpect(jsonPath("$.panels[10].available").value(false));
         }
     }
 
@@ -82,16 +88,17 @@ class PanelsControllerTests {
             context.refresh();
             BootUiProperties properties = new BootUiProperties();
             properties.getTelemetry().setEnabled(false);
-            MockMvc mvc = standaloneSetup(new PanelsController(context, context.getEnvironment(), properties)).build();
+            MockMvc mvc = standaloneSetup(new PanelsController(context, context.getEnvironment(), properties))
+                    .build();
 
             mvc.perform(get("/bootui/api/panels"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.panels[18].id").value("traces"))
-                .andExpect(jsonPath("$.panels[18].available").value(false))
-                .andExpect(jsonPath("$.panels[18].unavailableReason").value("Telemetry receiver is disabled"))
-                .andExpect(jsonPath("$.panels[19].id").value("ai"))
-                .andExpect(jsonPath("$.panels[19].available").value(false))
-                .andExpect(jsonPath("$.panels[19].unavailableReason").value("Telemetry receiver is disabled"));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.panels[18].id").value("traces"))
+                    .andExpect(jsonPath("$.panels[18].available").value(false))
+                    .andExpect(jsonPath("$.panels[18].unavailableReason").value("Telemetry receiver is disabled"))
+                    .andExpect(jsonPath("$.panels[19].id").value("ai"))
+                    .andExpect(jsonPath("$.panels[19].available").value(false))
+                    .andExpect(jsonPath("$.panels[19].unavailableReason").value("Telemetry receiver is disabled"));
         }
     }
 
@@ -99,14 +106,16 @@ class PanelsControllerTests {
     void panelsMarksAiUnavailableWithoutSpringAi() throws Exception {
         try (GenericApplicationContext context = new GenericApplicationContext()) {
             context.refresh();
-            MockMvc mvc = standaloneSetup(new PanelsController(context, context.getEnvironment(), new BootUiProperties())).build();
+            MockMvc mvc = standaloneSetup(
+                            new PanelsController(context, context.getEnvironment(), new BootUiProperties()))
+                    .build();
 
             mvc.perform(get("/bootui/api/panels"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.panels[19].id").value("ai"))
-                .andExpect(jsonPath("$.panels[19].available").value(false))
-                .andExpect(jsonPath("$.panels[19].unavailableReason")
-                    .value("Spring AI ChatClient is not on the classpath"));
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.panels[19].id").value("ai"))
+                    .andExpect(jsonPath("$.panels[19].available").value(false))
+                    .andExpect(jsonPath("$.panels[19].unavailableReason")
+                            .value("Spring AI ChatClient is not on the classpath"));
         }
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ProfileControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ProfileControllerTests.java
@@ -1,19 +1,18 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Map;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 class ProfileControllerTests {
 
@@ -24,11 +23,13 @@ class ProfileControllerTests {
     void setUp() {
         MockEnvironment environment = new MockEnvironment();
         environment.setActiveProfiles("dev");
-        environment.getPropertySources().addFirst(new MapPropertySource(
-            "application-dev.properties",
-            Map.of(
-                "sample.name", "demo",
-                "sample.password", "secret")));
+        environment
+                .getPropertySources()
+                .addFirst(new MapPropertySource(
+                        "application-dev.properties",
+                        Map.of(
+                                "sample.name", "demo",
+                                "sample.password", "secret")));
         properties = new BootUiProperties();
         mvc = standaloneSetup(new ProfileController(environment, properties)).build();
     }
@@ -36,13 +37,13 @@ class ProfileControllerTests {
     @Test
     void profilesMaskSecretValuesByDefault() throws Exception {
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.activeProfiles[0]").value("dev"))
-            .andExpect(jsonPath("$.profileSources[0].profile").value("dev"))
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
-                .value(true))
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].value")
-                .value("******"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeProfiles[0]").value("dev"))
+                .andExpect(jsonPath("$.profileSources[0].profile").value("dev"))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
+                        .value(true))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].value")
+                        .value("******"));
     }
 
     @Test
@@ -50,11 +51,11 @@ class ProfileControllerTests {
         properties.setExposeValues(ValueExposure.METADATA_ONLY);
 
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.name')].value[0]")
-                .doesNotExist())
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
-                .value(false));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.name')].value[0]")
+                        .doesNotExist())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
+                        .value(false));
     }
 
     @Test
@@ -62,10 +63,10 @@ class ProfileControllerTests {
         properties.setExposeValues(ValueExposure.FULL);
 
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
-                .value(false))
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].value")
-                .value("secret"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='sample.password')].value")
+                        .value("secret"));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ProfileDiffMaskingTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ProfileDiffMaskingTests.java
@@ -1,18 +1,17 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
-import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
-import io.github.jdubois.bootui.core.SecretMasker;
-import org.junit.jupiter.api.Test;
-import org.springframework.core.env.MapPropertySource;
-import org.springframework.mock.env.MockEnvironment;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.Map;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.SecretMasker;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.web.servlet.MockMvc;
 
 /**
  * Masking edge-case tests for {@link ProfileController}.
@@ -37,28 +36,31 @@ class ProfileDiffMaskingTests {
         MockEnvironment environment = new MockEnvironment();
         environment.setActiveProfiles("staging");
         // Only "staging" profile has this secret key
-        environment.getPropertySources().addFirst(new MapPropertySource(
-            "application-staging.properties",
-            Map.of(
-                "db.password", "supersecret",
-                "db.url", "jdbc:h2:mem:test")));
+        environment
+                .getPropertySources()
+                .addFirst(new MapPropertySource(
+                        "application-staging.properties",
+                        Map.of(
+                                "db.password", "supersecret",
+                                "db.url", "jdbc:h2:mem:test")));
 
         BootUiProperties properties = new BootUiProperties(); // defaults: MASKED, maskSecrets=true
-        MockMvc mvc = standaloneSetup(new ProfileController(environment, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new ProfileController(environment, properties)).build();
 
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.profileSources[0].profile").value("staging"))
-            // secret-named key must be masked
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='db.password')].masked")
-                .value(true))
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='db.password')].value")
-                .value(SecretMasker.MASKED_VALUE))
-            // non-secret key is exposed normally
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='db.url')].masked")
-                .value(false))
-            .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='db.url')].value")
-                .value("jdbc:h2:mem:test"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileSources[0].profile").value("staging"))
+                // secret-named key must be masked
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='db.password')].masked")
+                        .value(true))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='db.password')].value")
+                        .value(SecretMasker.MASKED_VALUE))
+                // non-secret key is exposed normally
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='db.url')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='db.url')].value")
+                        .value("jdbc:h2:mem:test"));
     }
 
     // ── same secret key in two profile sources ────────────────────────────────
@@ -67,31 +69,34 @@ class ProfileDiffMaskingTests {
     void sameSecretKeyInTwoProfileSourcesBothMasked() throws Exception {
         MockEnvironment environment = new MockEnvironment();
         environment.setActiveProfiles("dev", "prod");
-        environment.getPropertySources().addFirst(new MapPropertySource(
-            "application-dev.properties",
-            Map.of("spring.datasource.password", "dev-pass")));
-        environment.getPropertySources().addFirst(new MapPropertySource(
-            "application-prod.properties",
-            Map.of("spring.datasource.password", "prod-pass-different")));
+        environment
+                .getPropertySources()
+                .addFirst(new MapPropertySource(
+                        "application-dev.properties", Map.of("spring.datasource.password", "dev-pass")));
+        environment
+                .getPropertySources()
+                .addFirst(new MapPropertySource(
+                        "application-prod.properties", Map.of("spring.datasource.password", "prod-pass-different")));
 
         BootUiProperties properties = new BootUiProperties();
-        MockMvc mvc = standaloneSetup(new ProfileController(environment, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new ProfileController(environment, properties)).build();
 
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            // Two profile source entries; both must mask the password key
-            .andExpect(jsonPath(
-                "$.profileSources[?(@.profile=='dev')].properties[?(@.name=='spring.datasource.password')].masked")
-                .value(true))
-            .andExpect(jsonPath(
-                "$.profileSources[?(@.profile=='dev')].properties[?(@.name=='spring.datasource.password')].value")
-                .value(SecretMasker.MASKED_VALUE))
-            .andExpect(jsonPath(
-                "$.profileSources[?(@.profile=='prod')].properties[?(@.name=='spring.datasource.password')].masked")
-                .value(true))
-            .andExpect(jsonPath(
-                "$.profileSources[?(@.profile=='prod')].properties[?(@.name=='spring.datasource.password')].value")
-                .value(SecretMasker.MASKED_VALUE));
+                .andExpect(status().isOk())
+                // Two profile source entries; both must mask the password key
+                .andExpect(jsonPath(
+                                "$.profileSources[?(@.profile=='dev')].properties[?(@.name=='spring.datasource.password')].masked")
+                        .value(true))
+                .andExpect(jsonPath(
+                                "$.profileSources[?(@.profile=='dev')].properties[?(@.name=='spring.datasource.password')].value")
+                        .value(SecretMasker.MASKED_VALUE))
+                .andExpect(jsonPath(
+                                "$.profileSources[?(@.profile=='prod')].properties[?(@.name=='spring.datasource.password')].masked")
+                        .value(true))
+                .andExpect(jsonPath(
+                                "$.profileSources[?(@.profile=='prod')].properties[?(@.name=='spring.datasource.password')].value")
+                        .value(SecretMasker.MASKED_VALUE));
     }
 
     // ── non-string (integer) property values ──────────────────────────────────
@@ -101,27 +106,24 @@ class ProfileDiffMaskingTests {
         MockEnvironment environment = new MockEnvironment();
         environment.setActiveProfiles("test");
         Map<String, Object> props = new java.util.LinkedHashMap<>();
-        props.put("server.port", 9090);        // Integer, non-secret
-        props.put("app.secret.count", 42);     // Integer, but key contains "secret"
-        environment.getPropertySources().addFirst(new MapPropertySource(
-            "application-test.properties", props));
+        props.put("server.port", 9090); // Integer, non-secret
+        props.put("app.secret.count", 42); // Integer, but key contains "secret"
+        environment.getPropertySources().addFirst(new MapPropertySource("application-test.properties", props));
 
         BootUiProperties properties = new BootUiProperties();
-        MockMvc mvc = standaloneSetup(new ProfileController(environment, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new ProfileController(environment, properties)).build();
 
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            // Non-secret integer: stringified value exposed
-            .andExpect(jsonPath(
-                "$.profileSources[0].properties[?(@.name=='server.port')].value")
-                .value("9090"))
-            // Secret-named integer: stringified then masked
-            .andExpect(jsonPath(
-                "$.profileSources[0].properties[?(@.name=='app.secret.count')].masked")
-                .value(true))
-            .andExpect(jsonPath(
-                "$.profileSources[0].properties[?(@.name=='app.secret.count')].value")
-                .value(SecretMasker.MASKED_VALUE));
+                .andExpect(status().isOk())
+                // Non-secret integer: stringified value exposed
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='server.port')].value")
+                        .value("9090"))
+                // Secret-named integer: stringified then masked
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='app.secret.count')].masked")
+                        .value(true))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='app.secret.count')].value")
+                        .value(SecretMasker.MASKED_VALUE));
     }
 
     // ── maskSecrets opt-out ───────────────────────────────────────────────────
@@ -130,23 +132,22 @@ class ProfileDiffMaskingTests {
     void maskSecretsDisabledExposesSecretNamedKeyInPlainText() throws Exception {
         MockEnvironment environment = new MockEnvironment();
         environment.setActiveProfiles("ci");
-        environment.getPropertySources().addFirst(new MapPropertySource(
-            "application-ci.properties",
-            Map.of("api.token", "plaintext-token")));
+        environment
+                .getPropertySources()
+                .addFirst(new MapPropertySource("application-ci.properties", Map.of("api.token", "plaintext-token")));
 
         BootUiProperties properties = new BootUiProperties();
-        properties.setMaskSecrets(false);       // opt-out of masking
+        properties.setMaskSecrets(false); // opt-out of masking
         // exposeValues stays at default MASKED
-        MockMvc mvc = standaloneSetup(new ProfileController(environment, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new ProfileController(environment, properties)).build();
 
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath(
-                "$.profileSources[0].properties[?(@.name=='api.token')].masked")
-                .value(false))
-            .andExpect(jsonPath(
-                "$.profileSources[0].properties[?(@.name=='api.token')].value")
-                .value("plaintext-token"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='api.token')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='api.token')].value")
+                        .value("plaintext-token"));
     }
 
     // ── non-secret key never masked ───────────────────────────────────────────
@@ -155,21 +156,21 @@ class ProfileDiffMaskingTests {
     void nonSecretKeyIsNeverMaskedRegardlessOfValue() throws Exception {
         MockEnvironment environment = new MockEnvironment();
         environment.setActiveProfiles("perf");
-        environment.getPropertySources().addFirst(new MapPropertySource(
-            "application-perf.properties",
-            Map.of("spring.application.name", "boot-ui-perf")));
+        environment
+                .getPropertySources()
+                .addFirst(new MapPropertySource(
+                        "application-perf.properties", Map.of("spring.application.name", "boot-ui-perf")));
 
         BootUiProperties properties = new BootUiProperties(); // default: MASKED, maskSecrets=true
-        MockMvc mvc = standaloneSetup(new ProfileController(environment, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new ProfileController(environment, properties)).build();
 
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath(
-                "$.profileSources[0].properties[?(@.name=='spring.application.name')].masked")
-                .value(false))
-            .andExpect(jsonPath(
-                "$.profileSources[0].properties[?(@.name=='spring.application.name')].value")
-                .value("boot-ui-perf"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='spring.application.name')].masked")
+                        .value(false))
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='spring.application.name')].value")
+                        .value("boot-ui-perf"));
     }
 
     // ── null property value ───────────────────────────────────────────────────
@@ -180,16 +181,15 @@ class ProfileDiffMaskingTests {
         environment.setActiveProfiles("nulltest");
         Map<String, Object> props = new java.util.LinkedHashMap<>();
         props.put("nullable.key", null);
-        environment.getPropertySources().addFirst(new MapPropertySource(
-            "application-nulltest.properties", props));
+        environment.getPropertySources().addFirst(new MapPropertySource("application-nulltest.properties", props));
 
         BootUiProperties properties = new BootUiProperties();
-        MockMvc mvc = standaloneSetup(new ProfileController(environment, properties)).build();
+        MockMvc mvc =
+                standaloneSetup(new ProfileController(environment, properties)).build();
 
         mvc.perform(get("/bootui/api/profiles"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath(
-                "$.profileSources[0].properties[?(@.name=='nullable.key')].value[0]")
-                .doesNotExist());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.profileSources[0].properties[?(@.name=='nullable.key')].value[0]")
+                        .doesNotExist());
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ScheduledControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ScheduledControllerTests.java
@@ -1,20 +1,19 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.time.Duration;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.MediaType;
 import org.springframework.scheduling.config.*;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.Duration;
-import java.util.Set;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Controller-level tests for {@link ScheduledController}.
@@ -51,11 +50,11 @@ class ScheduledControllerTests {
         MockMvc mvc = standaloneSetup(new ScheduledController(emptyProvider())).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.schedulingPresent").value(false))
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.tasks").isArray())
-            .andExpect(jsonPath("$.tasks").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.schedulingPresent").value(false))
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.tasks").isArray())
+                .andExpect(jsonPath("$.tasks").isEmpty());
     }
 
     @Test
@@ -63,13 +62,14 @@ class ScheduledControllerTests {
         ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
         when(holder.getScheduledTasks()).thenReturn(Set.of());
 
-        MockMvc mvc = standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc =
+                standaloneSetup(new ScheduledController(providerOf(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.schedulingPresent").value(true))
-            .andExpect(jsonPath("$.total").value(0))
-            .andExpect(jsonPath("$.tasks").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.schedulingPresent").value(true))
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.tasks").isEmpty());
     }
 
     @Test
@@ -83,22 +83,22 @@ class ScheduledControllerTests {
         ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
         when(holder.getScheduledTasks()).thenReturn(Set.of(scheduledTask));
 
-        MockMvc mvc = standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc =
+                standaloneSetup(new ScheduledController(providerOf(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.schedulingPresent").value(true))
-            .andExpect(jsonPath("$.total").value(1))
-            .andExpect(jsonPath("$.tasks[0].triggerType").value("CRON"))
-            .andExpect(jsonPath("$.tasks[0].expression").value("0 0/5 * * * ?"))
-            .andExpect(jsonPath("$.tasks[0].runnable").value("com.example.MyJob#executeJob"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.schedulingPresent").value(true))
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.tasks[0].triggerType").value("CRON"))
+                .andExpect(jsonPath("$.tasks[0].expression").value("0 0/5 * * * ?"))
+                .andExpect(jsonPath("$.tasks[0].runnable").value("com.example.MyJob#executeJob"));
     }
 
     @Test
     void scheduledReturnsFixedRateTask() throws Exception {
         Runnable runnable = new NamedRunnable("com.example.MyPollerTask");
-        FixedRateTask fixedRateTask = new FixedRateTask(runnable,
-            Duration.ofSeconds(30), Duration.ofSeconds(5));
+        FixedRateTask fixedRateTask = new FixedRateTask(runnable, Duration.ofSeconds(30), Duration.ofSeconds(5));
 
         ScheduledTask scheduledTask = inlineMock(ScheduledTask.class);
         when(scheduledTask.getTask()).thenReturn(fixedRateTask);
@@ -106,21 +106,21 @@ class ScheduledControllerTests {
         ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
         when(holder.getScheduledTasks()).thenReturn(Set.of(scheduledTask));
 
-        MockMvc mvc = standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc =
+                standaloneSetup(new ScheduledController(providerOf(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.tasks[0].triggerType").value("FIXED_RATE"))
-            .andExpect(jsonPath("$.tasks[0].expression").value("30000"))
-            .andExpect(jsonPath("$.tasks[0].initialDelayMs").value(5000))
-            .andExpect(jsonPath("$.tasks[0].timeUnit").value("s"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tasks[0].triggerType").value("FIXED_RATE"))
+                .andExpect(jsonPath("$.tasks[0].expression").value("30000"))
+                .andExpect(jsonPath("$.tasks[0].initialDelayMs").value(5000))
+                .andExpect(jsonPath("$.tasks[0].timeUnit").value("s"));
     }
 
     @Test
     void scheduledReturnsFixedDelayTask() throws Exception {
         Runnable runnable = new NamedRunnable("com.example.MyCleanupTask");
-        FixedDelayTask fixedDelayTask = new FixedDelayTask(runnable,
-            Duration.ofMillis(500), Duration.ZERO);
+        FixedDelayTask fixedDelayTask = new FixedDelayTask(runnable, Duration.ofMillis(500), Duration.ZERO);
 
         ScheduledTask scheduledTask = inlineMock(ScheduledTask.class);
         when(scheduledTask.getTask()).thenReturn(fixedDelayTask);
@@ -128,13 +128,14 @@ class ScheduledControllerTests {
         ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
         when(holder.getScheduledTasks()).thenReturn(Set.of(scheduledTask));
 
-        MockMvc mvc = standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc =
+                standaloneSetup(new ScheduledController(providerOf(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.tasks[0].triggerType").value("FIXED_DELAY"))
-            .andExpect(jsonPath("$.tasks[0].expression").value("500"))
-            .andExpect(jsonPath("$.tasks[0].timeUnit").value("ms"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tasks[0].triggerType").value("FIXED_DELAY"))
+                .andExpect(jsonPath("$.tasks[0].expression").value("500"))
+                .andExpect(jsonPath("$.tasks[0].timeUnit").value("ms"));
     }
 
     /**
@@ -148,8 +149,7 @@ class ScheduledControllerTests {
         }
 
         @Override
-        public void run() {
-        }
+        public void run() {}
 
         @Override
         public String toString() {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/SecurityControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/SecurityControllerTests.java
@@ -1,7 +1,16 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
+import java.util.List;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.mock.env.MockEnvironment;
@@ -13,16 +22,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
-
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Standalone MockMvc tests for {@link SecurityController}.
@@ -41,30 +40,30 @@ class SecurityControllerTests {
     // ── chain listing ─────────────────────────────────────────────────────────
 
     @SuppressWarnings("unchecked")
-    private static MockMvc buildMvc(FilterChainProxy proxy,
-                                    AuthenticationProvider authProvider,
-                                    UserDetailsService userDetailsService,
-                                    MockEnvironment env,
-                                    BootUiProperties properties) {
+    private static MockMvc buildMvc(
+            FilterChainProxy proxy,
+            AuthenticationProvider authProvider,
+            UserDetailsService userDetailsService,
+            MockEnvironment env,
+            BootUiProperties properties) {
         ObjectProvider<FilterChainProxy> proxyProvider = mock(ObjectProvider.class);
         when(proxyProvider.getIfAvailable()).thenReturn(proxy);
         when(proxyProvider.stream()).thenReturn(proxy == null ? Stream.empty() : Stream.of(proxy));
 
         ObjectProvider<AuthenticationProvider> authProviderProvider = mock(ObjectProvider.class);
         when(authProviderProvider.getIfAvailable()).thenReturn(authProvider);
-        when(authProviderProvider.stream())
-            .thenReturn(authProvider == null ? Stream.empty() : Stream.of(authProvider));
+        when(authProviderProvider.stream()).thenReturn(authProvider == null ? Stream.empty() : Stream.of(authProvider));
 
         ObjectProvider<UserDetailsService> udsProvider = mock(ObjectProvider.class);
         when(udsProvider.getIfAvailable()).thenReturn(userDetailsService);
         when(udsProvider.stream())
-            .thenReturn(userDetailsService == null ? Stream.empty() : Stream.of(userDetailsService));
+                .thenReturn(userDetailsService == null ? Stream.empty() : Stream.of(userDetailsService));
 
         ObjectProvider<RequestMappingInfoHandlerMapping> mappingProvider = mock(ObjectProvider.class);
         when(mappingProvider.stream()).thenReturn(Stream.empty());
 
         SecurityController controller = new SecurityController(
-            proxyProvider, authProviderProvider, udsProvider, mappingProvider, env, properties);
+                proxyProvider, authProviderProvider, udsProvider, mappingProvider, env, properties);
 
         return standaloneSetup(controller).build();
     }
@@ -80,11 +79,11 @@ class SecurityControllerTests {
         MockMvc mvc = buildMvc(proxy, null, null, new MockEnvironment(), new BootUiProperties());
 
         mvc.perform(get("/bootui/api/security"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.springSecurityPresent").value(true))
-            .andExpect(jsonPath("$.chains.length()").value(2))
-            .andExpect(jsonPath("$.chains[0].order").value(0))
-            .andExpect(jsonPath("$.chains[1].order").value(1));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.springSecurityPresent").value(true))
+                .andExpect(jsonPath("$.chains.length()").value(2))
+                .andExpect(jsonPath("$.chains[0].order").value(0))
+                .andExpect(jsonPath("$.chains[1].order").value(1));
     }
 
     // ── disabled (FilterChainProxy absent) ───────────────────────────────────
@@ -93,16 +92,15 @@ class SecurityControllerTests {
     void singleChainFiltersListedBySimpleClassName() throws Exception {
         jakarta.servlet.Filter namedFilter = new NamedFilter("SampleFilter");
 
-        SecurityFilterChain chain = new DefaultSecurityFilterChain(
-            AnyRequestMatcher.INSTANCE, List.of(namedFilter));
+        SecurityFilterChain chain = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE, List.of(namedFilter));
         FilterChainProxy proxy = mock(FilterChainProxy.class);
         when(proxy.getFilterChains()).thenReturn(List.of(chain));
 
         MockMvc mvc = buildMvc(proxy, null, null, new MockEnvironment(), new BootUiProperties());
 
         mvc.perform(get("/bootui/api/security"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.chains[0].filters[0]").value("NamedFilter"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.chains[0].filters[0]").value("NamedFilter"));
     }
 
     @Test
@@ -110,9 +108,9 @@ class SecurityControllerTests {
         MockMvc mvc = buildMvc(null, null, null, new MockEnvironment(), new BootUiProperties());
 
         mvc.perform(get("/bootui/api/security"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.springSecurityPresent").value(false))
-            .andExpect(jsonPath("$.chains").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.springSecurityPresent").value(false))
+                .andExpect(jsonPath("$.chains").isEmpty());
     }
 
     // ── credential non-disclosure ─────────────────────────────────────────────
@@ -121,11 +119,9 @@ class SecurityControllerTests {
     void explainEndpointWithAbsentProxyReturnsUnmatchedResult() throws Exception {
         MockMvc mvc = buildMvc(null, null, null, new MockEnvironment(), new BootUiProperties());
 
-        mvc.perform(get("/bootui/api/security/explain")
-                .param("method", "GET")
-                .param("path", "/some/path"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.matched").value(false));
+        mvc.perform(get("/bootui/api/security/explain").param("method", "GET").param("path", "/some/path"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.matched").value(false));
     }
 
     @Test
@@ -140,11 +136,11 @@ class SecurityControllerTests {
         MockMvc mvc = buildMvc(proxy, null, null, env, new BootUiProperties());
 
         mvc.perform(get("/bootui/api/security"))
-            .andExpect(status().isOk())
-            // username is exposed for developer convenience
-            .andExpect(jsonPath("$.auth.configuredUsername").value("admin"))
-            // The response body must not contain the raw password anywhere
-            .andExpect(jsonPath("$..super-secret-pw").doesNotExist());
+                .andExpect(status().isOk())
+                // username is exposed for developer convenience
+                .andExpect(jsonPath("$.auth.configuredUsername").value("admin"))
+                // The response body must not contain the raw password anywhere
+                .andExpect(jsonPath("$..super-secret-pw").doesNotExist());
     }
 
     // ── auth providers listed ─────────────────────────────────────────────────
@@ -163,8 +159,8 @@ class SecurityControllerTests {
         MockMvc mvc = buildMvc(proxy, null, null, env, properties);
 
         mvc.perform(get("/bootui/api/security"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.auth.configuredUsername").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.auth.configuredUsername").isEmpty());
     }
 
     @Test
@@ -176,8 +172,9 @@ class SecurityControllerTests {
         MockMvc mvc = buildMvc(proxy, provider, null, new MockEnvironment(), new BootUiProperties());
 
         mvc.perform(get("/bootui/api/security"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.auth.authenticationProviderTypes.length()").value(1));
+                .andExpect(status().isOk())
+                .andExpect(
+                        jsonPath("$.auth.authenticationProviderTypes.length()").value(1));
     }
 
     // ── best-effort explain ───────────────────────────────────────────────────
@@ -190,28 +187,25 @@ class SecurityControllerTests {
         MockMvc mvc = buildMvc(proxy, null, null, new MockEnvironment(), new BootUiProperties());
 
         mvc.perform(get("/bootui/api/security"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.auth.authenticationProviderTypes").isEmpty())
-            .andExpect(jsonPath("$.auth.userDetailsServiceTypes").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.auth.authenticationProviderTypes").isEmpty())
+                .andExpect(jsonPath("$.auth.userDetailsServiceTypes").isEmpty());
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
     @Test
     void explainMatchesChainWhenPathMatches() throws Exception {
-        SecurityFilterChain chain = new DefaultSecurityFilterChain(
-            AnyRequestMatcher.INSTANCE, List.of());
+        SecurityFilterChain chain = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE, List.of());
         FilterChainProxy proxy = mock(FilterChainProxy.class);
         when(proxy.getFilterChains()).thenReturn(List.of(chain));
 
         MockMvc mvc = buildMvc(proxy, null, null, new MockEnvironment(), new BootUiProperties());
 
-        mvc.perform(get("/bootui/api/security/explain")
-                .param("method", "GET")
-                .param("path", "/api/test"))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.matched").value(true))
-            .andExpect(jsonPath("$.chainIndex").value(0));
+        mvc.perform(get("/bootui/api/security/explain").param("method", "GET").param("path", "/api/test"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.matched").value(true))
+                .andExpect(jsonPath("$.chainIndex").value(0));
     }
 
     /**
@@ -225,10 +219,11 @@ class SecurityControllerTests {
         }
 
         @Override
-        public void doFilter(jakarta.servlet.ServletRequest req,
-                             jakarta.servlet.ServletResponse res,
-                             jakarta.servlet.FilterChain chain)
-            throws java.io.IOException, jakarta.servlet.ServletException {
+        public void doFilter(
+                jakarta.servlet.ServletRequest req,
+                jakarta.servlet.ServletResponse res,
+                jakarta.servlet.FilterChain chain)
+                throws java.io.IOException, jakarta.servlet.ServletException {
             chain.doFilter(req, res);
         }
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/StartupControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/StartupControllerTests.java
@@ -1,5 +1,13 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
 import org.springframework.beans.factory.ObjectProvider;
@@ -10,15 +18,6 @@ import org.springframework.boot.context.metrics.buffering.StartupTimeline.Timeli
 import org.springframework.core.metrics.StartupStep;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.time.Duration;
-import java.util.List;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 /**
  * Controller-level tests for {@link StartupController}.
@@ -51,24 +50,26 @@ class StartupControllerTests {
         MockMvc mvc = standaloneSetup(new StartupController(emptyProvider())).build();
 
         mvc.perform(get("/bootui/api/startup").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.steps").isArray())
-            .andExpect(jsonPath("$.steps").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.steps").isArray())
+                .andExpect(jsonPath("$.steps").isEmpty());
     }
 
     @Test
     void startupReturnsEmptyWhenTimelineIsNull() throws Exception {
-        StartupDescriptor descriptor = mock(StartupDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        StartupDescriptor descriptor =
+                mock(StartupDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(descriptor.getTimeline()).thenReturn(null);
 
         StartupEndpoint endpoint = mock(StartupEndpoint.class);
         when(endpoint.startupSnapshot()).thenReturn(descriptor);
 
-        MockMvc mvc = standaloneSetup(new StartupController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new StartupController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/startup").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.steps").isEmpty());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.steps").isEmpty());
     }
 
     @Test
@@ -98,23 +99,25 @@ class StartupControllerTests {
         StartupTimeline timeline = mock(StartupTimeline.class);
         when(timeline.getEvents()).thenReturn(List.of(event));
 
-        StartupDescriptor descriptor = mock(StartupDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        StartupDescriptor descriptor =
+                mock(StartupDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(descriptor.getTimeline()).thenReturn(timeline);
 
         StartupEndpoint endpoint = mock(StartupEndpoint.class);
         when(endpoint.startupSnapshot()).thenReturn(descriptor);
 
-        MockMvc mvc = standaloneSetup(new StartupController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new StartupController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/startup").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.steps.length()").value(1))
-            .andExpect(jsonPath("$.steps[0].id").value(1))
-            .andExpect(jsonPath("$.steps[0].parentId").doesNotExist())
-            .andExpect(jsonPath("$.steps[0].name").value("spring.beans.instantiate"))
-            .andExpect(jsonPath("$.steps[0].durationMs").value(42))
-            .andExpect(jsonPath("$.steps[0].tags[0].key").value("bean.name"))
-            .andExpect(jsonPath("$.steps[0].tags[0].value").value("dataSource"));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.steps.length()").value(1))
+                .andExpect(jsonPath("$.steps[0].id").value(1))
+                .andExpect(jsonPath("$.steps[0].parentId").doesNotExist())
+                .andExpect(jsonPath("$.steps[0].name").value("spring.beans.instantiate"))
+                .andExpect(jsonPath("$.steps[0].durationMs").value(42))
+                .andExpect(jsonPath("$.steps[0].tags[0].key").value("bean.name"))
+                .andExpect(jsonPath("$.steps[0].tags[0].value").value("dataSource"));
     }
 
     @Test
@@ -132,17 +135,19 @@ class StartupControllerTests {
         StartupTimeline timeline = mock(StartupTimeline.class);
         when(timeline.getEvents()).thenReturn(List.of(event));
 
-        StartupDescriptor descriptor = mock(StartupDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        StartupDescriptor descriptor =
+                mock(StartupDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(descriptor.getTimeline()).thenReturn(timeline);
 
         StartupEndpoint endpoint = mock(StartupEndpoint.class);
         when(endpoint.startupSnapshot()).thenReturn(descriptor);
 
-        MockMvc mvc = standaloneSetup(new StartupController(providerOf(endpoint))).build();
+        MockMvc mvc =
+                standaloneSetup(new StartupController(providerOf(endpoint))).build();
 
         mvc.perform(get("/bootui/api/startup").accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.steps[0].durationMs").value(0))
-            .andExpect(jsonPath("$.steps[0].parentId").value(1));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.steps[0].durationMs").value(0))
+                .andExpect(jsonPath("$.steps[0].parentId").value(1));
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -11,407 +11,290 @@ import java.util.Map;
  */
 public final class BootUiDtos {
 
-    private BootUiDtos() {
-    }
+    private BootUiDtos() {}
 
     /**
      * High-level information about the running application.
      */
     public record OverviewDto(
-        String bootUiVersion,
-        String applicationName,
-        String springBootVersion,
-        String javaVersion,
-        String javaVendor,
-        List<String> activeProfiles,
-        List<String> defaultProfiles,
-        String webApplicationType,
-        Integer serverPort,
-        Integer managementPort,
-        String contextPath,
-        Long startupTimeMillis,
-        ActivationStatus activation,
-        String openApiUrl) {
-    }
+            String bootUiVersion,
+            String applicationName,
+            String springBootVersion,
+            String javaVersion,
+            String javaVendor,
+            List<String> activeProfiles,
+            List<String> defaultProfiles,
+            String webApplicationType,
+            Integer serverPort,
+            Integer managementPort,
+            String contextPath,
+            Long startupTimeMillis,
+            ActivationStatus activation,
+            String openApiUrl) {}
 
     /**
      * Reason why BootUI activated, plus current safety settings.
      */
-    public record ActivationStatus(
-        boolean enabled,
-        boolean localhostOnly,
-        String reason,
-        List<String> warnings) {
-    }
+    public record ActivationStatus(boolean enabled, boolean localhostOnly, String reason, List<String> warnings) {}
 
     /**
      * Availability status for one BootUI sidebar panel.
      */
-    public record PanelDto(
-        String id,
-        String title,
-        boolean available,
-        String unavailableReason) {
-    }
+    public record PanelDto(String id, String title, boolean available, String unavailableReason) {}
 
-    public record PanelsReport(List<PanelDto> panels) {
-    }
+    public record PanelsReport(List<PanelDto> panels) {}
 
     /**
      * Spring-managed bean summary.
      */
     public record BeanSummary(
-        String name,
-        String type,
-        String scope,
-        String resource,
-        List<String> dependencies,
-        List<String> aliases,
-        String classification) {
-    }
+            String name,
+            String type,
+            String scope,
+            String resource,
+            List<String> dependencies,
+            List<String> aliases,
+            String classification) {}
 
-    public record BeanList(int total, List<BeanSummary> beans) {
-    }
+    public record BeanList(int total, List<BeanSummary> beans) {}
 
     /**
      * One auto-configuration evaluation entry.
      */
-    public record ConditionEntry(
-        String autoConfigurationClass,
-        String condition,
-        String message,
-        String outcome) {
-    }
+    public record ConditionEntry(String autoConfigurationClass, String condition, String message, String outcome) {}
 
     public record ConditionsReport(
-        List<ConditionEntry> positiveMatches,
-        List<ConditionEntry> negativeMatches,
-        List<String> unconditionalClasses,
-        List<String> exclusions) {
-    }
+            List<ConditionEntry> positiveMatches,
+            List<ConditionEntry> negativeMatches,
+            List<String> unconditionalClasses,
+            List<String> exclusions) {}
 
     /**
      * A single configuration property value, with its source.
      */
     public record ConfigPropertyDto(
-        String name,
-        Object value,
-        String source,
-        String origin,
-        boolean masked,
-        boolean override,
-        String description,
-        Object defaultValue) {
-    }
+            String name,
+            Object value,
+            String source,
+            String origin,
+            boolean masked,
+            boolean override,
+            String description,
+            Object defaultValue) {}
 
     /**
      * A known configuration property that can be used for new overrides.
      */
-    public record ConfigPropertySuggestionDto(
-        String name,
-        String type,
-        String description,
-        Object defaultValue) {
-    }
+    public record ConfigPropertySuggestionDto(String name, String type, String description, Object defaultValue) {}
 
     public record ConfigReport(
-        List<String> activeProfiles,
-        List<String> sources,
-        List<ConfigPropertyDto> properties,
-        List<ConfigPropertySuggestionDto> propertySuggestions) {
-    }
+            List<String> activeProfiles,
+            List<String> sources,
+            List<ConfigPropertyDto> properties,
+            List<ConfigPropertySuggestionDto> propertySuggestions) {}
 
     /**
      * Request to add/update a runtime property override.
      */
-    public record ConfigOverrideRequest(String name, String value, Boolean persist) {
-    }
+    public record ConfigOverrideRequest(String name, String value, Boolean persist) {}
 
     /**
      * Result of mutating a property override.
      */
     public record ConfigOverrideResult(
-        String name,
-        String value,
-        String previousValue,
-        boolean persisted,
-        String message) {
-    }
+            String name, String value, String previousValue, boolean persisted, String message) {}
 
     /**
      * One HTTP mapping.
      */
-    public record MappingDto(
-        String method,
-        String pattern,
-        String handler,
-        String produces,
-        String consumes) {
-    }
+    public record MappingDto(String method, String pattern, String handler, String produces, String consumes) {}
 
-    public record MappingsReport(int total, List<MappingDto> mappings) {
-    }
+    public record MappingsReport(int total, List<MappingDto> mappings) {}
 
     /**
      * Request from the browser to probe a local HTTP endpoint.
      */
-    public record HttpProbeRequest(
-        String method,
-        String path,
-        String body,
-        Map<String, String> headers) {
-    }
+    public record HttpProbeRequest(String method, String path, String body, Map<String, String> headers) {}
 
     /**
      * Result of an HTTP probe.
      */
     public record HttpProbeResponse(
-        int status,
-        String statusText,
-        Map<String, String> headers,
-        String body,
-        long durationMs,
-        String error) {
-    }
+            int status, String statusText, Map<String, String> headers, String body, long durationMs, String error) {}
 
     /**
      * Health node, possibly nested.
      */
-    public record HealthNodeDto(
-        String name,
-        String status,
-        Object details,
-        List<HealthNodeDto> components) {
-    }
+    public record HealthNodeDto(String name, String status, Object details, List<HealthNodeDto> components) {}
 
-    public record LoggerDto(
-        String name,
-        String configuredLevel,
-        String effectiveLevel) {
-    }
+    public record LoggerDto(String name, String configuredLevel, String effectiveLevel) {}
 
-    public record LoggersReport(List<String> availableLevels, List<LoggerDto> loggers) {
-    }
+    public record LoggersReport(List<String> availableLevels, List<LoggerDto> loggers) {}
 
     /**
      * A single log line for the live log tail.
      */
-    public record LogLineDto(long timestamp, String level, String logger, String message, String thread) {
-    }
+    public record LogLineDto(long timestamp, String level, String logger, String message, String thread) {}
 
     /**
      * DevTools-backed reload and restart status.
      */
     public record DevToolsStatus(
-        boolean restartAvailable,
-        String restartUnavailableReason,
-        boolean restartPending,
-        boolean liveReloadAvailable,
-        Integer liveReloadPort,
-        String liveReloadUnavailableReason) {
-    }
+            boolean restartAvailable,
+            String restartUnavailableReason,
+            boolean restartPending,
+            boolean liveReloadAvailable,
+            Integer liveReloadPort,
+            String liveReloadUnavailableReason) {}
 
     /**
      * Request to restart the application through Spring Boot DevTools.
      */
-    public record DevToolsRestartRequest(Boolean confirm) {
-    }
+    public record DevToolsRestartRequest(Boolean confirm) {}
 
     /**
      * Result of a DevTools reload or restart action.
      */
-    public record DevToolsActionResult(String action, String status, String message) {
-    }
+    public record DevToolsActionResult(String action, String status, String message) {}
 
-    public record StartupStepDto(
-        long id,
-        Long parentId,
-        String name,
-        long durationMs,
-        List<TagDto> tags) {
-    }
+    public record StartupStepDto(long id, Long parentId, String name, long durationMs, List<TagDto> tags) {}
 
-    public record TagDto(String key, String value) {
-    }
+    public record TagDto(String key, String value) {}
 
-    public record StartupReport(List<StartupStepDto> steps) {
-    }
+    public record StartupReport(List<StartupStepDto> steps) {}
 
     /**
      * Summary of a @Scheduled task registered in the application context.
      */
     public record ScheduledTaskDto(
-        String runnable,
-        String triggerType,
-        String expression,
-        Long initialDelayMs,
-        String timeUnit) {
-    }
+            String runnable, String triggerType, String expression, Long initialDelayMs, String timeUnit) {}
 
-    public record ScheduledReport(boolean schedulingPresent, int total, List<ScheduledTaskDto> tasks) {
-    }
+    public record ScheduledReport(boolean schedulingPresent, int total, List<ScheduledTaskDto> tasks) {}
 
     /**
      * Summary of one Spring Data repository discovered in the context.
      */
     public record RepositoryDto(
-        String beanName,
-        String repositoryInterface,
-        String domainType,
-        String idType,
-        String storeModule,
-        String customImplementation,
-        int queryMethodCount,
-        int fragmentCount) {
-    }
+            String beanName,
+            String repositoryInterface,
+            String domainType,
+            String idType,
+            String storeModule,
+            String customImplementation,
+            int queryMethodCount,
+            int fragmentCount) {}
 
     /**
      * Detail view of a Spring Data repository, including its query methods.
      */
     public record RepositoryDetailDto(
-        String beanName,
-        String repositoryInterface,
-        String domainType,
-        String idType,
-        String storeModule,
-        String customImplementation,
-        List<RepositoryMethodDto> methods,
-        List<String> fragments) {
-    }
+            String beanName,
+            String repositoryInterface,
+            String domainType,
+            String idType,
+            String storeModule,
+            String customImplementation,
+            List<RepositoryMethodDto> methods,
+            List<String> fragments) {}
 
     /**
      * One query method on a Spring Data repository.
      */
     public record RepositoryMethodDto(
-        String name,
-        String signature,
-        String origin,
-        String query,
-        boolean nativeQuery,
-        String namedQuery) {
-    }
+            String name, String signature, String origin, String query, boolean nativeQuery, String namedQuery) {}
 
-    public record RepositoriesReport(
-        boolean springDataPresent,
-        int total,
-        List<RepositoryDto> repositories) {
-    }
+    public record RepositoriesReport(boolean springDataPresent, int total, List<RepositoryDto> repositories) {}
 
     /**
      * Current Micrometer cache metrics for one cache, when cache meters are registered.
      */
     public record CacheMetricsDto(
-        boolean available,
-        Double hits,
-        Double misses,
-        Double hitRatio,
-        Double puts,
-        Double evictions,
-        Double removals,
-        Double size) {
-    }
+            boolean available,
+            Double hits,
+            Double misses,
+            Double hitRatio,
+            Double puts,
+            Double evictions,
+            Double removals,
+            Double size) {}
 
     /**
      * One cache known to a Spring {@code CacheManager}.
      */
-    public record CacheDto(
-        String managerName,
-        String name,
-        String nativeType,
-        Long size,
-        CacheMetricsDto metrics) {
-    }
+    public record CacheDto(String managerName, String name, String nativeType, Long size, CacheMetricsDto metrics) {}
 
     /**
      * One Spring {@code CacheManager} bean and its currently known caches.
      */
-    public record CacheManagerDto(
-        String name,
-        String type,
-        boolean noOp,
-        List<CacheDto> caches) {
-    }
+    public record CacheManagerDto(String name, String type, boolean noOp, List<CacheDto> caches) {}
 
     /**
      * One cache annotation operation discovered on an application bean method.
      */
     public record CacheOperationDto(
-        String beanName,
-        String targetType,
-        String method,
-        String operation,
-        List<String> caches,
-        String key,
-        String condition,
-        String unless,
-        boolean allEntries,
-        boolean beforeInvocation) {
-    }
+            String beanName,
+            String targetType,
+            String method,
+            String operation,
+            List<String> caches,
+            String key,
+            String condition,
+            String unless,
+            boolean allEntries,
+            boolean beforeInvocation) {}
 
     /**
      * Top-level Spring Cache report.
      */
     public record CacheReport(
-        boolean cacheAvailable,
-        boolean clearEnabled,
-        int managerCount,
-        int cacheCount,
-        int operationCount,
-        List<CacheManagerDto> managers,
-        List<CacheOperationDto> operations,
-        List<String> warnings) {
-    }
+            boolean cacheAvailable,
+            boolean clearEnabled,
+            int managerCount,
+            int cacheCount,
+            int operationCount,
+            List<CacheManagerDto> managers,
+            List<CacheOperationDto> operations,
+            List<String> warnings) {}
 
     /**
      * Request to clear one cache or every known cache.
      */
-    public record CacheClearRequest(String managerName, String cacheName, Boolean all, Boolean confirm) {
-    }
+    public record CacheClearRequest(String managerName, String cacheName, Boolean all, Boolean confirm) {}
 
     /**
      * Result of a cache clear operation.
      */
-    public record CacheClearResult(String status, String message, int clearedCaches, List<String> caches) {
-    }
+    public record CacheClearResult(String status, String message, int clearedCaches, List<String> caches) {}
 
     /**
      * Properties contributed by a single profile-specific property source.
      */
-    public record ProfileSourceDto(
-        String sourceName,
-        String profile,
-        List<ConfigPropertyDto> properties) {
-    }
+    public record ProfileSourceDto(String sourceName, String profile, List<ConfigPropertyDto> properties) {}
 
     /**
      * Profile-aware view of the active configuration.
      */
-    public record ProfilesReport(
-        List<String> activeProfiles,
-        List<ProfileSourceDto> profileSources) {
-    }
+    public record ProfilesReport(List<String> activeProfiles, List<ProfileSourceDto> profileSources) {}
 
     /**
      * One Spring Security filter chain.
      */
     public record SecurityFilterChainDto(
-        int order,
-        String requestMatcher,
-        String requestMatcherType,
-        List<String> filters,
-        boolean csrfEnabled,
-        boolean corsEnabled,
-        boolean sessionManagementPresent) {
-    }
+            int order,
+            String requestMatcher,
+            String requestMatcherType,
+            List<String> filters,
+            boolean csrfEnabled,
+            boolean corsEnabled,
+            boolean sessionManagementPresent) {}
 
     /**
      * Authentication and user-details summary.
      */
     public record SecurityAuthDto(
-        List<String> authenticationProviderTypes,
-        List<String> userDetailsServiceTypes,
-        String configuredUsername) {
-    }
+            List<String> authenticationProviderTypes,
+            List<String> userDetailsServiceTypes,
+            String configuredUsername) {}
 
     /**
      * Result of the best-effort chain-matching explain.
@@ -421,21 +304,13 @@ public final class BootUiDtos {
      * session-based matchers.</p>
      */
     public record SecurityExplainDto(
-        boolean matched,
-        boolean bestEffort,
-        Integer chainIndex,
-        String matcherDescription,
-        List<String> filters) {
-    }
+            boolean matched, boolean bestEffort, Integer chainIndex, String matcherDescription, List<String> filters) {}
 
     /**
      * Top-level Spring Security report.
      */
     public record SecurityReport(
-        boolean springSecurityPresent,
-        List<SecurityFilterChainDto> chains,
-        SecurityAuthDto auth) {
-    }
+            boolean springSecurityPresent, List<SecurityFilterChainDto> chains, SecurityAuthDto auth) {}
 
     /**
      * Authorization rule that applies to a single HTTP endpoint.
@@ -456,139 +331,122 @@ public final class BootUiDtos {
      * that did not include headers/session state.</p>
      */
     public record SecurityEndpointDto(
-        String method,
-        String pattern,
-        String handler,
-        boolean secured,
-        String rule,
-        List<String> roles,
-        Integer chainIndex,
-        String matcherDescription,
-        String description,
-        boolean bestEffort) {
-    }
+            String method,
+            String pattern,
+            String handler,
+            boolean secured,
+            String rule,
+            List<String> roles,
+            Integer chainIndex,
+            String matcherDescription,
+            String description,
+            boolean bestEffort) {}
 
     /**
      * Per-endpoint Spring Security authorization report.
      */
     public record SecurityEndpointsReport(
-        boolean springSecurityPresent,
-        boolean handlerMappingAvailable,
-        int total,
-        List<SecurityEndpointDto> endpoints) {
-    }
+            boolean springSecurityPresent,
+            boolean handlerMappingAvailable,
+            int total,
+            List<SecurityEndpointDto> endpoints) {}
 
     /**
      * One Micrometer meter exposed by the application's meter registry.
      */
     public record MetricMeterDto(
-        String name,
-        String description,
-        String baseUnit,
-        String type,
-        List<MetricAvailableTagDto> availableTags) {
-    }
+            String name, String description, String baseUnit, String type, List<MetricAvailableTagDto> availableTags) {}
 
     /**
      * A concrete tag attached to a Micrometer meter sample.
      */
-    public record MetricTagDto(String key, String value) {
-    }
+    public record MetricTagDto(String key, String value) {}
 
     /**
      * Available values for one Micrometer meter tag key.
      */
-    public record MetricAvailableTagDto(String key, List<String> values, boolean truncated) {
-    }
+    public record MetricAvailableTagDto(String key, List<String> values, boolean truncated) {}
 
     /**
      * One measured statistic for a Micrometer meter.
      */
-    public record MetricMeasurementDto(String statistic, double value) {
-    }
+    public record MetricMeasurementDto(String statistic, double value) {}
 
     /**
      * One concrete tagged Micrometer meter sample.
      */
-    public record MetricSampleDto(List<MetricTagDto> tags, List<MetricMeasurementDto> measurements) {
-    }
+    public record MetricSampleDto(List<MetricTagDto> tags, List<MetricMeasurementDto> measurements) {}
 
     /**
      * Browseable list of Micrometer meters.
      */
-    public record MetricsReport(boolean metricsAvailable, int total, List<MetricMeterDto> meters) {
-    }
+    public record MetricsReport(boolean metricsAvailable, int total, List<MetricMeterDto> meters) {}
 
     /**
      * Detail view for one Micrometer meter name, including current values.
      */
     public record MetricDetailDto(
-        boolean metricsAvailable,
-        String name,
-        String description,
-        String baseUnit,
-        String type,
-        List<MetricMeasurementDto> measurements,
-        List<MetricAvailableTagDto> availableTags,
-        List<MetricSampleDto> samples) {
-    }
+            boolean metricsAvailable,
+            String name,
+            String description,
+            String baseUnit,
+            String type,
+            List<MetricMeasurementDto> measurements,
+            List<MetricAvailableTagDto> availableTags,
+            List<MetricSampleDto> samples) {}
 
     /**
      * One Maven dependency discovered on the running application's classpath.
      */
     public record DependencyDto(
-        String groupId,
-        String artifactId,
-        String version,
-        String packageName,
-        String source,
-        int vulnerabilityCount,
-        String highestSeverity,
-        List<DependencyVulnerabilityDto> vulnerabilities) {
-    }
+            String groupId,
+            String artifactId,
+            String version,
+            String packageName,
+            String source,
+            int vulnerabilityCount,
+            String highestSeverity,
+            List<DependencyVulnerabilityDto> vulnerabilities) {}
 
     /**
      * One vulnerability advisory affecting a dependency.
      */
     public record DependencyVulnerabilityDto(
-        String id,
-        String summary,
-        String details,
-        String severity,
-        Double score,
-        List<String> aliases,
-        List<String> references,
-        List<String> fixedVersions) {
-    }
+            String id,
+            String summary,
+            String details,
+            String severity,
+            Double score,
+            List<String> aliases,
+            List<String> references,
+            List<String> fixedVersions) {}
 
     /**
      * Count of vulnerability advisories by normalized severity.
      */
-    public record DependencySeverityCountDto(String severity, int count) {
-    }
+    public record DependencySeverityCountDto(String severity, int count) {}
 
     /**
      * Metadata about the dependency vulnerability scan.
      */
     public record DependencyScanStatusDto(
-        String scanner,
-        String status,
-        String message,
-        Long scannedAt,
-        int packagesScanned,
-        int vulnerabilitiesFound) {
-    }
+            String scanner,
+            String status,
+            String message,
+            Long scannedAt,
+            int packagesScanned,
+            int vulnerabilitiesFound) {}
 
     /**
      * Top-level report for dependency inventory and vulnerability findings.
      */
     public record DependenciesReport(
-        boolean scanningEnabled,
-        int total,
-        int vulnerable,
-        List<DependencySeverityCountDto> severityCounts,
-        DependencyScanStatusDto scan,
-        List<DependencyDto> dependencies) {
+            boolean scanningEnabled,
+            int total,
+            int vulnerable,
+            List<DependencySeverityCountDto> severityCounts,
+            DependencyScanStatusDto scan,
+            List<DependencyDto> dependencies) {
 
         public String status() {
             return scan == null ? null : scan.status();
@@ -598,25 +456,18 @@ public final class BootUiDtos {
     /**
      * A single JVM memory pool (heap, non-heap, or GC pool).
      */
-    public record MemoryPoolDto(
-        String name,
-        long usedBytes,
-        long committedBytes,
-        long maxBytes,
-        int usedPercent) {
-    }
+    public record MemoryPoolDto(String name, long usedBytes, long committedBytes, long maxBytes, int usedPercent) {}
 
     /**
      * Snapshot of JVM memory metrics.
      */
     public record MemoryReport(
-        MemoryPoolDto heap,
-        MemoryPoolDto nonHeap,
-        List<MemoryPoolDto> pools,
-        List<String> jvmInputArguments,
-        String suggestedJvmOptions,
-        MemoryCalculationDto calculation) {
-    }
+            MemoryPoolDto heap,
+            MemoryPoolDto nonHeap,
+            List<MemoryPoolDto> pools,
+            List<String> jvmInputArguments,
+            String suggestedJvmOptions,
+            MemoryCalculationDto calculation) {}
 
     /**
      * Result of the Paketo-style memory calculator.
@@ -628,245 +479,194 @@ public final class BootUiDtos {
      * with a safety factor instead of the buildpack's build-time JAR-entry estimate.
      */
     public record MemoryCalculationDto(
-        long totalMemoryBytes,
-        long heapBytes,
-        long metaspaceBytes,
-        long codeCacheBytes,
-        long directMemoryBytes,
-        long stackBytesPerThread,
-        long stackBytesTotal,
-        long headRoomBytes,
-        long fixedRegionsBytes,
-        int threadCount,
-        int loadedClasses,
-        int liveThreadCount,
-        int liveLoadedClassCount,
-        int headRoomPercent,
-        String jvmOptions,
-        boolean valid,
-        String error) {
-    }
+            long totalMemoryBytes,
+            long heapBytes,
+            long metaspaceBytes,
+            long codeCacheBytes,
+            long directMemoryBytes,
+            long stackBytesPerThread,
+            long stackBytesTotal,
+            long headRoomBytes,
+            long fixedRegionsBytes,
+            int threadCount,
+            int loadedClasses,
+            int liveThreadCount,
+            int liveLoadedClassCount,
+            int headRoomPercent,
+            String jvmOptions,
+            boolean valid,
+            String error) {}
 
     /**
      * A host/container port mapping exposed by a local development service.
      */
-    public record DevServicePortDto(
-        Integer containerPort,
-        Integer hostPort,
-        String protocol) {
-    }
+    public record DevServicePortDto(Integer containerPort, Integer hostPort, String protocol) {}
 
     /**
      * One Docker Compose, Testcontainers, or service-connection entry.
      */
     public record DevServiceDto(
-        String id,
-        String name,
-        String type,
-        String source,
-        String image,
-        String status,
-        String host,
-        List<DevServicePortDto> ports,
-        Map<String, Object> connectionDetails,
-        boolean restartable,
-        boolean logsAvailable,
-        String note) {
-    }
+            String id,
+            String name,
+            String type,
+            String source,
+            String image,
+            String status,
+            String host,
+            List<DevServicePortDto> ports,
+            Map<String, Object> connectionDetails,
+            boolean restartable,
+            boolean logsAvailable,
+            String note) {}
 
     /**
      * Top-level report for local development services.
      */
     public record DevServicesReport(
-        boolean dockerComposePresent,
-        boolean testcontainersPresent,
-        long snapshotTimestamp,
-        int total,
-        List<DevServiceDto> services) {
-    }
+            boolean dockerComposePresent,
+            boolean testcontainersPresent,
+            long snapshotTimestamp,
+            int total,
+            List<DevServiceDto> services) {}
 
     /**
      * Tail of logs for one local development service.
      */
-    public record DevServiceLogReport(
-        String id,
-        String logs,
-        boolean truncated,
-        int maxBytes) {
-    }
+    public record DevServiceLogReport(String id, String logs, boolean truncated, int maxBytes) {}
 
     /**
      * Result of restarting a local development service.
      */
-    public record DevServiceRestartResult(
-        String id,
-        String status,
-        String message) {
-    }
+    public record DevServiceRestartResult(String id, String status, String message) {}
 
     // ----- OTLP traces + AI panel ----------------------------------------------------------
 
     /**
      * Summary describing a span attribute, normalized to a JSON-friendly value type.
      */
-    public record SpanAttributeDto(
-        String key,
-        String type,
-        Object value) {
-    }
+    public record SpanAttributeDto(String key, String type, Object value) {}
 
     /**
      * Discrete event recorded inside a span.
      */
-    public record SpanEventDto(
-        String name,
-        long timeOffsetNanos,
-        List<SpanAttributeDto> attributes) {
-    }
+    public record SpanEventDto(String name, long timeOffsetNanos, List<SpanAttributeDto> attributes) {}
 
     /**
      * Detailed span record returned by the Traces detail endpoint.
      */
     public record SpanDto(
-        String traceId,
-        String spanId,
-        String parentSpanId,
-        String name,
-        String kind,
-        String serviceName,
-        String scope,
-        long startEpochNanos,
-        long endEpochNanos,
-        long durationNanos,
-        String statusCode,
-        String statusMessage,
-        List<SpanAttributeDto> attributes,
-        List<SpanEventDto> events) {
-    }
+            String traceId,
+            String spanId,
+            String parentSpanId,
+            String name,
+            String kind,
+            String serviceName,
+            String scope,
+            long startEpochNanos,
+            long endEpochNanos,
+            long durationNanos,
+            String statusCode,
+            String statusMessage,
+            List<SpanAttributeDto> attributes,
+            List<SpanEventDto> events) {}
 
     /**
      * Summary used by the Traces list view.
      */
     public record TraceSummaryDto(
-        String traceId,
-        String rootSpanName,
-        List<String> services,
-        long startEpochNanos,
-        long endEpochNanos,
-        long durationNanos,
-        int spanCount,
-        boolean hasError,
-        boolean hasAi) {
-    }
+            String traceId,
+            String rootSpanName,
+            List<String> services,
+            long startEpochNanos,
+            long endEpochNanos,
+            long durationNanos,
+            int spanCount,
+            boolean hasError,
+            boolean hasAi) {}
 
     /**
      * Top-level Traces list payload.
      */
-    public record TracesReport(
-        boolean enabled,
-        int retained,
-        int capacity,
-        List<TraceSummaryDto> traces) {
-    }
+    public record TracesReport(boolean enabled, int retained, int capacity, List<TraceSummaryDto> traces) {}
 
     /**
      * Top-level Trace detail payload.
      */
-    public record TraceDetailDto(
-        String traceId,
-        List<SpanDto> spans) {
-    }
+    public record TraceDetailDto(String traceId, List<SpanDto> spans) {}
 
     /**
      * Summary of a single AI chat completion span.
      */
     public record AiChatSummaryDto(
-        String traceId,
-        String spanId,
-        long startEpochNanos,
-        long durationNanos,
-        String provider,
-        String requestModel,
-        String responseModel,
-        Long inputTokens,
-        Long outputTokens,
-        Long totalTokens,
-        String finishReason,
-        String statusCode,
-        String operation,
-        int toolCallCount,
-        int vectorOperationCount) {
-    }
+            String traceId,
+            String spanId,
+            long startEpochNanos,
+            long durationNanos,
+            String provider,
+            String requestModel,
+            String responseModel,
+            Long inputTokens,
+            Long outputTokens,
+            Long totalTokens,
+            String finishReason,
+            String statusCode,
+            String operation,
+            int toolCallCount,
+            int vectorOperationCount) {}
 
     /**
      * Tool call (function call) emitted by Spring AI advisors.
      */
     public record AiToolCallDto(
-        String spanId,
-        String name,
-        long startEpochNanos,
-        long durationNanos,
-        String statusCode) {
-    }
+            String spanId, String name, long startEpochNanos, long durationNanos, String statusCode) {}
 
     /**
      * Vector store operation linked to the same trace.
      */
     public record AiVectorOpDto(
-        String spanId,
-        String operation,
-        String collectionName,
-        long startEpochNanos,
-        long durationNanos,
-        String statusCode) {
-    }
+            String spanId,
+            String operation,
+            String collectionName,
+            long startEpochNanos,
+            long durationNanos,
+            String statusCode) {}
 
     /**
      * Detail of a single AI chat span, including linked tool calls and vector operations from the same trace.
      */
     public record AiChatDetailDto(
-        AiChatSummaryDto summary,
-        List<AiToolCallDto> toolCalls,
-        List<AiVectorOpDto> vectorOperations,
-        List<SpanAttributeDto> attributes,
-        List<SpanEventDto> events,
-        boolean contentCaptured,
-        String contentBanner) {
-    }
+            AiChatSummaryDto summary,
+            List<AiToolCallDto> toolCalls,
+            List<AiVectorOpDto> vectorOperations,
+            List<SpanAttributeDto> attributes,
+            List<SpanEventDto> events,
+            boolean contentCaptured,
+            String contentBanner) {}
 
     /**
      * Per-minute token usage bucket.
      */
-    public record AiTokenBucketDto(
-        long epochMinute,
-        long inputTokens,
-        long outputTokens,
-        int callCount) {
-    }
+    public record AiTokenBucketDto(long epochMinute, long inputTokens, long outputTokens, int callCount) {}
 
     /**
      * Token usage time series payload.
      */
-    public record AiTokenSeriesDto(
-        int minutes,
-        List<AiTokenBucketDto> buckets) {
-    }
+    public record AiTokenSeriesDto(int minutes, List<AiTokenBucketDto> buckets) {}
 
     /**
      * AI Usage overview payload.
      */
     public record AiOverviewDto(
-        boolean enabled,
-        boolean springAiDetected,
-        int totalChats,
-        long totalInputTokens,
-        long totalOutputTokens,
-        Map<String, Long> tokensByModel,
-        Map<String, Integer> callsByModel,
-        int toolCallCount,
-        int vectorOperationCount,
-        int embeddingCount,
-        List<AiChatSummaryDto> recent,
-        String contentBanner) {
-    }
+            boolean enabled,
+            boolean springAiDetected,
+            int totalChats,
+            long totalInputTokens,
+            long totalOutputTokens,
+            Map<String, Long> tokensByModel,
+            Map<String, Integer> callsByModel,
+            int toolCallCount,
+            int vectorOperationCount,
+            int embeddingCount,
+            List<AiChatSummaryDto> recent,
+            String contentBanner) {}
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiInfo.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiInfo.java
@@ -13,6 +13,5 @@ public final class BootUiInfo {
 
     public static final String DEFAULT_API_PATH = "/bootui/api";
 
-    private BootUiInfo() {
-    }
+    private BootUiInfo() {}
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/SecretMasker.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/SecretMasker.java
@@ -16,22 +16,22 @@ public final class SecretMasker {
 
     public static final String MASKED_VALUE = "******";
     private static final Set<String> DEFAULT_KEY_PATTERNS = Set.of(
-        "password",
-        "passwd",
-        "secret",
-        "token",
-        "key",
-        "credential",
-        "credentials",
-        "private",
-        "apikey",
-        "api-key",
-        "client-secret",
-        "client_secret",
-        "auth",
-        "authorization",
-        "session-id",
-        "session_id");
+            "password",
+            "passwd",
+            "secret",
+            "token",
+            "key",
+            "credential",
+            "credentials",
+            "private",
+            "apikey",
+            "api-key",
+            "client-secret",
+            "client_secret",
+            "auth",
+            "authorization",
+            "session-id",
+            "session_id");
     private final Set<String> keyPatterns;
 
     public SecretMasker() {

--- a/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerBrowserVisibleSurfaceTests.java
+++ b/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerBrowserVisibleSurfaceTests.java
@@ -1,8 +1,8 @@
 package io.github.jdubois.bootui.core;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that {@link SecretMasker} correctly masks every category of property
@@ -134,7 +134,7 @@ class SecretMaskerBrowserVisibleSurfaceTests {
     void masksPrivateKeyProperty() {
         assertThat(masker.isSecret("ssl.private-key")).isTrue();
         assertThat(masker.mask("ssl.private-key", "-----BEGIN RSA PRIVATE KEY-----"))
-            .isEqualTo(SecretMasker.MASKED_VALUE);
+                .isEqualTo(SecretMasker.MASKED_VALUE);
     }
 
     @Test
@@ -154,8 +154,7 @@ class SecretMaskerBrowserVisibleSurfaceTests {
     @Test
     void masksAuthorizationHeader() {
         assertThat(masker.isSecret("http.authorization")).isTrue();
-        assertThat(masker.mask("http.authorization", "******"))
-            .isEqualTo(SecretMasker.MASKED_VALUE);
+        assertThat(masker.mask("http.authorization", "******")).isEqualTo(SecretMasker.MASKED_VALUE);
     }
 
     @Test
@@ -174,10 +173,10 @@ class SecretMaskerBrowserVisibleSurfaceTests {
 
     @Test
     void masksOAuthClientSecretHyphenated() {
-        assertThat(masker.isSecret("spring.security.oauth2.client.registration.github.client-secret")).isTrue();
-        assertThat(masker.mask(
-            "spring.security.oauth2.client.registration.github.client-secret",
-            "super-secret")).isEqualTo(SecretMasker.MASKED_VALUE);
+        assertThat(masker.isSecret("spring.security.oauth2.client.registration.github.client-secret"))
+                .isTrue();
+        assertThat(masker.mask("spring.security.oauth2.client.registration.github.client-secret", "super-secret"))
+                .isEqualTo(SecretMasker.MASKED_VALUE);
     }
 
     @Test

--- a/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerCustomPatternsTests.java
+++ b/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerCustomPatternsTests.java
@@ -1,11 +1,10 @@
 package io.github.jdubois.bootui.core;
 
-import org.junit.jupiter.api.Test;
-
-import java.util.Set;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
 
 class SecretMaskerCustomPatternsTests {
 
@@ -35,8 +34,7 @@ class SecretMaskerCustomPatternsTests {
 
     @Test
     void nullPatternsThrow() {
-        assertThatThrownBy(() -> new SecretMasker(null))
-            .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new SecretMasker(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test

--- a/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerTests.java
+++ b/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerTests.java
@@ -1,8 +1,8 @@
 package io.github.jdubois.bootui.core;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 class SecretMaskerTests {
 
@@ -20,8 +20,7 @@ class SecretMaskerTests {
 
     @Test
     void masksValueWhenKeyMatches() {
-        assertThat(masker.mask("spring.datasource.password", "hunter2"))
-            .isEqualTo(SecretMasker.MASKED_VALUE);
+        assertThat(masker.mask("spring.datasource.password", "hunter2")).isEqualTo(SecretMasker.MASKED_VALUE);
         assertThat(masker.mask("server.port", 8080)).isEqualTo(8080);
         assertThat(masker.mask("spring.datasource.password", null)).isNull();
     }

--- a/bootui-sample-app/e2e/README.md
+++ b/bootui-sample-app/e2e/README.md
@@ -11,7 +11,7 @@ Each Playwright spec file targets one of the BootUI views (or a cross-cutting
 flow) exposed by the sample app:
 
 | Spec                   | Verifies                                                                                                              |
-|------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
 | `app-shell.spec.js`    | Top navbar, sidebar links, deep-linking, navigation between every section                                             |
 | `overview.spec.js`     | Application / Runtime / Activation cards, refresh button                                                              |
 | `beans.spec.js`        | Bean list rendering, name filter, classification filter                                                               |
@@ -35,9 +35,9 @@ flow) exposed by the sample app:
 
 ## Prerequisites
 
-* Node.js 20+
-* Java 25 and the repository Maven Wrapper (used to build & run the sample app)
-* The BootUI parent build must be installed locally so the sample app can
+- Node.js 20+
+- Java 25 and the repository Maven Wrapper (used to build & run the sample app)
+- The BootUI parent build must be installed locally so the sample app can
   resolve its modules:
 
   ```bash
@@ -74,8 +74,8 @@ npm test
 
 ## Configuration
 
-* `BOOTUI_BASE_URL` — override the base URL (default `http://localhost:8080`).
-* `BOOTUI_SAMPLE_PORT` — override the port used to build the default base URL.
+- `BOOTUI_BASE_URL` — override the base URL (default `http://localhost:8080`).
+- `BOOTUI_SAMPLE_PORT` — override the port used to build the default base URL.
 
 ## Artefacts
 

--- a/bootui-sample-app/e2e/package-lock.json
+++ b/bootui-sample-app/e2e/package-lock.json
@@ -8,7 +8,8 @@
       "name": "bootui-sample-app-e2e",
       "version": "0.1.0",
       "devDependencies": {
-        "@playwright/test": "1.60.0"
+        "@playwright/test": "1.60.0",
+        "prettier": "3.8.3"
       }
     },
     "node_modules/@playwright/test": {
@@ -72,6 +73,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     }
   }

--- a/bootui-sample-app/e2e/package.json
+++ b/bootui-sample-app/e2e/package.json
@@ -9,9 +9,12 @@
     "test:headed": "playwright test --headed",
     "test:ui": "playwright test --ui",
     "screenshots": "node scripts/capture-docs-screenshots.mjs",
-    "report": "playwright show-report"
+    "report": "playwright show-report",
+    "format": "prettier --config ../../prettier.config.cjs --ignore-path ../../.prettierignore --write .",
+    "format:check": "prettier --config ../../prettier.config.cjs --ignore-path ../../.prettierignore --check ."
   },
   "devDependencies": {
-    "@playwright/test": "1.60.0"
+    "@playwright/test": "1.60.0",
+    "prettier": "3.8.3"
   }
 }

--- a/bootui-sample-app/e2e/playwright.config.js
+++ b/bootui-sample-app/e2e/playwright.config.js
@@ -43,13 +43,15 @@ export default defineConfig({
 
   // Set BOOTUI_SKIP_WEBSERVER=1 to disable the auto-started Maven server when
   // running the tests against an already-deployed instance, listing tests, etc.
-  webServer: process.env.BOOTUI_SKIP_WEBSERVER ? undefined : {
-    // Run from the e2e module through the root Maven Wrapper.
-    command: '../../mvnw -f ../pom.xml -q spring-boot:run',
-    url: `${BASE_URL}/bootui/api/overview`,
-    reuseExistingServer: !process.env.CI,
-    stdout: 'pipe',
-    stderr: 'pipe',
-    timeout: 240_000
-  }
+  webServer: process.env.BOOTUI_SKIP_WEBSERVER
+    ? undefined
+    : {
+        // Run from the e2e module through the root Maven Wrapper.
+        command: '../../mvnw -f ../pom.xml -q spring-boot:run',
+        url: `${BASE_URL}/bootui/api/overview`,
+        reuseExistingServer: !process.env.CI,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        timeout: 240_000
+      }
 })

--- a/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -130,7 +130,8 @@ const memory = {
     liveLoadedClassCount: 14872,
     loadedClasses: 18590
   },
-  suggestedJvmOptions: '-Xms438m -Xmx438m -XX:MaxMetaspaceSize=94m -XX:ReservedCodeCacheSize=96m -XX:MaxDirectMemorySize=64m -XX:+UseG1GC',
+  suggestedJvmOptions:
+    '-Xms438m -Xmx438m -XX:MaxMetaspaceSize=94m -XX:ReservedCodeCacheSize=96m -XX:MaxDirectMemorySize=64m -XX:+UseG1GC',
   heap: {usedBytes: 172 * MB, committedBytes: 256 * MB, maxBytes: 438 * MB, usedPercent: 39},
   nonHeap: {usedBytes: 116 * MB, committedBytes: 148 * MB, maxBytes: -1, usedPercent: 78},
   pools: [
@@ -171,23 +172,27 @@ function metricDetail(name) {
   const value = name === 'process.uptime' ? 1420 + metricSample : 183_500_000 + metricSample * 2_000_000
   return {
     name,
-    description: metrics.meters.find(meter => meter.name === name)?.description || 'Sample metric',
-    type: metrics.meters.find(meter => meter.name === name)?.type || 'GAUGE',
+    description: metrics.meters.find((meter) => meter.name === name)?.description || 'Sample metric',
+    type: metrics.meters.find((meter) => meter.name === name)?.type || 'GAUGE',
     baseUnit: name.includes('memory') ? 'bytes' : null,
-    measurements: [
-      {statistic: 'VALUE', value}
-    ],
+    measurements: [{statistic: 'VALUE', value}],
     availableTags: [
       {key: 'area', values: ['heap', 'nonheap'], truncated: false},
       {key: 'id', values: ['G1 Old Gen', 'Metaspace'], truncated: false}
     ],
     samples: [
       {
-        tags: [{key: 'area', value: 'heap'}, {key: 'id', value: 'G1 Old Gen'}],
+        tags: [
+          {key: 'area', value: 'heap'},
+          {key: 'id', value: 'G1 Old Gen'}
+        ],
         measurements: [{statistic: 'VALUE', value}]
       },
       {
-        tags: [{key: 'area', value: 'nonheap'}, {key: 'id', value: 'Metaspace'}],
+        tags: [
+          {key: 'area', value: 'nonheap'},
+          {key: 'id', value: 'Metaspace'}
+        ],
         measurements: [{statistic: 'VALUE', value: 86_200_000}]
       }
     ]
@@ -293,7 +298,11 @@ const mappings = {
 
 const configuration = {
   activeProfiles: ['dev', 'local'],
-  sources: ['applicationConfig: [classpath:/application.properties]', '.bootui/application-bootui.properties', 'systemProperties'],
+  sources: [
+    'applicationConfig: [classpath:/application.properties]',
+    '.bootui/application-bootui.properties',
+    'systemProperties'
+  ],
   propertySuggestions: [
     {name: 'server.port', type: 'java.lang.Integer', defaultValue: 8080, description: 'Server HTTP port.'},
     {
@@ -421,10 +430,46 @@ const traceDetail = {
   traceId,
   spans: [
     span(traceId, 'aaaaaaaaaaaaaaaa', null, 'POST /api/chat', 'SERVER', 'bootui-sample', 0, 1_220_000_000),
-    span(traceId, 'bbbbbbbbbbbbbbbb', 'aaaaaaaaaaaaaaaa', 'ChatClient call', 'CLIENT', 'bootui-sample', 80_000_000, 980_000_000),
-    span(traceId, 'cccccccccccccccc', 'bbbbbbbbbbbbbbbb', 'POST /api/generate', 'CLIENT', 'ollama', 130_000_000, 760_000_000),
-    span(traceId, 'dddddddddddddddd', 'aaaaaaaaaaaaaaaa', 'GET sample-greetings', 'CLIENT', 'redis', 40_000_000, 30_000_000),
-    span(traceId, 'eeeeeeeeeeeeeeee', 'aaaaaaaaaaaaaaaa', 'INSERT chat_audit', 'CLIENT', 'postgres', 1_060_000_000, 90_000_000)
+    span(
+      traceId,
+      'bbbbbbbbbbbbbbbb',
+      'aaaaaaaaaaaaaaaa',
+      'ChatClient call',
+      'CLIENT',
+      'bootui-sample',
+      80_000_000,
+      980_000_000
+    ),
+    span(
+      traceId,
+      'cccccccccccccccc',
+      'bbbbbbbbbbbbbbbb',
+      'POST /api/generate',
+      'CLIENT',
+      'ollama',
+      130_000_000,
+      760_000_000
+    ),
+    span(
+      traceId,
+      'dddddddddddddddd',
+      'aaaaaaaaaaaaaaaa',
+      'GET sample-greetings',
+      'CLIENT',
+      'redis',
+      40_000_000,
+      30_000_000
+    ),
+    span(
+      traceId,
+      'eeeeeeeeeeeeeeee',
+      'aaaaaaaaaaaaaaaa',
+      'INSERT chat_audit',
+      'CLIENT',
+      'postgres',
+      1_060_000_000,
+      90_000_000
+    )
   ]
 }
 
@@ -444,7 +489,8 @@ const aiOverview = {
     aiChat('2222222222222222', 'ollama', 'qwen2.5:0.5b', 305, 141, 820_000_000, 'stop'),
     aiChat('3333333333333333', 'ollama', 'llama3.2:1b', 288, 205, 1_120_000_000, 'length')
   ],
-  contentBanner: 'Prompt and completion text is hidden by default. Enable Spring AI content observations to inspect message snippets locally.'
+  contentBanner:
+    'Prompt and completion text is hidden by default. Enable Spring AI content observations to inspect message snippets locally.'
 }
 
 const aiTokens = {
@@ -716,7 +762,13 @@ const security = {
       csrfEnabled: false,
       corsEnabled: true,
       sessionManagementPresent: false,
-      filters: ['DisableEncodeUrlFilter', 'WebAsyncManagerIntegrationFilter', 'HeaderWriterFilter', 'CorsFilter', 'AuthorizationFilter']
+      filters: [
+        'DisableEncodeUrlFilter',
+        'WebAsyncManagerIntegrationFilter',
+        'HeaderWriterFilter',
+        'CorsFilter',
+        'AuthorizationFilter'
+      ]
     },
     {
       order: 1,
@@ -725,7 +777,14 @@ const security = {
       csrfEnabled: true,
       corsEnabled: true,
       sessionManagementPresent: true,
-      filters: ['SecurityContextHolderFilter', 'CsrfFilter', 'LogoutFilter', 'UsernamePasswordAuthenticationFilter', 'BasicAuthenticationFilter', 'AuthorizationFilter']
+      filters: [
+        'SecurityContextHolderFilter',
+        'CsrfFilter',
+        'LogoutFilter',
+        'UsernamePasswordAuthenticationFilter',
+        'BasicAuthenticationFilter',
+        'AuthorizationFilter'
+      ]
     }
   ],
   auth: {
@@ -813,10 +872,22 @@ const dependencies = {
     dependency('pkg:maven/org.springframework.boot/spring-boot-starter-web', '4.0.6', 'NONE', []),
     dependency('pkg:maven/com.fasterxml.jackson.core/jackson-databind', '2.20.1', 'NONE', []),
     dependency('pkg:maven/org.postgresql/postgresql', '42.2.19', 'HIGH', [
-      vulnerability('GHSA-example-001', 'HIGH', 'Sample advisory showing why local dependency scans are useful.', ['CVE-2026-0001'], ['42.7.4'])
+      vulnerability(
+        'GHSA-example-001',
+        'HIGH',
+        'Sample advisory showing why local dependency scans are useful.',
+        ['CVE-2026-0001'],
+        ['42.7.4']
+      )
     ]),
     dependency('pkg:maven/io.netty/netty-handler', '4.1.95.Final', 'MEDIUM', [
-      vulnerability('GHSA-example-002', 'MEDIUM', 'Sample TLS handling advisory in a transitive dependency.', ['CVE-2026-0002'], ['4.1.118.Final']),
+      vulnerability(
+        'GHSA-example-002',
+        'MEDIUM',
+        'Sample TLS handling advisory in a transitive dependency.',
+        ['CVE-2026-0002'],
+        ['4.1.118.Final']
+      ),
       vulnerability('GHSA-example-003', 'MEDIUM', 'Sample denial-of-service advisory.', [], ['4.1.119.Final'])
     ]),
     dependency('pkg:maven/org.springframework.ai/spring-ai-core', '2.0.0-M7', 'NONE', []),
@@ -829,10 +900,15 @@ const screenshots = [
   ['startup', 'Startup Timeline', 'bootui-startup-timeline.png', waitForText('spring.context.refresh')],
   ['memory', 'Memory', 'bootui-memory.png', waitForText('JVM memory calculator')],
   ['health', 'Health', 'bootui-health.png', waitForText('Component tree')],
-  ['metrics', 'Metrics', 'bootui-metrics.png', async page => {
-    await page.getByText('Micrometer metrics').waitFor()
-    await page.waitForTimeout(2300)
-  }],
+  [
+    'metrics',
+    'Metrics',
+    'bootui-metrics.png',
+    async (page) => {
+      await page.getByText('Micrometer metrics').waitFor()
+      await page.waitForTimeout(2300)
+    }
+  ],
   ['conditions', 'Conditions', 'bootui-conditions.png', waitForText('BootUiAutoConfiguration')],
   ['beans', 'Beans', 'bootui-beans.png', waitForText('sampleController')],
   ['mappings', 'Mappings', 'bootui-mappings.png', waitForText('/api/sample/products')],
@@ -841,19 +917,29 @@ const screenshots = [
   ['loggers', 'Loggers', 'bootui-loggers.png', waitForText('io.github.jdubois.bootui')],
   ['log-tail', 'Log Tail', 'bootui-log-tail.png', waitForText('Started BootUI sample application')],
   ['traces', 'Traces', 'bootui-traces.png', waitForText('POST /api/chat')],
-  ['http-probe', 'HTTP Probe', 'bootui-http-probe.png', async page => {
-    await page.getByPlaceholder('/api/sample/hello').fill('/api/sample/products')
-    await page.getByRole('button', {name: 'Send'}).click()
-    await page.getByText('200 OK').waitFor()
-  }],
+  [
+    'http-probe',
+    'HTTP Probe',
+    'bootui-http-probe.png',
+    async (page) => {
+      await page.getByPlaceholder('/api/sample/hello').fill('/api/sample/products')
+      await page.getByRole('button', {name: 'Send'}).click()
+      await page.getByText('200 OK').waitFor()
+    }
+  ],
   ['devtools', 'DevTools', 'bootui-devtools.png', waitForText('Trigger LiveReload')],
   ['dev-services', 'Dev Services', 'bootui-dev-services.png', waitForText('postgres')],
   ['scheduled', 'Scheduled Tasks', 'bootui-scheduled-tasks.png', waitForText('EchoScheduler.echo')],
-  ['data', 'Data', 'bootui-data.png', async page => {
-    await page.getByText('ProductRepository').waitFor()
-    await page.getByRole('button', {name: /ProductRepository/}).click()
-    await page.getByText('findByActiveTrueOrderByNameAsc').waitFor()
-  }],
+  [
+    'data',
+    'Data',
+    'bootui-data.png',
+    async (page) => {
+      await page.getByText('ProductRepository').waitFor()
+      await page.getByRole('button', {name: /ProductRepository/}).click()
+      await page.getByText('findByActiveTrueOrderByNameAsc').waitFor()
+    }
+  ],
   ['cache', 'Cache', 'bootui-cache.png', waitForText('sample-products')],
   ['ai', 'AI Usage', 'bootui-ai.png', waitForText('Token usage')],
   ['security', 'Security', 'bootui-security.png', waitForText('/api/sample/hello')],
@@ -880,8 +966,9 @@ try {
     deviceScaleFactor: 1
   })
 
-  await page.addInitScript(({logLines}) => {
-    const styleText = `
+  await page.addInitScript(
+    ({logLines}) => {
+      const styleText = `
       *, *::before, *::after {
         animation-duration: 0s !important;
         animation-delay: 0s !important;
@@ -890,51 +977,56 @@ try {
         transition-delay: 0s !important;
       }
     `
-    document.addEventListener('DOMContentLoaded', () => {
-      const style = document.createElement('style')
-      style.textContent = styleText
-      document.head.appendChild(style)
-    })
+      document.addEventListener('DOMContentLoaded', () => {
+        const style = document.createElement('style')
+        style.textContent = styleText
+        document.head.appendChild(style)
+      })
 
-    class FakeEventSource {
-      constructor() {
-        this.listeners = new Map()
-        this.readyState = 0
-        setTimeout(() => {
-          this.readyState = 1
-          this.emit('open', {type: 'open'})
-          logLines.forEach((line, index) => {
-            setTimeout(() => this.emit('log', {type: 'log', data: JSON.stringify(line)}), 40 + index * 50)
-          })
-        }, 20)
-      }
-
-      addEventListener(type, listener) {
-        const listeners = this.listeners.get(type) || []
-        listeners.push(listener)
-        this.listeners.set(type, listeners)
-      }
-
-      removeEventListener(type, listener) {
-        const listeners = this.listeners.get(type) || []
-        this.listeners.set(type, listeners.filter(candidate => candidate !== listener))
-      }
-
-      close() {
-        this.readyState = 2
-      }
-
-      emit(type, event) {
-        for (const listener of this.listeners.get(type) || []) {
-          listener(event)
+      class FakeEventSource {
+        constructor() {
+          this.listeners = new Map()
+          this.readyState = 0
+          setTimeout(() => {
+            this.readyState = 1
+            this.emit('open', {type: 'open'})
+            logLines.forEach((line, index) => {
+              setTimeout(() => this.emit('log', {type: 'log', data: JSON.stringify(line)}), 40 + index * 50)
+            })
+          }, 20)
         }
-        const handler = this[`on${type}`]
-        if (handler) handler(event)
-      }
-    }
 
-    window.EventSource = FakeEventSource
-  }, {logLines: sampleLogLines()})
+        addEventListener(type, listener) {
+          const listeners = this.listeners.get(type) || []
+          listeners.push(listener)
+          this.listeners.set(type, listeners)
+        }
+
+        removeEventListener(type, listener) {
+          const listeners = this.listeners.get(type) || []
+          this.listeners.set(
+            type,
+            listeners.filter((candidate) => candidate !== listener)
+          )
+        }
+
+        close() {
+          this.readyState = 2
+        }
+
+        emit(type, event) {
+          for (const listener of this.listeners.get(type) || []) {
+            listener(event)
+          }
+          const handler = this[`on${type}`]
+          if (handler) handler(event)
+        }
+      }
+
+      window.EventSource = FakeEventSource
+    },
+    {logLines: sampleLogLines()}
+  )
 
   await page.route('**/bootui/api/**', handleApiRoute)
 
@@ -964,9 +1056,9 @@ function startVite() {
     stdio: ['ignore', 'pipe', 'pipe'],
     env: {...process.env, BROWSER: 'none'}
   })
-  child.stdout.on('data', data => process.stdout.write(data))
-  child.stderr.on('data', data => process.stderr.write(data))
-  child.on('exit', code => {
+  child.stdout.on('data', (data) => process.stdout.write(data))
+  child.stderr.on('data', (data) => process.stderr.write(data))
+  child.on('exit', (code) => {
     if (code !== null && code !== 0 && code !== 143) {
       console.error(`Vite exited with status ${code}`)
     }
@@ -978,7 +1070,7 @@ async function waitForServer(url) {
   const deadline = Date.now() + 60_000
   while (Date.now() < deadline) {
     if (await isServerReady(url)) return
-    await new Promise(resolve => setTimeout(resolve, 500))
+    await new Promise((resolve) => setTimeout(resolve, 500))
   }
   throw new Error(`Timed out waiting for ${url}`)
 }
@@ -998,14 +1090,16 @@ async function handleApiRoute(route) {
   const endpoint = decodeURIComponent(url.pathname.replace(/^\/bootui\/api\/?/, ''))
 
   if (endpoint === 'overview') return fulfillJson(route, overview)
-  if (endpoint === 'panels') return fulfillJson(route, {
-    panels: panelOrder.map(([id, title]) => ({id, title, available: true, unavailableReason: null}))
-  })
+  if (endpoint === 'panels')
+    return fulfillJson(route, {
+      panels: panelOrder.map(([id, title]) => ({id, title, available: true, unavailableReason: null}))
+    })
   if (endpoint === 'startup') return fulfillJson(route, startup)
   if (endpoint.startsWith('memory')) return fulfillJson(route, memory)
   if (endpoint === 'health') return fulfillJson(route, health)
   if (endpoint === 'metrics') return fulfillJson(route, metrics)
-  if (endpoint === 'metrics/detail') return fulfillJson(route, metricDetail(url.searchParams.get('name') || 'jvm.memory.used'))
+  if (endpoint === 'metrics/detail')
+    return fulfillJson(route, metricDetail(url.searchParams.get('name') || 'jvm.memory.used'))
   if (endpoint === 'conditions') return fulfillJson(route, conditions)
   if (endpoint === 'beans') return fulfillJson(route, beans)
   if (endpoint === 'mappings') return fulfillJson(route, mappings)
@@ -1034,13 +1128,14 @@ async function handleApiRoute(route) {
   if (endpoint === 'cache') return fulfillJson(route, cache)
   if (endpoint === 'security') return fulfillJson(route, security)
   if (endpoint === 'security/endpoints') return fulfillJson(route, securityEndpoints)
-  if (endpoint === 'security/explain') return fulfillJson(route, {
-    matched: true,
-    bestEffort: false,
-    chainIndex: 1,
-    matcherDescription: 'any request',
-    filters: security.chains[1].filters
-  })
+  if (endpoint === 'security/explain')
+    return fulfillJson(route, {
+      matched: true,
+      bestEffort: false,
+      chainIndex: 1,
+      matcherDescription: 'any request',
+      filters: security.chains[1].filters
+    })
   if (endpoint === 'dependencies') return fulfillJson(route, dependencies)
   if (endpoint === 'dependencies/scan') return fulfillJson(route, dependencies)
 
@@ -1048,7 +1143,7 @@ async function handleApiRoute(route) {
 }
 
 function waitForText(text) {
-  return page => page.getByText(text).first().waitFor()
+  return (page) => page.getByText(text).first().waitFor()
 }
 
 function mapping(method, pattern, handler) {
@@ -1182,13 +1277,17 @@ function probeResponse(request) {
       'content-type': 'application/json',
       'x-bootui-probe': 'local'
     },
-    body: JSON.stringify({
-      path: request.path || '/api/sample/products',
-      products: [
-        {id: 1, name: 'BootUI Starter', category: 'library'},
-        {id: 2, name: 'Sample Console', category: 'demo'}
-      ]
-    }, null, 2),
+    body: JSON.stringify(
+      {
+        path: request.path || '/api/sample/products',
+        products: [
+          {id: 1, name: 'BootUI Starter', category: 'library'},
+          {id: 2, name: 'Sample Console', category: 'demo'}
+        ]
+      },
+      null,
+      2
+    ),
     durationMs: 18,
     error: null
   }

--- a/bootui-sample-app/e2e/tests/ai.spec.js
+++ b/bootui-sample-app/e2e/tests/ai.spec.js
@@ -65,21 +65,23 @@ const detail = {
       statusCode: 'OK'
     }
   ],
-  attributes: [
-    {key: 'gen_ai.system', type: 'string', value: 'ollama'}
-  ],
+  attributes: [{key: 'gen_ai.system', type: 'string', value: 'ollama'}],
   events: [],
   contentCaptured: false,
   contentBanner: 'Message content is not on this span.'
 }
 
 test.describe('AI Usage view', () => {
-
   test('renders AI token usage, model breakdowns, and chat detail', async ({page}) => {
     await stubAi(page, overview)
 
     await page.goto('/bootui/#/ai')
-    await expect(page.locator('main h2').filter({hasText: /AI Usage/}).first()).toBeVisible()
+    await expect(
+      page
+        .locator('main h2')
+        .filter({hasText: /AI Usage/})
+        .first()
+    ).toBeVisible()
     await expect(page.getByText('Spring AI detected')).toBeVisible()
     await expect(page.locator('.card', {hasText: 'Input tokens'}).getByText('42', {exact: true})).toBeVisible()
     await expect(page.locator('.card', {hasText: 'Tokens by model'}).getByText('qwen2.5:0.5b')).toBeVisible()
@@ -133,52 +135,67 @@ test.describe('AI Usage view', () => {
 
 async function stubAi(page, overviewResponse) {
   await stubShell(page, overviewResponse.enabled && overviewResponse.springAiDetected)
-  await page.route(url => url.pathname === '/bootui/api/ai/overview', async route => {
-    await route.fulfill({contentType: 'application/json', body: JSON.stringify(overviewResponse)})
-  })
-  await page.route(url => url.pathname === '/bootui/api/ai/tokens', async route => {
-    await route.fulfill({contentType: 'application/json', body: JSON.stringify(tokenSeries)})
-  })
-  await page.route(url => url.pathname === `/bootui/api/ai/chats/${chatSpanId}`, async route => {
-    await route.fulfill({contentType: 'application/json', body: JSON.stringify(detail)})
-  })
+  await page.route(
+    (url) => url.pathname === '/bootui/api/ai/overview',
+    async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(overviewResponse)})
+    }
+  )
+  await page.route(
+    (url) => url.pathname === '/bootui/api/ai/tokens',
+    async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(tokenSeries)})
+    }
+  )
+  await page.route(
+    (url) => url.pathname === `/bootui/api/ai/chats/${chatSpanId}`,
+    async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(detail)})
+    }
+  )
 }
 
 async function stubShell(page, aiAvailable) {
-  await page.route(url => url.pathname === '/bootui/api/overview', async route => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify({
-        bootUiVersion: 'test',
-        applicationName: 'bootui-sample',
-        springBootVersion: '4.0.6',
-        javaVersion: '25',
-        javaVendor: 'test',
-        activeProfiles: ['dev'],
-        defaultProfiles: ['default'],
-        webApplicationType: 'SERVLET',
-        serverPort: 8080,
-        managementPort: null,
-        contextPath: '',
-        startupTimeMillis: 1000,
-        activation: {enabled: true, localhostOnly: true, reason: 'test', warnings: []},
-        openApiUrl: null
+  await page.route(
+    (url) => url.pathname === '/bootui/api/overview',
+    async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          bootUiVersion: 'test',
+          applicationName: 'bootui-sample',
+          springBootVersion: '4.0.6',
+          javaVersion: '25',
+          javaVendor: 'test',
+          activeProfiles: ['dev'],
+          defaultProfiles: ['default'],
+          webApplicationType: 'SERVLET',
+          serverPort: 8080,
+          managementPort: null,
+          contextPath: '',
+          startupTimeMillis: 1000,
+          activation: {enabled: true, localhostOnly: true, reason: 'test', warnings: []},
+          openApiUrl: null
+        })
       })
-    })
-  })
-  await page.route(url => url.pathname === '/bootui/api/panels', async route => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify({
-        panels: [
-          {
-            id: 'ai',
-            title: 'AI Usage',
-            available: aiAvailable,
-            unavailableReason: aiAvailable ? null : 'AI usage unavailable in this test state'
-          }
-        ]
+    }
+  )
+  await page.route(
+    (url) => url.pathname === '/bootui/api/panels',
+    async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          panels: [
+            {
+              id: 'ai',
+              title: 'AI Usage',
+              available: aiAvailable,
+              unavailableReason: aiAvailable ? null : 'AI usage unavailable in this test state'
+            }
+          ]
+        })
       })
-    })
-  })
+    }
+  )
 }

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('BootUI app shell', () => {
-
   test('navbar shows the application name and Spring Boot / Java versions', async ({page}) => {
     await page.goto('/bootui/')
 
@@ -22,16 +21,17 @@ test.describe('BootUI app shell', () => {
   })
 
   test('sidebar does not label unavailable panels', async ({page}) => {
-    await page.route(url => url.pathname === '/bootui/api/panels', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify({
-          panels: [
-            {id: 'overview', available: false}
-          ]
+    await page.route(
+      (url) => url.pathname === '/bootui/api/panels',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            panels: [{id: 'overview', available: false}]
+          })
         })
-      })
-    })
+      }
+    )
     await page.goto('/bootui/')
 
     const overviewLink = page.locator('aside .nav-link', {hasText: 'Overview'})
@@ -69,8 +69,7 @@ test.describe('BootUI app shell', () => {
 
     for (const link of links) {
       await page.locator('aside .nav-link', {hasText: link.title}).click()
-      await expect(page.locator('main h2').filter({hasText: link.heading}).first())
-        .toBeVisible({timeout: 15_000})
+      await expect(page.locator('main h2').filter({hasText: link.heading}).first()).toBeVisible({timeout: 15_000})
     }
   })
 

--- a/bootui-sample-app/e2e/tests/beans.spec.js
+++ b/bootui-sample-app/e2e/tests/beans.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Beans view', () => {
-
   test('lists beans and supports filtering by name and classification', async ({openView}) => {
     const page = await openView('beans', 'Beans')
 
@@ -19,6 +18,6 @@ test.describe('Beans view', () => {
     await page.locator('select.form-select').selectOption('BOOTUI')
     await expect(rows.first()).toBeVisible()
     const classifications = await page.locator('table tbody tr td:nth-child(4) .badge').allInnerTexts()
-    expect(classifications.every(c => c === 'BOOTUI')).toBeTruthy()
+    expect(classifications.every((c) => c === 'BOOTUI')).toBeTruthy()
   })
 })

--- a/bootui-sample-app/e2e/tests/cache.spec.js
+++ b/bootui-sample-app/e2e/tests/cache.spec.js
@@ -2,9 +2,8 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Cache view', () => {
-
   test('lists caches, cache annotations, and clears a cache', async ({openView, page}) => {
-    page.on('dialog', dialog => dialog.accept())
+    page.on('dialog', (dialog) => dialog.accept())
 
     await openView('cache', 'Spring Cache')
 

--- a/bootui-sample-app/e2e/tests/conditions.spec.js
+++ b/bootui-sample-app/e2e/tests/conditions.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Auto-configuration conditions view', () => {
-
   test('shows positive matches by default and lets the user switch to negative ones', async ({openView}) => {
     const page = await openView('conditions', 'Auto-configuration conditions')
 

--- a/bootui-sample-app/e2e/tests/config.spec.js
+++ b/bootui-sample-app/e2e/tests/config.spec.js
@@ -1,10 +1,9 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
 
-const escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 test.describe('Configuration view', () => {
-
   test('lists properties and supports searching', async ({openView, page}) => {
     await openView('config', 'Configuration')
 
@@ -22,7 +21,7 @@ test.describe('Configuration view', () => {
     const propertyValue = 'hello-from-playwright'
 
     // Auto-dismiss the confirm() dialog raised by the delete button.
-    page.on('dialog', dialog => dialog.accept())
+    page.on('dialog', (dialog) => dialog.accept())
 
     // Create the override.
     await page.getByRole('button', {name: /Add override/}).click()
@@ -31,8 +30,9 @@ test.describe('Configuration view', () => {
     await page.locator('tr.table-warning button.btn-success', {hasText: 'Save'}).click()
 
     // Wait for the banner confirmation.
-    await expect(page.locator('.alert.alert-success'))
-      .toContainText(new RegExp(`Override saved for ${escapeRegExp(propertyName)}`))
+    await expect(page.locator('.alert.alert-success')).toContainText(
+      new RegExp(`Override saved for ${escapeRegExp(propertyName)}`)
+    )
 
     // Filter down to the new row and verify it is flagged as an override.
     await page.getByPlaceholder(/Filter by name or value/).fill(propertyName)
@@ -43,8 +43,9 @@ test.describe('Configuration view', () => {
 
     // Remove the override.
     await newRow.first().locator('button[title="Remove override"]').click()
-    await expect(page.locator('.alert.alert-success'))
-      .toContainText(new RegExp(`Override removed for ${escapeRegExp(propertyName)}`))
+    await expect(page.locator('.alert.alert-success')).toContainText(
+      new RegExp(`Override removed for ${escapeRegExp(propertyName)}`)
+    )
     await expect(page.locator('table tbody tr', {hasText: propertyName})).toHaveCount(0)
   })
 

--- a/bootui-sample-app/e2e/tests/data.spec.js
+++ b/bootui-sample-app/e2e/tests/data.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Data (Spring Data repositories) view', () => {
-
   test('lists the ProductRepository and shows its searchByName query', async ({openView, page}) => {
     await openView('data', 'Spring Data repositories')
 

--- a/bootui-sample-app/e2e/tests/dependencies.spec.js
+++ b/bootui-sample-app/e2e/tests/dependencies.spec.js
@@ -67,23 +67,33 @@ const scannedReport = {
 }
 
 test.describe('Vulnerabilities view', () => {
-
   test('renders inventory and on-demand vulnerability scan results', async ({page}) => {
-    await page.route(url => url.pathname === '/bootui/api/dependencies', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify(inventoryReport)
-      })
-    })
-    await page.route(url => url.pathname === '/bootui/api/dependencies/scan', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify(scannedReport)
-      })
-    })
+    await page.route(
+      (url) => url.pathname === '/bootui/api/dependencies',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify(inventoryReport)
+        })
+      }
+    )
+    await page.route(
+      (url) => url.pathname === '/bootui/api/dependencies/scan',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify(scannedReport)
+        })
+      }
+    )
 
     await page.goto('/bootui/#/vulnerabilities')
-    await expect(page.locator('main h2').filter({hasText: /^Vulnerabilities/}).first()).toBeVisible()
+    await expect(
+      page
+        .locator('main h2')
+        .filter({hasText: /^Vulnerabilities/})
+        .first()
+    ).toBeVisible()
     await expect(page.getByText('2 of 2 dependencies')).toBeVisible()
     await expect(page.getByText('NOT_SCANNED')).toBeVisible()
     await expect(page.getByText('No vulnerability scan data yet')).toBeVisible()

--- a/bootui-sample-app/e2e/tests/dev-services.spec.js
+++ b/bootui-sample-app/e2e/tests/dev-services.spec.js
@@ -40,17 +40,18 @@ const devServicesReport = {
 
 const restartableDevServicesReport = {
   ...devServicesReport,
-  services: devServicesReport.services.map(service => service.id === 'bean:redisContainer'
-    ? {
-      ...service,
-      restartable: true,
-      note: 'Restart may require application clients to reconnect.'
-    }
-    : service)
+  services: devServicesReport.services.map((service) =>
+    service.id === 'bean:redisContainer'
+      ? {
+          ...service,
+          restartable: true,
+          note: 'Restart may require application clients to reconnect.'
+        }
+      : service
+  )
 }
 
 test.describe('Dev Services view', () => {
-
   test('renders the live Dev Services report or the empty state', async ({openView, page}) => {
     await openView('dev-services', 'Dev Services')
 
@@ -64,26 +65,37 @@ test.describe('Dev Services view', () => {
   })
 
   test('filters services, opens details, loads logs, and hides unavailable restart', async ({page}) => {
-    await page.route(url => url.pathname === '/bootui/api/dev-services', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify(devServicesReport)
-      })
-    })
-    await page.route(url => url.pathname === '/bootui/api/dev-services/bean%3AredisContainer/logs', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify({
-          id: 'bean:redisContainer',
-          logs: 'Redis container started\nReady to accept connections',
-          truncated: false,
-          maxBytes: 65536
+    await page.route(
+      (url) => url.pathname === '/bootui/api/dev-services',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify(devServicesReport)
         })
-      })
-    })
+      }
+    )
+    await page.route(
+      (url) => url.pathname === '/bootui/api/dev-services/bean%3AredisContainer/logs',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'bean:redisContainer',
+            logs: 'Redis container started\nReady to accept connections',
+            truncated: false,
+            maxBytes: 65536
+          })
+        })
+      }
+    )
 
     await page.goto('/bootui/#/dev-services')
-    await expect(page.locator('main h2').filter({hasText: /^Dev Services/}).first()).toBeVisible()
+    await expect(
+      page
+        .locator('main h2')
+        .filter({hasText: /^Dev Services/})
+        .first()
+    ).toBeVisible()
     await expect(page.getByText('2 / 2 services')).toBeVisible()
     await expect(page.getByRole('columnheader', {name: 'Source'})).toHaveCount(0)
 
@@ -106,24 +118,30 @@ test.describe('Dev Services view', () => {
 
   test('posts restart for restartable services', async ({page}) => {
     let restartCalled = false
-    await page.route(url => url.pathname === '/bootui/api/dev-services', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify(restartableDevServicesReport)
-      })
-    })
-    await page.route(url => url.pathname === '/bootui/api/dev-services/bean%3AredisContainer/restart', async route => {
-      expect(route.request().method()).toBe('POST')
-      restartCalled = true
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify({
-          id: 'bean:redisContainer',
-          status: 'restarted',
-          message: 'Service restarted. Already-created client beans may need an application restart to reconnect.'
+    await page.route(
+      (url) => url.pathname === '/bootui/api/dev-services',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify(restartableDevServicesReport)
         })
-      })
-    })
+      }
+    )
+    await page.route(
+      (url) => url.pathname === '/bootui/api/dev-services/bean%3AredisContainer/restart',
+      async (route) => {
+        expect(route.request().method()).toBe('POST')
+        restartCalled = true
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            id: 'bean:redisContainer',
+            status: 'restarted',
+            message: 'Service restarted. Already-created client beans may need an application restart to reconnect.'
+          })
+        })
+      }
+    )
 
     await page.goto('/bootui/#/dev-services')
     const redisRow = page.locator('tbody tr', {hasText: 'redis'})

--- a/bootui-sample-app/e2e/tests/devtools.spec.js
+++ b/bootui-sample-app/e2e/tests/devtools.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('DevTools view', () => {
-
   test('renders LiveReload and restart status cards without triggering restart', async ({openView, page}) => {
     await openView('devtools', 'DevTools')
 
@@ -18,32 +17,43 @@ test.describe('DevTools view', () => {
   })
 
   test('triggering LiveReload shows action feedback and keeps restart guarded', async ({page}) => {
-    await page.route(url => url.pathname === '/bootui/api/devtools', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify({
-          restartAvailable: false,
-          restartUnavailableReason: 'Spring Boot DevTools Restarter is not initialized.',
-          restartPending: false,
-          liveReloadAvailable: true,
-          liveReloadPort: 35729,
-          liveReloadUnavailableReason: null
+    await page.route(
+      (url) => url.pathname === '/bootui/api/devtools',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            restartAvailable: false,
+            restartUnavailableReason: 'Spring Boot DevTools Restarter is not initialized.',
+            restartPending: false,
+            liveReloadAvailable: true,
+            liveReloadPort: 35729,
+            liveReloadUnavailableReason: null
+          })
         })
-      })
-    })
-    await page.route(url => url.pathname === '/bootui/api/devtools/livereload', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify({
-          action: 'livereload',
-          status: 'triggered',
-          message: 'LiveReload notification sent to connected browsers.'
+      }
+    )
+    await page.route(
+      (url) => url.pathname === '/bootui/api/devtools/livereload',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            action: 'livereload',
+            status: 'triggered',
+            message: 'LiveReload notification sent to connected browsers.'
+          })
         })
-      })
-    })
+      }
+    )
 
     await page.goto('/bootui/#/devtools')
-    await expect(page.locator('main h2').filter({hasText: /^DevTools/}).first()).toBeVisible()
+    await expect(
+      page
+        .locator('main h2')
+        .filter({hasText: /^DevTools/})
+        .first()
+    ).toBeVisible()
 
     await expect(page.getByText('LiveReload port:')).toBeVisible()
     await expect(page.getByRole('button', {name: /Restart app/})).toBeDisabled()
@@ -52,4 +62,3 @@ test.describe('DevTools view', () => {
     await expect(page.locator('.alert-success')).toContainText('LiveReload notification sent')
   })
 })
-

--- a/bootui-sample-app/e2e/tests/fixtures.js
+++ b/bootui-sample-app/e2e/tests/fixtures.js
@@ -18,9 +18,7 @@ export const test = base.extend({
      */
     async function openView(route, heading) {
       await page.goto(`/bootui/#/${route}`)
-      const matcher = typeof heading === 'string'
-        ? new RegExp(heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
-        : heading
+      const matcher = typeof heading === 'string' ? new RegExp(heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')) : heading
       await expect(page.locator('main h2').filter({hasText: matcher}).first()).toBeVisible()
       return page
     }

--- a/bootui-sample-app/e2e/tests/health.spec.js
+++ b/bootui-sample-app/e2e/tests/health.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Health view', () => {
-
   test('renders friendly health summary and tree', async ({openView, page}) => {
     await openView('health', 'Health')
 

--- a/bootui-sample-app/e2e/tests/http-probe.spec.js
+++ b/bootui-sample-app/e2e/tests/http-probe.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('HTTP Probe view', () => {
-
   test('sends a GET request to the sample API and shows the response body', async ({openView, page}) => {
     await openView('http-probe', 'HTTP Probe')
 

--- a/bootui-sample-app/e2e/tests/log-tail.spec.js
+++ b/bootui-sample-app/e2e/tests/log-tail.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Log Tail view', () => {
-
   test('connects to the SSE stream, then can pause and resume', async ({openView, page}) => {
     await openView('log-tail', 'Log Tail')
 
@@ -30,7 +29,7 @@ test.describe('Log Tail view', () => {
     const empty = page.locator('text=No log lines to display.')
     const lineCount = page.locator('.log-pane code span.d-block')
     await expect(async () => {
-      const visible = await empty.count() + (await lineCount.count() === 0 ? 1 : 0)
+      const visible = (await empty.count()) + ((await lineCount.count()) === 0 ? 1 : 0)
       expect(visible).toBeGreaterThan(0)
     }).toPass()
   })

--- a/bootui-sample-app/e2e/tests/loggers.spec.js
+++ b/bootui-sample-app/e2e/tests/loggers.spec.js
@@ -4,7 +4,6 @@ import {expect, test} from './fixtures.js'
 const SAMPLE_LOGGER = 'io.github.jdubois.bootui.sample'
 
 test.describe('Loggers view', () => {
-
   test('filters loggers and changes the level of the sample logger', async ({openView, page}) => {
     await openView('loggers', 'Loggers')
 

--- a/bootui-sample-app/e2e/tests/mappings.spec.js
+++ b/bootui-sample-app/e2e/tests/mappings.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('HTTP mappings view', () => {
-
   test('lists the sample app endpoints and filters them', async ({openView, page}) => {
     await openView('mappings', 'HTTP mappings')
 

--- a/bootui-sample-app/e2e/tests/memory.spec.js
+++ b/bootui-sample-app/e2e/tests/memory.spec.js
@@ -2,14 +2,14 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Memory view', () => {
-
   test('renders the JVM options panel and heap/non-heap cards', async ({openView, page, browserName, context}) => {
     // Grant clipboard permissions for the copy button. Not all browsers expose them
     // through the same API; ignore failures gracefully.
     if (browserName === 'chromium') {
       try {
         await context.grantPermissions(['clipboard-read', 'clipboard-write'])
-      } catch { /* no-op */
+      } catch {
+        /* no-op */
       }
     }
 
@@ -66,10 +66,15 @@ test.describe('Memory view', () => {
     await totalInput.blur()
 
     // Debounced re-fetch is 300 ms; allow up to 5 s.
-    await expect.poll(async () => {
-      const text = await optionsBlock.innerText()
-      const m = text.match(/-Xmx(\d+)m/)
-      return m ? parseInt(m[1], 10) : 0
-    }, {timeout: 5_000}).not.toBe(beforeXmx)
+    await expect
+      .poll(
+        async () => {
+          const text = await optionsBlock.innerText()
+          const m = text.match(/-Xmx(\d+)m/)
+          return m ? parseInt(m[1], 10) : 0
+        },
+        {timeout: 5_000}
+      )
+      .not.toBe(beforeXmx)
   })
 })

--- a/bootui-sample-app/e2e/tests/metrics.spec.js
+++ b/bootui-sample-app/e2e/tests/metrics.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Metrics view', () => {
-
   test('renders meter browser, measurements and live graph', async ({openView, page}) => {
     await openView('metrics', 'Metrics')
 

--- a/bootui-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-sample-app/e2e/tests/overview.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Overview view', () => {
-
   test('renders the application, runtime and activation cards', async ({openView}) => {
     const page = await openView('overview', 'Overview')
 
@@ -23,8 +22,9 @@ test.describe('Overview view', () => {
 
   test('refresh button re-fetches the overview', async ({openView, page}) => {
     await openView('overview', 'Overview')
-    const requestPromise = page.waitForResponse(res =>
-      res.url().endsWith('/bootui/api/overview') && res.request().method() === 'GET')
+    const requestPromise = page.waitForResponse(
+      (res) => res.url().endsWith('/bootui/api/overview') && res.request().method() === 'GET'
+    )
     await page.getByRole('button', {name: /Refresh/}).click()
     const response = await requestPromise
     expect(response.ok()).toBeTruthy()
@@ -33,7 +33,9 @@ test.describe('Overview view', () => {
   test('hero links to the BootUI GitHub project', async ({openView}) => {
     const page = await openView('overview', 'Overview')
 
-    await expect(page.getByRole('link', {name: /BootUI GitHub project/}))
-      .toHaveAttribute('href', 'https://github.com/jdubois/boot-ui')
+    await expect(page.getByRole('link', {name: /BootUI GitHub project/})).toHaveAttribute(
+      'href',
+      'https://github.com/jdubois/boot-ui'
+    )
   })
 })

--- a/bootui-sample-app/e2e/tests/profile-diff.spec.js
+++ b/bootui-sample-app/e2e/tests/profile-diff.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Profile Diff view', () => {
-
   test('renders the active-profile badges and the property table or empty state', async ({openView, page}) => {
     await openView('profiles', 'Profile Diff')
 
@@ -11,7 +10,9 @@ test.describe('Profile Diff view', () => {
     // The sample app's integration tests activate the dev profile, but a manual
     // run does not — accept either case as long as the page rendered correctly.
     const hasSources = await page.locator('main table').count()
-    const hasEmptyState = await page.locator('.alert', {hasText: /No profile-specific configuration sources found/}).count()
+    const hasEmptyState = await page
+      .locator('.alert', {hasText: /No profile-specific configuration sources found/})
+      .count()
     expect(hasSources + hasEmptyState).toBeGreaterThan(0)
 
     // The filter input is always shown when data has loaded.

--- a/bootui-sample-app/e2e/tests/sample-api.spec.js
+++ b/bootui-sample-app/e2e/tests/sample-api.spec.js
@@ -7,7 +7,6 @@ import {expect, test} from '@playwright/test'
  * so we want explicit coverage of their behaviour from a real client.
  */
 test.describe('Sample application REST API', () => {
-
   test('GET / serves a welcome page that links to BootUI', async ({request}) => {
     const response = await request.get('/')
     expect(response.status()).toBe(200)
@@ -40,7 +39,7 @@ test.describe('Sample application REST API', () => {
       expect(product).toHaveProperty('category')
       expect(product.active).toBe(true)
     }
-    const names = products.map(p => p.name)
+    const names = products.map((p) => p.name)
     expect(names).toContain('BootUI Starter')
     expect(names).toContain('Sample Console')
     expect(names).not.toContain('Archived Prototype')

--- a/bootui-sample-app/e2e/tests/scheduled.spec.js
+++ b/bootui-sample-app/e2e/tests/scheduled.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Scheduled tasks view', () => {
-
   test('renders the sample echo scheduled task', async ({openView, page}) => {
     await openView('scheduled', 'Scheduled Tasks')
 

--- a/bootui-sample-app/e2e/tests/security.spec.js
+++ b/bootui-sample-app/e2e/tests/security.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Security view', () => {
-
   test('lists filter chains including the ADMIN-only chain', async ({openView, page}) => {
     await openView('security', 'Spring Security')
 

--- a/bootui-sample-app/e2e/tests/startup.spec.js
+++ b/bootui-sample-app/e2e/tests/startup.spec.js
@@ -2,7 +2,6 @@
 import {expect, test} from './fixtures.js'
 
 test.describe('Startup timeline view', () => {
-
   test('renders startup steps and supports filtering', async ({openView, page}) => {
     await openView('startup', 'Startup timeline')
 
@@ -21,7 +20,7 @@ test.describe('Startup timeline view', () => {
     await page.getByRole('button', {name: 'Expand all'}).click()
     await expect.poll(async () => steps.count()).toBeGreaterThan(collapsedCount)
 
-    await page.getByPlaceholder(/Filter by step name/).fill('spring.boot');
+    await page.getByPlaceholder(/Filter by step name/).fill('spring.boot')
     // Either the filter produces a smaller list, or the explicit "no matches" state.
     await expect(async () => {
       const visible = await steps.count()

--- a/bootui-sample-app/e2e/tests/traces.spec.js
+++ b/bootui-sample-app/e2e/tests/traces.spec.js
@@ -61,18 +61,28 @@ const traceDetail = {
 }
 
 test.describe('Traces view', () => {
-
   test('renders trace summaries and waterfall details', async ({page}) => {
     await stubShell(page)
-    await page.route(url => url.pathname === '/bootui/api/traces', async route => {
-      await route.fulfill({contentType: 'application/json', body: JSON.stringify(traceReport)})
-    })
-    await page.route(url => url.pathname === `/bootui/api/traces/${traceId}`, async route => {
-      await route.fulfill({contentType: 'application/json', body: JSON.stringify(traceDetail)})
-    })
+    await page.route(
+      (url) => url.pathname === '/bootui/api/traces',
+      async (route) => {
+        await route.fulfill({contentType: 'application/json', body: JSON.stringify(traceReport)})
+      }
+    )
+    await page.route(
+      (url) => url.pathname === `/bootui/api/traces/${traceId}`,
+      async (route) => {
+        await route.fulfill({contentType: 'application/json', body: JSON.stringify(traceDetail)})
+      }
+    )
 
     await page.goto('/bootui/#/traces')
-    await expect(page.locator('main h2').filter({hasText: /^Traces/}).first()).toBeVisible()
+    await expect(
+      page
+        .locator('main h2')
+        .filter({hasText: /^Traces/})
+        .first()
+    ).toBeVisible()
     await expect(page.getByText('1 / 500 retained trace')).toBeVisible()
     const traceRow = page.locator('tbody tr', {hasText: 'GET /api/sample/hello'})
     await expect(traceRow).toBeVisible()
@@ -87,12 +97,15 @@ test.describe('Traces view', () => {
 
   test('shows disabled mode when telemetry is unavailable', async ({page}) => {
     await stubShell(page)
-    await page.route(url => url.pathname === '/bootui/api/traces', async route => {
-      await route.fulfill({
-        contentType: 'application/json',
-        body: JSON.stringify({enabled: false, retained: 0, capacity: 500, traces: []})
-      })
-    })
+    await page.route(
+      (url) => url.pathname === '/bootui/api/traces',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({enabled: false, retained: 0, capacity: 500, traces: []})
+        })
+      }
+    )
 
     await page.goto('/bootui/#/traces')
     await expect(page.getByText('Telemetry receiver is disabled')).toBeVisible()
@@ -101,31 +114,37 @@ test.describe('Traces view', () => {
 })
 
 async function stubShell(page) {
-  await page.route(url => url.pathname === '/bootui/api/overview', async route => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify({
-        bootUiVersion: 'test',
-        applicationName: 'bootui-sample',
-        springBootVersion: '4.0.6',
-        javaVersion: '25',
-        javaVendor: 'test',
-        activeProfiles: ['dev'],
-        defaultProfiles: ['default'],
-        webApplicationType: 'SERVLET',
-        serverPort: 8080,
-        managementPort: null,
-        contextPath: '',
-        startupTimeMillis: 1000,
-        activation: {enabled: true, localhostOnly: true, reason: 'test', warnings: []},
-        openApiUrl: null
+  await page.route(
+    (url) => url.pathname === '/bootui/api/overview',
+    async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          bootUiVersion: 'test',
+          applicationName: 'bootui-sample',
+          springBootVersion: '4.0.6',
+          javaVersion: '25',
+          javaVendor: 'test',
+          activeProfiles: ['dev'],
+          defaultProfiles: ['default'],
+          webApplicationType: 'SERVLET',
+          serverPort: 8080,
+          managementPort: null,
+          contextPath: '',
+          startupTimeMillis: 1000,
+          activation: {enabled: true, localhostOnly: true, reason: 'test', warnings: []},
+          openApiUrl: null
+        })
       })
-    })
-  })
-  await page.route(url => url.pathname === '/bootui/api/panels', async route => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify({panels: [{id: 'traces', title: 'Traces', available: true, unavailableReason: null}]})
-    })
-  })
+    }
+  )
+  await page.route(
+    (url) => url.pathname === '/bootui/api/panels',
+    async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({panels: [{id: 'traces', title: 'Traces', available: true, unavailableReason: null}]})
+      })
+    }
+  )
 }

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/BootUiSampleApplication.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/BootUiSampleApplication.java
@@ -1,5 +1,11 @@
 package io.github.jdubois.bootui.sample;
 
+import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -13,13 +19,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.io.Serializable;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 @SpringBootApplication
 @EnableCaching
 @EnableScheduling
@@ -28,8 +27,9 @@ public class BootUiSampleApplication {
 
     public static void main(String[] args) {
         SpringApplication application = new SpringApplication(BootUiSampleApplication.class);
-        composeFileDefault().ifPresent(composeFile -> application.setDefaultProperties(
-            Map.of("spring.docker.compose.file", composeFile.toString())));
+        composeFileDefault()
+                .ifPresent(composeFile ->
+                        application.setDefaultProperties(Map.of("spring.docker.compose.file", composeFile.toString())));
         application.run(args);
     }
 
@@ -109,13 +109,12 @@ public class BootUiSampleApplication {
         @Cacheable(cacheNames = "sample-products", key = "'active'", unless = "#result.isEmpty()")
         public List<ProductSummary> activeProducts() {
             return products.findByActiveTrueOrderByNameAsc().stream()
-                .map(ProductSummary::from)
-                .toList();
+                    .map(ProductSummary::from)
+                    .toList();
         }
 
         @CacheEvict(cacheNames = "sample-products", allEntries = true)
-        public void evictProducts() {
-        }
+        public void evictProducts() {}
     }
 
     public record ProductSummary(Long id, String name, String category, boolean active) implements Serializable {

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/ChatController.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/ChatController.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.sample;
 
+import java.util.Map;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.ResponseEntity;
@@ -8,8 +9,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/chat")
@@ -20,8 +19,9 @@ public class ChatController {
     public ChatController(ObjectProvider<ChatClient.Builder> builderProvider) {
         ChatClient.Builder builder = builderProvider.getIfAvailable();
         this.chatClient = (builder != null)
-            ? builder.defaultSystem("You are a concise assistant. Reply in two sentences or less.").build()
-            : null;
+                ? builder.defaultSystem("You are a concise assistant. Reply in two sentences or less.")
+                        .build()
+                : null;
     }
 
     @PostMapping
@@ -31,17 +31,15 @@ public class ChatController {
         }
         if (chatClient == null) {
             return ResponseEntity.status(503)
-                .body(Map.of("error",
-                    "Spring AI ChatClient is not configured. Ensure Ollama auto-configuration is enabled and a model is reachable."));
+                    .body(
+                            Map.of(
+                                    "error",
+                                    "Spring AI ChatClient is not configured. Ensure Ollama auto-configuration is enabled and a model is reachable."));
         }
         String message = request.message().trim();
-        String reply = chatClient.prompt()
-            .user(message)
-            .call()
-            .content();
+        String reply = chatClient.prompt().user(message).call().content();
         return ResponseEntity.ok(Map.of("reply", reply == null ? "" : reply));
     }
 
-    public record ChatRequest(String message) {
-    }
+    public record ChatRequest(String message) {}
 }

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/Product.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/Product.java
@@ -16,8 +16,7 @@ public class Product {
 
     private boolean active;
 
-    protected Product() {
-    }
+    protected Product() {}
 
     public Product(String name, String category, boolean active) {
         this.name = name;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/ProductRepository.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/ProductRepository.java
@@ -1,10 +1,9 @@
 package io.github.jdubois.bootui.sample;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/SecurityConfiguration.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/SecurityConfiguration.java
@@ -1,9 +1,12 @@
 package io.github.jdubois.bootui.sample;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -20,57 +23,49 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-
-import static org.springframework.security.config.Customizer.withDefaults;
-
 @Configuration(proxyBeanMethods = false)
 class SecurityConfiguration {
 
     @Bean
     @Order(1)
     SecurityFilterChain bootUiSecurity(HttpSecurity http) throws Exception {
-        return http
-            .securityMatcher("/bootui/**")
-            .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
-            .csrf(csrf -> csrf
-                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                .csrfTokenRequestHandler(csrfTokenRequestHandler())
-                .ignoringRequestMatchers("/bootui/api/otlp/**"))
-            .addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class)
-            .build();
+        return http.securityMatcher("/bootui/**")
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+                .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRequestHandler(csrfTokenRequestHandler())
+                        .ignoringRequestMatchers("/bootui/api/otlp/**"))
+                .addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class)
+                .build();
     }
 
     @Bean
     @Order(2)
     SecurityFilterChain adminSecurity(HttpSecurity http) throws Exception {
-        return http
-            .securityMatcher("/admin/**", "/api/secure")
-            .authorizeHttpRequests(authorize -> authorize.anyRequest().hasRole("ADMIN"))
-            .httpBasic(withDefaults())
-            .build();
+        return http.securityMatcher("/admin/**", "/api/secure")
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().hasRole("ADMIN"))
+                .httpBasic(withDefaults())
+                .build();
     }
 
     @Bean
     @Order(3)
     SecurityFilterChain applicationSecurity(HttpSecurity http) throws Exception {
-        return http
-            .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
-            .csrf(csrf -> csrf.ignoringRequestMatchers("/api/chat"))
-            .build();
+        return http.authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/chat"))
+                .build();
     }
 
     @Bean
     UserDetailsService users(PasswordEncoder passwordEncoder) {
         return new InMemoryUserDetailsManager(
-            User.withUsername("developer")
-                .password(passwordEncoder.encode("developer"))
-                .roles("USER")
-                .build(),
-            User.withUsername("admin")
-                .password(passwordEncoder.encode("admin"))
-                .roles("ADMIN")
-                .build());
+                User.withUsername("developer")
+                        .password(passwordEncoder.encode("developer"))
+                        .roles("USER")
+                        .build(),
+                User.withUsername("admin")
+                        .password(passwordEncoder.encode("admin"))
+                        .roles("ADMIN")
+                        .build());
     }
 
     @Bean
@@ -87,8 +82,9 @@ class SecurityConfiguration {
     private static final class CsrfCookieFilter extends OncePerRequestFilter {
 
         @Override
-        protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+        protected void doFilterInternal(
+                HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws ServletException, IOException {
             CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
             if (csrfToken != null) {
                 csrfToken.getToken();

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -1,5 +1,18 @@
 package io.github.jdubois.bootui.sample;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.CookieManager;
+import java.net.HttpCookie;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -19,44 +32,30 @@ import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import java.net.CookieManager;
-import java.net.HttpCookie;
-import java.net.Proxy;
-import java.net.ProxySelector;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * End-to-end tests that boot the sample app on a random port and call BootUI's
  * REST API through HTTP, exercising auto-configuration, the localhost-only filter
  * for loopback callers, and the override persistence path.
  */
 @SpringBootTest(
-    classes = BootUiSampleApplication.class,
-    webEnvironment = WebEnvironment.RANDOM_PORT,
-    properties = {
-        "spring.profiles.active=dev",
-        "spring.docker.compose.enabled=false",
-        "spring.cache.type=simple",
-        "spring.autoconfigure.exclude="
-            + "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration,"
-            + "org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration,"
-            + "org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration,"
-            + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisHealthContributorAutoConfiguration,"
-            + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisReactiveHealthContributorAutoConfiguration,"
-            + "org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration,"
-            + "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration,"
-            + "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration",
-        "bootui.show-banner=false",
-        "bootui.overrides-file=target/bootui-test-overrides.properties"
-    })
+        classes = BootUiSampleApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.profiles.active=dev",
+            "spring.docker.compose.enabled=false",
+            "spring.cache.type=simple",
+            "spring.autoconfigure.exclude="
+                    + "org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration,"
+                    + "org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration,"
+                    + "org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration,"
+                    + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisHealthContributorAutoConfiguration,"
+                    + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisReactiveHealthContributorAutoConfiguration,"
+                    + "org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration,"
+                    + "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration,"
+                    + "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration",
+            "bootui.show-banner=false",
+            "bootui.overrides-file=target/bootui-test-overrides.properties"
+        })
 @Testcontainers
 class BootUiSampleApplicationIntegrationTests {
 
@@ -91,15 +90,14 @@ class BootUiSampleApplicationIntegrationTests {
     private RestClient client() {
         if (client == null) {
             client = RestClient.builder()
-                .baseUrl("http://localhost:" + port)
-                .requestFactory(new JdkClientHttpRequestFactory(HttpClient.newBuilder()
-                    .cookieHandler(cookieManager)
-                    .proxy(new NoProxySelector())
-                    .build()))
-                // Never throw on non-2xx — tests inspect the status directly.
-                .defaultStatusHandler(HttpStatusCode::isError, (req, res) -> {
-                })
-                .build();
+                    .baseUrl("http://localhost:" + port)
+                    .requestFactory(new JdkClientHttpRequestFactory(HttpClient.newBuilder()
+                            .cookieHandler(cookieManager)
+                            .proxy(new NoProxySelector())
+                            .build()))
+                    // Never throw on non-2xx — tests inspect the status directly.
+                    .defaultStatusHandler(HttpStatusCode::isError, (req, res) -> {})
+                    .build();
         }
         return client;
     }
@@ -127,10 +125,10 @@ class BootUiSampleApplicationIntegrationTests {
 
     private ResponseEntity<String> getStringWithBasicAuth(String path, String username, String password) {
         return client().get()
-            .uri(path)
-            .headers(headers -> headers.setBasicAuth(username, password))
-            .retrieve()
-            .toEntity(String.class);
+                .uri(path)
+                .headers(headers -> headers.setBasicAuth(username, password))
+                .retrieve()
+                .toEntity(String.class);
     }
 
     private void applyCsrfToken(String path, HttpHeaders headers) {
@@ -176,16 +174,14 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void configEndpointListsPropertiesAndMasksSecrets() {
-        postMap("/bootui/api/config/overrides",
-            Map.of("name", "demo.api.token", "value", "topsecret"));
+        postMap("/bootui/api/config/overrides", Map.of("name", "demo.api.token", "value", "topsecret"));
 
         ResponseEntity<Map> response = getMap("/bootui/api/config");
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         Map<?, ?> body = response.getBody();
         assertThat(body).isNotNull();
-        assertThat((Iterable<?>) body.get("sources"))
-            .anyMatch(s -> "bootui-overrides".equals(s));
+        assertThat((Iterable<?>) body.get("sources")).anyMatch(s -> "bootui-overrides".equals(s));
 
         boolean found = false;
         for (Object p : (Iterable<?>) body.get("properties")) {
@@ -223,9 +219,8 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void postLoggerLevelChangesEffectiveLevel() {
-        ResponseEntity<Map> response = postMap(
-            "/bootui/api/loggers/io.github.jdubois.bootui.sample",
-            Map.of("level", "WARN"));
+        ResponseEntity<Map> response =
+                postMap("/bootui/api/loggers/io.github.jdubois.bootui.sample", Map.of("level", "WARN"));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -236,9 +231,8 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void invalidLoggerLevelReturnsBadRequest() {
-        ResponseEntity<Map> response = postMap(
-            "/bootui/api/loggers/io.github.jdubois.bootui.sample",
-            Map.of("level", "NOT-A-LEVEL"));
+        ResponseEntity<Map> response =
+                postMap("/bootui/api/loggers/io.github.jdubois.bootui.sample", Map.of("level", "NOT-A-LEVEL"));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).isNotNull();
@@ -247,8 +241,8 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void configOverrideRoundtripPersistsAndDeletes() throws Exception {
-        ResponseEntity<Map> put = postMap("/bootui/api/config/overrides",
-            Map.of("name", "sample.greeting", "value", "Hola"));
+        ResponseEntity<Map> put =
+                postMap("/bootui/api/config/overrides", Map.of("name", "sample.greeting", "value", "Hola"));
 
         assertThat(put.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> putBody = put.getBody();
@@ -260,10 +254,10 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(Files.readString(OVERRIDES_FILE)).contains("sample.greeting=Hola");
 
         ResponseEntity<Map> delete = client().delete()
-            .uri("/bootui/api/config/overrides/sample.greeting")
-            .headers(headers -> applyCsrfToken("/bootui/api/config/overrides/sample.greeting", headers))
-            .retrieve()
-            .toEntity(Map.class);
+                .uri("/bootui/api/config/overrides/sample.greeting")
+                .headers(headers -> applyCsrfToken("/bootui/api/config/overrides/sample.greeting", headers))
+                .retrieve()
+                .toEntity(Map.class);
         assertThat(delete.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> deleteBody = delete.getBody();
         assertThat(deleteBody).isNotNull();
@@ -324,12 +318,11 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(body).isNotNull();
         assertThat(body.get("schedulingPresent")).isEqualTo(true);
         assertThat(((Number) body.get("total")).intValue()).isGreaterThan(0);
-        assertThat((Iterable<?>) body.get("tasks"))
-            .anySatisfy(task -> {
-                Map<?, ?> dto = (Map<?, ?>) task;
-                assertThat(dto.get("runnable")).asString().contains("EchoScheduler");
-                assertThat(dto.get("triggerType")).isIn("FIXED_RATE", "FIXED_DELAY", "CRON");
-            });
+        assertThat((Iterable<?>) body.get("tasks")).anySatisfy(task -> {
+            Map<?, ?> dto = (Map<?, ?>) task;
+            assertThat(dto.get("runnable")).asString().contains("EchoScheduler");
+            assertThat(dto.get("triggerType")).isIn("FIXED_RATE", "FIXED_DELAY", "CRON");
+        });
     }
 
     @Test
@@ -363,10 +356,11 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(calculation.containsKey("headRoomBytes")).isTrue();
         assertThat(calculation.containsKey("threadCount")).isTrue();
         assertThat(calculation.containsKey("loadedClasses")).isTrue();
-        assertThat(calculation.get("jvmOptions")).asString()
-            .contains("-Xmx")
-            .contains("-XX:MaxMetaspaceSize=")
-            .contains("-XX:ReservedCodeCacheSize=");
+        assertThat(calculation.get("jvmOptions"))
+                .asString()
+                .contains("-Xmx")
+                .contains("-XX:MaxMetaspaceSize=")
+                .contains("-XX:ReservedCodeCacheSize=");
     }
 
     @Test
@@ -382,8 +376,9 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void httpProbeEndpointCallsLoopbackSampleEndpoint() {
-        ResponseEntity<Map> response = postMap("/bootui/api/probe",
-            Map.of("method", "get", "path", "api/hello", "headers", Map.of("X-Ignored", "ok")));
+        ResponseEntity<Map> response = postMap(
+                "/bootui/api/probe",
+                Map.of("method", "get", "path", "api/hello", "headers", Map.of("X-Ignored", "ok")));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -415,7 +410,8 @@ class BootUiSampleApplicationIntegrationTests {
         ResponseEntity<String> adminWithoutCredentials = getString("/admin");
         assertThat(adminWithoutCredentials.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 
-        ResponseEntity<String> adminWithDeveloperCredentials = getStringWithBasicAuth("/admin", "developer", "developer");
+        ResponseEntity<String> adminWithDeveloperCredentials =
+                getStringWithBasicAuth("/admin", "developer", "developer");
         assertThat(adminWithDeveloperCredentials.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
         ResponseEntity<String> adminWithAdminCredentials = getStringWithBasicAuth("/admin", "admin", "admin");
@@ -447,9 +443,10 @@ class BootUiSampleApplicationIntegrationTests {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody()).extracting(product -> ((Map<?, ?>) product).get("name"))
-            .contains("BootUI Starter", "Sample Console")
-            .doesNotContain("Archived Prototype");
+        assertThat(response.getBody())
+                .extracting(product -> ((Map<?, ?>) product).get("name"))
+                .contains("BootUI Starter", "Sample Console")
+                .doesNotContain("Archived Prototype");
     }
 
     @Test
@@ -458,13 +455,13 @@ class BootUiSampleApplicationIntegrationTests {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody())
-            .contains("Welcome to the BootUI sample app")
-            .contains("Open BootUI")
-            .contains("href=\"/bootui/\"")
-            .contains("Ask Spring AI")
-            .contains("id=\"ai-chat-form\"")
-            .contains("POST /api/chat")
-            .contains("GET /api/sample/products");
+                .contains("Welcome to the BootUI sample app")
+                .contains("Open BootUI")
+                .contains("href=\"/bootui/\"")
+                .contains("Ask Spring AI")
+                .contains("id=\"ai-chat-form\"")
+                .contains("POST /api/chat")
+                .contains("GET /api/sample/products");
     }
 
     @Test
@@ -472,8 +469,8 @@ class BootUiSampleApplicationIntegrationTests {
         ResponseEntity<String> secureWithoutCredentials = getString("/api/secure");
         assertThat(secureWithoutCredentials.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
 
-        ResponseEntity<String> secureWithDeveloperCredentials = getStringWithBasicAuth("/api/secure", "developer",
-            "developer");
+        ResponseEntity<String> secureWithDeveloperCredentials =
+                getStringWithBasicAuth("/api/secure", "developer", "developer");
         assertThat(secureWithDeveloperCredentials.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
         ResponseEntity<String> secureWithAdminCredentials = getStringWithBasicAuth("/api/secure", "admin", "admin");
@@ -490,14 +487,13 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(body).isNotNull();
         assertThat(body.get("springDataPresent")).isEqualTo(true);
         assertThat(((Number) body.get("total")).intValue()).isGreaterThan(0);
-        assertThat((Iterable<?>) body.get("repositories"))
-            .anySatisfy(repository -> {
-                Map<?, ?> dto = (Map<?, ?>) repository;
-                assertThat(dto.get("repositoryInterface")).isEqualTo(ProductRepository.class.getName());
-                assertThat(dto.get("domainType")).isEqualTo(Product.class.getName());
-                assertThat(dto.get("storeModule")).isEqualTo("JPA");
-                assertThat(((Number) dto.get("queryMethodCount")).intValue()).isGreaterThan(0);
-            });
+        assertThat((Iterable<?>) body.get("repositories")).anySatisfy(repository -> {
+            Map<?, ?> dto = (Map<?, ?>) repository;
+            assertThat(dto.get("repositoryInterface")).isEqualTo(ProductRepository.class.getName());
+            assertThat(dto.get("domainType")).isEqualTo(Product.class.getName());
+            assertThat(dto.get("storeModule")).isEqualTo("JPA");
+            assertThat(((Number) dto.get("queryMethodCount")).intValue()).isGreaterThan(0);
+        });
     }
 
     @Test
@@ -507,13 +503,12 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
         assertThat(body).isNotNull();
-        assertThat((Iterable<?>) body.get("methods"))
-            .anySatisfy(method -> {
-                Map<?, ?> dto = (Map<?, ?>) method;
-                assertThat(dto.get("name")).isEqualTo("searchByName");
-                assertThat(dto.get("origin")).isEqualTo("ANNOTATED");
-                assertThat((String) dto.get("query")).contains("select p from Product p");
-            });
+        assertThat((Iterable<?>) body.get("methods")).anySatisfy(method -> {
+            Map<?, ?> dto = (Map<?, ?>) method;
+            assertThat(dto.get("name")).isEqualTo("searchByName");
+            assertThat(dto.get("origin")).isEqualTo("ANNOTATED");
+            assertThat((String) dto.get("query")).contains("select p from Product p");
+        });
     }
 
     @Test
@@ -527,23 +522,22 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(body).isNotNull();
         assertThat(body.get("cacheAvailable")).isEqualTo(true);
         assertThat(body.get("clearEnabled")).isEqualTo(true);
-        assertThat((Iterable<?>) body.get("managers"))
-            .anySatisfy(manager -> {
-                Map<?, ?> dto = (Map<?, ?>) manager;
-                assertThat(dto.get("type")).asString().contains("ConcurrentMapCacheManager");
-                assertThat((Iterable<?>) dto.get("caches"))
-                    .anySatisfy(cache -> assertThat(((Map<?, ?>) cache).get("name"))
-                        .isEqualTo("sample-products"));
-            });
-        assertThat((Iterable<?>) body.get("operations"))
-            .anySatisfy(operation -> {
-                Map<?, ?> dto = (Map<?, ?>) operation;
-                assertThat(dto.get("operation")).isEqualTo("@Cacheable");
-                assertThat((Iterable<Object>) dto.get("caches")).contains("sample-products");
-            });
+        assertThat((Iterable<?>) body.get("managers")).anySatisfy(manager -> {
+            Map<?, ?> dto = (Map<?, ?>) manager;
+            assertThat(dto.get("type")).asString().contains("ConcurrentMapCacheManager");
+            assertThat((Iterable<?>) dto.get("caches"))
+                    .anySatisfy(
+                            cache -> assertThat(((Map<?, ?>) cache).get("name")).isEqualTo("sample-products"));
+        });
+        assertThat((Iterable<?>) body.get("operations")).anySatisfy(operation -> {
+            Map<?, ?> dto = (Map<?, ?>) operation;
+            assertThat(dto.get("operation")).isEqualTo("@Cacheable");
+            assertThat((Iterable<Object>) dto.get("caches")).contains("sample-products");
+        });
 
-        ResponseEntity<Map> clear = postMap("/bootui/api/cache/clear",
-            Map.of("managerName", "cacheManager", "cacheName", "sample-products", "confirm", true));
+        ResponseEntity<Map> clear = postMap(
+                "/bootui/api/cache/clear",
+                Map.of("managerName", "cacheManager", "cacheName", "sample-products", "confirm", true));
         assertThat(clear.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(clear.getBody()).isNotNull();
         assertThat(clear.getBody().get("status")).isEqualTo("cleared");
@@ -557,18 +551,17 @@ class BootUiSampleApplicationIntegrationTests {
         Map<?, ?> body = response.getBody();
         assertThat(body).isNotNull();
         assertThat(body.get("springSecurityPresent")).isEqualTo(true);
-        assertThat((Iterable<?>) body.get("chains"))
-            .anySatisfy(chain -> {
-                Map<?, ?> dto = (Map<?, ?>) chain;
-                assertThat(dto.get("requestMatcher")).asString().contains("/api/secure");
-                assertThat((Iterable<?>) dto.get("filters"))
+        assertThat((Iterable<?>) body.get("chains")).anySatisfy(chain -> {
+            Map<?, ?> dto = (Map<?, ?>) chain;
+            assertThat(dto.get("requestMatcher")).asString().contains("/api/secure");
+            assertThat((Iterable<?>) dto.get("filters"))
                     .anySatisfy(filter -> assertThat(filter).isEqualTo("BasicAuthenticationFilter"));
-            });
+        });
 
         Map<?, ?> auth = (Map<?, ?>) body.get("auth");
         assertThat(auth).isNotNull();
         assertThat((Iterable<?>) auth.get("userDetailsServiceTypes"))
-            .anySatisfy(type -> assertThat(type).isEqualTo(InMemoryUserDetailsManager.class.getName()));
+                .anySatisfy(type -> assertThat(type).isEqualTo(InMemoryUserDetailsManager.class.getName()));
     }
 
     @Test
@@ -581,7 +574,7 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(body.get("matched")).isEqualTo(true);
         assertThat(body.get("matcherDescription")).asString().contains("/api/secure");
         assertThat((Iterable<?>) body.get("filters"))
-            .anySatisfy(filter -> assertThat(filter).isEqualTo("BasicAuthenticationFilter"));
+                .anySatisfy(filter -> assertThat(filter).isEqualTo("BasicAuthenticationFilter"));
     }
 
     @Test
@@ -610,9 +603,8 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void bootUiSpaIndexIsServed() {
-        ResponseEntity<String> response = client().get().uri("/bootui/")
-            .retrieve()
-            .toEntity(String.class);
+        ResponseEntity<String> response =
+                client().get().uri("/bootui/").retrieve().toEntity(String.class);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         // The bundled Vue index.html is served from bootui-ui's META-INF/resources.
@@ -627,7 +619,6 @@ class BootUiSampleApplicationIntegrationTests {
         }
 
         @Override
-        public void connectFailed(URI uri, java.net.SocketAddress sa, java.io.IOException ioe) {
-        }
+        public void connectFailed(URI uri, java.net.SocketAddress sa, java.io.IOException ioe) {}
     }
 }

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationTests.java
@@ -1,18 +1,16 @@
 package io.github.jdubois.bootui.sample;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class BootUiSampleApplicationTests {
 
     @Test
-    void leavesDockerComposeDiscoveryAloneWhenRunningFromSampleModule(@TempDir Path workingDirectory)
-        throws Exception {
+    void leavesDockerComposeDiscoveryAloneWhenRunningFromSampleModule(@TempDir Path workingDirectory) throws Exception {
         Files.createFile(workingDirectory.resolve("compose.yaml"));
 
         assertThat(BootUiSampleApplication.composeFileDefault(workingDirectory)).isEmpty();
@@ -20,9 +18,9 @@ class BootUiSampleApplicationTests {
 
     @Test
     void pointsDockerComposeToSampleModuleWhenRunningFromRepositoryRoot(@TempDir Path workingDirectory)
-        throws Exception {
+            throws Exception {
         Path composeFile = Files.createDirectories(workingDirectory.resolve("bootui-sample-app"))
-            .resolve("compose.yaml");
+                .resolve("compose.yaml");
         Files.createFile(composeFile);
 
         assertThat(BootUiSampleApplication.composeFileDefault(workingDirectory)).contains(composeFile);

--- a/bootui-ui/src/main/frontend/index.html
+++ b/bootui-ui/src/main/frontend/index.html
@@ -1,14 +1,17 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%236db33f'/%3E%3Ctext x='8' y='11' font-size='8' font-family='monospace' font-weight='bold' text-anchor='middle' fill='white'%3EB%3C/text%3E%3C/svg%3E" rel="icon"
-        type="image/svg+xml"/>
-  <title>BootUI</title>
-</head>
-<body>
-<div id="app"></div>
-<script src="/src/main.js" type="module"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <link
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%236db33f'/%3E%3Ctext x='8' y='11' font-size='8' font-family='monospace' font-weight='bold' text-anchor='middle' fill='white'%3EB%3C/text%3E%3C/svg%3E"
+      rel="icon"
+      type="image/svg+xml"
+    />
+    <title>BootUI</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/src/main.js" type="module"></script>
+  </body>
 </html>

--- a/bootui-ui/src/main/frontend/package-lock.json
+++ b/bootui-ui/src/main/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "6.0.7",
+        "prettier": "3.8.3",
         "vite": "8.0.14"
       }
     },
@@ -1361,6 +1362,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/quansync": {

--- a/bootui-ui/src/main/frontend/package.json
+++ b/bootui-ui/src/main/frontend/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format": "prettier --config ../../../../prettier.config.cjs --ignore-path ../../../../.prettierignore --write .",
+    "format:check": "prettier --config ../../../../prettier.config.cjs --ignore-path ../../../../.prettierignore --check ."
   },
   "dependencies": {
     "bootstrap": "5.3.8",
@@ -16,6 +18,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "6.0.7",
+    "prettier": "3.8.3",
     "vite": "8.0.14"
   }
 }

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -8,8 +8,8 @@ const overview = ref(null)
 const panels = ref(null)
 const error = ref(null)
 
-const routes = router.options.routes.filter(r => r.name)
-const panelLookup = computed(() => new Map((panels.value?.panels ?? []).map(panel => [panel.id, panel])))
+const routes = router.options.routes.filter((r) => r.name)
+const panelLookup = computed(() => new Map((panels.value?.panels ?? []).map((panel) => [panel.id, panel])))
 const activeTitle = computed(() => route.meta?.title ?? 'BootUI')
 const activeIcon = computed(() => route.meta?.icon ?? 'bi-speedometer2')
 const applicationTitle = computed(() => overview.value?.applicationName || 'Spring Boot app')
@@ -74,7 +74,8 @@ onMounted(loadShellData)
             'bootui-nav-link--unavailable': panelLookup.get(r.name)?.available === false
           }"
           :to="r.path"
-          class="nav-link bootui-nav-link">
+          class="nav-link bootui-nav-link"
+        >
           <i :class="['bi', r.meta.icon]"></i>
           <span class="bootui-nav-link__label">{{ r.meta.title }}</span>
         </router-link>
@@ -85,7 +86,8 @@ onMounted(loadShellData)
           :href="githubProjectUrl"
           class="contribute-card text-decoration-none"
           rel="noopener noreferrer"
-          target="_blank">
+          target="_blank"
+        >
           <span class="contribute-icon">
             <i class="bi bi-github"></i>
           </span>
@@ -128,31 +130,33 @@ onMounted(loadShellData)
           </div>
         </div>
 
-        <router-view v-slot="{ Component }">
+        <router-view v-slot="{Component}">
           <transition mode="out-in" name="page-slide">
-            <component :is="Component" :key="route.fullPath" class="page-panel"/>
+            <component :is="Component" :key="route.fullPath" class="page-panel" />
           </transition>
         </router-view>
       </main>
 
-      <footer class="bootui-footer">
-        BootUI · embedded in your Spring Boot app · no external service required
-      </footer>
+      <footer class="bootui-footer">BootUI · embedded in your Spring Boot app · no external service required</footer>
     </div>
   </div>
 </template>
 
 <style scoped>
 :global(body) {
-  background: radial-gradient(circle at top left, rgba(25, 135, 84, 0.18), transparent 34rem),
-  linear-gradient(135deg, #f6fbf8 0%, #eef6ff 46%, #f7f4ff 100%);
+  background:
+    radial-gradient(circle at top left, rgba(25, 135, 84, 0.18), transparent 34rem),
+    linear-gradient(135deg, #f6fbf8 0%, #eef6ff 46%, #f7f4ff 100%);
 }
 
 :global(.card) {
   border: 1px solid rgba(15, 23, 42, 0.08);
   border-radius: 1.1rem;
   box-shadow: 0 1rem 2.5rem rgba(15, 23, 42, 0.07);
-  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
 }
 
 :global(.card:hover) {
@@ -238,7 +242,9 @@ onMounted(loadShellData)
   display: flex;
   gap: 0.85rem;
   padding: 0.85rem;
-  transition: transform 180ms ease, box-shadow 180ms ease;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
 }
 
 .brand-card:hover {
@@ -299,7 +305,10 @@ onMounted(loadShellData)
   gap: 0.75rem;
   padding: 0.62rem 0.75rem;
   position: relative;
-  transition: background 160ms ease, color 160ms ease, transform 160ms ease;
+  transition:
+    background 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
 }
 
 .bootui-nav-link:hover {
@@ -344,7 +353,10 @@ onMounted(loadShellData)
   display: flex;
   gap: 0.75rem;
   padding: 0.9rem;
-  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .contribute-card:hover {
@@ -467,7 +479,9 @@ onMounted(loadShellData)
 
 .page-slide-enter-active,
 .page-slide-leave-active {
-  transition: opacity 180ms ease, transform 180ms ease;
+  transition:
+    opacity 180ms ease,
+    transform 180ms ease;
 }
 
 .page-slide-enter-from {

--- a/bootui-ui/src/main/frontend/src/api.js
+++ b/bootui-ui/src/main/frontend/src/api.js
@@ -1,13 +1,13 @@
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'TRACE'])
 
 export async function apiFetch(input, init = {}) {
-  const options = { ...init }
+  const options = {...init}
   const method = (options.method || 'GET').toUpperCase()
 
   if (!SAFE_METHODS.has(method)) {
     let token = csrfToken()
     if (!token) {
-      await fetch('api/overview', { cache: 'no-store' })
+      await fetch('api/overview', {cache: 'no-store'})
       token = csrfToken()
     }
     if (token) {
@@ -25,8 +25,8 @@ function csrfToken() {
 
   const cookie = document.cookie
     .split(';')
-    .map(part => part.trim())
-    .find(part => part.startsWith('XSRF-TOKEN='))
+    .map((part) => part.trim())
+    .find((part) => part.startsWith('XSRF-TOKEN='))
 
   if (!cookie) return null
   return decodeURIComponent(cookie.substring('XSRF-TOKEN='.length))

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -13,10 +13,7 @@ async function load() {
   loading.value = true
   error.value = null
   try {
-    const [ovRes, tsRes] = await Promise.all([
-      fetch('api/ai/overview'),
-      fetch('api/ai/tokens')
-    ])
+    const [ovRes, tsRes] = await Promise.all([fetch('api/ai/overview'), fetch('api/ai/tokens')])
     if (!ovRes.ok) throw new Error('HTTP ' + ovRes.status)
     overview.value = await ovRes.json()
     if (tsRes.ok) {
@@ -77,14 +74,12 @@ function formatNumber(n) {
 
 const tokensByModelEntries = computed(() => {
   if (!overview.value || !overview.value.tokensByModel) return []
-  return Object.entries(overview.value.tokensByModel)
-    .sort((a, b) => b[1] - a[1])
+  return Object.entries(overview.value.tokensByModel).sort((a, b) => b[1] - a[1])
 })
 
 const callsByModelEntries = computed(() => {
   if (!overview.value || !overview.value.callsByModel) return []
-  return Object.entries(overview.value.callsByModel)
-    .sort((a, b) => b[1] - a[1])
+  return Object.entries(overview.value.callsByModel).sort((a, b) => b[1] - a[1])
 })
 
 const sparkline = computed(() => {
@@ -146,9 +141,8 @@ onMounted(load)
 
       <div v-else-if="!hasAnyData" class="alert alert-secondary">
         No AI chat completions recorded yet. Make sure your application uses Spring AI with OpenTelemetry tracing
-        enabled
-        and exports OTLP to <code>/bootui/api/otlp/v1/traces</code>, then exercise a chat endpoint to populate this
-        panel.
+        enabled and exports OTLP to <code>/bootui/api/otlp/v1/traces</code>, then exercise a chat endpoint to populate
+        this panel.
       </div>
 
       <template v-else>
@@ -182,8 +176,7 @@ onMounted(load)
               <div class="card-body">
                 <div class="text-muted small">Tool calls · Vector ops · Embeddings</div>
                 <div class="fs-5 fw-semibold">
-                  {{ formatNumber(overview.toolCallCount) }} ·
-                  {{ formatNumber(overview.vectorOperationCount) }} ·
+                  {{ formatNumber(overview.toolCallCount) }} · {{ formatNumber(overview.vectorOperationCount) }} ·
                   {{ formatNumber(overview.embeddingCount) }}
                 </div>
               </div>
@@ -194,8 +187,8 @@ onMounted(load)
         <div v-if="sparkline" class="card mb-3">
           <div class="card-body">
             <h6 class="mb-2">Token usage (last {{ series.minutes }} min)</h6>
-            <svg :viewBox="'0 0 ' + sparkline.width + ' ' + sparkline.height" class="w-100" style="max-height: 100px;">
-              <polyline :points="sparkline.polyline" fill="none" stroke="#0d6efd" stroke-width="2"/>
+            <svg :viewBox="'0 0 ' + sparkline.width + ' ' + sparkline.height" class="w-100" style="max-height: 100px">
+              <polyline :points="sparkline.polyline" fill="none" stroke="#0d6efd" stroke-width="2" />
             </svg>
             <div class="text-muted small">Peak {{ formatNumber(sparkline.maxTokens) }} tokens/min</div>
           </div>
@@ -208,10 +201,12 @@ onMounted(load)
                 <h6>Tokens by model</h6>
                 <table class="table table-sm mb-0">
                   <tbody>
-                  <tr v-for="[model, tokens] in tokensByModelEntries" :key="model">
-                    <td><code>{{ model }}</code></td>
-                    <td class="text-end">{{ formatNumber(tokens) }}</td>
-                  </tr>
+                    <tr v-for="[model, tokens] in tokensByModelEntries" :key="model">
+                      <td>
+                        <code>{{ model }}</code>
+                      </td>
+                      <td class="text-end">{{ formatNumber(tokens) }}</td>
+                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -223,10 +218,12 @@ onMounted(load)
                 <h6>Calls by model</h6>
                 <table class="table table-sm mb-0">
                   <tbody>
-                  <tr v-for="[model, calls] in callsByModelEntries" :key="model">
-                    <td><code>{{ model }}</code></td>
-                    <td class="text-end">{{ formatNumber(calls) }}</td>
-                  </tr>
+                    <tr v-for="[model, calls] in callsByModelEntries" :key="model">
+                      <td>
+                        <code>{{ model }}</code>
+                      </td>
+                      <td class="text-end">{{ formatNumber(calls) }}</td>
+                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -238,112 +235,136 @@ onMounted(load)
         <div class="table-responsive">
           <table class="table table-sm table-hover align-middle">
             <thead>
-            <tr>
-              <th>Started</th>
-              <th>Provider</th>
-              <th>Model</th>
-              <th>Tokens in/out</th>
-              <th>Duration</th>
-              <th>Status</th>
-              <th></th>
-            </tr>
+              <tr>
+                <th>Started</th>
+                <th>Provider</th>
+                <th>Model</th>
+                <th>Tokens in/out</th>
+                <th>Duration</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
             </thead>
             <tbody>
-            <template v-for="chat in overview.recent" :key="chat.spanId">
-              <tr :class="{ 'table-active': chat.spanId === selectedSpanId }">
-                <td class="text-muted small">{{ formatTime(chat.startEpochNanos) }}</td>
-                <td>{{ chat.provider || '—' }}</td>
-                <td><code>{{ chat.requestModel || '—' }}</code></td>
-                <td>{{ formatNumber(chat.inputTokens) }} / {{ formatNumber(chat.outputTokens) }}</td>
-                <td>{{ formatDuration(chat.durationNanos) }}</td>
-                <td>
-                  <span v-if="chat.statusCode === 'ERROR'" class="badge text-bg-danger">error</span>
-                  <span v-else class="badge text-bg-success">{{ chat.finishReason || 'ok' }}</span>
-                </td>
-                <td class="text-end">
-                  <button
-                    :aria-expanded="chat.spanId === selectedSpanId"
-                    class="btn btn-sm btn-outline-primary"
-                    @click="toggleChat(chat.spanId)">
-                    {{ chat.spanId === selectedSpanId ? 'Close' : 'Open' }}
-                  </button>
-                </td>
-              </tr>
-              <tr v-if="chat.spanId === selectedSpanId" class="chat-detail-row">
-                <td class="p-0" colspan="7">
-                  <div class="card m-2">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                      <div><i class="bi bi-stars me-2"></i>Chat <code>{{ selectedSpanId }}</code></div>
-                      <button class="btn btn-sm btn-outline-secondary" @click="closeDrawer">Close</button>
+              <template v-for="chat in overview.recent" :key="chat.spanId">
+                <tr :class="{'table-active': chat.spanId === selectedSpanId}">
+                  <td class="text-muted small">{{ formatTime(chat.startEpochNanos) }}</td>
+                  <td>{{ chat.provider || '—' }}</td>
+                  <td>
+                    <code>{{ chat.requestModel || '—' }}</code>
+                  </td>
+                  <td>{{ formatNumber(chat.inputTokens) }} / {{ formatNumber(chat.outputTokens) }}</td>
+                  <td>{{ formatDuration(chat.durationNanos) }}</td>
+                  <td>
+                    <span v-if="chat.statusCode === 'ERROR'" class="badge text-bg-danger">error</span>
+                    <span v-else class="badge text-bg-success">{{ chat.finishReason || 'ok' }}</span>
+                  </td>
+                  <td class="text-end">
+                    <button
+                      :aria-expanded="chat.spanId === selectedSpanId"
+                      class="btn btn-sm btn-outline-primary"
+                      @click="toggleChat(chat.spanId)"
+                    >
+                      {{ chat.spanId === selectedSpanId ? 'Close' : 'Open' }}
+                    </button>
+                  </td>
+                </tr>
+                <tr v-if="chat.spanId === selectedSpanId" class="chat-detail-row">
+                  <td class="p-0" colspan="7">
+                    <div class="card m-2">
+                      <div class="card-header d-flex justify-content-between align-items-center">
+                        <div>
+                          <i class="bi bi-stars me-2"></i>Chat <code>{{ selectedSpanId }}</code>
+                        </div>
+                        <button class="btn btn-sm btn-outline-secondary" @click="closeDrawer">Close</button>
+                      </div>
+                      <div class="card-body">
+                        <div v-if="detailLoading" class="text-muted">Loading…</div>
+                        <template v-else-if="detail && detail.summary">
+                          <div v-if="detail.contentBanner && !detail.contentCaptured" class="alert alert-info small">
+                            <i class="bi bi-info-circle me-1"></i>{{ detail.contentBanner }}
+                          </div>
+                          <dl class="row mb-3">
+                            <dt class="col-sm-3">Provider</dt>
+                            <dd class="col-sm-9">{{ detail.summary.provider || '—' }}</dd>
+                            <dt class="col-sm-3">Request model</dt>
+                            <dd class="col-sm-9">
+                              <code>{{ detail.summary.requestModel || '—' }}</code>
+                            </dd>
+                            <dt class="col-sm-3">Response model</dt>
+                            <dd class="col-sm-9">
+                              <code>{{ detail.summary.responseModel || '—' }}</code>
+                            </dd>
+                            <dt class="col-sm-3">Tokens</dt>
+                            <dd class="col-sm-9">
+                              in {{ formatNumber(detail.summary.inputTokens) }} · out
+                              {{ formatNumber(detail.summary.outputTokens) }} · total
+                              {{ formatNumber(detail.summary.totalTokens) }}
+                            </dd>
+                            <dt class="col-sm-3">Duration</dt>
+                            <dd class="col-sm-9">{{ formatDuration(detail.summary.durationNanos) }}</dd>
+                            <dt class="col-sm-3">Finish reason</dt>
+                            <dd class="col-sm-9">{{ detail.summary.finishReason || '—' }}</dd>
+                          </dl>
+
+                          <div v-if="detail.toolCalls && detail.toolCalls.length" class="mb-3">
+                            <h6>Tool calls</h6>
+                            <ul class="list-group">
+                              <li
+                                v-for="tc in detail.toolCalls"
+                                :key="tc.spanId"
+                                class="list-group-item d-flex justify-content-between"
+                              >
+                                <span
+                                  ><i class="bi bi-tools me-1"></i><code>{{ tc.name || '(unnamed)' }}</code></span
+                                >
+                                <span class="text-muted small">{{ formatDuration(tc.durationNanos) }}</span>
+                              </li>
+                            </ul>
+                          </div>
+
+                          <div v-if="detail.vectorOperations && detail.vectorOperations.length" class="mb-3">
+                            <h6>Vector operations</h6>
+                            <ul class="list-group">
+                              <li
+                                v-for="vo in detail.vectorOperations"
+                                :key="vo.spanId"
+                                class="list-group-item d-flex justify-content-between"
+                              >
+                                <span
+                                  ><i class="bi bi-database me-1"></i><code>{{ vo.collectionName || '?' }}</code> ·
+                                  {{ vo.operation || '—' }}</span
+                                >
+                                <span class="text-muted small">{{ formatDuration(vo.durationNanos) }}</span>
+                              </li>
+                            </ul>
+                          </div>
+
+                          <details v-if="detail.attributes && detail.attributes.length">
+                            <summary class="text-muted">Span attributes ({{ detail.attributes.length }})</summary>
+                            <table class="table table-sm mt-2">
+                              <tbody>
+                                <tr v-for="a in detail.attributes" :key="a.key">
+                                  <td>
+                                    <code>{{ a.key }}</code>
+                                  </td>
+                                  <td>
+                                    <code>{{ a.value }}</code>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </details>
+                        </template>
+                        <div v-else-if="detail && detail.error" class="alert alert-danger small">
+                          {{ detail.error }}
+                        </div>
+                        <div v-else class="text-muted small">No detail available.</div>
+                      </div>
                     </div>
-                    <div class="card-body">
-                      <div v-if="detailLoading" class="text-muted">Loading…</div>
-                      <template v-else-if="detail && detail.summary">
-                        <div v-if="detail.contentBanner && !detail.contentCaptured" class="alert alert-info small">
-                          <i class="bi bi-info-circle me-1"></i>{{ detail.contentBanner }}
-                        </div>
-                        <dl class="row mb-3">
-                          <dt class="col-sm-3">Provider</dt>
-                          <dd class="col-sm-9">{{ detail.summary.provider || '—' }}</dd>
-                          <dt class="col-sm-3">Request model</dt>
-                          <dd class="col-sm-9"><code>{{ detail.summary.requestModel || '—' }}</code></dd>
-                          <dt class="col-sm-3">Response model</dt>
-                          <dd class="col-sm-9"><code>{{ detail.summary.responseModel || '—' }}</code></dd>
-                          <dt class="col-sm-3">Tokens</dt>
-                          <dd class="col-sm-9">
-                            in {{ formatNumber(detail.summary.inputTokens) }} ·
-                            out {{ formatNumber(detail.summary.outputTokens) }} ·
-                            total {{ formatNumber(detail.summary.totalTokens) }}
-                          </dd>
-                          <dt class="col-sm-3">Duration</dt>
-                          <dd class="col-sm-9">{{ formatDuration(detail.summary.durationNanos) }}</dd>
-                          <dt class="col-sm-3">Finish reason</dt>
-                          <dd class="col-sm-9">{{ detail.summary.finishReason || '—' }}</dd>
-                        </dl>
-
-                        <div v-if="detail.toolCalls && detail.toolCalls.length" class="mb-3">
-                          <h6>Tool calls</h6>
-                          <ul class="list-group">
-                            <li v-for="tc in detail.toolCalls" :key="tc.spanId"
-                                class="list-group-item d-flex justify-content-between">
-                              <span><i class="bi bi-tools me-1"></i><code>{{ tc.name || '(unnamed)' }}</code></span>
-                              <span class="text-muted small">{{ formatDuration(tc.durationNanos) }}</span>
-                            </li>
-                          </ul>
-                        </div>
-
-                        <div v-if="detail.vectorOperations && detail.vectorOperations.length" class="mb-3">
-                          <h6>Vector operations</h6>
-                          <ul class="list-group">
-                            <li v-for="vo in detail.vectorOperations" :key="vo.spanId"
-                                class="list-group-item d-flex justify-content-between">
-                              <span><i class="bi bi-database me-1"></i><code>{{
-                                  vo.collectionName || '?'
-                                }}</code> · {{ vo.operation || '—' }}</span>
-                              <span class="text-muted small">{{ formatDuration(vo.durationNanos) }}</span>
-                            </li>
-                          </ul>
-                        </div>
-
-                        <details v-if="detail.attributes && detail.attributes.length">
-                          <summary class="text-muted">Span attributes ({{ detail.attributes.length }})</summary>
-                          <table class="table table-sm mt-2">
-                            <tbody>
-                            <tr v-for="a in detail.attributes" :key="a.key">
-                              <td><code>{{ a.key }}</code></td>
-                              <td><code>{{ a.value }}</code></td>
-                            </tr>
-                            </tbody>
-                          </table>
-                        </details>
-                      </template>
-                      <div v-else-if="detail && detail.error" class="alert alert-danger small">{{ detail.error }}</div>
-                      <div v-else class="text-muted small">No detail available.</div>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-            </template>
+                  </td>
+                </tr>
+              </template>
             </tbody>
           </table>
         </div>

--- a/bootui-ui/src/main/frontend/src/views/Beans.vue
+++ b/bootui-ui/src/main/frontend/src/views/Beans.vue
@@ -12,12 +12,11 @@ async function load() {
 
 const filtered = computed(() => {
   if (!data.value) return []
-  return data.value.beans.filter(b => {
+  return data.value.beans.filter((b) => {
     if (classification.value && b.classification !== classification.value) return false
     if (filter.value) {
       const f = filter.value.toLowerCase()
-      return b.name.toLowerCase().includes(f) ||
-        (b.type && b.type.toLowerCase().includes(f))
+      return b.name.toLowerCase().includes(f) || (b.type && b.type.toLowerCase().includes(f))
     }
     return true
   })
@@ -33,7 +32,7 @@ onMounted(load)
 
     <div class="row g-2 mb-3">
       <div class="col-md-8">
-        <input v-model="filter" class="form-control" placeholder="Filter by name or type…"/>
+        <input v-model="filter" class="form-control" placeholder="Filter by name or type…" />
       </div>
       <div class="col-md-4">
         <select v-model="classification" class="form-select">
@@ -50,30 +49,39 @@ onMounted(load)
     <div class="table-responsive">
       <table class="table table-sm table-hover beans-table">
         <colgroup>
-          <col class="beans-table-name"/>
-          <col class="beans-table-type"/>
-          <col class="beans-table-scope"/>
-          <col class="beans-table-classification"/>
-          <col class="beans-table-dependencies"/>
+          <col class="beans-table-name" />
+          <col class="beans-table-type" />
+          <col class="beans-table-scope" />
+          <col class="beans-table-classification" />
+          <col class="beans-table-dependencies" />
         </colgroup>
         <thead>
-        <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Scope</th>
-          <th>Class.</th>
-          <th>Dependencies</th>
-        </tr>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Scope</th>
+            <th>Class.</th>
+            <th>Dependencies</th>
+          </tr>
         </thead>
         <tbody>
-        <tr v-for="b in filtered" :key="b.name">
-          <td><code :title="b.name" class="text-truncate d-block">{{ b.name }}</code></td>
-          <td><small :title="b.type" class="text-truncate d-block">{{ b.type }}</small></td>
-          <td>{{ b.scope }}</td>
-          <td><span class="badge bg-light text-dark">{{ b.classification }}</span></td>
-          <td><small :title="b.dependencies.join(', ')"
-                     class="text-muted text-truncate d-block">{{ b.dependencies.join(', ') }}</small></td>
-        </tr>
+          <tr v-for="b in filtered" :key="b.name">
+            <td>
+              <code :title="b.name" class="text-truncate d-block">{{ b.name }}</code>
+            </td>
+            <td>
+              <small :title="b.type" class="text-truncate d-block">{{ b.type }}</small>
+            </td>
+            <td>{{ b.scope }}</td>
+            <td>
+              <span class="badge bg-light text-dark">{{ b.classification }}</span>
+            </td>
+            <td>
+              <small :title="b.dependencies.join(', ')" class="text-muted text-truncate d-block">{{
+                b.dependencies.join(', ')
+              }}</small>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/bootui-ui/src/main/frontend/src/views/Cache.vue
+++ b/bootui-ui/src/main/frontend/src/views/Cache.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
-import { apiFetch } from '../api.js'
+import {apiFetch} from '../api.js'
 
 const report = ref(null)
 const loading = ref(true)
@@ -26,8 +26,8 @@ async function load() {
 
 const caches = computed(() => {
   if (!report.value) return []
-  return report.value.managers.flatMap(manager =>
-    manager.caches.map(cache => ({
+  return report.value.managers.flatMap((manager) =>
+    manager.caches.map((cache) => ({
       ...cache,
       managerType: manager.type,
       managerNoOp: manager.noOp
@@ -38,10 +38,11 @@ const caches = computed(() => {
 const filteredCaches = computed(() => {
   const value = cacheFilter.value.trim().toLowerCase()
   if (!value) return caches.value
-  return caches.value.filter(cache =>
-    (cache.managerName || '').toLowerCase().includes(value)
-    || (cache.name || '').toLowerCase().includes(value)
-    || (cache.nativeType || '').toLowerCase().includes(value)
+  return caches.value.filter(
+    (cache) =>
+      (cache.managerName || '').toLowerCase().includes(value) ||
+      (cache.name || '').toLowerCase().includes(value) ||
+      (cache.nativeType || '').toLowerCase().includes(value)
   )
 })
 
@@ -49,12 +50,13 @@ const filteredOperations = computed(() => {
   if (!report.value) return []
   const value = operationFilter.value.trim().toLowerCase()
   if (!value) return report.value.operations
-  return report.value.operations.filter(operation =>
-    (operation.beanName || '').toLowerCase().includes(value)
-    || (operation.targetType || '').toLowerCase().includes(value)
-    || (operation.method || '').toLowerCase().includes(value)
-    || (operation.operation || '').toLowerCase().includes(value)
-    || (operation.caches || []).join(' ').toLowerCase().includes(value)
+  return report.value.operations.filter(
+    (operation) =>
+      (operation.beanName || '').toLowerCase().includes(value) ||
+      (operation.targetType || '').toLowerCase().includes(value) ||
+      (operation.method || '').toLowerCase().includes(value) ||
+      (operation.operation || '').toLowerCase().includes(value) ||
+      (operation.caches || []).join(' ').toLowerCase().includes(value)
   )
 })
 
@@ -79,25 +81,38 @@ function cacheKey(cache) {
 }
 
 function operationClass(operation) {
-  return {
-    '@Cacheable': 'text-bg-primary',
-    '@CachePut': 'text-bg-success',
-    '@CacheEvict': 'text-bg-danger'
-  }[operation] || 'text-bg-secondary'
+  return (
+    {
+      '@Cacheable': 'text-bg-primary',
+      '@CachePut': 'text-bg-success',
+      '@CacheEvict': 'text-bg-danger'
+    }[operation] || 'text-bg-secondary'
+  )
 }
 
 async function clearOne(cache) {
-  if (!confirm(`Clear cache "${cache.name}" from manager "${cache.managerName}"? Cached data will be recomputed on demand.`)) return
-  await clearCaches({
-    managerName: cache.managerName,
-    cacheName: cache.name,
-    confirm: true
-  }, cacheKey(cache))
+  if (
+    !confirm(
+      `Clear cache "${cache.name}" from manager "${cache.managerName}"? Cached data will be recomputed on demand.`
+    )
+  )
+    return
+  await clearCaches(
+    {
+      managerName: cache.managerName,
+      cacheName: cache.name,
+      confirm: true
+    },
+    cacheKey(cache)
+  )
 }
 
 async function clearAll() {
   if (!report.value) return
-  if (!confirm(`Clear all ${report.value.cacheCount} known caches across ${report.value.managerCount} cache manager(s)?`)) return
+  if (
+    !confirm(`Clear all ${report.value.cacheCount} known caches across ${report.value.managerCount} cache manager(s)?`)
+  )
+    return
   await clearCaches({all: true, confirm: true}, '__all__')
 }
 
@@ -140,16 +155,18 @@ onMounted(load)
       <div>
         <h2 class="mb-1"><i class="bi bi-hdd-stack me-2"></i>Spring Cache</h2>
         <div v-if="report" class="text-muted small">
-          {{ report.managerCount }} manager{{ report.managerCount === 1 ? '' : 's' }} ·
-          {{ report.cacheCount }} cache{{ report.cacheCount === 1 ? '' : 's' }} ·
-          {{ report.operationCount }} annotation operation{{ report.operationCount === 1 ? '' : 's' }}
+          {{ report.managerCount }} manager{{ report.managerCount === 1 ? '' : 's' }} · {{ report.cacheCount }} cache{{
+            report.cacheCount === 1 ? '' : 's'
+          }}
+          · {{ report.operationCount }} annotation operation{{ report.operationCount === 1 ? '' : 's' }}
         </div>
       </div>
       <div class="d-flex gap-2">
         <button
           :disabled="!report || !report.clearEnabled || report.cacheCount === 0 || busy"
           class="btn btn-sm btn-outline-danger"
-          @click="clearAll">
+          @click="clearAll"
+        >
           <span v-if="busy === '__all__'" class="spinner-border spinner-border-sm me-1"></span>
           <i v-else class="bi bi-trash me-1"></i>
           Clear all
@@ -184,11 +201,14 @@ onMounted(load)
 
       <section class="mb-4">
         <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
-          <h5 class="mb-0">Caches <span class="badge bg-secondary">{{ report.cacheCount }}</span></h5>
+          <h5 class="mb-0">
+            Caches <span class="badge bg-secondary">{{ report.cacheCount }}</span>
+          </h5>
           <input
             v-model="cacheFilter"
             class="form-control form-control-sm cache-filter"
-            placeholder="Filter by manager, cache, or implementation…"/>
+            placeholder="Filter by manager, cache, or implementation…"
+          />
         </div>
 
         <div v-if="report.cacheAvailable && report.cacheCount === 0" class="alert alert-secondary small">
@@ -199,55 +219,54 @@ onMounted(load)
         <div v-else-if="filteredCaches.length" class="table-responsive">
           <table class="table table-sm table-hover align-middle">
             <thead>
-            <tr>
-              <th>Manager</th>
-              <th>Cache</th>
-              <th>Implementation</th>
-              <th>Size</th>
-              <th>Metrics</th>
-              <th class="text-end">Actions</th>
-            </tr>
+              <tr>
+                <th>Manager</th>
+                <th>Cache</th>
+                <th>Implementation</th>
+                <th>Size</th>
+                <th>Metrics</th>
+                <th class="text-end">Actions</th>
+              </tr>
             </thead>
             <tbody>
-            <tr v-for="cache in filteredCaches" :key="cacheKey(cache)">
-              <td>
-                <code>{{ cache.managerName }}</code>
-                <span v-if="cache.managerNoOp" class="badge text-bg-secondary ms-1">No-op</span>
-              </td>
-              <td class="fw-semibold">{{ cache.name }}</td>
-              <td>
-                <code>{{ shortName(cache.nativeType) }}</code>
-                <div class="small text-muted">{{ cache.nativeType || 'No native cache reported' }}</div>
-              </td>
-              <td>{{ formatNumber(cache.size ?? cache.metrics?.size) }}</td>
-              <td>
-                <div v-if="cache.metrics && cache.metrics.available" class="cache-metrics">
-                  <span class="badge text-bg-success">hits {{ formatNumber(cache.metrics.hits) }}</span>
-                  <span class="badge text-bg-warning">misses {{ formatNumber(cache.metrics.misses) }}</span>
-                  <span class="badge text-bg-info">ratio {{ formatRatio(cache.metrics.hitRatio) }}</span>
-                  <span class="badge text-bg-secondary">puts {{ formatNumber(cache.metrics.puts) }}</span>
-                  <span class="badge text-bg-secondary">evictions {{ formatNumber(cache.metrics.evictions) }}</span>
-                  <span class="badge text-bg-secondary">removals {{ formatNumber(cache.metrics.removals) }}</span>
-                </div>
-                <span v-else class="text-muted small">No cache metrics registered</span>
-              </td>
-              <td class="text-end">
-                <button
-                  :disabled="!report.clearEnabled || busy"
-                  class="btn btn-sm btn-outline-danger"
-                  @click="clearOne(cache)">
-                  <span v-if="busy === cacheKey(cache)" class="spinner-border spinner-border-sm me-1"></span>
-                  Clear
-                </button>
-              </td>
-            </tr>
+              <tr v-for="cache in filteredCaches" :key="cacheKey(cache)">
+                <td>
+                  <code>{{ cache.managerName }}</code>
+                  <span v-if="cache.managerNoOp" class="badge text-bg-secondary ms-1">No-op</span>
+                </td>
+                <td class="fw-semibold">{{ cache.name }}</td>
+                <td>
+                  <code>{{ shortName(cache.nativeType) }}</code>
+                  <div class="small text-muted">{{ cache.nativeType || 'No native cache reported' }}</div>
+                </td>
+                <td>{{ formatNumber(cache.size ?? cache.metrics?.size) }}</td>
+                <td>
+                  <div v-if="cache.metrics && cache.metrics.available" class="cache-metrics">
+                    <span class="badge text-bg-success">hits {{ formatNumber(cache.metrics.hits) }}</span>
+                    <span class="badge text-bg-warning">misses {{ formatNumber(cache.metrics.misses) }}</span>
+                    <span class="badge text-bg-info">ratio {{ formatRatio(cache.metrics.hitRatio) }}</span>
+                    <span class="badge text-bg-secondary">puts {{ formatNumber(cache.metrics.puts) }}</span>
+                    <span class="badge text-bg-secondary">evictions {{ formatNumber(cache.metrics.evictions) }}</span>
+                    <span class="badge text-bg-secondary">removals {{ formatNumber(cache.metrics.removals) }}</span>
+                  </div>
+                  <span v-else class="text-muted small">No cache metrics registered</span>
+                </td>
+                <td class="text-end">
+                  <button
+                    :disabled="!report.clearEnabled || busy"
+                    class="btn btn-sm btn-outline-danger"
+                    @click="clearOne(cache)"
+                  >
+                    <span v-if="busy === cacheKey(cache)" class="spinner-border spinner-border-sm me-1"></span>
+                    Clear
+                  </button>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
 
-        <div v-else-if="report.cacheAvailable" class="text-muted small">
-          No caches match the current filter.
-        </div>
+        <div v-else-if="report.cacheAvailable" class="text-muted small">No caches match the current filter.</div>
       </section>
 
       <section>
@@ -258,7 +277,8 @@ onMounted(load)
           <input
             v-model="operationFilter"
             class="form-control form-control-sm cache-filter"
-            placeholder="Filter by bean, method, operation, or cache…"/>
+            placeholder="Filter by bean, method, operation, or cache…"
+          />
         </div>
 
         <div v-if="report.operationCount === 0" class="alert alert-secondary small">
@@ -268,50 +288,69 @@ onMounted(load)
         <div v-else-if="filteredOperations.length" class="table-responsive">
           <table class="table table-sm table-hover align-middle">
             <thead>
-            <tr>
-              <th>Operation</th>
-              <th>Bean / method</th>
-              <th>Caches</th>
-              <th>Expressions</th>
-            </tr>
+              <tr>
+                <th>Operation</th>
+                <th>Bean / method</th>
+                <th>Caches</th>
+                <th>Expressions</th>
+              </tr>
             </thead>
             <tbody>
-            <tr v-for="operation in filteredOperations"
-                :key="operation.beanName + operation.method + operation.operation">
-              <td><span :class="operationClass(operation.operation)" class="badge">{{ operation.operation }}</span></td>
-              <td>
-                <div><code>{{ operation.beanName }}</code></div>
-                <div class="small">
-                  <code>{{ operation.method }}</code>
-                  <span class="text-muted"> · {{ shortName(operation.targetType) }}</span>
-                </div>
-              </td>
-              <td>
+              <tr
+                v-for="operation in filteredOperations"
+                :key="operation.beanName + operation.method + operation.operation"
+              >
+                <td>
+                  <span :class="operationClass(operation.operation)" class="badge">{{ operation.operation }}</span>
+                </td>
+                <td>
+                  <div>
+                    <code>{{ operation.beanName }}</code>
+                  </div>
+                  <div class="small">
+                    <code>{{ operation.method }}</code>
+                    <span class="text-muted"> · {{ shortName(operation.targetType) }}</span>
+                  </div>
+                </td>
+                <td>
                   <span
                     v-for="cache in operation.caches"
                     :key="cache"
-                    class="badge text-bg-light border text-dark me-1">
+                    class="badge text-bg-light border text-dark me-1"
+                  >
                     {{ cache }}
                   </span>
-              </td>
-              <td class="small">
-                <div v-if="operation.key">key: <code>{{ operation.key }}</code></div>
-                <div v-if="operation.condition">condition: <code>{{ operation.condition }}</code></div>
-                <div v-if="operation.unless">unless: <code>{{ operation.unless }}</code></div>
-                <div v-if="operation.allEntries" class="text-danger">all entries</div>
-                <div v-if="operation.beforeInvocation" class="text-muted">before invocation</div>
-                <span
-                  v-if="!operation.key && !operation.condition && !operation.unless && !operation.allEntries && !operation.beforeInvocation"
-                  class="text-muted">—</span>
-              </td>
-            </tr>
+                </td>
+                <td class="small">
+                  <div v-if="operation.key">
+                    key: <code>{{ operation.key }}</code>
+                  </div>
+                  <div v-if="operation.condition">
+                    condition: <code>{{ operation.condition }}</code>
+                  </div>
+                  <div v-if="operation.unless">
+                    unless: <code>{{ operation.unless }}</code>
+                  </div>
+                  <div v-if="operation.allEntries" class="text-danger">all entries</div>
+                  <div v-if="operation.beforeInvocation" class="text-muted">before invocation</div>
+                  <span
+                    v-if="
+                      !operation.key &&
+                      !operation.condition &&
+                      !operation.unless &&
+                      !operation.allEntries &&
+                      !operation.beforeInvocation
+                    "
+                    class="text-muted"
+                    >—</span
+                  >
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
 
-        <div v-else class="text-muted small">
-          No annotation operations match the current filter.
-        </div>
+        <div v-else class="text-muted small">No annotation operations match the current filter.</div>
       </section>
     </template>
   </div>

--- a/bootui-ui/src/main/frontend/src/views/Conditions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.vue
@@ -15,9 +15,9 @@ const entries = computed(() => {
   const items = tab.value === 'positive' ? data.value.positiveMatches : data.value.negativeMatches
   if (!filter.value) return items
   const f = filter.value.toLowerCase()
-  return items.filter(e =>
-    (e.autoConfigurationClass || '').toLowerCase().includes(f) ||
-    (e.message || '').toLowerCase().includes(f))
+  return items.filter(
+    (e) => (e.autoConfigurationClass || '').toLowerCase().includes(f) || (e.message || '').toLowerCase().includes(f)
+  )
 })
 
 onMounted(load)
@@ -28,17 +28,17 @@ onMounted(load)
     <h2><i class="bi bi-check2-circle me-2"></i>Auto-configuration conditions</h2>
     <ul class="nav nav-tabs mb-3">
       <li class="nav-item">
-        <a :class="{ active: tab === 'positive' }" class="nav-link" href="#" @click.prevent="tab = 'positive'">
+        <a :class="{active: tab === 'positive'}" class="nav-link" href="#" @click.prevent="tab = 'positive'">
           Positive ({{ data ? data.positiveMatches.length : 0 }})
         </a>
       </li>
       <li class="nav-item">
-        <a :class="{ active: tab === 'negative' }" class="nav-link" href="#" @click.prevent="tab = 'negative'">
+        <a :class="{active: tab === 'negative'}" class="nav-link" href="#" @click.prevent="tab = 'negative'">
           Negative ({{ data ? data.negativeMatches.length : 0 }})
         </a>
       </li>
     </ul>
-    <input v-model="filter" class="form-control mb-3" placeholder="Filter…"/>
+    <input v-model="filter" class="form-control mb-3" placeholder="Filter…" />
     <div v-for="e in entries" :key="e.autoConfigurationClass + e.condition" class="mb-2">
       <div class="d-flex">
         <span :class="tab === 'positive' ? 'bg-success' : 'bg-secondary'" class="badge me-2">{{ e.outcome }}</span>

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, nextTick, onMounted, ref} from 'vue'
-import { apiFetch } from '../api.js'
+import {apiFetch} from '../api.js'
 
 const data = ref(null)
 const loading = ref(true)
@@ -23,12 +23,11 @@ const propertySuggestions = computed(() => data.value?.propertySuggestions || []
 
 const suggestionByName = computed(() => {
   const byName = new Map()
-  propertySuggestions.value.forEach(s => byName.set(s.name, s))
+  propertySuggestions.value.forEach((s) => byName.set(s.name, s))
   return byName
 })
 
-const selectedNewSuggestion = computed(() =>
-  suggestionByName.value.get((newRowName.value || '').trim()) || null)
+const selectedNewSuggestion = computed(() => suggestionByName.value.get((newRowName.value || '').trim()) || null)
 
 async function load() {
   loading.value = true
@@ -45,22 +44,29 @@ async function load() {
 
 const filtered = computed(() => {
   if (!data.value) return []
-  return data.value.properties.filter(p => {
+  return data.value.properties.filter((p) => {
     if (showOnlyOverrides.value && !p.override) return false
     if (sourceFilter.value && p.source !== sourceFilter.value) return false
     if (filter.value) {
       const f = filter.value.toLowerCase()
-      return p.name.toLowerCase().includes(f) ||
-        String(p.value ?? '').toLowerCase().includes(f) ||
-        String(p.description ?? '').toLowerCase().includes(f) ||
-        String(p.defaultValue ?? '').toLowerCase().includes(f)
+      return (
+        p.name.toLowerCase().includes(f) ||
+        String(p.value ?? '')
+          .toLowerCase()
+          .includes(f) ||
+        String(p.description ?? '')
+          .toLowerCase()
+          .includes(f) ||
+        String(p.defaultValue ?? '')
+          .toLowerCase()
+          .includes(f)
+      )
     }
     return true
   })
 })
 
-const overrideCount = computed(() =>
-  data.value ? data.value.properties.filter(p => p.override).length : 0)
+const overrideCount = computed(() => (data.value ? data.value.properties.filter((p) => p.override).length : 0))
 
 function startEdit(p) {
   newRow.value = null
@@ -147,7 +153,7 @@ async function postOverride(name, value, onSuccess) {
     })
     const result = await res.json().catch(() => ({}))
     if (!res.ok) {
-      const msg = result.message || result.error || ('HTTP ' + res.status)
+      const msg = result.message || result.error || 'HTTP ' + res.status
       flash('Could not save override: ' + msg, 'danger')
       return
     }
@@ -169,7 +175,7 @@ async function removeOverride(name) {
     const res = await apiFetch('api/config/overrides/' + encodeURIComponent(name), {method: 'DELETE'})
     const result = await res.json().catch(() => ({}))
     if (!res.ok) {
-      flash('Could not remove override: ' + (result.message || ('HTTP ' + res.status)), 'danger')
+      flash('Could not remove override: ' + (result.message || 'HTTP ' + res.status), 'danger')
       return
     }
     flash('Override removed for ' + name + '.', 'success')
@@ -194,9 +200,7 @@ onMounted(load)
     <div class="d-flex justify-content-between align-items-start mb-2">
       <div>
         <h2 class="mb-1"><i class="bi bi-sliders me-2"></i>Configuration</h2>
-        <p class="text-muted mb-0 small">
-          Inspect and override every Spring property the running application can see.
-        </p>
+        <p class="text-muted mb-0 small">Inspect and override every Spring property the running application can see.</p>
       </div>
       <div class="d-flex gap-2">
         <button :disabled="!!newRow" class="btn btn-success" @click="startCreate">
@@ -214,20 +218,18 @@ onMounted(load)
         <strong>Properties are editable.</strong>
         Click <span class="badge bg-primary"><i class="bi bi-pencil"></i> Edit</span>
         on any row to set a runtime override, or use
-        <strong>Add override</strong> to add a new property.
-        The new-property picker includes known Spring Boot configuration keys and their defaults.
-        Overrides are persisted to
+        <strong>Add override</strong> to add a new property. The new-property picker includes known Spring Boot
+        configuration keys and their defaults. Overrides are persisted to
         <code>.bootui/application-bootui.properties</code> and take precedence over all other property sources.
         <span class="text-muted">
-          Note: properties already bound to a <code>@ConfigurationProperties</code> bean keep
-          their value until restart.
+          Note: properties already bound to a <code>@ConfigurationProperties</code> bean keep their value until restart.
         </span>
       </div>
     </div>
 
     <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
-      <div><i :class="banner.type === 'danger' ? 'bi-exclamation-triangle-fill' : 'bi-check-circle-fill'"
-              class="bi"></i>
+      <div>
+        <i :class="banner.type === 'danger' ? 'bi-exclamation-triangle-fill' : 'bi-check-circle-fill'" class="bi"></i>
         <span class="ms-2">{{ banner.text }}</span>
       </div>
       <button class="btn-close" @click="banner = null"></button>
@@ -237,7 +239,7 @@ onMounted(load)
       <div class="col-md-6">
         <div class="input-group">
           <span class="input-group-text"><i class="bi bi-search"></i></span>
-          <input v-model="filter" class="form-control" placeholder="Filter by name or value…"/>
+          <input v-model="filter" class="form-control" placeholder="Filter by name or value…" />
         </div>
       </div>
       <div class="col-md-4">
@@ -248,151 +250,175 @@ onMounted(load)
       </div>
       <div class="col-md-2">
         <div class="form-check form-switch mt-2">
-          <input id="onlyOverrides" v-model="showOnlyOverrides" class="form-check-input" type="checkbox"/>
-          <label class="form-check-label small" for="onlyOverrides">
-            Only overrides ({{ overrideCount }})
-          </label>
+          <input id="onlyOverrides" v-model="showOnlyOverrides" class="form-check-input" type="checkbox" />
+          <label class="form-check-label small" for="onlyOverrides"> Only overrides ({{ overrideCount }}) </label>
         </div>
       </div>
     </div>
 
     <p class="small text-muted">
       Active profiles:
-      <span v-for="p in (data?.activeProfiles || [])" :key="p" class="badge bg-success me-1">{{ p }}</span>
+      <span v-for="p in data?.activeProfiles || []" :key="p" class="badge bg-success me-1">{{ p }}</span>
       <span v-if="!data?.activeProfiles?.length">(none)</span>
     </p>
 
     <div class="table-responsive">
       <table class="table table-sm align-middle">
         <thead class="table-light">
-        <tr>
-          <th style="width:30%">Property</th>
-          <th style="width:25%">Value</th>
-          <th style="width:20%">Default</th>
-          <th style="width:13%">Source</th>
-          <th class="text-end" style="width:12%">Actions</th>
-        </tr>
+          <tr>
+            <th style="width: 30%">Property</th>
+            <th style="width: 25%">Value</th>
+            <th style="width: 20%">Default</th>
+            <th style="width: 13%">Source</th>
+            <th class="text-end" style="width: 12%">Actions</th>
+          </tr>
         </thead>
         <tbody>
-        <!-- New override row -->
-        <tr v-if="newRow" class="table-warning">
-          <td>
-            <input ref="newNameInput" v-model="newRowName"
-                   class="form-control form-control-sm font-monospace"
-                   list="bootPropertySuggestions"
-                   placeholder="spring.application.name"
-                   @keyup.enter="saveCreate"
-                   @keyup.esc="cancelCreate"/>
-            <datalist id="bootPropertySuggestions">
-              <option v-for="s in propertySuggestions"
-                      :key="s.name"
-                      :label="suggestionLabel(s)"
-                      :value="s.name"></option>
-            </datalist>
-            <div v-if="selectedNewSuggestion" class="small text-muted mt-1">
-              <div v-if="selectedNewSuggestion.description">{{ selectedNewSuggestion.description }}</div>
-              <div>
-                <span v-if="selectedNewSuggestion.type">Type: <code>{{ selectedNewSuggestion.type }}</code></span>
-                <span v-if="selectedNewSuggestion.type && hasDefaultValue(selectedNewSuggestion)" class="mx-1">·</span>
-                <span v-if="hasDefaultValue(selectedNewSuggestion)">
+          <!-- New override row -->
+          <tr v-if="newRow" class="table-warning">
+            <td>
+              <input
+                ref="newNameInput"
+                v-model="newRowName"
+                class="form-control form-control-sm font-monospace"
+                list="bootPropertySuggestions"
+                placeholder="spring.application.name"
+                @keyup.enter="saveCreate"
+                @keyup.esc="cancelCreate"
+              />
+              <datalist id="bootPropertySuggestions">
+                <option
+                  v-for="s in propertySuggestions"
+                  :key="s.name"
+                  :label="suggestionLabel(s)"
+                  :value="s.name"
+                ></option>
+              </datalist>
+              <div v-if="selectedNewSuggestion" class="small text-muted mt-1">
+                <div v-if="selectedNewSuggestion.description">{{ selectedNewSuggestion.description }}</div>
+                <div>
+                  <span v-if="selectedNewSuggestion.type"
+                    >Type: <code>{{ selectedNewSuggestion.type }}</code></span
+                  >
+                  <span v-if="selectedNewSuggestion.type && hasDefaultValue(selectedNewSuggestion)" class="mx-1"
+                    >·</span
+                  >
+                  <span v-if="hasDefaultValue(selectedNewSuggestion)">
                     Default: <code>{{ formatDefaultValue(selectedNewSuggestion.defaultValue) }}</code>
                   </span>
+                </div>
               </div>
-            </div>
-            <div v-if="newRowError" class="text-danger small mt-1">
-              <i class="bi bi-exclamation-circle"></i> {{ newRowError }}
-            </div>
-          </td>
-          <td>
-            <div class="input-group input-group-sm">
-              <input v-model="newRowValue"
-                     :placeholder="hasDefaultValue(selectedNewSuggestion)
-                         ? 'default: ' + formatDefaultValue(selectedNewSuggestion.defaultValue)
-                         : 'new value'"
-                     class="form-control font-monospace"
-                     @keyup.enter="saveCreate"
-                     @keyup.esc="cancelCreate"/>
-              <button v-if="hasDefaultValue(selectedNewSuggestion)"
-                      class="btn btn-outline-secondary"
-                      type="button"
-                      @click="useSelectedDefault">
-                Use default
-              </button>
-            </div>
-          </td>
-          <td>
-            <code v-if="hasDefaultValue(selectedNewSuggestion)" class="text-body">
-              {{ formatDefaultValue(selectedNewSuggestion.defaultValue) }}
-            </code>
-            <span v-else class="text-muted">—</span>
-          </td>
-          <td><span class="badge bg-warning text-dark">new override</span></td>
-          <td class="text-end">
-            <button :disabled="saving" class="btn btn-sm btn-success" @click="saveCreate">
-              <i class="bi bi-check-lg"></i> Save
-            </button>
-            <button :disabled="saving" class="btn btn-sm btn-outline-secondary ms-1" @click="cancelCreate">
-              Cancel
-            </button>
-          </td>
-        </tr>
-
-        <!-- Existing rows -->
-        <tr v-for="p in filtered" :key="p.name + ':' + p.source"
-            :class="{ 'table-warning': p.override, 'table-active': editingName === p.name }">
-          <td class="align-top pt-2">
-            <code class="text-body">{{ p.name }}</code>
-            <span v-if="p.override" class="badge bg-warning text-dark ms-2">override</span>
-            <div v-if="p.description" class="small text-muted mt-1">{{ p.description }}</div>
-          </td>
-          <td>
-            <template v-if="editingName === p.name">
-              <input ref="editInput" v-model="editedValue"
-                     class="form-control form-control-sm font-monospace"
-                     @keyup.enter="saveEdit(p)"
-                     @keyup.esc="cancelEdit"/>
-            </template>
-            <template v-else>
-              <code v-if="!p.masked" class="text-body">{{ p.value }}</code>
-              <span v-else class="text-muted"><i class="bi bi-lock-fill"></i> masked</span>
-            </template>
-          </td>
-          <td class="align-top pt-2">
-            <code v-if="p.defaultValue !== null && p.defaultValue !== undefined" class="text-body">
-              {{ formatDefaultValue(p.defaultValue) }}
-            </code>
-            <span v-else-if="metadataFor(p.name)?.type" class="text-muted small">
-                {{ metadataFor(p.name).type }}
-              </span>
-            <span v-else class="text-muted">—</span>
-          </td>
-          <td class="align-top pt-2"><small class="text-muted">{{ p.source }}</small></td>
-          <td class="text-end align-top pt-1">
-            <template v-if="editingName === p.name">
-              <button :disabled="saving" class="btn btn-sm btn-success" @click="saveEdit(p)">
+              <div v-if="newRowError" class="text-danger small mt-1">
+                <i class="bi bi-exclamation-circle"></i> {{ newRowError }}
+              </div>
+            </td>
+            <td>
+              <div class="input-group input-group-sm">
+                <input
+                  v-model="newRowValue"
+                  :placeholder="
+                    hasDefaultValue(selectedNewSuggestion)
+                      ? 'default: ' + formatDefaultValue(selectedNewSuggestion.defaultValue)
+                      : 'new value'
+                  "
+                  class="form-control font-monospace"
+                  @keyup.enter="saveCreate"
+                  @keyup.esc="cancelCreate"
+                />
+                <button
+                  v-if="hasDefaultValue(selectedNewSuggestion)"
+                  class="btn btn-outline-secondary"
+                  type="button"
+                  @click="useSelectedDefault"
+                >
+                  Use default
+                </button>
+              </div>
+            </td>
+            <td>
+              <code v-if="hasDefaultValue(selectedNewSuggestion)" class="text-body">
+                {{ formatDefaultValue(selectedNewSuggestion.defaultValue) }}
+              </code>
+              <span v-else class="text-muted">—</span>
+            </td>
+            <td><span class="badge bg-warning text-dark">new override</span></td>
+            <td class="text-end">
+              <button :disabled="saving" class="btn btn-sm btn-success" @click="saveCreate">
                 <i class="bi bi-check-lg"></i> Save
               </button>
-              <button :disabled="saving" class="btn btn-sm btn-outline-secondary ms-1" @click="cancelEdit">
+              <button :disabled="saving" class="btn btn-sm btn-outline-secondary ms-1" @click="cancelCreate">
                 Cancel
               </button>
-            </template>
-            <template v-else>
-              <button :disabled="saving" class="btn btn-sm btn-primary" @click="startEdit(p)">
-                <i class="bi bi-pencil"></i> Edit
-              </button>
-              <button v-if="p.override" :disabled="saving"
-                      class="btn btn-sm btn-outline-danger ms-1" title="Remove override" @click="removeOverride(p.name)">
-                <i class="bi bi-trash"></i>
-              </button>
-            </template>
-          </td>
-        </tr>
+            </td>
+          </tr>
 
-        <tr v-if="!loading && filtered.length === 0 && !newRow">
-          <td class="text-center text-muted py-4" colspan="5">
-            No properties match your filters.
-          </td>
-        </tr>
+          <!-- Existing rows -->
+          <tr
+            v-for="p in filtered"
+            :key="p.name + ':' + p.source"
+            :class="{'table-warning': p.override, 'table-active': editingName === p.name}"
+          >
+            <td class="align-top pt-2">
+              <code class="text-body">{{ p.name }}</code>
+              <span v-if="p.override" class="badge bg-warning text-dark ms-2">override</span>
+              <div v-if="p.description" class="small text-muted mt-1">{{ p.description }}</div>
+            </td>
+            <td>
+              <template v-if="editingName === p.name">
+                <input
+                  ref="editInput"
+                  v-model="editedValue"
+                  class="form-control form-control-sm font-monospace"
+                  @keyup.enter="saveEdit(p)"
+                  @keyup.esc="cancelEdit"
+                />
+              </template>
+              <template v-else>
+                <code v-if="!p.masked" class="text-body">{{ p.value }}</code>
+                <span v-else class="text-muted"><i class="bi bi-lock-fill"></i> masked</span>
+              </template>
+            </td>
+            <td class="align-top pt-2">
+              <code v-if="p.defaultValue !== null && p.defaultValue !== undefined" class="text-body">
+                {{ formatDefaultValue(p.defaultValue) }}
+              </code>
+              <span v-else-if="metadataFor(p.name)?.type" class="text-muted small">
+                {{ metadataFor(p.name).type }}
+              </span>
+              <span v-else class="text-muted">—</span>
+            </td>
+            <td class="align-top pt-2">
+              <small class="text-muted">{{ p.source }}</small>
+            </td>
+            <td class="text-end align-top pt-1">
+              <template v-if="editingName === p.name">
+                <button :disabled="saving" class="btn btn-sm btn-success" @click="saveEdit(p)">
+                  <i class="bi bi-check-lg"></i> Save
+                </button>
+                <button :disabled="saving" class="btn btn-sm btn-outline-secondary ms-1" @click="cancelEdit">
+                  Cancel
+                </button>
+              </template>
+              <template v-else>
+                <button :disabled="saving" class="btn btn-sm btn-primary" @click="startEdit(p)">
+                  <i class="bi bi-pencil"></i> Edit
+                </button>
+                <button
+                  v-if="p.override"
+                  :disabled="saving"
+                  class="btn btn-sm btn-outline-danger ms-1"
+                  title="Remove override"
+                  @click="removeOverride(p.name)"
+                >
+                  <i class="bi bi-trash"></i>
+                </button>
+              </template>
+            </td>
+          </tr>
+
+          <tr v-if="!loading && filtered.length === 0 && !newRow">
+            <td class="text-center text-muted py-4" colspan="5">No properties match your filters.</td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/bootui-ui/src/main/frontend/src/views/Data.vue
+++ b/bootui-ui/src/main/frontend/src/views/Data.vue
@@ -35,50 +35,54 @@ async function open(repo) {
 
 const stores = computed(() => {
   if (!report.value) return []
-  const set = new Set(report.value.repositories.map(r => r.storeModule))
+  const set = new Set(report.value.repositories.map((r) => r.storeModule))
   return Array.from(set).sort()
 })
 
 const filtered = computed(() => {
   if (!report.value) return []
   const f = filter.value.toLowerCase()
-  return report.value.repositories.filter(r => {
+  return report.value.repositories.filter((r) => {
     if (storeFilter.value && r.storeModule !== storeFilter.value) return false
     if (!f) return true
-    return (r.repositoryInterface || '').toLowerCase().includes(f)
-      || (r.domainType || '').toLowerCase().includes(f)
-      || (r.beanName || '').toLowerCase().includes(f)
+    return (
+      (r.repositoryInterface || '').toLowerCase().includes(f) ||
+      (r.domainType || '').toLowerCase().includes(f) ||
+      (r.beanName || '').toLowerCase().includes(f)
+    )
   })
 })
 
-const shortName = name => {
+const shortName = (name) => {
   if (!name) return ''
   const i = name.lastIndexOf('.')
   return i < 0 ? name : name.substring(i + 1)
 }
 
-const storeClass = s => ({
-  JPA: 'bg-primary',
-  JDBC: 'bg-info text-dark',
-  MONGO: 'bg-success',
-  REDIS: 'bg-danger',
-  R2DBC: 'bg-warning text-dark',
-  CASSANDRA: 'bg-secondary',
-  NEO4J: 'bg-dark',
-  ELASTICSEARCH: 'bg-warning text-dark',
-  COUCHBASE: 'bg-info text-dark',
-  COMMONS: 'bg-light text-dark border',
-  GENERIC: 'bg-light text-dark border'
-}[s] || 'bg-secondary')
+const storeClass = (s) =>
+  ({
+    JPA: 'bg-primary',
+    JDBC: 'bg-info text-dark',
+    MONGO: 'bg-success',
+    REDIS: 'bg-danger',
+    R2DBC: 'bg-warning text-dark',
+    CASSANDRA: 'bg-secondary',
+    NEO4J: 'bg-dark',
+    ELASTICSEARCH: 'bg-warning text-dark',
+    COUCHBASE: 'bg-info text-dark',
+    COMMONS: 'bg-light text-dark border',
+    GENERIC: 'bg-light text-dark border'
+  })[s] || 'bg-secondary'
 
-const originClass = o => ({
-  CRUD: 'bg-light text-dark border',
-  DERIVED: 'bg-success',
-  QUERY: 'bg-primary',
-  ANNOTATED: 'bg-primary',
-  FRAGMENT: 'bg-warning text-dark',
-  DEFAULT: 'bg-info text-dark'
-}[o] || 'bg-secondary')
+const originClass = (o) =>
+  ({
+    CRUD: 'bg-light text-dark border',
+    DERIVED: 'bg-success',
+    QUERY: 'bg-primary',
+    ANNOTATED: 'bg-primary',
+    FRAGMENT: 'bg-warning text-dark',
+    DEFAULT: 'bg-info text-dark'
+  })[o] || 'bg-secondary'
 
 onMounted(load)
 </script>
@@ -88,21 +92,20 @@ onMounted(load)
     <h2><i class="bi bi-database me-2"></i>Spring Data repositories</h2>
 
     <div v-if="!springDataPresent" class="alert alert-info">
-      Spring Data is not on the classpath of this application. Add a Spring Data
-      starter (e.g. <code>spring-boot-starter-data-jpa</code>) to see repositories here.
+      Spring Data is not on the classpath of this application. Add a Spring Data starter (e.g.
+      <code>spring-boot-starter-data-jpa</code>) to see repositories here.
     </div>
 
     <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
 
     <div v-else-if="report && report.total === 0" class="alert alert-secondary">
-      Spring Data is on the classpath, but no repository beans were detected in the
-      application context.
+      Spring Data is on the classpath, but no repository beans were detected in the application context.
     </div>
 
     <template v-else-if="report">
       <div class="row g-2 mb-3">
         <div class="col-md-6">
-          <input v-model="filter" class="form-control" placeholder="Filter by interface, entity, or bean name…"/>
+          <input v-model="filter" class="form-control" placeholder="Filter by interface, entity, or bean name…" />
         </div>
         <div class="col-md-3">
           <select v-model="storeFilter" class="form-select">
@@ -121,13 +124,16 @@ onMounted(load)
             <button
               v-for="r in filtered"
               :key="r.beanName"
-              :class="{ active: selected === r.repositoryInterface }"
+              :class="{active: selected === r.repositoryInterface}"
               class="list-group-item list-group-item-action"
               type="button"
-              @click="open(r)">
+              @click="open(r)"
+            >
               <div class="d-flex justify-content-between align-items-start">
                 <div>
-                  <div><strong>{{ shortName(r.repositoryInterface) }}</strong></div>
+                  <div>
+                    <strong>{{ shortName(r.repositoryInterface) }}</strong>
+                  </div>
                   <div class="small text-muted">
                     {{ shortName(r.domainType) }}
                     <span v-if="r.idType"> · id: {{ shortName(r.idType) }}</span>
@@ -159,39 +165,51 @@ onMounted(load)
                   <span :class="storeClass(detail.storeModule)" class="badge">{{ detail.storeModule }}</span>
                 </dd>
                 <dt class="col-sm-3">Domain type</dt>
-                <dd class="col-sm-9"><code>{{ detail.domainType }}</code></dd>
+                <dd class="col-sm-9">
+                  <code>{{ detail.domainType }}</code>
+                </dd>
                 <dt class="col-sm-3">ID type</dt>
-                <dd class="col-sm-9"><code>{{ detail.idType }}</code></dd>
+                <dd class="col-sm-9">
+                  <code>{{ detail.idType }}</code>
+                </dd>
                 <dt class="col-sm-3">Bean name</dt>
-                <dd class="col-sm-9"><code>{{ detail.beanName }}</code></dd>
+                <dd class="col-sm-9">
+                  <code>{{ detail.beanName }}</code>
+                </dd>
                 <template v-if="detail.customImplementation">
                   <dt class="col-sm-3">Base class</dt>
-                  <dd class="col-sm-9"><code>{{ detail.customImplementation }}</code></dd>
+                  <dd class="col-sm-9">
+                    <code>{{ detail.customImplementation }}</code>
+                  </dd>
                 </template>
               </dl>
 
-              <h6 class="mb-2">Methods <span class="badge bg-secondary">{{ detail.methods.length }}</span></h6>
+              <h6 class="mb-2">
+                Methods <span class="badge bg-secondary">{{ detail.methods.length }}</span>
+              </h6>
               <table class="table table-sm table-hover">
                 <thead>
-                <tr>
-                  <th style="width:110px">Origin</th>
-                  <th>Signature</th>
-                  <th>Query</th>
-                </tr>
+                  <tr>
+                    <th style="width: 110px">Origin</th>
+                    <th>Signature</th>
+                    <th>Query</th>
+                  </tr>
                 </thead>
                 <tbody>
-                <tr v-for="m in detail.methods" :key="m.signature">
-                  <td>
-                    <span :class="originClass(m.origin)" class="badge">{{ m.origin }}</span>
-                  </td>
-                  <td><code>{{ m.signature }}</code></td>
-                  <td>
-                    <code v-if="m.query" class="small">{{ m.query }}</code>
-                    <span v-else-if="m.namedQuery" class="small text-muted">named: {{ m.namedQuery }}</span>
-                    <span v-else class="text-muted small">—</span>
-                    <span v-if="m.nativeQuery" class="badge bg-warning text-dark ms-1">native</span>
-                  </td>
-                </tr>
+                  <tr v-for="m in detail.methods" :key="m.signature">
+                    <td>
+                      <span :class="originClass(m.origin)" class="badge">{{ m.origin }}</span>
+                    </td>
+                    <td>
+                      <code>{{ m.signature }}</code>
+                    </td>
+                    <td>
+                      <code v-if="m.query" class="small">{{ m.query }}</code>
+                      <span v-else-if="m.namedQuery" class="small text-muted">named: {{ m.namedQuery }}</span>
+                      <span v-else class="text-muted small">—</span>
+                      <span v-if="m.nativeQuery" class="badge bg-warning text-dark ms-1">native</span>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/bootui-ui/src/main/frontend/src/views/Dependencies.vue
+++ b/bootui-ui/src/main/frontend/src/views/Dependencies.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
-import { apiFetch } from '../api.js'
+import {apiFetch} from '../api.js'
 
 const data = ref(null)
 const error = ref(null)
@@ -21,9 +21,8 @@ const filteredDependencies = computed(() => {
   if (!data.value) return []
   const q = search.value.trim().toLowerCase()
   return data.value.dependencies.filter((dependency) => {
-    const matchesSearch = !q ||
-      dependency.packageName.toLowerCase().includes(q) ||
-      dependency.version.toLowerCase().includes(q)
+    const matchesSearch =
+      !q || dependency.packageName.toLowerCase().includes(q) || dependency.version.toLowerCase().includes(q)
     const matchesVulnerable = !vulnerableOnly.value || dependency.vulnerabilityCount > 0
     return matchesSearch && matchesVulnerable
   })
@@ -97,7 +96,8 @@ onMounted(loadDependencies)
         :disabled="loading || data?.scanningEnabled === false"
         class="btn btn-primary"
         type="button"
-        @click="scanDependencies">
+        @click="scanDependencies"
+      >
         <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
         Scan with OSV.dev
       </button>
@@ -160,8 +160,11 @@ onMounted(loadDependencies)
             </div>
             <div class="col">
               <div :aria-label="`${item.severity} vulnerabilities: ${item.count}`" class="progress" role="img">
-                <div :class="severityClass(item.severity)" :style="{ width: severityWidth(item.count) }"
-                     class="progress-bar"></div>
+                <div
+                  :class="severityClass(item.severity)"
+                  :style="{width: severityWidth(item.count)}"
+                  class="progress-bar"
+                ></div>
               </div>
             </div>
             <div class="col-auto small text-muted">{{ item.count }}</div>
@@ -177,10 +180,13 @@ onMounted(loadDependencies)
               <div class="text-muted small">{{ filteredDependencies.length }} of {{ data.total }} dependencies</div>
             </div>
             <div class="d-flex flex-wrap gap-2">
-              <input v-model="search" class="form-control form-control-sm dependency-search"
-                     placeholder="Search group, artifact, or version">
+              <input
+                v-model="search"
+                class="form-control form-control-sm dependency-search"
+                placeholder="Search group, artifact, or version"
+              />
               <div class="form-check form-switch">
-                <input id="vulnerableOnly" v-model="vulnerableOnly" class="form-check-input" type="checkbox">
+                <input id="vulnerableOnly" v-model="vulnerableOnly" class="form-check-input" type="checkbox" />
                 <label class="form-check-label small" for="vulnerableOnly">Vulnerable only</label>
               </div>
             </div>
@@ -189,54 +195,58 @@ onMounted(loadDependencies)
         <div class="table-responsive">
           <table class="table table-sm align-middle mb-0">
             <thead>
-            <tr>
-              <th>Dependency</th>
-              <th>Version</th>
-              <th>Risk</th>
-              <th>Advisories</th>
-            </tr>
+              <tr>
+                <th>Dependency</th>
+                <th>Version</th>
+                <th>Risk</th>
+                <th>Advisories</th>
+              </tr>
             </thead>
             <tbody>
-            <tr v-for="dependency in filteredDependencies" :key="`${dependency.packageName}:${dependency.version}`">
-              <td>
-                <code>{{ dependency.packageName }}</code>
-              </td>
-              <td>{{ dependency.version }}</td>
-              <td>
+              <tr v-for="dependency in filteredDependencies" :key="`${dependency.packageName}:${dependency.version}`">
+                <td>
+                  <code>{{ dependency.packageName }}</code>
+                </td>
+                <td>{{ dependency.version }}</td>
+                <td>
                   <span :class="severityClass(dependency.highestSeverity)" class="badge">
                     {{ dependency.highestSeverity }}
                   </span>
-              </td>
-              <td>
-                <span v-if="dependency.vulnerabilityCount === 0" class="text-muted">None found</span>
-                <div v-else class="vulnerability-list">
-                  <div v-for="vulnerability in dependency.vulnerabilities" :key="vulnerability.id" class="mb-2">
-                    <div class="d-flex flex-wrap align-items-center gap-2">
-                      <span :class="severityClass(vulnerability.severity)" class="badge">{{
+                </td>
+                <td>
+                  <span v-if="dependency.vulnerabilityCount === 0" class="text-muted">None found</span>
+                  <div v-else class="vulnerability-list">
+                    <div v-for="vulnerability in dependency.vulnerabilities" :key="vulnerability.id" class="mb-2">
+                      <div class="d-flex flex-wrap align-items-center gap-2">
+                        <span :class="severityClass(vulnerability.severity)" class="badge">{{
                           vulnerability.severity
                         }}</span>
-                      <a v-if="vulnerability.references.length" :href="vulnerability.references[0]" rel="noreferrer"
-                         target="_blank">
-                        {{ vulnerability.id }}
-                      </a>
-                      <span v-else class="fw-semibold">{{ vulnerability.id }}</span>
-                      <span v-if="vulnerability.fixedVersions.length" class="small text-muted">
+                        <a
+                          v-if="vulnerability.references.length"
+                          :href="vulnerability.references[0]"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          {{ vulnerability.id }}
+                        </a>
+                        <span v-else class="fw-semibold">{{ vulnerability.id }}</span>
+                        <span v-if="vulnerability.fixedVersions.length" class="small text-muted">
                           fixed in {{ vulnerability.fixedVersions.join(', ') }}
                         </span>
-                    </div>
-                    <div class="small">
-                      {{ vulnerability.summary || vulnerability.details || 'No advisory summary available.' }}
-                    </div>
-                    <div v-if="vulnerability.aliases.length" class="small text-muted">
-                      {{ vulnerability.aliases.join(', ') }}
+                      </div>
+                      <div class="small">
+                        {{ vulnerability.summary || vulnerability.details || 'No advisory summary available.' }}
+                      </div>
+                      <div v-if="vulnerability.aliases.length" class="small text-muted">
+                        {{ vulnerability.aliases.join(', ') }}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </td>
-            </tr>
-            <tr v-if="filteredDependencies.length === 0">
-              <td class="text-muted text-center py-4" colspan="4">No dependencies match the current filters.</td>
-            </tr>
+                </td>
+              </tr>
+              <tr v-if="filteredDependencies.length === 0">
+                <td class="text-muted text-center py-4" colspan="4">No dependencies match the current filters.</td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
-import { apiFetch } from '../api.js'
+import {apiFetch} from '../api.js'
 
 const report = ref(null)
 const loading = ref(true)
@@ -33,29 +33,34 @@ const filtered = computed(() => {
   if (!report.value) return []
   const value = filter.value.trim().toLowerCase()
   if (!value) return report.value.services
-  return report.value.services.filter(service =>
-    (service.name || '').toLowerCase().includes(value)
-    || (service.type || '').toLowerCase().includes(value)
-    || (service.status || '').toLowerCase().includes(value)
-    || (service.image || '').toLowerCase().includes(value)
+  return report.value.services.filter(
+    (service) =>
+      (service.name || '').toLowerCase().includes(value) ||
+      (service.type || '').toLowerCase().includes(value) ||
+      (service.status || '').toLowerCase().includes(value) ||
+      (service.image || '').toLowerCase().includes(value)
   )
 })
 
 function sourceClass(source) {
-  return {
-    'Docker Compose': 'bg-primary',
-    Testcontainers: 'bg-success',
-    'Connection details': 'bg-info text-dark'
-  }[source] || 'bg-secondary'
+  return (
+    {
+      'Docker Compose': 'bg-primary',
+      Testcontainers: 'bg-success',
+      'Connection details': 'bg-info text-dark'
+    }[source] || 'bg-secondary'
+  )
 }
 
 function statusClass(status) {
-  return {
-    RUNNING: 'text-bg-success',
-    STOPPED: 'text-bg-secondary',
-    AVAILABLE: 'text-bg-info',
-    READY_AT_STARTUP: 'text-bg-primary'
-  }[status] || 'text-bg-secondary'
+  return (
+    {
+      RUNNING: 'text-bg-success',
+      STOPPED: 'text-bg-secondary',
+      AVAILABLE: 'text-bg-info',
+      READY_AT_STARTUP: 'text-bg-primary'
+    }[status] || 'text-bg-secondary'
+  )
 }
 
 function formatSnapshot(timestamp) {
@@ -71,8 +76,9 @@ function formatSnapshot(timestamp) {
 function formatPorts(service) {
   if (!service.ports || service.ports.length === 0) return '—'
   return service.ports
-    .map(port => {
-      if (port.containerPort && port.hostPort) return `${port.containerPort} → ${port.hostPort}/${port.protocol || 'tcp'}`
+    .map((port) => {
+      if (port.containerPort && port.hostPort)
+        return `${port.containerPort} → ${port.hostPort}/${port.protocol || 'tcp'}`
       if (port.hostPort) return `${port.hostPort}/${port.protocol || 'tcp'}`
       return port.containerPort || '—'
     })
@@ -95,7 +101,7 @@ function syncSelectedService() {
     logs.value = null
     return
   }
-  const updated = services.find(service => service.id === selected.value.id)
+  const updated = services.find((service) => service.id === selected.value.id)
   if (updated) {
     selected.value = updated
     return
@@ -178,9 +184,9 @@ onMounted(load)
       <div>
         <h2 class="mb-1"><i class="bi bi-box-seam me-2"></i>Dev Services</h2>
         <div v-if="report" class="text-muted small">
-          Snapshot {{ formatSnapshot(report.snapshotTimestamp) }} ·
-          Docker Compose {{ report.dockerComposePresent ? 'available' : 'not detected' }} ·
-          Testcontainers {{ report.testcontainersPresent ? 'available' : 'not detected' }}
+          Snapshot {{ formatSnapshot(report.snapshotTimestamp) }} · Docker Compose
+          {{ report.dockerComposePresent ? 'available' : 'not detected' }} · Testcontainers
+          {{ report.testcontainersPresent ? 'available' : 'not detected' }}
         </div>
       </div>
       <button class="btn btn-sm btn-outline-secondary" @click="load">
@@ -202,10 +208,7 @@ onMounted(load)
     <template v-else-if="report">
       <div class="row g-2 mb-3">
         <div class="col-md-8">
-          <input
-            v-model="filter"
-            class="form-control"
-            placeholder="Filter by name, type, status, or image…"/>
+          <input v-model="filter" class="form-control" placeholder="Filter by name, type, status, or image…" />
         </div>
         <div class="col-md-4 text-end small text-muted align-self-center">
           {{ filtered.length }} / {{ report.total }} services
@@ -221,67 +224,70 @@ onMounted(load)
           <div class="table-responsive">
             <table class="table table-sm table-hover align-middle">
               <thead>
-              <tr>
-                <th>Service</th>
-                <th>Status</th>
-                <th>Host / ports</th>
-                <th class="text-end">Actions</th>
-              </tr>
+                <tr>
+                  <th>Service</th>
+                  <th>Status</th>
+                  <th>Host / ports</th>
+                  <th class="text-end">Actions</th>
+                </tr>
               </thead>
               <tbody>
-              <tr v-for="service in filtered" :key="service.id" :class="{ 'selected-row': isSelected(service) }">
-                <td data-label="Service">
-                  <div class="fw-semibold">{{ service.name }}</div>
-                  <div class="small text-muted">
-                    {{ service.type }}
-                    <span v-if="service.image"> · <code>{{ service.image }}</code></span>
-                  </div>
-                </td>
-                <td data-label="Status"><span :class="statusClass(service.status)" class="badge">{{
-                    service.status
-                  }}</span></td>
-                <td class="small" data-label="Host / ports">
-                  <div>{{ service.host || '—' }}</div>
-                  <code>{{ formatPorts(service) }}</code>
-                </td>
-                <td class="text-end" data-label="Actions">
-                  <div class="d-flex flex-wrap justify-content-end gap-1 service-actions">
-                    <button
-                      :aria-pressed="isSelected(service)"
-                      :class="isSelected(service) ? 'btn-primary' : 'btn-outline-primary'"
-                      class="btn btn-sm"
-                      @click="selectService(service)">
-                      <i class="bi bi-info-circle me-1"></i>
-                      {{ isSelected(service) ? 'Details shown' : 'View details' }}
-                    </button>
-                    <button
-                      v-if="service.logsAvailable"
-                      :disabled="busyService === service.id"
-                      class="btn btn-sm btn-outline-secondary"
-                      @click="openLogs(service)">
-                      <i class="bi bi-card-text me-1"></i>
-                      View logs
-                    </button>
-                    <button
-                      v-if="service.restartable"
-                      :disabled="busyService === service.id"
-                      class="btn btn-sm btn-outline-danger"
-                      @click="restart(service)">
-                      <i class="bi bi-arrow-repeat me-1"></i>
-                      Restart
-                    </button>
-                  </div>
-                </td>
-              </tr>
+                <tr v-for="service in filtered" :key="service.id" :class="{'selected-row': isSelected(service)}">
+                  <td data-label="Service">
+                    <div class="fw-semibold">{{ service.name }}</div>
+                    <div class="small text-muted">
+                      {{ service.type }}
+                      <span v-if="service.image">
+                        · <code>{{ service.image }}</code></span
+                      >
+                    </div>
+                  </td>
+                  <td data-label="Status">
+                    <span :class="statusClass(service.status)" class="badge">{{ service.status }}</span>
+                  </td>
+                  <td class="small" data-label="Host / ports">
+                    <div>{{ service.host || '—' }}</div>
+                    <code>{{ formatPorts(service) }}</code>
+                  </td>
+                  <td class="text-end" data-label="Actions">
+                    <div class="d-flex flex-wrap justify-content-end gap-1 service-actions">
+                      <button
+                        :aria-pressed="isSelected(service)"
+                        :class="isSelected(service) ? 'btn-primary' : 'btn-outline-primary'"
+                        class="btn btn-sm"
+                        @click="selectService(service)"
+                      >
+                        <i class="bi bi-info-circle me-1"></i>
+                        {{ isSelected(service) ? 'Details shown' : 'View details' }}
+                      </button>
+                      <button
+                        v-if="service.logsAvailable"
+                        :disabled="busyService === service.id"
+                        class="btn btn-sm btn-outline-secondary"
+                        @click="openLogs(service)"
+                      >
+                        <i class="bi bi-card-text me-1"></i>
+                        View logs
+                      </button>
+                      <button
+                        v-if="service.restartable"
+                        :disabled="busyService === service.id"
+                        class="btn btn-sm btn-outline-danger"
+                        @click="restart(service)"
+                      >
+                        <i class="bi bi-arrow-repeat me-1"></i>
+                        Restart
+                      </button>
+                    </div>
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>
         </div>
 
         <div class="col-xl-5">
-          <div v-if="!selected" class="text-muted small">
-            Select a service to inspect connection details.
-          </div>
+          <div v-if="!selected" class="text-muted small">Select a service to inspect connection details.</div>
           <div v-else class="card">
             <div class="card-header d-flex justify-content-between align-items-start gap-2">
               <div>
@@ -295,11 +301,17 @@ onMounted(load)
                 <dt class="col-sm-4">Type</dt>
                 <dd class="col-sm-8">{{ selected.type }}</dd>
                 <dt class="col-sm-4">Image</dt>
-                <dd class="col-sm-8"><code>{{ selected.image || '—' }}</code></dd>
+                <dd class="col-sm-8">
+                  <code>{{ selected.image || '—' }}</code>
+                </dd>
                 <dt class="col-sm-4">Host</dt>
-                <dd class="col-sm-8"><code>{{ selected.host || '—' }}</code></dd>
+                <dd class="col-sm-8">
+                  <code>{{ selected.host || '—' }}</code>
+                </dd>
                 <dt class="col-sm-4">Ports</dt>
-                <dd class="col-sm-8"><code>{{ formatPorts(selected) }}</code></dd>
+                <dd class="col-sm-8">
+                  <code>{{ formatPorts(selected) }}</code>
+                </dd>
               </dl>
 
               <h6>Connection details</h6>
@@ -308,10 +320,12 @@ onMounted(load)
               </div>
               <table v-else class="table table-sm">
                 <tbody>
-                <tr v-for="[key, value] in detailEntries(selected)" :key="key">
-                  <th class="text-nowrap small">{{ key }}</th>
-                  <td><code>{{ value ?? '—' }}</code></td>
-                </tr>
+                  <tr v-for="[key, value] in detailEntries(selected)" :key="key">
+                    <th class="text-nowrap small">{{ key }}</th>
+                    <td>
+                      <code>{{ value ?? '—' }}</code>
+                    </td>
+                  </tr>
                 </tbody>
               </table>
 

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, onMounted, onUnmounted, ref} from 'vue'
-import { apiFetch } from '../api.js'
+import {apiFetch} from '../api.js'
 
 const status = ref(null)
 const loading = ref(true)
@@ -31,7 +31,7 @@ async function triggerLiveReload() {
     const res = await apiFetch('api/devtools/livereload', {method: 'POST'})
     const result = await res.json().catch(() => ({}))
     if (!res.ok) {
-      flash(result.message || result.error || ('HTTP ' + res.status), 'warning')
+      flash(result.message || result.error || 'HTTP ' + res.status, 'warning')
       await load()
       return
     }
@@ -45,7 +45,8 @@ async function triggerLiveReload() {
 }
 
 async function restart() {
-  if (!confirm('Restart this Spring Boot application now? In-memory state and in-flight requests will be interrupted.')) return
+  if (!confirm('Restart this Spring Boot application now? In-memory state and in-flight requests will be interrupted.'))
+    return
 
   actionLoading.value = 'restart'
   try {
@@ -56,7 +57,7 @@ async function restart() {
     })
     const result = await res.json().catch(() => ({}))
     if (!res.ok) {
-      flash(result.message || result.error || ('HTTP ' + res.status), 'warning')
+      flash(result.message || result.error || 'HTTP ' + res.status, 'warning')
       await load()
       return
     }
@@ -116,7 +117,7 @@ onUnmounted(clearReconnectTimer)
         </p>
       </div>
       <button :disabled="loading || restarting" class="btn btn-outline-secondary" title="Refresh" @click="load">
-        <i :class="{ 'spin': loading }" class="bi bi-arrow-clockwise"></i>
+        <i :class="{spin: loading}" class="bi bi-arrow-clockwise"></i>
       </button>
     </div>
 
@@ -160,7 +161,9 @@ onUnmounted(clearReconnectTimer)
             </div>
 
             <div class="small text-muted mb-3">
-              <span v-if="status.liveReloadPort">LiveReload port: <code>{{ status.liveReloadPort }}</code></span>
+              <span v-if="status.liveReloadPort"
+                >LiveReload port: <code>{{ status.liveReloadPort }}</code></span
+              >
               <span v-else>{{ status.liveReloadUnavailableReason || 'No LiveReload port reported.' }}</span>
             </div>
 
@@ -182,12 +185,10 @@ onUnmounted(clearReconnectTimer)
                   <i class="bi bi-arrow-clockwise"></i>
                 </div>
                 <h3 class="h5 fw-bold mt-3 mb-1">Restart application</h3>
-                <p class="text-muted small mb-0">
-                  Schedules a DevTools restart after the API response is sent.
-                </p>
+                <p class="text-muted small mb-0">Schedules a DevTools restart after the API response is sent.</p>
               </div>
               <span :class="restartReady ? 'text-bg-success' : 'text-bg-secondary'" class="badge">
-                {{ status.restartPending ? 'Pending' : (restartReady ? 'Available' : 'Unavailable') }}
+                {{ status.restartPending ? 'Pending' : restartReady ? 'Available' : 'Unavailable' }}
               </span>
             </div>
 
@@ -207,8 +208,8 @@ onUnmounted(clearReconnectTimer)
       <div class="col-12">
         <div class="alert alert-info small mb-0">
           <strong>Note:</strong>
-          LiveReload notifies connected browser tooling; it does not force this BootUI tab to reload.
-          Restart interrupts the current JVM context and is intended for local development only.
+          LiveReload notifies connected browser tooling; it does not force this BootUI tab to reload. Restart interrupts
+          the current JVM context and is intended for local development only.
         </div>
       </div>
     </div>

--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -27,15 +27,17 @@ function flatten(node) {
 
 const nodes = computed(() => flatten(root.value))
 const componentCount = computed(() => Math.max(nodes.value.length - 1, 0))
-const problemNodes = computed(() =>
-  nodes.value.filter(node => !['UP', 'UNKNOWN'].includes(node.status)))
-const detailsHidden = computed(() =>
-  root.value && !root.value.details && (!root.value.components || root.value.components.length === 0))
+const problemNodes = computed(() => nodes.value.filter((node) => !['UP', 'UNKNOWN'].includes(node.status)))
+const detailsHidden = computed(
+  () => root.value && !root.value.details && (!root.value.components || root.value.components.length === 0)
+)
 
 const statusMessage = computed(() => {
   if (!root.value) return ''
   if (problemNodes.value.length) {
-    return problemNodes.value.length + ' component' + (problemNodes.value.length === 1 ? ' needs' : 's need') + ' attention'
+    return (
+      problemNodes.value.length + ' component' + (problemNodes.value.length === 1 ? ' needs' : 's need') + ' attention'
+    )
   }
   if (root.value.status === 'UP') return 'All reported components are healthy'
   if (root.value.status === 'UNKNOWN') return 'Health endpoint did not report component details'
@@ -69,12 +71,15 @@ onMounted(load)
             <div class="card-body">
               <div class="text-muted small text-uppercase">Overall status</div>
               <div class="fs-4 fw-semibold">
-                <span :class="{
-                  'bg-success': root.status === 'UP',
-                  'bg-danger': root.status === 'DOWN',
-                  'bg-warning text-dark': root.status === 'OUT_OF_SERVICE',
-                  'bg-secondary': !['UP', 'DOWN', 'OUT_OF_SERVICE'].includes(root.status)
-                }" class="badge">
+                <span
+                  :class="{
+                    'bg-success': root.status === 'UP',
+                    'bg-danger': root.status === 'DOWN',
+                    'bg-warning text-dark': root.status === 'OUT_OF_SERVICE',
+                    'bg-secondary': !['UP', 'DOWN', 'OUT_OF_SERVICE'].includes(root.status)
+                  }"
+                  class="badge"
+                >
                   {{ root.status }}
                 </span>
               </div>
@@ -110,7 +115,7 @@ onMounted(load)
       </div>
 
       <h5 class="mb-2">Component tree</h5>
-      <HealthNode :node="root"/>
+      <HealthNode :node="root" />
     </template>
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
@@ -41,7 +41,7 @@ function formatScalar(value) {
     <span v-if="value.length === 0" class="text-muted">None</span>
     <ol v-else class="mb-0 ps-3">
       <li v-for="(item, index) in value" :key="index" class="mb-1">
-        <HealthDetails :value="item"/>
+        <HealthDetails :value="item" />
       </li>
     </ol>
   </div>
@@ -49,15 +49,15 @@ function formatScalar(value) {
   <div v-else-if="isPlainObject(value)" class="table-responsive">
     <table class="table table-sm table-borderless align-middle mb-0">
       <tbody>
-      <tr v-for="[key, item] in entries(value)" :key="key">
-        <th class="text-muted fw-normal ps-0" style="width: 34%">{{ labelFor(key) }}</th>
-        <td class="pe-0">
-          <code v-if="isScalar(item)">{{ formatScalar(item) }}</code>
-          <div v-else class="border rounded bg-light-subtle p-2">
-            <HealthDetails :value="item"/>
-          </div>
-        </td>
-      </tr>
+        <tr v-for="[key, item] in entries(value)" :key="key">
+          <th class="text-muted fw-normal ps-0" style="width: 34%">{{ labelFor(key) }}</th>
+          <td class="pe-0">
+            <code v-if="isScalar(item)">{{ formatScalar(item) }}</code>
+            <div v-else class="border rounded bg-light-subtle p-2">
+              <HealthDetails :value="item" />
+            </div>
+          </td>
+        </tr>
       </tbody>
     </table>
   </div>

--- a/bootui-ui/src/main/frontend/src/views/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthNode.vue
@@ -10,23 +10,25 @@ const props = defineProps({
   depth: {type: Number, default: 0}
 })
 
-const statusClass = s => ({
-  UP: 'bg-success',
-  DOWN: 'bg-danger',
-  OUT_OF_SERVICE: 'bg-warning text-dark',
-  UNKNOWN: 'bg-secondary'
-}[s] || 'bg-secondary')
+const statusClass = (s) =>
+  ({
+    UP: 'bg-success',
+    DOWN: 'bg-danger',
+    OUT_OF_SERVICE: 'bg-warning text-dark',
+    UNKNOWN: 'bg-secondary'
+  })[s] || 'bg-secondary'
 
-const statusIcon = s => ({
-  UP: 'bi-check-circle-fill text-success',
-  DOWN: 'bi-x-circle-fill text-danger',
-  OUT_OF_SERVICE: 'bi-exclamation-triangle-fill text-warning',
-  UNKNOWN: 'bi-question-circle-fill text-secondary'
-}[s] || 'bi-question-circle-fill text-secondary')
+const statusIcon = (s) =>
+  ({
+    UP: 'bi-check-circle-fill text-success',
+    DOWN: 'bi-x-circle-fill text-danger',
+    OUT_OF_SERVICE: 'bi-exclamation-triangle-fill text-warning',
+    UNKNOWN: 'bi-question-circle-fill text-secondary'
+  })[s] || 'bi-question-circle-fill text-secondary'
 
-const childCount = node => (node.components || []).length
+const childCount = (node) => (node.components || []).length
 
-const detailCount = node => {
+const detailCount = (node) => {
   if (!node.details || typeof node.details !== 'object' || Array.isArray(node.details)) return node.details ? 1 : 0
   return Object.keys(node.details).length
 }
@@ -51,16 +53,12 @@ const detailCount = node => {
     <div v-if="childCount(node) || node.details" class="card-body">
       <section v-if="node.details" class="mb-3">
         <h6 class="text-muted text-uppercase small mb-2">Details</h6>
-        <HealthDetails :value="node.details"/>
+        <HealthDetails :value="node.details" />
       </section>
 
       <section v-if="childCount(node)">
         <h6 v-if="node.details" class="text-muted text-uppercase small mb-2">Components</h6>
-        <HealthNode
-          v-for="c in node.components"
-          :key="c.name"
-          :depth="depth + 1"
-          :node="c"/>
+        <HealthNode v-for="c in node.components" :key="c.name" :depth="depth + 1" :node="c" />
       </section>
     </div>
   </details>

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, ref} from 'vue'
-import { apiFetch } from '../api.js'
+import {apiFetch} from '../api.js'
 
 const method = ref('GET')
 const path = ref('')
@@ -124,9 +124,7 @@ function clearForm() {
               placeholder="/api/sample/hello"
               @keyup.enter="sendProbe"
             />
-            <div class="form-text">
-              Relative to the application root. Requests are always sent to localhost.
-            </div>
+            <div class="form-text">Relative to the application root. Requests are always sent to localhost.</div>
           </div>
         </div>
 
@@ -166,7 +164,8 @@ function clearForm() {
           <h6>Headers</h6>
           <ul class="list-unstyled small mb-0">
             <li v-for="(value, name) in response.headers" :key="name">
-              <code>{{ name }}</code>: {{ value }}
+              <code>{{ name }}</code
+              >: {{ value }}
             </li>
           </ul>
         </div>

--- a/bootui-ui/src/main/frontend/src/views/LogTail.vue
+++ b/bootui-ui/src/main/frontend/src/views/LogTail.vue
@@ -28,24 +28,25 @@ const visibleLines = computed(() => {
   const filter = textFilter.value.trim().toLowerCase()
   const threshold = levelThreshold[levelFilter.value] ?? -1
 
-  return lines.value.filter(line => {
+  return lines.value.filter((line) => {
     const rank = levelRank[line.level] ?? -1
     const logger = (line.logger || '').toLowerCase()
     const message = (line.message || '').toLowerCase()
     const matchesLevel = threshold < 0 || rank >= threshold
-    const matchesText = !filter
-      || logger.startsWith(filter)
-      || message.includes(filter)
+    const matchesText = !filter || logger.startsWith(filter) || message.includes(filter)
 
     return matchesLevel && matchesText
   })
 })
 
-const statusClass = computed(() => ({
-  Connected: 'text-bg-success',
-  Paused: 'text-bg-secondary',
-  Disconnected: 'text-bg-danger'
-}[status.value] || 'text-bg-secondary'))
+const statusClass = computed(
+  () =>
+    ({
+      Connected: 'text-bg-success',
+      Paused: 'text-bg-secondary',
+      Disconnected: 'text-bg-danger'
+    })[status.value] || 'text-bg-secondary'
+)
 
 function connect() {
   disconnect(false)
@@ -54,7 +55,7 @@ function connect() {
   eventSource.onopen = () => {
     status.value = 'Connected'
   }
-  eventSource.addEventListener('log', event => {
+  eventSource.addEventListener('log', (event) => {
     const line = JSON.parse(event.data)
     lines.value.push(line)
     if (lines.value.length > 500) {
@@ -99,13 +100,15 @@ function formatTime(timestamp) {
 }
 
 function levelClass(level) {
-  return {
-    ERROR: 'text-danger',
-    WARN: 'text-warning',
-    INFO: 'text-success',
-    DEBUG: 'text-info',
-    TRACE: 'text-secondary'
-  }[level] || 'text-light'
+  return (
+    {
+      ERROR: 'text-danger',
+      WARN: 'text-warning',
+      INFO: 'text-success',
+      DEBUG: 'text-info',
+      TRACE: 'text-secondary'
+    }[level] || 'text-light'
+  )
 }
 
 async function scrollToBottom() {
@@ -117,7 +120,7 @@ async function scrollToBottom() {
 }
 
 watch(visibleLines, scrollToBottom)
-watch(autoScroll, enabled => {
+watch(autoScroll, (enabled) => {
   if (enabled) {
     scrollToBottom()
   }
@@ -137,10 +140,7 @@ onBeforeUnmount(() => disconnect(false))
     <div class="row g-3 mb-3 align-items-end">
       <div class="col-lg-4">
         <label class="form-label">Filter</label>
-        <input
-          v-model="textFilter"
-          class="form-control"
-          placeholder="Logger prefix or message text"/>
+        <input v-model="textFilter" class="form-control" placeholder="Logger prefix or message text" />
       </div>
       <div class="col-sm-4 col-lg-2">
         <label class="form-label">Level</label>
@@ -153,14 +153,12 @@ onBeforeUnmount(() => disconnect(false))
       </div>
       <div class="col-sm-4 col-lg-2">
         <div class="form-check pt-sm-4">
-          <input id="auto-scroll" v-model="autoScroll" class="form-check-input" type="checkbox"/>
+          <input id="auto-scroll" v-model="autoScroll" class="form-check-input" type="checkbox" />
           <label class="form-check-label" for="auto-scroll">Auto-scroll</label>
         </div>
       </div>
       <div class="col-sm-4 col-lg-4 d-flex gap-2 justify-content-sm-end">
-        <button class="btn btn-outline-secondary" @click="clearLines">
-          <i class="bi bi-trash me-1"></i>Clear
-        </button>
+        <button class="btn btn-outline-secondary" @click="clearLines"><i class="bi bi-trash me-1"></i>Clear</button>
         <button class="btn btn-outline-primary" @click="toggleStreaming">
           <i :class="['bi', status === 'Connected' ? 'bi-pause-circle' : 'bi-play-circle', 'me-1']"></i>
           {{ status === 'Connected' ? 'Pause' : 'Resume' }}

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
-import { apiFetch } from '../api.js'
+import {apiFetch} from '../api.js'
 
 const data = ref(null)
 const filter = ref('')
@@ -15,7 +15,7 @@ const filtered = computed(() => {
   if (!data.value) return []
   if (!filter.value) return data.value.loggers
   const f = filter.value.toLowerCase()
-  return data.value.loggers.filter(l => l.name.toLowerCase().includes(f))
+  return data.value.loggers.filter((l) => l.name.toLowerCase().includes(f))
 })
 
 async function changeLevel(logger, level) {
@@ -27,7 +27,7 @@ async function changeLevel(logger, level) {
   })
   if (res.ok) {
     const updated = await res.json()
-    const i = data.value.loggers.findIndex(l => l.name === logger.name)
+    const i = data.value.loggers.findIndex((l) => l.name === logger.name)
     if (i >= 0) data.value.loggers[i] = updated
     message.value = 'Level updated for ' + logger.name
     setTimeout(() => {
@@ -36,15 +36,16 @@ async function changeLevel(logger, level) {
   }
 }
 
-const levelClass = l => ({
-  TRACE: 'text-secondary',
-  DEBUG: 'text-info',
-  INFO: 'text-success',
-  WARN: 'text-warning',
-  ERROR: 'text-danger',
-  FATAL: 'text-danger fw-bold',
-  OFF: 'text-muted'
-}[l] || 'text-secondary')
+const levelClass = (l) =>
+  ({
+    TRACE: 'text-secondary',
+    DEBUG: 'text-info',
+    INFO: 'text-success',
+    WARN: 'text-warning',
+    ERROR: 'text-danger',
+    FATAL: 'text-danger fw-bold',
+    OFF: 'text-muted'
+  })[l] || 'text-secondary'
 
 onMounted(load)
 </script>
@@ -53,39 +54,45 @@ onMounted(load)
   <div>
     <h2><i class="bi bi-journal-text me-2"></i>Loggers</h2>
     <div v-if="message" class="alert alert-success">{{ message }}</div>
-    <input v-model="filter" class="form-control mb-3" placeholder="Filter loggers by name…"/>
+    <input v-model="filter" class="form-control mb-3" placeholder="Filter loggers by name…" />
     <div class="table-responsive">
       <table class="table table-sm table-hover loggers-table">
         <colgroup>
-          <col class="loggers-table-name"/>
-          <col class="loggers-table-level"/>
-          <col class="loggers-table-level"/>
-          <col class="loggers-table-actions"/>
+          <col class="loggers-table-name" />
+          <col class="loggers-table-level" />
+          <col class="loggers-table-level" />
+          <col class="loggers-table-actions" />
         </colgroup>
         <thead>
-        <tr>
-          <th>Logger</th>
-          <th>Configured</th>
-          <th>Effective</th>
-          <th>Set level</th>
-        </tr>
+          <tr>
+            <th>Logger</th>
+            <th>Configured</th>
+            <th>Effective</th>
+            <th>Set level</th>
+          </tr>
         </thead>
         <tbody>
-        <tr v-for="l in filtered" :key="l.name">
-          <td><code :title="l.name" class="text-truncate d-block">{{ l.name }}</code></td>
-          <td :class="levelClass(l.configuredLevel)">{{ l.configuredLevel || '—' }}</td>
-          <td :class="levelClass(l.effectiveLevel)">{{ l.effectiveLevel || '—' }}</td>
-          <td>
-            <div class="btn-group btn-group-sm">
-              <button v-for="lvl in data.availableLevels" :key="lvl"
-                      :class="{ active: l.configuredLevel === lvl }"
-                      class="btn btn-outline-secondary"
-                      @click="changeLevel(l, lvl)">{{ lvl }}
-              </button>
-              <button class="btn btn-outline-secondary" title="Reset" @click="changeLevel(l, null)">↺</button>
-            </div>
-          </td>
-        </tr>
+          <tr v-for="l in filtered" :key="l.name">
+            <td>
+              <code :title="l.name" class="text-truncate d-block">{{ l.name }}</code>
+            </td>
+            <td :class="levelClass(l.configuredLevel)">{{ l.configuredLevel || '—' }}</td>
+            <td :class="levelClass(l.effectiveLevel)">{{ l.effectiveLevel || '—' }}</td>
+            <td>
+              <div class="btn-group btn-group-sm">
+                <button
+                  v-for="lvl in data.availableLevels"
+                  :key="lvl"
+                  :class="{active: l.configuredLevel === lvl}"
+                  class="btn btn-outline-secondary"
+                  @click="changeLevel(l, lvl)"
+                >
+                  {{ lvl }}
+                </button>
+                <button class="btn btn-outline-secondary" title="Reset" @click="changeLevel(l, null)">↺</button>
+              </div>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/bootui-ui/src/main/frontend/src/views/Mappings.vue
+++ b/bootui-ui/src/main/frontend/src/views/Mappings.vue
@@ -23,8 +23,8 @@ const flat = computed(() => {
         const conds = h.details?.requestMappingConditions || {}
         const patterns = conds.patterns || []
         const methods = conds.methods || ['ANY']
-        for (const pattern of (patterns.length ? patterns : ['(any)'])) {
-          for (const method of (methods.length ? methods : ['ANY'])) {
+        for (const pattern of patterns.length ? patterns : ['(any)']) {
+          for (const method of methods.length ? methods : ['ANY']) {
             rows.push({method, pattern, handler: h.handler, predicate: h.predicate})
           }
         }
@@ -33,16 +33,23 @@ const flat = computed(() => {
   }
   if (!filter.value) return rows
   const f = filter.value.toLowerCase()
-  return rows.filter(r =>
-    (r.pattern || '').toLowerCase().includes(f) ||
-    (r.handler || '').toLowerCase().includes(f) ||
-    (r.method || '').toLowerCase().includes(f))
+  return rows.filter(
+    (r) =>
+      (r.pattern || '').toLowerCase().includes(f) ||
+      (r.handler || '').toLowerCase().includes(f) ||
+      (r.method || '').toLowerCase().includes(f)
+  )
 })
 
-const methodClass = m => ({
-  GET: 'bg-success', POST: 'bg-primary', PUT: 'bg-warning text-dark',
-  DELETE: 'bg-danger', PATCH: 'bg-info text-dark', ANY: 'bg-secondary'
-}[m] || 'bg-secondary')
+const methodClass = (m) =>
+  ({
+    GET: 'bg-success',
+    POST: 'bg-primary',
+    PUT: 'bg-warning text-dark',
+    DELETE: 'bg-danger',
+    PATCH: 'bg-info text-dark',
+    ANY: 'bg-secondary'
+  })[m] || 'bg-secondary'
 
 onMounted(load)
 </script>
@@ -50,22 +57,28 @@ onMounted(load)
 <template>
   <div>
     <h2><i class="bi bi-signpost-2 me-2"></i>HTTP mappings</h2>
-    <input v-model="filter" class="form-control mb-3" placeholder="Filter…"/>
+    <input v-model="filter" class="form-control mb-3" placeholder="Filter…" />
     <div class="table-responsive">
       <table class="table table-sm table-hover">
         <thead>
-        <tr>
-          <th style="width:90px">Method</th>
-          <th>Pattern</th>
-          <th>Handler</th>
-        </tr>
+          <tr>
+            <th style="width: 90px">Method</th>
+            <th>Pattern</th>
+            <th>Handler</th>
+          </tr>
         </thead>
         <tbody>
-        <tr v-for="(r, i) in flat" :key="i">
-          <td><span :class="methodClass(r.method)" class="badge">{{ r.method }}</span></td>
-          <td><code>{{ r.pattern }}</code></td>
-          <td><small>{{ r.handler }}</small></td>
-        </tr>
+          <tr v-for="(r, i) in flat" :key="i">
+            <td>
+              <span :class="methodClass(r.method)" class="badge">{{ r.method }}</span>
+            </td>
+            <td>
+              <code>{{ r.pattern }}</code>
+            </td>
+            <td>
+              <small>{{ r.handler }}</small>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -111,7 +111,7 @@ const breakdown = computed(() => {
     {key: 'headroom', label: 'Headroom', bytes: c.headRoomBytes, color: '#6c757d'}
   ]
   const total = segments.reduce((sum, s) => sum + Math.max(0, s.bytes || 0), 0)
-  return segments.map(s => ({
+  return segments.map((s) => ({
     ...s,
     bytes: Math.max(0, s.bytes || 0),
     percent: total > 0 ? (Math.max(0, s.bytes || 0) / total) * 100 : 0
@@ -158,10 +158,9 @@ onBeforeUnmount(() => {
         </div>
         <div class="card-body">
           <p class="text-muted small mb-3">
-            Inspired by the Paketo <code>libjvm</code> memory calculator.
-            Heap is whatever is left after subtracting metaspace (sized from
-            currently loaded classes × 1.25 safety factor), code cache, direct
-            memory, thread stacks, and headroom from your target memory.
+            Inspired by the Paketo <code>libjvm</code> memory calculator. Heap is whatever is left after subtracting
+            metaspace (sized from currently loaded classes × 1.25 safety factor), code cache, direct memory, thread
+            stacks, and headroom from your target memory.
           </p>
 
           <div class="row g-3 mb-3">
@@ -179,7 +178,8 @@ onBeforeUnmount(() => {
                   step="64"
                   type="number"
                 />
-                <button aria-label="Increase" class="btn btn-outline-secondary" type="button" @click="stepTotal(64)">+
+                <button aria-label="Increase" class="btn btn-outline-secondary" type="button" @click="stepTotal(64)">
+                  +
                 </button>
                 <span class="input-group-text">MB</span>
               </div>
@@ -187,9 +187,7 @@ onBeforeUnmount(() => {
             <div class="col-md-4">
               <label class="form-label small fw-semibold">
                 Thread count
-                <span class="text-muted fw-normal">
-                  (currently {{ data.calculation.liveThreadCount }})
-                </span>
+                <span class="text-muted fw-normal"> (currently {{ data.calculation.liveThreadCount }}) </span>
               </label>
               <input
                 v-model.number="threadCount"
@@ -218,11 +216,11 @@ onBeforeUnmount(() => {
           </div>
 
           <template v-else>
-            <div aria-label="Memory breakdown" class="progress breakdown-bar mb-2" role="img" style="height: 24px;">
+            <div aria-label="Memory breakdown" class="progress breakdown-bar mb-2" role="img" style="height: 24px">
               <div
                 v-for="seg in breakdown"
                 :key="seg.key"
-                :style="{ width: seg.percent + '%', backgroundColor: seg.color }"
+                :style="{width: seg.percent + '%', backgroundColor: seg.color}"
                 :title="seg.label + ': ' + formatBytes(seg.bytes)"
                 class="progress-bar"
               >
@@ -231,14 +229,14 @@ onBeforeUnmount(() => {
             </div>
             <div class="d-flex flex-wrap gap-3 small mb-2">
               <div v-for="seg in breakdown" :key="'leg-' + seg.key" class="d-flex align-items-center">
-                <span :style="{ backgroundColor: seg.color }" class="legend-swatch me-1"></span>
+                <span :style="{backgroundColor: seg.color}" class="legend-swatch me-1"></span>
                 <span class="text-muted me-1">{{ seg.label }}:</span>
                 <span class="fw-semibold">{{ formatBytes(seg.bytes) }}</span>
               </div>
             </div>
             <div class="small text-muted">
-              Currently {{ data.calculation.liveLoadedClassCount.toLocaleString() }} classes loaded ·
-              metaspace sized for {{ data.calculation.loadedClasses.toLocaleString() }} classes × 1.25 safety factor
+              Currently {{ data.calculation.liveLoadedClassCount.toLocaleString() }} classes loaded · metaspace sized
+              for {{ data.calculation.loadedClasses.toLocaleString() }} classes × 1.25 safety factor
             </div>
           </template>
         </div>
@@ -249,7 +247,7 @@ onBeforeUnmount(() => {
         <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
           <span><i class="bi bi-rocket-takeoff me-2"></i>Recommended JVM Options</span>
           <button
-            :class="{ 'btn-success': copied }"
+            :class="{'btn-success': copied}"
             :disabled="!data.calculation || !data.calculation.valid"
             class="btn btn-sm btn-light"
             @click="copyOptions"
@@ -260,11 +258,11 @@ onBeforeUnmount(() => {
         </div>
         <div class="card-body">
           <p class="text-muted small mb-2">
-            Generated from your calculator inputs. <code>-Xms == -Xmx</code> for predictable container startup;
-            GC picked automatically (G1 below 4 GB, ZGC above).
+            Generated from your calculator inputs. <code>-Xms == -Xmx</code> for predictable container startup; GC
+            picked automatically (G1 below 4 GB, ZGC above).
           </p>
           <pre
-            :class="{ 'opacity-50': data.calculation && !data.calculation.valid }"
+            :class="{'opacity-50': data.calculation && !data.calculation.valid}"
             class="bg-dark text-light rounded p-3 mb-0 options-box"
           ><code>{{ data.suggestedJvmOptions || '—' }}</code></pre>
           <div class="mt-2">
@@ -287,10 +285,16 @@ onBeforeUnmount(() => {
                 <span class="text-muted small">Used</span>
                 <span class="fw-semibold">{{ formatBytes(data.heap.usedBytes) }}</span>
               </div>
-              <div class="progress mb-3" style="height: 10px;">
-                <div :aria-valuenow="data.heap.usedPercent" :class="progressClass(data.heap.usedPercent)"
-                     :style="{ width: data.heap.usedPercent + '%' }" aria-valuemax="100"
-                     aria-valuemin="0" class="progress-bar" role="progressbar"></div>
+              <div class="progress mb-3" style="height: 10px">
+                <div
+                  :aria-valuenow="data.heap.usedPercent"
+                  :class="progressClass(data.heap.usedPercent)"
+                  :style="{width: data.heap.usedPercent + '%'}"
+                  aria-valuemax="100"
+                  aria-valuemin="0"
+                  class="progress-bar"
+                  role="progressbar"
+                ></div>
               </div>
               <div class="row text-center g-2">
                 <div class="col-4">
@@ -307,9 +311,7 @@ onBeforeUnmount(() => {
                 </div>
               </div>
             </div>
-            <div class="card-footer text-muted small">
-              {{ data.heap.usedPercent }}% of max used
-            </div>
+            <div class="card-footer text-muted small">{{ data.heap.usedPercent }}% of max used</div>
           </div>
         </div>
 
@@ -324,10 +326,15 @@ onBeforeUnmount(() => {
                 <span class="text-muted small">Used</span>
                 <span class="fw-semibold">{{ formatBytes(data.nonHeap.usedBytes) }}</span>
               </div>
-              <div class="progress mb-3" style="height: 10px;">
-                <div :aria-valuenow="data.nonHeap.usedPercent"
-                     :style="{ width: Math.min(data.nonHeap.usedPercent, 100) + '%' }" aria-valuemax="100"
-                     aria-valuemin="0" class="progress-bar bg-info" role="progressbar"></div>
+              <div class="progress mb-3" style="height: 10px">
+                <div
+                  :aria-valuenow="data.nonHeap.usedPercent"
+                  :style="{width: Math.min(data.nonHeap.usedPercent, 100) + '%'}"
+                  aria-valuemax="100"
+                  aria-valuemin="0"
+                  class="progress-bar bg-info"
+                  role="progressbar"
+                ></div>
               </div>
               <div class="row text-center g-2">
                 <div class="col-4">
@@ -346,9 +353,7 @@ onBeforeUnmount(() => {
                 </div>
               </div>
             </div>
-            <div class="card-footer text-muted small">
-              Metaspace, code cache, and JIT buffers
-            </div>
+            <div class="card-footer text-muted small">Metaspace, code cache, and JIT buffers</div>
           </div>
         </div>
       </div>
@@ -359,30 +364,36 @@ onBeforeUnmount(() => {
         <div class="table-responsive">
           <table class="table table-sm table-hover mb-0">
             <thead class="table-light">
-            <tr>
-              <th>Pool</th>
-              <th class="text-end">Used</th>
-              <th class="text-end">Committed</th>
-              <th class="text-end">Max</th>
-              <th style="width:140px">Usage</th>
-            </tr>
+              <tr>
+                <th>Pool</th>
+                <th class="text-end">Used</th>
+                <th class="text-end">Committed</th>
+                <th class="text-end">Max</th>
+                <th style="width: 140px">Usage</th>
+              </tr>
             </thead>
             <tbody>
-            <tr v-for="pool in data.pools" :key="pool.name">
-              <td><code>{{ pool.name }}</code></td>
-              <td class="text-end">{{ formatBytes(pool.usedBytes) }}</td>
-              <td class="text-end">{{ formatBytes(pool.committedBytes) }}</td>
-              <td class="text-end">{{ pool.maxBytes < 0 ? '∞' : formatBytes(pool.maxBytes) }}</td>
-              <td>
-                <div class="d-flex align-items-center gap-2">
-                  <div class="progress flex-grow-1" style="height: 6px;">
-                    <div :class="progressClass(pool.usedPercent)" :style="{ width: Math.min(pool.usedPercent, 100) + '%' }"
-                         class="progress-bar" role="progressbar"></div>
+              <tr v-for="pool in data.pools" :key="pool.name">
+                <td>
+                  <code>{{ pool.name }}</code>
+                </td>
+                <td class="text-end">{{ formatBytes(pool.usedBytes) }}</td>
+                <td class="text-end">{{ formatBytes(pool.committedBytes) }}</td>
+                <td class="text-end">{{ pool.maxBytes < 0 ? '∞' : formatBytes(pool.maxBytes) }}</td>
+                <td>
+                  <div class="d-flex align-items-center gap-2">
+                    <div class="progress flex-grow-1" style="height: 6px">
+                      <div
+                        :class="progressClass(pool.usedPercent)"
+                        :style="{width: Math.min(pool.usedPercent, 100) + '%'}"
+                        class="progress-bar"
+                        role="progressbar"
+                      ></div>
+                    </div>
+                    <span class="text-muted small" style="width: 32px; text-align: right">{{ pool.usedPercent }}%</span>
                   </div>
-                  <span class="text-muted small" style="width: 32px; text-align: right;">{{ pool.usedPercent }}%</span>
-                </div>
-              </td>
-            </tr>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -392,7 +403,8 @@ onBeforeUnmount(() => {
       <div v-if="data.jvmInputArguments && data.jvmInputArguments.length" class="card">
         <div class="card-header"><i class="bi bi-terminal me-2"></i>Current JVM Arguments</div>
         <div class="card-body">
-          <div v-if="data.jvmInputArguments.length === 0" class="text-muted small">No JVM arguments passed at startup.
+          <div v-if="data.jvmInputArguments.length === 0" class="text-muted small">
+            No JVM arguments passed at startup.
           </div>
           <ul v-else class="list-unstyled mb-0">
             <li v-for="arg in data.jvmInputArguments" :key="arg" class="mb-1">
@@ -433,4 +445,3 @@ onBeforeUnmount(() => {
   border-radius: 2px;
 }
 </style>
-

--- a/bootui-ui/src/main/frontend/src/views/Metrics.vue
+++ b/bootui-ui/src/main/frontend/src/views/Metrics.vue
@@ -19,9 +19,8 @@ const filteredMeters = computed(() => {
   if (!data.value) return []
   const q = search.value.trim().toLowerCase()
   return data.value.meters.filter((meter) => {
-    const matchesSearch = !q ||
-      meter.name.toLowerCase().includes(q) ||
-      (meter.description || '').toLowerCase().includes(q)
+    const matchesSearch =
+      !q || meter.name.toLowerCase().includes(q) || (meter.description || '').toLowerCase().includes(q)
     const matchesType = !typeFilter.value || meter.type === typeFilter.value
     return matchesSearch && matchesType
   })
@@ -34,8 +33,10 @@ const metricTypes = computed(() => {
 
 const selectedMeasurement = computed(() => {
   if (!detail.value?.measurements?.length) return null
-  return detail.value.measurements.find((measurement) => measurement.statistic === selectedStatistic.value) ||
+  return (
+    detail.value.measurements.find((measurement) => measurement.statistic === selectedStatistic.value) ||
     detail.value.measurements[0]
+  )
 })
 
 const chartPath = computed(() => {
@@ -45,11 +46,13 @@ const chartPath = computed(() => {
   const min = Math.min(...values)
   const max = Math.max(...values)
   const span = max - min || 1
-  return points.map((point, index) => {
-    const x = (index / (points.length - 1)) * 100
-    const y = 44 - ((point.value - min) / span) * 36
-    return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`
-  }).join(' ')
+  return points
+    .map((point, index) => {
+      const x = (index / (points.length - 1)) * 100
+      const y = 44 - ((point.value - min) / span) * 36
+      return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`
+    })
+    .join(' ')
 })
 
 function formatNumber(value) {
@@ -128,9 +131,11 @@ async function loadMetrics() {
 }
 
 function preferredInitialMeter(meters) {
-  return meters.find((meter) => meter.name === 'jvm.memory.used')?.name ||
+  return (
+    meters.find((meter) => meter.name === 'jvm.memory.used')?.name ||
     meters.find((meter) => meter.name === 'process.uptime')?.name ||
     meters[0].name
+  )
 }
 
 async function loadDetail() {
@@ -160,10 +165,7 @@ async function loadDetail() {
 
 function appendHistoryPoint() {
   if (!selectedMeasurement.value) return
-  history.value = [
-    ...history.value,
-    {timestamp: Date.now(), value: selectedMeasurement.value.value}
-  ].slice(-60)
+  history.value = [...history.value, {timestamp: Date.now(), value: selectedMeasurement.value.value}].slice(-60)
 }
 
 function scheduleNextPoll() {
@@ -213,7 +215,7 @@ onBeforeUnmount(() => {
               <div class="text-muted small">{{ filteredMeters.length }} of {{ data.total }} meters</div>
             </div>
             <div class="card-body border-bottom">
-              <input v-model="search" class="form-control form-control-sm mb-2" placeholder="Search meters">
+              <input v-model="search" class="form-control form-control-sm mb-2" placeholder="Search meters" />
               <select v-model="typeFilter" class="form-select form-select-sm">
                 <option value="">All meter types</option>
                 <option v-for="type in metricTypes" :key="type" :value="type">{{ type }}</option>
@@ -223,10 +225,11 @@ onBeforeUnmount(() => {
               <button
                 v-for="meter in filteredMeters"
                 :key="meter.name"
-                :class="{ active: meter.name === selectedName }"
+                :class="{active: meter.name === selectedName}"
                 class="list-group-item list-group-item-action"
                 type="button"
-                @click="selectMeter(meter.name)">
+                @click="selectMeter(meter.name)"
+              >
                 <div class="d-flex justify-content-between align-items-start gap-2">
                   <code class="meter-name">{{ meter.name }}</code>
                   <span class="badge text-bg-light">{{ meter.type }}</span>
@@ -256,8 +259,11 @@ onBeforeUnmount(() => {
                 <div class="col-md-4">
                   <label class="form-label small text-muted">Statistic</label>
                   <select :value="selectedStatistic" class="form-select" @change="changeStatistic">
-                    <option v-for="measurement in detail.measurements" :key="measurement.statistic"
-                            :value="measurement.statistic">
+                    <option
+                      v-for="measurement in detail.measurements"
+                      :key="measurement.statistic"
+                      :value="measurement.statistic"
+                    >
                       {{ measurement.statistic }}
                     </option>
                   </select>
@@ -266,12 +272,17 @@ onBeforeUnmount(() => {
                 </div>
                 <div class="col-md-8">
                   <div class="chart-box">
-                    <svg aria-label="Live metric value graph" preserveAspectRatio="none" role="img"
-                         viewBox="0 0 100 48">
-                      <line class="chart-axis" x1="0" x2="100" y1="44" y2="44"/>
-                      <path v-if="chartPath" :d="chartPath" class="chart-line"/>
+                    <svg
+                      aria-label="Live metric value graph"
+                      preserveAspectRatio="none"
+                      role="img"
+                      viewBox="0 0 100 48"
+                    >
+                      <line class="chart-axis" x1="0" x2="100" y1="44" y2="44" />
+                      <path v-if="chartPath" :d="chartPath" class="chart-line" />
                     </svg>
-                    <div v-if="history.length < 2" class="chart-empty text-muted small">Waiting for another sample…
+                    <div v-if="history.length < 2" class="chart-empty text-muted small">
+                      Waiting for another sample…
                     </div>
                   </div>
                 </div>
@@ -282,8 +293,8 @@ onBeforeUnmount(() => {
           <div v-if="detail" class="card mb-3">
             <div class="card-header d-flex justify-content-between align-items-center">
               <span>Tag filters</span>
-              <button v-if="selectedTags.length" class="btn btn-sm btn-outline-secondary" @click="clearTags">Clear
-                filters
+              <button v-if="selectedTags.length" class="btn btn-sm btn-outline-secondary" @click="clearTags">
+                Clear filters
               </button>
             </div>
             <div class="card-body">
@@ -297,7 +308,8 @@ onBeforeUnmount(() => {
                     :class="isTagSelected(tag.key, value) ? 'btn-primary' : 'btn-outline-primary'"
                     class="btn btn-sm"
                     type="button"
-                    @click="toggleTag(tag.key, value)">
+                    @click="toggleTag(tag.key, value)"
+                  >
                     {{ value || '(empty)' }}
                   </button>
                   <span v-if="tag.truncated" class="badge text-bg-warning">first 100 shown</span>
@@ -314,29 +326,29 @@ onBeforeUnmount(() => {
             <div class="table-responsive">
               <table class="table table-sm table-hover mb-0">
                 <thead class="table-light">
-                <tr>
-                  <th>Tags</th>
-                  <th>Measurements</th>
-                </tr>
+                  <tr>
+                    <th>Tags</th>
+                    <th>Measurements</th>
+                  </tr>
                 </thead>
                 <tbody>
-                <tr v-for="(sample, index) in detail.samples" :key="index">
-                  <td>
-                    <span v-if="!sample.tags.length" class="text-muted">none</span>
-                    <span v-for="tag in sample.tags" :key="tagLabel(tag)" class="badge text-bg-light me-1">
+                  <tr v-for="(sample, index) in detail.samples" :key="index">
+                    <td>
+                      <span v-if="!sample.tags.length" class="text-muted">none</span>
+                      <span v-for="tag in sample.tags" :key="tagLabel(tag)" class="badge text-bg-light me-1">
                         {{ tag.key }}={{ tag.value || '(empty)' }}
                       </span>
-                  </td>
-                  <td>
+                    </td>
+                    <td>
                       <span v-for="measurement in sample.measurements" :key="measurement.statistic" class="me-3">
                         <span class="text-muted">{{ measurement.statistic }}</span>
                         <code>{{ formatNumber(measurement.value) }}</code>
                       </span>
-                  </td>
-                </tr>
-                <tr v-if="!detail.samples.length">
-                  <td class="text-muted" colspan="2">No samples match the selected tag filters.</td>
-                </tr>
+                    </td>
+                  </tr>
+                  <tr v-if="!detail.samples.length">
+                    <td class="text-muted" colspan="2">No samples match the selected tag filters.</td>
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -101,8 +101,8 @@ onMounted(load)
         </span>
         <h2>Understand your Spring Boot app in minutes</h2>
         <p>
-          BootUI turns the local runtime into a guided map of profiles, ports,
-          safety status, Actuator-backed diagnostics, and the panels that explain how the app is wired.
+          BootUI turns the local runtime into a guided map of profiles, ports, safety status, Actuator-backed
+          diagnostics, and the panels that explain how the app is wired.
         </p>
       </div>
       <div class="hero-actions">
@@ -115,7 +115,7 @@ onMounted(load)
           BootUI GitHub project
         </a>
         <button :disabled="loading" class="btn btn-light hero-refresh" @click="load">
-          <i :class="{ 'spin': loading }" class="bi bi-arrow-clockwise me-1"></i>
+          <i :class="{spin: loading}" class="bi bi-arrow-clockwise me-1"></i>
           Refresh snapshot
         </button>
       </div>
@@ -128,7 +128,7 @@ onMounted(load)
     <template v-else-if="data">
       <div class="row g-3 mb-4">
         <div v-for="(stat, index) in stats" :key="stat.label" class="col-xl-3 col-md-6">
-          <div :style="{ animationDelay: `${index * 70}ms` }" class="metric-card h-100">
+          <div :style="{animationDelay: `${index * 70}ms`}" class="metric-card h-100">
             <span :class="['metric-icon', `metric-${stat.tone}`]">
               <i :class="['bi', stat.icon]"></i>
             </span>
@@ -151,7 +151,7 @@ onMounted(load)
                   <h3 class="h4 fw-bold mb-1">{{ data.applicationName }}</h3>
                   <div class="text-muted">{{ data.webApplicationType }} · context {{ data.contextPath || '/' }}</div>
                 </div>
-                <span :class="{ disabled: !data.activation.enabled }" class="activation-badge">
+                <span :class="{disabled: !data.activation.enabled}" class="activation-badge">
                   <i :class="['bi', data.activation.enabled ? 'bi-lightning-charge-fill' : 'bi-power']"></i>
                   {{ data.activation.enabled ? 'Enabled' : 'Disabled' }}
                 </span>
@@ -212,27 +212,37 @@ onMounted(load)
                   <span></span>
                   <div>
                     <strong>Development activation</strong>
-                    <p>{{
-                        data.activation.enabled ? 'BootUI is available for this runtime.' : 'BootUI reports disabled state for this runtime.'
-                      }}</p>
+                    <p>
+                      {{
+                        data.activation.enabled
+                          ? 'BootUI is available for this runtime.'
+                          : 'BootUI reports disabled state for this runtime.'
+                      }}
+                    </p>
                   </div>
                 </div>
-                <div :class="{ complete: data.activation.localhostOnly }" class="timeline-item">
+                <div :class="{complete: data.activation.localhostOnly}" class="timeline-item">
                   <span></span>
                   <div>
                     <strong>Loopback enforcement</strong>
-                    <p>{{
-                        data.activation.localhostOnly ? 'Non-local requests are rejected by default.' : 'Non-local access is explicitly allowed.'
-                      }}</p>
+                    <p>
+                      {{
+                        data.activation.localhostOnly
+                          ? 'Non-local requests are rejected by default.'
+                          : 'Non-local access is explicitly allowed.'
+                      }}
+                    </p>
                   </div>
                 </div>
-                <div :class="{ warning: warningCount }" class="timeline-item">
+                <div :class="{warning: warningCount}" class="timeline-item">
                   <span></span>
                   <div>
                     <strong>Warnings</strong>
-                    <p>{{
+                    <p>
+                      {{
                         warningCount ? `${warningCount} warning(s) need review.` : 'No activation warnings reported.'
-                      }}</p>
+                      }}
+                    </p>
                   </div>
                 </div>
               </div>
@@ -275,8 +285,9 @@ onMounted(load)
 <style scoped>
 .overview-hero {
   align-items: flex-start;
-  background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.38), transparent 18rem),
-  linear-gradient(135deg, #16794c, #0d6efd);
+  background:
+    radial-gradient(circle at top right, rgba(255, 255, 255, 0.38), transparent 18rem),
+    linear-gradient(135deg, #16794c, #0d6efd);
   border-radius: 1.4rem;
   box-shadow: 0 1.5rem 3.5rem rgba(13, 110, 253, 0.22);
   color: #fff;
@@ -291,7 +302,7 @@ onMounted(load)
 .overview-hero::after {
   animation: sweep 5s ease-in-out infinite;
   background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.18), transparent);
-  content: "";
+  content: '';
   height: 150%;
   position: absolute;
   right: 12%;
@@ -376,7 +387,9 @@ onMounted(load)
   display: flex;
   gap: 0.85rem;
   padding: 1rem;
-  transition: transform 180ms ease, box-shadow 180ms ease;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
 }
 
 .metric-card > div {
@@ -441,8 +454,9 @@ onMounted(load)
 }
 
 .app-map-card {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.74)),
-  radial-gradient(circle at top right, rgba(25, 135, 84, 0.12), transparent 18rem);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.74)),
+    radial-gradient(circle at top right, rgba(25, 135, 84, 0.12), transparent 18rem);
 }
 
 .activation-badge {
@@ -562,7 +576,10 @@ onMounted(load)
   gap: 0.85rem;
   height: 100%;
   padding: 1rem;
-  transition: background 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+  transition:
+    background 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
 }
 
 .quick-link-card:hover {

--- a/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
+++ b/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
@@ -24,13 +24,14 @@ const filteredSources = computed(() => {
   if (!data.value) return []
   const f = filter.value.toLowerCase()
   if (!f) return data.value.profileSources
-  return data.value.profileSources.map(source => ({
-    ...source,
-    properties: source.properties.filter(p =>
-      p.name.toLowerCase().includes(f) ||
-      (p.value != null && String(p.value).toLowerCase().includes(f))
-    )
-  })).filter(source => source.properties.length > 0)
+  return data.value.profileSources
+    .map((source) => ({
+      ...source,
+      properties: source.properties.filter(
+        (p) => p.name.toLowerCase().includes(f) || (p.value != null && String(p.value).toLowerCase().includes(f))
+      )
+    }))
+    .filter((source) => source.properties.length > 0)
 })
 
 onMounted(load)
@@ -56,7 +57,7 @@ onMounted(load)
         <span v-else class="text-muted small">(none)</span>
       </div>
 
-      <input v-model="filter" class="form-control mb-3" placeholder="Filter by property name or value…"/>
+      <input v-model="filter" class="form-control mb-3" placeholder="Filter by property name or value…" />
 
       <div v-if="filteredSources.length === 0" class="alert alert-info">
         <i class="bi bi-info-circle me-1"></i>
@@ -73,19 +74,21 @@ onMounted(load)
         <div class="table-responsive">
           <table class="table table-sm table-hover mb-0">
             <thead class="table-light">
-            <tr>
-              <th style="width:40%">Property</th>
-              <th>Value</th>
-            </tr>
+              <tr>
+                <th style="width: 40%">Property</th>
+                <th>Value</th>
+              </tr>
             </thead>
             <tbody>
-            <tr v-for="prop in source.properties" :key="prop.name">
-              <td><code>{{ prop.name }}</code></td>
-              <td>
-                <span v-if="prop.masked" class="text-muted font-monospace">••••••••</span>
-                <span v-else class="font-monospace">{{ prop.value ?? '(null)' }}</span>
-              </td>
-            </tr>
+              <tr v-for="prop in source.properties" :key="prop.name">
+                <td>
+                  <code>{{ prop.name }}</code>
+                </td>
+                <td>
+                  <span v-if="prop.masked" class="text-muted font-monospace">••••••••</span>
+                  <span v-else class="font-monospace">{{ prop.value ?? '(null)' }}</span>
+                </td>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/bootui-ui/src/main/frontend/src/views/Scheduled.vue
+++ b/bootui-ui/src/main/frontend/src/views/Scheduled.vue
@@ -24,18 +24,19 @@ const filtered = computed(() => {
   if (!report.value) return []
   const value = filter.value.trim().toLowerCase()
   if (!value) return report.value.tasks
-  return report.value.tasks.filter(task =>
-    (task.runnable || '').toLowerCase().includes(value)
-    || (task.expression || '').toLowerCase().includes(value)
+  return report.value.tasks.filter(
+    (task) =>
+      (task.runnable || '').toLowerCase().includes(value) || (task.expression || '').toLowerCase().includes(value)
   )
 })
 
-const triggerBadgeClass = triggerType => ({
-  CRON: 'bg-info text-dark',
-  FIXED_RATE: 'bg-success',
-  FIXED_DELAY: 'bg-warning text-dark',
-  ONE_SHOT: 'bg-secondary'
-}[triggerType] || 'bg-secondary')
+const triggerBadgeClass = (triggerType) =>
+  ({
+    CRON: 'bg-info text-dark',
+    FIXED_RATE: 'bg-success',
+    FIXED_DELAY: 'bg-warning text-dark',
+    ONE_SHOT: 'bg-secondary'
+  })[triggerType] || 'bg-secondary'
 
 function formatDuration(value, timeUnit) {
   if (value === null || value === undefined) return '—'
@@ -69,17 +70,11 @@ onMounted(load)
     <div v-else-if="report && !report.schedulingPresent" class="alert alert-info">
       No Spring Scheduling detected on the classpath.
     </div>
-    <div v-else-if="report && report.total === 0" class="alert alert-secondary">
-      No scheduled tasks registered.
-    </div>
+    <div v-else-if="report && report.total === 0" class="alert alert-secondary">No scheduled tasks registered.</div>
     <template v-else-if="report">
       <div class="row g-2 mb-3">
         <div class="col-md-8">
-          <input
-            v-model="filter"
-            class="form-control"
-            placeholder="Filter by runnable name or expression…"
-          />
+          <input v-model="filter" class="form-control" placeholder="Filter by runnable name or expression…" />
         </div>
         <div class="col-md-4 text-end small text-muted align-self-center">
           {{ filtered.length }} / {{ report.total }} tasks
@@ -89,23 +84,27 @@ onMounted(load)
       <div class="table-responsive">
         <table class="table table-sm table-hover align-middle">
           <thead>
-          <tr>
-            <th>Runnable</th>
-            <th style="width: 150px">Trigger Type</th>
-            <th style="width: 180px">Expression/Interval</th>
-            <th style="width: 160px">Initial Delay</th>
-          </tr>
+            <tr>
+              <th>Runnable</th>
+              <th style="width: 150px">Trigger Type</th>
+              <th style="width: 180px">Expression/Interval</th>
+              <th style="width: 160px">Initial Delay</th>
+            </tr>
           </thead>
           <tbody>
-          <tr v-for="(task, index) in filtered"
-              :key="`${task.runnable}-${task.triggerType}-${task.expression}-${index}`">
-            <td><code>{{ task.runnable }}</code></td>
-            <td>
-              <span :class="triggerBadgeClass(task.triggerType)" class="badge">{{ task.triggerType }}</span>
-            </td>
-            <td>{{ formatExpression(task) }}</td>
-            <td>{{ formatDuration(task.initialDelayMs, task.timeUnit) }}</td>
-          </tr>
+            <tr
+              v-for="(task, index) in filtered"
+              :key="`${task.runnable}-${task.triggerType}-${task.expression}-${index}`"
+            >
+              <td>
+                <code>{{ task.runnable }}</code>
+              </td>
+              <td>
+                <span :class="triggerBadgeClass(task.triggerType)" class="badge">{{ task.triggerType }}</span>
+              </td>
+              <td>{{ formatExpression(task) }}</td>
+              <td>{{ formatDuration(task.initialDelayMs, task.timeUnit) }}</td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -69,7 +69,7 @@ async function explain() {
 
 const httpMethods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS']
 
-const filterBadgeClass = name => {
+const filterBadgeClass = (name) => {
   if (name.includes('Csrf')) return 'bg-warning text-dark'
   if (name.includes('Cors')) return 'bg-info text-dark'
   if (name.includes('Session')) return 'bg-secondary'
@@ -79,7 +79,7 @@ const filterBadgeClass = name => {
   return 'bg-light text-dark border'
 }
 
-const ruleBadgeClass = rule => {
+const ruleBadgeClass = (rule) => {
   switch (rule) {
     case 'permitAll':
       return 'bg-success'
@@ -99,7 +99,7 @@ const ruleBadgeClass = rule => {
   }
 }
 
-const methodBadgeClass = method => {
+const methodBadgeClass = (method) => {
   switch (method) {
     case 'GET':
       return 'bg-info text-dark'
@@ -115,7 +115,7 @@ const methodBadgeClass = method => {
   }
 }
 
-const shortName = name => {
+const shortName = (name) => {
   if (!name) return ''
   const i = name.lastIndexOf('.')
   return i < 0 ? name : name.substring(i + 1)
@@ -125,11 +125,12 @@ const filteredEndpoints = computed(() => {
   if (!endpoints.value || !endpoints.value.endpoints) return []
   const needle = endpointFilter.value.trim().toLowerCase()
   if (!needle) return endpoints.value.endpoints
-  return endpoints.value.endpoints.filter(e =>
-    (e.pattern || '').toLowerCase().includes(needle)
-    || (e.method || '').toLowerCase().includes(needle)
-    || (e.handler || '').toLowerCase().includes(needle)
-    || (e.rule || '').toLowerCase().includes(needle)
+  return endpoints.value.endpoints.filter(
+    (e) =>
+      (e.pattern || '').toLowerCase().includes(needle) ||
+      (e.method || '').toLowerCase().includes(needle) ||
+      (e.handler || '').toLowerCase().includes(needle) ||
+      (e.rule || '').toLowerCase().includes(needle)
   )
 })
 
@@ -151,25 +152,24 @@ onMounted(() => {
     <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
 
     <template v-else-if="report">
-
       <!-- Filter chains -->
-      <h5 class="mt-3 mb-2">Filter chains <span class="badge bg-secondary">{{ report.chains.length }}</span></h5>
+      <h5 class="mt-3 mb-2">
+        Filter chains <span class="badge bg-secondary">{{ report.chains.length }}</span>
+      </h5>
 
       <div v-if="report.chains.length === 0" class="alert alert-secondary">
         No filter chains detected. Spring Security may be present but not configured.
       </div>
 
       <div v-else id="chains-accordion" class="accordion mb-4">
-        <div
-          v-for="chain in report.chains"
-          :key="chain.order"
-          class="accordion-item">
+        <div v-for="chain in report.chains" :key="chain.order" class="accordion-item">
           <h2 class="accordion-header">
             <button
               :data-bs-target="'#chain-' + chain.order"
               class="accordion-button collapsed"
               data-bs-toggle="collapse"
-              type="button">
+              type="button"
+            >
               <div class="d-flex align-items-center gap-2 flex-wrap">
                 <span class="badge bg-secondary">#{{ chain.order }}</span>
                 <code class="small">{{ chain.requestMatcher }}</code>
@@ -187,13 +187,11 @@ onMounted(() => {
                 <strong>Request matcher:</strong> {{ chain.requestMatcher }}
                 <span class="ms-2 badge bg-light text-dark border">{{ chain.requestMatcherType }}</span>
               </div>
-              <div class="mb-1 small"><strong>Filters ({{ chain.filters.length }}):</strong></div>
+              <div class="mb-1 small">
+                <strong>Filters ({{ chain.filters.length }}):</strong>
+              </div>
               <div class="d-flex flex-wrap gap-1">
-                <span
-                  v-for="filter in chain.filters"
-                  :key="filter"
-                  :class="filterBadgeClass(filter)"
-                  class="badge">
+                <span v-for="filter in chain.filters" :key="filter" :class="filterBadgeClass(filter)" class="badge">
                   {{ filter }}
                 </span>
               </div>
@@ -237,9 +235,10 @@ onMounted(() => {
 
         <div
           v-if="!report.auth.authenticationProviderTypes.length && !report.auth.userDetailsServiceTypes.length"
-          class="alert alert-secondary small">
-          No <code>AuthenticationProvider</code> or <code>UserDetailsService</code> beans found in the
-          application context. These may be configured internally by a parent context.
+          class="alert alert-secondary small"
+        >
+          No <code>AuthenticationProvider</code> or <code>UserDetailsService</code> beans found in the application
+          context. These may be configured internally by a parent context.
         </div>
       </div>
 
@@ -253,60 +252,64 @@ onMounted(() => {
         </button>
       </h5>
       <p class="text-muted small">
-        Per-endpoint authorization rule resolved by matching each Spring MVC mapping against the
-        configured filter chains. Resolution is best-effort: header- or session-based matchers may
-        not be evaluated accurately.
+        Per-endpoint authorization rule resolved by matching each Spring MVC mapping against the configured filter
+        chains. Resolution is best-effort: header- or session-based matchers may not be evaluated accurately.
       </p>
 
       <div v-if="endpointsError" class="alert alert-danger small">{{ endpointsError }}</div>
       <div v-else-if="endpoints && !endpoints.handlerMappingAvailable" class="alert alert-secondary small">
-        No <code>RequestMappingHandlerMapping</code> bean is available — endpoints cannot be
-        listed for this application.
+        No <code>RequestMappingHandlerMapping</code> bean is available — endpoints cannot be listed for this
+        application.
       </div>
       <template v-else-if="endpoints">
         <input
           v-model="endpointFilter"
           class="form-control form-control-sm mb-2"
-          placeholder="Filter by pattern, method, handler, or rule…"/>
+          placeholder="Filter by pattern, method, handler, or rule…"
+        />
 
         <div class="table-responsive">
           <table class="table table-sm table-hover small align-middle">
             <thead>
-            <tr>
-              <th style="width:5rem">Method</th>
-              <th>Pattern</th>
-              <th>Handler</th>
-              <th>Chain</th>
-              <th>Rule</th>
-            </tr>
+              <tr>
+                <th style="width: 5rem">Method</th>
+                <th>Pattern</th>
+                <th>Handler</th>
+                <th>Chain</th>
+                <th>Rule</th>
+              </tr>
             </thead>
             <tbody>
-            <tr v-for="(ep, idx) in filteredEndpoints" :key="idx">
-              <td>
-                <span :class="methodBadgeClass(ep.method)" class="badge">{{ ep.method }}</span>
-              </td>
-              <td><code>{{ ep.pattern }}</code></td>
-              <td class="text-muted">{{ ep.handler }}</td>
-              <td>
-                <span v-if="ep.chainIndex != null" class="badge bg-light text-dark border">#{{ ep.chainIndex }}</span>
-                <span v-else class="text-muted">—</span>
-              </td>
-              <td>
-                <span :class="ruleBadgeClass(ep.rule)" class="badge me-1">{{ ep.rule }}</span>
-                <span
-                  v-for="role in (ep.roles || [])"
-                  :key="role"
-                  class="badge bg-light text-dark border me-1">{{ role }}</span>
-                <span v-if="ep.bestEffort" class="badge bg-warning text-dark ms-1"
-                      title="Best effort: header- or session-based matchers may not be accurate">
+              <tr v-for="(ep, idx) in filteredEndpoints" :key="idx">
+                <td>
+                  <span :class="methodBadgeClass(ep.method)" class="badge">{{ ep.method }}</span>
+                </td>
+                <td>
+                  <code>{{ ep.pattern }}</code>
+                </td>
+                <td class="text-muted">{{ ep.handler }}</td>
+                <td>
+                  <span v-if="ep.chainIndex != null" class="badge bg-light text-dark border">#{{ ep.chainIndex }}</span>
+                  <span v-else class="text-muted">—</span>
+                </td>
+                <td>
+                  <span :class="ruleBadgeClass(ep.rule)" class="badge me-1">{{ ep.rule }}</span>
+                  <span v-for="role in ep.roles || []" :key="role" class="badge bg-light text-dark border me-1">{{
+                    role
+                  }}</span>
+                  <span
+                    v-if="ep.bestEffort"
+                    class="badge bg-warning text-dark ms-1"
+                    title="Best effort: header- or session-based matchers may not be accurate"
+                  >
                     <i class="bi bi-exclamation-triangle"></i>
                   </span>
-                <div v-if="ep.description" class="text-muted small">{{ ep.description }}</div>
-              </td>
-            </tr>
-            <tr v-if="filteredEndpoints.length === 0">
-              <td class="text-muted text-center" colspan="5">No endpoints match the filter.</td>
-            </tr>
+                  <div v-if="ep.description" class="text-muted small">{{ ep.description }}</div>
+                </td>
+              </tr>
+              <tr v-if="filteredEndpoints.length === 0">
+                <td class="text-muted text-center" colspan="5">No endpoints match the filter.</td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -316,12 +319,12 @@ onMounted(() => {
       <!-- Explain tool -->
       <h5 class="mt-4 mb-2">Explain a request</h5>
       <p class="text-muted small">
-        Enter a method and path to see which filter chain would handle that request.
-        Matching is best-effort: header- or session-based matchers may not be evaluated accurately.
+        Enter a method and path to see which filter chain would handle that request. Matching is best-effort: header- or
+        session-based matchers may not be evaluated accurately.
       </p>
       <div class="row g-2 mb-3">
         <div class="col-auto">
-          <select v-model="explainMethod" class="form-select form-select-sm" style="width:auto">
+          <select v-model="explainMethod" class="form-select form-select-sm" style="width: auto">
             <option v-for="m in httpMethods" :key="m" :value="m">{{ m }}</option>
           </select>
         </div>
@@ -330,7 +333,8 @@ onMounted(() => {
             v-model="explainPath"
             class="form-control form-control-sm"
             placeholder="/api/example"
-            @keyup.enter="explain"/>
+            @keyup.enter="explain"
+          />
         </div>
         <div class="col-auto">
           <button :disabled="explainLoading" class="btn btn-sm btn-primary" @click="explain">
@@ -346,9 +350,9 @@ onMounted(() => {
             <span v-if="explainResult.matched" class="badge bg-success me-2">Matched</span>
             <span v-else class="badge bg-danger me-2">No match</span>
             <span v-if="explainResult.bestEffort" class="badge bg-warning text-dark me-2">Best effort</span>
-            <span v-if="explainResult.chainIndex != null" class="text-muted">Chain #{{
-                explainResult.chainIndex
-              }}</span>
+            <span v-if="explainResult.chainIndex != null" class="text-muted"
+              >Chain #{{ explainResult.chainIndex }}</span
+            >
           </div>
           <div v-if="explainResult.matcherDescription" class="mb-2">
             <strong>Matcher:</strong> <code>{{ explainResult.matcherDescription }}</code>
@@ -360,7 +364,8 @@ onMounted(() => {
                 v-for="filter in explainResult.filters"
                 :key="filter"
                 :class="filterBadgeClass(filter)"
-                class="badge">
+                class="badge"
+              >
                 {{ filter }}
               </span>
             </div>
@@ -371,7 +376,6 @@ onMounted(() => {
           </div>
         </div>
       </div>
-
     </template>
 
     <div v-else class="text-muted small">Loading…</div>

--- a/bootui-ui/src/main/frontend/src/views/Startup.vue
+++ b/bootui-ui/src/main/frontend/src/views/Startup.vue
@@ -22,7 +22,7 @@ function normalizedDuration(durationMs) {
 }
 
 const durationScale = computed(() => {
-  const durations = report.value.steps.map(step => normalizedDuration(step.durationMs))
+  const durations = report.value.steps.map((step) => normalizedDuration(step.durationMs))
   if (durations.length === 0) {
     return {min: 0, max: 0, minLog: 0, span: 0}
   }
@@ -53,11 +53,11 @@ function buildTree(steps) {
   const byId = new Map()
   const roots = []
 
-  steps.forEach(step => {
+  steps.forEach((step) => {
     byId.set(step.id, {...step, children: []})
   })
 
-  steps.forEach(step => {
+  steps.forEach((step) => {
     const node = byId.get(step.id)
     const parentId = step.parentId
     if (!parentId || !byId.has(parentId)) {
@@ -84,7 +84,7 @@ async function load() {
     report.value = {
       steps
     }
-    expandedStepIds.value = new Set(buildTree(steps).map(step => step.id))
+    expandedStepIds.value = new Set(buildTree(steps).map((step) => step.id))
   } catch (err) {
     report.value = {steps: []}
     expandedStepIds.value = new Set()
@@ -94,16 +94,14 @@ async function load() {
   }
 }
 
-const sortedSteps = computed(() =>
-  [...report.value.steps].sort((a, b) => a.id - b.id)
-)
+const sortedSteps = computed(() => [...report.value.steps].sort((a, b) => a.id - b.id))
 
 const tree = computed(() => buildTree(sortedSteps.value))
 
 const durationBandCounts = computed(() =>
-  durationBands.map(band => ({
+  durationBands.map((band) => ({
     ...band,
-    count: report.value.steps.filter(step => durationBandFor(step.durationMs).id === band.id).length
+    count: report.value.steps.filter((step) => durationBandFor(step.durationMs).id === band.id).length
   }))
 )
 
@@ -118,7 +116,7 @@ function filterTree(nodes, query, durationBandId) {
     return nodes
   }
 
-  return nodes.flatMap(node => {
+  return nodes.flatMap((node) => {
     const children = filterTree(node.children, query, durationBandId)
     const matches = stepMatchesFilters(node, query, durationBandId)
     if (!matches && children.length === 0) {
@@ -129,12 +127,9 @@ function filterTree(nodes, query, durationBandId) {
 }
 
 function flattenVisible(nodes, hasActiveFilter, depth = 0) {
-  return nodes.flatMap(node => {
+  return nodes.flatMap((node) => {
     const expanded = hasActiveFilter || expandedStepIds.value.has(node.id)
-    return [
-      {...node, depth, expanded},
-      ...(expanded ? flattenVisible(node.children, hasActiveFilter, depth + 1) : [])
-    ]
+    return [{...node, depth, expanded}, ...(expanded ? flattenVisible(node.children, hasActiveFilter, depth + 1) : [])]
   })
 }
 
@@ -145,9 +140,7 @@ const visibleSteps = computed(() => {
   return flattenVisible(filterTree(tree.value, query, durationBandId), hasActiveFilter)
 })
 
-const branchStepCount = computed(() =>
-  report.value.steps.filter(step => step.parentId != null).length
-)
+const branchStepCount = computed(() => report.value.steps.filter((step) => step.parentId != null).length)
 
 function toggleStep(step) {
   if (!step.children?.length) {
@@ -164,9 +157,9 @@ function toggleStep(step) {
 }
 
 function expandAll() {
-  expandedStepIds.value = new Set(report.value.steps
-    .filter(step => treeStepHasChildren(step.id))
-    .map(step => step.id))
+  expandedStepIds.value = new Set(
+    report.value.steps.filter((step) => treeStepHasChildren(step.id)).map((step) => step.id)
+  )
 }
 
 function collapseAll() {
@@ -174,7 +167,7 @@ function collapseAll() {
 }
 
 function treeStepHasChildren(stepId) {
-  return report.value.steps.some(step => step.parentId === stepId)
+  return report.value.steps.some((step) => step.parentId === stepId)
 }
 
 onMounted(load)
@@ -187,18 +180,16 @@ onMounted(load)
         <h2 class="mb-1"><i class="bi bi-clock-history me-2"></i>Startup timeline</h2>
         <p class="text-muted mb-0">
           {{ report.steps.length }} steps · {{ branchStepCount }} nested<span
-          v-if="filter || selectedDurationBand !== 'all'"> · {{ visibleSteps.length }} shown</span>
+            v-if="filter || selectedDurationBand !== 'all'"
+          >
+            · {{ visibleSteps.length }} shown</span
+          >
         </p>
       </div>
       <div class="col-12 col-md-7 col-lg-6 px-0">
         <div class="input-group mb-2">
           <span class="input-group-text"><i class="bi bi-search"></i></span>
-          <input
-            v-model="filter"
-            class="form-control"
-            placeholder="Filter by step name…"
-            type="search"
-          />
+          <input v-model="filter" class="form-control" placeholder="Filter by step name…" type="search" />
           <button
             :disabled="loading || report.steps.length === 0"
             class="btn btn-outline-secondary"
@@ -221,7 +212,7 @@ onMounted(load)
           <div aria-label="Filter startup steps by duration color" class="btn-group flex-wrap" role="group">
             <button
               :aria-pressed="selectedDurationBand === 'all'"
-              :class="{ active: selectedDurationBand === 'all' }"
+              :class="{active: selectedDurationBand === 'all'}"
               class="btn btn-sm btn-outline-secondary"
               type="button"
               @click="selectedDurationBand = 'all'"
@@ -232,7 +223,7 @@ onMounted(load)
               v-for="band in durationBandCounts"
               :key="band.id"
               :aria-pressed="selectedDurationBand === band.id"
-              :class="{ active: selectedDurationBand === band.id }"
+              :class="{active: selectedDurationBand === band.id}"
               :title="`Show ${band.label.toLowerCase()} startup steps`"
               class="btn btn-sm btn-outline-secondary startup-duration-filter"
               type="button"
@@ -247,9 +238,7 @@ onMounted(load)
       </div>
     </div>
 
-    <div v-if="loading" class="text-muted">
-      <i class="bi bi-hourglass-split me-2"></i>Loading startup data…
-    </div>
+    <div v-if="loading" class="text-muted"><i class="bi bi-hourglass-split me-2"></i>Loading startup data…</div>
     <div v-else-if="error" class="alert alert-danger" role="alert">
       <i class="bi bi-exclamation-triangle me-2"></i>{{ error }}
     </div>
@@ -263,7 +252,7 @@ onMounted(load)
       <div
         v-for="step in visibleSteps"
         :key="step.id"
-        :style="{ paddingLeft: `${1 + step.depth * 1.25}rem` }"
+        :style="{paddingLeft: `${1 + step.depth * 1.25}rem`}"
         class="list-group-item py-3"
       >
         <div class="d-flex align-items-start justify-content-between gap-3">
@@ -272,7 +261,7 @@ onMounted(load)
               <button
                 :aria-expanded="step.expanded"
                 :aria-label="`${step.expanded ? 'Collapse' : 'Expand'} ${step.name}`"
-                :class="{ 'invisible': !step.children?.length }"
+                :class="{invisible: !step.children?.length}"
                 class="btn btn-sm btn-link text-decoration-none p-0 startup-tree-toggle"
                 type="button"
                 @click="toggleStep(step)"

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
-import { apiFetch } from '../api.js'
+import {apiFetch} from '../api.js'
 
 const report = ref(null)
 const detail = ref(null)
@@ -77,20 +77,22 @@ const filteredTraces = computed(() => {
   if (!report.value) return []
   const v = filter.value.trim().toLowerCase()
   if (!v) return report.value.traces
-  return report.value.traces.filter(t =>
-    (t.traceId || '').toLowerCase().includes(v)
-    || (t.rootSpanName || '').toLowerCase().includes(v)
-    || (t.services || []).join(' ').toLowerCase().includes(v))
+  return report.value.traces.filter(
+    (t) =>
+      (t.traceId || '').toLowerCase().includes(v) ||
+      (t.rootSpanName || '').toLowerCase().includes(v) ||
+      (t.services || []).join(' ').toLowerCase().includes(v)
+  )
 })
 
 const waterfall = computed(() => {
   if (!detail.value || !detail.value.spans || detail.value.spans.length === 0) return null
   const spans = [...detail.value.spans]
-  const minStart = spans.reduce((m, s) => s.startEpochNanos < m ? s.startEpochNanos : m, spans[0].startEpochNanos)
-  const maxEnd = spans.reduce((m, s) => s.endEpochNanos > m ? s.endEpochNanos : m, spans[0].endEpochNanos)
+  const minStart = spans.reduce((m, s) => (s.startEpochNanos < m ? s.startEpochNanos : m), spans[0].startEpochNanos)
+  const maxEnd = spans.reduce((m, s) => (s.endEpochNanos > m ? s.endEpochNanos : m), spans[0].endEpochNanos)
   const totalNanos = Math.max(maxEnd - minStart, 1)
   const sorted = spans
-    .map(s => ({
+    .map((s) => ({
       ...s,
       offsetPct: ((s.startEpochNanos - minStart) / totalNanos) * 100,
       widthPct: Math.max((s.durationNanos / totalNanos) * 100, 0.5)
@@ -140,8 +142,11 @@ onMounted(load)
         </div>
       </div>
       <div class="d-flex gap-2">
-        <button :disabled="!report || report.retained === 0 || busy" class="btn btn-sm btn-outline-danger"
-                @click="clearAll">
+        <button
+          :disabled="!report || report.retained === 0 || busy"
+          class="btn btn-sm btn-outline-danger"
+          @click="clearAll"
+        >
           <span v-if="busy" class="spinner-border spinner-border-sm me-1"></span>
           <i v-else class="bi bi-trash me-1"></i>Clear
         </button>
@@ -161,8 +166,8 @@ onMounted(load)
 
     <template v-else-if="report">
       <div v-if="!report.enabled" class="alert alert-info small">
-        Telemetry receiver is disabled. Set <code>bootui.telemetry.enabled=true</code> and configure your application
-        to export OTLP to <code>http://localhost:8080/bootui/api/otlp/v1/traces</code>.
+        Telemetry receiver is disabled. Set <code>bootui.telemetry.enabled=true</code> and configure your application to
+        export OTLP to <code>http://localhost:8080/bootui/api/otlp/v1/traces</code>.
         <span v-if="report.retained > 0">Showing spans retained before telemetry was disabled.</span>
       </div>
 
@@ -173,89 +178,97 @@ onMounted(load)
 
       <template v-if="report.retained > 0">
         <div class="mb-3">
-          <input v-model="filter" class="form-control form-control-sm"
-                 placeholder="Filter by trace id, root span, or service…"/>
+          <input
+            v-model="filter"
+            class="form-control form-control-sm"
+            placeholder="Filter by trace id, root span, or service…"
+          />
         </div>
 
         <div class="table-responsive">
           <table class="table table-sm table-hover align-middle">
             <thead>
-            <tr>
-              <th>Started</th>
-              <th>Root span</th>
-              <th>Services</th>
-              <th>Spans</th>
-              <th>Duration</th>
-              <th>Status</th>
-              <th></th>
-            </tr>
+              <tr>
+                <th>Started</th>
+                <th>Root span</th>
+                <th>Services</th>
+                <th>Spans</th>
+                <th>Duration</th>
+                <th>Status</th>
+                <th></th>
+              </tr>
             </thead>
             <tbody>
-            <template v-for="t in filteredTraces" :key="t.traceId">
-              <tr :class="{ 'table-active': t.traceId === selectedTraceId }">
-                <td class="text-muted small">{{ formatTime(t.startEpochNanos) }}</td>
-                <td>
-                  <code class="me-2">{{ shortId(t.traceId) }}</code>
-                  <span class="fw-semibold">{{ t.rootSpanName || '—' }}</span>
-                  <span v-if="t.hasAi" class="badge text-bg-info ms-1"><i class="bi bi-stars"></i> AI</span>
-                </td>
-                <td>
-                  <span v-for="s in t.services" :key="s" class="badge text-bg-secondary me-1">{{ s }}</span>
-                </td>
-                <td>{{ t.spanCount }}</td>
-                <td>{{ formatDuration(t.durationNanos) }}</td>
-                <td>
-                  <span v-if="t.hasError" class="badge text-bg-danger">error</span>
-                  <span v-else class="badge text-bg-success">ok</span>
-                </td>
-                <td class="text-end">
-                  <button
-                    :aria-expanded="t.traceId === selectedTraceId"
-                    class="btn btn-sm btn-outline-primary"
-                    @click="toggleTrace(t.traceId)">
-                    {{ t.traceId === selectedTraceId ? 'Close' : 'Open' }}
-                  </button>
-                </td>
-              </tr>
-              <tr v-if="t.traceId === selectedTraceId" class="trace-detail-row">
-                <td class="p-0" colspan="7">
-                  <div class="trace-drawer card m-2">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                      <div>
-                        <i class="bi bi-bezier2 me-2"></i>
-                        <code>{{ selectedTraceId }}</code>
-                      </div>
-                      <button class="btn btn-sm btn-outline-secondary" @click="closeDrawer">Close</button>
-                    </div>
-                    <div class="card-body">
-                      <div v-if="detailLoading" class="text-muted small">Loading spans…</div>
-                      <template v-else-if="waterfall">
-                        <div class="text-muted small mb-2">
-                          {{ waterfall.spans.length }} span{{ waterfall.spans.length === 1 ? '' : 's' }} ·
-                          total {{ formatDuration(waterfall.totalNanos) }}
+              <template v-for="t in filteredTraces" :key="t.traceId">
+                <tr :class="{'table-active': t.traceId === selectedTraceId}">
+                  <td class="text-muted small">{{ formatTime(t.startEpochNanos) }}</td>
+                  <td>
+                    <code class="me-2">{{ shortId(t.traceId) }}</code>
+                    <span class="fw-semibold">{{ t.rootSpanName || '—' }}</span>
+                    <span v-if="t.hasAi" class="badge text-bg-info ms-1"><i class="bi bi-stars"></i> AI</span>
+                  </td>
+                  <td>
+                    <span v-for="s in t.services" :key="s" class="badge text-bg-secondary me-1">{{ s }}</span>
+                  </td>
+                  <td>{{ t.spanCount }}</td>
+                  <td>{{ formatDuration(t.durationNanos) }}</td>
+                  <td>
+                    <span v-if="t.hasError" class="badge text-bg-danger">error</span>
+                    <span v-else class="badge text-bg-success">ok</span>
+                  </td>
+                  <td class="text-end">
+                    <button
+                      :aria-expanded="t.traceId === selectedTraceId"
+                      class="btn btn-sm btn-outline-primary"
+                      @click="toggleTrace(t.traceId)"
+                    >
+                      {{ t.traceId === selectedTraceId ? 'Close' : 'Open' }}
+                    </button>
+                  </td>
+                </tr>
+                <tr v-if="t.traceId === selectedTraceId" class="trace-detail-row">
+                  <td class="p-0" colspan="7">
+                    <div class="trace-drawer card m-2">
+                      <div class="card-header d-flex justify-content-between align-items-center">
+                        <div>
+                          <i class="bi bi-bezier2 me-2"></i>
+                          <code>{{ selectedTraceId }}</code>
                         </div>
-                        <div class="waterfall">
-                          <div v-for="(s, i) in waterfall.spans" :key="s.spanId + '-' + i" class="waterfall-row">
-                            <div :title="s.name" class="waterfall-label">
-                              <span class="text-muted small">{{ s.serviceName || '—' }}</span>
-                              <div class="text-truncate">{{ s.name }}</div>
-                            </div>
-                            <div class="waterfall-track">
-                              <div :class="spanColor(s)" :style="{ marginLeft: s.offsetPct + '%', width: s.widthPct + '%' }"
-                                   :title="formatDuration(s.durationNanos)"
-                                   class="waterfall-bar">
+                        <button class="btn btn-sm btn-outline-secondary" @click="closeDrawer">Close</button>
+                      </div>
+                      <div class="card-body">
+                        <div v-if="detailLoading" class="text-muted small">Loading spans…</div>
+                        <template v-else-if="waterfall">
+                          <div class="text-muted small mb-2">
+                            {{ waterfall.spans.length }} span{{ waterfall.spans.length === 1 ? '' : 's' }} · total
+                            {{ formatDuration(waterfall.totalNanos) }}
+                          </div>
+                          <div class="waterfall">
+                            <div v-for="(s, i) in waterfall.spans" :key="s.spanId + '-' + i" class="waterfall-row">
+                              <div :title="s.name" class="waterfall-label">
+                                <span class="text-muted small">{{ s.serviceName || '—' }}</span>
+                                <div class="text-truncate">{{ s.name }}</div>
+                              </div>
+                              <div class="waterfall-track">
+                                <div
+                                  :class="spanColor(s)"
+                                  :style="{marginLeft: s.offsetPct + '%', width: s.widthPct + '%'}"
+                                  :title="formatDuration(s.durationNanos)"
+                                  class="waterfall-bar"
+                                ></div>
+                              </div>
+                              <div class="waterfall-duration small text-muted">
+                                {{ formatDuration(s.durationNanos) }}
                               </div>
                             </div>
-                            <div class="waterfall-duration small text-muted">{{ formatDuration(s.durationNanos) }}</div>
                           </div>
-                        </div>
-                      </template>
-                      <div v-else class="text-muted">No spans in this trace.</div>
+                        </template>
+                        <div v-else class="text-muted">No spans in this trace.</div>
+                      </div>
                     </div>
-                  </div>
-                </td>
-              </tr>
-            </template>
+                  </td>
+                </tr>
+              </template>
             </tbody>
           </table>
         </div>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,8 @@
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <palantir-java-format.version>2.91.0</palantir-java-format.version>
+        <spotless-maven-plugin.version>3.6.0</spotless-maven-plugin.version>
         <node.version>v24.16.0</node.version>
         <npm.version>11.15.0</npm.version>
     </properties>
@@ -132,6 +134,11 @@
                     <version>${frontend-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>${spotless-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>${maven-antrun-plugin.version}</version>
@@ -177,6 +184,45 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <configuration>
+                    <java>
+                        <palantirJavaFormat>
+                            <version>${palantir-java-format.version}</version>
+                        </palantirJavaFormat>
+                        <removeUnusedImports/>
+                    </java>
+                    <formats>
+                        <format>
+                            <includes>
+                                <include>*.md</include>
+                                <include>.github/**/*.md</include>
+                                <include>.github/**/*.yml</include>
+                                <include>docs/**/*.md</include>
+                                <include>pom.xml</include>
+                                <include>src/**/*.json</include>
+                                <include>src/**/*.properties</include>
+                                <include>src/**/*.xml</include>
+                                <include>src/**/*.yaml</include>
+                                <include>src/**/*.yml</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/dist/**</exclude>
+                                <exclude>**/node_modules/**</exclude>
+                                <exclude>**/playwright-report/**</exclude>
+                                <exclude>**/target/**</exclude>
+                                <exclude>**/test-results/**</exclude>
+                            </excludes>
+                            <trimTrailingWhitespace/>
+                            <endWithNewline/>
+                        </format>
+                    </formats>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  semi: false,
+  singleQuote: true,
+  bracketSpacing: false,
+  trailingComma: 'none',
+  printWidth: 120,
+  tabWidth: 2
+}


### PR DESCRIPTION
Adds a consistent formatting setup so Java, frontend, and e2e code can be checked automatically before review.

This wires Spotless with Palantir Java Format for Maven modules, adds shared Prettier configuration for Vue and Playwright files, documents the formatter commands, and adds CI checks so formatting drift is caught early.

Validation:
- ./mvnw -B -ntp spotless:check
- npm run format:check in bootui-ui/src/main/frontend
- npm run format:check in bootui-sample-app/e2e
- ./mvnw -B -ntp clean install