### PR TITLE
Harden large BootUI panel lists

### DIFF
--- a/bootui-sample-app/e2e/tests/beans.spec.js
+++ b/bootui-sample-app/e2e/tests/beans.spec.js
@@ -20,4 +20,32 @@ test.describe('Beans view', () => {
     const classifications = await page.locator('table tbody tr td:nth-child(4) .badge').allInnerTexts()
     expect(classifications.every((c) => c === 'BOOTUI')).toBeTruthy()
   })
+
+  test('keeps large bean lists responsive while filters search the full set', async ({openView, page}) => {
+    const beans = Array.from({length: 205}, (_, index) => ({
+      name: `demoBean${index}`,
+      type: `com.example.DemoBean${index}`,
+      scope: 'singleton',
+      classification: 'APPLICATION',
+      dependencies: []
+    }))
+
+    await page.route('**/bootui/api/beans', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({total: beans.length, beans})
+      })
+    )
+
+    await openView('beans', 'Beans')
+
+    const rows = page.locator('table tbody tr')
+    await expect(rows).toHaveCount(200)
+    await expect(page.getByText('Showing 200 of 205 beans.')).toBeVisible()
+
+    await page.getByPlaceholder(/Filter by name or type/).fill('demoBean204')
+    await expect(rows).toHaveCount(1)
+    await expect(rows.first()).toContainText('demoBean204')
+  })
 })

--- a/bootui-ui/src/main/frontend/src/utils/useVisibleItems.js
+++ b/bootui-ui/src/main/frontend/src/utils/useVisibleItems.js
@@ -1,0 +1,41 @@
+import {computed, ref, unref, watch} from 'vue'
+
+const DEFAULT_CHUNK_SIZE = 200
+
+export function useVisibleItems(source, options = {}) {
+  const chunkSize = options.chunkSize || DEFAULT_CHUNK_SIZE
+  const initialLimit = options.initialLimit || chunkSize
+  const limit = ref(initialLimit)
+  const items = computed(() => unref(source) || [])
+  const totalCount = computed(() => items.value.length)
+  const visibleItems = computed(() => items.value.slice(0, limit.value))
+  const shownCount = computed(() => visibleItems.value.length)
+  const hiddenCount = computed(() => Math.max(totalCount.value - shownCount.value, 0))
+  const hasHiddenItems = computed(() => hiddenCount.value > 0)
+
+  function resetLimit() {
+    limit.value = initialLimit
+  }
+
+  function showMore() {
+    limit.value = Math.min(totalCount.value, limit.value + chunkSize)
+  }
+
+  function showAll() {
+    limit.value = totalCount.value
+  }
+
+  watch(items, resetLimit)
+
+  return {
+    chunkSize,
+    visibleItems,
+    totalCount,
+    shownCount,
+    hiddenCount,
+    hasHiddenItems,
+    resetLimit,
+    showMore,
+    showAll
+  }
+}

--- a/bootui-ui/src/main/frontend/src/views/Beans.vue
+++ b/bootui-ui/src/main/frontend/src/views/Beans.vue
@@ -1,5 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
+import {useVisibleItems} from '../utils/useVisibleItems.js'
+import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
 
 const data = ref(null)
 const filter = ref('')
@@ -22,13 +24,15 @@ const filtered = computed(() => {
   })
 })
 
+const {chunkSize, visibleItems: visibleBeans, shownCount, hiddenCount, showMore, showAll} = useVisibleItems(filtered)
+
 onMounted(load)
 </script>
 
 <template>
   <div>
     <h2><i class="bi bi-diagram-3 me-2"></i>Beans</h2>
-    <p class="text-muted">{{ data ? data.total : 0 }} beans · {{ filtered.length }} shown</p>
+    <p class="text-muted">{{ data ? data.total : 0 }} beans · {{ filtered.length }} matched</p>
 
     <div class="row g-2 mb-3">
       <div class="col-md-8">
@@ -65,7 +69,7 @@ onMounted(load)
           </tr>
         </thead>
         <tbody>
-          <tr v-for="b in filtered" :key="b.name">
+          <tr v-for="b in visibleBeans" :key="b.name">
             <td>
               <code :title="b.name" class="text-truncate d-block">{{ b.name }}</code>
             </td>
@@ -85,6 +89,15 @@ onMounted(load)
         </tbody>
       </table>
     </div>
+    <ProgressiveListFooter
+      :chunk-size="chunkSize"
+      :hidden="hiddenCount"
+      :shown="shownCount"
+      :total="filtered.length"
+      item-label="beans"
+      @show-all="showAll"
+      @show-more="showMore"
+    />
   </div>
 </template>
 

--- a/bootui-ui/src/main/frontend/src/views/Conditions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.vue
@@ -1,5 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
+import {useVisibleItems} from '../utils/useVisibleItems.js'
+import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
 
 const data = ref(null)
 const tab = ref('positive')
@@ -20,6 +22,8 @@ const entries = computed(() => {
   )
 })
 
+const {chunkSize, visibleItems: visibleEntries, shownCount, hiddenCount, showMore, showAll} = useVisibleItems(entries)
+
 onMounted(load)
 </script>
 
@@ -39,7 +43,8 @@ onMounted(load)
       </li>
     </ul>
     <input v-model="filter" class="form-control mb-3" placeholder="Filter…" />
-    <div v-for="e in entries" :key="e.autoConfigurationClass + e.condition" class="mb-2">
+    <p class="small text-muted">{{ entries.length }} matching entries</p>
+    <div v-for="e in visibleEntries" :key="e.autoConfigurationClass + e.condition" class="mb-2">
       <div class="d-flex">
         <span :class="tab === 'positive' ? 'bg-success' : 'bg-secondary'" class="badge me-2">{{ e.outcome }}</span>
         <div>
@@ -49,5 +54,14 @@ onMounted(load)
         </div>
       </div>
     </div>
+    <ProgressiveListFooter
+      :chunk-size="chunkSize"
+      :hidden="hiddenCount"
+      :shown="shownCount"
+      :total="entries.length"
+      item-label="condition entries"
+      @show-all="showAll"
+      @show-more="showMore"
+    />
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -1,6 +1,10 @@
 <script setup>
 import {computed, nextTick, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {useVisibleItems} from '../utils/useVisibleItems.js'
+import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
+
+const MAX_PROPERTY_SUGGESTIONS = 200
 
 const data = ref(null)
 const loading = ref(true)
@@ -20,6 +24,46 @@ const editInput = ref(null)
 const banner = ref(null)
 
 const propertySuggestions = computed(() => data.value?.propertySuggestions || [])
+
+const propertySuggestionQuery = computed(() => (newRowName.value || '').trim().toLowerCase())
+
+function propertySuggestionMatches(suggestion, query) {
+  if (!query) return true
+  return (suggestion.name || '').toLowerCase().includes(query)
+}
+
+const matchingPropertySuggestionCount = computed(
+  () =>
+    propertySuggestions.value.filter((suggestion) =>
+      propertySuggestionMatches(suggestion, propertySuggestionQuery.value)
+    ).length
+)
+
+const visiblePropertySuggestions = computed(() => {
+  const query = propertySuggestionQuery.value
+  if (!query) return propertySuggestions.value.slice(0, MAX_PROPERTY_SUGGESTIONS)
+  const prefixMatches = []
+  for (const suggestion of propertySuggestions.value) {
+    const name = (suggestion.name || '').toLowerCase()
+    if (name.startsWith(query)) {
+      prefixMatches.push(suggestion)
+    }
+    if (prefixMatches.length >= MAX_PROPERTY_SUGGESTIONS) return prefixMatches
+  }
+  const containsMatches = []
+  for (const suggestion of propertySuggestions.value) {
+    const name = (suggestion.name || '').toLowerCase()
+    if (!name.startsWith(query) && name.includes(query)) {
+      containsMatches.push(suggestion)
+    }
+    if (prefixMatches.length + containsMatches.length >= MAX_PROPERTY_SUGGESTIONS) break
+  }
+  return [...prefixMatches, ...containsMatches].slice(0, MAX_PROPERTY_SUGGESTIONS)
+})
+
+const hiddenPropertySuggestionCount = computed(() =>
+  Math.max(matchingPropertySuggestionCount.value - visiblePropertySuggestions.value.length, 0)
+)
 
 const suggestionByName = computed(() => {
   const byName = new Map()
@@ -65,6 +109,15 @@ const filtered = computed(() => {
     return true
   })
 })
+
+const {
+  chunkSize,
+  visibleItems: visibleProperties,
+  shownCount,
+  hiddenCount,
+  showMore,
+  showAll
+} = useVisibleItems(filtered)
 
 const overrideCount = computed(() => (data.value ? data.value.properties.filter((p) => p.override).length : 0))
 
@@ -288,12 +341,16 @@ onMounted(load)
               />
               <datalist id="bootPropertySuggestions">
                 <option
-                  v-for="s in propertySuggestions"
+                  v-for="s in visiblePropertySuggestions"
                   :key="s.name"
                   :label="suggestionLabel(s)"
                   :value="s.name"
                 ></option>
               </datalist>
+              <div v-if="hiddenPropertySuggestionCount > 0" class="small text-muted mt-1">
+                Showing the first {{ visiblePropertySuggestions.length }} matching suggestions. Keep typing to narrow
+                large metadata catalogs.
+              </div>
               <div v-if="selectedNewSuggestion" class="small text-muted mt-1">
                 <div v-if="selectedNewSuggestion.description">{{ selectedNewSuggestion.description }}</div>
                 <div>
@@ -354,7 +411,7 @@ onMounted(load)
 
           <!-- Existing rows -->
           <tr
-            v-for="p in filtered"
+            v-for="p in visibleProperties"
             :key="p.name + ':' + p.source"
             :class="{'table-warning': p.override, 'table-active': editingName === p.name}"
           >
@@ -422,6 +479,15 @@ onMounted(load)
         </tbody>
       </table>
     </div>
+    <ProgressiveListFooter
+      :chunk-size="chunkSize"
+      :hidden="hiddenCount"
+      :shown="shownCount"
+      :total="filtered.length"
+      item-label="properties"
+      @show-all="showAll"
+      @show-more="showMore"
+    />
   </div>
 </template>
 

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -1,6 +1,8 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {useVisibleItems} from '../utils/useVisibleItems.js'
+import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
 
 const data = ref(null)
 const filter = ref('')
@@ -17,6 +19,8 @@ const filtered = computed(() => {
   const f = filter.value.toLowerCase()
   return data.value.loggers.filter((l) => l.name.toLowerCase().includes(f))
 })
+
+const {chunkSize, visibleItems: visibleLoggers, shownCount, hiddenCount, showMore, showAll} = useVisibleItems(filtered)
 
 async function changeLevel(logger, level) {
   const body = level ? {level} : {}
@@ -55,6 +59,7 @@ onMounted(load)
     <h2><i class="bi bi-journal-text me-2"></i>Loggers</h2>
     <div v-if="message" class="alert alert-success">{{ message }}</div>
     <input v-model="filter" class="form-control mb-3" placeholder="Filter loggers by name…" />
+    <p v-if="data" class="small text-muted">{{ filtered.length }} of {{ data.loggers.length }} loggers matched</p>
     <div class="table-responsive">
       <table class="table table-sm table-hover loggers-table">
         <colgroup>
@@ -72,7 +77,7 @@ onMounted(load)
           </tr>
         </thead>
         <tbody>
-          <tr v-for="l in filtered" :key="l.name">
+          <tr v-for="l in visibleLoggers" :key="l.name">
             <td>
               <code :title="l.name" class="text-truncate d-block">{{ l.name }}</code>
             </td>
@@ -96,6 +101,15 @@ onMounted(load)
         </tbody>
       </table>
     </div>
+    <ProgressiveListFooter
+      :chunk-size="chunkSize"
+      :hidden="hiddenCount"
+      :shown="shownCount"
+      :total="filtered.length"
+      item-label="loggers"
+      @show-all="showAll"
+      @show-more="showMore"
+    />
   </div>
 </template>
 

--- a/bootui-ui/src/main/frontend/src/views/Mappings.vue
+++ b/bootui-ui/src/main/frontend/src/views/Mappings.vue
@@ -1,5 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
+import {useVisibleItems} from '../utils/useVisibleItems.js'
+import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
 
 const data = ref(null)
 const filter = ref('')
@@ -41,6 +43,8 @@ const flat = computed(() => {
   )
 })
 
+const {chunkSize, visibleItems: visibleMappings, shownCount, hiddenCount, showMore, showAll} = useVisibleItems(flat)
+
 const methodClass = (m) =>
   ({
     GET: 'bg-success',
@@ -58,6 +62,7 @@ onMounted(load)
   <div>
     <h2><i class="bi bi-signpost-2 me-2"></i>HTTP mappings</h2>
     <input v-model="filter" class="form-control mb-3" placeholder="Filter…" />
+    <p class="small text-muted">{{ flat.length }} matching mappings</p>
     <div class="table-responsive">
       <table class="table table-sm table-hover">
         <thead>
@@ -68,7 +73,7 @@ onMounted(load)
           </tr>
         </thead>
         <tbody>
-          <tr v-for="(r, i) in flat" :key="i">
+          <tr v-for="(r, i) in visibleMappings" :key="`${r.method}:${r.pattern}:${r.handler}:${i}`">
             <td>
               <span :class="methodClass(r.method)" class="badge">{{ r.method }}</span>
             </td>
@@ -82,5 +87,14 @@ onMounted(load)
         </tbody>
       </table>
     </div>
+    <ProgressiveListFooter
+      :chunk-size="chunkSize"
+      :hidden="hiddenCount"
+      :shown="shownCount"
+      :total="flat.length"
+      item-label="mappings"
+      @show-all="showAll"
+      @show-more="showMore"
+    />
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/components/ProgressiveListFooter.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ProgressiveListFooter.vue
@@ -1,0 +1,46 @@
+<script setup>
+import {computed} from 'vue'
+
+const props = defineProps({
+  shown: {
+    type: Number,
+    required: true
+  },
+  total: {
+    type: Number,
+    required: true
+  },
+  hidden: {
+    type: Number,
+    required: true
+  },
+  chunkSize: {
+    type: Number,
+    required: true
+  },
+  itemLabel: {
+    type: String,
+    default: 'items'
+  }
+})
+
+defineEmits(['showMore', 'showAll'])
+
+const nextCount = computed(() => Math.min(props.chunkSize, props.hidden))
+</script>
+
+<template>
+  <div
+    v-if="hidden > 0"
+    aria-live="polite"
+    class="d-flex flex-wrap justify-content-between align-items-center gap-2 text-muted small py-2"
+  >
+    <span>Showing {{ shown }} of {{ total }} {{ itemLabel }}. Filters search the full list.</span>
+    <div class="btn-group btn-group-sm">
+      <button class="btn btn-outline-secondary" type="button" @click="$emit('showMore')">
+        Show next {{ nextCount }}
+      </button>
+      <button class="btn btn-outline-secondary" type="button" @click="$emit('showAll')">Show all</button>
+    </div>
+  </div>
+</template>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -46,7 +46,8 @@ available measurements, and render a local live chart for a selected metric/tag 
 ## Conditions
 
 The Conditions panel explains Spring Boot auto-configuration decisions. It groups positive matches, negative matches,
-and unconditional classes so you can see why an auto-configuration applied or why it was skipped.
+and unconditional classes so you can see why an auto-configuration applied or why it was skipped. Large condition reports
+render progressively so the page stays responsive, while filtering still searches the full report.
 
 ![BootUI Conditions panel](images/bootui-conditions.png)
 
@@ -54,7 +55,8 @@ and unconditional classes so you can see why an auto-configuration applied or wh
 
 The Beans panel helps answer which Spring beans exist and where they came from. It supports search across bean names,
 classes, packages, scopes, resources, dependencies, aliases, and BootUI classifications such as application, BootUI,
-Spring framework, Java/Jakarta, and other beans.
+Spring framework, Java/Jakarta, and other beans. Large bean lists render progressively so the initial page stays usable;
+search and classification filters still apply to the full bean set.
 
 ![BootUI Beans panel](images/bootui-beans.png)
 
@@ -62,6 +64,7 @@ Spring framework, Java/Jakarta, and other beans.
 
 The Mappings panel lists HTTP routes from Actuator mappings data. It shows request methods, path patterns, handlers, and
 produces/consumes metadata so the running application's web surface is visible without reading controllers manually.
+Large mapping lists render progressively, and the filter continues to search every discovered route.
 
 ![BootUI Mappings panel](images/bootui-mappings.png)
 
@@ -69,7 +72,9 @@ produces/consumes metadata so the running application's web surface is visible w
 
 The Configuration panel shows effective configuration properties, sources, metadata descriptions, defaults when known,
 active profiles, and masked values. It can create, update, and delete local runtime overrides persisted to
-`.bootui/application-bootui.properties`, with restart and rebinding caveats shown for every mutation.
+`.bootui/application-bootui.properties`, with restart and rebinding caveats shown for every mutation. Large property
+tables render progressively, and the override property-name picker limits its datalist suggestions while narrowing
+against the full metadata catalog as you type.
 
 ![BootUI Configuration panel](images/bootui-configuration.png)
 
@@ -84,7 +89,8 @@ masking rules.
 ## Loggers
 
 The Loggers panel lists runtime logger configuration from Actuator. It shows configured and effective levels, supports
-search, and can update or clear logger levels without restarting the application.
+search, and can update or clear logger levels without restarting the application. Large logger lists render
+progressively, while filtering still searches the full logger set.
 
 ![BootUI Loggers panel](images/bootui-loggers.png)
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -101,7 +101,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
 | 4. Beans and Conditions panels           | Implemented and covered by sample e2e    | API and UI panels exist; large-app edge cases should be handled incrementally as v0.2 hardening work.                                                                                                                                                   |
 | 5. Config, Mappings, Health, and Loggers | Implemented and covered by sample e2e    | Runtime config overrides, secret masking, mappings, health, and logger controls exist. Config override plumbing has focused backend tests.                                                                                                              |
 | 6. Post-MVP diagnostic panels            | Implemented and covered                  | Startup, Memory, Spring Data, Spring Cache, Scheduled Tasks, HTTP Probe, Log Tail, Profile Diff, Security, Metrics, Vulnerabilities, DevTools, and Dev Services panels have API/UI slices plus backend edge-case tests and focused Playwright coverage. |
-| 7. Documentation and release hardening   | Validated for the current alpha; ongoing | User-facing docs are reconciled with current behavior, the changelog is current through `0.1.0-alpha.5`, and the CI-equivalent build plus sample-app Playwright suite passed on 2026-05-27. Keep release checks current as v0.2 work lands.             |
+| 7. Documentation and release hardening   | Validated for the current alpha; ongoing | User-facing docs are reconciled with current behavior, the changelog is current through `0.1.0-alpha.5`, and the CI-equivalent build plus sample-app Playwright suite passed on 2026-05-28. Keep release checks current as v0.2 work lands.             |
 | 8. In-app OTLP sink + Traces + AI Usage  | Delivered in `0.1.0-alpha.5`             | Adds an OTLP/HTTP receiver on `/bootui/api/otlp/v1/traces`, a Traces waterfall panel, an AI Usage panel for Spring AI observations, and a sample-app Ollama service started via `compose.yaml`.                                                         |
 
 ## 4. Current status and next work
@@ -128,13 +128,17 @@ The harden-all-visible-panels alpha test expansion is complete. Coverage now inc
    abstract bean definitions are silently excluded (documents actual Spring `getType` behavior). Testcontainers added
    as a `test`-scope dependency in `bootui-autoconfigure` so the `discoverTestcontainers` classpath guard does not
    short-circuit unit tests.
+10. Large-app rendering hardening (v0.2, 2026-05-28): high-cardinality Beans, Conditions, Mappings, Configuration, and
+    Loggers lists now render progressively instead of mounting every filtered row at once. Filters still search the full
+    in-memory result set, and the Configuration override property picker bounds its datalist suggestions while narrowing
+    against the full metadata catalog as the user types.
 
 Future backend test work should be incremental and tied to new or changed behavior, especially remaining v0.2
-candidates such as large-app edge cases and optional UI gating.
+candidates such as optional UI gating and server-side filtering or pagination if payload-size bottlenecks show up.
 
 ### 4.2 UI and product parity status
 
-The visible-route parity check is current. On 2026-05-28, the sample-app Playwright suite passed all 43 tests, covering:
+The visible-route parity check is current. On 2026-05-28, the sample-app Playwright suite passed all 57 tests, covering:
 
 1. Overview.
 2. Startup Timeline.
@@ -164,6 +168,10 @@ Startup, Memory, Spring Data, Spring Cache, HTTP Probe, Profile Diff, Log Tail, 
 Security, Metrics, Vulnerabilities, DevTools, and Dev Services are implemented, documented, covered by sample-app
 Playwright tests, and part of the supported alpha surface. Any new visible route or browser-facing behavior should
 update the router, README feature table, `docs/FEATURES.md`, and Playwright coverage together.
+
+The first v0.2 large-app pass is complete for the most obvious browser-rendering hotspots: Beans, Conditions, Mappings,
+Configuration, and Loggers progressively render large filtered result sets, while search/filter controls continue to
+operate over all received data.
 
 ### 4.3 User-facing documentation status
 
@@ -203,7 +211,7 @@ Completed reconciliation points:
 Last validation completed on 2026-05-28:
 
 - `./mvnw -B -ntp clean install` passed.
-- The sample-app Playwright suite passed all 43 tests.
+- The sample-app Playwright suite passed all 57 tests.
 - The working tree remained clean after validation.
 
 Before each release, rerun the CI-equivalent build:
@@ -317,9 +325,12 @@ Still excluded:
 Potential features:
 
 - ~~Dev Services hardening for Docker Compose/Testcontainers edge cases.~~ Done (2026-05-28, PR #88).
-- Large-app edge-case hardening for current panels as real-world usage reveals gaps.
+- ~~Large-app edge-case hardening for current panels as real-world usage reveals gaps.~~ Done (2026-05-28): the first
+  pass protects high-cardinality browser lists with progressive rendering and a bounded Configuration metadata datalist.
 - Optional UI gating based on classpath/endpoint availability so irrelevant panels can be hidden or clearly disabled.
 - Frontend test setup if the project decides to add Vitest or another UI test runner.
+- Server-side filtering or pagination for Actuator-backed APIs if real-world large apps expose response-size bottlenecks
+  that browser-side progressive rendering cannot solve.
 
 ## 7. v1.0 candidates
 
@@ -415,8 +426,9 @@ endpoint, `AdditionalMissingActuatorEndpointsTests`, `ConfigControllerHttpCrudTe
 `LoggersControllerMutationTests`, `CacheControllerTests`, `SecretMaskerBrowserVisibleSurfaceTests`, and edge-case tests
 for Scheduled, HTTP Probe, Log Tail, Profile Diff masking, Security, Memory, and OTLP trace ingestion.
 
-Dev Services edge-case hardening (first v0.2 item) was completed on 2026-05-28 (PR #88). The remaining v0.2 candidates
-are large-app edge-case hardening, optional UI gating, and frontend test setup.
+Dev Services edge-case hardening (first v0.2 item) was completed on 2026-05-28 (PR #88). Large-app browser-rendering
+hardening was completed next for high-cardinality lists. The remaining v0.2 candidates are optional UI gating, frontend
+test setup, and server-side filtering or pagination if payload-size bottlenecks show up in real-world apps.
 
 User-facing documentation is reconciled with current behavior: `README.md`, `docs/FEATURES.md`, and
 `docs/SPECIFICATION.md` use the `AUTO|ON|OFF` activation model, the persisted-overrides behavior, the plain-JavaScript
@@ -424,14 +436,14 @@ Vue 3 frontend, and the full visible panel set. The repository now ships a `CHAN
 `0.1.0-alpha.5`) and a sample-app walkthrough at `bootui-sample-app/README.md`.
 
 On 2026-05-28, `./mvnw -B -ntp clean install` and the Playwright suite under `bootui-sample-app/e2e` both passed on the
-current branch. The Playwright run covered all 43 sample-app browser tests.
+current branch. The Playwright run covered all 57 sample-app browser tests.
 
 The next workstream continues v0.2 with the remaining candidates in §6. Keep release validation and docs in sync as
 changes land.
 
 ## 10. Validation checklist
 
-Last completed on 2026-05-27:
+Last completed on 2026-05-28:
 
 - [x] `./mvnw -B -ntp clean install` passes.
 - [x] The UI build is executed automatically by Maven.


### PR DESCRIPTION
## What does this PR do?

Adds progressive rendering for high-cardinality BootUI browser lists in Beans, Conditions, Mappings, Configuration, and Loggers so large applications do not mount every filtered row at once. The shared frontend helper keeps filters scoped to the full loaded data set, and the Configuration override property-name picker now bounds datalist suggestions while narrowing against the full metadata catalog.

## Why is this change needed?

Large Spring Boot applications can expose hundreds or thousands of beans, properties, logger names, mappings, and condition entries. Rendering those lists progressively keeps the developer console responsive without changing the existing API response shapes or search behavior.

N/A - no linked issue.

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Also ran the full sample-app Playwright suite under `bootui-sample-app/e2e` with 57 passing tests.

## Screenshots (UI changes)

N/A - this is a responsiveness hardening change. The only visible difference is a progressive list footer when a filtered list exceeds the render limit.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed