### PR TITLE
docs: add feature screenshot guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -167,6 +167,9 @@ Playwright coverage aligned for:
   sample-app Playwright navigation tests should stay consistent when panels are added, renamed, hidden, or reordered.
 - New browser-facing behavior usually needs a stable DTO, controller tests where practical, Vue route/view updates,
   `docs/FEATURES.md` / README updates, and an e2e spec when the UI or sample app behavior changes.
+- Feature screenshots in `docs/images/bootui-*.png` should stay at the current 1600x900 px size so the feature page
+  remains visually consistent. When adding or refreshing screenshots, seed the sample app or local state with realistic
+  non-sensitive sample data that demonstrates how the panel works instead of capturing empty/default states.
 
 ## Java conventions
 


### PR DESCRIPTION
## What does this PR do?

Adds Copilot guidance for feature-page screenshots so future captures keep the existing 1600x900 px size and show realistic, non-sensitive sample data.

## Why is this change needed?

Consistent screenshot dimensions keep the feature page visually cohesive, and sample data helps each panel demonstrate how it works instead of showing empty/default states.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally (N/A - documentation-only instruction change)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (N/A - no runtime behavior change)
- [ ] Added or updated tests where applicable (N/A - no code path changed)

## Screenshots (UI changes)

N/A - no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no product behavior change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed