### PR TITLE
Automate BootUI trace capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ BootUI exposes these panels in the same grouped order as the application menu. S
 | Services        | [Cache](docs/FEATURES.md#cache)                       | Inspect Spring Cache managers, caches, metrics, annotations, and confirmed clear actions.                     |
 | Services        | [Security](docs/FEATURES.md#security)                 | Inspect Spring Security filter chains and best-effort endpoint rule explanations.                             |
 | Services        | [AI Usage](docs/FEATURES.md#ai-usage)                 | Summarize Spring AI chat conversations, token usage, latency, and model details from OpenTelemetry spans.     |
-| Diagnostics     | [Traces](docs/FEATURES.md#traces)                     | Inspect distributed tracing spans collected by the embedded OTLP receiver with a per-trace waterfall view.    |
+| Diagnostics     | [Traces](docs/FEATURES.md#traces)                     | Inspect local spans captured automatically by the starter, plus OTLP spans from cooperating services.         |
 | Diagnostics     | [Log Tail](docs/FEATURES.md#log-tail)                 | Read recent application logs and stream new local log events from the running process.                        |
 | Diagnostics     | [HTTP Probe](docs/FEATURES.md#http-probe)             | Send local-only HTTP requests to the app and inspect response status, headers, and body.                      |
 | Diagnostics     | [Vulnerabilities](docs/FEATURES.md#vulnerabilities)   | Review dependency inventory and local OSV vulnerability scan results.                                         |
@@ -96,6 +96,7 @@ BootUI is intended for local development only. By default it:
 - rejects non-loopback requests
 - masks secret-like configuration values
 - exposes the local Actuator endpoints used by BootUI panels when BootUI is active
+- captures local application spans for the Traces panel when telemetry and the panel are enabled
 - disables itself for `prod` / `production` profiles
 - stores runtime configuration overrides in `.bootui/application-bootui.properties`, not in your source config files
 
@@ -117,6 +118,7 @@ Common properties:
 | `bootui.cache.clear-enabled`           | `true`                                  | Enables Spring Cache clear actions after explicit browser confirmation.                  |
 | `bootui.dev-services.restart-enabled`  | `false`                                 | Enables restart controls for bean-backed Testcontainers services. Disabled by default.   |
 | `bootui.dev-services.log-tail-bytes`   | `65536`                                 | Maximum bytes returned by one Dev Services log request.                                  |
+| `bootui.telemetry.enabled`             | `true`                                  | Enables local in-memory trace capture and the OTLP receiver used by Traces and AI Usage. |
 | `bootui.copilot.enabled`               | `AUTO`                                  | Enable the Copilot panel. `AUTO` activates when `~/.copilot/session-state/` exists.      |
 | `bootui.copilot.session-state-dir`     | `~/.copilot/session-state`              | Directory scanned for Copilot CLI session directories and `events.jsonl` files.          |
 | `bootui.copilot.max-sessions`          | `100`                                   | Maximum recent sessions returned by the Copilot session explorer.                        |

--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>opentelemetry-proto</artifactId>
             <version>${opentelemetry-proto.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -10,6 +10,7 @@ import io.github.jdubois.bootui.autoconfigure.web.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -31,6 +32,9 @@ import org.springframework.core.env.Environment;
  * is a servlet web application, and when Spring MVC is on the classpath.</p>
  */
 @AutoConfiguration
+@AutoConfigureBefore(
+        name =
+                "org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.OpenTelemetryTracingAutoConfiguration")
 @Conditional(BootUiActivationCondition.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnClass(name = "org.springframework.web.servlet.DispatcherServlet")
@@ -62,7 +66,8 @@ import org.springframework.core.env.Environment;
     OtlpReceiverController.class,
     CopilotController.class,
     ClaudeCodeController.class,
-    BootUiIndexController.class
+    BootUiIndexController.class,
+    BootUiOpenTelemetryConfiguration.class
 })
 public class BootUiAutoConfiguration {
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiOpenTelemetryConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiOpenTelemetryConfiguration.java
@@ -1,0 +1,25 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import io.github.jdubois.bootui.autoconfigure.otlp.BootUiSpanExporter;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(name = "io.opentelemetry.sdk.trace.export.SpanExporter")
+class BootUiOpenTelemetryConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "bootui.telemetry", name = "enabled", havingValue = "true", matchIfMissing = true)
+    @ConditionalOnProperty(
+            prefix = "bootui.panels.traces",
+            name = "enabled",
+            havingValue = "true",
+            matchIfMissing = true)
+    SpanExporter bootUiSpanExporter(TelemetryStore store, BootUiProperties properties) {
+        return new BootUiSpanExporter(store, properties);
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -429,7 +429,8 @@ public class BootUiProperties {
     public static class Telemetry {
 
         /**
-         * Accept OTLP/HTTP trace payloads at the BootUI OTLP endpoint.
+         * Capture local trace spans and accept OTLP/HTTP trace payloads at the
+         * BootUI OTLP endpoint.
          */
         private boolean enabled = true;
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.config;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiActivationCondition;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
@@ -22,7 +23,11 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
     static final String REQUIRED_ENDPOINTS =
             "health,info,beans,conditions,configprops,env,loggers,mappings," + "metrics,startup,scheduledtasks";
 
-    private static final Map<String, Object> DEFAULTS = Map.of(
+    static final String TRACING_SAMPLING_PROBABILITY_PROPERTY = "management.tracing.sampling.probability";
+
+    static final String TRACING_SAMPLING_PROBABILITY = "1.0";
+
+    private static final Map<String, Object> ACTUATOR_DEFAULTS = Map.of(
             "management.endpoints.web.exposure.include",
             REQUIRED_ENDPOINTS,
             "management.endpoint.health.show-details",
@@ -44,6 +49,18 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
         if (sources.contains(PROPERTY_SOURCE_NAME)) {
             sources.remove(PROPERTY_SOURCE_NAME);
         }
-        sources.addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, DEFAULTS));
+        Map<String, Object> defaults = new LinkedHashMap<>(ACTUATOR_DEFAULTS);
+        if (telemetryEnabled(environment) && tracesPanelEnabled(environment)) {
+            defaults.put(TRACING_SAMPLING_PROBABILITY_PROPERTY, TRACING_SAMPLING_PROBABILITY);
+        }
+        sources.addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, defaults));
+    }
+
+    private boolean telemetryEnabled(ConfigurableEnvironment environment) {
+        return environment.getProperty("bootui.telemetry.enabled", Boolean.class, true);
+    }
+
+    private boolean tracesPanelEnabled(ConfigurableEnvironment environment) {
+        return environment.getProperty("bootui.panels.traces.enabled", Boolean.class, true);
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/BootUiSpanExporter.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/BootUiSpanExporter.java
@@ -1,0 +1,145 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.EventData;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class BootUiSpanExporter implements SpanExporter {
+
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+
+    private final TelemetryStore store;
+
+    private final BootUiProperties properties;
+
+    public BootUiSpanExporter(TelemetryStore store, BootUiProperties properties) {
+        this.store = store;
+        this.properties = properties;
+    }
+
+    @Override
+    public CompletableResultCode export(Collection<SpanData> spans) {
+        BootUiProperties.Telemetry telemetry = properties.getTelemetry();
+        if (!telemetry.isEnabled() || spans == null || spans.isEmpty()) {
+            return CompletableResultCode.ofSuccess();
+        }
+        String apiPath = properties.getApiPath();
+        for (SpanData span : spans) {
+            NormalizedSpan normalized = toNormalized(span);
+            if (telemetry.isExcludeSelfSpans() && TelemetrySpanFilter.isSelfSpan(normalized, apiPath)) {
+                continue;
+            }
+            store.add(normalized);
+        }
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    @Override
+    public CompletableResultCode shutdown() {
+        return CompletableResultCode.ofSuccess();
+    }
+
+    private NormalizedSpan toNormalized(SpanData span) {
+        long startNs = span.getStartEpochNanos();
+        List<NormalizedEvent> events = new ArrayList<>(span.getEvents().size());
+        for (EventData event : span.getEvents()) {
+            events.add(new NormalizedEvent(
+                    truncate(event.getName()),
+                    Math.max(0L, event.getEpochNanos() - startNs),
+                    toAttributeMap(event.getAttributes())));
+        }
+        SpanContext parent = span.getParentSpanContext();
+        StatusData status = span.getStatus();
+        return new NormalizedSpan(
+                span.getTraceId(),
+                span.getSpanId(),
+                parent.isValid() ? parent.getSpanId() : null,
+                truncate(span.getName()),
+                span.getKind().name(),
+                serviceName(span),
+                truncate(span.getInstrumentationScopeInfo().getName()),
+                startNs,
+                span.getEndEpochNanos(),
+                status.getStatusCode().name(),
+                truncate(emptyToNull(status.getDescription())),
+                toAttributeMap(span.getAttributes()),
+                events);
+    }
+
+    private Map<String, AttributeValue> toAttributeMap(Attributes attributes) {
+        Map<String, AttributeValue> map = new LinkedHashMap<>(attributes.size());
+        attributes.forEach((key, value) -> {
+            AttributeValue attributeValue = toAttributeValue(key, value);
+            if (attributeValue != null) {
+                map.put(key.getKey(), attributeValue);
+            }
+        });
+        return map;
+    }
+
+    private AttributeValue toAttributeValue(AttributeKey<?> key, Object value) {
+        if (value == null) {
+            return null;
+        }
+        return switch (key.getType()) {
+            case STRING -> AttributeValue.ofString(truncate((String) value));
+            case BOOLEAN -> AttributeValue.ofBoolean((Boolean) value);
+            case LONG, DOUBLE -> AttributeValue.ofNumber((Number) value);
+            case STRING_ARRAY, BOOLEAN_ARRAY, LONG_ARRAY, DOUBLE_ARRAY -> AttributeValue.ofList(toAttributeList(value));
+        };
+    }
+
+    private List<Object> toAttributeList(Object value) {
+        if (!(value instanceof List<?> values)) {
+            return List.of();
+        }
+        List<Object> normalized = new ArrayList<>(values.size());
+        for (Object item : values) {
+            normalized.add(item instanceof String s ? truncate(s) : item);
+        }
+        return normalized;
+    }
+
+    private String serviceName(SpanData span) {
+        String serviceName = span.getResource().getAttribute(SERVICE_NAME);
+        if (serviceName == null || serviceName.isBlank()) {
+            return "unknown_service";
+        }
+        return truncate(serviceName);
+    }
+
+    private String truncate(String value) {
+        if (value == null) {
+            return null;
+        }
+        int max = Math.max(
+                64,
+                Math.min(
+                        OtlpSpanDecoder.HARD_MAX_ATTRIBUTE_VALUE_CHARS,
+                        properties.getTelemetry().getMaxAttributeValueBytes()));
+        if (value.length() <= max) {
+            return value;
+        }
+        return value.substring(0, max) + "…[truncated " + (value.length() - max) + " chars]";
+    }
+
+    private static String emptyToNull(String s) {
+        return (s == null || s.isEmpty()) ? null : s;
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetrySpanFilter.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetrySpanFilter.java
@@ -1,0 +1,31 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+public final class TelemetrySpanFilter {
+
+    private TelemetrySpanFilter() {}
+
+    public static boolean isSelfSpan(NormalizedSpan span, String apiPath) {
+        if (span == null || apiPath == null || apiPath.isEmpty() || span.attributes() == null) {
+            return false;
+        }
+        String route = stringAttribute(span, "http.route");
+        if (startsWithBootUiPath(route, apiPath)) {
+            return true;
+        }
+        String urlPath = stringAttribute(span, "url.path");
+        if (startsWithBootUiPath(urlPath, apiPath)) {
+            return true;
+        }
+        String target = stringAttribute(span, "http.target");
+        return startsWithBootUiPath(target, apiPath);
+    }
+
+    private static boolean startsWithBootUiPath(String value, String apiPath) {
+        return value != null && (value.startsWith(apiPath) || value.startsWith("/bootui"));
+    }
+
+    private static String stringAttribute(NormalizedSpan span, String key) {
+        AttributeValue av = span.attributes().get(key);
+        return av != null ? av.asString() : null;
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryStore.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryStore.java
@@ -4,7 +4,7 @@ import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import java.util.*;
 
 /**
- * Bounded in-memory store for OTLP spans received over the BootUI OTLP receiver.
+ * Bounded in-memory store for telemetry spans captured by BootUI.
  *
  * <p>Spans are grouped by trace id. When the configured trace capacity is
  * exceeded the oldest trace bucket is dropped. Each trace also caps its span

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
@@ -4,6 +4,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
 import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetrySpanFilter;
 import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -50,33 +51,6 @@ public class OtlpReceiverController {
         this.properties = properties;
     }
 
-    private static boolean isSelfSpan(NormalizedSpan span, String apiPath) {
-        if (apiPath == null || apiPath.isEmpty()) {
-            return false;
-        }
-        if (span.attributes() == null) {
-            return false;
-        }
-        String route = stringAttribute(span, "http.route");
-        if (route != null && (route.startsWith(apiPath) || route.startsWith("/bootui"))) {
-            return true;
-        }
-        String urlPath = stringAttribute(span, "url.path");
-        if (urlPath != null && (urlPath.startsWith(apiPath) || urlPath.startsWith("/bootui"))) {
-            return true;
-        }
-        String target = stringAttribute(span, "http.target");
-        return target != null && (target.startsWith(apiPath) || target.startsWith("/bootui"));
-    }
-
-    private static String stringAttribute(NormalizedSpan span, String key) {
-        if (span.attributes() == null) {
-            return null;
-        }
-        var av = span.attributes().get(key);
-        return av != null ? av.asString() : null;
-    }
-
     private static ResponseEntity<byte[]> okResponse() {
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType("application/x-protobuf"))
@@ -106,7 +80,7 @@ public class OtlpReceiverController {
             String apiPath = properties.getApiPath();
             int kept = 0;
             for (NormalizedSpan span : spans) {
-                if (telemetry.isExcludeSelfSpans() && isSelfSpan(span, apiPath)) {
+                if (telemetry.isExcludeSelfSpans() && TelemetrySpanFilter.isSelfSpan(span, apiPath)) {
                     continue;
                 }
                 store.add(span);

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.autoconfigure;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
+import io.github.jdubois.bootui.autoconfigure.otlp.BootUiSpanExporter;
 import io.github.jdubois.bootui.autoconfigure.safety.LocalhostOnlyFilter;
 import io.github.jdubois.bootui.autoconfigure.safety.PanelAccessFilter;
 import io.github.jdubois.bootui.autoconfigure.web.*;
@@ -38,6 +39,7 @@ class BootUiAutoConfigurationTests {
                         .hasSingleBean(OverviewController.class)
                         .hasSingleBean(DevServicesController.class)
                         .hasSingleBean(DependenciesController.class)
+                        .hasSingleBean(BootUiSpanExporter.class)
                         .hasSingleBean(BootUiActivation.class));
     }
 
@@ -184,6 +186,25 @@ class BootUiAutoConfigurationTests {
         runner.withPropertyValues("bootui.enabled=ON")
                 .withClassLoader(new FilteredClassLoader("org.springframework.data.repository.core.support"))
                 .run(context -> assertThat(context).doesNotHaveBean(DataController.class));
+    }
+
+    @Test
+    void skipsBootUiSpanExporterWhenTelemetryIsDisabled() {
+        runner.withPropertyValues("bootui.enabled=ON", "bootui.telemetry.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiSpanExporter.class));
+    }
+
+    @Test
+    void skipsBootUiSpanExporterWhenTracesPanelIsDisabled() {
+        runner.withPropertyValues("bootui.enabled=ON", "bootui.panels.traces.enabled=false")
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiSpanExporter.class));
+    }
+
+    @Test
+    void skipsBootUiSpanExporterWhenOpenTelemetrySdkIsMissing() {
+        runner.withPropertyValues("bootui.enabled=ON")
+                .withClassLoader(new FilteredClassLoader("io.opentelemetry.sdk.trace.export"))
+                .run(context -> assertThat(context).doesNotHaveBean("bootUiSpanExporter"));
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
@@ -20,6 +20,9 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         assertThat(env.getProperty("management.endpoints.web.exposure.include"))
                 .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.REQUIRED_ENDPOINTS);
         assertThat(env.getProperty("management.endpoint.health.show-details")).isEqualTo("always");
+        assertThat(env.getProperty(
+                        BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY);
     }
 
     @Test
@@ -27,12 +30,47 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         MockEnvironment env = new MockEnvironment()
                 .withProperty("bootui.enabled", "ON")
                 .withProperty("management.endpoints.web.exposure.include", "health,info")
-                .withProperty("management.endpoint.health.show-details", "never");
+                .withProperty("management.endpoint.health.show-details", "never")
+                .withProperty(
+                        BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY, "0.25");
 
         processor.postProcessEnvironment(env, new SpringApplication());
 
         assertThat(env.getProperty("management.endpoints.web.exposure.include")).isEqualTo("health,info");
         assertThat(env.getProperty("management.endpoint.health.show-details")).isEqualTo("never");
+        assertThat(env.getProperty(
+                        BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
+                .isEqualTo("0.25");
+    }
+
+    @Test
+    void doesNotContributeTracingDefaultsWhenTelemetryIsDisabled() {
+        MockEnvironment env = new MockEnvironment()
+                .withProperty("bootui.enabled", "ON")
+                .withProperty("bootui.telemetry.enabled", "false");
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getProperty("management.endpoints.web.exposure.include"))
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.REQUIRED_ENDPOINTS);
+        assertThat(env.getProperty(
+                        BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
+                .isNull();
+    }
+
+    @Test
+    void doesNotContributeTracingDefaultsWhenTracesPanelIsDisabled() {
+        MockEnvironment env = new MockEnvironment()
+                .withProperty("bootui.enabled", "ON")
+                .withProperty("bootui.panels.traces.enabled", "false");
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getProperty("management.endpoints.web.exposure.include"))
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.REQUIRED_ENDPOINTS);
+        assertThat(env.getProperty(
+                        BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
+                .isNull();
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/otlp/BootUiSpanExporterTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/otlp/BootUiSpanExporterTests.java
@@ -1,0 +1,108 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class BootUiSpanExporterTests {
+
+    private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+
+    @Test
+    void exportsOpenTelemetrySpansToTheBootUiStore() {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        SdkTracerProvider provider = tracerProvider(new BootUiSpanExporter(store, properties));
+        try {
+            Tracer tracer = provider.get("bootui-test-scope");
+            Span span = tracer.spanBuilder("GET /api/orders")
+                    .setSpanKind(SpanKind.SERVER)
+                    .setAttribute("http.route", "/api/orders")
+                    .setAttribute("http.response.status_code", 200L)
+                    .setAttribute(AttributeKey.stringArrayKey("sample.tags"), List.of("orders", "local"))
+                    .startSpan();
+            span.addEvent("controller.done", Attributes.of(AttributeKey.stringKey("sample.event"), "ok"));
+            span.setStatus(StatusCode.OK);
+            span.end();
+            provider.forceFlush().join(1, TimeUnit.SECONDS);
+
+            assertThat(store.retainedTraceCount()).isEqualTo(1);
+            NormalizedSpan stored = store.recentTraces(1).get(0).spans().get(0);
+            assertThat(stored.name()).isEqualTo("GET /api/orders");
+            assertThat(stored.kind()).isEqualTo("SERVER");
+            assertThat(stored.serviceName()).isEqualTo("sample-service");
+            assertThat(stored.scope()).isEqualTo("bootui-test-scope");
+            assertThat(stored.statusCode()).isEqualTo("OK");
+            assertThat(stored.attributes().get("http.route").asString()).isEqualTo("/api/orders");
+            assertThat(stored.attributes().get("http.response.status_code").asLong())
+                    .isEqualTo(200L);
+            assertThat(stored.attributes().get("sample.tags").value()).isEqualTo(List.of("orders", "local"));
+            assertThat(stored.events()).singleElement().satisfies(event -> {
+                assertThat(event.name()).isEqualTo("controller.done");
+                assertThat(event.attributes().get("sample.event").asString()).isEqualTo("ok");
+            });
+        } finally {
+            provider.shutdown().join(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void dropsBootUiSelfSpansByDefault() {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        SdkTracerProvider provider = tracerProvider(new BootUiSpanExporter(store, properties));
+        try {
+            Span span = provider.get("bootui-test-scope")
+                    .spanBuilder("GET /bootui/api/traces")
+                    .setSpanKind(SpanKind.SERVER)
+                    .setAttribute("http.route", "/bootui/api/traces")
+                    .startSpan();
+            span.end();
+            provider.forceFlush().join(1, TimeUnit.SECONDS);
+
+            assertThat(store.retainedTraceCount()).isZero();
+        } finally {
+            provider.shutdown().join(1, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    void doesNotCaptureSpansWhenTelemetryIsDisabled() {
+        BootUiProperties properties = new BootUiProperties();
+        properties.getTelemetry().setEnabled(false);
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        SdkTracerProvider provider = tracerProvider(new BootUiSpanExporter(store, properties));
+        try {
+            Span span = provider.get("bootui-test-scope")
+                    .spanBuilder("GET /api/orders")
+                    .setSpanKind(SpanKind.SERVER)
+                    .setAttribute("http.route", "/api/orders")
+                    .startSpan();
+            span.end();
+            provider.forceFlush().join(1, TimeUnit.SECONDS);
+
+            assertThat(store.retainedTraceCount()).isZero();
+        } finally {
+            provider.shutdown().join(1, TimeUnit.SECONDS);
+        }
+    }
+
+    private SdkTracerProvider tracerProvider(BootUiSpanExporter exporter) {
+        return SdkTracerProvider.builder()
+                .setResource(Resource.create(Attributes.of(SERVICE_NAME, "sample-service")))
+                .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                .build();
+    }
+}

--- a/bootui-sample-app/e2e/tests/ai.spec.js
+++ b/bootui-sample-app/e2e/tests/ai.spec.js
@@ -110,7 +110,7 @@ test.describe('AI Usage view', () => {
     })
 
     await page.goto('/bootui/#/ai')
-    await expect(page.getByText('Enable the BootUI telemetry receiver')).toBeVisible()
+    await expect(page.getByText('Enable BootUI telemetry capture')).toBeVisible()
     await expect(page.getByText('No AI chat completions recorded yet')).toHaveCount(0)
   })
 
@@ -131,7 +131,7 @@ test.describe('AI Usage view', () => {
     await page.goto('/bootui/#/ai')
     await expect(page.getByText('No AI chat completions recorded yet')).toBeVisible()
     await expect(page.getByText('Telemetry ready')).toBeVisible()
-    await expect(page.getByText('Enable the BootUI telemetry receiver')).toHaveCount(0)
+    await expect(page.getByText('Enable BootUI telemetry capture')).toHaveCount(0)
     await expect(page.getByText('OTLP exporter configured')).toHaveCount(0)
   })
 

--- a/bootui-sample-app/e2e/tests/traces.spec.js
+++ b/bootui-sample-app/e2e/tests/traces.spec.js
@@ -108,7 +108,7 @@ test.describe('Traces view', () => {
     )
 
     await page.goto('/bootui/#/traces')
-    await expect(page.getByText('Telemetry receiver is disabled')).toBeVisible()
+    await expect(page.getByText('Telemetry capture is disabled')).toBeVisible()
     await expect(page.getByText('No traces received yet')).toHaveCount(0)
   })
 })

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -66,19 +66,6 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-micrometer-tracing-opentelemetry</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.micrometer</groupId>
-            <artifactId>micrometer-tracing-bridge-otel</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <optional>true</optional>
         </dependency>

--- a/bootui-sample-app/src/main/resources/application.properties
+++ b/bootui-sample-app/src/main/resources/application.properties
@@ -1,10 +1,5 @@
 spring.application.name=bootui-sample
 server.port=8080
-management.endpoints.web.exposure.include=*
-management.endpoint.health.show-details=always
-management.tracing.sampling.probability=1.0
-management.opentelemetry.tracing.export.otlp.endpoint=http://localhost:8080/bootui/api/otlp/v1/traces
-management.opentelemetry.tracing.export.otlp.compression=none
 spring.ai.ollama.base-url=http://localhost:11434
 spring.ai.ollama.chat.model=qwen2.5:0.5b
 spring.ai.ollama.init.pull-model-strategy=when_missing

--- a/bootui-spring-boot-starter/pom.xml
+++ b/bootui-spring-boot-starter/pom.xml
@@ -32,6 +32,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-tracing-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -510,8 +510,8 @@ onBeforeUnmount(() => {
               <span class="badge text-bg-info">Telemetry ready</span>
             </div>
             <p class="text-muted mb-0">
-              BootUI's telemetry receiver is active and Spring AI is detected. Exercise a Spring AI chat flow; this
-              panel will refresh automatically when the first completion span arrives.
+              BootUI's telemetry capture is active and Spring AI is detected. Exercise a Spring AI chat flow; this panel
+              will refresh automatically when the first completion span arrives.
             </p>
           </div>
         </div>

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -180,8 +180,8 @@ onMounted(load)
 
     <template v-else-if="report">
       <div v-if="!report.enabled" class="alert alert-info small">
-        Telemetry receiver is disabled. Set <code>bootui.telemetry.enabled=true</code> and configure your application to
-        export OTLP to <code>http://localhost:8080/bootui/api/otlp/v1/traces</code>.
+        Telemetry capture is disabled. Set <code>bootui.telemetry.enabled=true</code> to re-enable BootUI's local
+        in-memory trace capture.
         <span v-if="report.retained > 0">Showing spans retained before telemetry was disabled.</span>
       </div>
 
@@ -191,8 +191,9 @@ onMounted(load)
       </div>
 
       <div v-if="report.enabled && report.retained === 0" class="alert alert-secondary">
-        No traces received yet. Add an OTLP exporter pointed at
-        <code>/bootui/api/otlp/v1/traces</code> and exercise your application to populate this panel.
+        No traces received yet. With the BootUI starter on the classpath, local application spans are captured
+        automatically. Exercise your application to populate this panel; cooperating services can still export OTLP to
+        <code>/bootui/api/otlp/v1/traces</code>.
       </div>
 
       <template v-if="report.retained > 0">

--- a/bootui-ui/src/main/frontend/src/views/components/AiSetupChecklist.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/AiSetupChecklist.vue
@@ -23,11 +23,7 @@ async function copyToClipboard(text, key) {
   }
 }
 
-const otlpProps = `management.opentelemetry.tracing.export.otlp.endpoint=http://localhost:8080/bootui/api/otlp/v1/traces`
-const mavSnippet = `<dependency>
-  <groupId>io.micrometer</groupId>
-  <artifactId>micrometer-tracing-bridge-otel</artifactId>
-</dependency>`
+const otlpEndpoint = `/bootui/api/otlp/v1/traces`
 </script>
 
 <template>
@@ -53,7 +49,7 @@ const mavSnippet = `<dependency>
           <i :class="enabled ? 'bi-check-circle-fill' : 'bi-x-circle-fill'" class="bi"></i>
         </span>
         <div>
-          <div class="fw-semibold">Enable the BootUI telemetry receiver</div>
+          <div class="fw-semibold">Enable BootUI telemetry capture</div>
           <div v-if="!enabled" class="text-muted small">
             Add to your
             <code>application.properties</code>:
@@ -69,7 +65,7 @@ const mavSnippet = `<dependency>
               </button>
             </div>
           </div>
-          <div v-else class="text-muted small">Telemetry receiver is active.</div>
+          <div v-else class="text-muted small">Telemetry capture is active.</div>
         </div>
       </li>
       <li class="list-group-item d-flex align-items-start gap-3">
@@ -77,31 +73,24 @@ const mavSnippet = `<dependency>
           <i :class="hasData ? 'bi-check-circle-fill' : 'bi-circle'" class="bi"></i>
         </span>
         <div class="w-100">
-          <div class="fw-semibold">OTLP exporter configured</div>
+          <div class="fw-semibold">Trace capture ready</div>
           <div class="text-muted small">
-            Configure your application to export OTLP traces to BootUI:
+            The BootUI starter captures local application spans automatically. Exercise a Spring AI chat flow to
+            populate this panel.
             <div class="d-flex align-items-center gap-1 mt-1">
-              <code class="bg-light px-2 py-1 rounded text-break">{{ otlpProps }}</code>
+              <code class="bg-light px-2 py-1 rounded text-break">{{ otlpEndpoint }}</code>
               <button
                 :class="copiedKey === 'otlp' ? 'btn-success' : 'btn-outline-secondary'"
                 :title="copiedKey === 'otlp' ? 'Copied!' : 'Copy'"
                 class="btn btn-sm"
-                @click="copyToClipboard(otlpProps, 'otlp')"
+                @click="copyToClipboard(otlpEndpoint, 'otlp')"
               >
                 <i :class="copiedKey === 'otlp' ? 'bi-check-lg' : 'bi-clipboard'" class="bi"></i>
               </button>
             </div>
-            <div class="mt-2">Also add the tracing bridge dependency:</div>
-            <div class="d-flex align-items-start gap-1 mt-1">
-              <pre class="bg-light p-2 rounded small mb-0 flex-grow-1">{{ mavSnippet }}</pre>
-              <button
-                :class="copiedKey === 'maven' ? 'btn-success' : 'btn-outline-secondary'"
-                :title="copiedKey === 'maven' ? 'Copied!' : 'Copy'"
-                class="btn btn-sm"
-                @click="copyToClipboard(mavSnippet, 'maven')"
-              >
-                <i :class="copiedKey === 'maven' ? 'bi-check-lg' : 'bi-clipboard'" class="bi"></i>
-              </button>
+            <div class="mt-2">
+              Cooperating local services can still export OTLP traces to this endpoint when they are not using the
+              BootUI starter.
             </div>
           </div>
         </div>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -145,11 +145,13 @@ prompt, completion, total), latency, model, and the prompt/response snippet when
 content (`spring.ai.chat.client.observations.log-prompt`, `spring.ai.chat.observations.log-prompt`,
 `spring.ai.chat.observations.log-completion`). A small inline chart shows total token usage over recent calls so you can
 spot expensive interactions during local development. Vector store and embedding spans appear alongside chat spans when
-present. The sidebar dims the panel when telemetry is disabled or Spring AI is not on the classpath, and the view
+present. The BootUI starter captures local application spans automatically when telemetry is enabled. Cooperating local
+services can still send OTLP spans to the embedded receiver. The sidebar dims the panel when telemetry is disabled or
+Spring AI is not on the classpath, and the view
 explains the unavailable state. When both prerequisites are ready but no chat spans have arrived yet, the panel shows a
 ready empty state rather than setup guidance. Recent chats, model breakdowns, token-series windows, spans, and attributes
-are bounded so large local runs stay responsive. As with the Traces panel, data is sourced from the embedded OTLP
-receiver, is in-memory only, and is cleared on restart.
+are bounded so large local runs stay responsive. As with the Traces panel, data is sourced from BootUI's local telemetry
+capture, is in-memory only, and is cleared on restart.
 
 ![BootUI AI Usage panel](images/bootui-ai.png)
 
@@ -157,15 +159,16 @@ receiver, is in-memory only, and is cleared on restart.
 
 ### Traces
 
-The Traces panel shows distributed tracing spans collected by BootUI's embedded OTLP/HTTP receiver at
-`/bootui/api/otlp/v1/traces`. Any Spring Boot service that uses Micrometer Tracing with the OpenTelemetry bridge -
-including the host application itself when self-tracing is enabled - can export to this endpoint and have its traces
-appear here. The list shows the most recent traces with service name, root span name, status, duration, and span count;
-opening a trace renders a waterfall view of its spans so you can see latency contributions, errors, and parent/child
-relationships across services. Spans emitted by BootUI's own API are filtered out by default to keep the view focused on
-application traffic; this can be tuned with `bootui.telemetry.exclude-self-spans=false`. When
-`bootui.telemetry.enabled=false`, the sidebar dims the panel and the view shows a disabled state instead of implying
-that tracing is merely empty. The in-memory trace buffer is bounded by `bootui.telemetry.max-traces`,
+The Traces panel shows distributed tracing spans captured locally by the BootUI starter when telemetry and the Traces
+panel are enabled. The starter contributes the tracing dependencies and sampling default needed for local development, so
+the host application does not need manual `management.*` tracing properties. BootUI also keeps an embedded OTLP/HTTP
+receiver at `/bootui/api/otlp/v1/traces` so cooperating local services can export spans into the same in-memory store.
+The list shows the most recent traces with service name, root span name, status, duration, and span count; opening a trace
+renders a waterfall view of its spans so you can see latency contributions, errors, and parent/child relationships across
+services. Spans emitted by BootUI's own API are filtered out by default to keep the view focused on application traffic;
+this can be tuned with `bootui.telemetry.exclude-self-spans=false`. When `bootui.telemetry.enabled=false`, the sidebar
+dims the panel and the view shows a disabled state instead of implying that tracing is merely empty. The in-memory trace
+buffer is bounded by `bootui.telemetry.max-traces`,
 `bootui.telemetry.max-spans-per-trace`, request-size limits, and attribute-value truncation, with additional internal
 caps to keep misconfigured local exporters from overflowing the UI. Trace data is reset on application restart or via
 the panel's clear action.

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -90,7 +90,7 @@ Panel settings are consistent across the UI and API:
 | --- | --- | --- |
 | `bootui.panels.traces.enabled` | `true` | Show the Traces panel and its retained trace data. |
 | `bootui.panels.traces.read-only` | `false` | Disable clearing retained traces. OTLP ingestion remains controlled by `bootui.telemetry.enabled`. |
-| `bootui.telemetry.enabled` | `true` | Accept OTLP/HTTP trace payloads at BootUI's OTLP endpoint. |
+| `bootui.telemetry.enabled` | `true` | Enables local in-memory trace capture and accepts OTLP/HTTP trace payloads at BootUI's OTLP endpoint. |
 | `bootui.telemetry.max-traces` | `500` | Maximum distinct traces retained in memory. |
 | `bootui.telemetry.max-spans-per-trace` | `500` | Maximum spans retained per trace. |
 | `bootui.telemetry.max-attribute-value-bytes` | `4096` | Maximum attribute string length before truncation. |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -43,12 +43,14 @@ Make a running Spring Boot application understandable in minutes.
 ### 2.3 Non-goals for MVP
 
 - Production monitoring.
-- Multi-application _runtime_ orchestration. BootUI accepts OTLP traces from cooperating local services as a dev-time
-  sink, but it does not run, schedule, restart, or supervise other processes the way .NET Aspire's AppHost does.
+- Multi-application _runtime_ orchestration. BootUI captures host-application traces locally and accepts OTLP traces from
+  cooperating local services as a dev-time sink, but it does not run, schedule, restart, or supervise other processes the
+  way .NET Aspire's AppHost does.
 - Kubernetes workflow management.
 - Hosted dashboards.
 - Authentication and user management.
-- Full APM/tracing replacement. The OTLP receiver is dev-only, bounded in memory, and never forwards data anywhere.
+- Full APM/tracing replacement. BootUI's telemetry capture is dev-only, bounded in memory, and never forwards data
+  anywhere.
 - Upgrade automation.
 - Code editing.
 - Replacing Spring Boot Admin.
@@ -876,7 +878,7 @@ Initial properties:
 | `bootui.dependencies.max-advisories`         | `200`                                   | Maximum advisory detail documents fetched after a query.                                          |
 | `bootui.dev-services.restart-enabled`        | `false`                                 | Enables restart controls for bean-backed Testcontainers services.                                 |
 | `bootui.dev-services.log-tail-bytes`         | `65536`                                 | Maximum bytes returned by one Dev Services log request.                                           |
-| `bootui.telemetry.enabled`                   | `true`                                  | Enables the local OTLP/HTTP trace receiver used by the Traces and AI Usage panels.                |
+| `bootui.telemetry.enabled`                   | `true`                                  | Enables local trace capture and the OTLP/HTTP receiver used by the Traces and AI Usage panels.    |
 | `bootui.telemetry.max-traces`                | `500`                                   | Maximum distinct traces retained in memory; internally capped for UI safety.                      |
 | `bootui.telemetry.max-spans-per-trace`       | `500`                                   | Maximum spans retained for one trace; internally capped for UI safety.                            |
 | `bootui.telemetry.max-attribute-value-bytes` | `4096`                                  | Maximum attribute string length before truncation; internally capped for UI safety.               |
@@ -915,7 +917,7 @@ Rules:
 - Never display `.env` contents.
 - Never write configuration values back to application source files.
 - Persist runtime overrides only to BootUI's configured override file.
-- Never send telemetry by default.
+- Never forward telemetry off-process by default.
 - Never proxy arbitrary external URLs.
 - Never perform dependency vulnerability lookups until the developer explicitly starts an OSV scan.
 


### PR DESCRIPTION
## What does this PR do?

Automates BootUI trace capture for starter users by registering an in-process OpenTelemetry `SpanExporter` that writes local spans directly into BootUI's bounded telemetry store. The sample app now relies on BootUI defaults instead of manual `management.*` tracing properties, while the OTLP receiver remains available for cooperating local services.

## Why is this change needed?

The Traces panel previously worked in the sample app only because it configured Actuator tracing and OTLP export back to BootUI by hand. Starter users should get local traces automatically when BootUI is active, unless telemetry or the Traces panel is disabled.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `./mvnw -pl bootui-autoconfigure -Dtest=BootUiAutoConfigurationTests,BootUiActuatorDefaultsEnvironmentPostProcessorTests,BootUiSpanExporterTests test`
- [x] `./mvnw -pl bootui-core,bootui-autoconfigure,bootui-spring-boot-starter,bootui-sample-app -am clean test`
- [x] `npm test` in `bootui-ui/src/main/frontend`
- [x] `./mvnw -B -ntp spotless:check`
- [x] `npm run format:check` in `bootui-ui/src/main/frontend`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
