### PR TITLE
Harden Dev Services inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ for explanations and screenshots for every panel.
 | [Traces](docs/FEATURES.md#traces)                     | Inspect distributed tracing spans collected by the embedded OTLP receiver with a per-trace waterfall view. |
 | [HTTP Probe](docs/FEATURES.md#http-probe)             | Send local-only HTTP requests to the app and inspect response status, headers, and body.                   |
 | [DevTools](docs/FEATURES.md#devtools)                 | Check Spring Boot DevTools status, LiveReload availability, and restart controls.                          |
-| [Dev Services](docs/FEATURES.md#dev-services)         | Inspect Docker Compose snapshots, Testcontainers beans, service connection metadata, and bounded logs.     |
+| [Dev Services](docs/FEATURES.md#dev-services)         | Inspect Docker Compose snapshots, safe Testcontainers beans, service connection metadata, and bounded logs. |
 | [Scheduled Tasks](docs/FEATURES.md#scheduled-tasks)   | View registered scheduled tasks and their trigger metadata.                                                |
 | [Data](docs/FEATURES.md#data)                         | Explore Spring Data repositories, domain types, IDs, and query methods.                                    |
 | [Cache](docs/FEATURES.md#cache)                       | Inspect Spring Cache managers, caches, metrics, annotations, and confirmed clear actions.                  |

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesController.java
@@ -11,12 +11,13 @@ import java.lang.reflect.Modifier;
 import java.net.URI;
 import java.time.Instant;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.container.ContainerImageMetadata;
 import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
@@ -46,9 +47,20 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
 
     private final SecretMasker masker = new SecretMasker();
 
-    private final Map<String, DevServiceDto> dockerComposeServices = new ConcurrentHashMap<>();
+    private final AtomicReference<ComposeSnapshot> dockerComposeSnapshot =
+            new AtomicReference<>(ComposeSnapshot.empty());
 
-    private volatile long dockerComposeSnapshotTimestamp;
+    private record ComposeSnapshot(Map<String, DevServiceDto> services, List<String> warnings, long timestamp) {
+
+        private ComposeSnapshot {
+            services = Collections.unmodifiableMap(new LinkedHashMap<>(services));
+            warnings = List.copyOf(warnings);
+        }
+
+        private static ComposeSnapshot empty() {
+            return new ComposeSnapshot(Map.of(), List.of(), 0);
+        }
+    }
 
     public DevServicesController(ConfigurableApplicationContext applicationContext, BootUiProperties properties) {
         this.applicationContext = applicationContext;
@@ -62,32 +74,35 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         }
         List<?> runningServices = invokeList(event, "getRunningServices");
         Map<String, DevServiceDto> snapshot = new LinkedHashMap<>();
+        Map<String, Integer> ids = new HashMap<>();
+        List<String> warnings = new ArrayList<>();
         for (Object runningService : runningServices) {
-            DevServiceDto dto = dockerComposeDto(runningService);
+            DevServiceDto dto = dockerComposeDto(runningService, ids, warnings);
             snapshot.put(dto.id(), dto);
         }
-        this.dockerComposeServices.clear();
-        this.dockerComposeServices.putAll(snapshot);
-        this.dockerComposeSnapshotTimestamp = System.currentTimeMillis();
+        this.dockerComposeSnapshot.set(new ComposeSnapshot(snapshot, warnings, System.currentTimeMillis()));
     }
 
     @GetMapping
     public DevServicesReport list() {
+        ComposeSnapshot composeSnapshot = this.dockerComposeSnapshot.get();
         Map<String, DevServiceDto> services = new LinkedHashMap<>();
-        this.dockerComposeServices.values().stream()
+        List<String> warnings = new ArrayList<>(composeSnapshot.warnings());
+        composeSnapshot.services().values().stream()
                 .sorted(Comparator.comparing(DevServiceDto::name))
                 .forEach(service -> services.put(service.id(), service));
-        discoverTestcontainers(services);
-        discoverConnectionDetails(services);
+        discoverTestcontainers(services, warnings);
+        discoverConnectionDetails(services, warnings);
         List<DevServiceDto> sorted = services.values().stream()
                 .sorted(Comparator.comparing(DevServiceDto::source).thenComparing(DevServiceDto::name))
                 .toList();
         return new DevServicesReport(
                 isPresent("org.springframework.boot.docker.compose.lifecycle.DockerComposeServicesReadyEvent"),
                 isPresent("org.testcontainers.lifecycle.Startable"),
-                resolveSnapshotTimestamp(),
+                resolveSnapshotTimestamp(composeSnapshot),
                 sorted.size(),
-                sorted);
+                sorted,
+                List.copyOf(warnings));
     }
 
     @GetMapping("/{id}/logs")
@@ -140,14 +155,14 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         }
     }
 
-    private long resolveSnapshotTimestamp() {
-        if (this.dockerComposeSnapshotTimestamp > 0) {
-            return this.dockerComposeSnapshotTimestamp;
+    private long resolveSnapshotTimestamp(ComposeSnapshot composeSnapshot) {
+        if (composeSnapshot.timestamp() > 0) {
+            return composeSnapshot.timestamp();
         }
         return Instant.now().toEpochMilli();
     }
 
-    private void discoverTestcontainers(Map<String, DevServiceDto> services) {
+    private void discoverTestcontainers(Map<String, DevServiceDto> services, List<String> warnings) {
         if (!isPresent("org.testcontainers.lifecycle.Startable")) {
             return;
         }
@@ -157,8 +172,14 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
             if (type == null || !isTestcontainerType(type)) {
                 continue;
             }
+            String skipReason = inspectionSkipReason(beanFactory, beanName);
+            if (skipReason != null) {
+                warnings.add("Skipped Testcontainers bean '" + beanName + "' because " + skipReason + ".");
+                continue;
+            }
             Object bean = safeGetBean(beanFactory, beanName);
             if (bean == null) {
+                warnings.add("Skipped Testcontainers bean '" + beanName + "' because the bean could not be obtained.");
                 continue;
             }
             DevServiceDto dto = testcontainersDto(beanName, bean);
@@ -166,12 +187,19 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         }
     }
 
-    private void discoverConnectionDetails(Map<String, DevServiceDto> services) {
+    private void discoverConnectionDetails(Map<String, DevServiceDto> services, List<String> warnings) {
         ListableBeanFactory beanFactory = applicationContext.getBeanFactory();
         String[] names = beanFactory.getBeanNamesForType(ConnectionDetails.class, false, false);
         for (String beanName : names) {
+            String skipReason = inspectionSkipReason(beanFactory, beanName);
+            if (skipReason != null) {
+                warnings.add("Skipped service connection bean '" + beanName + "' because " + skipReason + ".");
+                continue;
+            }
             ConnectionDetails details = safeGetBean(beanFactory, beanName, ConnectionDetails.class);
             if (details == null) {
+                warnings.add(
+                        "Skipped service connection bean '" + beanName + "' because the bean could not be obtained.");
                 continue;
             }
             DevServiceDto dto = connectionDetailsDto(beanFactory, beanName, details);
@@ -179,16 +207,21 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         }
     }
 
-    private DevServiceDto dockerComposeDto(Object runningService) {
+    private DevServiceDto dockerComposeDto(Object runningService, Map<String, Integer> ids, List<String> warnings) {
         String name = stringValue(invoke(runningService, "name"));
         String image = stringValue(invoke(runningService, "image"));
+        if (name == null || name.isBlank()) {
+            name = firstNonBlank(image, "service");
+            warnings.add("Docker Compose reported a service without a name; BootUI displayed it as '" + name + "'.");
+        }
         String host = stringValue(invoke(runningService, "host"));
         Map<String, Object> details = new LinkedHashMap<>();
         details.put("snapshot", "Captured when Spring Boot reported Docker Compose services ready");
         Map<?, ?> labels = asMap(invoke(runningService, "labels"));
         String type = inferType(name, image, labels);
+        String id = uniqueId("compose:" + slug(name), ids, warnings);
         return new DevServiceDto(
-                "compose:" + slug(name),
+                id,
                 name,
                 type,
                 "Docker Compose",
@@ -347,7 +380,7 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
 
     private Object findBeanBackedService(String id) {
         if (id == null || !id.startsWith("bean:")) {
-            if (this.dockerComposeServices.containsKey(id)) {
+            if (this.dockerComposeSnapshot.get().services().containsKey(id)) {
                 throw new ResponseStatusException(
                         HttpStatus.CONFLICT,
                         "Docker Compose services are snapshots and cannot be controlled by BootUI");
@@ -355,7 +388,17 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Service not found");
         }
         String beanName = id.substring("bean:".length());
-        Object bean = safeGetBean(applicationContext.getBeanFactory(), beanName);
+        ListableBeanFactory beanFactory = applicationContext.getBeanFactory();
+        Class<?> type = safeGetType(beanFactory, beanName);
+        if (type == null || !isTestcontainerType(type)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Service not found");
+        }
+        String skipReason = inspectionSkipReason(beanFactory, beanName);
+        if (skipReason != null) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT, "Service cannot be inspected because " + skipReason + ".");
+        }
+        Object bean = safeGetBean(beanFactory, beanName);
         if (bean == null || !isTestcontainerType(bean.getClass())) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Service not found");
         }
@@ -460,6 +503,16 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         return normalized.isBlank() ? "service" : normalized;
     }
 
+    private String uniqueId(String baseId, Map<String, Integer> ids, List<String> warnings) {
+        int count = ids.merge(baseId, 1, Integer::sum);
+        if (count == 1) {
+            return baseId;
+        }
+        String id = baseId + "-" + count;
+        warnings.add("Docker Compose reported duplicate service id '" + baseId + "'; BootUI kept it as '" + id + "'.");
+        return id;
+    }
+
     private void addIfPresent(Map<String, Object> details, String key, Object value) {
         if (value != null) {
             details.put(key, value);
@@ -497,6 +550,40 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
             return beanFactory.getType(beanName, false);
         } catch (BeansException ex) {
             return null;
+        }
+    }
+
+    private String inspectionSkipReason(ListableBeanFactory beanFactory, String beanName) {
+        if (!(beanFactory instanceof ConfigurableListableBeanFactory configurableBeanFactory)) {
+            return null;
+        }
+        if (configurableBeanFactory.containsSingleton(beanName)) {
+            return null;
+        }
+        try {
+            BeanDefinition beanDefinition = configurableBeanFactory.getBeanDefinition(beanName);
+            if (beanDefinition.isAbstract()) {
+                return "it is an abstract bean definition";
+            }
+            if (!beanDefinition.isSingleton()) {
+                return beanDefinition.isPrototype() ? "it is a prototype bean" : "it is not a singleton bean";
+            }
+            if (beanDefinition.isLazyInit()) {
+                return "inspecting it would initialize a lazy bean";
+            }
+            return "it has not been initialized yet";
+        } catch (NoSuchBeanDefinitionException ex) {
+            return safeIsSingleton(beanFactory, beanName)
+                    ? "it has not been initialized yet"
+                    : "it is not a singleton bean";
+        }
+    }
+
+    private boolean safeIsSingleton(ListableBeanFactory beanFactory, String beanName) {
+        try {
+            return beanFactory.isSingleton(beanName);
+        } catch (BeansException ex) {
+            return false;
         }
     }
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesControllerTests.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -9,6 +10,13 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
+import io.github.jdubois.bootui.core.BootUiDtos.DevServiceDto;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
 import org.springframework.context.support.GenericApplicationContext;
@@ -26,7 +34,8 @@ class DevServicesControllerTests {
         mvc.perform(get("/bootui/api/dev-services"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.total").value(0))
-                .andExpect(jsonPath("$.services").isEmpty());
+                .andExpect(jsonPath("$.services").isEmpty())
+                .andExpect(jsonPath("$.warnings").isEmpty());
 
         context.close();
     }
@@ -71,6 +80,26 @@ class DevServicesControllerTests {
     }
 
     @Test
+    void listSkipsLazyConnectionDetailsWithoutInitializingBean() throws Exception {
+        LazyConnectionDetails.initialized.set(false);
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean(
+                "lazyConnectionDetails", LazyConnectionDetails.class, definition -> definition.setLazyInit(true));
+        context.refresh();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
+
+        mvc.perform(get("/bootui/api/dev-services"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.warnings[0]").value(containsString("lazyConnectionDetails")))
+                .andExpect(jsonPath("$.warnings[0]").value(containsString("lazy bean")));
+
+        assertThat(LazyConnectionDetails.initialized).isFalse();
+        context.close();
+    }
+
+    @Test
     void logsReturnsCappedTailForBeanBackedService() throws Exception {
         BootUiProperties properties = new BootUiProperties();
         properties.getDevServices().setLogTailBytes(12);
@@ -104,6 +133,23 @@ class DevServicesControllerTests {
     }
 
     @Test
+    void logsDoNotInitializeLazyBeanBackedService() throws Exception {
+        LazyTestcontainer.initialized.set(false);
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean(
+                "lazyPostgresTestcontainer", LazyTestcontainer.class, definition -> definition.setLazyInit(true));
+        context.refresh();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
+
+        mvc.perform(get("/bootui/api/dev-services/bean:lazyPostgresTestcontainer/logs"))
+                .andExpect(status().isConflict());
+
+        assertThat(LazyTestcontainer.initialized).isFalse();
+        context.close();
+    }
+
+    @Test
     void restartIsDisabledByDefault() throws Exception {
         GenericApplicationContext context = new GenericApplicationContext();
         context.registerBean("postgresTestcontainer", FakeTestcontainer.class);
@@ -132,8 +178,32 @@ class DevServicesControllerTests {
                 .andExpect(jsonPath("$.status").value("restarted"));
 
         FakeTestcontainer container = context.getBean(FakeTestcontainer.class);
-        org.assertj.core.api.Assertions.assertThat(container.restartCalls()).isEqualTo("stop,start");
+        assertThat(container.restartCalls()).isEqualTo("stop,start");
         context.close();
+    }
+
+    @Test
+    void dockerComposeDuplicateNamesReceiveUniqueIds() throws Exception {
+        DevServicesController controller =
+                new DevServicesController(new GenericApplicationContext(), new BootUiProperties());
+        Method method =
+                DevServicesController.class.getDeclaredMethod("dockerComposeDto", Object.class, Map.class, List.class);
+        method.setAccessible(true);
+        Map<String, Integer> ids = new HashMap<>();
+        List<String> warnings = new ArrayList<>();
+
+        DevServiceDto first = (DevServiceDto)
+                method.invoke(controller, new FakeComposeService("postgres", "postgres:16"), ids, warnings);
+        DevServiceDto second = (DevServiceDto)
+                method.invoke(controller, new FakeComposeService("postgres", "postgres:17"), ids, warnings);
+        DevServiceDto blank = (DevServiceDto) method.invoke(controller, new FakeComposeService("", ""), ids, warnings);
+
+        assertThat(first.id()).isEqualTo("compose:postgres");
+        assertThat(second.id()).isEqualTo("compose:postgres-2");
+        assertThat(blank.id()).isEqualTo("compose:service");
+        assertThat(warnings)
+                .anySatisfy(warning -> assertThat(warning).contains("duplicate service id 'compose:postgres'"));
+        assertThat(warnings).anySatisfy(warning -> assertThat(warning).contains("without a name"));
     }
 
     static class SampleConnectionDetails implements ConnectionDetails {
@@ -144,6 +214,19 @@ class DevServicesControllerTests {
 
         public String getPassword() {
             return "secret";
+        }
+    }
+
+    static class LazyConnectionDetails implements ConnectionDetails {
+
+        static final AtomicBoolean initialized = new AtomicBoolean();
+
+        LazyConnectionDetails() {
+            initialized.set(true);
+        }
+
+        public String getJdbcUrl() {
+            return "jdbc:postgresql://localhost:5432/app";
         }
     }
 
@@ -199,6 +282,49 @@ class DevServicesControllerTests {
 
         public String getLogs(String... outputTypes) {
             return "Redis container started";
+        }
+    }
+
+    static class LazyTestcontainer {
+
+        static final AtomicBoolean initialized = new AtomicBoolean();
+
+        LazyTestcontainer() {
+            initialized.set(true);
+        }
+
+        public String getDockerImageName() {
+            return "postgres:16";
+        }
+
+        public boolean isRunning() {
+            return true;
+        }
+
+        public String getLogs() {
+            return "lazy logs";
+        }
+    }
+
+    record FakeComposeService(String name, String image) {
+
+        public String host() {
+            return "localhost";
+        }
+
+        public Map<String, String> labels() {
+            return Map.of();
+        }
+
+        public FakeComposePorts ports() {
+            return new FakeComposePorts();
+        }
+    }
+
+    static class FakeComposePorts {
+
+        public List<Integer> getAll() {
+            return List.of(15432);
         }
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -527,7 +527,18 @@ public final class BootUiDtos {
             boolean testcontainersPresent,
             long snapshotTimestamp,
             int total,
-            List<DevServiceDto> services) {}
+            List<DevServiceDto> services,
+            List<String> warnings) {
+
+        public DevServicesReport(
+                boolean dockerComposePresent,
+                boolean testcontainersPresent,
+                long snapshotTimestamp,
+                int total,
+                List<DevServiceDto> services) {
+            this(dockerComposePresent, testcontainersPresent, snapshotTimestamp, total, services, List.of());
+        }
+    }
 
     /**
      * Tail of logs for one local development service.

--- a/bootui-sample-app/e2e/tests/dev-services.spec.js
+++ b/bootui-sample-app/e2e/tests/dev-services.spec.js
@@ -6,6 +6,7 @@ const devServicesReport = {
   testcontainersPresent: true,
   snapshotTimestamp: Date.now(),
   total: 2,
+  warnings: [],
   services: [
     {
       id: 'compose:postgres',
@@ -150,5 +151,24 @@ test.describe('Dev Services view', () => {
     await redisRow.getByRole('button', {name: 'Restart'}).click()
     await expect(page.locator('.alert-success')).toContainText('Service restarted')
     await expect.poll(async () => restartCalled).toBe(true)
+  })
+
+  test('shows safe-inspection warnings from the report', async ({page}) => {
+    await page.route(
+      (url) => url.pathname === '/bootui/api/dev-services',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ...devServicesReport,
+            warnings: ["Skipped Testcontainers bean 'lazyRedis' because inspecting it would initialize a lazy bean."]
+          })
+        })
+      }
+    )
+
+    await page.goto('/bootui/#/dev-services')
+    await expect(page.locator('.alert-warning')).toContainText('Some services were skipped')
+    await expect(page.locator('.alert-warning')).toContainText('lazyRedis')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -199,6 +199,13 @@ onMounted(load)
       bean-backed Testcontainers services when <code>bootui.dev-services.restart-enabled=true</code>.
     </div>
 
+    <div v-if="report?.warnings?.length" class="alert alert-warning">
+      <div class="fw-semibold mb-1">Some services were skipped or adjusted for safe inspection.</div>
+      <ul class="mb-0">
+        <li v-for="warning in report.warnings" :key="warning">{{ warning }}</li>
+      </ul>
+    </div>
+
     <div v-if="loading" class="text-muted">Loading…</div>
     <div v-else-if="error" class="alert alert-danger">{{ error }}</div>
     <div v-else-if="report && report.total === 0" class="alert alert-secondary">

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -131,7 +131,9 @@ are shown only when available and require explicit confirmation before execution
 The Dev Services panel surfaces local development services discovered from Docker Compose snapshots, Testcontainers
 beans, and service connection metadata. It masks sensitive connection information, can show bounded logs for supported
 services, and shows restart controls only for supported Testcontainers services when
-`bootui.dev-services.restart-enabled=true`.
+`bootui.dev-services.restart-enabled=true`. To keep opening the panel side-effect free, BootUI skips lazy,
+prototype, or otherwise uninitialized service beans that would need to be created just for inspection and reports those
+skips as warnings in the panel.
 
 ![BootUI Dev Services panel](images/bootui-dev-services.png)
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -654,6 +654,8 @@ Features:
 - Show bounded logs when a bean-backed Testcontainers service exposes them.
 - Show a restart action for bean-backed services only when explicitly enabled with
   `bootui.dev-services.restart-enabled=true`.
+- Skip lazy, prototype, abstract, or otherwise uninitialized service beans instead of creating them from a read-only
+  panel request, and show a warning that explains why they were skipped.
 
 Status: implemented and supported for `0.1.0-alpha.1` as part of the harden-all-visible-panels release scope.
 
@@ -666,6 +668,8 @@ Acceptance criteria:
 - Works even when Docker is not installed.
 - Docker Compose services are clearly identified as startup snapshots because
   Spring Boot does not expose live per-service lifecycle state.
+- Docker Compose snapshots preserve duplicate or unnamed service entries by assigning stable synthetic IDs and warning
+  when BootUI had to adjust an entry for display.
 - Restart controls are disabled by default and warn that already-created client
   beans may not reconnect after container ports change.
 


### PR DESCRIPTION
## What does this PR do?

Hardens Dev Services inspection so read-only panel loads skip lazy, prototype, abstract, or otherwise uninitialized service beans instead of creating them. It also preserves duplicate or unnamed Docker Compose snapshot entries with adjusted IDs and surfaces safe-inspection warnings in the UI.

## Why is this change needed?

Opening Dev Services should never start containers or initialize application beans just to render a report. This addresses the v0.2 Dev Services hardening workstream for a visible, safety-sensitive panel.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `./mvnw -pl bootui-autoconfigure -am test -Dtest=DevServicesControllerTests -Dsurefire.failIfNoSpecifiedTests=false`
- [x] `./mvnw -B -ntp spotless:check`
- [x] Frontend and e2e `format:check` with the Maven-managed Node/npm
- [x] Dev Services Playwright spec: `npm test -- tests/dev-services.spec.js` with the Maven-managed Node/npm

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed