### PR TITLE
Permit BootUI when Spring Security is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ BootUI is intended for local development only. By default it:
 
 - activates in `AUTO` mode only for `dev` / `local` profiles or DevTools
 - rejects non-loopback requests
+- permits `/bootui/**` through Spring Security when Spring Security is present, with a startup warning, so the local
+  console remains directly reachable while the loopback-only filter still applies
 - masks secret-like configuration values
 - exposes the local Actuator endpoints used by BootUI panels when BootUI is active
 - disables itself for `prod` / `production` profiles
@@ -140,6 +142,7 @@ app restarts; BootUI returns that warning with every override mutation.
 | `/bootui` returns 404        | Use the `dev` or `local` profile, add DevTools, or set `bootui.enabled=ON`.                                                     |
 | BootUI is disabled in `prod` | This is intentional; only `bootui.enabled=ON` can force activation with a disabled profile.                                     |
 | Browser is rejected          | BootUI accepts loopback callers by default. Use `bootui.allow-non-localhost=true` only for a trusted local network.             |
+| Spring Security blocks UI    | BootUI auto-registers a `/bootui/**` permit-all chain when Spring Security is active; check for a custom higher-priority chain. |
 | A panel is empty             | Enable the relevant Actuator endpoint or optional Spring module; BootUI degrades to stable empty DTOs when data is unavailable. |
 | Startup Timeline is empty    | Configure `BufferingApplicationStartup` in the host app.                                                                        |
 | Secrets are hidden           | Default exposure is `MASKED`; use `METADATA_ONLY` to hide all values or `FULL` only in trusted local sessions.                  |

--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>spring-security-web</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>io.opentelemetry.proto</groupId>

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiSpringSecurityAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiSpringSecurityAutoConfiguration.java
@@ -1,0 +1,98 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Opens BootUI's own route inside Spring Security while keeping the localhost-only
+ * servlet filter as the outer safety boundary.
+ */
+@AutoConfiguration(
+        afterName = "org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration")
+@Conditional(BootUiActivationCondition.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+@ConditionalOnClass(
+        name = {
+            "org.springframework.security.config.annotation.web.builders.HttpSecurity",
+            "org.springframework.security.web.SecurityFilterChain"
+        })
+@ConditionalOnBean(HttpSecurity.class)
+@EnableConfigurationProperties(BootUiProperties.class)
+public class BootUiSpringSecurityAutoConfiguration {
+
+    private static final Logger log = LoggerFactory.getLogger(BootUiSpringSecurityAutoConfiguration.class);
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    @ConditionalOnMissingBean(name = "bootUiSecurityFilterChain")
+    public SecurityFilterChain bootUiSecurityFilterChain(HttpSecurity http, BootUiProperties properties)
+            throws Exception {
+        String uiPattern = securityPattern(properties.getPath());
+        String apiPattern = securityPattern(properties.getApiPath());
+        String otlpPattern = childSecurityPattern(properties.getApiPath(), "otlp");
+        log.warn(
+                "BootUI detected Spring Security and is permitting unauthenticated access to {} and {}; "
+                        + "BootUI's localhost-only filter still rejects non-loopback callers unless "
+                        + "bootui.allow-non-localhost=true is set.",
+                uiPattern,
+                apiPattern);
+        return http.securityMatcher(uiPattern, apiPattern)
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+                .csrf(csrf -> csrf.spa().ignoringRequestMatchers(otlpPattern))
+                .addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class)
+                .build();
+    }
+
+    private static String securityPattern(String basePath) {
+        String normalized = withoutTrailingSlash(basePath);
+        return normalized + "/**";
+    }
+
+    private static String childSecurityPattern(String basePath, String childPath) {
+        return withoutTrailingSlash(basePath) + "/" + childPath + "/**";
+    }
+
+    private static String withoutTrailingSlash(String path) {
+        if (path == null || path.isBlank()) {
+            throw new IllegalArgumentException("BootUI path must not be blank");
+        }
+        if (path.length() > 1 && path.endsWith("/")) {
+            return path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    private static final class CsrfCookieFilter extends OncePerRequestFilter {
+
+        @Override
+        protected void doFilterInternal(
+                HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+                throws ServletException, IOException {
+            CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+            if (csrfToken != null) {
+                csrfToken.getToken();
+            }
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/bootui-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/bootui-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 io.github.jdubois.bootui.autoconfigure.BootUiAutoConfiguration
+io.github.jdubois.bootui.autoconfigure.BootUiSpringSecurityAutoConfiguration

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiSpringSecurityAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiSpringSecurityAutoConfigurationTests.java
@@ -1,0 +1,88 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.config.Customizer.withDefaults;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
+
+@SpringBootTest(
+        classes = BootUiSpringSecurityAutoConfigurationTests.TestApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = "bootui.enabled=ON")
+@ExtendWith(OutputCaptureExtension.class)
+class BootUiSpringSecurityAutoConfigurationTests {
+
+    @LocalServerPort
+    private int port;
+
+    private RestClient client;
+
+    @Test
+    void permitsBootUiRouteWhenApplicationSecurityRequiresAuthentication() {
+        ResponseEntity<String> bootUi =
+                client().get().uri("/bootui/api/overview").retrieve().toEntity(String.class);
+        assertThat(bootUi.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        ResponseEntity<String> protectedRoute =
+                client().get().uri("/protected").retrieve().toEntity(String.class);
+        assertThat(protectedRoute.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void logsWarningWhenOpeningBootUiRoute(CapturedOutput output) {
+        assertThat(output)
+                .contains("BootUI detected Spring Security and is permitting unauthenticated access to /bootui/**");
+    }
+
+    private RestClient client() {
+        if (client == null) {
+            client = RestClient.builder()
+                    .baseUrl("http://localhost:" + port)
+                    .defaultStatusHandler(HttpStatusCode::isError, (req, res) -> {})
+                    .build();
+        }
+        return client;
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @EnableWebSecurity
+    @Import(TestApplication.ProtectedController.class)
+    static class TestApplication {
+
+        @Bean
+        SecurityFilterChain applicationSecurity(HttpSecurity http) throws Exception {
+            return http.authorizeHttpRequests(
+                            authorize -> authorize.anyRequest().authenticated())
+                    .httpBasic(withDefaults())
+                    .build();
+        }
+
+        @RestController
+        static class ProtectedController {
+
+            @GetMapping("/protected")
+            String protectedEndpoint() {
+                return "protected";
+            }
+        }
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/SecurityConfiguration.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/SecurityConfiguration.java
@@ -2,11 +2,6 @@ package io.github.jdubois.bootui.sample;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -17,29 +12,12 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
-import org.springframework.security.web.csrf.CsrfFilter;
-import org.springframework.security.web.csrf.CsrfToken;
-import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
-import org.springframework.web.filter.OncePerRequestFilter;
 
 @Configuration(proxyBeanMethods = false)
 class SecurityConfiguration {
 
     @Bean
     @Order(1)
-    SecurityFilterChain bootUiSecurity(HttpSecurity http) throws Exception {
-        return http.securityMatcher("/bootui/**")
-                .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
-                .csrf(csrf -> csrf.csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
-                        .csrfTokenRequestHandler(csrfTokenRequestHandler())
-                        .ignoringRequestMatchers("/bootui/api/otlp/**"))
-                .addFilterAfter(new CsrfCookieFilter(), CsrfFilter.class)
-                .build();
-    }
-
-    @Bean
-    @Order(2)
     SecurityFilterChain adminSecurity(HttpSecurity http) throws Exception {
         return http.securityMatcher("/admin/**", "/api/secure")
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().hasRole("ADMIN"))
@@ -48,7 +26,7 @@ class SecurityConfiguration {
     }
 
     @Bean
-    @Order(3)
+    @Order(2)
     SecurityFilterChain applicationSecurity(HttpSecurity http) throws Exception {
         return http.authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
                 .csrf(csrf -> csrf.ignoringRequestMatchers("/api/chat"))
@@ -71,25 +49,5 @@ class SecurityConfiguration {
     @Bean
     PasswordEncoder passwordEncoder() {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-    }
-
-    private static CsrfTokenRequestAttributeHandler csrfTokenRequestHandler() {
-        CsrfTokenRequestAttributeHandler requestHandler = new CsrfTokenRequestAttributeHandler();
-        requestHandler.setCsrfRequestAttributeName(null);
-        return requestHandler;
-    }
-
-    private static final class CsrfCookieFilter extends OncePerRequestFilter {
-
-        @Override
-        protected void doFilterInternal(
-                HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-                throws ServletException, IOException {
-            CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
-            if (csrfToken != null) {
-                csrfToken.getToken();
-            }
-            filterChain.doFilter(request, response);
-        }
     }
 }

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -910,6 +910,9 @@ Rules:
 
 - Bind to local development only.
 - Reject non-loopback requests by default.
+- If Spring Security is present while BootUI is active, contribute a highest-precedence `/bootui/**` permit-all security
+  chain and log a warning so the developer console stays directly reachable. This must not weaken the localhost-only
+  servlet filter unless `bootui.allow-non-localhost=true` is explicitly set.
 - Disable in production profile by default.
 - Mask secret-like values by default.
 - Never display `.env` contents.


### PR DESCRIPTION
## What does this PR do?

Adds BootUI Spring Security auto-configuration that permits the BootUI UI and API routes when BootUI is active and Spring Security is present, while keeping the localhost-only servlet filter as the exposure boundary.

## Why is this change needed?

Host application security rules can otherwise protect BootUI and make the starter inaccessible immediately after installation. BootUI is a local developer console, so it should work out of the box when activated and clearly warn that Spring Security access is being opened for the BootUI route.

Closes: N/A

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end via the Playwright e2e suite
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed