### PR TITLE
Force optional npm dependencies in frontend build

### DIFF
--- a/bootui-ui/pom.xml
+++ b/bootui-ui/pom.xml
@@ -53,7 +53,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <arguments>ci --no-audit --no-fund</arguments>
+                            <arguments>ci --include=optional --no-audit --no-fund</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
## What does this PR do?

Forces Maven-managed frontend installs to include optional npm dependencies while still using `npm ci`.

## Why is this change needed?

The Windows build still failed because Rolldown's native package, `@rolldown/binding-win32-x64-msvc`, was not present in `node_modules`. `npm ci` recreates the dependency tree, but it can still respect user or environment config such as `omit=optional`; passing `--include=optional` makes the Maven build install platform-native optional packages required by Vite/Rolldown.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `NPM_CONFIG_OMIT=optional ./mvnw -pl bootui-ui test` passes locally
- [x] `./mvnw -pl bootui-ui spotless:check` passes locally

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
