### PR TITLE
Fix Heap Dump retained-size filter freeze

### DIFF
--- a/bootui-sample-app/e2e/tests/heap-dump.spec.js
+++ b/bootui-sample-app/e2e/tests/heap-dump.spec.js
@@ -34,4 +34,25 @@ test.describe('Heap Dump view', () => {
 
     await expect(page.locator('.card', {hasText: 'Last action'}).first().locator('.badge')).toHaveText('ANALYZED')
   })
+
+  test('keeps the class prefix filter editable when no classes match', async ({openView, page}) => {
+    await openView('heap-dump', 'Heap Dump')
+
+    const histogramCard = page.locator('.card', {hasText: 'Top classes by retained size'})
+    await page.getByRole('button', {name: 'Analyze live heap'}).click()
+
+    const rows = histogramCard.locator('tbody tr')
+    await expect.poll(async () => rows.count(), {timeout: 15_000}).toBeGreaterThan(0)
+
+    const filter = histogramCard.getByPlaceholder('Filter by class prefix…')
+    await filter.fill('zzzz.bootui.NoSuchClass')
+
+    await expect(histogramCard).toContainText('No classes match the current filter')
+    await expect(filter).toBeEnabled()
+
+    await filter.fill('')
+
+    await expect.poll(async () => rows.count(), {timeout: 15_000}).toBeGreaterThan(0)
+    await expect(histogramCard).not.toContainText('No classes match the current filter')
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.test.js
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.test.js
@@ -1,0 +1,100 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import HeapDump from './HeapDump.vue'
+
+function heapReport(overrides = {}) {
+  return {
+    hotspotAvailable: true,
+    captureEnabled: true,
+    rawDownloadEnabled: false,
+    outputDirectory: '/tmp/bootui',
+    maxDumps: 5,
+    dumpCount: 0,
+    liveHeapUsedBytes: 1024,
+    freeDiskBytes: 1024 * 1024,
+    capture: {
+      status: 'ANALYZED',
+      message: 'Live heap analyzed without writing a dump',
+      capturedAtEpochMs: 1780200000000
+    },
+    dumps: [],
+    histogramTotalInstances: 10,
+    histogramTotalBytes: 100,
+    topClasses: [
+      {
+        rank: 1,
+        className: 'java.lang.String',
+        instances: 10,
+        bytes: 100
+      }
+    ],
+    ...overrides
+  }
+}
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+describe('HeapDump', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps the class prefix filter editable when it matches no histogram rows', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(heapReport()))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mount(HeapDump)
+    await flushPromises()
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(heapReport({topClasses: []})))
+    await wrapper.get('input[type="text"]').setValue('com.missing')
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenLastCalledWith('api/heap-dump?filter=com.missing')
+    expect(wrapper.text()).toContain('No classes match the current filter')
+    expect(wrapper.get('input[type="text"]').attributes('disabled')).toBeUndefined()
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(heapReport()))
+    await wrapper.get('input[type="text"]').setValue('')
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenLastCalledWith('api/heap-dump')
+    expect(wrapper.text()).toContain('java.lang.String')
+  })
+
+  it('ignores stale filtered responses after the filter changes', async () => {
+    let resolveFiltered
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(heapReport()))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const wrapper = mount(HeapDump)
+    await flushPromises()
+
+    fetchMock.mockImplementationOnce(() => new Promise((resolve) => (resolveFiltered = resolve)))
+    await wrapper.get('input[type="text"]').setValue('com.missing')
+    await vi.advanceTimersByTimeAsync(250)
+
+    fetchMock.mockResolvedValueOnce(jsonResponse(heapReport()))
+    await wrapper.get('input[type="text"]').setValue('')
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('java.lang.String')
+
+    resolveFiltered(jsonResponse(heapReport({topClasses: []})))
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('java.lang.String')
+    expect(wrapper.text()).not.toContain('No classes match the current filter')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.vue
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {computed, onMounted, ref} from 'vue'
+import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 
@@ -14,6 +14,7 @@ const live = ref(true)
 const filter = ref('')
 const smartFilter = ref('')
 let filterTimer = null
+let reportRequestId = 0
 
 const statusClasses = {
   CAPTURED: 'text-bg-success',
@@ -22,7 +23,13 @@ const statusClasses = {
   ERROR: 'text-bg-danger'
 }
 
-const hasHistogram = computed(() => (report.value?.topClasses?.length ?? 0) > 0)
+const hasVisibleClasses = computed(() => (report.value?.topClasses?.length ?? 0) > 0)
+const hasHistogram = computed(() => {
+  const current = report.value
+  return (
+    hasVisibleClasses.value || (current?.histogramTotalInstances ?? 0) > 0 || (current?.histogramTotalBytes ?? 0) > 0
+  )
+})
 
 function barValue(entry) {
   if (smartFilter.value === 'big-objects' && entry.instances > 0) {
@@ -32,7 +39,7 @@ function barValue(entry) {
 }
 
 const maxBarValue = computed(() => {
-  if (!hasHistogram.value) return 1
+  if (!hasVisibleClasses.value) return 1
   return Math.max(1, ...report.value.topClasses.map(barValue))
 })
 
@@ -86,7 +93,8 @@ function formatTime(epochMs) {
   })
 }
 
-async function loadReport() {
+async function loadReport(options = {}) {
+  const requestId = options.requestId || ++reportRequestId
   try {
     const params = new URLSearchParams()
     if (filter.value.trim()) params.set('filter', filter.value.trim())
@@ -95,10 +103,12 @@ async function loadReport() {
     const url = qs ? 'api/heap-dump?' + qs : 'api/heap-dump'
     const res = await fetch(url)
     if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
+    const next = await res.json()
+    if (requestId !== reportRequestId) return
+    report.value = next
     error.value = null
   } catch (e) {
-    error.value = e.message
+    if (requestId === reportRequestId) error.value = e.message
   }
 }
 
@@ -149,8 +159,10 @@ function showReadOnlyMessage() {
 }
 
 function scheduleFilterReload() {
+  reportRequestId += 1
+  const requestId = reportRequestId
   clearTimeout(filterTimer)
-  filterTimer = setTimeout(loadReport, 250)
+  filterTimer = setTimeout(() => loadReport({requestId}), 250)
 }
 
 function toggleSmartFilter(name) {
@@ -159,6 +171,11 @@ function toggleSmartFilter(name) {
 }
 
 onMounted(loadReport)
+
+onBeforeUnmount(() => {
+  clearTimeout(filterTimer)
+  reportRequestId += 1
+})
 </script>
 
 <template>
@@ -293,6 +310,11 @@ onMounted(loadReport)
                 <i class="bi bi-bar-chart fs-2 d-block mb-2"></i>
                 <div class="fw-semibold text-body">No heap analysis yet</div>
                 <div>Use "Analyze live heap" or "Capture heap dump" to compute a class histogram.</div>
+              </div>
+              <div v-else-if="!hasVisibleClasses" class="text-center text-muted py-4">
+                <i class="bi bi-search fs-2 d-block mb-2"></i>
+                <div class="fw-semibold text-body">No classes match the current filter</div>
+                <div>Clear the class prefix filter or turn off the smart filter to show matching classes.</div>
               </div>
               <table v-else class="table table-sm align-middle mb-0">
                 <thead>


### PR DESCRIPTION
## What does this PR do?

Fixes the Heap Dump retained-size class filter so a no-match prefix shows an empty-results state without disabling the filter, and stale filtered responses cannot overwrite newer cleared-filter data.

## Why is this change needed?

A zero-match class prefix response made the panel treat the histogram as unavailable, which disabled the filter controls and trapped users in the filtered state.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally (not run; focused checks below)
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Focused checks run:

- `(cd bootui-ui/src/main/frontend && npm test)`
- `(cd bootui-ui/src/main/frontend && npm run format:check)`
- `(cd bootui-sample-app/e2e && npm run format:check)`
- `./mvnw -B -ntp -pl bootui-ui,bootui-spring-boot-starter -am install`
- `(cd bootui-sample-app/e2e && npx playwright test tests/heap-dump.spec.js --project=chromium)`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (not applicable: bug fix only)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed