### PR TITLE
Remove empty starter JAR warning

### DIFF
--- a/bootui-spring-boot-starter/src/main/resources/META-INF/bootui/starter.marker
+++ b/bootui-spring-boot-starter/src/main/resources/META-INF/bootui/starter.marker
@@ -1,0 +1,3 @@
+BootUI Spring Boot starter marker.
+
+This dependency-only artifact intentionally contains no Java classes.


### PR DESCRIPTION
## What does this PR do?

Adds a harmless classpath marker resource to the dependency-only `bootui-spring-boot-starter` artifact so Maven no longer warns that the starter JAR is empty.

## Why is this change needed?

The starter intentionally has no Java classes, but the full Maven build currently emits `JAR will be empty - no content was marked for inclusion!`. Including a marker file keeps the artifact behavior unchanged while making the build output clean.

N/A

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (N/A - packaging-only change)
- [ ] Added or updated tests where applicable (N/A - marker resource only)

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no behavior change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed