### PR TITLE
Harden security, fix bugs, and add tests from first project audit

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -161,7 +161,7 @@ paths.
 
 ## Current panel surface
 
-The selected `0.1.0-alpha.1` stance is to harden **all visible panels**, not hide newer ones. Keep API, UI, docs, and
+The `0.1.0` stance is to harden **all visible panels**, not hide newer ones. Keep API, UI, docs, and
 Playwright coverage aligned for:
 
 - Overview, Startup Timeline, Memory, Health, Metrics, Conditions, Beans, Mappings, Configuration, Profile Diff,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '24.16.0'
           cache: npm
           cache-dependency-path: |
             bootui-ui/src/main/frontend/package-lock.json

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,6 +58,9 @@ jobs:
 
       - name: Build (Java)
         if: steps.code-scanning.outputs.enabled == 'true' && matrix.language == 'java-kotlin'
+        # CodeQL only needs the Java sources compiled for analysis, so we skip
+        # tests and the frontend bundling/release plumbing that the full
+        # build.yml `clean install` runs. `package` is sufficient and faster here.
         run: ./mvnw -B -ntp -DskipTests package
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
         if: steps.code-scanning.outputs.enabled == 'true' && matrix.language == 'java-kotlin'
         uses: actions/setup-node@v6
         with:
-          node-version: '24'
+          node-version: '24.16.0'
 
       - name: Initialize CodeQL
         if: steps.code-scanning.outputs.enabled == 'true'

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilter.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilter.java
@@ -66,7 +66,7 @@ public class LocalhostOnlyFilter extends OncePerRequestFilter {
         }
         try {
             InetAddress address = InetAddress.getByName(remoteAddr);
-            return address.isLoopbackAddress() || address.isAnyLocalAddress();
+            return address.isLoopbackAddress();
         } catch (UnknownHostException e) {
             return false;
         }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ClaudeCodeController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ClaudeCodeController.java
@@ -34,6 +34,9 @@ public class ClaudeCodeController {
     private final BootUiProperties properties;
     private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
 
+    /** Upper bound on simultaneous activity streams; this is a local dev tool, not a fan-out hub. */
+    static final int MAX_CONCURRENT_STREAMS = 20;
+
     @Autowired
     public ClaudeCodeController(
             @Qualifier("bootUiClaudeCodeSessionStore") ObjectProvider<ClaudeCodeSessionStore> storeProvider,
@@ -106,6 +109,10 @@ public class ClaudeCodeController {
     public SseEmitter stream() {
         ClaudeCodeSessionStore store = store();
         SseEmitter emitter = new SseEmitter(0L);
+        if (emitters.size() >= MAX_CONCURRENT_STREAMS) {
+            emitter.completeWithError(new IllegalStateException("Too many concurrent BootUI Claude Code streams"));
+            return emitter;
+        }
         emitters.add(emitter);
 
         AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {});

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CopilotController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CopilotController.java
@@ -40,6 +40,9 @@ public class CopilotController {
     private final BootUiProperties properties;
     private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
 
+    /** Upper bound on simultaneous activity streams; this is a local dev tool, not a fan-out hub. */
+    static final int MAX_CONCURRENT_STREAMS = 20;
+
     @Autowired
     public CopilotController(
             @Qualifier("bootUiCopilotSessionStore") ObjectProvider<CopilotSessionStore> storeProvider,
@@ -112,6 +115,10 @@ public class CopilotController {
     public SseEmitter stream() {
         CopilotSessionStore store = store();
         SseEmitter emitter = new SseEmitter(0L);
+        if (emitters.size() >= MAX_CONCURRENT_STREAMS) {
+            emitter.completeWithError(new IllegalStateException("Too many concurrent BootUI Copilot streams"));
+            return emitter;
+        }
         emitters.add(emitter);
 
         AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {});

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeController.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,6 +24,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class HttpProbeController {
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(10);
+
+    /**
+     * Hop-by-hop and connection-management headers that the {@link HttpClient}
+     * manages itself. The JDK rejects attempts to set these, so a probe that
+     * forwarded them verbatim would fail with an opaque error; they are stripped
+     * instead so the rest of the request still goes through.
+     */
+    private static final Set<String> RESTRICTED_HEADERS = Set.of(
+            "host",
+            "connection",
+            "content-length",
+            "expect",
+            "upgrade",
+            "transfer-encoding",
+            "proxy-connection",
+            "keep-alive",
+            "te");
 
     private final Environment environment;
 
@@ -40,9 +58,6 @@ public class HttpProbeController {
         String method = normalizeMethod(request == null ? null : request.method());
         String path = normalizePath(request == null ? null : request.path());
         String url = "http://localhost:" + resolveServerPort() + path;
-        if (!url.startsWith("http://localhost:") && !url.startsWith("http://127.0.0.1:")) {
-            return new HttpProbeResponse(0, "Forbidden", Map.of(), null, 0, "Only loopback probes allowed");
-        }
 
         try {
             HttpRequest.Builder builder =
@@ -78,6 +93,9 @@ public class HttpProbeController {
         }
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            if (RESTRICTED_HEADERS.contains(entry.getKey().trim().toLowerCase(Locale.ROOT))) {
                 continue;
             }
             builder.header(entry.getKey(), entry.getValue());

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
@@ -20,6 +20,9 @@ public class LogTailController {
     private final BootUiLogAppender appender;
     private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
 
+    /** Upper bound on simultaneous log-tail streams; this is a local dev tool, not a fan-out hub. */
+    static final int MAX_CONCURRENT_STREAMS = 20;
+
     public LogTailController() {
         this.appender = BootUiLogAppender.install();
     }
@@ -36,6 +39,10 @@ public class LogTailController {
     @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter stream() {
         SseEmitter emitter = new SseEmitter(0L);
+        if (emitters.size() >= MAX_CONCURRENT_STREAMS) {
+            emitter.completeWithError(new IllegalStateException("Too many concurrent BootUI log-tail streams"));
+            return emitter;
+        }
         emitters.add(emitter);
 
         AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {});

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -336,7 +336,8 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                             .map(vulnerabilities::get)
                             .filter(vulnerability -> vulnerability != null)
                             .map(vulnerability -> vulnerability(vulnerability, dependency))
-                            .sorted(Comparator.comparing(DependencyVulnerabilityDto::severity)
+                            .sorted(Comparator.comparingInt((DependencyVulnerabilityDto vulnerability) ->
+                                            severityRank(vulnerability.severity()))
                                     .thenComparing(DependencyVulnerabilityDto::id))
                             .toList();
             enriched.add(new DependencyDto(

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilterTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilterTests.java
@@ -98,6 +98,26 @@ class LocalhostOnlyFilterTests {
         assertThat(response.getStatus()).isEqualTo(403);
     }
 
+    @Test
+    void rejectsWildcardIpv4Address() throws Exception {
+        MockHttpServletRequest request = bootUiRequest("/bootui/", "0.0.0.0");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void rejectsWildcardIpv6Address() throws Exception {
+        MockHttpServletRequest request = bootUiRequest("/bootui/", "::");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
     private MockHttpServletRequest bootUiRequest(String uri, String remoteAddr) {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
         request.setRequestURI(uri);

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/CopilotControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/CopilotControllerTests.java
@@ -46,6 +46,22 @@ class CopilotControllerTests {
     }
 
     @Test
+    void streamRejectsBeyondConcurrentLimit(@TempDir Path tempDir) {
+        BootUiProperties props = propertiesFor(tempDir);
+        CopilotSessionStore store = storeFor(props);
+        CopilotController controller = new CopilotController(store, props);
+
+        for (int i = 0; i < CopilotController.MAX_CONCURRENT_STREAMS; i++) {
+            controller.stream();
+        }
+        assertThat(controller.emittersForTesting()).hasSize(CopilotController.MAX_CONCURRENT_STREAMS);
+
+        // The next stream is over the cap: it is completed with an error and never tracked.
+        controller.stream();
+        assertThat(controller.emittersForTesting()).hasSize(CopilotController.MAX_CONCURRENT_STREAMS);
+    }
+
+    @Test
     void sessionsReturnsUnavailableWhenDirectoryMissing(@TempDir Path tempDir) throws Exception {
         Path missing = tempDir.resolve("does-not-exist");
         BootUiProperties props = propertiesFor(missing);

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeControllerTests.java
@@ -279,6 +279,37 @@ class HttpProbeControllerTests {
                 .andExpect(jsonPath("$.durationMs").isNumber());
     }
 
+    // ── request header handling ───────────────────────────────────────────────
+
+    @Test
+    void forwardsCustomRequestHeadersAndStripsRestrictedOnes() throws Exception {
+        server.createContext("/echo-headers", exchange -> {
+            String custom = exchange.getRequestHeaders().getFirst("X-Custom");
+            String host = exchange.getRequestHeaders().getFirst("Host");
+            String body = "custom=" + custom + ";host=" + host;
+            byte[] bytes = body.getBytes();
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+            exchange.close();
+        });
+        MockMvc mvc = buildMvc();
+
+        var headers = new java.util.LinkedHashMap<String, String>();
+        headers.put("X-Custom", "forwarded");
+        headers.put("Host", "evil.example.com");
+
+        mvc.perform(post("/bootui/api/probe")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(new HttpProbeRequest("GET", "/echo-headers", null, headers))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                // custom header forwarded; the spoofed Host is stripped so it never reaches the target
+                .andExpect(jsonPath("$.body").value(org.hamcrest.Matchers.containsString("custom=forwarded")))
+                .andExpect(jsonPath("$.body")
+                        .value(org.hamcrest.Matchers.not(
+                                org.hamcrest.Matchers.containsString("host=evil.example.com"))));
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private MockMvc buildMvc() {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -91,6 +91,50 @@ class OsvVulnerabilityScannerTests {
     }
 
     @Test
+    void ordersVulnerabilitiesBySeverityRankNotAlphabetically() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                    {"results":[{"vulns":[{"id":"V-LOW"},{"id":"V-CRITICAL"},{"id":"V-MEDIUM"}]}]}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        registerAdvisory("V-LOW", "LOW");
+        registerAdvisory("V-CRITICAL", "CRITICAL");
+        registerAdvisory("V-MEDIUM", "MEDIUM");
+        server.start();
+
+        BootUiProperties.Dependencies properties = new BootUiProperties.Dependencies();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.dependencies().getFirst().vulnerabilities())
+                .extracting("severity")
+                .containsExactly("CRITICAL", "MEDIUM", "LOW");
+        assertThat(report.dependencies().getFirst().highestSeverity()).isEqualTo("CRITICAL");
+    }
+
+    private void registerAdvisory(String id, String severity) {
+        server.createContext("/v1/vulns/" + id, exchange -> {
+            byte[] body = ("{\"id\":\"" + id + "\",\"database_specific\":{\"severity\":\"" + severity + "\"}}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+    }
+
+    @Test
     void reportsErrorWithoutDroppingDependencyInventory() throws IOException {
         server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext("/v1/querybatch", exchange -> {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/SecretMasker.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/SecretMasker.java
@@ -18,6 +18,8 @@ public final class SecretMasker {
     private static final Set<String> DEFAULT_KEY_PATTERNS = Set.of(
             "password",
             "passwd",
+            "passphrase",
+            "pwd",
             "secret",
             "token",
             "key",

--- a/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerTests.java
+++ b/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerTests.java
@@ -19,6 +19,12 @@ class SecretMaskerTests {
     }
 
     @Test
+    void detectsPassphraseAndPwdAbbreviations() {
+        assertThat(masker.isSecret("keystore.passphrase")).isTrue();
+        assertThat(masker.isSecret("DB_PWD")).isTrue();
+    }
+
+    @Test
     void masksValueWhenKeyMatches() {
         assertThat(masker.mask("spring.datasource.password", "hunter2")).isEqualTo(SecretMasker.MASKED_VALUE);
         assertThat(masker.mask("server.port", 8080)).isEqualTo(8080);

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -21,7 +21,25 @@ const unavailableNavigationGroup = {
   icon: 'bi-slash-circle'
 }
 const routes = router.options.routes.filter((r) => r.name)
-const expandedGroups = reactive({runtime: true})
+const EXPANDED_GROUPS_STORAGE_KEY = 'bootui.expandedGroups'
+
+function loadExpandedGroups() {
+  const defaults = {runtime: true}
+  try {
+    const stored = window.localStorage?.getItem(EXPANDED_GROUPS_STORAGE_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored)
+      if (parsed && typeof parsed === 'object') {
+        return {...defaults, ...parsed}
+      }
+    }
+  } catch {
+    // Ignore unavailable or malformed storage; fall back to defaults.
+  }
+  return defaults
+}
+
+const expandedGroups = reactive(loadExpandedGroups())
 const panelLookup = computed(() => new Map((panels.value?.panels ?? []).map((panel) => [panel.id, panel])))
 const activeRoute = computed(() => routes.find((r) => r.name === route.name))
 const activePanel = computed(() => (route.name ? panelLookup.value.get(route.name) : null))
@@ -172,6 +190,18 @@ watch(
     }
   },
   {immediate: true}
+)
+
+watch(
+  expandedGroups,
+  (groups) => {
+    try {
+      window.localStorage?.setItem(EXPANDED_GROUPS_STORAGE_KEY, JSON.stringify(groups))
+    } catch {
+      // Ignore storage write failures (e.g. private mode / quota).
+    }
+  },
+  {deep: true}
 )
 
 onMounted(loadShellData)

--- a/bootui-ui/src/main/frontend/src/utils/useCopyToClipboard.js
+++ b/bootui-ui/src/main/frontend/src/utils/useCopyToClipboard.js
@@ -1,0 +1,34 @@
+import {onBeforeUnmount, ref} from 'vue'
+
+/**
+ * Shared "copy to clipboard" behaviour used by panels that expose copy buttons.
+ *
+ * Tracks which key was most recently copied so the UI can flash a confirmation,
+ * then clears it after `resetMs`. The reset timer is cleared on unmount.
+ *
+ * @param {number} resetMs how long the copied indicator stays set
+ * @returns {{copiedKey: import('vue').Ref<string|null>, copyToClipboard: (text: string, key?: string) => Promise<void>}}
+ */
+export function useCopyToClipboard(resetMs = 1500) {
+  const copiedKey = ref(null)
+  let copiedTimer = null
+
+  async function copyToClipboard(text, key) {
+    try {
+      await navigator.clipboard.writeText(text)
+      copiedKey.value = key ?? text
+      if (copiedTimer) clearTimeout(copiedTimer)
+      copiedTimer = setTimeout(() => {
+        copiedKey.value = null
+      }, resetMs)
+    } catch (_) {
+      // Clipboard access can be denied; ignore and leave the indicator unchanged.
+    }
+  }
+
+  onBeforeUnmount(() => {
+    if (copiedTimer) clearTimeout(copiedTimer)
+  })
+
+  return {copiedKey, copyToClipboard}
+}

--- a/bootui-ui/src/main/frontend/src/utils/useCopyToClipboard.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/useCopyToClipboard.test.js
@@ -1,0 +1,47 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest'
+import {mount} from '@vue/test-utils'
+import {useCopyToClipboard} from './useCopyToClipboard'
+
+function harness() {
+  let api
+  const wrapper = mount({
+    setup() {
+      api = useCopyToClipboard(50)
+      return () => null
+    }
+  })
+  return {wrapper, api}
+}
+
+describe('useCopyToClipboard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.assign(navigator, {clipboard: {writeText: vi.fn().mockResolvedValue()}})
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('writes text and sets the copied key, then clears it', async () => {
+    const {api} = harness()
+    await api.copyToClipboard('hello', 'k1')
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello')
+    expect(api.copiedKey.value).toBe('k1')
+    vi.advanceTimersByTime(50)
+    expect(api.copiedKey.value).toBe(null)
+  })
+
+  it('falls back to the text when no key is given', async () => {
+    const {api} = harness()
+    await api.copyToClipboard('plain')
+    expect(api.copiedKey.value).toBe('plain')
+  })
+
+  it('leaves the indicator unchanged when the clipboard rejects', async () => {
+    navigator.clipboard.writeText.mockRejectedValueOnce(new Error('denied'))
+    const {api} = harness()
+    await api.copyToClipboard('nope', 'k')
+    expect(api.copiedKey.value).toBe(null)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/utils/useServerPagedList.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/useServerPagedList.test.js
@@ -1,0 +1,96 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest'
+import {mount} from '@vue/test-utils'
+import {useServerPagedList} from './useServerPagedList'
+
+function harness(...args) {
+  let api
+  const wrapper = mount({
+    setup() {
+      api = useServerPagedList(...args)
+      return () => null
+    }
+  })
+  return {wrapper, api}
+}
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+describe('useServerPagedList', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('requests offset/limit and only non-empty query params', async () => {
+    global.fetch = vi.fn().mockResolvedValue(jsonResponse({things: [{id: 1}], page: {matched: 5, total: 9}}))
+    const {api} = harness('api/things', 'things', () => ({q: 'foo', blank: '', missing: null}), {pageSize: 50})
+
+    await api.load()
+
+    const url = global.fetch.mock.calls[0][0]
+    expect(url).toContain('q=foo')
+    expect(url).not.toContain('blank')
+    expect(url).not.toContain('missing')
+    expect(url).toContain('offset=0')
+    expect(url).toContain('limit=50')
+    expect(api.items.value).toEqual([{id: 1}])
+    expect(api.matchedCount.value).toBe(5)
+    expect(api.totalCount.value).toBe(9)
+    expect(api.hiddenCount.value).toBe(4)
+  })
+
+  it('appends the next page and offsets by current item count', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({things: [{id: 1}, {id: 2}], page: {matched: 4, total: 4}}))
+      .mockResolvedValueOnce(jsonResponse({things: [{id: 3}, {id: 4}], page: {matched: 4, total: 4}}))
+    const {api} = harness('api/things', 'things', () => ({}), {pageSize: 2})
+
+    await api.load()
+    await api.loadMore()
+
+    expect(global.fetch.mock.calls[1][0]).toContain('offset=2')
+    expect(api.items.value).toEqual([{id: 1}, {id: 2}, {id: 3}, {id: 4}])
+  })
+
+  it('does not loadMore when nothing is hidden', async () => {
+    global.fetch = vi.fn().mockResolvedValue(jsonResponse({things: [{id: 1}], page: {matched: 1, total: 1}}))
+    const {api} = harness('api/things', 'things', () => ({}))
+    await api.load()
+    await api.loadMore()
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a stale response when a newer request supersedes it', async () => {
+    let resolveFirst
+    global.fetch = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockResolvedValueOnce(jsonResponse({things: [{id: 99}], page: {matched: 1, total: 1}}))
+    const {api} = harness('api/things', 'things', () => ({}))
+
+    const firstLoad = api.load()
+    // A newer scheduled reload bumps the request id while the first load is in flight.
+    api.scheduleReload()
+    await vi.advanceTimersByTimeAsync(250)
+
+    // Now the stale first request resolves; its data must be discarded.
+    resolveFirst(jsonResponse({things: [{id: 1}], page: {matched: 1, total: 1}}))
+    await firstLoad
+
+    expect(api.items.value).toEqual([{id: 99}])
+  })
+
+  it('captures an error message on a non-ok response', async () => {
+    global.fetch = vi.fn().mockResolvedValue(jsonResponse(null, false, 503))
+    const {api} = harness('api/things', 'things', () => ({}))
+    await api.load()
+    expect(api.error.value).toBe('HTTP 503')
+    expect(api.loading.value).toBe(false)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
 import {formatDuration, formatNumber, formatRelative, formatTime} from '../utils/format.js'
+import {useCopyToClipboard} from '../utils/useCopyToClipboard'
 import AiSetupChecklist from './components/AiSetupChecklist.vue'
 
 const overview = ref(null)
@@ -203,21 +204,7 @@ const filteredChats = computed(() => {
 
 const pagedChats = computed(() => filteredChats.value.slice(0, pageSize.value))
 
-const copiedKey = ref(null)
-let copiedTimer = null
-
-async function copyToClipboard(text, key) {
-  try {
-    await navigator.clipboard.writeText(text)
-    copiedKey.value = key || text
-    if (copiedTimer) clearTimeout(copiedTimer)
-    copiedTimer = setTimeout(() => {
-      copiedKey.value = null
-    }, 1500)
-  } catch (_) {
-    // ignore
-  }
-}
+const {copiedKey, copyToClipboard} = useCopyToClipboard()
 
 function durationClass(nanos) {
   if (nanos == null) return ''

--- a/bootui-ui/src/main/frontend/src/views/Beans.vue
+++ b/bootui-ui/src/main/frontend/src/views/Beans.vue
@@ -88,6 +88,9 @@ watch([filter, classification], scheduleReload)
               }}</small>
             </td>
           </tr>
+          <tr v-if="!loading && matchedCount === 0">
+            <td class="text-center text-muted py-4" colspan="5">No beans match your filters.</td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/bootui-ui/src/main/frontend/src/views/Conditions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.vue
@@ -109,6 +109,7 @@ onBeforeUnmount(() => {
         </div>
       </div>
     </div>
+    <div v-if="!loading && matchedCount === 0" class="text-muted py-3">No {{ tab }} entries match your filter.</div>
     <ServerListFooter
       v-if="!loading"
       :loading="loadingMore"

--- a/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
@@ -1,7 +1,3 @@
-<script>
-export default {name: 'HealthDetails'}
-</script>
-
 <script setup>
 defineProps({
   value: {required: false, default: null}

--- a/bootui-ui/src/main/frontend/src/views/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthNode.vue
@@ -1,7 +1,3 @@
-<script>
-export default {name: 'HealthNode'}
-</script>
-
 <script setup>
 import HealthDetails from './HealthDetails.vue'
 

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -127,6 +127,9 @@ watch(filter, scheduleReload)
               </div>
             </td>
           </tr>
+          <tr v-if="!loading && matchedCount === 0">
+            <td class="text-center text-muted py-4" colspan="4">No loggers match your filters.</td>
+          </tr>
         </tbody>
       </table>
     </div>

--- a/bootui-ui/src/main/frontend/src/views/components/AiSetupChecklist.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/AiSetupChecklist.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {ref} from 'vue'
+import {useCopyToClipboard} from '../../utils/useCopyToClipboard'
 
 defineProps({
   springAiDetected: Boolean,
@@ -7,21 +7,7 @@ defineProps({
   hasData: Boolean
 })
 
-const copiedKey = ref(null)
-let copiedTimer = null
-
-async function copyToClipboard(text, key) {
-  try {
-    await navigator.clipboard.writeText(text)
-    copiedKey.value = key
-    if (copiedTimer) clearTimeout(copiedTimer)
-    copiedTimer = setTimeout(() => {
-      copiedKey.value = null
-    }, 1500)
-  } catch (_) {
-    // ignore
-  }
-}
+const {copiedKey, copyToClipboard} = useCopyToClipboard()
 
 const otlpProps = `management.opentelemetry.tracing.export.otlp.endpoint=http://localhost:8080/bootui/api/otlp/v1/traces`
 const mavSnippet = `<dependency>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -211,6 +211,12 @@ services, and shows restart controls only for supported Testcontainers services 
 otherwise uninitialized service beans that would need to be created just for inspection and reports those skips as
 warnings in the panel.
 
+> **Masking scope:** BootUI masks discovered *connection details* (for example credentials embedded in a JDBC URL or
+> connection properties) before they reach the browser. Raw container **log output** is streamed verbatim, bounded by
+> `bootui.dev-services.log-tail-bytes`, and is **not** scanned for secrets — a service that prints credentials to its
+> own logs will surface them in this panel. This is consistent with BootUI being a local-only, loopback-restricted
+> developer console.
+
 ![BootUI Dev Services panel](images/bootui-dev-services.png)
 
 ### Copilot


### PR DESCRIPTION
## What does this PR do?

Addresses the 14 verified findings from the first full audit of BootUI, grouped into security hardening, correctness fixes, frontend polish, test coverage, and docs/CI consistency. One commit per finding.

## Why is this change needed?

This was the project's first comprehensive audit. After independently verifying every reported issue (and discarding a large set of false positives), 14 findings remained that genuinely improve safety, correctness, and maintainability. Several touch the fail-closed safety model, which is core to BootUI's local-only guarantee.

**Security hardening**
- `LocalhostOnlyFilter` no longer treats wildcard binds (`0.0.0.0`, `::`) as loopback; it now only accepts `isLoopbackAddress()`, keeping the filter fail-closed.
- HTTP Probe strips restricted/hop-by-hop forwarded headers (host, connection, content-length, transfer-encoding, etc.) and drops a dead URL guard.
- Concurrent SSE streams (Log Tail, Copilot, Claude Code) are capped to prevent unbounded emitter accumulation.
- `SecretMasker` default patterns now also catch `passphrase` and `pwd`.

**Correctness**
- OSV vulnerabilities are sorted by severity rank instead of alphabetically, so CRITICAL surfaces above HIGH.
- Removed redundant `name` blocks from the recursive Health components (filename-based inference already supports recursion).

**Frontend polish**
- Extracted a shared `useCopyToClipboard` composable (reused by AI views).
- Added consistent empty-filter states to Beans, Loggers, and Conditions, matching Configuration.
- Sidebar group expand/collapse state now persists to `localStorage`.

**Tests, docs, CI**
- New unit tests for `useServerPagedList` (offset/limit math, append paging, stale-response race, error handling) plus added Java coverage for the changes above.
- Documented Dev Services log masking scope, refreshed a stale `0.1.0-alpha.1` reference, pinned CI Node to `24.16.0` to match the pom, and documented the CodeQL skip-tests build intent.

## How was it tested?

- [x] Targeted backend suites pass (LocalhostOnlyFilter, HttpProbeController, CopilotController, OsvVulnerabilityScanner, SecretMasker)
- [x] Frontend Vitest suite passes (26 tests) and `vite build` succeeds
- [x] `spotless:check` and `prettier --check` both clean
- [ ] `./mvnw clean install` full reactor (not run end-to-end locally)
- [ ] Started `bootui-sample-app` and verified `/bootui` end-to-end

## Screenshots (UI changes)

N/A - UI changes are small (empty-state rows, sidebar persistence, internal composable refactor) with no visual redesign.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (Dev Services masking scope in `docs/FEATURES.md`)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

Note for reviewers: the `LocalhostOnlyFilter` change is the most behavior-affecting one. If a deployment was relying on wildcard binds being treated as local, it must now set `bootui.allow-non-localhost=true` explicitly, which is the intended fail-closed posture.