### PR TITLE
Lazy-load request-driven BootUI beans

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -8,8 +8,11 @@ import io.github.jdubois.bootui.autoconfigure.pentest.*;
 import io.github.jdubois.bootui.autoconfigure.safety.LocalhostOnlyFilter;
 import io.github.jdubois.bootui.autoconfigure.safety.PanelAccessFilter;
 import io.github.jdubois.bootui.autoconfigure.web.*;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -74,6 +77,51 @@ import org.springframework.core.env.Environment;
 public class BootUiAutoConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(BootUiAutoConfiguration.class);
+
+    private static final Set<String> LAZY_CONTROLLER_CLASS_NAMES = Set.of(
+            AiController.class.getName(),
+            BeansController.class.getName(),
+            BootUiIndexController.class.getName(),
+            CacheController.class.getName(),
+            ClaudeCodeController.class.getName(),
+            ConditionsController.class.getName(),
+            ConfigController.class.getName(),
+            CopilotController.class.getName(),
+            DataController.class.getName(),
+            DependenciesController.class.getName(),
+            DevToolsController.class.getName(),
+            HealthController.class.getName(),
+            HttpProbeController.class.getName(),
+            LoggersController.class.getName(),
+            MappingsController.class.getName(),
+            MemoryController.class.getName(),
+            MetricsController.class.getName(),
+            OtlpReceiverController.class.getName(),
+            OverviewController.class.getName(),
+            PanelsController.class.getName(),
+            PentestController.class.getName(),
+            ProfileController.class.getName(),
+            ScheduledController.class.getName(),
+            SecurityController.class.getName(),
+            StartupController.class.getName(),
+            TracesController.class.getName());
+
+    private static final Set<String> LAZY_BEAN_NAMES =
+            Set.of("bootUiConfigOverrideService", "bootUiDevToolsBridge", "bootUiOtlpSpanDecoder");
+
+    @Bean
+    static BeanFactoryPostProcessor bootUiLazyBeanPostProcessor() {
+        return beanFactory -> {
+            for (String beanName : beanFactory.getBeanDefinitionNames()) {
+                BeanDefinition beanDefinition = beanFactory.getBeanDefinition(beanName);
+                String beanClassName = beanDefinition.getBeanClassName();
+                if (LAZY_BEAN_NAMES.contains(beanName)
+                        || (beanClassName != null && LAZY_CONTROLLER_CLASS_NAMES.contains(beanClassName))) {
+                    beanDefinition.setLazyInit(true);
+                }
+            }
+        };
+    }
 
     @Bean
     public BootUiActivation bootUiActivation(Environment environment) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -9,11 +9,16 @@ import io.github.jdubois.bootui.autoconfigure.safety.LocalhostOnlyFilter;
 import io.github.jdubois.bootui.autoconfigure.safety.PanelAccessFilter;
 import io.github.jdubois.bootui.autoconfigure.web.*;
 import java.nio.file.Path;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
+import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 class BootUiAutoConfigurationTests {
 
@@ -145,6 +150,73 @@ class BootUiAutoConfigurationTests {
     }
 
     @Test
+    void requestDrivenBootUiBeansAreLazyWhileInfrastructureStaysEager() {
+        runner.withPropertyValues("bootui.enabled=ON").run(context -> {
+            ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+
+            List.of(
+                            AiController.class,
+                            BeansController.class,
+                            BootUiIndexController.class,
+                            CacheController.class,
+                            ClaudeCodeController.class,
+                            ConditionsController.class,
+                            ConfigController.class,
+                            CopilotController.class,
+                            DataController.class,
+                            DependenciesController.class,
+                            DevToolsController.class,
+                            HealthController.class,
+                            HttpProbeController.class,
+                            LoggersController.class,
+                            MappingsController.class,
+                            MemoryController.class,
+                            MetricsController.class,
+                            OtlpReceiverController.class,
+                            OverviewController.class,
+                            PanelsController.class,
+                            PentestController.class,
+                            ProfileController.class,
+                            ScheduledController.class,
+                            SecurityController.class,
+                            StartupController.class,
+                            TracesController.class)
+                    .forEach(beanType -> assertLazyBean(beanFactory, beanType));
+
+            assertLazyBeanDefinition(beanFactory, "bootUiConfigOverrideService");
+            assertLazyBeanDefinition(beanFactory, "bootUiDevToolsBridge");
+            assertLazyBeanDefinition(beanFactory, "bootUiOtlpSpanDecoder");
+
+            assertEagerBean(beanFactory, BootUiActivation.class);
+            assertEagerBean(beanFactory, DevServicesController.class);
+            assertEagerBean(beanFactory, LocalhostOnlyFilter.class);
+            assertEagerBean(beanFactory, LogTailController.class);
+            assertEagerBean(beanFactory, PanelAccessFilter.class);
+        });
+    }
+
+    @Test
+    void lazyControllersKeepTheirRequestMappingsRegistered() {
+        new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        DispatcherServletAutoConfiguration.class,
+                        WebMvcAutoConfiguration.class,
+                        BootUiAutoConfiguration.class))
+                .withPropertyValues("bootui.enabled=ON")
+                .run(context -> {
+                    ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+                    String overviewBeanName = singleBeanName(beanFactory, OverviewController.class);
+
+                    RequestMappingHandlerMapping handlerMapping = context.getBean(RequestMappingHandlerMapping.class);
+
+                    assertThat(handlerMapping.getHandlerMethods().keySet())
+                            .anySatisfy(mappingInfo ->
+                                    assertThat(mappingInfo.getPatternValues()).contains("/bootui/api/overview"));
+                    assertThat(beanFactory.containsSingleton(overviewBeanName)).isFalse();
+                });
+    }
+
+    @Test
     void copilotAndClaudeCodeSessionStoresAreLazy(@TempDir Path tempDir) {
         runner.withPropertyValues(
                         "bootui.enabled=ON",
@@ -235,5 +307,28 @@ class BootUiAutoConfigurationTests {
         runner.withPropertyValues("bootui.enabled=ON")
                 .withClassLoader(new FilteredClassLoader("org.springframework.security.web.FilterChainProxy"))
                 .run(context -> assertThat(context).doesNotHaveBean(SecurityController.class));
+    }
+
+    private static void assertLazyBean(ConfigurableListableBeanFactory beanFactory, Class<?> beanType) {
+        String beanName = singleBeanName(beanFactory, beanType);
+        assertLazyBeanDefinition(beanFactory, beanName);
+        assertThat(beanFactory.containsSingleton(beanName)).isFalse();
+    }
+
+    private static void assertEagerBean(ConfigurableListableBeanFactory beanFactory, Class<?> beanType) {
+        String beanName = singleBeanName(beanFactory, beanType);
+        assertThat(beanFactory.getBeanDefinition(beanName).isLazyInit()).isFalse();
+        assertThat(beanFactory.containsSingleton(beanName)).isTrue();
+    }
+
+    private static void assertLazyBeanDefinition(ConfigurableListableBeanFactory beanFactory, String beanName) {
+        assertThat(beanFactory.getBeanDefinition(beanName).isLazyInit()).isTrue();
+        assertThat(beanFactory.containsSingleton(beanName)).isFalse();
+    }
+
+    private static String singleBeanName(ConfigurableListableBeanFactory beanFactory, Class<?> beanType) {
+        String[] beanNames = beanFactory.getBeanNamesForType(beanType, false, false);
+        assertThat(beanNames).hasSize(1);
+        return beanNames[0];
     }
 }


### PR DESCRIPTION
## What does this PR do?

Selectively lazy-loads request-driven BootUI starter beans from auto-configuration, including panel controllers and request-only helper beans, while keeping safety and startup-sensitive infrastructure eager.

## Why is this change needed?

Installing the BootUI starter should have minimal startup-time and memory impact until a local developer actually opens a BootUI panel. This centralizes the lazy-loading policy in auto-configuration instead of annotating every controller, and deliberately keeps fail-closed filters, activation, telemetry capture, Log Tail, and Dev Services startup snapshot behavior eager.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional validation:

- [x] `./mvnw -B -ntp -pl bootui-autoconfigure -am spotless:apply test`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: no public documentation change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed