### PR TITLE
Group sidebar navigation sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,39 +15,39 @@ UI into the starter so consuming applications do not need Node.js or npm.
 
 ## Features
 
-BootUI exposes these panels in the same order as the application menu. See the [feature details guide](docs/FEATURES.md)
-for explanations and screenshots for every panel.
+BootUI exposes these panels in the same grouped order as the application menu. See the
+[feature details guide](docs/FEATURES.md) for explanations and screenshots for every panel.
 
-| Feature                                               | What it helps with                                                                                         |
-|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-| [Overview](docs/FEATURES.md#overview)                 | See runtime identity, versions, ports, active profiles, activation reason, and safety state.               |
-| [Startup Timeline](docs/FEATURES.md#startup-timeline) | Inspect Spring Boot startup steps and durations when startup data is available.                            |
-| [Memory](docs/FEATURES.md#memory)                     | Review JVM heap, non-heap, memory pools, garbage collectors, and suggested JVM options.                    |
-| [Health](docs/FEATURES.md#health)                     | Explore the Actuator health tree and contributor details.                                                  |
-| [Metrics](docs/FEATURES.md#metrics)                   | Browse Micrometer meters, tags, measurements, and a local live chart for selected metrics.                 |
-| [Conditions](docs/FEATURES.md#conditions)             | Understand why auto-configuration classes matched, did not match, or were unconditional.                   |
-| [Beans](docs/FEATURES.md#beans)                       | Search Spring beans by name, type, and BootUI classification with server-side paging.                      |
-| [Mappings](docs/FEATURES.md#mappings)                 | Review HTTP routes, handlers, methods, patterns, and produces/consumes metadata.                           |
-| [Configuration](docs/FEATURES.md#configuration)       | Inspect effective configuration values, metadata, masking, and local runtime overrides.                    |
-| [Profile Diff](docs/FEATURES.md#profile-diff)         | Compare profile-specific property sources and values while preserving secret masking.                      |
-| [Loggers](docs/FEATURES.md#loggers)                   | Inspect and change logger levels at runtime through the Actuator loggers endpoint.                         |
-| [Log Tail](docs/FEATURES.md#log-tail)                 | Read recent application logs and stream new local log events from the running process.                     |
-| [Traces](docs/FEATURES.md#traces)                     | Inspect distributed tracing spans collected by the embedded OTLP receiver with a per-trace waterfall view. |
-| [HTTP Probe](docs/FEATURES.md#http-probe)             | Send local-only HTTP requests to the app and inspect response status, headers, and body.                   |
-| [Copilot](docs/FEATURES.md#copilot)                   | Dashboard sanitized local GitHub Copilot CLI sessions: activity trends, tool mix, MCP, hooks, skills, errors. |
-| [Claude Code](docs/FEATURES.md#claude-code)           | Dashboard sanitized local Claude Code project logs: activity trends, tool mix, models, and failures.       |
-| [DevTools](docs/FEATURES.md#devtools)                 | Check Spring Boot DevTools status, LiveReload availability, and restart controls.                          |
-| [Dev Services](docs/FEATURES.md#dev-services)         | Inspect Docker Compose snapshots, safe Testcontainers beans, service connection metadata, and bounded logs. |
-| [Scheduled Tasks](docs/FEATURES.md#scheduled-tasks)   | View registered scheduled tasks and their trigger metadata.                                                |
-| [Data](docs/FEATURES.md#data)                         | Explore Spring Data repositories, domain types, IDs, and query methods.                                    |
-| [Cache](docs/FEATURES.md#cache)                       | Inspect Spring Cache managers, caches, metrics, annotations, and confirmed clear actions.                  |
-| [AI Usage](docs/FEATURES.md#ai-usage)                 | Summarize Spring AI chat conversations, token usage, latency, and model details from OpenTelemetry spans.  |
-| [Security](docs/FEATURES.md#security)                 | Inspect Spring Security filter chains and best-effort endpoint rule explanations.                          |
-| [Vulnerabilities](docs/FEATURES.md#vulnerabilities)   | Review dependency inventory and local OSV vulnerability scan results.                                      |
+| Group           | Feature                                               | What it helps with                                                                                            |
+| --------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Overview        | [Overview](docs/FEATURES.md#overview)                 | See runtime identity, versions, ports, active profiles, activation reason, and safety state.                  |
+| Runtime         | [Health](docs/FEATURES.md#health)                     | Explore the Actuator health tree and contributor details.                                                     |
+| Runtime         | [Metrics](docs/FEATURES.md#metrics)                   | Browse Micrometer meters, tags, measurements, and a local live chart for selected metrics.                    |
+| Runtime         | [Memory](docs/FEATURES.md#memory)                     | Review JVM heap, non-heap, memory pools, garbage collectors, and suggested JVM options.                       |
+| Runtime         | [Startup Timeline](docs/FEATURES.md#startup-timeline) | Inspect Spring Boot startup steps and durations when startup data is available.                               |
+| Runtime         | [Scheduled Tasks](docs/FEATURES.md#scheduled-tasks)   | View registered scheduled tasks and their trigger metadata.                                                   |
+| Configuration   | [Configuration](docs/FEATURES.md#configuration)       | Inspect effective configuration values, metadata, masking, and local runtime overrides.                       |
+| Configuration   | [Profile Diff](docs/FEATURES.md#profile-diff)         | Compare profile-specific property sources and values while preserving secret masking.                         |
+| Configuration   | [Loggers](docs/FEATURES.md#loggers)                   | Inspect and change logger levels at runtime through the Actuator loggers endpoint.                            |
+| Configuration   | [Beans](docs/FEATURES.md#beans)                       | Search Spring beans by name, type, and BootUI classification with server-side paging.                         |
+| Configuration   | [Conditions](docs/FEATURES.md#conditions)             | Understand why auto-configuration classes matched, did not match, or were unconditional.                      |
+| Configuration   | [Mappings](docs/FEATURES.md#mappings)                 | Review HTTP routes, handlers, methods, patterns, and produces/consumes metadata.                              |
+| Services        | [Data](docs/FEATURES.md#data)                         | Explore Spring Data repositories, domain types, IDs, and query methods.                                       |
+| Services        | [Cache](docs/FEATURES.md#cache)                       | Inspect Spring Cache managers, caches, metrics, annotations, and confirmed clear actions.                     |
+| Services        | [Security](docs/FEATURES.md#security)                 | Inspect Spring Security filter chains and best-effort endpoint rule explanations.                             |
+| Services        | [AI Usage](docs/FEATURES.md#ai-usage)                 | Summarize Spring AI chat conversations, token usage, latency, and model details from OpenTelemetry spans.     |
+| Diagnostics     | [Traces](docs/FEATURES.md#traces)                     | Inspect distributed tracing spans collected by the embedded OTLP receiver with a per-trace waterfall view.    |
+| Diagnostics     | [Log Tail](docs/FEATURES.md#log-tail)                 | Read recent application logs and stream new local log events from the running process.                        |
+| Diagnostics     | [HTTP Probe](docs/FEATURES.md#http-probe)             | Send local-only HTTP requests to the app and inspect response status, headers, and body.                      |
+| Diagnostics     | [Vulnerabilities](docs/FEATURES.md#vulnerabilities)   | Review dependency inventory and local OSV vulnerability scan results.                                         |
+| Developer tools | [DevTools](docs/FEATURES.md#devtools)                 | Check Spring Boot DevTools status, LiveReload availability, and restart controls.                             |
+| Developer tools | [Dev Services](docs/FEATURES.md#dev-services)         | Inspect Docker Compose snapshots, safe Testcontainers beans, service connection metadata, and bounded logs.   |
+| Developer tools | [Copilot](docs/FEATURES.md#copilot)                   | Dashboard sanitized local GitHub Copilot CLI sessions: activity trends, tool mix, MCP, hooks, skills, errors. |
+| Developer tools | [Claude Code](docs/FEATURES.md#claude-code)           | Dashboard sanitized local Claude Code project logs: activity trends, tool mix, models, and failures.          |
 
 Some panels depend on optional Spring, Actuator, or development infrastructure. When data is unavailable, BootUI returns
-stable empty responses or shows an explanatory empty state. The sidebar also dims panels whose backing classpath or
-endpoint support is unavailable, and opening a dimmed panel shows the unavailable reason at the top of the page.
+stable empty responses or shows an explanatory empty state. The sidebar also moves unavailable non-overview panels into
+a collapsed Disabled / unavailable group, and opening a dimmed panel shows the unavailable reason at the top of the page.
 
 ## Setup
 
@@ -101,25 +101,25 @@ BootUI is intended for local development only. By default it:
 
 Common properties:
 
-| Property                              | Default                                 | Description                                                                              |
-|---------------------------------------|-----------------------------------------|------------------------------------------------------------------------------------------|
-| `bootui.enabled`                      | `AUTO`                                  | `AUTO`, `ON`, or `OFF`.                                                                  |
-| `bootui.enabled-profiles`             | `dev,local`                             | Profiles that activate BootUI in auto mode.                                              |
-| `bootui.disabled-profiles`            | `prod,production`                       | Profiles that disable BootUI unless forced on.                                           |
-| `bootui.allow-non-localhost`          | `false`                                 | Explicit opt-out of loopback-only protection.                                            |
-| `bootui.expose-values`                | `MASKED`                                | `MASKED`, `METADATA_ONLY`, or `FULL`; `FULL` can disclose secrets and should stay local. |
-| `bootui.overrides-file`               | `.bootui/application-bootui.properties` | Runtime override persistence file.                                                       |
-| `bootui.cache.clear-enabled`          | `true`                                  | Enables Spring Cache clear actions after explicit browser confirmation.                  |
-| `bootui.dev-services.restart-enabled` | `false`                                 | Enables restart controls for bean-backed Testcontainers services. Disabled by default.   |
-| `bootui.dev-services.log-tail-bytes`  | `65536`                                 | Maximum bytes returned by one Dev Services log request.                                  |
-| `bootui.copilot.enabled`              | `AUTO`                                  | Enable the Copilot panel. `AUTO` activates when `~/.copilot/session-state/` exists.      |
-| `bootui.copilot.session-state-dir`    | `~/.copilot/session-state`              | Directory scanned for Copilot CLI session directories and `events.jsonl` files.          |
-| `bootui.copilot.max-sessions`         | `100`                                   | Maximum recent sessions returned by the Copilot session explorer.                        |
-| `bootui.copilot.allow-raw-reveal`     | `true`                                  | When `false`, the opt-in raw-event reveal endpoint returns 404 even on loopback.         |
-| `bootui.claude-code.enabled`          | `AUTO`                                  | Enable the Claude Code panel. `AUTO` activates when `~/.claude/projects/` exists.        |
+| Property                               | Default                                 | Description                                                                              |
+| -------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `bootui.enabled`                       | `AUTO`                                  | `AUTO`, `ON`, or `OFF`.                                                                  |
+| `bootui.enabled-profiles`              | `dev,local`                             | Profiles that activate BootUI in auto mode.                                              |
+| `bootui.disabled-profiles`             | `prod,production`                       | Profiles that disable BootUI unless forced on.                                           |
+| `bootui.allow-non-localhost`           | `false`                                 | Explicit opt-out of loopback-only protection.                                            |
+| `bootui.expose-values`                 | `MASKED`                                | `MASKED`, `METADATA_ONLY`, or `FULL`; `FULL` can disclose secrets and should stay local. |
+| `bootui.overrides-file`                | `.bootui/application-bootui.properties` | Runtime override persistence file.                                                       |
+| `bootui.cache.clear-enabled`           | `true`                                  | Enables Spring Cache clear actions after explicit browser confirmation.                  |
+| `bootui.dev-services.restart-enabled`  | `false`                                 | Enables restart controls for bean-backed Testcontainers services. Disabled by default.   |
+| `bootui.dev-services.log-tail-bytes`   | `65536`                                 | Maximum bytes returned by one Dev Services log request.                                  |
+| `bootui.copilot.enabled`               | `AUTO`                                  | Enable the Copilot panel. `AUTO` activates when `~/.copilot/session-state/` exists.      |
+| `bootui.copilot.session-state-dir`     | `~/.copilot/session-state`              | Directory scanned for Copilot CLI session directories and `events.jsonl` files.          |
+| `bootui.copilot.max-sessions`          | `100`                                   | Maximum recent sessions returned by the Copilot session explorer.                        |
+| `bootui.copilot.allow-raw-reveal`      | `true`                                  | When `false`, the opt-in raw-event reveal endpoint returns 404 even on loopback.         |
+| `bootui.claude-code.enabled`           | `AUTO`                                  | Enable the Claude Code panel. `AUTO` activates when `~/.claude/projects/` exists.        |
 | `bootui.claude-code.session-state-dir` | `~/.claude/projects`                    | Directory scanned for Claude Code project JSONL logs.                                    |
-| `bootui.claude-code.max-sessions`     | `100`                                   | Maximum recent sessions returned by the Claude Code session explorer.                    |
-| `bootui.claude-code.allow-raw-reveal` | `false`                                 | Explicitly enable raw JSONL reveal; raw Claude Code logs can include prompts and output. |
+| `bootui.claude-code.max-sessions`      | `100`                                   | Maximum recent sessions returned by the Claude Code session explorer.                    |
+| `bootui.claude-code.allow-raw-reveal`  | `false`                                 | Explicitly enable raw JSONL reveal; raw Claude Code logs can include prompts and output. |
 
 ## Runtime overrides
 
@@ -131,7 +131,7 @@ app restarts; BootUI returns that warning with every override mutation.
 ## Troubleshooting
 
 | Symptom                      | Check                                                                                                                           |
-|------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `/bootui` returns 404        | Use the `dev` or `local` profile, add DevTools, or set `bootui.enabled=ON`.                                                     |
 | BootUI is disabled in `prod` | This is intentional; only `bootui.enabled=ON` can force activation with a disabled profile.                                     |
 | Browser is rejected          | BootUI accepts loopback callers by default. Use `bootui.allow-non-localhost=true` only for a trusted local network.             |

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -1,6 +1,63 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
 
+const allPanelLinks = [
+  {id: 'overview', title: 'Overview', heading: /^Overview/},
+  {id: 'health', title: 'Health', heading: /^Health/},
+  {id: 'metrics', title: 'Metrics', heading: /^Metrics/},
+  {id: 'memory', title: 'Memory', heading: /^Memory/},
+  {id: 'startup', title: 'Startup Timeline', heading: /Startup timeline/},
+  {id: 'scheduled', title: 'Scheduled Tasks', heading: /Scheduled Tasks/},
+  {id: 'config', title: 'Configuration', heading: /^Configuration/},
+  {id: 'profiles', title: 'Profile Diff', heading: /Profile Diff/},
+  {id: 'loggers', title: 'Loggers', heading: /^Loggers/},
+  {id: 'beans', title: 'Beans', heading: /^Beans/},
+  {id: 'conditions', title: 'Conditions', heading: /Auto-configuration conditions/},
+  {id: 'mappings', title: 'Mappings', heading: /HTTP mappings/},
+  {id: 'data', title: 'Data', heading: /Spring Data repositories/},
+  {id: 'cache', title: 'Cache', heading: /Spring Cache/},
+  {id: 'security', title: 'Security', heading: /Spring Security/},
+  {id: 'ai', title: 'AI Usage', heading: /AI Usage/},
+  {id: 'traces', title: 'Traces', heading: /^Traces/},
+  {id: 'log-tail', title: 'Log Tail', heading: /Log Tail/},
+  {id: 'http-probe', title: 'HTTP Probe', heading: /HTTP Probe/},
+  {id: 'vulnerabilities', title: 'Vulnerabilities', heading: /^Vulnerabilities/},
+  {id: 'devtools', title: 'DevTools', heading: /^DevTools/},
+  {id: 'dev-services', title: 'Dev Services', heading: /^Dev Services/},
+  {id: 'copilot', title: 'Copilot', heading: /^Copilot/},
+  {id: 'claude-code', title: 'Claude Code', heading: /^Claude Code/}
+]
+
+async function mockPanelAvailability(page, overrides = {}) {
+  await page.route(
+    (url) => url.pathname === '/bootui/api/panels',
+    async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          panels: allPanelLinks.map((link) => ({
+            id: link.id,
+            title: link.title,
+            available: overrides[link.id]?.available ?? true,
+            unavailableReason: overrides[link.id]?.unavailableReason ?? null
+          }))
+        })
+      })
+    }
+  )
+}
+
+async function expandAllSidebarGroups(page) {
+  const toggles = page.locator('aside .bootui-nav-group__toggle')
+  const count = await toggles.count()
+  for (let index = 0; index < count; index += 1) {
+    const toggle = toggles.nth(index)
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+      await toggle.click()
+    }
+  }
+}
+
 test.describe('BootUI app shell', () => {
   test('navbar shows the application name and Spring Boot / Java versions', async ({page}) => {
     await page.goto('/bootui/')
@@ -18,6 +75,30 @@ test.describe('BootUI app shell', () => {
     const contributeLink = page.getByRole('link', {name: /Contribute to the project/})
     await expect(contributeLink).toHaveAttribute('href', 'https://github.com/jdubois/boot-ui')
     await expect(contributeLink.locator('.bi-github')).toBeVisible()
+  })
+
+  test('sidebar groups panels into collapsible sections', async ({page}) => {
+    await mockPanelAvailability(page)
+    await page.goto('/bootui/')
+
+    const groups = [
+      {title: 'Runtime', count: 5},
+      {title: 'Configuration', count: 6},
+      {title: 'Services', count: 4},
+      {title: 'Diagnostics', count: 4},
+      {title: 'Developer tools', count: 4}
+    ]
+
+    for (const group of groups) {
+      const toggle = page.getByRole('button', {name: new RegExp(`${group.title}\\s+${group.count}`)})
+      await expect(toggle).toBeVisible()
+      await expect(toggle).toHaveAttribute('aria-expanded', group.title === 'Runtime' ? 'true' : 'false')
+    }
+
+    await page.getByRole('button', {name: /Services\s+4/}).click()
+    await expect(page.locator('aside .nav-link', {hasText: 'Data'})).toBeVisible()
+    await expect(page.locator('aside .nav-link', {hasText: 'Security'})).toBeVisible()
+    await expect(page.locator('aside .nav-link', {hasText: 'AI Usage'})).toBeVisible()
   })
 
   test('sidebar dims unavailable panels and the active panel explains why', async ({page}) => {
@@ -58,37 +139,37 @@ test.describe('BootUI app shell', () => {
     )
   })
 
-  test('sidebar links open every BootUI section', async ({page}) => {
-    const links = [
-      {title: 'Overview', heading: /^Overview/},
-      {title: 'Startup Timeline', heading: /Startup timeline/},
-      {title: 'Memory', heading: /^Memory/},
-      {title: 'Health', heading: /^Health/},
-      {title: 'Metrics', heading: /^Metrics/},
-      {title: 'Conditions', heading: /Auto-configuration conditions/},
-      {title: 'Beans', heading: /^Beans/},
-      {title: 'Mappings', heading: /HTTP mappings/},
-      {title: 'Configuration', heading: /^Configuration/},
-      {title: 'Profile Diff', heading: /Profile Diff/},
-      {title: 'Loggers', heading: /^Loggers/},
-      {title: 'Log Tail', heading: /Log Tail/},
-      {title: 'Traces', heading: /^Traces/},
-      {title: 'HTTP Probe', heading: /HTTP Probe/},
-      {title: 'Copilot', heading: /^Copilot/},
-      {title: 'Claude Code', heading: /^Claude Code/},
-      {title: 'DevTools', heading: /^DevTools/},
-      {title: 'Dev Services', heading: /^Dev Services/},
-      {title: 'Scheduled Tasks', heading: /Scheduled Tasks/},
-      {title: 'Data', heading: /Spring Data repositories/},
-      {title: 'Cache', heading: /Spring Cache/},
-      {title: 'AI Usage', heading: /AI Usage/},
-      {title: 'Security', heading: /Spring Security/},
-      {title: 'Vulnerabilities', heading: /^Vulnerabilities/}
-    ]
-
+  test('sidebar collects unavailable non-overview panels in a collapsed group', async ({page}) => {
+    await mockPanelAvailability(page, {
+      ai: {
+        available: false,
+        unavailableReason: 'Spring AI is not available in this test state'
+      }
+    })
     await page.goto('/bootui/')
 
-    for (const link of links) {
+    const unavailableToggle = page.getByRole('button', {name: /Disabled \/ unavailable\s+1/})
+    await expect(unavailableToggle).toBeVisible()
+    await expect(unavailableToggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(page.locator('aside .nav-link', {hasText: 'AI Usage'})).not.toBeVisible()
+
+    await unavailableToggle.click()
+
+    const aiLink = page.locator('aside .nav-link', {hasText: 'AI Usage'})
+    await expect(aiLink).toBeVisible()
+    await expect(aiLink).toHaveClass(/bootui-nav-link--unavailable/)
+    await expect(aiLink).toHaveAttribute(
+      'aria-label',
+      'AI Usage - unavailable: Spring AI is not available in this test state'
+    )
+  })
+
+  test('sidebar links open every BootUI section', async ({page}) => {
+    await mockPanelAvailability(page)
+    await page.goto('/bootui/')
+    await expandAllSidebarGroups(page)
+
+    for (const link of allPanelLinks) {
       await page.locator('aside .nav-link', {hasText: link.title}).click()
       await expect(page.locator('main h2').filter({hasText: link.heading}).first()).toBeVisible({timeout: 15_000})
     }

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {computed, onMounted, ref} from 'vue'
+import {computed, onMounted, reactive, ref, watch} from 'vue'
 import {useRoute, useRouter} from 'vue-router'
 
 const router = useRouter()
@@ -8,8 +8,22 @@ const overview = ref(null)
 const panels = ref(null)
 const error = ref(null)
 
+const semanticNavigationGroups = [
+  {key: 'runtime', title: 'Runtime', icon: 'bi-activity'},
+  {key: 'configuration', title: 'Configuration', icon: 'bi-sliders'},
+  {key: 'services', title: 'Services', icon: 'bi-hdd-network'},
+  {key: 'diagnostics', title: 'Diagnostics', icon: 'bi-search'},
+  {key: 'developer-tools', title: 'Developer tools', icon: 'bi-tools'}
+]
+const unavailableNavigationGroup = {
+  key: 'unavailable',
+  title: 'Disabled / unavailable',
+  icon: 'bi-slash-circle'
+}
 const routes = router.options.routes.filter((r) => r.name)
+const expandedGroups = reactive({runtime: true})
 const panelLookup = computed(() => new Map((panels.value?.panels ?? []).map((panel) => [panel.id, panel])))
+const activeRoute = computed(() => routes.find((r) => r.name === route.name))
 const activePanel = computed(() => (route.name ? panelLookup.value.get(route.name) : null))
 const activePanelUnavailable = computed(() => activePanel.value?.available === false)
 const activePanelUnavailableReason = computed(
@@ -30,6 +44,35 @@ const activationLabel = computed(() => {
   return overview.value.activation.enabled ? 'Active' : 'Disabled'
 })
 const githubProjectUrl = 'https://github.com/jdubois/boot-ui'
+const navigationSections = computed(() => {
+  const sections = [
+    {
+      key: 'overview',
+      title: 'Overview',
+      collapsible: false,
+      routes: routes.filter((r) => r.meta?.group === 'overview')
+    }
+  ]
+
+  for (const group of semanticNavigationGroups) {
+    const groupRoutes = routes.filter((r) => r.meta?.group === group.key && !routeUnavailable(r))
+    if (groupRoutes.length) {
+      sections.push({...group, collapsible: true, unavailable: false, routes: groupRoutes})
+    }
+  }
+
+  const unavailableRoutes = routes.filter((r) => r.meta?.group !== 'overview' && routeUnavailable(r))
+  if (unavailableRoutes.length) {
+    sections.push({...unavailableNavigationGroup, collapsible: true, unavailable: true, routes: unavailableRoutes})
+  }
+
+  return sections
+})
+const activeNavigationGroupKey = computed(() => {
+  const currentRoute = activeRoute.value
+  if (!currentRoute || currentRoute.meta?.group === 'overview') return null
+  return routeUnavailable(currentRoute) ? unavailableNavigationGroup.key : currentRoute.meta?.group
+})
 
 async function loadOverview() {
   try {
@@ -71,6 +114,32 @@ function routeAvailabilityLabel(r) {
   return r.meta.title
 }
 
+function groupDomId(group) {
+  return `bootui-nav-group-${group.key}`
+}
+
+function groupHasActiveRoute(group) {
+  return group.routes.some((r) => r.name === route.name)
+}
+
+function isGroupExpanded(groupKey) {
+  return expandedGroups[groupKey] === true
+}
+
+function toggleGroup(groupKey) {
+  expandedGroups[groupKey] = !isGroupExpanded(groupKey)
+}
+
+watch(
+  activeNavigationGroupKey,
+  (groupKey) => {
+    if (groupKey) {
+      expandedGroups[groupKey] = true
+    }
+  },
+  {immediate: true}
+)
+
 onMounted(loadShellData)
 </script>
 
@@ -88,25 +157,64 @@ onMounted(loadShellData)
         </span>
       </router-link>
 
-      <nav class="nav nav-pills flex-column gap-1 sidebar-nav">
-        <router-link v-for="r in routes" :key="r.name" v-slot="{href, navigate}" :to="r.path" custom>
-          <a
-            :aria-current="route.name === r.name ? 'page' : undefined"
-            :aria-label="routeAvailabilityLabel(r)"
-            :class="{
-              active: route.name === r.name,
-              'bootui-nav-link--unavailable': routeUnavailable(r)
-            }"
-            :href="href"
-            :title="routeAvailabilityLabel(r)"
-            class="nav-link bootui-nav-link"
-            @click="navigate"
+      <nav aria-label="BootUI panels" class="nav nav-pills flex-column sidebar-nav">
+        <div
+          v-for="section in navigationSections"
+          :key="section.key"
+          :class="{
+            'bootui-nav-section--overview': !section.collapsible,
+            'bootui-nav-section--unavailable': section.unavailable
+          }"
+          class="bootui-nav-section"
+        >
+          <button
+            v-if="section.collapsible"
+            :aria-controls="groupDomId(section)"
+            :aria-expanded="isGroupExpanded(section.key)"
+            :class="{active: groupHasActiveRoute(section)}"
+            class="bootui-nav-group__toggle"
+            type="button"
+            @click="toggleGroup(section.key)"
           >
-            <i :class="['bi', r.meta.icon]"></i>
-            <span class="bootui-nav-link__label">{{ r.meta.title }}</span>
-            <i v-if="routeUnavailable(r)" aria-hidden="true" class="bi bi-slash-circle bootui-nav-link__status"></i>
-          </a>
-        </router-link>
+            <span class="bootui-nav-group__label">
+              <i :class="['bi', section.icon]"></i>
+              <span>{{ section.title }}</span>
+            </span>
+            <span class="bootui-nav-group__count">{{ section.routes.length }}</span>
+            <i
+              :class="['bi', isGroupExpanded(section.key) ? 'bi-chevron-up' : 'bi-chevron-down']"
+              aria-hidden="true"
+              class="bootui-nav-group__chevron"
+            ></i>
+          </button>
+
+          <div
+            v-show="!section.collapsible || isGroupExpanded(section.key)"
+            :id="groupDomId(section)"
+            :aria-label="`${section.title} panels`"
+            class="bootui-nav-group__items"
+            role="group"
+          >
+            <router-link v-for="r in section.routes" :key="r.name" v-slot="{href, navigate}" :to="r.path" custom>
+              <a
+                :aria-current="route.name === r.name ? 'page' : undefined"
+                :aria-label="routeAvailabilityLabel(r)"
+                :class="{
+                  active: route.name === r.name,
+                  'bootui-nav-link--unavailable': routeUnavailable(r)
+                }"
+                :href="href"
+                :title="routeAvailabilityLabel(r)"
+                class="nav-link bootui-nav-link"
+                @click="navigate"
+              >
+                <i :class="['bi', r.meta.icon]"></i>
+                <span class="bootui-nav-link__label">{{ r.meta.title }}</span>
+                <i v-if="routeUnavailable(r)" aria-hidden="true" class="bi bi-slash-circle bootui-nav-link__status"></i>
+              </a>
+            </router-link>
+          </div>
+        </div>
       </nav>
 
       <div class="sidebar-bottom mt-auto">
@@ -322,6 +430,7 @@ onMounted(loadShellData)
 
 .sidebar-nav {
   animation: fade-up 420ms ease both;
+  gap: 0.45rem;
 }
 
 .eyebrow {
@@ -344,6 +453,90 @@ onMounted(loadShellData)
     background 160ms ease,
     color 160ms ease,
     transform 160ms ease;
+}
+
+.bootui-nav-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.bootui-nav-section:not(.bootui-nav-section--overview) .bootui-nav-group__items {
+  border-left: 1px solid rgba(100, 116, 139, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin-left: 0.85rem;
+  padding-left: 0.5rem;
+}
+
+.bootui-nav-group__items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.bootui-nav-group__toggle {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  border-radius: 0.9rem;
+  color: #64748b;
+  display: flex;
+  font-size: 0.72rem;
+  font-weight: 800;
+  gap: 0.45rem;
+  letter-spacing: 0.06em;
+  padding: 0.56rem 0.7rem;
+  text-align: left;
+  text-transform: uppercase;
+  transition:
+    background 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    transform 160ms ease;
+  width: 100%;
+}
+
+.bootui-nav-group__toggle:hover,
+.bootui-nav-group__toggle.active {
+  background: rgba(25, 135, 84, 0.08);
+  border-color: rgba(25, 135, 84, 0.18);
+  color: #146c43;
+  transform: translateX(2px);
+}
+
+.bootui-nav-group__label {
+  align-items: center;
+  display: flex;
+  flex: 1;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.bootui-nav-group__count {
+  background: rgba(100, 116, 139, 0.1);
+  border-radius: 999px;
+  color: #64748b;
+  font-size: 0.68rem;
+  line-height: 1;
+  padding: 0.22rem 0.42rem;
+}
+
+.bootui-nav-group__chevron {
+  font-size: 0.8rem;
+}
+
+.bootui-nav-section--unavailable .bootui-nav-group__toggle {
+  background: rgba(148, 163, 184, 0.08);
+  border-color: rgba(100, 116, 139, 0.12);
+  color: #94a3b8;
+  opacity: 0.72;
+}
+
+.bootui-nav-section--unavailable .bootui-nav-group__count {
+  background: rgba(148, 163, 184, 0.12);
+  color: #94a3b8;
 }
 
 .bootui-nav-link:hover {

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -28,63 +28,152 @@ import Traces from './views/Traces.vue'
 import Ai from './views/Ai.vue'
 import Copilot from './views/Copilot.vue'
 
+const groups = {
+  overview: 'overview',
+  runtime: 'runtime',
+  configuration: 'configuration',
+  services: 'services',
+  diagnostics: 'diagnostics',
+  developerTools: 'developer-tools'
+}
+
 const router = createRouter({
   history: createWebHashHistory(),
   routes: [
     {path: '/', redirect: '/overview'},
-    {path: '/overview', name: 'overview', component: Overview, meta: {icon: 'bi-speedometer2', title: 'Overview'}},
+    {
+      path: '/overview',
+      name: 'overview',
+      component: Overview,
+      meta: {group: groups.overview, icon: 'bi-speedometer2', title: 'Overview'}
+    },
+    {
+      path: '/health',
+      name: 'health',
+      component: Health,
+      meta: {group: groups.runtime, icon: 'bi-heart-pulse', title: 'Health'}
+    },
+    {
+      path: '/metrics',
+      name: 'metrics',
+      component: Metrics,
+      meta: {group: groups.runtime, icon: 'bi-activity', title: 'Metrics'}
+    },
+    {
+      path: '/memory',
+      name: 'memory',
+      component: Memory,
+      meta: {group: groups.runtime, icon: 'bi-memory', title: 'Memory'}
+    },
     {
       path: '/startup',
       name: 'startup',
       component: Startup,
-      meta: {icon: 'bi-bar-chart-steps', title: 'Startup Timeline'}
-    },
-    {path: '/memory', name: 'memory', component: Memory, meta: {icon: 'bi-memory', title: 'Memory'}},
-    {path: '/health', name: 'health', component: Health, meta: {icon: 'bi-heart-pulse', title: 'Health'}},
-    {path: '/metrics', name: 'metrics', component: Metrics, meta: {icon: 'bi-activity', title: 'Metrics'}},
-    {
-      path: '/conditions',
-      name: 'conditions',
-      component: Conditions,
-      meta: {icon: 'bi-check2-circle', title: 'Conditions'}
-    },
-    {path: '/beans', name: 'beans', component: Beans, meta: {icon: 'bi-diagram-3', title: 'Beans'}},
-    {path: '/mappings', name: 'mappings', component: Mappings, meta: {icon: 'bi-signpost-2', title: 'Mappings'}},
-    {path: '/config', name: 'config', component: Config, meta: {icon: 'bi-sliders', title: 'Configuration'}},
-    {path: '/profiles', name: 'profiles', component: ProfileDiff, meta: {icon: 'bi-layers', title: 'Profile Diff'}},
-    {path: '/loggers', name: 'loggers', component: Loggers, meta: {icon: 'bi-journal-text', title: 'Loggers'}},
-    {path: '/log-tail', name: 'log-tail', component: LogTail, meta: {icon: 'bi-terminal', title: 'Log Tail'}},
-    {path: '/traces', name: 'traces', component: Traces, meta: {icon: 'bi-bezier2', title: 'Traces'}},
-    {path: '/http-probe', name: 'http-probe', component: HttpProbe, meta: {icon: 'bi-send', title: 'HTTP Probe'}},
-    {path: '/copilot', name: 'copilot', component: Copilot, meta: {icon: 'bi-robot', title: 'Copilot'}},
-    {
-      path: '/claude-code',
-      name: 'claude-code',
-      component: Copilot,
-      meta: {icon: 'bi-stars', title: 'Claude Code'}
-    },
-    {path: '/devtools', name: 'devtools', component: DevTools, meta: {icon: 'bi-lightning-charge', title: 'DevTools'}},
-    {
-      path: '/dev-services',
-      name: 'dev-services',
-      component: DevServices,
-      meta: {icon: 'bi-box-seam', title: 'Dev Services'}
+      meta: {group: groups.runtime, icon: 'bi-bar-chart-steps', title: 'Startup Timeline'}
     },
     {
       path: '/scheduled',
       name: 'scheduled',
       component: Scheduled,
-      meta: {icon: 'bi-clock-history', title: 'Scheduled Tasks'}
+      meta: {group: groups.runtime, icon: 'bi-clock-history', title: 'Scheduled Tasks'}
     },
-    {path: '/data', name: 'data', component: Data, meta: {icon: 'bi-database', title: 'Data'}},
-    {path: '/cache', name: 'cache', component: Cache, meta: {icon: 'bi-hdd-stack', title: 'Cache'}},
-    {path: '/ai', name: 'ai', component: Ai, meta: {icon: 'bi-stars', title: 'AI Usage'}},
-    {path: '/security', name: 'security', component: Security, meta: {icon: 'bi-person-lock', title: 'Security'}},
+    {
+      path: '/config',
+      name: 'config',
+      component: Config,
+      meta: {group: groups.configuration, icon: 'bi-sliders', title: 'Configuration'}
+    },
+    {
+      path: '/profiles',
+      name: 'profiles',
+      component: ProfileDiff,
+      meta: {group: groups.configuration, icon: 'bi-layers', title: 'Profile Diff'}
+    },
+    {
+      path: '/loggers',
+      name: 'loggers',
+      component: Loggers,
+      meta: {group: groups.configuration, icon: 'bi-journal-text', title: 'Loggers'}
+    },
+    {
+      path: '/beans',
+      name: 'beans',
+      component: Beans,
+      meta: {group: groups.configuration, icon: 'bi-diagram-3', title: 'Beans'}
+    },
+    {
+      path: '/conditions',
+      name: 'conditions',
+      component: Conditions,
+      meta: {group: groups.configuration, icon: 'bi-check2-circle', title: 'Conditions'}
+    },
+    {
+      path: '/mappings',
+      name: 'mappings',
+      component: Mappings,
+      meta: {group: groups.configuration, icon: 'bi-signpost-2', title: 'Mappings'}
+    },
+    {path: '/data', name: 'data', component: Data, meta: {group: groups.services, icon: 'bi-database', title: 'Data'}},
+    {
+      path: '/cache',
+      name: 'cache',
+      component: Cache,
+      meta: {group: groups.services, icon: 'bi-hdd-stack', title: 'Cache'}
+    },
+    {
+      path: '/security',
+      name: 'security',
+      component: Security,
+      meta: {group: groups.services, icon: 'bi-person-lock', title: 'Security'}
+    },
+    {path: '/ai', name: 'ai', component: Ai, meta: {group: groups.services, icon: 'bi-stars', title: 'AI Usage'}},
+    {
+      path: '/traces',
+      name: 'traces',
+      component: Traces,
+      meta: {group: groups.diagnostics, icon: 'bi-bezier2', title: 'Traces'}
+    },
+    {
+      path: '/log-tail',
+      name: 'log-tail',
+      component: LogTail,
+      meta: {group: groups.diagnostics, icon: 'bi-terminal', title: 'Log Tail'}
+    },
+    {
+      path: '/http-probe',
+      name: 'http-probe',
+      component: HttpProbe,
+      meta: {group: groups.diagnostics, icon: 'bi-send', title: 'HTTP Probe'}
+    },
     {
       path: '/vulnerabilities',
       name: 'vulnerabilities',
       component: Vulnerabilities,
-      meta: {icon: 'bi-bug', title: 'Vulnerabilities'}
+      meta: {group: groups.diagnostics, icon: 'bi-bug', title: 'Vulnerabilities'}
+    },
+    {
+      path: '/devtools',
+      name: 'devtools',
+      component: DevTools,
+      meta: {group: groups.developerTools, icon: 'bi-lightning-charge', title: 'DevTools'}
+    },
+    {
+      path: '/dev-services',
+      name: 'dev-services',
+      component: DevServices,
+      meta: {group: groups.developerTools, icon: 'bi-box-seam', title: 'Dev Services'}
+    },
+    {
+      path: '/copilot',
+      name: 'copilot',
+      component: Copilot,
+      meta: {group: groups.developerTools, icon: 'bi-robot', title: 'Copilot'}
+    },
+    {
+      path: '/claude-code',
+      name: 'claude-code',
+      component: Copilot,
+      meta: {group: groups.developerTools, icon: 'bi-stars', title: 'Claude Code'}
     },
     {path: '/dependencies', redirect: '/vulnerabilities'}
   ]

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,8 +1,9 @@
 # BootUI feature details
 
-BootUI panels are documented here in the same order as the application menu. When a panel's backing infrastructure is
-missing, the sidebar keeps the route visible but dims it so you can tell at a glance that the panel has no live data for
-the current application. Opening a dimmed panel also shows the unavailable reason at the top of the page.
+BootUI panels are documented here in the same grouped order as the application menu. When a panel's backing
+infrastructure is missing, the sidebar moves non-overview panels into the collapsed Disabled / unavailable group so you
+can tell at a glance which panels have no live data for the current application. Opening a dimmed panel also shows the
+unavailable reason at the top of the page.
 
 ## Overview
 
@@ -12,23 +13,9 @@ first place to confirm whether BootUI is active for the reason you expect.
 
 ![BootUI Overview panel](images/bootui-overview.png)
 
-## Startup Timeline
+## Runtime
 
-The Startup Timeline panel visualizes Spring Boot startup steps from Actuator startup data. It helps identify expensive
-startup phases, slow bean initialization, and the overall application startup shape. If the host app does not expose
-startup data, the panel shows an empty state instead of failing.
-
-![BootUI Startup Timeline panel](images/bootui-startup-timeline.png)
-
-## Memory
-
-The Memory panel summarizes JVM heap and non-heap usage, memory pools, garbage collectors, and selected runtime memory
-settings. It also suggests JVM options that are useful during local development when memory pressure or startup behavior
-needs tuning.
-
-![BootUI Memory panel](images/bootui-memory.png)
-
-## Health
+### Health
 
 The Health panel displays the Actuator health tree, including nested contributors and detailed status information when
 the host app exposes it. It keeps unavailable health data separate from unhealthy application state so missing Actuator
@@ -36,41 +23,39 @@ infrastructure is clear.
 
 ![BootUI Health panel](images/bootui-health.png)
 
-## Metrics
+### Metrics
 
 The Metrics panel browses Micrometer meters exposed by Actuator. You can inspect meter descriptions, base units, tags,
 available measurements, and render a local live chart for a selected metric/tag combination.
 
 ![BootUI Metrics panel](images/bootui-metrics.png)
 
-## Conditions
+### Memory
 
-The Conditions panel explains Spring Boot auto-configuration decisions. It groups positive matches, negative matches,
-and unconditional classes so you can see why an auto-configuration applied or why it was skipped. Large condition reports
-load in bounded pages, and filtering runs on the server so the browser does not need the full report before narrowing
-results.
+The Memory panel summarizes JVM heap and non-heap usage, memory pools, garbage collectors, and selected runtime memory
+settings. It also suggests JVM options that are useful during local development when memory pressure or startup behavior
+needs tuning.
 
-![BootUI Conditions panel](images/bootui-conditions.png)
+![BootUI Memory panel](images/bootui-memory.png)
 
-## Beans
+### Startup Timeline
 
-The Beans panel helps answer which Spring beans exist and where they came from. It supports server-side search across
-bean names and types, plus BootUI classifications such as application, BootUI, Spring framework, Java/Jakarta, and other
-beans. Large bean lists load in bounded pages so the initial payload stays small while filters still apply to the full
-bean set.
+The Startup Timeline panel visualizes Spring Boot startup steps from Actuator startup data. It helps identify expensive
+startup phases, slow bean initialization, and the overall application startup shape. If the host app does not expose
+startup data, the panel shows an empty state instead of failing.
 
-![BootUI Beans panel](images/bootui-beans.png)
+![BootUI Startup Timeline panel](images/bootui-startup-timeline.png)
 
-## Mappings
+### Scheduled Tasks
 
-The Mappings panel lists HTTP routes from Actuator mappings data. It shows request methods, path patterns, handlers, and
-produces/consumes metadata so the running application's web surface is visible without reading controllers manually.
-Large mapping lists load through a stable, paged BootUI DTO, and the filter continues to search every discovered route
-on the server.
+The Scheduled Tasks panel lists scheduled jobs registered with Spring scheduling infrastructure. It shows task type and
+trigger metadata so background activity is visible during local development.
 
-![BootUI Mappings panel](images/bootui-mappings.png)
+![BootUI Scheduled Tasks panel](images/bootui-scheduled-tasks.png)
 
 ## Configuration
+
+### Configuration
 
 The Configuration panel shows effective configuration properties, sources, metadata descriptions, defaults when known,
 active profiles, and masked values. It can create, update, and delete local runtime overrides persisted to
@@ -80,7 +65,7 @@ picker limits its datalist suggestions while narrowing against the full metadata
 
 ![BootUI Configuration panel](images/bootui-configuration.png)
 
-## Profile Diff
+### Profile Diff
 
 The Profile Diff panel compares profile-specific property sources and values. It is useful for understanding what
 changes between local development profiles while still routing browser-visible names and values through BootUI's secret
@@ -88,7 +73,7 @@ masking rules.
 
 ![BootUI Profile Diff panel](images/bootui-profile-diff.png)
 
-## Loggers
+### Loggers
 
 The Loggers panel lists runtime logger configuration from Actuator. It shows configured and effective levels, supports
 server-side search, and can update or clear logger levels without restarting the application. Large logger lists load in
@@ -96,108 +81,43 @@ bounded pages while filtering still searches the full logger set.
 
 ![BootUI Loggers panel](images/bootui-loggers.png)
 
-## Log Tail
+### Beans
 
-The Log Tail panel reads recent local application logs and streams new log events from the running process. It is
-intended for quick local diagnosis without leaving the BootUI console.
+The Beans panel helps answer which Spring beans exist and where they came from. It supports server-side search across
+bean names and types, plus BootUI classifications such as application, BootUI, Spring framework, Java/Jakarta, and other
+beans. Large bean lists load in bounded pages so the initial payload stays small while filters still apply to the full
+bean set.
 
-![BootUI Log Tail panel](images/bootui-log-tail.png)
+![BootUI Beans panel](images/bootui-beans.png)
 
-## Traces
+### Conditions
 
-The Traces panel shows distributed tracing spans collected by BootUI's embedded OTLP/HTTP receiver at
-`/bootui/api/otlp/v1/traces`. Any Spring Boot service that uses Micrometer Tracing with the OpenTelemetry bridge —
-including the host application itself when self-tracing is enabled — can export to this endpoint and have its traces
-appear here. The list shows the most recent traces with service name, root span name, status, duration, and span count;
-opening a trace renders a waterfall view of its spans so you can see latency contributions, errors, and parent/child
-relationships across services. Spans emitted by BootUI's own API are filtered out by default to keep the view focused on
-application traffic; this can be tuned with `bootui.telemetry.exclude-self-spans=false`. When
-`bootui.telemetry.enabled=false`, the sidebar dims the panel and the view shows a disabled state instead of implying
-that tracing is merely empty. The in-memory trace buffer is bounded by `bootui.telemetry.max-traces`,
-`bootui.telemetry.max-spans-per-trace`, request-size limits, and attribute-value truncation, with additional internal
-caps to keep misconfigured local exporters from overflowing the UI. Trace data is reset on application restart or via
-the panel's clear action.
+The Conditions panel explains Spring Boot auto-configuration decisions. It groups positive matches, negative matches,
+and unconditional classes so you can see why an auto-configuration applied or why it was skipped. Large condition reports
+load in bounded pages, and filtering runs on the server so the browser does not need the full report before narrowing
+results.
 
-![BootUI Traces panel](images/bootui-traces.png)
+![BootUI Conditions panel](images/bootui-conditions.png)
 
-## HTTP Probe
+### Mappings
 
-The HTTP Probe panel sends local-only requests to the running application and displays response status, headers,
-duration, and body. It is designed for quick route checks from inside the same local development context as BootUI.
+The Mappings panel lists HTTP routes from Actuator mappings data. It shows request methods, path patterns, handlers, and
+produces/consumes metadata so the running application's web surface is visible without reading controllers manually.
+Large mapping lists load through a stable, paged BootUI DTO, and the filter continues to search every discovered route
+on the server.
 
-![BootUI HTTP Probe panel](images/bootui-http-probe.png)
+![BootUI Mappings panel](images/bootui-mappings.png)
 
-## Copilot
+## Services
 
-The Copilot panel surfaces sanitized signals from local
-[GitHub Copilot CLI](https://github.com/github/copilot-cli) sessions. It reads the session directories and `events.jsonl`
-files Copilot CLI writes under `~/.copilot/session-state/` (configurable via `bootui.copilot.session-state-dir`) and
-aggregates recent activity into a clean dashboard: active sessions, total sanitized events, failures, 24-hour activity,
-7-day activity, event category mix, top tools, model usage, and recent sessions. The session explorer remains available
-for drilling into tool calls, edits, reads, searches, shell commands, web/docs lookups, MCP tool calls, hook callbacks,
-skills, sub-agents, and ASK/intent/plan calls. To keep large local histories responsive, the session explorer returns the
-most recent `bootui.copilot.max-sessions` sessions by default, and the activity charts can filter the explorer to sessions
-active during a selected hour or day. Failure lists use retained failure events and include sanitized tool/type context.
-Each event row shows only an allowlisted summary - raw prompts, tool arguments, command output, and diffs are deliberately
-excluded. The per-event "Reveal raw" action is an explicit, local-only escape hatch that returns the source JSON; it can be disabled with
-`bootui.copilot.allow-raw-reveal=false` and is also blocked when `bootui.expose-values=METADATA_ONLY`. The sidebar dims
-the panel when no session-state directory is found. Data is read-only - BootUI never modifies anything under
-`~/.copilot/`. The panel watches the directory through a Java NIO `WatchService` thread and pushes live updates via
-Server-Sent Events. Inspired by
-[copilot-mission-control](https://github.com/DanWahlin/copilot-mission-control), which pioneered this dashboarding of
-Copilot CLI session state.
-
-![BootUI Copilot panel](images/bootui-copilot.png)
-
-## Claude Code
-
-The Claude Code panel mirrors the Copilot dashboard for local
-[Claude Code](https://www.anthropic.com/claude-code) project logs. It reads JSONL session files under
-`~/.claude/projects/` (configurable via `bootui.claude-code.session-state-dir`) and surfaces sanitized activity trends,
-tool usage, model usage, failures, recent sessions, and per-session event drill-downs. BootUI treats Claude Code logs as
-especially sensitive: prompts, assistant text, tool inputs, file contents, command output, and tool-result content are
-excluded from normal responses. The raw JSONL reveal endpoint is disabled by default with
-`bootui.claude-code.allow-raw-reveal=false`; enabling it is an explicit local-only escape hatch and is still blocked when
-`bootui.expose-values=METADATA_ONLY`. The sidebar dims the panel when no Claude Code projects directory is found. Data is
-read-only - BootUI never modifies anything under `~/.claude/`. Because Claude Code writes sessions inside per-project
-subdirectories, BootUI refreshes this panel through bounded polling rather than relying on root-directory file-system
-events.
-
-![BootUI Claude Code panel](images/bootui-claude-code.png)
-
-## DevTools
-
-The DevTools panel reports Spring Boot DevTools availability, LiveReload status, and restart support. Restart actions
-are shown only when available and require explicit confirmation before execution.
-
-![BootUI DevTools panel](images/bootui-devtools.png)
-
-## Dev Services
-
-The Dev Services panel surfaces local development services discovered from Docker Compose snapshots, Testcontainers
-beans, and service connection metadata. It masks sensitive connection information, can show bounded logs for supported
-services, and shows restart controls only for supported Testcontainers services when
-`bootui.dev-services.restart-enabled=true`. To keep opening the panel side-effect free, BootUI skips lazy,
-prototype, or otherwise uninitialized service beans that would need to be created just for inspection and reports those
-skips as warnings in the panel.
-
-![BootUI Dev Services panel](images/bootui-dev-services.png)
-
-## Scheduled Tasks
-
-The Scheduled Tasks panel lists scheduled jobs registered with Spring scheduling infrastructure. It shows task type and
-trigger metadata so background activity is visible during local development.
-
-![BootUI Scheduled Tasks panel](images/bootui-scheduled-tasks.png)
-
-## Data
+### Data
 
 The Data panel inspects Spring Data repositories. It shows repository interfaces, domain types, ID types, and query
 methods, and degrades to a clear empty state when Spring Data is not present or no repositories are registered.
 
 ![BootUI Data panel](images/bootui-data.png)
 
-## Cache
+### Cache
 
 The Cache panel inspects Spring Cache infrastructure. It lists cache manager beans, known caches, native
 implementations, safe local sizes, Micrometer cache metrics when registered, and discovered `@Cacheable`, `@CachePut`,
@@ -206,7 +126,14 @@ confirmation, and can be disabled with `bootui.cache.clear-enabled=false`.
 
 ![BootUI Cache panel](images/bootui-cache.png)
 
-## AI Usage
+### Security
+
+The Security panel inspects Spring Security filter chains and provides best-effort endpoint rule explanations. It is
+meant to explain local security wiring without exposing credentials or replacing a full security audit.
+
+![BootUI Security panel](images/bootui-security.png)
+
+### AI Usage
 
 The AI Usage panel summarizes Spring AI activity collected from OpenTelemetry spans emitted by Spring AI's built-in
 observability. It groups chat client and chat model spans by conversation so you can see request count, token usage (
@@ -222,16 +149,100 @@ receiver, is in-memory only, and is cleared on restart.
 
 ![BootUI AI Usage panel](images/bootui-ai.png)
 
-## Security
+## Diagnostics
 
-The Security panel inspects Spring Security filter chains and provides best-effort endpoint rule explanations. It is
-meant to explain local security wiring without exposing credentials or replacing a full security audit.
+### Traces
 
-![BootUI Security panel](images/bootui-security.png)
+The Traces panel shows distributed tracing spans collected by BootUI's embedded OTLP/HTTP receiver at
+`/bootui/api/otlp/v1/traces`. Any Spring Boot service that uses Micrometer Tracing with the OpenTelemetry bridge -
+including the host application itself when self-tracing is enabled - can export to this endpoint and have its traces
+appear here. The list shows the most recent traces with service name, root span name, status, duration, and span count;
+opening a trace renders a waterfall view of its spans so you can see latency contributions, errors, and parent/child
+relationships across services. Spans emitted by BootUI's own API are filtered out by default to keep the view focused on
+application traffic; this can be tuned with `bootui.telemetry.exclude-self-spans=false`. When
+`bootui.telemetry.enabled=false`, the sidebar dims the panel and the view shows a disabled state instead of implying
+that tracing is merely empty. The in-memory trace buffer is bounded by `bootui.telemetry.max-traces`,
+`bootui.telemetry.max-spans-per-trace`, request-size limits, and attribute-value truncation, with additional internal
+caps to keep misconfigured local exporters from overflowing the UI. Trace data is reset on application restart or via
+the panel's clear action.
 
-## Vulnerabilities
+![BootUI Traces panel](images/bootui-traces.png)
+
+### Log Tail
+
+The Log Tail panel reads recent local application logs and streams new log events from the running process. It is
+intended for quick local diagnosis without leaving the BootUI console.
+
+![BootUI Log Tail panel](images/bootui-log-tail.png)
+
+### HTTP Probe
+
+The HTTP Probe panel sends local-only requests to the running application and displays response status, headers,
+duration, and body. It is designed for quick route checks from inside the same local development context as BootUI.
+
+![BootUI HTTP Probe panel](images/bootui-http-probe.png)
+
+### Vulnerabilities
 
 The Vulnerabilities panel shows dependency inventory and local OSV vulnerability scan results. It helps identify known
 vulnerable dependencies from the running project's dependency set during the local development loop.
 
 ![BootUI Vulnerabilities panel](images/bootui-vulnerabilities.png)
+
+## Developer tools
+
+### DevTools
+
+The DevTools panel reports Spring Boot DevTools availability, LiveReload status, and restart support. Restart actions
+are shown only when available and require explicit confirmation before execution.
+
+![BootUI DevTools panel](images/bootui-devtools.png)
+
+### Dev Services
+
+The Dev Services panel surfaces local development services discovered from Docker Compose snapshots, Testcontainers
+beans, and service connection metadata. It masks sensitive connection information, can show bounded logs for supported
+services, and shows restart controls only for supported Testcontainers services when
+`bootui.dev-services.restart-enabled=true`. To keep opening the panel side-effect free, BootUI skips lazy, prototype, or
+otherwise uninitialized service beans that would need to be created just for inspection and reports those skips as
+warnings in the panel.
+
+![BootUI Dev Services panel](images/bootui-dev-services.png)
+
+### Copilot
+
+The Copilot panel surfaces sanitized signals from local
+[GitHub Copilot CLI](https://github.com/github/copilot-cli) sessions. It reads the session directories and `events.jsonl`
+files Copilot CLI writes under `~/.copilot/session-state/` (configurable via `bootui.copilot.session-state-dir`) and
+aggregates recent activity into a clean dashboard: active sessions, total sanitized events, failures, 24-hour activity,
+7-day activity, event category mix, top tools, model usage, and recent sessions. The session explorer remains available
+for drilling into tool calls, edits, reads, searches, shell commands, web/docs lookups, MCP tool calls, hook callbacks,
+skills, sub-agents, and ASK/intent/plan calls. To keep large local histories responsive, the session explorer returns
+the most recent `bootui.copilot.max-sessions` sessions by default, and the activity charts can filter the explorer to
+sessions active during a selected hour or day. Failure lists use retained failure events and include sanitized tool/type
+context. Each event row shows only an allowlisted summary - raw prompts, tool arguments, command output, and diffs are
+deliberately excluded. The per-event "Reveal raw" action is an explicit, local-only escape hatch that returns the source
+JSON; it can be disabled with `bootui.copilot.allow-raw-reveal=false` and is also blocked when
+`bootui.expose-values=METADATA_ONLY`. The sidebar dims the panel when no session-state directory is found. Data is
+read-only - BootUI never modifies anything under `~/.copilot/`. The panel watches the directory through a Java NIO
+`WatchService` thread and pushes live updates via Server-Sent Events. Inspired by
+[copilot-mission-control](https://github.com/DanWahlin/copilot-mission-control), which pioneered this dashboarding of
+Copilot CLI session state.
+
+![BootUI Copilot panel](images/bootui-copilot.png)
+
+### Claude Code
+
+The Claude Code panel mirrors the Copilot dashboard for local
+[Claude Code](https://www.anthropic.com/claude-code) project logs. It reads JSONL session files under
+`~/.claude/projects/` (configurable via `bootui.claude-code.session-state-dir`) and surfaces sanitized activity trends,
+tool usage, model usage, failures, recent sessions, and per-session event drill-downs. BootUI treats Claude Code logs as
+especially sensitive: prompts, assistant text, tool inputs, file contents, command output, and tool-result content are
+excluded from normal responses. The raw JSONL reveal endpoint is disabled by default with
+`bootui.claude-code.allow-raw-reveal=false`; enabling it is an explicit local-only escape hatch and is still blocked when
+`bootui.expose-values=METADATA_ONLY`. The sidebar dims the panel when no Claude Code projects directory is found. Data is
+read-only - BootUI never modifies anything under `~/.claude/`. Because Claude Code writes sessions inside per-project
+subdirectories, BootUI refreshes this panel through bounded polling rather than relying on root-directory file-system
+events.
+
+![BootUI Claude Code panel](images/bootui-claude-code.png)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -95,7 +95,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
 ## 3. Milestone status
 
 | Milestone                                | Status                                   | Notes                                                                                                                                                                                                                                                   |
-|------------------------------------------|------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 0. Project foundation                    | Done                                     | Multi-module build, Java/Spring baseline, sample app, docs, and CI exist.                                                                                                                                                                               |
 | 1. Auto-configuration and safety         | Implemented and covered                  | Activation, auto-configuration, localhost filter, banner, and overview API exist. Activation, localhost behavior, and fail-closed edge cases have focused tests.                                                                                        |
 | 2. Static UI shell                       | Implemented and smoke-tested             | Vue shell, Maven frontend build, classpath packaging, and routes exist; Playwright verifies sidebar navigation across every visible section.                                                                                                            |
@@ -146,32 +146,15 @@ Future backend test work should be incremental and tied to new or changed behavi
 
 ### 4.2 UI and product parity status
 
-The visible-route parity check is current. On 2026-05-28, the sample-app Playwright suite passed all 57 tests, covering:
+The visible-route parity check is current. The sample-app Playwright suite covers the grouped navigation order:
 
 1. Overview.
-2. Startup Timeline.
-3. Memory.
-4. Health.
-5. Metrics.
-6. Conditions.
-7. Beans.
-8. Mappings.
-9. Configuration.
-10. Profile Diff.
-11. Loggers.
-12. Log Tail.
-13. Traces.
-14. HTTP Probe.
-15. Copilot.
-16. Claude Code.
-17. DevTools.
-18. Dev Services.
-19. Scheduled Tasks.
-20. Data.
-21. Cache.
-22. AI Usage.
-23. Security.
-24. Vulnerabilities.
+2. Runtime: Health, Metrics, Memory, Startup Timeline, Scheduled Tasks.
+3. Configuration: Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings.
+4. Services: Data, Cache, Security, AI Usage.
+5. Diagnostics: Traces, Log Tail, HTTP Probe, Vulnerabilities.
+6. Developer tools: DevTools, Dev Services, Copilot, Claude Code.
+7. Disabled / unavailable grouping for unavailable non-overview panels.
 
 Startup, Memory, Spring Data, Spring Cache, HTTP Probe, Profile Diff, Log Tail, Traces, AI Usage, Copilot, Claude Code,
 Scheduled Tasks, Security, Metrics, Vulnerabilities, DevTools, and Dev Services are implemented, documented, covered by sample-app
@@ -183,9 +166,9 @@ Mappings, Configuration, and Loggers request bounded server-side pages with filt
 already returned by the API.
 
 Optional UI gating is complete for the visible route set (v0.2, 2026-05-28). `/bootui/api/panels` reports classpath,
-endpoint, and configuration availability for each sidebar route. The Vue shell keeps routes visible, dims unavailable
-links, exposes the reason through accessible labels/tooltips, and shows a page-level unavailable-state banner when a
-dimmed panel is opened.
+endpoint, and configuration availability for each sidebar route. The Vue shell keeps routes reachable, moves unavailable
+non-overview panels into a collapsed Disabled / unavailable group, dims unavailable links, exposes the reason through
+accessible labels/tooltips, and shows a page-level unavailable-state banner when a dimmed panel is opened.
 
 Frontend unit test setup is complete for v0.2. The Vue app now uses Vitest with Vue Test Utils and jsdom for fast
 component/composable coverage that complements the browser-level Playwright suite.
@@ -259,11 +242,11 @@ Manual smoke checks:
 
 The codebase contains more than the original v0.1 MVP. The first alpha used this release strategy:
 
-| Strategy                       | Scope                                                                                                                                         | Trade-off                                                                                        |
-|--------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| Strategy                       | Scope                                                                                                                                         | Trade-off                                                                                                                             |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | Harden all visible panels      | Ship every current route as supported alpha functionality.                                                                                    | Delivered for `0.1.0-alpha.1` and extended through `0.1.0-alpha.5`; keep focused backend tests, docs, and release validation current. |
-| Mark newer panels experimental | Keep all routes visible but clearly label Data, Startup, Memory, Scheduled, HTTP Probe, Log Tail, Profile Diff, and Security as experimental. | Faster release, but docs must set expectations.                                                  |
-| Hide unfinished panels         | Only expose the original MVP routes plus any fully hardened additions.                                                                        | Safest alpha surface, but requires UI gating work.                                               |
+| Mark newer panels experimental | Keep all routes visible but clearly label Data, Startup, Memory, Scheduled, HTTP Probe, Log Tail, Profile Diff, and Security as experimental. | Faster release, but docs must set expectations.                                                                                       |
+| Hide unfinished panels         | Only expose the original MVP routes plus any fully hardened additions.                                                                        | Safest alpha surface, but requires UI gating work.                                                                                    |
 
 Delivered alpha stance: **harden all visible panels**.
 
@@ -497,7 +480,7 @@ Before future alphas, rerun this checklist after any release-facing code or docu
 ## 11. Risks
 
 | Risk                                 | Impact | Mitigation                                                                                                                                                         |
-|--------------------------------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Accidentally exposing sensitive data | High   | Localhost-only, dev-only activation, secret masking, value exposure controls, production fail-closed defaults, and focused tests for every panel surfacing values. |
 | Regressing visible panel hardening   | High   | Keep the current route set as the supported alpha surface, and require focused tests, docs, and release validation for release-facing changes.                     |
 | Actuator endpoints unavailable       | Medium | Internal bridge, stable empty DTOs, graceful UI states, setup guidance.                                                                                            |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -43,7 +43,7 @@ Make a running Spring Boot application understandable in minutes.
 ### 2.3 Non-goals for MVP
 
 - Production monitoring.
-- Multi-application *runtime* orchestration. BootUI accepts OTLP traces from cooperating local services as a dev-time
+- Multi-application _runtime_ orchestration. BootUI accepts OTLP traces from cooperating local services as a dev-time
   sink, but it does not run, schedule, restart, or supervise other processes the way .NET Aspire's AppHost does.
 - Kubernetes workflow management.
 - Hosted dashboards.
@@ -56,7 +56,7 @@ Make a running Spring Boot application understandable in minutes.
 ## 3. Target users
 
 | Persona                      | Needs                                                                   | BootUI value                                                                 |
-|------------------------------|-------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| ---------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | Solo/backend developer       | Understand a project quickly, configure it correctly, inspect endpoints | One local URL with beans, config, mappings, health, and logs                 |
 | Enterprise service onboarder | Understand inherited profiles, conditional beans, and dependencies      | Explains effective runtime state without reading the whole codebase first    |
 | Platform engineer            | Standardize inspection across many Spring Boot services                 | Common diagnostic surface for all teams                                      |
@@ -806,45 +806,45 @@ return page metadata so the SPA can avoid fetching every row before filtering.
 
 Initial endpoints:
 
-| Endpoint                                | Method | Purpose                                                                  |
-|-----------------------------------------|--------|--------------------------------------------------------------------------|
-| `/bootui/api/overview`                  | GET    | App, runtime, Spring Boot, profile, and BootUI status                    |
-| `/bootui/api/beans`                     | GET    | Searchable bean summary                                                  |
-| `/bootui/api/conditions`                | GET    | Auto-configuration conditions                                            |
-| `/bootui/api/config`                    | GET    | Effective configuration values                                           |
-| `/bootui/api/config/overrides`          | POST   | Create or update a local runtime configuration property override         |
-| `/bootui/api/config/overrides/{name}`   | DELETE | Remove a local runtime configuration property override                   |
-| `/bootui/api/mappings`                  | GET    | HTTP mappings                                                            |
-| `/bootui/api/mappings/flat`             | GET    | Stable, paged HTTP mapping summaries                                     |
-| `/bootui/api/health`                    | GET    | Health tree                                                              |
-| `/bootui/api/loggers`                   | GET    | Logger levels                                                            |
-| `/bootui/api/loggers/{name}`            | POST   | Change logger level                                                      |
-| `/bootui/api/startup`                   | GET    | Startup timeline                                                         |
-| `/bootui/api/metrics`                   | GET    | Browseable Micrometer meter list                                         |
-| `/bootui/api/metrics/detail`            | GET    | Micrometer meter detail and live measurements                            |
-| `/bootui/api/dependencies`              | GET    | Runtime Maven dependency inventory without external scanning             |
-| `/bootui/api/dependencies/scan`         | POST   | Explicit on-demand OSV.dev vulnerability scan                            |
-| `/bootui/api/devtools`                  | GET    | Spring Boot DevTools status                                              |
-| `/bootui/api/devtools/livereload`       | POST   | Trigger a DevTools LiveReload notification when available                |
-| `/bootui/api/devtools/restart`          | POST   | Schedule a DevTools restart after explicit confirmation                  |
-| `/bootui/api/memory`                    | GET    | JVM memory report                                                        |
-| `/bootui/api/scheduled`                 | GET    | Scheduled tasks                                                          |
-| `/bootui/api/probe`                     | POST   | Local HTTP probe                                                         |
-| `/bootui/api/logs/recent`               | GET    | Recent log lines                                                         |
-| `/bootui/api/logs/stream`               | GET    | Log stream over Server-Sent Events                                       |
-| `/bootui/api/profiles`                  | GET    | Profile-specific property sources                                        |
-| `/bootui/api/dev-services`              | GET    | Docker Compose, Testcontainers, and service connection entries           |
-| `/bootui/api/dev-services/{id}/logs`    | GET    | Bounded log tail for a bean-backed service when available                |
-| `/bootui/api/dev-services/{id}/restart` | POST   | Restart a bean-backed service only when explicitly enabled               |
-| `/bootui/api/data/repositories`         | GET    | Detected Spring Data repositories (summary)                              |
-| `/bootui/api/data/repositories/{name}`  | GET    | Spring Data repository detail with query methods                         |
-| `/bootui/api/cache`                     | GET    | Spring Cache managers, caches, metrics, and annotation operations        |
-| `/bootui/api/cache/clear`               | POST   | Clear one or all known caches only when explicitly enabled and confirmed |
-| `/bootui/api/security`                  | GET    | Spring Security filter chain report                                      |
-| `/bootui/api/security/explain`          | GET    | Best-effort chain match for a method/path                                |
-| `/bootui/api/security/endpoints`        | GET    | Best-effort per-endpoint authorization report                            |
+| Endpoint                                | Method | Purpose                                                                   |
+| --------------------------------------- | ------ | ------------------------------------------------------------------------- |
+| `/bootui/api/overview`                  | GET    | App, runtime, Spring Boot, profile, and BootUI status                     |
+| `/bootui/api/beans`                     | GET    | Searchable bean summary                                                   |
+| `/bootui/api/conditions`                | GET    | Auto-configuration conditions                                             |
+| `/bootui/api/config`                    | GET    | Effective configuration values                                            |
+| `/bootui/api/config/overrides`          | POST   | Create or update a local runtime configuration property override          |
+| `/bootui/api/config/overrides/{name}`   | DELETE | Remove a local runtime configuration property override                    |
+| `/bootui/api/mappings`                  | GET    | HTTP mappings                                                             |
+| `/bootui/api/mappings/flat`             | GET    | Stable, paged HTTP mapping summaries                                      |
+| `/bootui/api/health`                    | GET    | Health tree                                                               |
+| `/bootui/api/loggers`                   | GET    | Logger levels                                                             |
+| `/bootui/api/loggers/{name}`            | POST   | Change logger level                                                       |
+| `/bootui/api/startup`                   | GET    | Startup timeline                                                          |
+| `/bootui/api/metrics`                   | GET    | Browseable Micrometer meter list                                          |
+| `/bootui/api/metrics/detail`            | GET    | Micrometer meter detail and live measurements                             |
+| `/bootui/api/dependencies`              | GET    | Runtime Maven dependency inventory without external scanning              |
+| `/bootui/api/dependencies/scan`         | POST   | Explicit on-demand OSV.dev vulnerability scan                             |
+| `/bootui/api/devtools`                  | GET    | Spring Boot DevTools status                                               |
+| `/bootui/api/devtools/livereload`       | POST   | Trigger a DevTools LiveReload notification when available                 |
+| `/bootui/api/devtools/restart`          | POST   | Schedule a DevTools restart after explicit confirmation                   |
+| `/bootui/api/memory`                    | GET    | JVM memory report                                                         |
+| `/bootui/api/scheduled`                 | GET    | Scheduled tasks                                                           |
+| `/bootui/api/probe`                     | POST   | Local HTTP probe                                                          |
+| `/bootui/api/logs/recent`               | GET    | Recent log lines                                                          |
+| `/bootui/api/logs/stream`               | GET    | Log stream over Server-Sent Events                                        |
+| `/bootui/api/profiles`                  | GET    | Profile-specific property sources                                         |
+| `/bootui/api/dev-services`              | GET    | Docker Compose, Testcontainers, and service connection entries            |
+| `/bootui/api/dev-services/{id}/logs`    | GET    | Bounded log tail for a bean-backed service when available                 |
+| `/bootui/api/dev-services/{id}/restart` | POST   | Restart a bean-backed service only when explicitly enabled                |
+| `/bootui/api/data/repositories`         | GET    | Detected Spring Data repositories (summary)                               |
+| `/bootui/api/data/repositories/{name}`  | GET    | Spring Data repository detail with query methods                          |
+| `/bootui/api/cache`                     | GET    | Spring Cache managers, caches, metrics, and annotation operations         |
+| `/bootui/api/cache/clear`               | POST   | Clear one or all known caches only when explicitly enabled and confirmed  |
+| `/bootui/api/security`                  | GET    | Spring Security filter chain report                                       |
+| `/bootui/api/security/explain`          | GET    | Best-effort chain match for a method/path                                 |
+| `/bootui/api/security/endpoints`        | GET    | Best-effort per-endpoint authorization report                             |
 | `/bootui/api/copilot/**`                | GET    | Sanitized GitHub Copilot CLI session dashboard, explorer, raw reveal, SSE |
-| `/bootui/api/claude-code/**`            | GET    | Sanitized Claude Code project-log dashboard, explorer, raw reveal, SSE   |
+| `/bootui/api/claude-code/**`            | GET    | Sanitized Claude Code project-log dashboard, explorer, raw reveal, SSE    |
 
 ### 6.5 Configuration properties
 
@@ -856,43 +856,43 @@ bootui.*
 
 Initial properties:
 
-| Property                                     | Default                                 | Description                                                                                     |
-|----------------------------------------------|-----------------------------------------|-------------------------------------------------------------------------------------------------|
-| `bootui.enabled`                             | `AUTO`                                  | Enables BootUI. Values: `AUTO`, `ON`, `OFF`.                                                    |
-| `bootui.path`                                | `/bootui`                               | UI base path used by the banner and safety filter; `/bootui` is the supported v0.1 route.       |
-| `bootui.api-path`                            | `/bootui/api`                           | Internal API base path used by the safety filter; controllers currently serve `/bootui/api/**`. |
-| `bootui.localhost-only`                      | `true`                                  | Reject non-local requests.                                                                      |
-| `bootui.allow-non-localhost`                 | `false`                                 | Explicitly allow non-loopback requests.                                                         |
-| `bootui.mask-secrets`                        | `true`                                  | Mask secret-like config values.                                                                 |
-| `bootui.expose-values`                       | `MASKED`                                | One of `MASKED`, `METADATA_ONLY`, `FULL`.                                                       |
-| `bootui.show-banner`                         | `true`                                  | Print BootUI URL on startup.                                                                    |
-| `bootui.enabled-profiles`                    | `dev,local`                             | Profiles that activate BootUI.                                                                  |
-| `bootui.disabled-profiles`                   | `prod,production`                       | Profiles that disable BootUI unless `bootui.enabled=ON`.                                        |
-| `bootui.overrides-file`                      | `.bootui/application-bootui.properties` | File used to persist local runtime configuration overrides.                                     |
-| `bootui.endpoint-timeout`                    | `5s`                                    | Timeout for endpoint-related calls.                                                             |
-| `bootui.cache.clear-enabled`                 | `true`                                  | Enable Spring Cache clear actions after explicit browser confirmation.                          |
-| `bootui.dependencies.osv-enabled`            | `true`                                  | Allow the user-initiated OSV.dev vulnerability scan action.                                     |
-| `bootui.dependencies.request-timeout`        | `10s`                                   | Timeout applied to each OSV request.                                                            |
-| `bootui.dependencies.max-packages`           | `250`                                   | Maximum packages sent in one OSV batch query.                                                   |
-| `bootui.dependencies.max-advisories`         | `200`                                   | Maximum advisory detail documents fetched after a query.                                        |
-| `bootui.dev-services.restart-enabled`        | `false`                                 | Enables restart controls for bean-backed Testcontainers services.                               |
-| `bootui.dev-services.log-tail-bytes`         | `65536`                                 | Maximum bytes returned by one Dev Services log request.                                         |
-| `bootui.telemetry.enabled`                   | `true`                                  | Enables the local OTLP/HTTP trace receiver used by the Traces and AI Usage panels.              |
-| `bootui.telemetry.max-traces`                | `500`                                   | Maximum distinct traces retained in memory; internally capped for UI safety.                    |
-| `bootui.telemetry.max-spans-per-trace`       | `500`                                   | Maximum spans retained for one trace; internally capped for UI safety.                          |
-| `bootui.telemetry.max-attribute-value-bytes` | `4096`                                  | Maximum attribute string length before truncation; internally capped for UI safety.             |
-| `bootui.telemetry.exclude-self-spans`        | `true`                                  | Drops spans for BootUI's own API routes from the retained trace data.                           |
-| `bootui.telemetry.max-request-bytes`         | `8388608`                               | Maximum OTLP payload size accepted by the local receiver.                                       |
-| `bootui.ai.token-series-minutes`             | `60`                                    | Default token-usage chart window for the AI Usage panel, capped by the API.                     |
-| `bootui.ai.max-recent-chats`                 | `100`                                   | Maximum recent chat rows surfaced by the AI Usage panel, capped by the API.                     |
-| `bootui.ai.show-content-capture-banner`      | `true`                                  | Shows guidance when Spring AI prompt/completion content is not captured in spans.               |
-| `bootui.copilot.enabled`                     | `AUTO`                                  | Enable the Copilot panel when local Copilot CLI session state exists.                           |
-| `bootui.copilot.session-state-dir`           | `~/.copilot/session-state`              | Directory scanned for Copilot CLI session directories and `events.jsonl` files.                 |
-| `bootui.copilot.max-sessions`                | `100`                                   | Maximum recent sessions returned by the Copilot session explorer.                               |
-| `bootui.copilot.allow-raw-reveal`            | `true`                                  | Allows opt-in raw Copilot event JSON reveal on loopback.                                        |
-| `bootui.claude-code.enabled`                 | `AUTO`                                  | Enable the Claude Code panel when local Claude Code project logs exist.                         |
-| `bootui.claude-code.session-state-dir`       | `~/.claude/projects`                    | Directory scanned for Claude Code project JSONL logs.                                           |
-| `bootui.claude-code.max-sessions`            | `100`                                   | Maximum recent sessions returned by the Claude Code session explorer.                           |
+| Property                                     | Default                                 | Description                                                                                       |
+| -------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `bootui.enabled`                             | `AUTO`                                  | Enables BootUI. Values: `AUTO`, `ON`, `OFF`.                                                      |
+| `bootui.path`                                | `/bootui`                               | UI base path used by the banner and safety filter; `/bootui` is the supported v0.1 route.         |
+| `bootui.api-path`                            | `/bootui/api`                           | Internal API base path used by the safety filter; controllers currently serve `/bootui/api/**`.   |
+| `bootui.localhost-only`                      | `true`                                  | Reject non-local requests.                                                                        |
+| `bootui.allow-non-localhost`                 | `false`                                 | Explicitly allow non-loopback requests.                                                           |
+| `bootui.mask-secrets`                        | `true`                                  | Mask secret-like config values.                                                                   |
+| `bootui.expose-values`                       | `MASKED`                                | One of `MASKED`, `METADATA_ONLY`, `FULL`.                                                         |
+| `bootui.show-banner`                         | `true`                                  | Print BootUI URL on startup.                                                                      |
+| `bootui.enabled-profiles`                    | `dev,local`                             | Profiles that activate BootUI.                                                                    |
+| `bootui.disabled-profiles`                   | `prod,production`                       | Profiles that disable BootUI unless `bootui.enabled=ON`.                                          |
+| `bootui.overrides-file`                      | `.bootui/application-bootui.properties` | File used to persist local runtime configuration overrides.                                       |
+| `bootui.endpoint-timeout`                    | `5s`                                    | Timeout for endpoint-related calls.                                                               |
+| `bootui.cache.clear-enabled`                 | `true`                                  | Enable Spring Cache clear actions after explicit browser confirmation.                            |
+| `bootui.dependencies.osv-enabled`            | `true`                                  | Allow the user-initiated OSV.dev vulnerability scan action.                                       |
+| `bootui.dependencies.request-timeout`        | `10s`                                   | Timeout applied to each OSV request.                                                              |
+| `bootui.dependencies.max-packages`           | `250`                                   | Maximum packages sent in one OSV batch query.                                                     |
+| `bootui.dependencies.max-advisories`         | `200`                                   | Maximum advisory detail documents fetched after a query.                                          |
+| `bootui.dev-services.restart-enabled`        | `false`                                 | Enables restart controls for bean-backed Testcontainers services.                                 |
+| `bootui.dev-services.log-tail-bytes`         | `65536`                                 | Maximum bytes returned by one Dev Services log request.                                           |
+| `bootui.telemetry.enabled`                   | `true`                                  | Enables the local OTLP/HTTP trace receiver used by the Traces and AI Usage panels.                |
+| `bootui.telemetry.max-traces`                | `500`                                   | Maximum distinct traces retained in memory; internally capped for UI safety.                      |
+| `bootui.telemetry.max-spans-per-trace`       | `500`                                   | Maximum spans retained for one trace; internally capped for UI safety.                            |
+| `bootui.telemetry.max-attribute-value-bytes` | `4096`                                  | Maximum attribute string length before truncation; internally capped for UI safety.               |
+| `bootui.telemetry.exclude-self-spans`        | `true`                                  | Drops spans for BootUI's own API routes from the retained trace data.                             |
+| `bootui.telemetry.max-request-bytes`         | `8388608`                               | Maximum OTLP payload size accepted by the local receiver.                                         |
+| `bootui.ai.token-series-minutes`             | `60`                                    | Default token-usage chart window for the AI Usage panel, capped by the API.                       |
+| `bootui.ai.max-recent-chats`                 | `100`                                   | Maximum recent chat rows surfaced by the AI Usage panel, capped by the API.                       |
+| `bootui.ai.show-content-capture-banner`      | `true`                                  | Shows guidance when Spring AI prompt/completion content is not captured in spans.                 |
+| `bootui.copilot.enabled`                     | `AUTO`                                  | Enable the Copilot panel when local Copilot CLI session state exists.                             |
+| `bootui.copilot.session-state-dir`           | `~/.copilot/session-state`              | Directory scanned for Copilot CLI session directories and `events.jsonl` files.                   |
+| `bootui.copilot.max-sessions`                | `100`                                   | Maximum recent sessions returned by the Copilot session explorer.                                 |
+| `bootui.copilot.allow-raw-reveal`            | `true`                                  | Allows opt-in raw Copilot event JSON reveal on loopback.                                          |
+| `bootui.claude-code.enabled`                 | `AUTO`                                  | Enable the Claude Code panel when local Claude Code project logs exist.                           |
+| `bootui.claude-code.session-state-dir`       | `~/.claude/projects`                    | Directory scanned for Claude Code project JSONL logs.                                             |
+| `bootui.claude-code.max-sessions`            | `100`                                   | Maximum recent sessions returned by the Claude Code session explorer.                             |
 | `bootui.claude-code.allow-raw-reveal`        | `false`                                 | Allows opt-in raw Claude Code JSONL reveal; disabled by default because logs can include content. |
 
 ### 6.6 Security model
@@ -928,32 +928,39 @@ The second property should be required to expose BootUI beyond localhost.
 
 ### 7.1 Navigation
 
-Top-level tabs:
+Top-level navigation:
 
 - Overview.
-- Startup Timeline.
-- Memory.
-- Health.
-- Metrics.
-- Conditions.
-- Beans.
-- Mappings.
-- Configuration.
-- Profile Diff.
-- Loggers.
-- Log Tail.
-- Traces.
-- HTTP Probe.
-- Copilot.
-- Claude Code.
-- DevTools.
-- Dev Services.
-- Scheduled Tasks.
-- Data.
-- Cache.
-- AI Usage.
-- Security.
-- Vulnerabilities.
+- Runtime:
+  - Health.
+  - Metrics.
+  - Memory.
+  - Startup Timeline.
+  - Scheduled Tasks.
+- Configuration:
+  - Configuration.
+  - Profile Diff.
+  - Loggers.
+  - Beans.
+  - Conditions.
+  - Mappings.
+- Services:
+  - Data.
+  - Cache.
+  - Security.
+  - AI Usage.
+- Diagnostics:
+  - Traces.
+  - Log Tail.
+  - HTTP Probe.
+  - Vulnerabilities.
+- Developer tools:
+  - DevTools.
+  - Dev Services.
+  - Copilot.
+  - Claude Code.
+- Disabled / unavailable:
+  - Non-overview panels whose backing infrastructure is unavailable.
 
 ### 7.2 UI principles
 
@@ -1035,9 +1042,10 @@ Future compatibility:
 BootUI v0.1 is complete when:
 
 - A sample Spring Boot app can add the starter and open `/bootui`.
-- The UI shows Overview, Startup Timeline, Memory, Health, Metrics, Conditions, Beans, Mappings, Configuration, Profile
-  Diff, Loggers, Log Tail, Traces, HTTP Probe, Copilot, Claude Code, DevTools, Dev Services, Scheduled Tasks, Data,
-  Cache, AI Usage, Security, and Vulnerabilities.
+- The UI shows Overview, Runtime, Configuration, Services, Diagnostics, Developer tools, and Disabled / unavailable
+  navigation groups covering Health, Metrics, Memory, Startup Timeline, Scheduled Tasks, Configuration, Profile Diff,
+  Loggers, Beans, Conditions, Mappings, Data, Cache, Security, AI Usage, Traces, Log Tail, HTTP Probe, Vulnerabilities,
+  DevTools, Dev Services, Copilot, and Claude Code.
 - Secret-like values are masked.
 - BootUI is disabled by default outside local/dev contexts.
 - Tests verify activation and safety behavior.


### PR DESCRIPTION
## What does this PR do?

Groups the BootUI sidebar into collapsible sections, keeps Runtime open by default, and moves unavailable non-overview panels into a muted Disabled / unavailable group.

## Why is this change needed?

BootUI has accumulated enough panels that the flat menu is harder to scan. Grouping related panels makes the console easier to navigate while keeping disabled or unsupported panels discoverable without making them visually prominent.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks run:

- `npm run format` for frontend and e2e
- Prettier checks for frontend, e2e, README, and docs
- Frontend Vitest suite
- `./mvnw -B -ntp -pl bootui-ui,bootui-spring-boot-starter -am install -DskipTests`
- Focused Playwright app-shell coverage

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed