### PR TITLE
Update release notes for alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5] - 2026-05-27
+
+Latest tagged alpha with the expanded panel surface, telemetry features, and release hardening.
+
 ### Added
 
 - Backend test coverage for `BootUiProperties` binding, additional activation rules
@@ -17,12 +21,36 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (Data, Scheduled, HTTP Probe, Log Tail, Profile Diff, Security, Metrics, DevTools,
   Dev Services, Memory).
 - `CHANGELOG.md` and a sample-app walkthrough at `bootui-sample-app/README.md`.
+- Spring Cache panel for cache managers, known caches, safe local sizes, Micrometer cache metrics,
+  cache annotations, and confirmation-gated clear actions.
+- Embedded OTLP/HTTP trace receiver at `/bootui/api/otlp/v1/traces`, plus Traces and AI Usage panels
+  for local trace waterfalls, Spring AI observations, token usage, tool calls, and bounded in-memory
+  telemetry.
+- Optional panel availability metadata so the sidebar can dim panels whose backing classpath,
+  Actuator endpoint, or local infrastructure is unavailable.
+- GitHub project links in the UI and sample-app AI prompt helpers for exercising telemetry locally.
 
 ### Changed
 
 - Documentation reconciled with the implemented `AUTO|ON|OFF` activation model,
   persisted runtime overrides, plain-JavaScript Vue 3 frontend, and the full
   visible panel set as supported alpha functionality.
+- Dev Services, Vulnerabilities, Traces, and AI Usage now have stronger empty/disabled states,
+  bounded data handling, and focused Playwright coverage.
+- Vulnerability scan results are retained in memory after an explicit scan so the panel can keep
+  showing the latest local results.
+- Sample app PostgreSQL JDBC driver updated to 42.7.11.
+- Repository formatting checks and release documentation now cover the alpha release workflow,
+  README version synchronization, and Maven Central signing constraints.
+
+### Fixed
+
+- Corrected the sample Redis service port mapping used by the Cache panel tests.
+- Fixed GitHub code scanning workflow permissions and an incomplete string escaping/encoding finding.
+
+### Security
+
+- Enabled CSRF protection in the sample app.
 
 ## [0.1.0-alpha.4] - 2026
 
@@ -80,7 +108,9 @@ First tagged BootUI alpha. Highlights of the harden-all-visible-panels scope:
   request history, distributed tracing, multi-service orchestration, and live
   Docker Compose lifecycle control are intentionally out of scope for the alpha.
 
-[Unreleased]: https://github.com/jdubois/boot-ui/compare/v0.1.0-alpha.4...HEAD
+[Unreleased]: https://github.com/jdubois/boot-ui/compare/v0.1.0-alpha.5...HEAD
+
+[0.1.0-alpha.5]: https://github.com/jdubois/boot-ui/releases/tag/v0.1.0-alpha.5
 
 [0.1.0-alpha.4]: https://github.com/jdubois/boot-ui/releases/tag/v0.1.0-alpha.4
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -99,8 +99,8 @@ The project has moved beyond the original skeleton and the initial MVP panel set
 | 4. Beans and Conditions panels           | Implemented and covered by sample e2e    | API and UI panels exist; large-app edge cases should be handled incrementally as v0.2 hardening work.                                                                                                                                                   |
 | 5. Config, Mappings, Health, and Loggers | Implemented and covered by sample e2e    | Runtime config overrides, secret masking, mappings, health, and logger controls exist. Config override plumbing has focused backend tests.                                                                                                              |
 | 6. Post-MVP diagnostic panels            | Implemented and covered                  | Startup, Memory, Spring Data, Spring Cache, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, Security, Metrics, Vulnerabilities, DevTools, and Dev Services panels have API/UI slices plus backend edge-case tests and focused Playwright coverage. |
-| 7. Documentation and release hardening   | Validated for the current alpha; ongoing | User-facing docs are reconciled with current behavior, and the CI-equivalent build plus sample-app Playwright suite passed on 2026-05-27. Keep release checks current as v0.2 work lands.                                                               |
-| 8. In-app OTLP sink + Traces + AI Usage  | In progress                              | Adds an OTLP/HTTP receiver on `/bootui/api/otlp/v1/traces`, a Traces waterfall panel, an AI Usage panel for Spring AI observations, and a sample-app Ollama service started via `compose.yaml`.                                                         |
+| 7. Documentation and release hardening   | Validated for the current alpha; ongoing | User-facing docs are reconciled with current behavior, the changelog is current through `0.1.0-alpha.5`, and the CI-equivalent build plus sample-app Playwright suite passed on 2026-05-27. Keep release checks current as v0.2 work lands.             |
+| 8. In-app OTLP sink + Traces + AI Usage  | Delivered in `0.1.0-alpha.5`             | Adds an OTLP/HTTP receiver on `/bootui/api/otlp/v1/traces`, a Traces waterfall panel, an AI Usage panel for Spring AI observations, and a sample-app Ollama service started via `compose.yaml`.                                                         |
 
 ## 4. Current status and next work
 
@@ -158,7 +158,7 @@ update the router, README feature table, `docs/FEATURES.md`, and Playwright cove
 
 ### 4.3 User-facing documentation status
 
-The first-alpha documentation refresh is complete. Keep these user-facing topics current as behavior changes:
+The alpha documentation is current through `0.1.0-alpha.5`. Keep these user-facing topics current as behavior changes:
 
 1. Installation.
 2. Activation rules, including `bootui.enabled=AUTO|ON|OFF`, enabled profiles, disabled profiles, and devtools
@@ -186,8 +186,8 @@ Completed reconciliation points:
 - Dev Services / Docker Compose / Testcontainers behavior is documented: Docker Compose entries are startup snapshots,
   bean-backed Testcontainers services can expose bounded logs, and restart is disabled unless
   `bootui.dev-services.restart-enabled=true`.
-- Maven Central publishing has been exercised for the first alpha; the release profile signs and stages artifacts
-  through the Sonatype Central Publishing plugin.
+- Maven Central publishing has been exercised for the alpha line; the release profile signs and stages artifacts through
+  the Sonatype Central Publishing plugin, and release notes are current through `0.1.0-alpha.5`.
 
 ### 4.4 Release readiness validation
 
@@ -227,7 +227,7 @@ The codebase contains more than the original v0.1 MVP. The first alpha used this
 
 | Strategy                       | Scope                                                                                                                                         | Trade-off                                                                                        |
 |--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| Harden all visible panels      | Ship every current route as supported alpha functionality.                                                                                    | Delivered for `0.1.0-alpha.1`; keep focused backend tests, docs, and release validation current. |
+| Harden all visible panels      | Ship every current route as supported alpha functionality.                                                                                    | Delivered for `0.1.0-alpha.1` and extended through `0.1.0-alpha.5`; keep focused backend tests, docs, and release validation current. |
 | Mark newer panels experimental | Keep all routes visible but clearly label Data, Startup, Memory, Scheduled, HTTP Probe, Log Tail, Profile Diff, and Security as experimental. | Faster release, but docs must set expectations.                                                  |
 | Hide unfinished panels         | Only expose the original MVP routes plus any fully hardened additions.                                                                        | Safest alpha surface, but requires UI gating work.                                               |
 
@@ -268,7 +268,7 @@ Already implemented beyond the original MVP surface:
 - DevTools reload/restart controls.
 - In-app OTLP/HTTP traces receiver, Traces panel, and AI Usage panel.
 
-Newly in scope (added 2026-06):
+Added in `0.1.0-alpha.5` (2026-05):
 
 - **In-app OTLP/HTTP receiver**. BootUI exposes `POST /bootui/api/otlp/v1/traces` and accepts protobuf-encoded
   `ExportTraceServiceRequest` payloads from the host JVM (and from any cooperating local service that points its OTLP
@@ -389,7 +389,8 @@ Reason:
 ## 9. Suggested next steps
 
 Maven Central publishing prerequisites (`central` server credentials, GPG signing key, and release-profile deploy
-configuration) are in place, and the first alpha has been released to Maven Central via the `Prepare Release` workflow.
+configuration) are in place, and the alpha line is currently tagged at `0.1.0-alpha.5` via the `Prepare Release`
+workflow.
 
 Backend test coverage for the harden-all-visible-panels scope has been completed: `BootUiPropertiesTests`,
 `BootUiActivationConditionAdditionalTests`, controller mapping and DTO serialization tests for every `/bootui/api/**`
@@ -399,8 +400,8 @@ for Scheduled, HTTP Probe, Log Tail, Profile Diff masking, Security, Memory, and
 
 User-facing documentation is reconciled with current behavior: `README.md`, `docs/FEATURES.md`, and
 `docs/SPECIFICATION.md` use the `AUTO|ON|OFF` activation model, the persisted-overrides behavior, the plain-JavaScript
-Vue 3 frontend, and the full visible panel set. The repository now ships a `CHANGELOG.md` (release notes back to
-`0.1.0-alpha.1`) and a sample-app walkthrough at `bootui-sample-app/README.md`.
+Vue 3 frontend, and the full visible panel set. The repository now ships a `CHANGELOG.md` (release notes through
+`0.1.0-alpha.5`) and a sample-app walkthrough at `bootui-sample-app/README.md`.
 
 On 2026-05-27, `./mvnw -B -ntp clean install` and the Playwright suite under `bootui-sample-app/e2e` both passed on the
 current branch. The Playwright run covered all 43 sample-app browser tests.


### PR DESCRIPTION
## What does this PR do?

Updates `CHANGELOG.md` for the tagged `0.1.0-alpha.5` release and refreshes `docs/PLAN.md` so the release status matches what shipped.

## Why is this change needed?

The repository version and latest tag are already at `0.1.0-alpha.5`, but the changelog still treated those changes as unreleased and the plan still marked the OTLP/Traces/AI Usage work as in progress. This keeps release documentation aligned with the current alpha state.

Closes N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

N/A - documentation-only change. Verified the markdown diff has no whitespace errors and stale alpha.4/unreleased references were removed.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed