### PR TITLE
Add panel availability guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ for explanations and screenshots for every panel.
 
 Some panels depend on optional Spring, Actuator, or development infrastructure. When data is unavailable, BootUI returns
 stable empty responses or shows an explanatory empty state. The sidebar also dims panels whose backing classpath or
-endpoint support is unavailable so you can spot empty sections immediately.
+endpoint support is unavailable, and opening a dimmed panel shows the unavailable reason at the top of the page.
 
 ## Setup
 

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -20,14 +20,21 @@ test.describe('BootUI app shell', () => {
     await expect(contributeLink.locator('.bi-github')).toBeVisible()
   })
 
-  test('sidebar does not label unavailable panels', async ({page}) => {
+  test('sidebar dims unavailable panels and the active panel explains why', async ({page}) => {
     await page.route(
       (url) => url.pathname === '/bootui/api/panels',
       async (route) => {
         await route.fulfill({
           contentType: 'application/json',
           body: JSON.stringify({
-            panels: [{id: 'overview', available: false}]
+            panels: [
+              {
+                id: 'overview',
+                title: 'Overview',
+                available: false,
+                unavailableReason: 'Overview support is unavailable in this test state'
+              }
+            ]
           })
         })
       }
@@ -36,7 +43,19 @@ test.describe('BootUI app shell', () => {
 
     const overviewLink = page.locator('aside .nav-link', {hasText: 'Overview'})
     await expect(overviewLink).toHaveClass(/bootui-nav-link--unavailable/)
+    await expect(overviewLink).toHaveAttribute(
+      'aria-label',
+      'Overview - unavailable: Overview support is unavailable in this test state'
+    )
+    await expect(overviewLink).toHaveAttribute(
+      'title',
+      'Overview - unavailable: Overview support is unavailable in this test state'
+    )
     await expect(overviewLink).not.toContainText('Unavailable')
+    await expect(page.locator('.panel-availability-alert')).toContainText('Panel unavailable')
+    await expect(page.locator('.panel-availability-alert')).toContainText(
+      'Overview support is unavailable in this test state'
+    )
   })
 
   test('sidebar links open every BootUI section', async ({page}) => {

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -10,6 +10,13 @@ const error = ref(null)
 
 const routes = router.options.routes.filter((r) => r.name)
 const panelLookup = computed(() => new Map((panels.value?.panels ?? []).map((panel) => [panel.id, panel])))
+const activePanel = computed(() => (route.name ? panelLookup.value.get(route.name) : null))
+const activePanelUnavailable = computed(() => activePanel.value?.available === false)
+const activePanelUnavailableReason = computed(
+  () =>
+    activePanel.value?.unavailableReason ||
+    'Required classpath or endpoint support is unavailable for this application.'
+)
 const activeTitle = computed(() => route.meta?.title ?? 'BootUI')
 const activeIcon = computed(() => route.meta?.icon ?? 'bi-speedometer2')
 const applicationTitle = computed(() => overview.value?.applicationName || 'Spring Boot app')
@@ -48,6 +55,22 @@ async function loadShellData() {
   await Promise.all([loadOverview(), loadPanels()])
 }
 
+function panelForRoute(r) {
+  return panelLookup.value.get(r.name)
+}
+
+function routeUnavailable(r) {
+  return panelForRoute(r)?.available === false
+}
+
+function routeAvailabilityLabel(r) {
+  const panel = panelForRoute(r)
+  if (panel?.available === false) {
+    return `${r.meta.title} - unavailable: ${panel.unavailableReason || 'required support is unavailable'}`
+  }
+  return r.meta.title
+}
+
 onMounted(loadShellData)
 </script>
 
@@ -66,18 +89,23 @@ onMounted(loadShellData)
       </router-link>
 
       <nav class="nav nav-pills flex-column gap-1 sidebar-nav">
-        <router-link
-          v-for="r in routes"
-          :key="r.name"
-          :class="{
-            active: route.name === r.name,
-            'bootui-nav-link--unavailable': panelLookup.get(r.name)?.available === false
-          }"
-          :to="r.path"
-          class="nav-link bootui-nav-link"
-        >
-          <i :class="['bi', r.meta.icon]"></i>
-          <span class="bootui-nav-link__label">{{ r.meta.title }}</span>
+        <router-link v-for="r in routes" :key="r.name" v-slot="{href, navigate}" :to="r.path" custom>
+          <a
+            :aria-current="route.name === r.name ? 'page' : undefined"
+            :aria-label="routeAvailabilityLabel(r)"
+            :class="{
+              active: route.name === r.name,
+              'bootui-nav-link--unavailable': routeUnavailable(r)
+            }"
+            :href="href"
+            :title="routeAvailabilityLabel(r)"
+            class="nav-link bootui-nav-link"
+            @click="navigate"
+          >
+            <i :class="['bi', r.meta.icon]"></i>
+            <span class="bootui-nav-link__label">{{ r.meta.title }}</span>
+            <i v-if="routeUnavailable(r)" aria-hidden="true" class="bi bi-slash-circle bootui-nav-link__status"></i>
+          </a>
         </router-link>
       </nav>
 
@@ -128,6 +156,13 @@ onMounted(loadShellData)
             <div class="eyebrow">Current panel</div>
             <h2>{{ activeTitle }}</h2>
           </div>
+        </div>
+        <div v-if="activePanelUnavailable" class="alert alert-warning panel-availability-alert shadow-sm" role="status">
+          <div class="panel-availability-alert__title">
+            <i class="bi bi-slash-circle"></i>
+            <strong>Panel unavailable</strong>
+          </div>
+          <div>{{ activePanelUnavailableReason }}</div>
         </div>
 
         <router-view v-slot="{Component}">
@@ -331,6 +366,12 @@ onMounted(loadShellData)
   flex: 1;
 }
 
+.bootui-nav-link__status {
+  color: #94a3b8;
+  font-size: 0.95rem;
+  opacity: 0.65;
+}
+
 .bootui-nav-link--unavailable {
   opacity: 0.55;
 }
@@ -468,6 +509,17 @@ onMounted(loadShellData)
 .panel-alert {
   border: 0;
   box-shadow: 0 0.75rem 1.75rem rgba(180, 83, 9, 0.12);
+}
+
+.panel-availability-alert {
+  border: 1px solid rgba(245, 158, 11, 0.28);
+}
+
+.panel-availability-alert__title {
+  align-items: center;
+  display: flex;
+  gap: 0.45rem;
+  margin-bottom: 0.25rem;
 }
 
 .bootui-footer {

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,7 +2,7 @@
 
 BootUI panels are documented here in the same order as the application menu. When a panel's backing infrastructure is
 missing, the sidebar keeps the route visible but dims it so you can tell at a glance that the panel has no live data for
-the current application.
+the current application. Opening a dimmed panel also shows the unavailable reason at the top of the page.
 
 ## Overview
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -134,7 +134,7 @@ The harden-all-visible-panels alpha test expansion is complete. Coverage now inc
     against the full metadata catalog as the user types.
 
 Future backend test work should be incremental and tied to new or changed behavior, especially remaining v0.2
-candidates such as optional UI gating and server-side filtering or pagination if payload-size bottlenecks show up.
+candidates such as server-side filtering or pagination if payload-size bottlenecks show up.
 
 ### 4.2 UI and product parity status
 
@@ -172,6 +172,11 @@ update the router, README feature table, `docs/FEATURES.md`, and Playwright cove
 The first v0.2 large-app pass is complete for the most obvious browser-rendering hotspots: Beans, Conditions, Mappings,
 Configuration, and Loggers progressively render large filtered result sets, while search/filter controls continue to
 operate over all received data.
+
+Optional UI gating is complete for the visible route set (v0.2, 2026-05-28). `/bootui/api/panels` reports classpath,
+endpoint, and configuration availability for each sidebar route. The Vue shell keeps routes visible, dims unavailable
+links, exposes the reason through accessible labels/tooltips, and shows a page-level unavailable-state banner when a
+dimmed panel is opened.
 
 ### 4.3 User-facing documentation status
 
@@ -327,7 +332,9 @@ Potential features:
 - ~~Dev Services hardening for Docker Compose/Testcontainers edge cases.~~ Done (2026-05-28, PR #88).
 - ~~Large-app edge-case hardening for current panels as real-world usage reveals gaps.~~ Done (2026-05-28): the first
   pass protects high-cardinality browser lists with progressive rendering and a bounded Configuration metadata datalist.
-- Optional UI gating based on classpath/endpoint availability so irrelevant panels can be hidden or clearly disabled.
+- ~~Optional UI gating based on classpath/endpoint availability so irrelevant panels can be hidden or clearly disabled.~~
+  Done (2026-05-28): the panel availability API drives sidebar dimming, accessible unavailable labels/tooltips, and an
+  active-panel reason banner while keeping routes navigable.
 - Frontend test setup if the project decides to add Vitest or another UI test runner.
 - Server-side filtering or pagination for Actuator-backed APIs if real-world large apps expose response-size bottlenecks
   that browser-side progressive rendering cannot solve.
@@ -427,8 +434,10 @@ endpoint, `AdditionalMissingActuatorEndpointsTests`, `ConfigControllerHttpCrudTe
 for Scheduled, HTTP Probe, Log Tail, Profile Diff masking, Security, Memory, and OTLP trace ingestion.
 
 Dev Services edge-case hardening (first v0.2 item) was completed on 2026-05-28 (PR #88). Large-app browser-rendering
-hardening was completed next for high-cardinality lists. The remaining v0.2 candidates are optional UI gating, frontend
-test setup, and server-side filtering or pagination if payload-size bottlenecks show up in real-world apps.
+hardening was completed next for high-cardinality lists. Optional UI gating was completed after that with the
+`/bootui/api/panels` availability report, sidebar dimming, accessible unavailable labels/tooltips, and an active-panel
+reason banner. The remaining v0.2 candidates are frontend test setup and server-side filtering or pagination if
+payload-size bottlenecks show up in real-world apps.
 
 User-facing documentation is reconciled with current behavior: `README.md`, `docs/FEATURES.md`, and
 `docs/SPECIFICATION.md` use the `AUTO|ON|OFF` activation model, the persisted-overrides behavior, the plain-JavaScript
@@ -438,8 +447,8 @@ Vue 3 frontend, and the full visible panel set. The repository now ships a `CHAN
 On 2026-05-28, `./mvnw -B -ntp clean install` and the Playwright suite under `bootui-sample-app/e2e` both passed on the
 current branch. The Playwright run covered all 57 sample-app browser tests.
 
-The next workstream continues v0.2 with the remaining candidates in §6. Keep release validation and docs in sync as
-changes land.
+The next workstream continues v0.2 with the remaining candidates in §6: frontend test setup and server-side filtering or
+pagination if payload-size bottlenecks show up. Keep release validation and docs in sync as changes land.
 
 ## 10. Validation checklist
 


### PR DESCRIPTION
## What does this PR do?

Adds clearer optional panel availability guidance in the BootUI shell: unavailable panels remain navigable, but their sidebar links are dimmed, labeled for assistive tech/tooltips, and opening one shows a page-level reason banner.

## Why is this change needed?

Optional panels can be irrelevant when their backing classpath, endpoint, or configuration support is absent. This makes that state obvious without hiding routes or making dimmed links feel broken.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks run:

- [x] `./mvnw -pl bootui-autoconfigure test -Dtest=PanelsControllerTests`
- [x] `./mvnw -pl bootui-ui generate-resources`
- [x] `npm run format:check && npm run build` in `bootui-ui/src/main/frontend` using Maven-managed Node/npm
- [x] `npm run format:check` in `bootui-sample-app/e2e` using Maven-managed Node/npm
- [x] `npm test -- app-shell.spec.js` in `bootui-sample-app/e2e` using Maven-managed Node/npm
- [x] `./mvnw -B -ntp spotless:apply spotless:check`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed