### PR TITLE
Make agent session stores lazy

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 
@@ -110,6 +111,7 @@ public class BootUiAutoConfiguration {
     }
 
     @Bean(destroyMethod = "stop")
+    @Lazy
     public io.github.jdubois.bootui.autoconfigure.web.CopilotSessionStore bootUiCopilotSessionStore(
             BootUiProperties properties) {
         io.github.jdubois.bootui.autoconfigure.web.CopilotSessionStore store =
@@ -121,6 +123,7 @@ public class BootUiAutoConfiguration {
     }
 
     @Bean(destroyMethod = "stop")
+    @Lazy
     public io.github.jdubois.bootui.autoconfigure.web.ClaudeCodeSessionStore bootUiClaudeCodeSessionStore(
             BootUiProperties properties) {
         io.github.jdubois.bootui.autoconfigure.web.ClaudeCodeSessionStore store =

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ClaudeCodeController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ClaudeCodeController.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -27,12 +30,22 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/bootui/api/claude-code")
 public class ClaudeCodeController {
 
-    private final ClaudeCodeSessionStore store;
+    private final Supplier<ClaudeCodeSessionStore> store;
     private final BootUiProperties properties;
     private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
 
+    @Autowired
     public ClaudeCodeController(
-            @Qualifier("bootUiClaudeCodeSessionStore") ClaudeCodeSessionStore store, BootUiProperties properties) {
+            @Qualifier("bootUiClaudeCodeSessionStore") ObjectProvider<ClaudeCodeSessionStore> storeProvider,
+            BootUiProperties properties) {
+        this(storeProvider::getObject, properties);
+    }
+
+    ClaudeCodeController(ClaudeCodeSessionStore store, BootUiProperties properties) {
+        this(() -> store, properties);
+    }
+
+    private ClaudeCodeController(Supplier<ClaudeCodeSessionStore> store, BootUiProperties properties) {
         this.store = store;
         this.properties = properties;
     }
@@ -41,17 +54,17 @@ public class ClaudeCodeController {
     public CopilotSessionListDto sessions(
             @RequestParam(name = "since", required = false) Long since,
             @RequestParam(name = "until", required = false) Long until) {
-        return store.listSessions(since, until);
+        return store().listSessions(since, until);
     }
 
     @GetMapping("/dashboard")
     public CopilotDashboardDto dashboard() {
-        return store.dashboard();
+        return store().dashboard();
     }
 
     @GetMapping("/sessions/{id}")
     public ResponseEntity<CopilotSessionDetail> session(@PathVariable String id) {
-        CopilotSessionDetail detail = store.getSession(id);
+        CopilotSessionDetail detail = store().getSession(id);
         if (detail == null) {
             return ResponseEntity.notFound().build();
         }
@@ -64,6 +77,7 @@ public class ClaudeCodeController {
             @RequestParam(name = "category", required = false) String category,
             @RequestParam(name = "since", required = false) Long since,
             @RequestParam(name = "limit", required = false, defaultValue = "200") int limit) {
+        ClaudeCodeSessionStore store = store();
         if (store.getSession(id) == null) {
             return ResponseEntity.notFound().build();
         }
@@ -74,6 +88,7 @@ public class ClaudeCodeController {
 
     @GetMapping("/sessions/{id}/events/{eventId}/raw")
     public ResponseEntity<CopilotRawEventDto> raw(@PathVariable String id, @PathVariable String eventId) {
+        ClaudeCodeSessionStore store = store();
         if (!store.isRawRevealAllowed()) {
             return ResponseEntity.notFound().build();
         }
@@ -89,6 +104,7 @@ public class ClaudeCodeController {
 
     @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter stream() {
+        ClaudeCodeSessionStore store = store();
         SseEmitter emitter = new SseEmitter(0L);
         emitters.add(emitter);
 
@@ -131,5 +147,9 @@ public class ClaudeCodeController {
     // exposed only for testing
     List<SseEmitter> emittersForTesting() {
         return emitters;
+    }
+
+    private ClaudeCodeSessionStore store() {
+        return store.get();
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CopilotController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CopilotController.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -33,12 +36,22 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequestMapping("/bootui/api/copilot")
 public class CopilotController {
 
-    private final CopilotSessionStore store;
+    private final Supplier<CopilotSessionStore> store;
     private final BootUiProperties properties;
     private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
 
+    @Autowired
     public CopilotController(
-            @Qualifier("bootUiCopilotSessionStore") CopilotSessionStore store, BootUiProperties properties) {
+            @Qualifier("bootUiCopilotSessionStore") ObjectProvider<CopilotSessionStore> storeProvider,
+            BootUiProperties properties) {
+        this(storeProvider::getObject, properties);
+    }
+
+    CopilotController(CopilotSessionStore store, BootUiProperties properties) {
+        this(() -> store, properties);
+    }
+
+    private CopilotController(Supplier<CopilotSessionStore> store, BootUiProperties properties) {
         this.store = store;
         this.properties = properties;
     }
@@ -47,17 +60,17 @@ public class CopilotController {
     public CopilotSessionListDto sessions(
             @RequestParam(name = "since", required = false) Long since,
             @RequestParam(name = "until", required = false) Long until) {
-        return store.listSessions(since, until);
+        return store().listSessions(since, until);
     }
 
     @GetMapping("/dashboard")
     public CopilotDashboardDto dashboard() {
-        return store.dashboard();
+        return store().dashboard();
     }
 
     @GetMapping("/sessions/{id}")
     public ResponseEntity<CopilotSessionDetail> session(@PathVariable String id) {
-        CopilotSessionDetail detail = store.getSession(id);
+        CopilotSessionDetail detail = store().getSession(id);
         if (detail == null) {
             return ResponseEntity.notFound().build();
         }
@@ -70,6 +83,7 @@ public class CopilotController {
             @RequestParam(name = "category", required = false) String category,
             @RequestParam(name = "since", required = false) Long since,
             @RequestParam(name = "limit", required = false, defaultValue = "200") int limit) {
+        CopilotSessionStore store = store();
         if (store.getSession(id) == null) {
             return ResponseEntity.notFound().build();
         }
@@ -80,6 +94,7 @@ public class CopilotController {
 
     @GetMapping("/sessions/{id}/events/{eventId}/raw")
     public ResponseEntity<CopilotRawEventDto> raw(@PathVariable String id, @PathVariable String eventId) {
+        CopilotSessionStore store = store();
         if (!store.isRawRevealAllowed()) {
             return ResponseEntity.notFound().build();
         }
@@ -95,6 +110,7 @@ public class CopilotController {
 
     @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter stream() {
+        CopilotSessionStore store = store();
         SseEmitter emitter = new SseEmitter(0L);
         emitters.add(emitter);
 
@@ -137,5 +153,9 @@ public class CopilotController {
     // exposed only for testing
     List<SseEmitter> emittersForTesting() {
         return emitters;
+    }
+
+    private CopilotSessionStore store() {
+        return store.get();
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -6,7 +6,9 @@ import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
 import io.github.jdubois.bootui.autoconfigure.safety.LocalhostOnlyFilter;
 import io.github.jdubois.bootui.autoconfigure.safety.PanelAccessFilter;
 import io.github.jdubois.bootui.autoconfigure.web.*;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -128,6 +130,41 @@ class BootUiAutoConfigurationTests {
                     assertThat(properties.getDependencies().isOsvEnabled()).isFalse();
                     assertThat(properties.getDependencies().getMaxPackages()).isEqualTo(42);
                     assertThat(properties.getDependencies().getMaxAdvisories()).isEqualTo(24);
+                });
+    }
+
+    @Test
+    void copilotAndClaudeCodeSessionStoresAreLazy(@TempDir Path tempDir) {
+        runner.withPropertyValues(
+                        "bootui.enabled=ON",
+                        "bootui.copilot.enabled=ON",
+                        "bootui.copilot.session-state-dir=" + tempDir.resolve("copilot"),
+                        "bootui.claude-code.enabled=ON",
+                        "bootui.claude-code.session-state-dir=" + tempDir.resolve("claude"))
+                .run(context -> {
+                    var beanFactory = context.getBeanFactory();
+                    assertThat(beanFactory
+                                    .getBeanDefinition("bootUiCopilotSessionStore")
+                                    .isLazyInit())
+                            .isTrue();
+                    assertThat(beanFactory
+                                    .getBeanDefinition("bootUiClaudeCodeSessionStore")
+                                    .isLazyInit())
+                            .isTrue();
+                    assertThat(beanFactory.containsSingleton("bootUiCopilotSessionStore"))
+                            .isFalse();
+                    assertThat(beanFactory.containsSingleton("bootUiClaudeCodeSessionStore"))
+                            .isFalse();
+
+                    context.getBean(CopilotController.class).dashboard();
+                    assertThat(beanFactory.containsSingleton("bootUiCopilotSessionStore"))
+                            .isTrue();
+                    assertThat(beanFactory.containsSingleton("bootUiClaudeCodeSessionStore"))
+                            .isFalse();
+
+                    context.getBean(ClaudeCodeController.class).dashboard();
+                    assertThat(beanFactory.containsSingleton("bootUiClaudeCodeSessionStore"))
+                            .isTrue();
                 });
     }
 


### PR DESCRIPTION
## What does this PR do?

Makes the Copilot and Claude Code session stores lazy, then resolves them through controller `ObjectProvider`s so their initial session scan starts only when the corresponding API is first used.

## Why is this change needed?

Starting BootUI eagerly created both agent session stores during context refresh, and `AgentSessionStore.start()` performs a synchronous `refresh()` before launching its watcher thread. Deferring store creation removes that startup cost without introducing background-start race conditions or changing API behavior.

Closes: N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- `./mvnw -pl bootui-autoconfigure spotless:check`
- `./mvnw -pl bootui-autoconfigure test`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: no public behavior change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
