### PR TITLE
Limit agent panel session parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,12 @@ Common properties:
 | `bootui.copilot.enabled`               | `AUTO`                                  | Enable the Copilot panel. `AUTO` activates when `~/.copilot/session-state/` exists.      |
 | `bootui.copilot.session-state-dir`     | `~/.copilot/session-state`              | Directory scanned for Copilot CLI session directories and `events.jsonl` files.          |
 | `bootui.copilot.max-sessions`          | `100`                                   | Maximum recent sessions returned by the Copilot session explorer.                        |
+| `bootui.copilot.max-parsed-sessions`   | `100`                                   | Maximum recent Copilot session files parsed and retained in memory.                      |
 | `bootui.copilot.allow-raw-reveal`      | `true`                                  | When `false`, the opt-in raw-event reveal endpoint returns 404 even on loopback.         |
 | `bootui.claude-code.enabled`           | `AUTO`                                  | Enable the Claude Code panel. `AUTO` activates when `~/.claude/projects/` exists.        |
 | `bootui.claude-code.session-state-dir` | `~/.claude/projects`                    | Directory scanned for Claude Code project JSONL logs.                                    |
 | `bootui.claude-code.max-sessions`      | `100`                                   | Maximum recent sessions returned by the Claude Code session explorer.                    |
+| `bootui.claude-code.max-parsed-sessions` | `100`                                 | Maximum recent Claude Code JSONL files parsed and retained in memory.                    |
 | `bootui.claude-code.allow-raw-reveal`  | `false`                                 | Explicitly enable raw JSONL reveal; raw Claude Code logs can include prompts and output. |
 
 ## Runtime overrides

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -581,6 +581,11 @@ public class BootUiProperties {
         private int maxSessions = 100;
 
         /**
+         * Maximum number of recent session files parsed and retained in memory.
+         */
+        private int maxParsedSessions = 100;
+
+        /**
          * Debounce window applied to file-system events before refreshing parsed sessions
          * and notifying SSE subscribers.
          */
@@ -606,6 +611,10 @@ public class BootUiProperties {
 
         public String getWatcherThreadName() {
             return "bootui-copilot-watcher";
+        }
+
+        public String maxParsedSessionsPropertyName() {
+            return "bootui.copilot.max-parsed-sessions";
         }
 
         public boolean isProjectSessionDirectoryLayout() {
@@ -642,6 +651,14 @@ public class BootUiProperties {
 
         public void setMaxSessions(int maxSessions) {
             this.maxSessions = maxSessions;
+        }
+
+        public int getMaxParsedSessions() {
+            return maxParsedSessions;
+        }
+
+        public void setMaxParsedSessions(int maxParsedSessions) {
+            this.maxParsedSessions = maxParsedSessions;
         }
 
         public Duration getStreamDebounce() {
@@ -692,6 +709,11 @@ public class BootUiProperties {
         @Override
         public String getWatcherThreadName() {
             return "bootui-claude-code-watcher";
+        }
+
+        @Override
+        public String maxParsedSessionsPropertyName() {
+            return "bootui.claude-code.max-parsed-sessions";
         }
 
         @Override

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AgentSessionStore.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AgentSessionStore.java
@@ -30,11 +30,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -92,6 +94,9 @@ public abstract class AgentSessionStore {
     private volatile Thread watcherThread;
     private volatile boolean stopped;
     private volatile CopilotDashboardDto dashboardCache;
+    private volatile int availableSessionFileCount;
+    private volatile int selectedSessionFileCount;
+    private volatile int selectedSessionFileLimit;
 
     protected AgentSessionStore(BootUiProperties.Copilot properties) {
         this(properties, Clock.systemDefaultZone());
@@ -141,55 +146,70 @@ public abstract class AgentSessionStore {
         if (!isDirectoryAvailable()) {
             sessions.clear();
             dashboardCache = unavailableDashboard();
+            availableSessionFileCount = 0;
+            selectedSessionFileCount = 0;
+            selectedSessionFileLimit = 0;
             return 0;
         }
-        Map<String, Boolean> seen = new HashMap<>();
+        List<SessionFileCandidate> candidates = new ArrayList<>();
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(sessionStateDir)) {
             for (Path entry : stream) {
-                scanEntry(entry, seen);
+                collectEntry(entry, candidates);
             }
         } catch (IOException ex) {
             log.warn("BootUI {}: failed to list {}: {}", sourceName, sessionStateDir, ex.toString());
         }
-        // remove sessions whose files have disappeared
-        sessions.keySet().removeIf(id -> !seen.containsKey(id));
+        int maxParsedSessions = effectiveMaxParsedSessions();
+        List<SessionFileCandidate> selectedCandidates = candidates.stream()
+                .sorted(sessionFileCandidateComparator())
+                .limit(maxParsedSessions)
+                .toList();
+        Set<String> seen = new HashSet<>();
+        for (SessionFileCandidate candidate : selectedCandidates) {
+            scanCandidate(candidate, seen);
+        }
+        // remove sessions whose files disappeared or are outside the parse cap
+        sessions.keySet().removeIf(id -> !seen.contains(id));
+        availableSessionFileCount = candidates.size();
+        selectedSessionFileCount = selectedCandidates.size();
+        selectedSessionFileLimit = maxParsedSessions;
         dashboardCache = buildDashboard();
         return sessions.size();
     }
 
-    private void scanEntry(Path entry, Map<String, Boolean> seen) {
+    private void collectEntry(Path entry, List<SessionFileCandidate> candidates) {
         if (Files.isSymbolicLink(entry)) {
             return;
         }
         if (properties.isProjectSessionDirectoryLayout()) {
-            scanProjectLayoutEntry(entry, seen);
+            collectProjectLayoutEntry(entry, candidates);
             return;
         }
         if (Files.isDirectory(entry)) {
             Path eventsFile = entry.resolve(EVENTS_JSONL);
             if (Files.isRegularFile(eventsFile)) {
-                scanJsonlSession(entry.getFileName().toString(), eventsFile, seen);
+                addCandidate(entry.getFileName().toString(), eventsFile, SessionFileFormat.JSONL, candidates);
             }
             return;
         }
         String name = entry.getFileName().toString();
         if (Files.isRegularFile(entry) && name.toLowerCase(Locale.ROOT).endsWith(".json")) {
-            scanLegacyJsonSession(sessionIdFor(entry), entry, seen);
+            addCandidate(sessionIdFor(entry), entry, SessionFileFormat.LEGACY_JSON, candidates);
         }
     }
 
-    private void scanProjectLayoutEntry(Path entry, Map<String, Boolean> seen) {
+    private void collectProjectLayoutEntry(Path entry, List<SessionFileCandidate> candidates) {
         if (Files.isDirectory(entry)) {
-            scanProjectDirectory(entry, seen);
+            collectProjectDirectory(entry, candidates);
             return;
         }
         String name = entry.getFileName().toString().toLowerCase(Locale.ROOT);
         if (Files.isRegularFile(entry) && name.endsWith(".jsonl")) {
-            scanJsonlSession(jsonlSessionIdFor(entry), entry, seen);
+            addCandidate(jsonlSessionIdFor(entry), entry, SessionFileFormat.JSONL, candidates);
         }
     }
 
-    private void scanProjectDirectory(Path directory, Map<String, Boolean> seen) {
+    private void collectProjectDirectory(Path directory, List<SessionFileCandidate> candidates) {
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory)) {
             for (Path file : stream) {
                 if (Files.isSymbolicLink(file)) {
@@ -197,7 +217,7 @@ public abstract class AgentSessionStore {
                 }
                 String name = file.getFileName().toString().toLowerCase(Locale.ROOT);
                 if (Files.isRegularFile(file) && name.endsWith(".jsonl")) {
-                    scanJsonlSession(jsonlSessionIdFor(file), file, seen);
+                    addCandidate(jsonlSessionIdFor(file), file, SessionFileFormat.JSONL, candidates);
                 }
             }
         } catch (IOException ex) {
@@ -205,8 +225,7 @@ public abstract class AgentSessionStore {
         }
     }
 
-    private void scanLegacyJsonSession(String id, Path file, Map<String, Boolean> seen) {
-        seen.put(id, Boolean.TRUE);
+    private void addCandidate(String id, Path file, SessionFileFormat format, List<SessionFileCandidate> candidates) {
         try {
             BasicFileAttributes attrs = Files.readAttributes(file, BasicFileAttributes.class);
             if (attrs.size() > MAX_FILE_BYTES) {
@@ -218,6 +237,26 @@ public abstract class AgentSessionStore {
                         MAX_FILE_BYTES);
                 return;
             }
+            candidates.add(new SessionFileCandidate(id, file, attrs, format));
+        } catch (IOException ex) {
+            log.debug("BootUI {}: failed to inspect {}: {}", sourceName, file, ex.toString());
+        }
+    }
+
+    private void scanCandidate(SessionFileCandidate candidate, Set<String> seen) {
+        seen.add(candidate.id());
+        if (candidate.format() == SessionFileFormat.LEGACY_JSON) {
+            scanLegacyJsonSession(candidate);
+            return;
+        }
+        scanJsonlSession(candidate);
+    }
+
+    private void scanLegacyJsonSession(SessionFileCandidate candidate) {
+        String id = candidate.id();
+        Path file = candidate.file();
+        BasicFileAttributes attrs = candidate.attrs();
+        try {
             long mtime = attrs.lastModifiedTime().toMillis();
             ParsedSession existing = sessions.get(id);
             if (existing != null && existing.fileSize == attrs.size() && existing.fileMtime == mtime) {
@@ -226,24 +265,16 @@ public abstract class AgentSessionStore {
             JsonNode root = objectMapper.readTree(file.toFile());
             ParsedSession parsed = parse(id, file, root, attrs);
             sessions.put(id, parsed);
-        } catch (IOException ex) {
+        } catch (RuntimeException ex) {
             log.debug("BootUI {}: failed to parse {}: {}", sourceName, file, ex.toString());
         }
     }
 
-    private void scanJsonlSession(String id, Path file, Map<String, Boolean> seen) {
-        seen.put(id, Boolean.TRUE);
+    private void scanJsonlSession(SessionFileCandidate candidate) {
+        String id = candidate.id();
+        Path file = candidate.file();
+        BasicFileAttributes attrs = candidate.attrs();
         try {
-            BasicFileAttributes attrs = Files.readAttributes(file, BasicFileAttributes.class);
-            if (attrs.size() > MAX_FILE_BYTES) {
-                log.warn(
-                        "BootUI {}: skipping {} ({} bytes exceeds {} byte limit)",
-                        sourceName,
-                        file.getFileName(),
-                        attrs.size(),
-                        MAX_FILE_BYTES);
-                return;
-            }
             long mtime = attrs.lastModifiedTime().toMillis();
             ParsedSession existing = sessions.get(id);
             if (existing != null && existing.fileSize == attrs.size() && existing.fileMtime == mtime) {
@@ -394,6 +425,7 @@ public abstract class AgentSessionStore {
                 .toList();
         List<CopilotSessionSummary> limited = sorted.stream().limit(maxSessions).toList();
         List<String> warnings = new ArrayList<>();
+        addParsedSessionCapWarning(warnings);
         if (sorted.size() > limited.size()) {
             warnings.add("Showing the "
                     + limited.size()
@@ -421,6 +453,32 @@ public abstract class AgentSessionStore {
 
     private int effectiveMaxSessions() {
         return Math.min(Math.max(1, properties.getMaxSessions()), HARD_MAX_SESSION_EXPLORER_ITEMS);
+    }
+
+    private int effectiveMaxParsedSessions() {
+        return Math.min(Math.max(1, properties.getMaxParsedSessions()), HARD_MAX_SESSION_EXPLORER_ITEMS);
+    }
+
+    private static Comparator<SessionFileCandidate> sessionFileCandidateComparator() {
+        return Comparator.comparingLong(SessionFileCandidate::lastModifiedTimeMillis)
+                .reversed()
+                .thenComparing(SessionFileCandidate::id)
+                .thenComparing(candidate -> candidate.file().toString());
+    }
+
+    private void addParsedSessionCapWarning(List<String> warnings) {
+        if (availableSessionFileCount <= selectedSessionFileCount || selectedSessionFileLimit <= 0) {
+            return;
+        }
+        warnings.add("Loaded the "
+                + selectedSessionFileCount
+                + " most recently modified "
+                + properties.getPanelTitle()
+                + " session files out of "
+                + availableSessionFileCount
+                + "; increase "
+                + properties.maxParsedSessionsPropertyName()
+                + " to inspect older sessions.");
     }
 
     private static boolean matchesActivityWindow(ParsedSession session, Long sinceEpochMillis, Long untilEpochMillis) {
@@ -573,12 +631,14 @@ public abstract class AgentSessionStore {
                 .sorted(sessionSummaryComparator())
                 .limit(DASHBOARD_RECENT_SESSION_LIMIT)
                 .toList();
-        List<String> warnings = sessionsWithSchemaDrift > 0
-                ? List.of(sessionsWithSchemaDrift
-                        + " "
-                        + properties.getPanelTitle()
-                        + " sessions did not match the expected schema; some metrics may be incomplete.")
-                : List.of();
+        List<String> warnings = new ArrayList<>();
+        addParsedSessionCapWarning(warnings);
+        if (sessionsWithSchemaDrift > 0) {
+            warnings.add(sessionsWithSchemaDrift
+                    + " "
+                    + properties.getPanelTitle()
+                    + " sessions did not match the expected schema; some metrics may be incomplete.");
+        }
 
         return new CopilotDashboardDto(
                 true,
@@ -599,7 +659,7 @@ public abstract class AgentSessionStore {
                 activityBuckets,
                 dailyActivityBuckets,
                 recentSessions,
-                warnings);
+                List.copyOf(warnings));
     }
 
     private String displaySessionStateDir() {
@@ -1753,6 +1813,18 @@ public abstract class AgentSessionStore {
     private record JsonNodeRawEventReference(JsonNode node) implements RawEventReference {}
 
     private record JsonlLineRawEventReference(Path file, int lineNumber) implements RawEventReference {}
+
+    private enum SessionFileFormat {
+        LEGACY_JSON,
+        JSONL
+    }
+
+    private record SessionFileCandidate(String id, Path file, BasicFileAttributes attrs, SessionFileFormat format) {
+
+        long lastModifiedTimeMillis() {
+            return attrs.lastModifiedTime().toMillis();
+        }
+    }
 
     private record SessionAggregates(Map<String, Integer> toolCounts, Map<Long, BucketCounts> activityByHour) {}
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -93,6 +93,8 @@ class BootUiAutoConfigurationTests {
             assertThat(properties.getDevServices().isRestartEnabled()).isFalse();
             assertThat(properties.getDevServices().getLogTailBytes()).isEqualTo(64 * 1024);
             assertThat(properties.getCache().isClearEnabled()).isTrue();
+            assertThat(properties.getCopilot().getMaxParsedSessions()).isEqualTo(100);
+            assertThat(properties.getClaudeCode().getMaxParsedSessions()).isEqualTo(100);
         });
     }
 
@@ -113,7 +115,9 @@ class BootUiAutoConfigurationTests {
                         "bootui.cache.clear-enabled=false",
                         "bootui.dependencies.osv-enabled=false",
                         "bootui.dependencies.max-packages=42",
-                        "bootui.dependencies.max-advisories=24")
+                        "bootui.dependencies.max-advisories=24",
+                        "bootui.copilot.max-parsed-sessions=12",
+                        "bootui.claude-code.max-parsed-sessions=8")
                 .run(context -> {
                     BootUiProperties properties = context.getBean(BootUiProperties.class);
                     assertThat(properties.getPath()).isEqualTo("/admin");
@@ -130,6 +134,9 @@ class BootUiAutoConfigurationTests {
                     assertThat(properties.getDependencies().isOsvEnabled()).isFalse();
                     assertThat(properties.getDependencies().getMaxPackages()).isEqualTo(42);
                     assertThat(properties.getDependencies().getMaxAdvisories()).isEqualTo(24);
+                    assertThat(properties.getCopilot().getMaxParsedSessions()).isEqualTo(12);
+                    assertThat(properties.getClaudeCode().getMaxParsedSessions())
+                            .isEqualTo(8);
                 });
     }
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ClaudeCodeControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ClaudeCodeControllerTests.java
@@ -12,6 +12,7 @@ import io.github.jdubois.bootui.core.BootUiDtos.CopilotActivityEvent;
 import io.github.jdubois.bootui.core.BootUiDtos.CopilotSessionDetail;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -87,6 +88,33 @@ class ClaudeCodeControllerTests {
                 .doesNotContain("SECRET_COMMAND")
                 .doesNotContain("SECRET_FILE")
                 .doesNotContain("SECRET_OUTPUT");
+    }
+
+    @Test
+    void refreshParsesOnlyMostRecentlyModifiedProjectSessions(@TempDir Path tempDir) throws Exception {
+        Path old = tempDir.resolve("project-one").resolve("session-old.jsonl");
+        Path middle = tempDir.resolve("project-one").resolve("session-middle.jsonl");
+        Path latest = tempDir.resolve("project-two").resolve("session-new.jsonl");
+        writeClaudeSession(old);
+        writeClaudeSession(middle);
+        writeClaudeSession(latest);
+        Files.setLastModifiedTime(old, FileTime.fromMillis(1));
+        Files.setLastModifiedTime(middle, FileTime.fromMillis(2));
+        Files.setLastModifiedTime(latest, FileTime.fromMillis(3));
+        BootUiProperties props = propertiesFor(tempDir);
+        props.getClaudeCode().setMaxSessions(10);
+        props.getClaudeCode().setMaxParsedSessions(1);
+        ClaudeCodeSessionStore store = storeFor(props);
+
+        var list = store.listSessions();
+        assertThat(list.total()).isEqualTo(1);
+        assertThat(list.returned()).isEqualTo(1);
+        assertThat(list.sessions()).extracting(summary -> summary.id()).containsExactly("session-new");
+        assertThat(list.warnings())
+                .containsExactly(
+                        "Loaded the 1 most recently modified Claude Code session files out of 3; increase bootui.claude-code.max-parsed-sessions to inspect older sessions.");
+        assertThat(store.getSession("session-old")).isNull();
+        assertThat(store.getSession("session-middle")).isNull();
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/CopilotControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/CopilotControllerTests.java
@@ -12,6 +12,7 @@ import io.github.jdubois.bootui.core.BootUiDtos.CopilotSessionDetail;
 import io.github.jdubois.bootui.core.BootUiDtos.CopilotSessionListDto;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -166,6 +167,40 @@ class CopilotControllerTests {
                 .andExpect(jsonPath("$.sessions[0].id").value("new"))
                 .andExpect(jsonPath("$.sessions[1].id").value("middle"))
                 .andExpect(jsonPath("$.warnings[0]").value("Showing the 2 most recent Copilot sessions out of 3."));
+    }
+
+    @Test
+    void refreshParsesOnlyMostRecentlyModifiedSessions(@TempDir Path tempDir) throws Exception {
+        Path old = tempDir.resolve("old.json");
+        Path middle = tempDir.resolve("middle.json");
+        Path latest = tempDir.resolve("new.json");
+        Files.writeString(old, "{\"updated_at\":1700000000,\"events\":[{\"type\":\"t\"}]}");
+        Files.writeString(middle, "{\"updated_at\":1700000001,\"events\":[{\"type\":\"t\"}]}");
+        Files.writeString(latest, "{\"updated_at\":1700000002,\"events\":[{\"type\":\"t\"}]}");
+        Files.setLastModifiedTime(old, FileTime.fromMillis(1));
+        Files.setLastModifiedTime(middle, FileTime.fromMillis(2));
+        Files.setLastModifiedTime(latest, FileTime.fromMillis(3));
+        BootUiProperties props = propertiesFor(tempDir);
+        props.getCopilot().setMaxSessions(10);
+        props.getCopilot().setMaxParsedSessions(2);
+        CopilotSessionStore store = storeFor(props);
+
+        CopilotSessionListDto first = store.listSessions();
+        assertThat(first.total()).isEqualTo(2);
+        assertThat(first.returned()).isEqualTo(2);
+        assertThat(first.sessions()).extracting(summary -> summary.id()).containsExactly("new", "middle");
+        assertThat(first.warnings())
+                .containsExactly(
+                        "Loaded the 2 most recently modified Copilot session files out of 3; increase bootui.copilot.max-parsed-sessions to inspect older sessions.");
+        assertThat(store.getSession("old")).isNull();
+
+        Files.setLastModifiedTime(old, FileTime.fromMillis(4));
+        store.refresh();
+
+        CopilotSessionListDto refreshed = store.listSessions();
+        assertThat(refreshed.sessions()).extracting(summary -> summary.id()).containsExactly("new", "old");
+        assertThat(store.getSession("old")).isNotNull();
+        assertThat(store.getSession("middle")).isNull();
     }
 
     @Test

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -222,14 +222,15 @@ aggregates recent activity into a clean dashboard: active sessions, total saniti
 7-day activity, event category mix, top tools, model usage, and recent sessions. The session explorer remains available
 for drilling into tool calls, edits, reads, searches, shell commands, web/docs lookups, MCP tool calls, hook callbacks,
 skills, sub-agents, and ASK/intent/plan calls. To keep large local histories responsive, the session explorer returns
-the most recent `bootui.copilot.max-sessions` sessions by default, and the activity charts can filter the explorer to
-sessions active during a selected hour or day. Failure lists use retained failure events and include sanitized tool/type
-context. Each event row shows only an allowlisted summary - raw prompts, tool arguments, command output, and diffs are
-deliberately excluded. The per-event "Reveal raw" action is an explicit, local-only escape hatch that returns the source
-JSON; it can be disabled with `bootui.copilot.allow-raw-reveal=false` and is also blocked when
-`bootui.expose-values=METADATA_ONLY`. The sidebar dims the panel when no session-state directory is found. Data is
-read-only - BootUI never modifies anything under `~/.copilot/`. The panel watches the directory through a Java NIO
-`WatchService` thread and pushes live updates via Server-Sent Events. Inspired by
+the most recent `bootui.copilot.max-sessions` sessions by default, while `bootui.copilot.max-parsed-sessions` caps how
+many recent session files are parsed and retained in JVM heap. The activity charts can filter the explorer to sessions
+active during a selected hour or day. Failure lists use retained failure events and include sanitized tool/type context.
+Each event row shows only an allowlisted summary - raw prompts, tool arguments, command output, and diffs are deliberately
+excluded. The per-event "Reveal raw" action is an explicit, local-only escape hatch that returns the source JSON; it can
+be disabled with `bootui.copilot.allow-raw-reveal=false` and is also blocked when `bootui.expose-values=METADATA_ONLY`.
+The sidebar dims the panel when no session-state directory is found. Data is read-only - BootUI never modifies anything
+under `~/.copilot/`. The panel watches the directory through a Java NIO `WatchService` thread and pushes live updates via
+Server-Sent Events. Inspired by
 [copilot-mission-control](https://github.com/DanWahlin/copilot-mission-control), which pioneered this dashboarding of
 Copilot CLI session state.
 
@@ -242,11 +243,11 @@ The Claude Code panel mirrors the Copilot dashboard for local
 `~/.claude/projects/` (configurable via `bootui.claude-code.session-state-dir`) and surfaces sanitized activity trends,
 tool usage, model usage, failures, recent sessions, and per-session event drill-downs. BootUI treats Claude Code logs as
 especially sensitive: prompts, assistant text, tool inputs, file contents, command output, and tool-result content are
-excluded from normal responses. The raw JSONL reveal endpoint is disabled by default with
-`bootui.claude-code.allow-raw-reveal=false`; enabling it is an explicit local-only escape hatch and is still blocked when
-`bootui.expose-values=METADATA_ONLY`. The sidebar dims the panel when no Claude Code projects directory is found. Data is
-read-only - BootUI never modifies anything under `~/.claude/`. Because Claude Code writes sessions inside per-project
-subdirectories, BootUI refreshes this panel through bounded polling rather than relying on root-directory file-system
-events.
+excluded from normal responses. `bootui.claude-code.max-parsed-sessions` caps how many recent JSONL files are parsed and
+retained in JVM heap. The raw JSONL reveal endpoint is disabled by default with `bootui.claude-code.allow-raw-reveal=false`;
+enabling it is an explicit local-only escape hatch and is still blocked when `bootui.expose-values=METADATA_ONLY`. The
+sidebar dims the panel when no Claude Code projects directory is found. Data is read-only - BootUI never modifies anything
+under `~/.claude/`. Because Claude Code writes sessions inside per-project subdirectories, BootUI refreshes this panel
+through bounded polling rather than relying on root-directory file-system events.
 
 ![BootUI Claude Code panel](images/bootui-claude-code.png)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -307,15 +307,16 @@ Added for the final `0.1.0` release after `0.1.0-alpha.5`:
 - **Copilot panel**. Reads the session directories and `events.jsonl` files that GitHub Copilot CLI writes under
   `~/.copilot/session-state/` and presents a sanitized activity dashboard: session count, total events, failures,
   24-hour and 7-day activity charts, event category mix, top tools, and model usage. The session explorer lets you
-  drill into individual sessions with a turn-by-turn story, recent events, and failure list. Raw event JSON is
-  opt-in and local-only. Live updates are pushed via SSE. Inspired by
+  drill into individual sessions with a turn-by-turn story, recent events, and failure list, while a configurable
+  parsed-session cap bounds heap usage for large local histories. Raw event JSON is opt-in and local-only. Live updates
+  are pushed via SSE. Inspired by
   [copilot-mission-control](https://github.com/DanWahlin/copilot-mission-control).
 - **Claude Code panel**. Reads Claude Code JSONL project logs under `~/.claude/projects/` and presents the same
   sanitized session dashboard shape for local Claude Code usage. Normal responses only expose tool names, categories,
   timestamps, model names, coarse status, and failure state; prompts, assistant text, tool inputs, command output, file
-  contents, and tool-result content stay out of the browser payload. Raw JSONL reveal is disabled by default because
-  Claude Code logs can inline sensitive local content, and the panel refreshes through bounded polling to handle
-  per-project subdirectories.
+  contents, and tool-result content stay out of the browser payload. A configurable parsed-session cap bounds heap usage
+  for large project-log directories. Raw JSONL reveal is disabled by default because Claude Code logs can inline
+  sensitive local content, and the panel refreshes through bounded polling to handle per-project subdirectories.
 
 Still excluded:
 

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -168,8 +168,10 @@ bootui.dev-services.restart-enabled=true
 | `bootui.copilot.enabled` | `AUTO` | Enable the Copilot panel. `AUTO` activates when the session-state directory exists. |
 | `bootui.copilot.session-state-dir` | `~/.copilot/session-state` | Directory scanned for Copilot CLI sessions. |
 | `bootui.copilot.max-sessions` | `100` | Maximum recent Copilot sessions returned by the explorer. |
+| `bootui.copilot.max-parsed-sessions` | `100` | Maximum recent Copilot session files parsed and retained in memory. |
 | `bootui.copilot.allow-raw-reveal` | `true` | Allow explicit raw event reveal when value exposure is not `METADATA_ONLY`. |
 | `bootui.claude-code.enabled` | `AUTO` | Enable the Claude Code panel. `AUTO` activates when the project log directory exists. |
 | `bootui.claude-code.session-state-dir` | `~/.claude/projects` | Directory scanned for Claude Code project JSONL logs. |
 | `bootui.claude-code.max-sessions` | `100` | Maximum recent Claude Code sessions returned by the explorer. |
+| `bootui.claude-code.max-parsed-sessions` | `100` | Maximum recent Claude Code JSONL files parsed and retained in memory. |
 | `bootui.claude-code.allow-raw-reveal` | `false` | Allow explicit raw Claude Code JSONL reveal; disabled by default because logs can include prompts and outputs. |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -889,12 +889,14 @@ Initial properties:
 | `bootui.copilot.session-state-dir`           | `~/.copilot/session-state`              | Directory scanned for Copilot CLI session directories and `events.jsonl` files.                   |
 | `bootui.copilot.max-events-per-session`      | `2000`                                  | Maximum Copilot events retained per parsed session.                                               |
 | `bootui.copilot.max-sessions`                | `100`                                   | Maximum recent sessions returned by the Copilot session explorer.                                 |
+| `bootui.copilot.max-parsed-sessions`         | `100`                                   | Maximum recent Copilot session files parsed and retained in memory.                               |
 | `bootui.copilot.stream-debounce`             | `400ms`                                 | Debounce window before refreshing parsed Copilot sessions and notifying stream subscribers.       |
 | `bootui.copilot.allow-raw-reveal`            | `true`                                  | Allows opt-in raw Copilot event JSON reveal on loopback.                                          |
 | `bootui.claude-code.enabled`                 | `AUTO`                                  | Enable the Claude Code panel when local Claude Code project logs exist.                           |
 | `bootui.claude-code.session-state-dir`       | `~/.claude/projects`                    | Directory scanned for Claude Code project JSONL logs.                                             |
 | `bootui.claude-code.max-events-per-session`  | `2000`                                  | Maximum Claude Code events retained per parsed session.                                           |
 | `bootui.claude-code.max-sessions`            | `100`                                   | Maximum recent sessions returned by the Claude Code session explorer.                             |
+| `bootui.claude-code.max-parsed-sessions`     | `100`                                   | Maximum recent Claude Code JSONL files parsed and retained in memory.                             |
 | `bootui.claude-code.stream-debounce`         | `400ms`                                 | Debounce window before refreshing parsed Claude Code sessions and notifying stream subscribers.   |
 | `bootui.claude-code.allow-raw-reveal`        | `false`                                 | Allows opt-in raw Claude Code JSONL reveal; disabled by default because logs can include content. |
 


### PR DESCRIPTION
## What does this PR do?

Adds configurable parse caps for the Copilot and Claude Code panels so BootUI only parses and retains the most recently modified local session files in memory.

## Why is this change needed?

Large local Copilot or Claude Code histories could make BootUI parse every eligible session file when the panels initialize, creating unnecessary JVM heap pressure. The existing `max-sessions` setting only limited API output, so this adds `bootui.copilot.max-parsed-sessions` and `bootui.claude-code.max-parsed-sessions` to bound the heavier parsing/cache work.

Older files outside the parse cap remain on disk but are intentionally unavailable through the panel until the cap is increased or the files become recent enough; list and dashboard responses now warn when that happens.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Focused checks run:

- `./mvnw -B -ntp -pl bootui-autoconfigure test -Dtest=CopilotControllerTests,ClaudeCodeControllerTests,BootUiAutoConfigurationTests`
- `./mvnw -B -ntp -pl bootui-autoconfigure spotless:check`
- `./mvnw -B -ntp -pl bootui-autoconfigure test`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed