### PR TITLE
Fix Windows build issues

### DIFF
--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiPropertiesTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiPropertiesTests.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.bind.BindResult;
@@ -149,7 +150,9 @@ class BootUiPropertiesTests {
     @Test
     void defaultClaudeCodeSessionDirectoryIsProjectsDirectory() {
         BootUiProperties props = new BootUiProperties();
-        assertThat(props.getClaudeCode().defaultSessionStateDir().toString()).endsWith(".claude/projects");
+        Path defaultSessionStateDir = props.getClaudeCode().defaultSessionStateDir();
+        assertThat(defaultSessionStateDir.getFileName()).hasToString("projects");
+        assertThat(defaultSessionStateDir.getParent().getFileName()).hasToString(".claude");
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Fixes two Windows-specific build/test issues by making the Claude Code path test platform-neutral and making Maven frontend builds recreate dependencies from `package-lock.json`.

## Why is this change needed?

The Claude Code default session directory test compared `Path.toString()` with a Unix-style suffix, which failed on Windows because paths use backslashes. The frontend Maven build also used `npm install`, which can leave an existing `node_modules` tree without platform-specific optional dependencies like `@rolldown/binding-win32-x64-msvc`; `npm ci` recreates the tree from the complete lock file so Rolldown's native binding is installed for the current platform.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `./mvnw -pl bootui-autoconfigure test -Dtest=BootUiPropertiesTests` passes locally
- [x] `./mvnw -pl bootui-autoconfigure spotless:check` passes locally
- [x] `./mvnw -pl bootui-ui test` passes locally
- [x] `./mvnw -pl bootui-ui spotless:check` passes locally

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
