### PR TITLE
Add server-side pagination for large panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ for explanations and screenshots for every panel.
 | [Health](docs/FEATURES.md#health)                     | Explore the Actuator health tree and contributor details.                                                  |
 | [Metrics](docs/FEATURES.md#metrics)                   | Browse Micrometer meters, tags, measurements, and a local live chart for selected metrics.                 |
 | [Conditions](docs/FEATURES.md#conditions)             | Understand why auto-configuration classes matched, did not match, or were unconditional.                   |
-| [Beans](docs/FEATURES.md#beans)                       | Search Spring beans by name, type, scope, resource, dependency, and BootUI classification.                 |
+| [Beans](docs/FEATURES.md#beans)                       | Search Spring beans by name, type, and BootUI classification with server-side paging.                      |
 | [Mappings](docs/FEATURES.md#mappings)                 | Review HTTP routes, handlers, methods, patterns, and produces/consumes metadata.                           |
 | [Configuration](docs/FEATURES.md#configuration)       | Inspect effective configuration values, metadata, masking, and local runtime overrides.                    |
 | [Profile Diff](docs/FEATURES.md#profile-diff)         | Compare profile-specific property sources and values while preserving secret masking.                      |

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BeansController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BeansController.java
@@ -10,6 +10,7 @@ import org.springframework.boot.actuate.beans.BeansEndpoint.BeansDescriptor;
 import org.springframework.boot.actuate.beans.BeansEndpoint.ContextBeansDescriptor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,7 +24,11 @@ public class BeansController {
     }
 
     @GetMapping
-    public BeanList beans() {
+    public BeanList beans(
+            @RequestParam(name = "q", required = false) String query,
+            @RequestParam(name = "classification", required = false) String classification,
+            @RequestParam(name = "offset", required = false) Integer offset,
+            @RequestParam(name = "limit", required = false) Integer limit) {
         BeansEndpoint be = endpoint.getIfAvailable();
         if (be == null) {
             return new BeanList(0, List.of());
@@ -38,7 +43,14 @@ public class BeansController {
             }
         }
         summaries.sort(Comparator.comparing(BeanSummary::name));
-        return new BeanList(summaries.size(), summaries);
+        String normalizedQuery = PagedList.normalize(query);
+        String normalizedClassification = PagedList.normalize(classification).toUpperCase(Locale.ROOT);
+        PagedList.Result<BeanSummary> page = PagedList.from(
+                summaries,
+                bean -> matchesClassification(bean, normalizedClassification) && matchesQuery(bean, normalizedQuery),
+                offset,
+                limit);
+        return new BeanList(summaries.size(), page.items(), page.page());
     }
 
     private BeanSummary toSummary(String name, BeanDescriptor descriptor) {
@@ -67,5 +79,13 @@ public class BeansController {
             return "PLATFORM";
         }
         return "APPLICATION";
+    }
+
+    private boolean matchesClassification(BeanSummary bean, String classification) {
+        return classification.isEmpty() || classification.equals(bean.classification());
+    }
+
+    private boolean matchesQuery(BeanSummary bean, String query) {
+        return PagedList.contains(bean.name(), query) || PagedList.contains(bean.type(), query);
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConditionsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConditionsController.java
@@ -1,8 +1,11 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import io.github.jdubois.bootui.core.BootUiDtos.ConditionCounts;
 import io.github.jdubois.bootui.core.BootUiDtos.ConditionEntry;
 import io.github.jdubois.bootui.core.BootUiDtos.ConditionsReport;
+import io.github.jdubois.bootui.core.BootUiDtos.PageMetadata;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -14,6 +17,7 @@ import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReport
 import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint.MessageAndConditionsDescriptor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,7 +31,11 @@ public class ConditionsController {
     }
 
     @GetMapping
-    public ConditionsReport conditions() {
+    public ConditionsReport conditions(
+            @RequestParam(name = "q", required = false) String query,
+            @RequestParam(name = "outcome", required = false) String outcome,
+            @RequestParam(name = "offset", required = false) Integer offset,
+            @RequestParam(name = "limit", required = false) Integer limit) {
         ConditionsReportEndpoint cre = endpoint.getIfAvailable();
         if (cre == null) {
             return new ConditionsReport(List.of(), List.of(), List.of(), List.of());
@@ -70,6 +78,59 @@ public class ConditionsController {
                 exclusions.addAll(ex);
             }
         }
-        return new ConditionsReport(positive, negative, unconditional, exclusions);
+        positive.sort(conditionComparator());
+        negative.sort(conditionComparator());
+        unconditional.sort(String::compareTo);
+        exclusions.sort(String::compareTo);
+
+        String normalizedQuery = PagedList.normalize(query);
+        List<ConditionEntry> positiveFiltered = positive.stream()
+                .filter(entry -> matchesQuery(entry, normalizedQuery))
+                .toList();
+        List<ConditionEntry> negativeFiltered = negative.stream()
+                .filter(entry -> matchesQuery(entry, normalizedQuery))
+                .toList();
+        ConditionCounts counts = new ConditionCounts(
+                positive.size(),
+                positiveFiltered.size(),
+                negative.size(),
+                negativeFiltered.size(),
+                unconditional.size(),
+                exclusions.size());
+
+        String normalizedOutcome = PagedList.normalize(outcome);
+        if ("positive".equals(normalizedOutcome)) {
+            PagedList.Result<ConditionEntry> page =
+                    PagedList.from(positive, entry -> matchesQuery(entry, normalizedQuery), offset, limit);
+            return new ConditionsReport(page.items(), List.of(), unconditional, exclusions, page.page(), counts);
+        }
+        if ("negative".equals(normalizedOutcome)) {
+            PagedList.Result<ConditionEntry> page =
+                    PagedList.from(negative, entry -> matchesQuery(entry, normalizedQuery), offset, limit);
+            return new ConditionsReport(List.of(), page.items(), unconditional, exclusions, page.page(), counts);
+        }
+
+        PageMetadata page = new PageMetadata(
+                positive.size() + negative.size(),
+                positiveFiltered.size() + negativeFiltered.size(),
+                0,
+                positiveFiltered.size() + negativeFiltered.size(),
+                positiveFiltered.size() + negativeFiltered.size(),
+                false);
+        return new ConditionsReport(positiveFiltered, negativeFiltered, unconditional, exclusions, page, counts);
+    }
+
+    private Comparator<ConditionEntry> conditionComparator() {
+        return Comparator.comparing(ConditionEntry::autoConfigurationClass, Comparator.nullsLast(String::compareTo))
+                .thenComparing(ConditionEntry::condition, Comparator.nullsLast(String::compareTo))
+                .thenComparing(ConditionEntry::message, Comparator.nullsLast(String::compareTo))
+                .thenComparing(ConditionEntry::outcome, Comparator.nullsLast(String::compareTo));
+    }
+
+    private boolean matchesQuery(ConditionEntry entry, String query) {
+        return PagedList.contains(entry.autoConfigurationClass(), query)
+                || PagedList.contains(entry.condition(), query)
+                || PagedList.contains(entry.message(), query)
+                || PagedList.contains(entry.outcome(), query);
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigController.java
@@ -49,7 +49,12 @@ public class ConfigController {
     }
 
     @GetMapping
-    public ConfigReport list() {
+    public ConfigReport list(
+            @RequestParam(name = "q", required = false) String query,
+            @RequestParam(name = "source", required = false) String sourceFilter,
+            @RequestParam(name = "overridesOnly", required = false, defaultValue = "false") boolean overridesOnly,
+            @RequestParam(name = "offset", required = false) Integer offset,
+            @RequestParam(name = "limit", required = false) Integer limit) {
         List<String> sources = new ArrayList<>();
         Map<String, ConfigPropertyDto> merged = new LinkedHashMap<>();
 
@@ -69,8 +74,22 @@ public class ConfigController {
 
         List<ConfigPropertyDto> sorted = new ArrayList<>(merged.values());
         sorted.sort(Comparator.comparing(ConfigPropertyDto::name));
+        String normalizedQuery = PagedList.normalize(query);
+        String normalizedSource = sourceFilter == null ? "" : sourceFilter.trim();
+        PagedList.Result<ConfigPropertyDto> page = PagedList.from(
+                sorted,
+                property -> matchesSource(property, normalizedSource)
+                        && matchesOverrideFilter(property, overridesOnly)
+                        && matchesQuery(property, normalizedQuery),
+                offset,
+                limit);
         return new ConfigReport(
-                Arrays.asList(environment.getActiveProfiles()), sources, sorted, metadataCatalog.suggestions());
+                Arrays.asList(environment.getActiveProfiles()),
+                sources,
+                page.items(),
+                metadataCatalog.suggestions(),
+                page.page(),
+                (int) sorted.stream().filter(ConfigPropertyDto::override).count());
     }
 
     @PostMapping("/overrides")
@@ -108,5 +127,24 @@ public class ConfigController {
                 isOverride,
                 metadata == null ? null : metadata.description(),
                 metadata == null ? null : metadata.defaultValue());
+    }
+
+    private boolean matchesSource(ConfigPropertyDto property, String source) {
+        return source.isEmpty() || source.equals(property.source());
+    }
+
+    private boolean matchesOverrideFilter(ConfigPropertyDto property, boolean overridesOnly) {
+        return !overridesOnly || property.override();
+    }
+
+    private boolean matchesQuery(ConfigPropertyDto property, String query) {
+        return PagedList.contains(property.name(), query)
+                || PagedList.contains(text(property.value()), query)
+                || PagedList.contains(property.description(), query)
+                || PagedList.contains(text(property.defaultValue()), query);
+    }
+
+    private String text(Object value) {
+        return value == null ? null : String.valueOf(value);
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LoggersController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LoggersController.java
@@ -27,7 +27,10 @@ public class LoggersController {
     }
 
     @GetMapping
-    public LoggersReport loggers() {
+    public LoggersReport loggers(
+            @RequestParam(name = "q", required = false) String query,
+            @RequestParam(name = "offset", required = false) Integer offset,
+            @RequestParam(name = "limit", required = false) Integer limit) {
         LoggersEndpoint le = endpoint.getIfAvailable();
         if (le == null) {
             return new LoggersReport(List.of(), List.of());
@@ -52,7 +55,10 @@ public class LoggersController {
             }
         }
         loggers.sort(Comparator.comparing(LoggerDto::name));
-        return new LoggersReport(levels, loggers);
+        String normalizedQuery = PagedList.normalize(query);
+        PagedList.Result<LoggerDto> page =
+                PagedList.from(loggers, logger -> PagedList.contains(logger.name(), normalizedQuery), offset, limit);
+        return new LoggersReport(levels, page.items(), page.page());
     }
 
     @PostMapping("/{name}")

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MappingsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MappingsController.java
@@ -1,11 +1,24 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import io.github.jdubois.bootui.core.BootUiDtos.MappingDto;
+import io.github.jdubois.bootui.core.BootUiDtos.MappingsReport;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.web.mappings.MappingsEndpoint;
 import org.springframework.boot.actuate.web.mappings.MappingsEndpoint.ApplicationMappingsDescriptor;
+import org.springframework.boot.actuate.web.mappings.MappingsEndpoint.ContextMappingsDescriptor;
+import org.springframework.boot.webmvc.actuate.web.mappings.DispatcherServletMappingDescription;
+import org.springframework.boot.webmvc.actuate.web.mappings.DispatcherServletMappingDetails;
+import org.springframework.boot.webmvc.actuate.web.mappings.RequestMappingConditionsDescription;
+import org.springframework.boot.webmvc.actuate.web.mappings.RequestMappingConditionsDescription.MediaTypeExpressionDescription;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,5 +38,90 @@ public class MappingsController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(me.mappings());
+    }
+
+    @GetMapping("/flat")
+    public MappingsReport flatMappings(
+            @RequestParam(name = "q", required = false) String query,
+            @RequestParam(name = "offset", required = false) Integer offset,
+            @RequestParam(name = "limit", required = false) Integer limit) {
+        MappingsEndpoint me = endpoint.getIfAvailable();
+        if (me == null) {
+            return new MappingsReport(0, List.of());
+        }
+        List<MappingDto> mappings = flatten(me.mappings());
+        Comparator<String> nullSafeString = Comparator.nullsLast(String::compareTo);
+        mappings.sort(Comparator.comparing(MappingDto::pattern, nullSafeString)
+                .thenComparing(MappingDto::method, nullSafeString)
+                .thenComparing(MappingDto::handler, nullSafeString));
+        String normalizedQuery = PagedList.normalize(query);
+        PagedList.Result<MappingDto> page =
+                PagedList.from(mappings, mapping -> matchesQuery(mapping, normalizedQuery), offset, limit);
+        return new MappingsReport(mappings.size(), page.items(), page.page());
+    }
+
+    private List<MappingDto> flatten(ApplicationMappingsDescriptor descriptor) {
+        List<MappingDto> mappings = new ArrayList<>();
+        for (ContextMappingsDescriptor context : descriptor.getContexts().values()) {
+            Object dispatcherServlets = context.getMappings().get("dispatcherServlets");
+            if (!(dispatcherServlets instanceof Map<?, ?> dispatchers)) {
+                continue;
+            }
+            for (Object descriptions : dispatchers.values()) {
+                if (!(descriptions instanceof Iterable<?> iterable)) {
+                    continue;
+                }
+                for (Object description : iterable) {
+                    if (description instanceof DispatcherServletMappingDescription dispatcherMapping) {
+                        mappings.addAll(toMappings(dispatcherMapping));
+                    }
+                }
+            }
+        }
+        return mappings;
+    }
+
+    private List<MappingDto> toMappings(DispatcherServletMappingDescription description) {
+        DispatcherServletMappingDetails details = description.getDetails();
+        RequestMappingConditionsDescription conditions = details == null ? null : details.getRequestMappingConditions();
+        Set<String> patterns = conditions == null ? Set.of() : conditions.getPatterns();
+        Set<?> methods = conditions == null ? Set.of() : conditions.getMethods();
+        List<String> safePatterns =
+                patterns == null || patterns.isEmpty() ? List.of(predicate(description)) : new ArrayList<>(patterns);
+        List<String> safeMethods = methods == null || methods.isEmpty()
+                ? List.of("ANY")
+                : methods.stream().map(Object::toString).sorted().toList();
+        String produces = conditions == null ? null : mediaTypes(conditions.getProduces());
+        String consumes = conditions == null ? null : mediaTypes(conditions.getConsumes());
+        List<MappingDto> mappings = new ArrayList<>();
+        for (String pattern : safePatterns) {
+            for (String method : safeMethods) {
+                mappings.add(new MappingDto(method, pattern, description.getHandler(), produces, consumes));
+            }
+        }
+        return mappings;
+    }
+
+    private String mediaTypes(List<MediaTypeExpressionDescription> descriptions) {
+        if (descriptions == null || descriptions.isEmpty()) {
+            return null;
+        }
+        return descriptions.stream()
+                .map(description -> (description.isNegated() ? "!" : "") + description.getMediaType())
+                .sorted()
+                .reduce((left, right) -> left + ", " + right)
+                .orElse(null);
+    }
+
+    private String predicate(DispatcherServletMappingDescription description) {
+        return description.getPredicate() == null ? "(any)" : description.getPredicate();
+    }
+
+    private boolean matchesQuery(MappingDto mapping, String query) {
+        return PagedList.contains(mapping.method(), query)
+                || PagedList.contains(mapping.pattern(), query)
+                || PagedList.contains(mapping.handler(), query)
+                || PagedList.contains(mapping.produces(), query)
+                || PagedList.contains(mapping.consumes(), query);
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PagedList.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PagedList.java
@@ -1,0 +1,53 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.core.BootUiDtos.PageMetadata;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Predicate;
+
+final class PagedList {
+
+    static final int DEFAULT_LIMIT = 200;
+
+    static final int MAX_LIMIT = 1000;
+
+    private PagedList() {}
+
+    static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        return value.trim().toLowerCase(Locale.ROOT);
+    }
+
+    static boolean contains(String value, String query) {
+        return query.isEmpty()
+                || (value != null && value.toLowerCase(Locale.ROOT).contains(query));
+    }
+
+    static <T> Result<T> from(List<T> items, Predicate<T> matches, Integer offset, Integer limit) {
+        List<T> matched = new ArrayList<>();
+        for (T item : items) {
+            if (matches.test(item)) {
+                matched.add(item);
+            }
+        }
+
+        int safeOffset = offset == null ? 0 : Math.max(0, offset);
+        int safeLimit = limit == null ? matched.size() : Math.max(1, Math.min(MAX_LIMIT, limit));
+        int fromIndex = Math.min(safeOffset, matched.size());
+        int toIndex = Math.min(fromIndex + safeLimit, matched.size());
+        List<T> page = List.copyOf(matched.subList(fromIndex, toIndex));
+        return new Result<>(
+                page,
+                new PageMetadata(
+                        items.size(), matched.size(), fromIndex, safeLimit, page.size(), toIndex < matched.size()));
+    }
+
+    static <T> Result<T> from(List<T> items, Integer offset, Integer limit) {
+        return from(items, ignored -> true, offset, limit);
+    }
+
+    record Result<T>(List<T> items, PageMetadata page) {}
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/BeansControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/BeansControllerTests.java
@@ -168,4 +168,56 @@ class BeansControllerTests {
                 .andExpect(jsonPath("$.beans[0].name").value("apple"))
                 .andExpect(jsonPath("$.beans[1].name").value("zebra"));
     }
+
+    @Test
+    void beansSupportsServerSideFilteringAndPaging() throws Exception {
+        BeanDescriptor alphaBean = inlineMock(BeanDescriptor.class);
+        doReturn(String.class).when(alphaBean).getType();
+        when(alphaBean.getDependencies()).thenReturn(new String[0]);
+        when(alphaBean.getAliases()).thenReturn(new String[0]);
+
+        BeanDescriptor betaBean = inlineMock(BeanDescriptor.class);
+        doReturn(Runtime.class).when(betaBean).getType();
+        when(betaBean.getDependencies()).thenReturn(new String[0]);
+        when(betaBean.getAliases()).thenReturn(new String[0]);
+
+        BeanDescriptor springBean = inlineMock(BeanDescriptor.class);
+        doReturn(org.springframework.context.ApplicationContext.class)
+                .when(springBean)
+                .getType();
+        when(springBean.getDependencies()).thenReturn(new String[0]);
+        when(springBean.getAliases()).thenReturn(new String[0]);
+
+        ContextBeansDescriptor ctx = inlineMock(ContextBeansDescriptor.class);
+        when(ctx.getBeans())
+                .thenReturn(Map.of(
+                        "alphaBean", alphaBean,
+                        "betaBean", betaBean,
+                        "springBean", springBean));
+
+        BeansDescriptor descriptor = inlineMock(BeansDescriptor.class);
+        when(descriptor.getContexts()).thenReturn(Map.of("root", ctx));
+
+        BeansEndpoint endpoint = mock(BeansEndpoint.class);
+        when(endpoint.beans()).thenReturn(descriptor);
+
+        MockMvc mvc = standaloneSetup(new BeansController(providerOf(endpoint))).build();
+
+        mvc.perform(get("/bootui/api/beans")
+                        .param("q", "java")
+                        .param("classification", "PLATFORM")
+                        .param("offset", "1")
+                        .param("limit", "1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(3))
+                .andExpect(jsonPath("$.beans").isArray())
+                .andExpect(jsonPath("$.beans.length()").value(1))
+                .andExpect(jsonPath("$.beans[0].name").value("betaBean"))
+                .andExpect(jsonPath("$.page.total").value(3))
+                .andExpect(jsonPath("$.page.matched").value(2))
+                .andExpect(jsonPath("$.page.offset").value(1))
+                .andExpect(jsonPath("$.page.returned").value(1))
+                .andExpect(jsonPath("$.page.hasMore").value(false));
+    }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConditionsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConditionsControllerTests.java
@@ -161,4 +161,51 @@ class ConditionsControllerTests {
                 .andExpect(jsonPath("$.unconditionalClasses[0]").value("org.example.UnconditionalConfig"))
                 .andExpect(jsonPath("$.exclusions[0]").value("org.example.ExcludedAutoConfig"));
     }
+
+    @Test
+    void conditionsSupportsOutcomeFilteringAndPaging() throws Exception {
+        MessageAndConditionDescriptor alpha = mock(MessageAndConditionDescriptor.class);
+        when(alpha.getCondition()).thenReturn("OnClassCondition");
+        when(alpha.getMessage()).thenReturn("alpha matched");
+
+        MessageAndConditionDescriptor beta = mock(MessageAndConditionDescriptor.class);
+        when(beta.getCondition()).thenReturn("OnBeanCondition");
+        when(beta.getMessage()).thenReturn("beta matched");
+
+        ContextConditionsDescriptor ccd = inlineMock(ContextConditionsDescriptor.class);
+        when(ccd.getPositiveMatches())
+                .thenReturn(Map.of(
+                        "org.example.AlphaConfig", List.of(alpha),
+                        "org.example.BetaConfig", List.of(beta)));
+        when(ccd.getNegativeMatches()).thenReturn(Map.of());
+        when(ccd.getUnconditionalClasses()).thenReturn(Set.of());
+        when(ccd.getExclusions()).thenReturn(List.of());
+
+        ConditionsDescriptor descriptor = inlineMock(ConditionsDescriptor.class);
+        when(descriptor.getContexts()).thenReturn(Map.of("application", ccd));
+
+        ConditionsReportEndpoint endpoint = mock(ConditionsReportEndpoint.class);
+        when(endpoint.conditions()).thenReturn(descriptor);
+
+        MockMvc mvc =
+                standaloneSetup(new ConditionsController(providerOf(endpoint))).build();
+
+        mvc.perform(get("/bootui/api/conditions")
+                        .param("outcome", "positive")
+                        .param("q", "Config")
+                        .param("offset", "1")
+                        .param("limit", "1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.positiveMatches.length()").value(1))
+                .andExpect(
+                        jsonPath("$.positiveMatches[0].autoConfigurationClass").value("org.example.BetaConfig"))
+                .andExpect(jsonPath("$.negativeMatches").isEmpty())
+                .andExpect(jsonPath("$.page.total").value(2))
+                .andExpect(jsonPath("$.page.matched").value(2))
+                .andExpect(jsonPath("$.page.offset").value(1))
+                .andExpect(jsonPath("$.page.returned").value(1))
+                .andExpect(jsonPath("$.counts.positiveTotal").value(2))
+                .andExpect(jsonPath("$.counts.positiveMatched").value(2));
+    }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ConfigControllerTests.java
@@ -63,6 +63,25 @@ class ConfigControllerTests {
     }
 
     @Test
+    void listSupportsServerSideFilteringAndPaging() throws Exception {
+        environment.setProperty("server.address", "127.0.0.1");
+        environment.setProperty("management.server.port", "8081");
+
+        mvc.perform(get("/bootui/api/config")
+                        .param("q", "server")
+                        .param("offset", "1")
+                        .param("limit", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.properties.length()").value(1))
+                .andExpect(jsonPath("$.properties[0].name").value("server.address"))
+                .andExpect(jsonPath("$.page.total").value(org.hamcrest.Matchers.greaterThanOrEqualTo(4)))
+                .andExpect(jsonPath("$.page.matched").value(3))
+                .andExpect(jsonPath("$.page.offset").value(1))
+                .andExpect(jsonPath("$.page.returned").value(1))
+                .andExpect(jsonPath("$.page.hasMore").value(true));
+    }
+
+    @Test
     void listMasksSecretValuesByDefault() throws Exception {
         mvc.perform(get("/bootui/api/config"))
                 .andExpect(status().isOk())

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LoggersControllerMutationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LoggersControllerMutationTests.java
@@ -122,6 +122,40 @@ class LoggersControllerMutationTests {
         verify(endpoint, times(1)).configureLogLevel(eq("com.example"), eq(LogLevel.DEBUG));
     }
 
+    @Test
+    void getAllSupportsServerSideFilteringAndPaging() throws Exception {
+        Map<String, LoggerLevelsDescriptor> loggersMap = new LinkedHashMap<>();
+        loggersMap.put(
+                "com.example.Alpha",
+                new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("com.example.Alpha", LogLevel.DEBUG, LogLevel.DEBUG)));
+        loggersMap.put(
+                "com.example.Beta",
+                new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("com.example.Beta", LogLevel.INFO, LogLevel.INFO)));
+        loggersMap.put(
+                "org.springframework",
+                new SingleLoggerLevelsDescriptor(
+                        new LoggerConfiguration("org.springframework", LogLevel.WARN, LogLevel.WARN)));
+        LoggersEndpoint endpoint = mock(LoggersEndpoint.class);
+        when(endpoint.loggers()).thenReturn(new LoggersDescriptor(new TreeSet<>(), loggersMap, Map.of()));
+
+        MockMvc mvc =
+                standaloneSetup(new LoggersController(providerOf(endpoint))).build();
+
+        mvc.perform(get("/bootui/api/loggers")
+                        .param("q", "com.example")
+                        .param("offset", "1")
+                        .param("limit", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.loggers.length()").value(1))
+                .andExpect(jsonPath("$.loggers[0].name").value("com.example.Beta"))
+                .andExpect(jsonPath("$.page.total").value(3))
+                .andExpect(jsonPath("$.page.matched").value(2))
+                .andExpect(jsonPath("$.page.offset").value(1))
+                .andExpect(jsonPath("$.page.returned").value(1));
+    }
+
     // ── missing endpoint + POST ───────────────────────────────────────────────
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MappingsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MappingsControllerTests.java
@@ -3,15 +3,19 @@ package io.github.jdubois.bootui.autoconfigure.web;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.web.mappings.MappingsEndpoint;
 import org.springframework.boot.actuate.web.mappings.MappingsEndpoint.ApplicationMappingsDescriptor;
+import org.springframework.boot.actuate.web.mappings.MappingsEndpoint.ContextMappingsDescriptor;
+import org.springframework.boot.webmvc.actuate.web.mappings.DispatcherServletMappingDescription;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -61,5 +65,45 @@ class MappingsControllerTests {
         mvc.perform(get("/bootui/api/mappings").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void flatMappingsReturnsStablePagedDto() throws Exception {
+        DispatcherServletMappingDescription alpha = mock(DispatcherServletMappingDescription.class);
+        when(alpha.getPredicate()).thenReturn("/alpha");
+        when(alpha.getHandler()).thenReturn("org.example.AlphaController#alpha");
+
+        DispatcherServletMappingDescription beta = mock(DispatcherServletMappingDescription.class);
+        when(beta.getPredicate()).thenReturn("/beta");
+        when(beta.getHandler()).thenReturn("org.example.BetaController#beta");
+
+        ContextMappingsDescriptor context =
+                mock(ContextMappingsDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        when(context.getMappings())
+                .thenReturn(Map.of("dispatcherServlets", Map.of("dispatcherServlet", List.of(alpha, beta))));
+
+        ApplicationMappingsDescriptor descriptor =
+                mock(ApplicationMappingsDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        when(descriptor.getContexts()).thenReturn(Map.of("application", context));
+
+        MappingsEndpoint endpoint = mock(MappingsEndpoint.class);
+        when(endpoint.mappings()).thenReturn(descriptor);
+
+        MockMvc mvc =
+                standaloneSetup(new MappingsController(providerOf(endpoint))).build();
+
+        mvc.perform(get("/bootui/api/mappings/flat")
+                        .param("q", "alpha")
+                        .param("limit", "1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.mappings.length()").value(1))
+                .andExpect(jsonPath("$.mappings[0].method").value("ANY"))
+                .andExpect(jsonPath("$.mappings[0].pattern").value("/alpha"))
+                .andExpect(jsonPath("$.mappings[0].handler").value("org.example.AlphaController#alpha"))
+                .andExpect(jsonPath("$.page.total").value(2))
+                .andExpect(jsonPath("$.page.matched").value(1))
+                .andExpect(jsonPath("$.page.returned").value(1));
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -56,18 +56,63 @@ public final class BootUiDtos {
             List<String> aliases,
             String classification) {}
 
-    public record BeanList(int total, List<BeanSummary> beans) {}
+    /**
+     * Paging metadata for list-style reports.
+     */
+    public record PageMetadata(int total, int matched, int offset, int limit, int returned, boolean hasMore) {}
+
+    public record BeanList(int total, List<BeanSummary> beans, PageMetadata page) {
+        public BeanList(int total, List<BeanSummary> beans) {
+            this(total, beans, new PageMetadata(total, beans.size(), 0, beans.size(), beans.size(), false));
+        }
+    }
 
     /**
      * One auto-configuration evaluation entry.
      */
     public record ConditionEntry(String autoConfigurationClass, String condition, String message, String outcome) {}
 
+    public record ConditionCounts(
+            int positiveTotal,
+            int positiveMatched,
+            int negativeTotal,
+            int negativeMatched,
+            int unconditionalTotal,
+            int exclusionsTotal) {}
+
     public record ConditionsReport(
             List<ConditionEntry> positiveMatches,
             List<ConditionEntry> negativeMatches,
             List<String> unconditionalClasses,
-            List<String> exclusions) {}
+            List<String> exclusions,
+            PageMetadata page,
+            ConditionCounts counts) {
+        public ConditionsReport(
+                List<ConditionEntry> positiveMatches,
+                List<ConditionEntry> negativeMatches,
+                List<String> unconditionalClasses,
+                List<String> exclusions) {
+            this(
+                    positiveMatches,
+                    negativeMatches,
+                    unconditionalClasses,
+                    exclusions,
+                    new PageMetadata(
+                            positiveMatches.size() + negativeMatches.size(),
+                            positiveMatches.size() + negativeMatches.size(),
+                            0,
+                            positiveMatches.size() + negativeMatches.size(),
+                            positiveMatches.size() + negativeMatches.size(),
+                            false),
+                    new ConditionCounts(
+                            positiveMatches.size(),
+                            positiveMatches.size(),
+                            negativeMatches.size(),
+                            negativeMatches.size(),
+                            unconditionalClasses.size(),
+                            exclusions.size()));
+        }
+    }
 
     /**
      * A single configuration property value, with its source.
@@ -91,7 +136,26 @@ public final class BootUiDtos {
             List<String> activeProfiles,
             List<String> sources,
             List<ConfigPropertyDto> properties,
-            List<ConfigPropertySuggestionDto> propertySuggestions) {}
+            List<ConfigPropertySuggestionDto> propertySuggestions,
+            PageMetadata page,
+            int overrideCount) {
+        public ConfigReport(
+                List<String> activeProfiles,
+                List<String> sources,
+                List<ConfigPropertyDto> properties,
+                List<ConfigPropertySuggestionDto> propertySuggestions) {
+            this(
+                    activeProfiles,
+                    sources,
+                    properties,
+                    propertySuggestions,
+                    new PageMetadata(
+                            properties.size(), properties.size(), 0, properties.size(), properties.size(), false),
+                    (int) properties.stream()
+                            .filter(ConfigPropertyDto::override)
+                            .count());
+        }
+    }
 
     /**
      * Request to add/update a runtime property override.
@@ -109,7 +173,11 @@ public final class BootUiDtos {
      */
     public record MappingDto(String method, String pattern, String handler, String produces, String consumes) {}
 
-    public record MappingsReport(int total, List<MappingDto> mappings) {}
+    public record MappingsReport(int total, List<MappingDto> mappings, PageMetadata page) {
+        public MappingsReport(int total, List<MappingDto> mappings) {
+            this(total, mappings, new PageMetadata(total, mappings.size(), 0, mappings.size(), mappings.size(), false));
+        }
+    }
 
     /**
      * Request from the browser to probe a local HTTP endpoint.
@@ -129,7 +197,14 @@ public final class BootUiDtos {
 
     public record LoggerDto(String name, String configuredLevel, String effectiveLevel) {}
 
-    public record LoggersReport(List<String> availableLevels, List<LoggerDto> loggers) {}
+    public record LoggersReport(List<String> availableLevels, List<LoggerDto> loggers, PageMetadata page) {
+        public LoggersReport(List<String> availableLevels, List<LoggerDto> loggers) {
+            this(
+                    availableLevels,
+                    loggers,
+                    new PageMetadata(loggers.size(), loggers.size(), 0, loggers.size(), loggers.size(), false));
+        }
+    }
 
     /**
      * A single log line for the live log tail.

--- a/bootui-sample-app/e2e/tests/beans.spec.js
+++ b/bootui-sample-app/e2e/tests/beans.spec.js
@@ -30,19 +30,40 @@ test.describe('Beans view', () => {
       dependencies: []
     }))
 
-    await page.route('**/bootui/api/beans', (route) =>
-      route.fulfill({
+    await page.route('**/bootui/api/beans?*', (route) => {
+      const url = new URL(route.request().url())
+      const query = (url.searchParams.get('q') || '').toLowerCase()
+      const offset = Number(url.searchParams.get('offset') || 0)
+      const limit = Number(url.searchParams.get('limit') || 200)
+      const matched = query
+        ? beans.filter((bean) => bean.name.toLowerCase().includes(query) || bean.type.toLowerCase().includes(query))
+        : beans
+      const pageBeans = matched.slice(offset, offset + limit)
+
+      return route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({total: beans.length, beans})
+        body: JSON.stringify({
+          total: beans.length,
+          beans: pageBeans,
+          page: {
+            total: beans.length,
+            matched: matched.length,
+            offset,
+            limit,
+            returned: pageBeans.length,
+            hasMore: offset + pageBeans.length < matched.length
+          }
+        })
       })
-    )
+    })
 
     await openView('beans', 'Beans')
 
     const rows = page.locator('table tbody tr')
     await expect(rows).toHaveCount(200)
-    await expect(page.getByText('Showing 200 of 205 beans.')).toBeVisible()
+    await expect(page.getByText(/Showing 200 of 205 matching beans/)).toBeVisible()
+    await expect(page.getByRole('button', {name: /Load next 5/})).toBeVisible()
 
     await page.getByPlaceholder(/Filter by name or type/).fill('demoBean204')
     await expect(rows).toHaveCount(1)

--- a/bootui-ui/src/main/frontend/src/utils/useServerPagedList.js
+++ b/bootui-ui/src/main/frontend/src/utils/useServerPagedList.js
@@ -1,0 +1,97 @@
+import {computed, onBeforeUnmount, ref} from 'vue'
+
+export const SERVER_PAGE_SIZE = 200
+
+export function useServerPagedList(endpoint, itemsKey, queryParams, options = {}) {
+  const pageSize = options.pageSize || SERVER_PAGE_SIZE
+  const debounceMs = options.debounceMs || 250
+  const data = ref(null)
+  const loading = ref(false)
+  const loadingMore = ref(false)
+  const error = ref(null)
+
+  let requestId = 0
+  let timer = null
+
+  const items = computed(() => data.value?.[itemsKey] || [])
+  const page = computed(() => data.value?.page || null)
+  const shownCount = computed(() => items.value.length)
+  const matchedCount = computed(() => page.value?.matched ?? shownCount.value)
+  const totalCount = computed(() => page.value?.total ?? matchedCount.value)
+  const hiddenCount = computed(() => Math.max(matchedCount.value - shownCount.value, 0))
+
+  function buildUrl(offset) {
+    const params = new URLSearchParams()
+    const values = queryParams ? queryParams() : {}
+    for (const [key, value] of Object.entries(values || {})) {
+      if (value !== null && value !== undefined && value !== '') {
+        params.set(key, String(value))
+      }
+    }
+    params.set('offset', String(offset))
+    params.set('limit', String(pageSize))
+    return `${endpoint}?${params.toString()}`
+  }
+
+  async function load(options = {}) {
+    const append = options.append === true
+    const id = options.requestId || ++requestId
+    const targetLoading = append ? loadingMore : loading
+    const currentItems = append ? items.value : []
+    targetLoading.value = true
+    error.value = null
+    try {
+      const res = await fetch(buildUrl(currentItems.length))
+      if (!res.ok) throw new Error('HTTP ' + res.status)
+      const next = await res.json()
+      if (id !== requestId) return
+      data.value =
+        append && data.value
+          ? {
+              ...next,
+              [itemsKey]: [...currentItems, ...(next[itemsKey] || [])]
+            }
+          : next
+    } catch (e) {
+      if (id === requestId) error.value = e.message
+    } finally {
+      if (id === requestId) targetLoading.value = false
+    }
+  }
+
+  function scheduleReload() {
+    requestId += 1
+    const id = requestId
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => load({requestId: id}), debounceMs)
+  }
+
+  function loadMore() {
+    if (hiddenCount.value > 0 && !loadingMore.value) {
+      return load({append: true})
+    }
+    return Promise.resolve()
+  }
+
+  onBeforeUnmount(() => {
+    if (timer) clearTimeout(timer)
+    requestId += 1
+  })
+
+  return {
+    data,
+    error,
+    hiddenCount,
+    items,
+    load,
+    loadMore,
+    loading,
+    loadingMore,
+    matchedCount,
+    page,
+    pageSize,
+    scheduleReload,
+    shownCount,
+    totalCount
+  }
+}

--- a/bootui-ui/src/main/frontend/src/views/Beans.vue
+++ b/bootui-ui/src/main/frontend/src/views/Beans.vue
@@ -1,38 +1,40 @@
 <script setup>
-import {computed, onMounted, ref} from 'vue'
-import {useVisibleItems} from '../utils/useVisibleItems.js'
-import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
+import {onMounted, ref, watch} from 'vue'
+import {useServerPagedList} from '../utils/useServerPagedList.js'
+import ServerListFooter from './components/ServerListFooter.vue'
 
-const data = ref(null)
 const filter = ref('')
 const classification = ref('')
 
-async function load() {
-  const res = await fetch('api/beans')
-  data.value = await res.json()
-}
-
-const filtered = computed(() => {
-  if (!data.value) return []
-  return data.value.beans.filter((b) => {
-    if (classification.value && b.classification !== classification.value) return false
-    if (filter.value) {
-      const f = filter.value.toLowerCase()
-      return b.name.toLowerCase().includes(f) || (b.type && b.type.toLowerCase().includes(f))
-    }
-    return true
-  })
+const {
+  data,
+  error,
+  items: visibleBeans,
+  load,
+  loadMore,
+  loading,
+  loadingMore,
+  matchedCount,
+  pageSize,
+  scheduleReload,
+  shownCount,
+  totalCount
+} = useServerPagedList('api/beans', 'beans', () => {
+  return {
+    q: filter.value.trim(),
+    classification: classification.value
+  }
 })
 
-const {chunkSize, visibleItems: visibleBeans, shownCount, hiddenCount, showMore, showAll} = useVisibleItems(filtered)
-
 onMounted(load)
+watch([filter, classification], scheduleReload)
 </script>
 
 <template>
   <div>
     <h2><i class="bi bi-diagram-3 me-2"></i>Beans</h2>
-    <p class="text-muted">{{ data ? data.total : 0 }} beans · {{ filtered.length }} matched</p>
+    <p class="text-muted">{{ totalCount }} beans · {{ matchedCount }} matched</p>
+    <div v-if="error" class="alert alert-danger">Could not load beans: {{ error }}</div>
 
     <div class="row g-2 mb-3">
       <div class="col-md-8">
@@ -89,14 +91,15 @@ onMounted(load)
         </tbody>
       </table>
     </div>
-    <ProgressiveListFooter
-      :chunk-size="chunkSize"
-      :hidden="hiddenCount"
+    <ServerListFooter
+      v-if="!loading"
+      :loading="loadingMore"
+      :matched="matchedCount"
+      :page-size="pageSize"
       :shown="shownCount"
-      :total="filtered.length"
+      :total="totalCount"
       item-label="beans"
-      @show-all="showAll"
-      @show-more="showMore"
+      @load-more="loadMore"
     />
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/Conditions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.vue
@@ -1,30 +1,84 @@
 <script setup>
-import {computed, onMounted, ref} from 'vue'
-import {useVisibleItems} from '../utils/useVisibleItems.js'
-import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
+import {computed, onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {SERVER_PAGE_SIZE} from '../utils/useServerPagedList.js'
+import ServerListFooter from './components/ServerListFooter.vue'
 
 const data = ref(null)
 const tab = ref('positive')
 const filter = ref('')
+const loading = ref(false)
+const loadingMore = ref(false)
+const error = ref(null)
 
-async function load() {
-  const res = await fetch('api/conditions')
-  data.value = await res.json()
+let requestId = 0
+let timer = null
+
+const entriesKey = computed(() => (tab.value === 'positive' ? 'positiveMatches' : 'negativeMatches'))
+const entries = computed(() => data.value?.[entriesKey.value] || [])
+const counts = computed(() => data.value?.counts || {})
+const matchedCount = computed(() =>
+  tab.value === 'positive' ? counts.value.positiveMatched || 0 : counts.value.negativeMatched || 0
+)
+const totalCount = computed(() =>
+  tab.value === 'positive' ? counts.value.positiveTotal || 0 : counts.value.negativeTotal || 0
+)
+const shownCount = computed(() => entries.value.length)
+const hiddenCount = computed(() => Math.max(matchedCount.value - shownCount.value, 0))
+
+function buildUrl(offset) {
+  const params = new URLSearchParams()
+  params.set('outcome', tab.value)
+  params.set('offset', String(offset))
+  params.set('limit', String(SERVER_PAGE_SIZE))
+  if (filter.value.trim()) params.set('q', filter.value.trim())
+  return `api/conditions?${params.toString()}`
 }
 
-const entries = computed(() => {
-  if (!data.value) return []
-  const items = tab.value === 'positive' ? data.value.positiveMatches : data.value.negativeMatches
-  if (!filter.value) return items
-  const f = filter.value.toLowerCase()
-  return items.filter(
-    (e) => (e.autoConfigurationClass || '').toLowerCase().includes(f) || (e.message || '').toLowerCase().includes(f)
-  )
-})
+async function load(options = {}) {
+  const append = options.append === true
+  const id = options.requestId || ++requestId
+  const targetLoading = append ? loadingMore : loading
+  targetLoading.value = true
+  error.value = null
+  try {
+    const res = await fetch(buildUrl(append ? entries.value.length : 0))
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const next = await res.json()
+    if (id !== requestId) return
+    data.value =
+      append && data.value
+        ? {
+            ...next,
+            [entriesKey.value]: [...entries.value, ...(next[entriesKey.value] || [])]
+          }
+        : next
+  } catch (e) {
+    if (id === requestId) error.value = e.message
+  } finally {
+    if (id === requestId) targetLoading.value = false
+  }
+}
 
-const {chunkSize, visibleItems: visibleEntries, shownCount, hiddenCount, showMore, showAll} = useVisibleItems(entries)
+function scheduleReload() {
+  requestId += 1
+  const id = requestId
+  if (timer) clearTimeout(timer)
+  timer = setTimeout(() => load({requestId: id}), 250)
+}
+
+function loadMore() {
+  if (hiddenCount.value > 0 && !loadingMore.value) {
+    return load({append: true})
+  }
+  return Promise.resolve()
+}
 
 onMounted(load)
+watch([tab, filter], scheduleReload)
+onBeforeUnmount(() => {
+  if (timer) clearTimeout(timer)
+  requestId += 1
+})
 </script>
 
 <template>
@@ -33,18 +87,19 @@ onMounted(load)
     <ul class="nav nav-tabs mb-3">
       <li class="nav-item">
         <a :class="{active: tab === 'positive'}" class="nav-link" href="#" @click.prevent="tab = 'positive'">
-          Positive ({{ data ? data.positiveMatches.length : 0 }})
+          Positive ({{ counts.positiveMatched || 0 }})
         </a>
       </li>
       <li class="nav-item">
         <a :class="{active: tab === 'negative'}" class="nav-link" href="#" @click.prevent="tab = 'negative'">
-          Negative ({{ data ? data.negativeMatches.length : 0 }})
+          Negative ({{ counts.negativeMatched || 0 }})
         </a>
       </li>
     </ul>
+    <div v-if="error" class="alert alert-danger">Could not load conditions: {{ error }}</div>
     <input v-model="filter" class="form-control mb-3" placeholder="Filter…" />
-    <p class="small text-muted">{{ entries.length }} matching entries</p>
-    <div v-for="e in visibleEntries" :key="e.autoConfigurationClass + e.condition" class="mb-2">
+    <p class="small text-muted">{{ matchedCount }} of {{ totalCount }} {{ tab }} entries matched</p>
+    <div v-for="e in entries" :key="e.autoConfigurationClass + e.condition + e.message" class="mb-2">
       <div class="d-flex">
         <span :class="tab === 'positive' ? 'bg-success' : 'bg-secondary'" class="badge me-2">{{ e.outcome }}</span>
         <div>
@@ -54,14 +109,15 @@ onMounted(load)
         </div>
       </div>
     </div>
-    <ProgressiveListFooter
-      :chunk-size="chunkSize"
-      :hidden="hiddenCount"
+    <ServerListFooter
+      v-if="!loading"
+      :loading="loadingMore"
+      :matched="matchedCount"
+      :page-size="SERVER_PAGE_SIZE"
       :shown="shownCount"
-      :total="entries.length"
+      :total="totalCount"
       item-label="condition entries"
-      @show-all="showAll"
-      @show-more="showMore"
+      @load-more="loadMore"
     />
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -1,13 +1,11 @@
 <script setup>
-import {computed, nextTick, onMounted, ref} from 'vue'
+import {computed, nextTick, onMounted, ref, watch} from 'vue'
 import {apiFetch} from '../api.js'
-import {useVisibleItems} from '../utils/useVisibleItems.js'
-import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
+import {useServerPagedList} from '../utils/useServerPagedList.js'
+import ServerListFooter from './components/ServerListFooter.vue'
 
 const MAX_PROPERTY_SUGGESTIONS = 200
 
-const data = ref(null)
-const loading = ref(true)
 const filter = ref('')
 const sourceFilter = ref('')
 const showOnlyOverrides = ref(false)
@@ -22,6 +20,27 @@ const newRowError = ref(null)
 const newNameInput = ref(null)
 const editInput = ref(null)
 const banner = ref(null)
+
+const {
+  data,
+  error,
+  items: visibleProperties,
+  load,
+  loadMore,
+  loading,
+  loadingMore,
+  matchedCount,
+  pageSize,
+  scheduleReload,
+  shownCount,
+  totalCount
+} = useServerPagedList('api/config', 'properties', () => {
+  return {
+    q: filter.value.trim(),
+    source: sourceFilter.value,
+    overridesOnly: showOnlyOverrides.value ? 'true' : ''
+  }
+})
 
 const propertySuggestions = computed(() => data.value?.propertySuggestions || [])
 
@@ -73,53 +92,7 @@ const suggestionByName = computed(() => {
 
 const selectedNewSuggestion = computed(() => suggestionByName.value.get((newRowName.value || '').trim()) || null)
 
-async function load() {
-  loading.value = true
-  try {
-    const res = await fetch('api/config')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    data.value = await res.json()
-  } catch (e) {
-    flash(e.message, 'danger')
-  } finally {
-    loading.value = false
-  }
-}
-
-const filtered = computed(() => {
-  if (!data.value) return []
-  return data.value.properties.filter((p) => {
-    if (showOnlyOverrides.value && !p.override) return false
-    if (sourceFilter.value && p.source !== sourceFilter.value) return false
-    if (filter.value) {
-      const f = filter.value.toLowerCase()
-      return (
-        p.name.toLowerCase().includes(f) ||
-        String(p.value ?? '')
-          .toLowerCase()
-          .includes(f) ||
-        String(p.description ?? '')
-          .toLowerCase()
-          .includes(f) ||
-        String(p.defaultValue ?? '')
-          .toLowerCase()
-          .includes(f)
-      )
-    }
-    return true
-  })
-})
-
-const {
-  chunkSize,
-  visibleItems: visibleProperties,
-  shownCount,
-  hiddenCount,
-  showMore,
-  showAll
-} = useVisibleItems(filtered)
-
-const overrideCount = computed(() => (data.value ? data.value.properties.filter((p) => p.override).length : 0))
+const overrideCount = computed(() => data.value?.overrideCount || 0)
 
 function startEdit(p) {
   newRow.value = null
@@ -246,6 +219,7 @@ function flash(text, type) {
 }
 
 onMounted(load)
+watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
 </script>
 
 <template>
@@ -287,6 +261,7 @@ onMounted(load)
       </div>
       <button class="btn-close" @click="banner = null"></button>
     </div>
+    <div v-if="error" class="alert alert-danger">Could not load configuration properties: {{ error }}</div>
 
     <div class="row g-2 mb-3">
       <div class="col-md-6">
@@ -473,20 +448,21 @@ onMounted(load)
             </td>
           </tr>
 
-          <tr v-if="!loading && filtered.length === 0 && !newRow">
+          <tr v-if="!loading && matchedCount === 0 && !newRow">
             <td class="text-center text-muted py-4" colspan="5">No properties match your filters.</td>
           </tr>
         </tbody>
       </table>
     </div>
-    <ProgressiveListFooter
-      :chunk-size="chunkSize"
-      :hidden="hiddenCount"
+    <ServerListFooter
+      v-if="!loading"
+      :loading="loadingMore"
+      :matched="matchedCount"
+      :page-size="pageSize"
       :shown="shownCount"
-      :total="filtered.length"
+      :total="totalCount"
       item-label="properties"
-      @show-all="showAll"
-      @show-more="showMore"
+      @load-more="loadMore"
     />
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -1,26 +1,28 @@
 <script setup>
-import {computed, onMounted, ref} from 'vue'
+import {onMounted, ref, watch} from 'vue'
 import {apiFetch} from '../api.js'
-import {useVisibleItems} from '../utils/useVisibleItems.js'
-import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
+import {useServerPagedList} from '../utils/useServerPagedList.js'
+import ServerListFooter from './components/ServerListFooter.vue'
 
-const data = ref(null)
 const filter = ref('')
 const message = ref(null)
 
-async function load() {
-  const res = await fetch('api/loggers')
-  data.value = await res.json()
-}
-
-const filtered = computed(() => {
-  if (!data.value) return []
-  if (!filter.value) return data.value.loggers
-  const f = filter.value.toLowerCase()
-  return data.value.loggers.filter((l) => l.name.toLowerCase().includes(f))
+const {
+  data,
+  error,
+  items: visibleLoggers,
+  load,
+  loadMore,
+  loading,
+  loadingMore,
+  matchedCount,
+  pageSize,
+  scheduleReload,
+  shownCount,
+  totalCount
+} = useServerPagedList('api/loggers', 'loggers', () => {
+  return {q: filter.value.trim()}
 })
-
-const {chunkSize, visibleItems: visibleLoggers, shownCount, hiddenCount, showMore, showAll} = useVisibleItems(filtered)
 
 async function changeLevel(logger, level) {
   const body = level ? {level} : {}
@@ -52,14 +54,16 @@ const levelClass = (l) =>
   })[l] || 'text-secondary'
 
 onMounted(load)
+watch(filter, scheduleReload)
 </script>
 
 <template>
   <div>
     <h2><i class="bi bi-journal-text me-2"></i>Loggers</h2>
     <div v-if="message" class="alert alert-success">{{ message }}</div>
+    <div v-if="error" class="alert alert-danger">Could not load loggers: {{ error }}</div>
     <input v-model="filter" class="form-control mb-3" placeholder="Filter loggers by name…" />
-    <p v-if="data" class="small text-muted">{{ filtered.length }} of {{ data.loggers.length }} loggers matched</p>
+    <p v-if="data" class="small text-muted">{{ matchedCount }} of {{ totalCount }} loggers matched</p>
     <div class="table-responsive">
       <table class="table table-sm table-hover loggers-table">
         <colgroup>
@@ -101,14 +105,15 @@ onMounted(load)
         </tbody>
       </table>
     </div>
-    <ProgressiveListFooter
-      :chunk-size="chunkSize"
-      :hidden="hiddenCount"
+    <ServerListFooter
+      v-if="!loading"
+      :loading="loadingMore"
+      :matched="matchedCount"
+      :page-size="pageSize"
       :shown="shownCount"
-      :total="filtered.length"
+      :total="totalCount"
       item-label="loggers"
-      @show-all="showAll"
-      @show-more="showMore"
+      @load-more="loadMore"
     />
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/Mappings.vue
+++ b/bootui-ui/src/main/frontend/src/views/Mappings.vue
@@ -1,49 +1,25 @@
 <script setup>
-import {computed, onMounted, ref} from 'vue'
-import {useVisibleItems} from '../utils/useVisibleItems.js'
-import ProgressiveListFooter from './components/ProgressiveListFooter.vue'
+import {onMounted, ref, watch} from 'vue'
+import {useServerPagedList} from '../utils/useServerPagedList.js'
+import ServerListFooter from './components/ServerListFooter.vue'
 
-const data = ref(null)
 const filter = ref('')
 
-async function load() {
-  const res = await fetch('api/mappings')
-  if (res.status === 204) return
-  data.value = await res.json()
-}
-
-const flat = computed(() => {
-  if (!data.value) return []
-  const rows = []
-  const contexts = data.value.contexts || {}
-  for (const ctxName of Object.keys(contexts)) {
-    const ctx = contexts[ctxName]
-    const dispatchers = ctx.mappings?.dispatcherServlets || ctx.mappings?.dispatcherHandlers || {}
-    for (const dispatcherName of Object.keys(dispatchers)) {
-      const handlers = dispatchers[dispatcherName] || []
-      for (const h of handlers) {
-        const conds = h.details?.requestMappingConditions || {}
-        const patterns = conds.patterns || []
-        const methods = conds.methods || ['ANY']
-        for (const pattern of patterns.length ? patterns : ['(any)']) {
-          for (const method of methods.length ? methods : ['ANY']) {
-            rows.push({method, pattern, handler: h.handler, predicate: h.predicate})
-          }
-        }
-      }
-    }
-  }
-  if (!filter.value) return rows
-  const f = filter.value.toLowerCase()
-  return rows.filter(
-    (r) =>
-      (r.pattern || '').toLowerCase().includes(f) ||
-      (r.handler || '').toLowerCase().includes(f) ||
-      (r.method || '').toLowerCase().includes(f)
-  )
+const {
+  error,
+  items: visibleMappings,
+  load,
+  loadMore,
+  loading,
+  loadingMore,
+  matchedCount,
+  pageSize,
+  scheduleReload,
+  shownCount,
+  totalCount
+} = useServerPagedList('api/mappings/flat', 'mappings', () => {
+  return {q: filter.value.trim()}
 })
-
-const {chunkSize, visibleItems: visibleMappings, shownCount, hiddenCount, showMore, showAll} = useVisibleItems(flat)
 
 const methodClass = (m) =>
   ({
@@ -56,13 +32,15 @@ const methodClass = (m) =>
   })[m] || 'bg-secondary'
 
 onMounted(load)
+watch(filter, scheduleReload)
 </script>
 
 <template>
   <div>
     <h2><i class="bi bi-signpost-2 me-2"></i>HTTP mappings</h2>
+    <div v-if="error" class="alert alert-danger">Could not load mappings: {{ error }}</div>
     <input v-model="filter" class="form-control mb-3" placeholder="Filter…" />
-    <p class="small text-muted">{{ flat.length }} matching mappings</p>
+    <p class="small text-muted">{{ matchedCount }} of {{ totalCount }} mappings matched</p>
     <div class="table-responsive">
       <table class="table table-sm table-hover">
         <thead>
@@ -87,14 +65,15 @@ onMounted(load)
         </tbody>
       </table>
     </div>
-    <ProgressiveListFooter
-      :chunk-size="chunkSize"
-      :hidden="hiddenCount"
+    <ServerListFooter
+      v-if="!loading"
+      :loading="loadingMore"
+      :matched="matchedCount"
+      :page-size="pageSize"
       :shown="shownCount"
-      :total="flat.length"
+      :total="totalCount"
       item-label="mappings"
-      @show-all="showAll"
-      @show-more="showMore"
+      @load-more="loadMore"
     />
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/components/ServerListFooter.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/ServerListFooter.test.js
@@ -1,0 +1,42 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+
+import ServerListFooter from './ServerListFooter.vue'
+
+function mountFooter(props = {}) {
+  return mount(ServerListFooter, {
+    props: {
+      shown: 200,
+      matched: 450,
+      total: 900,
+      pageSize: 200,
+      itemLabel: 'beans',
+      ...props
+    }
+  })
+}
+
+describe('ServerListFooter', () => {
+  it('renders server-side counts and emits load more', async () => {
+    const wrapper = mountFooter()
+
+    expect(wrapper.text()).toContain('Showing 200 of 450 matching beans (900 total). Filters run on the server.')
+    expect(wrapper.text()).toContain('Load next 200')
+
+    await wrapper.find('button').trigger('click')
+
+    expect(wrapper.emitted('loadMore')).toHaveLength(1)
+  })
+
+  it('uses the remaining hidden count when it is smaller than the page size', () => {
+    const wrapper = mountFooter({shown: 430})
+
+    expect(wrapper.text()).toContain('Load next 20')
+  })
+
+  it('hides the button when every matching item is loaded', () => {
+    const wrapper = mountFooter({shown: 450})
+
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/ServerListFooter.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ServerListFooter.vue
@@ -1,0 +1,58 @@
+<script setup>
+import {computed} from 'vue'
+
+const props = defineProps({
+  shown: {
+    type: Number,
+    required: true
+  },
+  matched: {
+    type: Number,
+    required: true
+  },
+  total: {
+    type: Number,
+    required: true
+  },
+  pageSize: {
+    type: Number,
+    required: true
+  },
+  loading: {
+    type: Boolean,
+    default: false
+  },
+  itemLabel: {
+    type: String,
+    default: 'items'
+  }
+})
+
+defineEmits(['loadMore'])
+
+const hidden = computed(() => Math.max(props.matched - props.shown, 0))
+const nextCount = computed(() => Math.min(props.pageSize, hidden.value))
+</script>
+
+<template>
+  <div
+    aria-live="polite"
+    class="d-flex flex-wrap justify-content-between align-items-center gap-2 text-muted small py-2"
+  >
+    <span>
+      Showing {{ shown }} of {{ matched }} matching {{ itemLabel }}
+      <span v-if="total !== matched">({{ total }} total).</span>
+      <span v-else>.</span>
+      Filters run on the server.
+    </span>
+    <button
+      v-if="hidden > 0"
+      :disabled="loading"
+      class="btn btn-sm btn-outline-secondary"
+      type="button"
+      @click="$emit('loadMore')"
+    >
+      {{ loading ? 'Loading…' : 'Load next ' + nextCount }}
+    </button>
+  </div>
+</template>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -47,16 +47,17 @@ available measurements, and render a local live chart for a selected metric/tag 
 
 The Conditions panel explains Spring Boot auto-configuration decisions. It groups positive matches, negative matches,
 and unconditional classes so you can see why an auto-configuration applied or why it was skipped. Large condition reports
-render progressively so the page stays responsive, while filtering still searches the full report.
+load in bounded pages, and filtering runs on the server so the browser does not need the full report before narrowing
+results.
 
 ![BootUI Conditions panel](images/bootui-conditions.png)
 
 ## Beans
 
-The Beans panel helps answer which Spring beans exist and where they came from. It supports search across bean names,
-classes, packages, scopes, resources, dependencies, aliases, and BootUI classifications such as application, BootUI,
-Spring framework, Java/Jakarta, and other beans. Large bean lists render progressively so the initial page stays usable;
-search and classification filters still apply to the full bean set.
+The Beans panel helps answer which Spring beans exist and where they came from. It supports server-side search across
+bean names and types, plus BootUI classifications such as application, BootUI, Spring framework, Java/Jakarta, and other
+beans. Large bean lists load in bounded pages so the initial payload stays small while filters still apply to the full
+bean set.
 
 ![BootUI Beans panel](images/bootui-beans.png)
 
@@ -64,7 +65,8 @@ search and classification filters still apply to the full bean set.
 
 The Mappings panel lists HTTP routes from Actuator mappings data. It shows request methods, path patterns, handlers, and
 produces/consumes metadata so the running application's web surface is visible without reading controllers manually.
-Large mapping lists render progressively, and the filter continues to search every discovered route.
+Large mapping lists load through a stable, paged BootUI DTO, and the filter continues to search every discovered route
+on the server.
 
 ![BootUI Mappings panel](images/bootui-mappings.png)
 
@@ -73,8 +75,8 @@ Large mapping lists render progressively, and the filter continues to search eve
 The Configuration panel shows effective configuration properties, sources, metadata descriptions, defaults when known,
 active profiles, and masked values. It can create, update, and delete local runtime overrides persisted to
 `.bootui/application-bootui.properties`, with restart and rebinding caveats shown for every mutation. Large property
-tables render progressively, and the override property-name picker limits its datalist suggestions while narrowing
-against the full metadata catalog as you type.
+tables load in bounded server-side pages for search, source, and override-only filters. The override property-name
+picker limits its datalist suggestions while narrowing against the full metadata catalog as you type.
 
 ![BootUI Configuration panel](images/bootui-configuration.png)
 
@@ -89,8 +91,8 @@ masking rules.
 ## Loggers
 
 The Loggers panel lists runtime logger configuration from Actuator. It shows configured and effective levels, supports
-search, and can update or clear logger levels without restarting the application. Large logger lists render
-progressively, while filtering still searches the full logger set.
+server-side search, and can update or clear logger levels without restarting the application. Large logger lists load in
+bounded pages while filtering still searches the full logger set.
 
 ![BootUI Loggers panel](images/bootui-loggers.png)
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -135,9 +135,12 @@ The harden-all-visible-panels alpha test expansion is complete. Coverage now inc
 11. Frontend unit test setup (v0.2, 2026-05-28): Vitest, Vue Test Utils, and jsdom are wired into the Vite frontend. The
     first tests cover the progressive rendering composable and footer component, and Maven runs `npm run test` during the
     `test` phase unless `-DskipTests` is set.
+12. Server-side filtering and pagination (v0.2, 2026-05-28): high-cardinality Beans, Conditions, Mappings, Configuration,
+    and Loggers reports now accept bounded query parameters and return page metadata. The Vue panels request server-side
+    pages instead of fetching every row up front, and the Mappings panel uses a stable BootUI DTO while the legacy raw
+    Actuator descriptor remains available at `/bootui/api/mappings`.
 
-Future backend test work should be incremental and tied to new or changed behavior, especially remaining v0.2
-candidates such as server-side filtering or pagination if payload-size bottlenecks show up.
+Future backend test work should be incremental and tied to new or changed behavior.
 
 ### 4.2 UI and product parity status
 
@@ -172,9 +175,9 @@ Security, Metrics, Vulnerabilities, DevTools, and Dev Services are implemented, 
 Playwright tests, and part of the supported alpha surface. Any new visible route or browser-facing behavior should
 update the router, README feature table, `docs/FEATURES.md`, and Playwright coverage together.
 
-The first v0.2 large-app pass is complete for the most obvious browser-rendering hotspots: Beans, Conditions, Mappings,
-Configuration, and Loggers progressively render large filtered result sets, while search/filter controls continue to
-operate over all received data.
+The v0.2 large-app hardening pass is complete for the most obvious list and payload hotspots: Beans, Conditions,
+Mappings, Configuration, and Loggers request bounded server-side pages with filter parameters and render only the rows
+already returned by the API.
 
 Optional UI gating is complete for the visible route set (v0.2, 2026-05-28). `/bootui/api/panels` reports classpath,
 endpoint, and configuration availability for each sidebar route. The Vue shell keeps routes visible, dims unavailable
@@ -344,8 +347,9 @@ Potential features:
 - ~~Frontend test setup if the project decides to add Vitest or another UI test runner.~~ Done (2026-05-28): Vitest,
   Vue Test Utils, and jsdom run through `npm run test` and the Maven `test` phase, with seed coverage for progressive
   list rendering.
-- Server-side filtering or pagination for Actuator-backed APIs if real-world large apps expose response-size bottlenecks
-  that browser-side progressive rendering cannot solve.
+- ~~Server-side filtering or pagination for Actuator-backed APIs if real-world large apps expose response-size
+  bottlenecks that browser-side progressive rendering cannot solve.~~ Done (2026-05-28): Beans, Conditions, Mappings,
+  Configuration, and Loggers now expose bounded server-side pages with filter-aware counts and page metadata.
 
 ## 7. v1.0 candidates
 
@@ -444,8 +448,8 @@ for Scheduled, HTTP Probe, Log Tail, Profile Diff masking, Security, Memory, and
 Dev Services edge-case hardening (first v0.2 item) was completed on 2026-05-28 (PR #88). Large-app browser-rendering
 hardening was completed next for high-cardinality lists. Optional UI gating was completed after that with the
 `/bootui/api/panels` availability report, sidebar dimming, accessible unavailable labels/tooltips, and an active-panel
-reason banner. Frontend unit test setup followed with Vitest, Vue Test Utils, jsdom, and Maven test-phase wiring. The
-remaining v0.2 candidate is server-side filtering or pagination if payload-size bottlenecks show up in real-world apps.
+reason banner. Frontend unit test setup followed with Vitest, Vue Test Utils, jsdom, and Maven test-phase wiring.
+Server-side filtering and pagination completed the listed v0.2 candidate set for high-cardinality list payloads.
 
 User-facing documentation is reconciled with current behavior: `README.md`, `docs/FEATURES.md`, and
 `docs/SPECIFICATION.md` use the `AUTO|ON|OFF` activation model, the persisted-overrides behavior, the plain-JavaScript
@@ -455,8 +459,8 @@ Vue 3 frontend, and the full visible panel set. The repository now ships a `CHAN
 On 2026-05-28, `./mvnw -B -ntp clean install` and the Playwright suite under `bootui-sample-app/e2e` both passed on the
 current branch. The Playwright run covered all 57 sample-app browser tests.
 
-The next workstream continues v0.2 with the remaining candidate in §6: server-side filtering or pagination if
-payload-size bottlenecks show up. Keep release validation and docs in sync as changes land.
+The listed v0.2 candidate set is complete. The next workstream should be release validation for the next alpha or a new
+candidate promoted from §7, with docs kept in sync as behavior changes land.
 
 ## 10. Validation checklist
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -801,7 +801,8 @@ BootUI should expose its own development-only API under:
 ```
 
 The browser UI should not depend directly on raw Actuator response shapes. BootUI should normalize them into stable
-DTOs.
+DTOs. High-cardinality list endpoints should support bounded server-side `q` / filter / `offset` / `limit` access and
+return page metadata so the SPA can avoid fetching every row before filtering.
 
 Initial endpoints:
 
@@ -814,6 +815,7 @@ Initial endpoints:
 | `/bootui/api/config/overrides`          | POST   | Create or update a local runtime configuration property override         |
 | `/bootui/api/config/overrides/{name}`   | DELETE | Remove a local runtime configuration property override                   |
 | `/bootui/api/mappings`                  | GET    | HTTP mappings                                                            |
+| `/bootui/api/mappings/flat`             | GET    | Stable, paged HTTP mapping summaries                                     |
 | `/bootui/api/health`                    | GET    | Health tree                                                              |
 | `/bootui/api/loggers`                   | GET    | Logger levels                                                            |
 | `/bootui/api/loggers/{name}`            | POST   | Change logger level                                                      |


### PR DESCRIPTION
Large BootUI installations can expose Actuator reports with enough rows that fetching every item before filtering creates unnecessary payload and browser work. This completes the remaining v0.2 large-app hardening item by moving the obvious high-cardinality panels to bounded server-side queries.

## Summary

- Add shared paging metadata and bounded query helpers for Beans, Conditions, Configuration, Loggers, and stable flat Mappings reports.
- Update the Vue panels to request paged results, debounce filter changes, append additional pages, and show server-side count/status feedback.
- Keep the raw `/bootui/api/mappings` descriptor available for compatibility while the UI uses the new `/bootui/api/mappings/flat` DTO.
- Update README, `docs/FEATURES.md`, `docs/SPECIFICATION.md`, and `docs/PLAN.md` to mark the v0.2 candidate complete.

## Validation

- `./mvnw -B -ntp -pl bootui-autoconfigure -am test -Dtest=BeansControllerTests,ConditionsControllerTests,MappingsControllerTests,ConfigControllerTests,LoggersControllerMutationTests -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -B -ntp -pl bootui-ui test -DskipTests=false`
- `./mvnw -B -ntp spotless:check`
- `npm run format:check` through the Maven-managed Node/npm install
- `bootui-sample-app/e2e` Playwright suite: 57 passed
- `./mvnw -B -ntp clean install`