### PR TITLE
Add Maven Central sample app runner

### DIFF
--- a/bootui-sample-app/README.md
+++ b/bootui-sample-app/README.md
@@ -32,6 +32,21 @@ From the repository root:
 Spring Boot will start Docker Compose, wait for Postgres and Redis, and then
 bind the sample app to `http://localhost:8080`.
 
+## Run the published JAR from Maven Central
+
+Future releases package the sample app as an executable Spring Boot JAR. To
+download it with `curl` and run it with `java -jar`:
+
+```bash
+BOOTUI_VERSION=<version> ./scripts/run-sample-app-from-maven-central.sh
+```
+
+The script defaults to the latest Maven Central version, enables the `dev`
+profile unless you pass `--spring.profiles.active=...`, and uses the embedded
+Docker Compose file so the downloaded JAR can start its Postgres, Redis, and
+Ollama services. Versions published before the executable JAR change exit with
+a clear message because their sample app artifacts are thin, non-runnable JARs.
+
 ## Visit BootUI
 
 Open <http://localhost:8080/bootui> in a browser running on the same machine.

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -119,10 +119,28 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>${project.basedir}</directory>
+                <includes>
+                    <include>compose.yaml</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/BootUiSampleApplication.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/BootUiSampleApplication.java
@@ -1,8 +1,11 @@
 package io.github.jdubois.bootui.sample;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,7 +45,24 @@ public class BootUiSampleApplication {
             return Optional.empty();
         }
         Path moduleComposeFile = workingDirectory.resolve(Path.of("bootui-sample-app", "compose.yaml"));
-        return Files.isRegularFile(moduleComposeFile) ? Optional.of(moduleComposeFile) : Optional.empty();
+        if (Files.isRegularFile(moduleComposeFile)) {
+            return Optional.of(moduleComposeFile);
+        }
+        return embeddedComposeFile();
+    }
+
+    private static Optional<Path> embeddedComposeFile() {
+        try (InputStream inputStream = BootUiSampleApplication.class.getResourceAsStream("/compose.yaml")) {
+            if (inputStream == null) {
+                return Optional.empty();
+            }
+            Path composeFile = Files.createTempFile("bootui-sample-app-", "-compose.yaml");
+            Files.copy(inputStream, composeFile, StandardCopyOption.REPLACE_EXISTING);
+            composeFile.toFile().deleteOnExit();
+            return Optional.of(composeFile);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to prepare the embedded Docker Compose file.", ex);
+        }
     }
 
     @ConfigurationProperties(prefix = "sample")

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -27,7 +28,11 @@ class BootUiSampleApplicationTests {
     }
 
     @Test
-    void leavesDockerComposeDiscoveryAloneWhenNoSampleComposeFileExists(@TempDir Path workingDirectory) {
-        assertThat(BootUiSampleApplication.composeFileDefault(workingDirectory)).isEmpty();
+    void usesEmbeddedDockerComposeFileWhenNoSampleComposeFileExists(@TempDir Path workingDirectory) throws Exception {
+        Optional<Path> composeFile = BootUiSampleApplication.composeFileDefault(workingDirectory);
+
+        assertThat(composeFile).isPresent();
+        assertThat(composeFile.get()).exists();
+        assertThat(Files.readString(composeFile.get())).contains("postgres:", "redis:", "ollama:");
     }
 }

--- a/scripts/run-sample-app-from-maven-central.sh
+++ b/scripts/run-sample-app-from-maven-central.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_id="bootui-sample-app"
+group_path="com/julien-dubois/bootui"
+central_base_url="${MAVEN_CENTRAL_BASE_URL:-https://repo1.maven.org/maven2}"
+artifact_base_url="${central_base_url%/}/${group_path}/${artifact_id}"
+download_dir="${BOOTUI_DOWNLOAD_DIR:-${TMPDIR:-/tmp}/bootui-sample-app}"
+version="${BOOTUI_VERSION:-latest}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 127
+  fi
+}
+
+resolve_latest_version() {
+  local metadata
+  local resolved_version
+  metadata="$(curl -fsSL "${artifact_base_url}/maven-metadata.xml")"
+  resolved_version="$(printf '%s\n' "${metadata}" | sed -n 's:.*<release>\(.*\)</release>.*:\1:p' | tail -n 1)"
+  if [[ -z "${resolved_version}" ]]; then
+    resolved_version="$(printf '%s\n' "${metadata}" | sed -n 's:.*<latest>\(.*\)</latest>.*:\1:p' | tail -n 1)"
+  fi
+  printf '%s\n' "${resolved_version}"
+}
+
+has_active_profile_arg() {
+  local arg
+  for arg in "$@"; do
+    case "${arg}" in
+      --spring.profiles.active | --spring.profiles.active=*)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+require_command curl
+require_command java
+require_command jar
+
+if [[ "${version}" == "latest" ]]; then
+  version="$(resolve_latest_version)"
+  if [[ -z "${version}" ]]; then
+    echo "Unable to resolve the latest ${artifact_id} version from Maven Central." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "${download_dir}"
+download_dir="$(cd "${download_dir}" && pwd -P)"
+jar_file="${download_dir}/${artifact_id}-${version}.jar"
+jar_url="${artifact_base_url}/${version}/${artifact_id}-${version}.jar"
+
+echo "Downloading ${jar_url}"
+curl -fsSL --retry 3 --output "${jar_file}.tmp" "${jar_url}"
+mv "${jar_file}.tmp" "${jar_file}"
+
+manifest_dir="$(mktemp -d)"
+trap 'rm -rf "${manifest_dir}"' EXIT
+(cd "${manifest_dir}" && jar xf "${jar_file}" META-INF/MANIFEST.MF)
+
+if ! grep -q '^Main-Class: org.springframework.boot.loader.launch.JarLauncher' \
+  "${manifest_dir}/META-INF/MANIFEST.MF"; then
+  echo "The downloaded ${artifact_id} ${version} JAR is not executable with java -jar." >&2
+  echo "Use a BootUI version published after the sample app executable JAR change." >&2
+  exit 1
+fi
+if ! grep -q '^Start-Class: io.github.jdubois.bootui.sample.BootUiSampleApplication' \
+  "${manifest_dir}/META-INF/MANIFEST.MF"; then
+  echo "The downloaded ${artifact_id} ${version} JAR does not start the BootUI sample app." >&2
+  exit 1
+fi
+
+profile_args=()
+if ! has_active_profile_arg "$@"; then
+  profile_args=(--spring.profiles.active="${BOOTUI_PROFILE:-dev}")
+fi
+
+echo "Starting BootUI sample app ${version} at http://localhost:8080/bootui"
+cd "${download_dir}"
+exec java ${JAVA_OPTS:-} -jar "${jar_file}" "${profile_args[@]}" "$@"


### PR DESCRIPTION
## What does this PR do?

Adds a script that downloads `bootui-sample-app` from Maven Central with `curl` and launches it with `java -jar`, and updates future sample app builds to publish an executable Spring Boot JAR.

## Why is this change needed?

The current Maven Central sample app artifact can be downloaded, but it is a thin JAR without an executable manifest, so `java -jar` fails. This gives users a direct download-and-run path for future releases while making the script fail clearly for already-published non-executable artifacts.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks run:

- `./mvnw -B -ntp spotless:check`
- `./mvnw -B -ntp -pl bootui-sample-app test -Dtest=BootUiSampleApplicationTests`
- `./mvnw -B -ntp -pl bootui-sample-app package -DskipTests`
- `bash -n scripts/run-sample-app-from-maven-central.sh`
- Runner checked against a local Maven-style repository and against the current published `0.1.0` artifact failure path

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed