### PR TITLE
Add Apache Camel routes panel

### DIFF
--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -77,6 +77,17 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-management-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiCamelAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiCamelAutoConfiguration.java
@@ -1,0 +1,19 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import io.github.jdubois.bootui.autoconfigure.web.CamelController;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Import;
+
+@AutoConfiguration(
+        after = BootUiAutoConfiguration.class,
+        afterName = "org.apache.camel.spring.boot.CamelAutoConfiguration")
+@Conditional(BootUiActivationCondition.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnClass(name = "org.apache.camel.CamelContext")
+@ConditionalOnBean(type = "org.apache.camel.CamelContext")
+@Import(CamelController.class)
+class BootUiCamelAutoConfiguration {}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/panel/BootUiPanels.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/panel/BootUiPanels.java
@@ -37,6 +37,7 @@ public final class BootUiPanels {
     public static final String DEV_SERVICES = "dev-services";
     public static final String COPILOT = "copilot";
     public static final String CLAUDE_CODE = "claude-code";
+    public static final String CAMEL = "camel";
 
     private static final List<Panel> PANELS = List.of(
             new Panel(OVERVIEW, "Overview", false, "/overview"),
@@ -62,7 +63,8 @@ public final class BootUiPanels {
             new Panel(DEVTOOLS, "DevTools", true, "/devtools"),
             new Panel(DEV_SERVICES, "Dev Services", true, "/dev-services"),
             new Panel(COPILOT, "Copilot", false, "/copilot"),
-            new Panel(CLAUDE_CODE, "Claude Code", false, "/claude-code"));
+            new Panel(CLAUDE_CODE, "Claude Code", false, "/claude-code"),
+            new Panel(CAMEL, "CAMEL Routes", false, "/camel-routes"));
 
     private static final Map<String, Panel> BY_ID =
             PANELS.stream().collect(Collectors.toUnmodifiableMap(Panel::id, Function.identity()));

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CamelController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CamelController.java
@@ -1,0 +1,169 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.core.BootUiDtos.CamelRouteDto;
+import io.github.jdubois.bootui.core.BootUiDtos.CamelRoutesReport;
+import io.github.jdubois.bootui.core.BootUiDtos.CamelStatsDto;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Route;
+import org.apache.camel.ServiceStatus;
+import org.apache.camel.api.management.ManagedCamelContext;
+import org.apache.camel.api.management.mbean.ManagedRouteMBean;
+import org.apache.camel.console.DevConsole;
+import org.apache.camel.console.DevConsoleRegistry;
+import org.apache.camel.spi.RouteController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/bootui/api/camel")
+public class CamelController {
+
+    private static final Logger log = LoggerFactory.getLogger(CamelController.class);
+
+    private final CamelContext camelContext;
+    private final ExecutorService lifecycleExecutor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread(r, "bootui-camel-lifecycle");
+        t.setDaemon(true);
+        return t;
+    });
+
+    public CamelController(CamelContext camelContext) {
+        this.camelContext = camelContext;
+    }
+
+    @GetMapping("/routes")
+    public CamelRoutesReport routes() {
+        List<Route> routes = camelContext.getRoutes();
+        RouteController rc = camelContext.getRouteController();
+        List<CamelRouteDto> dtos = new ArrayList<>();
+        for (Route route : routes) {
+            ServiceStatus status = rc.getRouteStatus(route.getRouteId());
+            Endpoint ep = route.getEndpoint();
+            dtos.add(new CamelRouteDto(
+                    route.getRouteId(),
+                    ep != null ? ep.getEndpointUri() : null,
+                    status != null ? status.name() : "Unknown",
+                    route.getUptime(),
+                    route.getUptimeMillis(),
+                    route.getDescription()));
+        }
+        dtos.sort(java.util.Comparator.comparing(CamelRouteDto::routeId, String.CASE_INSENSITIVE_ORDER));
+        boolean diagramAvailable = findConsole("route-diagram") != null;
+        CamelStatsDto stats = aggregateStats(routes);
+        return new CamelRoutesReport(
+                camelContext.getVersion(), camelContext.getStatus().name(), dtos.size(), dtos, diagramAvailable, stats);
+    }
+
+    @GetMapping("/routes/diagram")
+    public Object diagram(
+            @RequestParam(required = false) String filter,
+            @RequestParam(required = false, defaultValue = "light") String theme) {
+        DevConsole console = findConsole("route-diagram");
+        if (console == null) {
+            return Map.of();
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("theme", theme);
+        params.put("metric", "true");
+        if (filter != null && !filter.isBlank()) {
+            params.put("filter", filter);
+        }
+        return console.call(DevConsole.MediaType.JSON, params);
+    }
+
+    @PostMapping("/routes/{id}/start")
+    public Map<String, String> startRoute(@PathVariable String id) {
+        return doLifecycle(id, "start");
+    }
+
+    @PostMapping("/routes/{id}/stop")
+    public Map<String, String> stopRoute(@PathVariable String id) {
+        return doLifecycle(id, "stop");
+    }
+
+    @PostMapping("/routes/{id}/suspend")
+    public Map<String, String> suspendRoute(@PathVariable String id) {
+        return doLifecycle(id, "suspend");
+    }
+
+    @PostMapping("/routes/{id}/resume")
+    public Map<String, String> resumeRoute(@PathVariable String id) {
+        return doLifecycle(id, "resume");
+    }
+
+    private CamelStatsDto aggregateStats(List<Route> routes) {
+        ManagedCamelContext mcc =
+                camelContext.getCamelContextExtension().getContextPlugin(ManagedCamelContext.class);
+        if (mcc == null) {
+            return null;
+        }
+        long totalExchanges = 0;
+        long totalFailed = 0;
+        long totalInflight = 0;
+        long maxPt = 0;
+        long weightedMeanSum = 0;
+        List<ManagedRouteMBean> managed = routes.stream()
+                .map(r -> mcc.getManagedRoute(r.getRouteId()))
+                .filter(Objects::nonNull)
+                .toList();
+        if (managed.isEmpty()) {
+            return null;
+        }
+        for (ManagedRouteMBean mrb : managed) {
+            long exchanges = mrb.getExchangesTotal();
+            totalExchanges += exchanges;
+            totalFailed += mrb.getExchangesFailed();
+            totalInflight += mrb.getExchangesInflight();
+            weightedMeanSum += mrb.getMeanProcessingTime() * exchanges;
+            maxPt = Math.max(maxPt, mrb.getMaxProcessingTime());
+        }
+        long meanPt = totalExchanges > 0 ? weightedMeanSum / totalExchanges : 0;
+        return new CamelStatsDto(totalExchanges, totalFailed, totalInflight, meanPt, maxPt);
+    }
+
+    private Map<String, String> doLifecycle(String routeId, String action) {
+        if (camelContext.getRoute(routeId) == null) {
+            return Map.of("status", "error", "message", "Route not found: " + routeId);
+        }
+        try {
+            RouteController rc = camelContext.getRouteController();
+            switch (action) {
+                case "start" -> rc.startRoute(routeId);
+                case "stop" -> {
+                    lifecycleExecutor.submit(() -> {
+                        try {
+                            rc.stopRoute(routeId);
+                        } catch (Exception e) {
+                            log.warn("Failed to stop route {}", routeId, e);
+                        }
+                    });
+                    return Map.of("status", "ok", "message", "Stop requested", "routeStatus", "Stopping");
+                }
+                case "suspend" -> rc.suspendRoute(routeId);
+                case "resume" -> rc.resumeRoute(routeId);
+            }
+            ServiceStatus status = rc.getRouteStatus(routeId);
+            return Map.of("status", "ok", "routeStatus", status != null ? status.name() : "Unknown");
+        } catch (Exception e) {
+            return Map.of("status", "error", "message", e.getMessage());
+        }
+    }
+
+    private DevConsole findConsole(String id) {
+        DevConsoleRegistry dcr =
+                camelContext.getCamelContextExtension().getContextPlugin(DevConsoleRegistry.class);
+        if (dcr == null || !dcr.isEnabled()) {
+            return null;
+        }
+        return dcr.resolveById(id);
+    }
+}

--- a/bootui-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/bootui-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 io.github.jdubois.bootui.autoconfigure.BootUiAutoConfiguration
+io.github.jdubois.bootui.autoconfigure.BootUiCamelAutoConfiguration

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
@@ -22,7 +22,7 @@ class PanelsControllerTests {
 
             mvc.perform(get("/bootui/api/panels"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.panels.length()").value(24))
+                    .andExpect(jsonPath("$.panels.length()").value(25))
                     .andExpect(jsonPath("$.panels[0].id").value("overview"))
                     .andExpect(jsonPath("$.panels[6].id").value("config"))
                     .andExpect(jsonPath("$.panels[16].id").value("traces"))

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -751,6 +751,32 @@ public final class BootUiDtos {
      */
     public record AiTokenSeriesDto(int minutes, List<AiTokenBucketDto> buckets) {}
 
+    // ----- Apache Camel integration ----------------------------------------------------------
+
+    /**
+     * Summary of one Camel route.
+     */
+    public record CamelRouteDto(
+            String routeId, String from, String status, String uptime, long uptimeMillis, String description) {}
+
+    /**
+     * Top-level Camel routes report with context metadata.
+     */
+    public record CamelRoutesReport(
+            String camelVersion,
+            String contextStatus,
+            int total,
+            List<CamelRouteDto> routes,
+            boolean diagramAvailable,
+            CamelStatsDto stats) {}
+
+    /**
+     * Aggregated exchange statistics across all Camel routes.
+     */
+    public record CamelStatsDto(
+            long exchangesTotal, long exchangesFailed, long exchangesInflight, long meanProcessingTime,
+            long maxProcessingTime) {}
+
     /**
      * AI Usage overview payload.
      */

--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -21,6 +21,7 @@ import DevTools from './views/DevTools.vue'
 import Traces from './views/Traces.vue'
 import Ai from './views/Ai.vue'
 import Copilot from './views/Copilot.vue'
+import CamelRoutes from './views/CamelRoutes.vue'
 
 export const groups = {
   overview: 'overview',
@@ -119,6 +120,12 @@ export const routes = [
     meta: {group: groups.services, icon: 'bi-person-lock', title: 'Security'}
   },
   {path: '/ai', name: 'ai', component: Ai, meta: {group: groups.services, icon: 'bi-cpu', title: 'AI Usage'}},
+  {
+    path: '/camel-routes',
+    name: 'camel-routes',
+    component: CamelRoutes,
+    meta: {group: groups.services, icon: 'bi-signpost-split', title: 'Camel Routes'}
+  },
   {
     path: '/traces',
     name: 'traces',

--- a/bootui-ui/src/main/frontend/src/views/CamelRoutes.vue
+++ b/bootui-ui/src/main/frontend/src/views/CamelRoutes.vue
@@ -1,0 +1,401 @@
+<script setup>
+import {computed, onBeforeUnmount, onMounted, reactive, ref} from 'vue'
+import {apiFetch} from '../api.js'
+
+const report = ref(null)
+const diagramImage = ref(null)
+const error = ref(null)
+const banner = ref(null)
+const selectedRoute = ref(null)
+const lastUpdated = ref(null)
+let polling = true
+let routesController = null
+let diagramController = null
+let bannerTimeout = null
+
+const selectedRouteData = computed(() =>
+  report.value?.routes?.find((r) => r.routeId === selectedRoute.value) || null
+)
+
+function statusBadge(status) {
+  if (status === 'Started') return 'text-bg-success'
+  if (status === 'Stopped') return 'text-bg-danger'
+  if (status === 'Suspended') return 'text-bg-warning'
+  if (status === 'Stopping') return 'text-bg-info'
+  return 'text-bg-secondary'
+}
+
+function lastUpdatedText() {
+  if (!lastUpdated.value) return ''
+  return lastUpdated.value.toLocaleTimeString([], {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  })
+}
+
+function showBanner(obj, autoDismiss) {
+  banner.value = obj
+  clearTimeout(bannerTimeout)
+  if (autoDismiss) {
+    bannerTimeout = setTimeout(() => {
+      banner.value = null
+    }, 4000)
+  }
+}
+
+async function loadRoutes() {
+  routesController?.abort()
+  routesController = new AbortController()
+  try {
+    const res = await apiFetch('api/camel/routes', {signal: routesController.signal})
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const data = await res.json()
+    for (const route of data.routes || []) {
+      if (stoppingRoutes.has(route.routeId)) {
+        if (route.status === 'Stopped') {
+          stoppingRoutes.delete(route.routeId)
+        } else {
+          route.status = 'Stopping'
+        }
+      }
+    }
+    report.value = data
+    error.value = null
+  } catch (e) {
+    if (e.name === 'AbortError') return
+    error.value = e.message
+  }
+}
+
+async function loadDiagram() {
+  if (!report.value?.diagramAvailable) {
+    diagramImage.value = null
+    return
+  }
+  diagramController?.abort()
+  diagramController = new AbortController()
+  try {
+    const params = new URLSearchParams({theme: 'light', metric: 'true'})
+    if (selectedRoute.value) params.set('filter', selectedRoute.value)
+    const res = await apiFetch(`api/camel/routes/diagram?${params}`, {signal: diagramController.signal})
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const data = await res.json()
+    diagramImage.value = data.image || null
+  } catch (e) {
+    if (e.name === 'AbortError') return
+    diagramImage.value = null
+  }
+}
+
+async function refresh() {
+  await loadRoutes()
+  await loadDiagram()
+  lastUpdated.value = new Date()
+}
+
+function selectRoute(routeId) {
+  selectedRoute.value = selectedRoute.value === routeId ? null : routeId
+  zoom.value = 1
+  loadDiagram()
+}
+
+const zoom = ref(1)
+
+function zoomIn() {
+  zoom.value = Math.min(zoom.value + 0.25, 4)
+}
+
+function zoomOut() {
+  zoom.value = Math.max(zoom.value - 0.25, 0.25)
+}
+
+function zoomReset() {
+  zoom.value = 1
+}
+
+const pendingActions = reactive(new Set())
+const stoppingRoutes = reactive(new Set())
+
+async function doLifecycle(routeId, action) {
+  const key = `${routeId}:${action}`
+  if (pendingActions.has(key)) return
+  pendingActions.add(key)
+  try {
+    const lc = new AbortController()
+    const timeout = setTimeout(() => lc.abort(), 15000)
+    const res = await apiFetch(`api/camel/routes/${routeId}/${action}`, {method: 'POST', signal: lc.signal})
+    clearTimeout(timeout)
+    if (!res.ok) throw new Error('HTTP ' + res.status)
+    const result = await res.json()
+    if (result.status === 'error') {
+      showBanner({type: 'danger', text: `${action} failed on ${routeId}: ${result.message}`}, true)
+    } else if (result.routeStatus === 'Stopping') {
+      stoppingRoutes.add(routeId)
+      if (report.value) {
+        const route = report.value.routes.find((r) => r.routeId === routeId)
+        if (route) route.status = 'Stopping'
+      }
+      showBanner({type: 'info', text: `Stopping route ${routeId}…`}, false)
+    } else {
+      showBanner({type: 'success', text: `Route ${routeId} ${action} successful`}, true)
+      await refresh()
+    }
+  } catch (e) {
+    if (e.name === 'AbortError') {
+      showBanner({type: 'warning', text: `${action} request timed out for ${routeId}`}, true)
+    } else {
+      showBanner({type: 'danger', text: `${action} failed on ${routeId}: ${e.message}`}, true)
+    }
+  } finally {
+    pendingActions.delete(key)
+  }
+}
+
+async function pollLoop() {
+  while (polling) {
+    await new Promise((r) => setTimeout(r, 5000))
+    if (!polling) break
+    if (document.visibilityState !== 'hidden') {
+      await refresh()
+    }
+  }
+}
+
+onMounted(async () => {
+  await refresh()
+  pollLoop()
+})
+
+onBeforeUnmount(() => {
+  polling = false
+  routesController?.abort()
+  diagramController?.abort()
+  clearTimeout(bannerTimeout)
+})
+</script>
+
+<template>
+  <div>
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+      <div>
+        <h3 class="h4 mb-1"><i class="bi bi-signpost-split me-2"></i>Camel Routes</h3>
+        <p v-if="report" class="text-muted mb-0">
+          Context: {{ report.contextStatus }} · v{{ report.camelVersion }} · {{ report.total }} route{{
+            report.total === 1 ? '' : 's'
+          }}
+        </p>
+      </div>
+      <div class="d-flex align-items-center gap-2">
+        <span v-if="lastUpdated" class="text-muted small">
+          <i class="bi bi-arrow-repeat me-1"></i>Updated {{ lastUpdatedText() }}
+        </span>
+        <button class="btn btn-sm btn-outline-secondary" @click="refresh">
+          <i class="bi bi-arrow-clockwise"></i> Refresh
+        </button>
+      </div>
+    </div>
+
+    <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
+      <div>{{ banner.text }}</div>
+      <button class="btn-close" @click="banner = null"></button>
+    </div>
+
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+
+    <template v-if="report">
+      <div v-if="report.stats" class="row g-2 mb-3">
+        <div class="col">
+          <div class="card text-center p-2">
+            <div class="fs-5 fw-semibold">{{ report.stats.exchangesTotal.toLocaleString() }}</div>
+            <div class="text-muted small">Exchanges</div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card text-center p-2">
+            <div :class="report.stats.exchangesFailed > 0 ? 'text-danger' : ''" class="fs-5 fw-semibold">
+              {{ report.stats.exchangesFailed.toLocaleString() }}
+            </div>
+            <div class="text-muted small">Failed</div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card text-center p-2">
+            <div class="fs-5 fw-semibold">{{ report.stats.exchangesInflight }}</div>
+            <div class="text-muted small">Inflight</div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card text-center p-2">
+            <div class="fs-5 fw-semibold">{{ report.stats.meanProcessingTime }} ms</div>
+            <div class="text-muted small">Mean time</div>
+          </div>
+        </div>
+        <div class="col">
+          <div class="card text-center p-2">
+            <div class="fs-5 fw-semibold">{{ report.stats.maxProcessingTime }} ms</div>
+            <div class="text-muted small">Max time</div>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="!report.stats" class="alert alert-info small mb-3">
+        <i class="bi bi-info-circle me-1"></i>Add <code>camel-management-starter</code> and set
+        <code>spring.jmx.enabled=true</code> to see exchange metrics.
+      </div>
+
+      <div v-if="!report.diagramAvailable" class="alert alert-info small mb-3">
+        <i class="bi bi-info-circle me-1"></i>Add <code>camel-diagram</code>,
+        <code>camel-console-starter</code> and set <code>camel.main.dev-console-enabled=true</code>
+        to see route diagrams.
+      </div>
+
+      <div class="row g-3">
+        <div class="col-lg-3">
+          <div class="card">
+            <div class="card-header fw-semibold">Routes</div>
+            <div class="list-group list-group-flush route-list">
+              <button
+                v-for="r in report.routes"
+                :key="r.routeId"
+                :class="{active: r.routeId === selectedRoute}"
+                class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
+                type="button"
+                @click="selectRoute(r.routeId)"
+              >
+                <div class="text-truncate me-2">
+                  <div class="fw-semibold">{{ r.routeId }}</div>
+                  <div v-if="r.from" class="small text-muted text-truncate">{{ r.from }}</div>
+                </div>
+                <span :class="statusBadge(r.status)" class="badge">{{ r.status }}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-9">
+          <div v-if="selectedRoute" class="mb-2 d-flex gap-2">
+            <button class="btn btn-sm btn-outline-success" :disabled="pendingActions.size > 0"
+                    @click="doLifecycle(selectedRoute, 'start')">
+              <i class="bi bi-play-fill"></i> Start
+            </button>
+            <button class="btn btn-sm btn-outline-danger" :disabled="pendingActions.size > 0"
+                    @click="doLifecycle(selectedRoute, 'stop')">
+              <i class="bi bi-stop-fill"></i> Stop
+            </button>
+            <button class="btn btn-sm btn-outline-warning" :disabled="pendingActions.size > 0"
+                    @click="doLifecycle(selectedRoute, 'suspend')">
+              <i class="bi bi-pause-fill"></i> Suspend
+            </button>
+            <button class="btn btn-sm btn-outline-primary" :disabled="pendingActions.size > 0"
+                    @click="doLifecycle(selectedRoute, 'resume')">
+              <i class="bi bi-skip-forward-fill"></i> Resume
+            </button>
+          </div>
+
+          <template v-if="selectedRouteData">
+            <div class="card mb-3">
+              <div class="card-header d-flex justify-content-between align-items-center">
+                <span>Route Details</span>
+                <span class="badge text-bg-primary">{{ selectedRouteData.routeId }}</span>
+              </div>
+              <div class="card-body">
+                <table class="table table-sm mb-0">
+                  <tbody>
+                    <tr>
+                      <th class="text-muted" style="width: 120px">Route ID</th>
+                      <td>{{ selectedRouteData.routeId }}</td>
+                    </tr>
+                    <tr>
+                      <th class="text-muted">From</th>
+                      <td><code>{{ selectedRouteData.from }}</code></td>
+                    </tr>
+                    <tr>
+                      <th class="text-muted">Status</th>
+                      <td><span :class="statusBadge(selectedRouteData.status)" class="badge">{{ selectedRouteData.status }}</span></td>
+                    </tr>
+                    <tr>
+                      <th class="text-muted">Uptime</th>
+                      <td>{{ selectedRouteData.uptime }}</td>
+                    </tr>
+                    <tr v-if="selectedRouteData.description">
+                      <th class="text-muted">Description</th>
+                      <td>{{ selectedRouteData.description }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div v-if="diagramImage" class="card">
+              <div class="card-header d-flex justify-content-between align-items-center">
+                <span>Route Diagram</span>
+                <div class="d-flex align-items-center gap-2">
+                  <button class="btn btn-sm btn-outline-secondary" @click="zoomIn">
+                    <i class="bi bi-zoom-in"></i>
+                  </button>
+                  <span class="text-muted small">{{ Math.round(zoom * 100) }}%</span>
+                  <button class="btn btn-sm btn-outline-secondary" @click="zoomOut">
+                    <i class="bi bi-zoom-out"></i>
+                  </button>
+                  <button class="btn btn-sm btn-outline-secondary" @click="zoomReset">
+                    <i class="bi bi-arrows-fullscreen"></i>
+                  </button>
+                  <span class="badge text-bg-primary">{{ selectedRouteData.routeId }}</span>
+                </div>
+              </div>
+              <div class="card-body diagram-container">
+                <img :src="'data:image/png;base64,' + diagramImage" alt="Route diagram" class="diagram-img"
+                     :style="{transform: `scale(${zoom})`, transformOrigin: 'top left'}"/>
+              </div>
+            </div>
+          </template>
+
+          <div v-else-if="!selectedRoute" class="alert alert-info small">
+            <i class="bi bi-info-circle me-1"></i>Select a route from the list to view its details.
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <div v-else-if="!error" class="text-muted">Loading Camel routes…</div>
+  </div>
+</template>
+
+<style scoped>
+.route-list {
+  max-height: 36rem;
+  overflow: auto;
+}
+
+.diagram-container {
+  overflow: scroll;
+  max-height: 70vh;
+  scrollbar-gutter: stable both-edges;
+}
+
+.diagram-container::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.diagram-container::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 6px;
+}
+
+.diagram-container::-webkit-scrollbar-thumb {
+  background: #adb5bd;
+  border-radius: 6px;
+}
+
+.diagram-container::-webkit-scrollbar-thumb:hover {
+  background: #6c757d;
+}
+
+.diagram-img {
+  max-width: 100%;
+  height: auto;
+}
+</style>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <spring-boot.version>4.0.6</spring-boot.version>
         <testcontainers.version>1.21.4</testcontainers.version>
+        <camel.version>4.20.0</camel.version>
         <opentelemetry-proto.version>1.10.0-alpha</opentelemetry-proto.version>
         <frontend-maven-plugin.version>2.0.0</frontend-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
@@ -97,6 +98,16 @@
                 <groupId>com.julien-dubois.bootui</groupId>
                 <artifactId>bootui-ui</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-api</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel</groupId>
+                <artifactId>camel-management-api</artifactId>
+                <version>${camel.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Adds a Camel Routes panel to BootUI with route listing, lifecycle management (start/stop/suspend/resume), and optional route diagram visualization via camel-diagram and exchange metrics via camel-management.

These are the dependency added:
```
$ mvn dependency:tree | grep camel
[INFO] +- org.apache.camel:camel-api:jar:4.20.0:compile (optional)
[INFO] |  +- org.apache.camel:camel-util:jar:4.20.0:compile (optional)
[INFO] +- org.apache.camel:camel-management-api:jar:4.20.0:compile (optional)
```

Attached you can find an app to that uses this PR. the app uses 4.21.0-SNAPSHOT since camel-diagram is not present in 4.20.0, but the idea is that bootui should work with any (unless API are changed) Camel version.

[test.zip](https://github.com/user-attachments/files/28399321/test.zip)
