### PR TITLE
Use npm ci for frontend Maven builds

### DIFF
--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiPropertiesTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiPropertiesTests.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.bind.BindResult;
@@ -149,7 +150,9 @@ class BootUiPropertiesTests {
     @Test
     void defaultClaudeCodeSessionDirectoryIsProjectsDirectory() {
         BootUiProperties props = new BootUiProperties();
-        assertThat(props.getClaudeCode().defaultSessionStateDir().toString()).endsWith(".claude/projects");
+        Path defaultSessionStateDir = props.getClaudeCode().defaultSessionStateDir();
+        assertThat(defaultSessionStateDir.getFileName()).hasToString("projects");
+        assertThat(defaultSessionStateDir.getParent().getFileName()).hasToString(".claude");
     }
 
     @Test

--- a/bootui-ui/pom.xml
+++ b/bootui-ui/pom.xml
@@ -53,7 +53,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <arguments>install --no-audit --no-fund</arguments>
+                            <arguments>ci --no-audit --no-fund</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
## What does this PR do?

Switches the Maven-managed frontend install from `npm install` to `npm ci`.

## Why is this change needed?

After the previous Windows fix was merged, a follow-up Windows build failure showed that `npm install` can leave an existing `node_modules` tree without platform-specific optional dependencies, including Rolldown's `@rolldown/binding-win32-x64-msvc`. Using `npm ci` recreates dependencies from `package-lock.json`, so the native binding for the current platform is installed consistently during Maven builds.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `./mvnw -pl bootui-ui test` passes locally
- [x] `./mvnw -pl bootui-ui spotless:check` passes locally

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed