### PR TITLE
Normalize heap dump histogram class names

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HeapDumpService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HeapDumpService.java
@@ -368,7 +368,7 @@ public class HeapDumpService {
             }
             long instances = Long.parseLong(matcher.group(1));
             long bytes = Long.parseLong(matcher.group(2));
-            String className = matcher.group(3);
+            String className = normalizeClassName(matcher.group(3));
             entries.add(new HeapClassHistogramEntryDto(0, className, instances, bytes));
         }
         entries.sort(Comparator.comparingLong(HeapClassHistogramEntryDto::bytes).reversed());
@@ -378,6 +378,49 @@ public class HeapDumpService {
             ranked.add(new HeapClassHistogramEntryDto(rank++, entry.className(), entry.instances(), entry.bytes()));
         }
         return ranked;
+    }
+
+    private static String normalizeClassName(String rawClassName) {
+        if (rawClassName == null || !rawClassName.startsWith("[")) {
+            return rawClassName;
+        }
+
+        int dimensions = 0;
+        while (dimensions < rawClassName.length() && rawClassName.charAt(dimensions) == '[') {
+            dimensions++;
+        }
+        if (dimensions == rawClassName.length()) {
+            return rawClassName;
+        }
+
+        char descriptor = rawClassName.charAt(dimensions);
+        String componentName;
+        switch (descriptor) {
+            case 'B' -> componentName = "byte";
+            case 'C' -> componentName = "char";
+            case 'D' -> componentName = "double";
+            case 'F' -> componentName = "float";
+            case 'I' -> componentName = "int";
+            case 'J' -> componentName = "long";
+            case 'S' -> componentName = "short";
+            case 'Z' -> componentName = "boolean";
+            case 'L' -> {
+                if (!rawClassName.endsWith(";") || rawClassName.length() <= dimensions + 2) {
+                    return rawClassName;
+                }
+                componentName = rawClassName
+                        .substring(dimensions + 1, rawClassName.length() - 1)
+                        .replace('/', '.');
+            }
+            default -> {
+                return rawClassName;
+            }
+        }
+
+        if (descriptor != 'L' && rawClassName.length() != dimensions + 1) {
+            return rawClassName;
+        }
+        return componentName + "[]".repeat(dimensions);
     }
 
     private static void dumpWithHotSpot(Path file, boolean live) throws Exception {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HeapDumpServiceTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HeapDumpServiceTests.java
@@ -33,6 +33,17 @@ class HeapDumpServiceTests {
             Total          1601         113000
             """;
 
+    private static final String HISTOGRAM_WITH_ARRAY_DESCRIPTORS = """
+            num     #instances         #bytes  class name (module)
+            -------------------------------------------------------
+              1:            10            100  [B (java.base@25)
+              2:             5             80  [I (java.base@25)
+              3:             4             72  [J (java.base@25)
+              4:             3             64  [Ljava.lang.String; (java.base@25)
+              5:             2             56  [[D (java.base@25)
+            Total            24            372
+            """;
+
     private BootUiProperties.HeapDump config() {
         return new BootUiProperties.HeapDump();
     }
@@ -119,7 +130,7 @@ class HeapDumpServiceTests {
 
         // Only the top-2 classes by bytes are kept; topClasses defaults to 25 so all stored are shown
         assertThat(report.topClasses()).hasSize(2);
-        assertThat(report.topClasses().get(0).className()).isEqualTo("[B");
+        assertThat(report.topClasses().get(0).className()).isEqualTo("byte[]");
         assertThat(report.topClasses().get(1).className()).isEqualTo("java.lang.String");
     }
 
@@ -131,10 +142,20 @@ class HeapDumpServiceTests {
         assertThat(report.histogramTotalInstances()).isEqualTo(1600);
         assertThat(report.histogramTotalBytes()).isEqualTo(108000);
         assertThat(report.topClasses()).hasSize(3);
-        assertThat(report.topClasses().get(0).className()).isEqualTo("[B");
+        assertThat(report.topClasses().get(0).className()).isEqualTo("byte[]");
         assertThat(report.topClasses().get(0).rank()).isEqualTo(1);
         assertThat(report.topClasses().get(0).bytes()).isEqualTo(80000);
         assertThat(report.dumpCount()).isZero();
+    }
+
+    @Test
+    void analyzeConvertsJvmArrayDescriptorsToReadableClassNames(@TempDir Path dir) {
+        HeapDumpReport report =
+                serviceWithHistogram(dir, HISTOGRAM_WITH_ARRAY_DESCRIPTORS).analyze();
+
+        assertThat(report.topClasses())
+                .extracting("className")
+                .containsExactly("byte[]", "int[]", "long[]", "java.lang.String[]", "double[][]");
     }
 
     @Test
@@ -226,13 +247,13 @@ class HeapDumpServiceTests {
 
         assertThat(report.topClasses()).isNotEmpty();
         assertThat(report.topClasses().get(0).className()).isEqualTo("com.example.LargeCache");
-        assertThat(report.topClasses().get(1).className()).isEqualTo("[B");
+        assertThat(report.topClasses().get(1).className()).isEqualTo("byte[]");
         assertThat(report.topClasses().get(2).className()).isEqualTo("java.lang.String");
     }
 
     @Test
     void collectionBloatSmartFilterReturnsOnlyCollectionClasses(@TempDir Path dir) {
-        // HISTOGRAM has java.util.HashMap$Node (collection inner class) plus [B and java.lang.String
+        // HISTOGRAM has java.util.HashMap$Node (collection inner class) plus byte[] and java.lang.String
         HeapDumpService service = service(config(), dir, true);
         service.analyze();
 


### PR DESCRIPTION
## What does this PR do?

Normalizes JVM array descriptors from the Heap Dump class histogram into readable Java-style class names before returning them to the UI.

## Why is this change needed?

HotSpot reports array classes as JVM descriptors such as `[B`, `[I`, and `[J`, which makes the Heap Dump panel look like class names are truncated. Showing `byte[]`, `int[]`, and `long[]` makes the Top classes table understandable without changing the underlying histogram data.

No linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Focused test run: `./mvnw -B -ntp -pl bootui-autoconfigure spotless:apply test -Dtest=HeapDumpServiceTests`

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed