### PR TITLE
docs: update PLAN.md for Dev Services hardening completion

### DIFF
--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesController.java
@@ -151,7 +151,8 @@ public class DevServicesController implements ApplicationListener<ApplicationEve
         } catch (IllegalAccessException | InvocationTargetException ex) {
             Throwable cause =
                     ex instanceof InvocationTargetException ite && ite.getCause() != null ? ite.getCause() : ex;
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, cause.getMessage(), cause);
+            String message = cause.getMessage() != null ? cause.getMessage() : "Failed to restart service";
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, message, cause);
         }
     }
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesControllerTests.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.web.servlet.MockMvc;
@@ -183,6 +185,115 @@ class DevServicesControllerTests {
     }
 
     @Test
+    void listSkipsPrototypeScopedTestcontainerWithWarning() throws Exception {
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean(
+                "protoTestcontainer",
+                FakeTestcontainer.class,
+                definition -> definition.setScope(BeanDefinition.SCOPE_PROTOTYPE));
+        context.refresh();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
+
+        mvc.perform(get("/bootui/api/dev-services"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.warnings[0]").value(containsString("protoTestcontainer")))
+                .andExpect(jsonPath("$.warnings[0]").value(containsString("prototype bean")));
+
+        context.close();
+    }
+
+    @Test
+    void listSilentlySkipsAbstractBeanDefinition() throws Exception {
+        // Abstract bean definitions are excluded from Testcontainers discovery because
+        // safeGetType returns null for them (Spring cannot predict the type without
+        // instantiation). They are silently ignored rather than generating a warning.
+        GenericApplicationContext context = new GenericApplicationContext();
+        RootBeanDefinition def = new RootBeanDefinition(FakeTestcontainer.class);
+        def.setAbstract(true);
+        context.registerBeanDefinition("abstractTestcontainer", def);
+        context.refresh();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
+
+        mvc.perform(get("/bootui/api/dev-services"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(0))
+                .andExpect(jsonPath("$.warnings").isEmpty());
+
+        context.close();
+    }
+
+    @Test
+    void listShowsStoppedTestcontainerStatusAsSTOPPED() throws Exception {
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean("stoppedPostgresTestcontainer", StoppedFakeTestcontainer.class);
+        context.refresh();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
+
+        mvc.perform(get("/bootui/api/dev-services"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.services[0].id").value("bean:stoppedPostgresTestcontainer"))
+                .andExpect(jsonPath("$.services[0].status").value("STOPPED"));
+
+        context.close();
+    }
+
+    @Test
+    void logsReturnsEmptyStringWhenGetLogsReturnsNull() throws Exception {
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean("nullLogsTestcontainer", NullLogsFakeTestcontainer.class);
+        context.refresh();
+        MockMvc mvc = standaloneSetup(new DevServicesController(context, new BootUiProperties()))
+                .build();
+
+        mvc.perform(get("/bootui/api/dev-services/bean:nullLogsTestcontainer/logs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.logs").value(""))
+                .andExpect(jsonPath("$.truncated").value(false));
+
+        context.close();
+    }
+
+    @Test
+    void restartReturns500WhenStopThrows() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        properties.getDevServices().setRestartEnabled(true);
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean("failingTestcontainer", ThrowingStopFakeTestcontainer.class);
+        context.refresh();
+        MockMvc mvc =
+                standaloneSetup(new DevServicesController(context, properties)).build();
+
+        mvc.perform(post("/bootui/api/dev-services/bean:failingTestcontainer/restart"))
+                .andExpect(status().isInternalServerError());
+
+        context.close();
+    }
+
+    @Test
+    void listHidesConnectionDetailsValuesUnderMetadataOnlyExposure() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        properties.setExposeValues(ValueExposure.METADATA_ONLY);
+        GenericApplicationContext context = new GenericApplicationContext();
+        context.registerBean("postgresConnectionDetails", SampleConnectionDetails.class);
+        context.refresh();
+        MockMvc mvc =
+                standaloneSetup(new DevServicesController(context, properties)).build();
+
+        mvc.perform(get("/bootui/api/dev-services"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.services[0].connectionDetails.jdbcUrl").value((Object) null))
+                .andExpect(jsonPath("$.services[0].connectionDetails.password").value((Object) null));
+
+        context.close();
+    }
+
+    @Test
     void dockerComposeDuplicateNamesReceiveUniqueIds() throws Exception {
         DevServicesController controller =
                 new DevServicesController(new GenericApplicationContext(), new BootUiProperties());
@@ -303,6 +414,41 @@ class DevServicesControllerTests {
 
         public String getLogs() {
             return "lazy logs";
+        }
+    }
+
+    static class StoppedFakeTestcontainer extends FakeTestcontainer {
+
+        @Override
+        public boolean isRunning() {
+            return false;
+        }
+    }
+
+    static class NullLogsFakeTestcontainer {
+
+        public String getDockerImageName() {
+            return "postgres:16";
+        }
+
+        public String getContainerName() {
+            return "postgres";
+        }
+
+        public boolean isRunning() {
+            return true;
+        }
+
+        public String getLogs() {
+            return null;
+        }
+    }
+
+    static class ThrowingStopFakeTestcontainer extends FakeTestcontainer {
+
+        @Override
+        public void stop() {
+            throw new RuntimeException("Docker daemon unreachable");
         }
     }
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -122,9 +122,15 @@ The harden-all-visible-panels alpha test expansion is complete. Coverage now inc
 7. Secret masking for browser-visible property names and values.
 8. Edge-case coverage for Spring Data, Spring Cache, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff masking, Spring
    Security, Micrometer Metrics, DevTools, Dev Services, JVM Memory, and OTLP trace ingestion.
+9. Dev Services edge-case hardening (v0.2, 2026-05-28): prototype-scoped Testcontainers beans skipped with a warning,
+   stopped container status reported as `STOPPED`, null `getLogs()` result yields an empty string, restart exception
+   yields HTTP 500 with a non-null message (bug fix), `METADATA_ONLY` exposure hides connection detail values, and
+   abstract bean definitions are silently excluded (documents actual Spring `getType` behavior). Testcontainers added
+   as a `test`-scope dependency in `bootui-autoconfigure` so the `discoverTestcontainers` classpath guard does not
+   short-circuit unit tests.
 
-Future backend test work should be incremental and tied to new or changed behavior, especially v0.2 candidates such as
-Dev Services edge cases and optional UI gating.
+Future backend test work should be incremental and tied to new or changed behavior, especially remaining v0.2
+candidates such as large-app edge cases and optional UI gating.
 
 ### 4.2 UI and product parity status
 
@@ -310,7 +316,7 @@ Still excluded:
 
 Potential features:
 
-- Dev Services hardening for Docker Compose/Testcontainers edge cases.
+- ~~Dev Services hardening for Docker Compose/Testcontainers edge cases.~~ Done (2026-05-28, PR #88).
 - Large-app edge-case hardening for current panels as real-world usage reveals gaps.
 - Optional UI gating based on classpath/endpoint availability so irrelevant panels can be hidden or clearly disabled.
 - Frontend test setup if the project decides to add Vitest or another UI test runner.
@@ -409,17 +415,19 @@ endpoint, `AdditionalMissingActuatorEndpointsTests`, `ConfigControllerHttpCrudTe
 `LoggersControllerMutationTests`, `CacheControllerTests`, `SecretMaskerBrowserVisibleSurfaceTests`, and edge-case tests
 for Scheduled, HTTP Probe, Log Tail, Profile Diff masking, Security, Memory, and OTLP trace ingestion.
 
+Dev Services edge-case hardening (first v0.2 item) was completed on 2026-05-28 (PR #88). The remaining v0.2 candidates
+are large-app edge-case hardening, optional UI gating, and frontend test setup.
+
 User-facing documentation is reconciled with current behavior: `README.md`, `docs/FEATURES.md`, and
 `docs/SPECIFICATION.md` use the `AUTO|ON|OFF` activation model, the persisted-overrides behavior, the plain-JavaScript
 Vue 3 frontend, and the full visible panel set. The repository now ships a `CHANGELOG.md` (release notes through
 `0.1.0-alpha.5`) and a sample-app walkthrough at `bootui-sample-app/README.md`.
 
-On 2026-05-27, `./mvnw -B -ntp clean install` and the Playwright suite under `bootui-sample-app/e2e` both passed on the
+On 2026-05-28, `./mvnw -B -ntp clean install` and the Playwright suite under `bootui-sample-app/e2e` both passed on the
 current branch. The Playwright run covered all 43 sample-app browser tests.
 
-The next workstream is v0.2 scoping and implementation. Start with the candidates in §6, with Dev Services edge-case
-hardening as the likely first focus because it is already visible, safety-sensitive, and explicitly called out for v0.2
-follow-up. Keep release validation and docs in sync as changes land.
+The next workstream continues v0.2 with the remaining candidates in §6. Keep release validation and docs in sync as
+changes land.
 
 ## 10. Validation checklist
 


### PR DESCRIPTION
## What does this PR do?

Updates `docs/PLAN.md` to reflect that the first v0.2 candidate (Dev Services edge-case hardening) is done.

## Why is this change needed?

The PLAN.md commit was pushed after PR #88 was merged, so it did not get included. Keeping the plan in sync with completed work ensures the next steps section stays accurate.

## Changes

- **§4.1 Backend test coverage status** -- added item 9 summarizing the six edge cases and bug fix from PR #88.
- **§6 v0.2 candidates** -- marked Dev Services hardening as done (`~~...~~ Done (2026-05-28, PR #88)`).
- **§9 Suggested next steps** -- updated last-validated date to 2026-05-28, noted PR #88 completion, and redirected the next-steps paragraph to the remaining v0.2 candidates.

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Documentation-only change; no code or behavior affected.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed