### PR TITLE
Prepare 0.2.0 release documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-30
+
+Second BootUI release, focused on local security diagnostics, safer defaults around host-application security, and
+release/documentation hardening for the full visible panel surface.
+
+### Added
+
+- Pentesting panel with explicit, local-only OWASP-aligned hygiene checks for security headers, CORS behavior, cookie
+  flags, verbose errors, Spring Security wiring, actuator exposure, DevTools, H2 console, and risky configuration values.
+- BootUI Spring Security integration that keeps `/bootui/**` and `/bootui/api/**` reachable in local applications using
+  Spring Security while preserving the localhost-only safety filter.
+- Automatic local application trace capture so Traces and AI Usage can populate from the host app without requiring a
+  separate local OTLP exporter setup.
+- CI test report publishing for Maven/JUnit and Playwright runs.
+
+### Changed
+
+- Monitoring panels now hide BootUI's own beans, mappings, loggers, metrics, traces, and related runtime data by default
+  through `bootui.monitoring.exclude-self=true`.
+- Request-driven BootUI controllers and agent session stores are lazy-loaded, and agent session parsing is bounded to
+  avoid unnecessary startup work.
+- Vulnerability findings are sorted by severity/importance first, with stable ordering inside each severity group.
+- Startup Timeline configuration, panel read-only controls, application property reference docs, pentest catalogue docs,
+  feature docs, screenshots, and E2E documentation were reconciled with the implemented `0.2.0` behavior.
+
+### Fixed
+
+- Fixed sample-app and BootUI security audit findings, including enabling CSRF protection in the sample app.
+- Fixed hidden-BootUI-internals assumptions in Beans E2E coverage after self-data filtering became the default.
+- Removed duplicated panel headings and restored Overview/Metrics heading behavior.
+- Added registry-level coverage so global read-only mode is checked for every action-capable panel.
+
 ## [0.1.0] - 2026-05-29
 
 First final BootUI release. This promotes the alpha line to the final `0.1.x` coordinate while keeping the local-only,
@@ -132,7 +164,9 @@ First tagged BootUI alpha. Highlights of the harden-all-visible-panels scope:
   request history, distributed tracing, multi-service orchestration, and live
   Docker Compose lifecycle control are intentionally out of scope for the alpha.
 
-[Unreleased]: https://github.com/jdubois/boot-ui/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/jdubois/boot-ui/compare/v0.2.0...HEAD
+
+[0.2.0]: https://github.com/jdubois/boot-ui/compare/v0.1.0...v0.2.0
 
 [0.1.0]: https://github.com/jdubois/boot-ui/compare/v0.1.0-alpha.5...v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Common properties:
 | `bootui.expose-values`                 | `MASKED`                                | `MASKED`, `METADATA_ONLY`, or `FULL`; `FULL` can disclose secrets and should stay local. |
 | `bootui.read-only`                     | `false`                                 | Disable all browser-triggered actions while keeping read-only panel data visible.         |
 | `bootui.overrides-file`                | `.bootui/application-bootui.properties` | Runtime override persistence file.                                                       |
+| `bootui.startup.enabled`               | `true`                                  | Auto-install startup buffering for the Startup Timeline panel while BootUI is active.     |
+| `bootui.startup.capacity`              | `4096`                                  | Maximum startup steps retained by BootUI's auto-installed startup buffer.                 |
 | `bootui.cache.clear-enabled`           | `true`                                  | Enables Spring Cache clear actions after explicit browser confirmation.                  |
 | `bootui.dev-services.restart-enabled`  | `false`                                 | Enables restart controls for bean-backed Testcontainers services. Disabled by default.   |
 | `bootui.dev-services.log-tail-bytes`   | `65536`                                 | Maximum bytes returned by one Dev Services log request.                                  |
@@ -149,7 +151,7 @@ app restarts; BootUI returns that warning with every override mutation.
 | Browser is rejected          | BootUI accepts loopback callers by default. Use `bootui.allow-non-localhost=true` only for a trusted local network.             |
 | Spring Security blocks UI    | BootUI auto-registers a `/bootui/**` permit-all chain when Spring Security is active; check for a custom higher-priority chain. |
 | A panel is empty             | Enable the relevant Actuator endpoint or optional Spring module; BootUI degrades to stable empty DTOs when data is unavailable. |
-| Startup Timeline is empty    | Configure `BufferingApplicationStartup` in the host app.                                                                        |
+| Startup Timeline is empty    | Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero, or provide your own `BufferingApplicationStartup`. |
 | Secrets are hidden           | Default exposure is `MASKED`; use `METADATA_ONLY` to hide all values or `FULL` only in trusted local sessions.                  |
 
 ## Repository modules

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentest/PentestChecks.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentest/PentestChecks.java
@@ -1374,7 +1374,7 @@ final class HeapdumpEndpointExposedCheck extends AbstractActuatorEndpointCheck {
         super(
                 new PentestDefinition(
                         "PT-A05-032",
-                        "Actuator heapdump endpoint is exposed",
+                        "Actuator /heapdump endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "HIGH",
                         "High",
@@ -1396,7 +1396,7 @@ final class HttpExchangesEndpointExposedCheck extends AbstractActuatorEndpointCh
         super(
                 new PentestDefinition(
                         "PT-A05-033",
-                        "Actuator httpexchanges/httptrace endpoint is exposed",
+                        "Actuator /httpexchanges (or /httptrace) endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "HIGH",
                         "High",
@@ -1419,7 +1419,7 @@ final class SessionsEndpointExposedCheck extends AbstractActuatorEndpointCheck {
         super(
                 new PentestDefinition(
                         "PT-A05-034",
-                        "Actuator sessions endpoint is exposed",
+                        "Actuator /sessions endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "HIGH",
                         "High",
@@ -1441,7 +1441,7 @@ final class LoggersEndpointExposedCheck extends AbstractActuatorEndpointCheck {
         super(
                 new PentestDefinition(
                         "PT-A05-035",
-                        "Actuator loggers endpoint is exposed",
+                        "Actuator /loggers endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "MEDIUM",
                         "Medium",
@@ -1463,7 +1463,7 @@ final class ThreaddumpEndpointExposedCheck extends AbstractActuatorEndpointCheck
         super(
                 new PentestDefinition(
                         "PT-A05-036",
-                        "Actuator threaddump endpoint is exposed",
+                        "Actuator /threaddump endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "MEDIUM",
                         "Medium",
@@ -1485,7 +1485,7 @@ final class GatewayRoutesEndpointExposedCheck extends AbstractActuatorEndpointCh
         super(
                 new PentestDefinition(
                         "PT-A05-037",
-                        "Actuator gateway/routes endpoint is exposed",
+                        "Actuator /gateway/routes endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "MEDIUM",
                         "Medium",
@@ -1507,7 +1507,7 @@ final class LogfileEndpointExposedCheck extends AbstractActuatorEndpointCheck {
         super(
                 new PentestDefinition(
                         "PT-A05-038",
-                        "Actuator logfile endpoint is exposed",
+                        "Actuator /logfile endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "MEDIUM",
                         "Medium",
@@ -1529,7 +1529,7 @@ final class CachesEndpointExposedCheck extends AbstractActuatorEndpointCheck {
         super(
                 new PentestDefinition(
                         "PT-A05-039",
-                        "Actuator caches endpoint is exposed",
+                        "Actuator /caches endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "LOW",
                         "Low",
@@ -1551,7 +1551,7 @@ final class PrometheusEndpointExposedCheck extends AbstractActuatorEndpointCheck
         super(
                 new PentestDefinition(
                         "PT-A05-040",
-                        "Actuator prometheus endpoint is exposed",
+                        "Actuator /prometheus endpoint is exposed",
                         "A05:2021 Security Misconfiguration",
                         "INFO",
                         "Low",

--- a/bootui-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/bootui-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "bootui.startup.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Install a BufferingApplicationStartup automatically while BootUI is active so the Startup Timeline panel has data.",
+      "defaultValue": true
+    },
+    {
+      "name": "bootui.startup.capacity",
+      "type": "java.lang.Integer",
+      "description": "Maximum startup steps retained by BootUI's auto-installed startup buffer. Values less than or equal to zero disable the buffer.",
+      "defaultValue": 4096
+    }
+  ]
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilterTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilterTests.java
@@ -3,6 +3,9 @@ package io.github.jdubois.bootui.autoconfigure.safety;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.panel.BootUiPanels;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockFilterChain;
@@ -86,25 +89,51 @@ class PanelAccessFilterTests {
     @Test
     void globalReadOnlyBlocksActionCapablePanelActions() throws Exception {
         properties.setReadOnly(true);
-        MockHttpServletRequest request = request("DELETE", "/bootui/api/traces");
-        MockHttpServletResponse response = new MockHttpServletResponse();
+        Map<String, ActionRequest> actionRequestsByPanel = actionRequestsByPanel();
 
-        filter.doFilter(request, response, new MockFilterChain());
+        assertThat(actionRequestsByPanel.keySet())
+                .containsExactlyElementsOf(BootUiPanels.all().stream()
+                        .filter(BootUiPanels.Panel::readOnlyCapable)
+                        .map(BootUiPanels.Panel::id)
+                        .toList());
+        for (Map.Entry<String, ActionRequest> entry : actionRequestsByPanel.entrySet()) {
+            MockHttpServletRequest request =
+                    request(entry.getValue().method(), entry.getValue().uri());
+            MockHttpServletResponse response = new MockHttpServletResponse();
 
-        assertThat(response.getStatus()).isEqualTo(403);
-        assertThat(response.getContentAsString()).contains("bootui.read-only=true");
+            filter.doFilter(request, response, new MockFilterChain());
+
+            assertThat(response.getStatus()).as(entry.getKey()).isEqualTo(403);
+            assertThat(response.getContentAsString())
+                    .as(entry.getKey())
+                    .contains("\"panel\":\"" + entry.getKey() + "\"")
+                    .contains("bootui.read-only=true");
+        }
     }
 
     @Test
-    void globalReadOnlyBlocksPentestScanAction() throws Exception {
-        properties.setReadOnly(true);
+    void perPanelReadOnlyBlocksPentestScanAction() throws Exception {
+        properties.panel("pentest").setReadOnly(true);
         MockHttpServletRequest request = request("POST", "/bootui/api/pentest/scan");
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         filter.doFilter(request, response, new MockFilterChain());
 
         assertThat(response.getStatus()).isEqualTo(403);
-        assertThat(response.getContentAsString()).contains("\"panel\":\"pentest\"");
+        assertThat(response.getContentAsString())
+                .contains("\"panel\":\"pentest\"")
+                .contains("bootui.panels.pentest.read-only=true");
+    }
+
+    @Test
+    void perPanelReadOnlyAllowsPentestReportRead() throws Exception {
+        properties.panel("pentest").setReadOnly(true);
+        MockHttpServletRequest request = request("GET", "/bootui/api/pentest");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(200);
     }
 
     @Test
@@ -159,4 +188,20 @@ class PanelAccessFilterTests {
         request.setRequestURI(uri);
         return request;
     }
+
+    private Map<String, ActionRequest> actionRequestsByPanel() {
+        Map<String, ActionRequest> requests = new LinkedHashMap<>();
+        requests.put("config", new ActionRequest("POST", "/bootui/api/config/overrides"));
+        requests.put("loggers", new ActionRequest("POST", "/bootui/api/loggers/io.github.jdubois.bootui"));
+        requests.put("cache", new ActionRequest("POST", "/bootui/api/cache/clear"));
+        requests.put("traces", new ActionRequest("DELETE", "/bootui/api/traces"));
+        requests.put("http-probe", new ActionRequest("POST", "/bootui/api/probe"));
+        requests.put("pentest", new ActionRequest("POST", "/bootui/api/pentest/scan"));
+        requests.put("vulnerabilities", new ActionRequest("POST", "/bootui/api/dependencies/scan"));
+        requests.put("devtools", new ActionRequest("POST", "/bootui/api/devtools/restart"));
+        requests.put("dev-services", new ActionRequest("POST", "/bootui/api/dev-services/services/demo/restart"));
+        return requests;
+    }
+
+    private record ActionRequest(String method, String uri) {}
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
@@ -1,11 +1,15 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.panel.BootUiPanels;
+import io.github.jdubois.bootui.core.BootUiDtos.PanelDto;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.web.servlet.MockMvc;
@@ -131,6 +135,7 @@ class PanelsControllerTests {
             BootUiProperties properties = new BootUiProperties();
             properties.panel("config").setEnabled(false);
             properties.panel("loggers").setReadOnly(true);
+            properties.panel("pentest").setReadOnly(true);
             MockMvc mvc = standaloneSetup(new PanelsController(context, context.getEnvironment(), properties))
                     .build();
 
@@ -144,27 +149,36 @@ class PanelsControllerTests {
                     .andExpect(jsonPath("$.panels[8].enabled").value(true))
                     .andExpect(jsonPath("$.panels[8].readOnly").value(true))
                     .andExpect(jsonPath("$.panels[8].readOnlyReason")
-                            .value("Panel is read-only via bootui.panels.loggers.read-only=true"));
+                            .value("Panel is read-only via bootui.panels.loggers.read-only=true"))
+                    .andExpect(jsonPath("$.panels[19].id").value("pentest"))
+                    .andExpect(jsonPath("$.panels[19].enabled").value(true))
+                    .andExpect(jsonPath("$.panels[19].readOnly").value(true))
+                    .andExpect(jsonPath("$.panels[19].readOnlyReason")
+                            .value("Panel is read-only via bootui.panels.pentest.read-only=true"));
         }
     }
 
     @Test
-    void panelsApplyGlobalReadOnlyOnlyToActionCapablePanels() throws Exception {
+    void panelsApplyGlobalReadOnlyToEveryActionCapablePanel() {
         try (GenericApplicationContext context = new GenericApplicationContext()) {
             context.refresh();
             BootUiProperties properties = new BootUiProperties();
             properties.setReadOnly(true);
-            MockMvc mvc = standaloneSetup(new PanelsController(context, context.getEnvironment(), properties))
-                    .build();
+            PanelsController controller = new PanelsController(context, context.getEnvironment(), properties);
 
-            mvc.perform(get("/bootui/api/panels"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.panels[0].id").value("overview"))
-                    .andExpect(jsonPath("$.panels[0].readOnly").value(false))
-                    .andExpect(jsonPath("$.panels[6].id").value("config"))
-                    .andExpect(jsonPath("$.panels[6].readOnly").value(true))
-                    .andExpect(jsonPath("$.panels[6].readOnlyReason")
-                            .value("BootUI is read-only via bootui.read-only=true"));
+            List<String> expectedReadOnlyPanelIds = BootUiPanels.all().stream()
+                    .filter(BootUiPanels.Panel::readOnlyCapable)
+                    .map(BootUiPanels.Panel::id)
+                    .toList();
+            List<PanelDto> panels = controller.panels().panels();
+            List<String> actualReadOnlyPanelIds =
+                    panels.stream().filter(PanelDto::readOnly).map(PanelDto::id).toList();
+
+            assertThat(actualReadOnlyPanelIds).containsExactlyElementsOf(expectedReadOnlyPanelIds);
+            assertThat(panels)
+                    .filteredOn(PanelDto::readOnly)
+                    .extracting(PanelDto::readOnlyReason)
+                    .containsOnly("BootUI is read-only via bootui.read-only=true");
         }
     }
 }

--- a/bootui-sample-app/e2e/README.md
+++ b/bootui-sample-app/e2e/README.md
@@ -10,29 +10,36 @@ console against a running Spring Boot application.
 Each Playwright spec file targets one of the BootUI views (or a cross-cutting
 flow) exposed by the sample app:
 
-| Spec                   | Verifies                                                                                                              |
-| ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `app-shell.spec.js`    | Top navbar, sidebar links, deep-linking, navigation between every section                                             |
-| `overview.spec.js`     | Application / Runtime / Activation cards, refresh button                                                              |
-| `beans.spec.js`        | Bean list rendering, name filter, classification filter                                                               |
-| `conditions.spec.js`   | Positive / negative auto-config tabs, filtering                                                                       |
-| `config.spec.js`       | Property search, add an override (`sample.greeting`), confirm + delete it                                             |
-| `mappings.spec.js`     | HTTP mappings include the sample app routes, filter narrows the list                                                  |
-| `health.spec.js`       | Health tree renders with an overall status badge                                                                      |
-| `loggers.spec.js`      | Logger search, change `io.github.jdubois.bootui.sample` to `WARN`, reset                                              |
-| `data.spec.js`         | `ProductRepository` is listed, detail panel shows `searchByName`                                                      |
-| `startup.spec.js`      | Startup timeline displays step rows                                                                                   |
-| `scheduled.spec.js`    | Scheduled tasks view lists the sample echo scheduler                                                                  |
-| `http-probe.spec.js`   | Probe `/api/hello` and assert the response body is shown                                                              |
-| `log-tail.spec.js`     | Log Tail connects, streams new events, pause / resume / clear controls work                                           |
-| `profile-diff.spec.js` | Profile sources & properties render with filtering                                                                    |
-| `security.spec.js`     | Filter chains list `/api/secure`, explain endpoint returns a match                                                    |
-| `memory.spec.js`       | Heap / non-heap cards render, JVM options copy button                                                                 |
-| `metrics.spec.js`      | Micrometer meter browser, live graph, measurements, and type filtering                                                |
-| `devtools.spec.js`     | DevTools LiveReload / restart status cards and guarded action feedback                                                |
-| `dev-services.spec.js` | Dev Services snapshot, filtering, details, log viewing, and disabled restart controls                                 |
-| `read-only.spec.js`    | Global and per-panel read-only properties block unsafe APIs and lock mutating browser controls                        |
-| `sample-api.spec.js`   | Sample REST API (`/api/hello`, `/api/secure`, `/api/sample/hello`, `/api/sample/products`) and basic-auth on `/admin` |
+| Spec                    | Verifies                                                                                                              |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `app-shell.spec.js`     | Top navbar, sidebar links, deep-linking, navigation between every section                                             |
+| `overview.spec.js`      | Application / Runtime / Activation cards, refresh button                                                              |
+| `health.spec.js`        | Health tree renders with an overall status badge                                                                      |
+| `metrics.spec.js`       | Micrometer meter browser, live graph, measurements, and type filtering                                                |
+| `memory.spec.js`        | Heap / non-heap cards render, JVM options copy button                                                                 |
+| `startup.spec.js`       | Startup timeline displays step rows                                                                                   |
+| `config.spec.js`        | Property search, add an override (`sample.greeting`), confirm + delete it                                             |
+| `profile-diff.spec.js`  | Profile sources & properties render with filtering                                                                    |
+| `loggers.spec.js`       | Logger search, change `io.github.jdubois.bootui.sample` to `WARN`, reset                                              |
+| `beans.spec.js`         | Bean list rendering, name filter, classification filter                                                               |
+| `conditions.spec.js`    | Positive / negative auto-config tabs, filtering                                                                       |
+| `mappings.spec.js`      | HTTP mappings include the sample app routes, filter narrows the list                                                  |
+| `scheduled.spec.js`     | Scheduled tasks view lists the sample echo scheduler                                                                  |
+| `data.spec.js`          | `ProductRepository` is listed, detail panel shows `searchByName`                                                      |
+| `cache.spec.js`         | Cache managers, cache details, annotations, metrics, and guarded clear actions                                        |
+| `security.spec.js`      | Filter chains list `/api/secure`, explain endpoint returns a match                                                    |
+| `ai.spec.js`            | AI Usage summaries, token charts, content-capture guidance, and disabled states                                       |
+| `traces.spec.js`        | Local trace list, waterfall details, OTLP ingest behavior, and clear action                                           |
+| `log-tail.spec.js`      | Log Tail connects, streams new events, pause / resume / clear controls work                                           |
+| `http-probe.spec.js`    | Probe `/api/hello` and assert the response body is shown                                                              |
+| `pentesting.spec.js`    | OWASP hygiene report rendering, check details, and explicit scan controls                                             |
+| `dependencies.spec.js`  | Vulnerability inventory, severity ordering, OSV scan states, and read-only behavior                                   |
+| `devtools.spec.js`      | DevTools LiveReload / restart status cards and guarded action feedback                                                |
+| `dev-services.spec.js`  | Dev Services snapshot, filtering, details, log viewing, and disabled restart controls                                 |
+| `copilot.spec.js`       | Copilot dashboard, session explorer, sanitized events, raw reveal gating, and live refresh                            |
+| `claude-code.spec.js`   | Claude Code dashboard, project-log parsing, sanitized events, raw reveal gating, and polling refresh                  |
+| `read-only.spec.js`     | Global and per-panel read-only properties block unsafe APIs and lock mutating browser controls                        |
+| `sample-api.spec.js`    | Sample REST API (`/api/hello`, `/api/secure`, `/api/sample/hello`, `/api/sample/products`) and basic-auth on `/admin` |
 
 ## Prerequisites
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -49,8 +49,10 @@ needs tuning.
 ### Startup Timeline
 
 The Startup Timeline panel visualizes Spring Boot startup steps from Actuator startup data. It helps identify expensive
-startup phases, slow bean initialization, and the overall application startup shape. If the host app does not expose
-startup data, the panel shows an empty state instead of failing.
+startup phases, slow bean initialization, and the overall application startup shape. When BootUI is active, the starter
+installs a `BufferingApplicationStartup` by default so the panel has data without host-app setup; disable that with
+`bootui.startup.enabled=false` or tune the retained step count with `bootui.startup.capacity`. If startup data is still
+unavailable, the panel shows an empty state instead of failing.
 
 ![BootUI Startup Timeline panel](images/bootui-startup-timeline.png)
 
@@ -198,7 +200,7 @@ duration, and body. It is designed for quick route checks from inside the same l
 
 The Pentesting panel runs explicit, local-only OWASP hygiene checks against the host application, not BootUI's
 `/bootui` routes. It combines passive Spring metadata with bounded synthetic localhost requests under the application
-root context for security headers, CORS behavior, cookie flags, verbose error exposure, Spring Security wiring, and
+context path for security headers, CORS behavior, cookie flags, verbose error exposure, Spring Security wiring, and
 actuator exposure. It also inspects Spring Boot configuration for common hardening gaps such as an enabled H2 console,
 in-config security credentials, value-revealing actuator endpoints, and DevTools left on the classpath. It intentionally
 does not sweep discovered application endpoints, send SQL/XSS/destructive payloads, or store raw response bodies.

--- a/docs/PENTEST-CHECKS.md
+++ b/docs/PENTEST-CHECKS.md
@@ -12,16 +12,16 @@ entry, never adding ad-hoc HTTP traffic.
 
 ## What BootUI does
 
-The scanner combines two passive evidence sources:
+The scanner combines two bounded evidence sources:
 
 - **Spring metadata** — `Environment` properties, classpath presence, Spring Security beans, the Spring MVC mapping
   inventory, and (for one check) reflection over registered `SecurityFilterChain` beans. No application property that
   BootUI itself injects (e.g. its actuator defaults) is ever read by a check.
-- **Synthetic HTTP requests** — **exactly two** localhost requests per scan against the host application context root
-  (never `/bootui`): one `GET` and one `OPTIONS`. Both are sent with deliberately suspicious headers
-  (`Origin: https://evil.example`, `Access-Control-Request-Method: PUT`, `Access-Control-Request-Headers: x-test`,
-  `Referer: https://evil.example/attacker`) so the application's own response headers reveal CORS, security-header,
-  and cookie posture. Bodies are inspected only for verbose-error markers and never persisted.
+- **Synthetic HTTP requests** — **exactly two** localhost requests per scan against
+  `/<context-path>/__bootui_pentest__/missing-resource` in the host application (never `/bootui`): one `GET` with
+  `Accept: text/html`, and one `OPTIONS` preflight with `Origin: https://evil.example` and
+  `Access-Control-Request-Method: GET`. The application's own response headers reveal CORS, security-header, and cookie
+  posture. Bodies are inspected only for verbose-error markers and never persisted.
 
 Findings are **heuristic review prompts**, not proof of exploitability. The panel is a developer hygiene tool, not a
 replacement for a real penetration test or DAST suite.
@@ -396,9 +396,9 @@ underlying signal indicates the finding.
 - **Fires when**: any of those four logger levels is set to `DEBUG` or `TRACE`. Verbose framework logging can leak
   request bodies, headers, and authentication detail.
 
-### PT-A05-041 — Developer console or API documentation endpoint is exposed
+### PT-A05-041 — API documentation or developer console is exposed
 
-- **Severity / confidence**: INFO / Low
+- **Severity / confidence**: INFO / Medium
 - **Source**: Spring metadata (Spring MVC mappings)
 - **Fires when**: a mapping prefix matches a well-known developer surface: `/v3/api-docs`, `/v2/api-docs`,
   `/swagger-ui`, `/graphiql`, `/graphql`, or `/h2-console`. These are typically helpful locally but should not ship to
@@ -406,9 +406,9 @@ underlying signal indicates the finding.
 - **Recommendation**: gate them behind a Spring profile (`dev`, `local`) or Spring Security rules; H2 console in
   particular should never be reachable from outside the JVM.
 
-### PT-A05-042 — Spring Security uses the permissive DefaultHttpFirewall
+### PT-A05-042 — Spring Security HttpFirewall is the permissive DefaultHttpFirewall
 
-- **Severity / confidence**: MEDIUM / Medium
+- **Severity / confidence**: MEDIUM / High
 - **Source**: Spring metadata (reflection over the registered `HttpFirewall` bean)
 - **Fires when**: the resolved bean type is `DefaultHttpFirewall`. The Spring Security default is `StrictHttpFirewall`,
   which rejects URL-encoded path traversal, semicolons, and other request-smuggling vectors. Switching to
@@ -416,7 +416,7 @@ underlying signal indicates the finding.
 - **Recommendation**: remove the `DefaultHttpFirewall` override and rely on `StrictHttpFirewall`. If a specific request
   shape must be allowed, customise `StrictHttpFirewall` instead of replacing it.
 
-### PT-A05-043 — Management server bound to a public address
+### PT-A05-043 — Management server bound to 0.0.0.0
 
 - **Severity / confidence**: MEDIUM / Medium
 - **Source**: Spring metadata (`management.server.port`, `management.server.address`)
@@ -426,9 +426,9 @@ underlying signal indicates the finding.
 - **Recommendation**: bind the management port to `127.0.0.1`/`::1`, a private interface, or a dedicated network
   segment. Combine with authentication on every sensitive actuator.
 
-### PT-A05-044 — server.forward-headers-strategy trusts proxy headers unconditionally
+### PT-A05-044 — server.forward-headers-strategy trusts X-Forwarded-* from any client
 
-- **Severity / confidence**: LOW / Medium
+- **Severity / confidence**: LOW / Low
 - **Source**: Spring metadata (`server.forward-headers-strategy`)
 - **Fires when**: set to `framework` or `native`. Forwarded headers (`X-Forwarded-For`, `X-Forwarded-Host`,
   `X-Forwarded-Proto`) are trusted from any source, which can be spoofed when the application is reachable directly
@@ -436,7 +436,7 @@ underlying signal indicates the finding.
 - **Recommendation**: only enable forwarded-headers handling when traffic actually flows through a trusted proxy that
   strips client-supplied headers, and confirm the proxy is the only ingress.
 
-### PT-A05-045 — server.error.include-path leaks request URIs in error responses
+### PT-A05-045 — server.error.include-path exposes request paths in error responses
 
 - **Severity / confidence**: INFO / Low
 - **Source**: Spring metadata (`server.error.include-path`)
@@ -474,7 +474,7 @@ underlying signal indicates the finding.
 - **Fires when**: the comma-separated list includes `URL`. URL session tracking leaks session identifiers in links,
   logs, and `Referer` headers.
 
-### PT-A07-005 — Auto-generated Spring Security default user is active
+### PT-A07-005 — Spring Boot auto-generated security password is in use
 
 - **Severity / confidence**: MEDIUM / Medium
 - **Source**: Spring metadata (Spring Security bean inventory + `spring.security.user.password` presence)

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -26,6 +26,8 @@ Panel settings are consistent across the UI and API:
 | `bootui.mask-secrets` | `true` | Enables secret-like value masking helpers. |
 | `bootui.expose-values` | `MASKED` | Configuration value exposure mode: `MASKED`, `METADATA_ONLY`, or `FULL`. `FULL` can disclose secrets. |
 | `bootui.show-banner` | `true` | Print the BootUI URL on application startup. |
+| `bootui.startup.enabled` | `true` | Install a `BufferingApplicationStartup` automatically while BootUI is active so the Startup Timeline panel has data. |
+| `bootui.startup.capacity` | `4096` | Maximum startup steps retained by BootUI's auto-installed startup buffer. Values less than or equal to zero disable the buffer. |
 | `bootui.read-only` | `false` | Disable every browser-triggered action while keeping read-only panel data visible. |
 | `bootui.overrides-file` | `.bootui/application-bootui.properties` | File used by the Configuration panel to persist local runtime overrides. |
 | `bootui.monitoring.exclude-self` | `true` | Hide BootUI's own beans, mappings, loggers, metrics, traces, and related runtime data from monitoring panels. |
@@ -61,6 +63,14 @@ Panel settings are consistent across the UI and API:
 | Developer tools | Claude Code | `claude-code` | `bootui.panels.claude-code.enabled` | Not applicable; view-only. |
 
 ## Per-panel action details
+
+### Startup Timeline
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `bootui.panels.startup.enabled` | `true` | Show the Startup Timeline panel. |
+| `bootui.startup.enabled` | `true` | Install a `BufferingApplicationStartup` automatically while BootUI is active. |
+| `bootui.startup.capacity` | `4096` | Maximum startup steps retained by the auto-installed startup buffer. |
 
 ### Configuration
 
@@ -176,11 +186,15 @@ bootui.dev-services.restart-enabled=true
 | `bootui.ai.show-content-capture-banner` | `true` | Show the AI content-capture explanation banner. |
 | `bootui.copilot.enabled` | `AUTO` | Enable the Copilot panel. `AUTO` activates when the session-state directory exists. |
 | `bootui.copilot.session-state-dir` | `~/.copilot/session-state` | Directory scanned for Copilot CLI sessions. |
+| `bootui.copilot.max-events-per-session` | `2000` | Maximum Copilot events retained per parsed session. |
 | `bootui.copilot.max-sessions` | `100` | Maximum recent Copilot sessions returned by the explorer. |
 | `bootui.copilot.max-parsed-sessions` | `100` | Maximum recent Copilot session files parsed and retained in memory. |
+| `bootui.copilot.stream-debounce` | `400ms` | Debounce window before refreshing parsed Copilot sessions and notifying stream subscribers. |
 | `bootui.copilot.allow-raw-reveal` | `true` | Allow explicit raw event reveal when value exposure is not `METADATA_ONLY`. |
 | `bootui.claude-code.enabled` | `AUTO` | Enable the Claude Code panel. `AUTO` activates when the project log directory exists. |
 | `bootui.claude-code.session-state-dir` | `~/.claude/projects` | Directory scanned for Claude Code project JSONL logs. |
+| `bootui.claude-code.max-events-per-session` | `2000` | Maximum Claude Code events retained per parsed session. |
 | `bootui.claude-code.max-sessions` | `100` | Maximum recent Claude Code sessions returned by the explorer. |
 | `bootui.claude-code.max-parsed-sessions` | `100` | Maximum recent Claude Code JSONL files parsed and retained in memory. |
+| `bootui.claude-code.stream-debounce` | `400ms` | Debounce window before refreshing parsed Claude Code sessions and notifying stream subscribers. |
 | `bootui.claude-code.allow-raw-reveal` | `false` | Allow explicit raw Claude Code JSONL reveal; disabled by default because logs can include prompts and outputs. |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -358,7 +358,8 @@ Purpose: answer "What made startup slow?"
 Data sources:
 
 - Actuator `startup` endpoint when configured.
-- Spring `ApplicationStartup`.
+- Spring `ApplicationStartup`; BootUI installs a `BufferingApplicationStartup` automatically while active unless
+  `bootui.startup.enabled=false` or `bootui.startup.capacity<=0`.
 
 Features:
 
@@ -366,7 +367,7 @@ Features:
 - Show timeline view.
 - Filter by tag.
 - Highlight slowest steps.
-- Explain when startup data is unavailable and how to enable it.
+- Explain when startup data is unavailable and how to re-enable or provide startup buffering.
 
 Acceptance criteria:
 
@@ -506,8 +507,8 @@ Data sources:
 
 - Passive Spring application context metadata.
 - Spring MVC request mapping metadata when available.
-- Explicit synthetic localhost requests to a host-application missing-resource path under the app root context, never
-  under BootUI's `/bootui` or `/bootui/api` paths.
+- Explicit synthetic localhost requests to a host-application missing-resource path under the application context path,
+  never under BootUI's `/bootui` or `/bootui/api` paths.
 
 Features:
 
@@ -904,6 +905,8 @@ Initial properties:
 | `bootui.expose-values`                       | `MASKED`                                | One of `MASKED`, `METADATA_ONLY`, `FULL`.                                                         |
 | `bootui.read-only`                           | `false`                                 | Disable all browser-triggered actions while keeping read-only panel data visible.                  |
 | `bootui.show-banner`                         | `true`                                  | Print BootUI URL on startup.                                                                      |
+| `bootui.startup.enabled`                     | `true`                                  | Install a `BufferingApplicationStartup` automatically while BootUI is active.                      |
+| `bootui.startup.capacity`                    | `4096`                                  | Maximum startup steps retained by BootUI's auto-installed startup buffer.                          |
 | `bootui.enabled-profiles`                    | `dev,local`                             | Profiles that activate BootUI.                                                                    |
 | `bootui.disabled-profiles`                   | `prod,production`                       | Profiles that disable BootUI unless `bootui.enabled=ON`.                                          |
 | `bootui.overrides-file`                      | `.bootui/application-bootui.properties` | File used to persist local runtime configuration overrides.                                       |
@@ -1035,7 +1038,8 @@ Examples:
 - No Actuator health details:
   - "Health details are hidden. In local development, set `management.endpoint.health.show-details=always`."
 - No startup timeline:
-  - "Startup data is unavailable. Configure `BufferingApplicationStartup` to collect startup steps."
+  - "Startup data is unavailable. Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero,
+    or provide your own `BufferingApplicationStartup`."
 - No mappings:
   - "No web mappings found. This may be a non-web application."
 


### PR DESCRIPTION
## What does this PR do?

Prepares the 0.2.0 release documentation by aligning the changelog, application properties reference, feature/spec docs, pentest catalogue, and E2E documentation with the current implementation. It also adds metadata for startup properties and regression coverage so read-only panel behavior stays aligned with the panel registry.

## Why is this change needed?

BootUI is preparing the next release, and the release-facing docs need to match the implemented Startup Timeline, Copilot/Claude Code event-stream, Pentest, and read-only panel behavior before tagging.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Focused validation run during preparation:

- `./mvnw -B -ntp spotless:check`
- `./mvnw -B -ntp -pl bootui-autoconfigure test -Dtest=PentestScannerTests`
- `./mvnw -B -ntp -pl bootui-autoconfigure test -Dtest=PanelAccessFilterTests,PanelsControllerTests`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed