### PR TITLE
Show only architecture rule violations

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureScanner.java
@@ -6,6 +6,7 @@ import io.github.jdubois.bootui.core.BootUiDtos.ArchitectureRuleResultDto;
 import io.github.jdubois.bootui.core.BootUiDtos.ArchitectureScanStatusDto;
 import io.github.jdubois.bootui.core.BootUiDtos.ArchitectureSeverityCountDto;
 import java.time.Clock;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,11 @@ final class ArchitectureScanner {
                     + "These checks complement, but do not replace, a project-specific ArchUnit test suite or an "
                     + "architecture review.";
     private static final List<String> SEVERITIES = List.of("HIGH", "MEDIUM", "LOW", "INFO");
+    private static final Comparator<ArchitectureRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(
+                    (ArchitectureRuleResultDto result) -> severityRank(result.severity()))
+            .thenComparing(Comparator.comparingInt(ArchitectureRuleResultDto::violationCount)
+                    .reversed())
+            .thenComparing(ArchitectureRuleResultDto::id);
 
     private final Supplier<List<String>> basePackagesSupplier;
     private final ArchitectureClassImporter importer;
@@ -123,8 +129,8 @@ final class ArchitectureScanner {
             int classesAnalyzed,
             int rulesEvaluated,
             List<ArchitectureRuleResultDto> results) {
-        int violationsFound =
-                (int) results.stream().filter(ArchitectureScanner::isViolation).count();
+        List<ArchitectureRuleResultDto> violations = violationResults(results);
+        int violationsFound = violations.size();
         ArchitectureScanStatusDto scan = new ArchitectureScanStatusDto(
                 ANALYZER, status, message, scannedAt, rulesEvaluated, classesAnalyzed, violationsFound);
         return new ArchitectureReport(
@@ -134,9 +140,9 @@ final class ArchitectureScanner {
                 classesAnalyzed,
                 rulesEvaluated,
                 violationsFound,
-                severityCounts(results),
+                severityCounts(violations),
                 scan,
-                results);
+                violations);
     }
 
     private List<ArchitectureSeverityCountDto> severityCounts(List<ArchitectureRuleResultDto> results) {
@@ -152,6 +158,18 @@ final class ArchitectureScanner {
         return counts.entrySet().stream()
                 .map(entry -> new ArchitectureSeverityCountDto(entry.getKey(), entry.getValue()))
                 .toList();
+    }
+
+    private List<ArchitectureRuleResultDto> violationResults(List<ArchitectureRuleResultDto> results) {
+        return results.stream()
+                .filter(ArchitectureScanner::isViolation)
+                .sorted(IMPORTANCE_ORDER)
+                .toList();
+    }
+
+    private static int severityRank(String severity) {
+        int index = SEVERITIES.indexOf(severity);
+        return index >= 0 ? index : SEVERITIES.size();
     }
 
     private static boolean isViolation(ArchitectureRuleResultDto result) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureScannerTests.java
@@ -7,6 +7,7 @@ import io.github.jdubois.bootui.core.BootUiDtos.ArchitectureRuleResultDto;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ class ArchitectureScannerTests {
     }
 
     @Test
-    void scanEvaluatesAllRulesAndDetectsStandardStreamViolation() {
+    void scanEvaluatesAllRulesAndReturnsOnlyViolationsOrderedByImportance() {
         ArchitectureReport report = scanner(List.of(FIXTURES)).scan();
 
         assertThat(report.scan().status()).isEqualTo("SCANNED");
@@ -41,7 +42,16 @@ class ArchitectureScannerTests {
         assertThat(report.rulesEvaluated())
                 .isEqualTo(ArchitectureRuleRegistry.activeRules().size());
         assertThat(report.classesAnalyzed()).isPositive();
-        assertThat(report.results()).extracting(ArchitectureRuleResultDto::id).contains("ARCH-CODE-001");
+        assertThat(report.results())
+                .allSatisfy(result -> assertThat(result.status()).isEqualTo("VIOLATION"));
+        assertThat(report.results())
+                .extracting(ArchitectureRuleResultDto::id)
+                .contains("ARCH-SPRING-004", "ARCH-SPRING-001", "ARCH-CODE-001")
+                .doesNotContain("ARCH-CODE-004");
+        assertThat(report.results().stream()
+                        .map(ArchitectureRuleResultDto::severity)
+                        .toList())
+                .isSortedAccordingTo(Comparator.comparingInt(ArchitectureScannerTests::severityRank));
 
         ArchitectureRuleResultDto standardStreams = report.results().stream()
                 .filter(result -> result.id().equals("ARCH-CODE-001"))
@@ -64,5 +74,9 @@ class ArchitectureScannerTests {
         assertThat(report.rulesEvaluated()).isZero();
         assertThat(report.results()).isEmpty();
         assertThat(report.violationsFound()).isZero();
+    }
+
+    private static int severityRank(String severity) {
+        return List.of("HIGH", "MEDIUM", "LOW", "INFO").indexOf(severity);
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/fixtures/ProblematicSpringBean.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/fixtures/ProblematicSpringBean.java
@@ -1,0 +1,25 @@
+package io.github.jdubois.bootui.autoconfigure.architecture.fixtures;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+/**
+ * Test fixture with medium and high severity Spring architecture violations.
+ */
+@Service
+public class ProblematicSpringBean {
+
+    @Autowired
+    private CleanComponent cleanComponent;
+
+    public void invoke() {
+        refresh();
+        if (cleanComponent != null) {
+            cleanComponent.name();
+        }
+    }
+
+    @Async
+    public void refresh() {}
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -532,7 +532,7 @@ public final class BootUiDtos {
     public record ArchitectureSeverityCountDto(String severity, int count) {}
 
     /**
-     * Outcome of one architecture rule evaluated against the host application classes.
+     * Outcome of one architecture rule violation evaluated against the host application classes.
      */
     public record ArchitectureRuleResultDto(
             String id,
@@ -546,7 +546,8 @@ public final class BootUiDtos {
             String recommendation) {}
 
     /**
-     * Top-level report for the local architecture (ArchUnit) hygiene panel.
+     * Top-level report for the local architecture (ArchUnit) hygiene panel. The results list contains
+     * violating rules only, ordered by severity and impact.
      */
     public record ArchitectureReport(
             boolean localOnly,

--- a/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -1082,119 +1082,15 @@ const architecture = {
   },
   results: [
     architectureResult(
-      'ARCH-PKG-001',
-      'Packages should be free of cycles',
-      'Package structure',
-      'MEDIUM',
-      'Detects cyclic dependencies between the top-level package slices under the application base package.',
-      'VIOLATION',
-      2,
-      [
-        'Cycle between slices: io.github.jdubois.bootui.sample.catalog -> io.github.jdubois.bootui.sample.order',
-        'Cycle between slices: io.github.jdubois.bootui.sample.order -> io.github.jdubois.bootui.sample.catalog'
-      ],
-      'Break the dependency cycle by extracting shared types or inverting one of the dependencies so packages form a directed acyclic graph.'
-    ),
-    architectureResult(
-      'ARCH-CODE-001',
-      'Classes should not access standard streams',
-      'Coding practices',
-      'LOW',
-      'Detects direct use of System.out or System.err instead of a logging framework.',
-      'PASS',
-      0,
-      [],
-      'Replace System.out / System.err with a logging framework such as SLF4J.'
-    ),
-    architectureResult(
-      'ARCH-CODE-002',
-      'Classes should not throw generic exceptions',
-      'Coding practices',
-      'LOW',
-      'Detects throwing of generic exception types such as Exception, RuntimeException, or Throwable.',
-      'PASS',
-      0,
-      [],
-      'Throw specific, meaningful exception types instead of generic ones.'
-    ),
-    architectureResult(
-      'ARCH-CODE-003',
-      'Classes should not use java.util.logging',
-      'Coding practices',
-      'LOW',
-      'Detects direct use of java.util.logging instead of the project logging facade.',
-      'PASS',
-      0,
-      [],
-      'Use the project logging facade (for example SLF4J) instead of java.util.logging.'
-    ),
-    architectureResult(
-      'ARCH-CODE-004',
-      'Classes should not use Joda-Time',
-      'Coding practices',
-      'INFO',
-      'Detects use of the legacy Joda-Time library instead of the java.time API.',
-      'PASS',
-      0,
-      [],
-      'Migrate to the java.time API instead of Joda-Time.'
-    ),
-    architectureResult(
-      'ARCH-CODE-005',
-      'Classes should not call Throwable.printStackTrace()',
-      'Coding practices',
-      'LOW',
-      'Detects calls to Throwable.printStackTrace(), which write to System.err and bypass structured logging.',
+      'ARCH-SPRING-004',
+      'Beans should not self-invoke their own proxied methods',
+      'Spring stereotypes',
+      'HIGH',
+      'Detects direct self-invocation of @Transactional, @Async, or @Cacheable methods, which bypasses the Spring proxy and silently disables the behaviour.',
       'VIOLATION',
       1,
-      [
-        'io.github.jdubois.bootui.sample.order.OrderService.process(OrderService.java:58) calls Throwable.printStackTrace()'
-      ],
-      'Log the exception through the project logging facade instead of calling printStackTrace().'
-    ),
-    architectureResult(
-      'ARCH-CODE-006',
-      'Classes should not call System.exit',
-      'Coding practices',
-      'MEDIUM',
-      'Detects calls to System.exit(int), which abruptly terminate the JVM and bypass orderly shutdown.',
-      'PASS',
-      0,
-      [],
-      'Signal failure through exceptions or a Spring exit code generator instead of System.exit.'
-    ),
-    architectureResult(
-      'ARCH-CODE-007',
-      'Classes should not access JDK-internal APIs',
-      'Coding practices',
-      'LOW',
-      'Detects dependencies on unsupported JDK-internal packages such as sun.., com.sun.., or jdk.internal...',
-      'PASS',
-      0,
-      [],
-      'Replace JDK-internal API usage with supported public APIs.'
-    ),
-    architectureResult(
-      'ARCH-CODE-008',
-      'Classes should not use legacy date and time classes',
-      'Coding practices',
-      'INFO',
-      'Detects use of legacy date/time classes such as java.util.Date, Calendar, GregorianCalendar, or java.sql date types.',
-      'PASS',
-      0,
-      [],
-      'Use the java.time API instead of legacy date/time classes.'
-    ),
-    architectureResult(
-      'ARCH-CODE-009',
-      'Classes should not use deprecated APIs',
-      'Coding practices',
-      'INFO',
-      'Detects access to members or types annotated with @Deprecated.',
-      'PASS',
-      0,
-      [],
-      'Migrate off the deprecated API to its documented replacement.'
+      ['io.github.jdubois.bootui.sample.order.OrderService.placeOrder() self-invokes @Transactional method confirm()'],
+      'Move the proxied method to a collaborating bean or inject a self-reference so the Spring proxy is applied.'
     ),
     architectureResult(
       'ARCH-SPRING-001',
@@ -1212,48 +1108,31 @@ const architecture = {
       'Inject collaborators through the constructor instead of annotating fields.'
     ),
     architectureResult(
-      'ARCH-SPRING-002',
-      'Controllers should not depend on repositories',
-      'Spring stereotypes',
-      'LOW',
-      'Detects @Controller / @RestController classes that depend directly on @Repository beans, bypassing a service layer.',
-      'PASS',
-      0,
-      [],
-      'Route controller calls through a service layer rather than depending on repositories directly.'
-    ),
-    architectureResult(
-      'ARCH-SPRING-003',
-      'Repositories should not depend on controllers',
-      'Spring stereotypes',
+      'ARCH-PKG-001',
+      'Packages should be free of cycles',
+      'Package structure',
       'MEDIUM',
-      'Detects @Repository beans that depend on @Controller / @RestController classes, inverting the expected layering.',
-      'PASS',
-      0,
-      [],
-      'Remove controller dependencies from repositories to keep layering directional.'
+      'Detects cyclic dependencies between the top-level package slices under the application base package.',
+      'VIOLATION',
+      2,
+      [
+        'Cycle between slices: io.github.jdubois.bootui.sample.catalog -> io.github.jdubois.bootui.sample.order',
+        'Cycle between slices: io.github.jdubois.bootui.sample.order -> io.github.jdubois.bootui.sample.catalog'
+      ],
+      'Break the dependency cycle by extracting shared types or inverting one of the dependencies so packages form a directed acyclic graph.'
     ),
     architectureResult(
-      'ARCH-SPRING-004',
-      'Beans should not self-invoke their own proxied methods',
-      'Spring stereotypes',
-      'HIGH',
-      'Detects direct self-invocation of @Transactional, @Async, or @Cacheable methods, which bypasses the Spring proxy and silently disables the behaviour.',
+      'ARCH-CODE-005',
+      'Classes should not call Throwable.printStackTrace()',
+      'Coding practices',
+      'LOW',
+      'Detects calls to Throwable.printStackTrace(), which write to System.err and bypass structured logging.',
       'VIOLATION',
       1,
-      ['io.github.jdubois.bootui.sample.order.OrderService.placeOrder() self-invokes @Transactional method confirm()'],
-      'Move the proxied method to a collaborating bean or inject a self-reference so the Spring proxy is applied.'
-    ),
-    architectureResult(
-      'ARCH-SPRING-005',
-      'Spring stereotypes should not reside in the default package',
-      'Spring stereotypes',
-      'MEDIUM',
-      'Detects @Component / @Service / @Repository / @Controller / @Configuration classes in the default (unnamed) package.',
-      'PASS',
-      0,
-      [],
-      'Place Spring stereotypes in a named package so component scanning is predictable.'
+      [
+        'io.github.jdubois.bootui.sample.order.OrderService.process(OrderService.java:58) calls Throwable.printStackTrace()'
+      ],
+      'Log the exception through the project logging facade instead of calling printStackTrace().'
     )
   ]
 }

--- a/bootui-ui/src/main/frontend/src/views/Architecture.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.test.js
@@ -1,0 +1,99 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import Architecture from './Architecture.vue'
+
+function ruleResult(id, name, severity, status, violationCount = 0) {
+  return {
+    id,
+    name,
+    category: 'Coding practices',
+    severity,
+    description: `${name} description.`,
+    status,
+    violationCount,
+    sampleViolations: violationCount > 0 ? [`${id} detail`] : [],
+    recommendation: `${name} recommendation.`
+  }
+}
+
+function architectureReport(
+  results,
+  violationsFound = results.filter((result) => result.status === 'VIOLATION').length
+) {
+  return {
+    localOnly: true,
+    disclaimer: 'Architecture disclaimer.',
+    basePackages: ['com.example'],
+    classesAnalyzed: 12,
+    rulesEvaluated: 15,
+    violationsFound,
+    severityCounts: [
+      {severity: 'HIGH', count: severityCount(results, 'HIGH')},
+      {severity: 'MEDIUM', count: severityCount(results, 'MEDIUM')},
+      {severity: 'LOW', count: severityCount(results, 'LOW')},
+      {severity: 'INFO', count: severityCount(results, 'INFO')}
+    ],
+    scan: {
+      analyzer: 'BootUI ArchUnit hygiene',
+      status: 'SCANNED',
+      message: 'Architecture rules completed.',
+      scannedAt: 1_700_000_000_000,
+      rulesEvaluated: 15,
+      classesAnalyzed: 12,
+      violationsFound
+    },
+    results
+  }
+}
+
+function severityCount(results, severity) {
+  return results.filter((result) => result.status === 'VIOLATION' && result.severity === severity).length
+}
+
+async function mountWithReport(report) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => Promise.resolve(new Response(JSON.stringify(report), {status: 200})))
+  )
+
+  const wrapper = mount(Architecture)
+  await flushPromises()
+  return wrapper
+}
+
+describe('Architecture', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows only violation results sorted by importance', async () => {
+    const wrapper = await mountWithReport(
+      architectureReport([
+        ruleResult('ARCH-CODE-005', 'Low severity violation', 'LOW', 'VIOLATION', 1),
+        ruleResult('ARCH-CODE-004', 'Passing informational rule', 'INFO', 'PASS'),
+        ruleResult('ARCH-SPRING-001', 'Medium severity violation', 'MEDIUM', 'VIOLATION', 3),
+        ruleResult('ARCH-SPRING-004', 'High severity violation', 'HIGH', 'VIOLATION', 1)
+      ])
+    )
+
+    expect(wrapper.text()).toContain('3 violating rules, sorted by importance')
+    expect(wrapper.text()).toContain('What happened:')
+    expect(wrapper.text()).toContain('3 violations found for this rule.')
+    expect(wrapper.text()).not.toContain('Passing informational rule')
+    expect(wrapper.findAll('.list-group-item h3').map((title) => title.text())).toEqual([
+      'High severity violation',
+      'Medium severity violation',
+      'Low severity violation'
+    ])
+  })
+
+  it('shows an empty violation state when every evaluated rule passes', async () => {
+    const wrapper = await mountWithReport(
+      architectureReport([ruleResult('ARCH-CODE-004', 'Passing informational rule', 'INFO', 'PASS')], 0)
+    )
+
+    expect(wrapper.text()).toContain('No architecture rule violations found')
+    expect(wrapper.text()).not.toContain('Passing informational rule')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -24,11 +24,23 @@ const statusClasses = {
   ERROR: 'text-bg-warning'
 }
 
+const severityOrder = ['HIGH', 'MEDIUM', 'LOW', 'INFO']
+
 const hasScanData = computed(() => report.value?.scan?.status && report.value.scan.status !== 'NOT_SCANNED')
 
 const maxSeverityCount = computed(() => {
   if (!report.value?.severityCounts?.length) return 1
   return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+})
+
+const visibleResults = computed(() =>
+  [...(report.value?.results || [])].filter((result) => result.status === 'VIOLATION').sort(compareImportance)
+)
+
+const emptyRuleResultsTitle = computed(() => {
+  if (!hasScanData.value) return 'Run architecture checks to see rule violations'
+  if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
+  return 'No architecture rule violations found'
 })
 
 function severityClass(severity) {
@@ -42,6 +54,27 @@ function statusClass(status) {
 function severityWidth(count) {
   if (count === 0) return '0%'
   return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
+}
+
+function compareImportance(left, right) {
+  const severityDiff = severityRank(left.severity) - severityRank(right.severity)
+  if (severityDiff !== 0) return severityDiff
+  const countDiff = right.violationCount - left.violationCount
+  if (countDiff !== 0) return countDiff
+  return left.id.localeCompare(right.id)
+}
+
+function severityRank(severity) {
+  const index = severityOrder.indexOf(severity)
+  return index === -1 ? severityOrder.length : index
+}
+
+function pluralize(count, singular, plural = `${singular}s`) {
+  return count === 1 ? singular : plural
+}
+
+function violationCountLabel(count) {
+  return `${count} ${pluralize(count, 'violation')} found`
 }
 
 function scanTime() {
@@ -209,19 +242,23 @@ onMounted(loadReport)
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
             <div class="fw-semibold">Rule results</div>
-            <div class="text-muted small">{{ report.violationsFound }} rule violation(s)</div>
+            <div class="text-muted small">
+              <template v-if="hasScanData && report.violationsFound > 0">
+                {{ report.violationsFound }} {{ pluralize(report.violationsFound, 'violating rule') }}, sorted by
+                importance
+              </template>
+              <template v-else>{{ report.violationsFound }} rule violation(s)</template>
+            </div>
           </div>
           <span v-if="hasScanData && report.violationsFound === 0" class="badge text-bg-success">No violations</span>
         </div>
-        <div v-if="!report.results || report.results.length === 0" class="card-body text-center text-muted py-5">
+        <div v-if="visibleResults.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-diagram-2 fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">
-            {{ hasScanData ? 'No rules were evaluated' : 'Run architecture checks to see rule results' }}
-          </div>
+          <div class="fw-semibold text-body">{{ emptyRuleResultsTitle }}</div>
           <div>A project-specific ArchUnit suite remains the best way to enforce your own architecture.</div>
         </div>
         <div v-else class="list-group list-group-flush">
-          <div v-for="result in report.results" :key="result.id" class="list-group-item">
+          <div v-for="result in visibleResults" :key="result.id" class="list-group-item">
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
               <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
@@ -230,9 +267,13 @@ onMounted(loadReport)
             </div>
             <h3 class="h6 mb-1">{{ result.name }}</h3>
             <div class="small text-muted mb-2">{{ result.description }}</div>
+            <div class="small mb-2">
+              <strong>What happened:</strong>
+              {{ violationCountLabel(result.violationCount) }} for this rule.
+            </div>
             <div v-if="result.sampleViolations && result.sampleViolations.length" class="mb-2">
               <div class="small fw-semibold">
-                {{ result.status === 'VIOLATION' ? `Sample violations (${result.violationCount} total)` : 'Details' }}
+                Sample details (showing {{ result.sampleViolations.length }} of {{ result.violationCount }})
               </div>
               <ul class="small mb-0">
                 <li v-for="(sample, index) in result.sampleViolations" :key="index" class="font-monospace">

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -47,8 +47,9 @@ Severity reflects the worst plausible impact if the finding is real, not the lik
 - **LOW** — defense-in-depth / hygiene gap (e.g. standard-stream use, generic exceptions, `java.util.logging`).
 - **INFO** — informational convention prompt (e.g. legacy library use, deprecated APIs).
 
-Each rule result is reported with a status (`PASS`, `VIOLATION`, `SKIPPED`, or `ERROR`), the number of violating
-instances, and up to a handful of sample detail lines from ArchUnit.
+The scan evaluates every registered rule, but the Rule results panel only lists rules that found violations. Violations
+are ordered by importance (`HIGH`, `MEDIUM`, `LOW`, `INFO`), then by the number of violating instances, and include up to
+a handful of sample detail lines from ArchUnit.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -236,7 +236,8 @@ the last report.
 
 Generic rules are necessarily less powerful than project-authored ArchUnit tests, so the panel is positioned as a
 starting-point and review aid that complements — rather than replaces — a project-specific ArchUnit test suite. Each
-rule is registered with a stable identifier, category, severity, and recommendation. See
+rule is registered with a stable identifier, category, severity, and recommendation; the rule results list shows only
+violating rules, sorted by severity and violation count. See
 [ARCHITECTURE-CHECKS.md](ARCHITECTURE-CHECKS.md) for the full catalogue of rules and what each one inspects.
 
 ![BootUI Architecture panel](images/bootui-architecture.png)


### PR DESCRIPTION
## What does this PR do?

Shows only Architecture rule violations in the Rule results panel, sorted by severity and violation count, with a short "What happened" summary for each violation. The backend report now returns the actionable violation rows, while keeping evaluated-rule counts and severity summaries intact.

## Why is this change needed?

When a scan finds violations, listing every passing rule buries the findings that need attention. This keeps the Architecture panel focused on the rules that actually failed, ordered by importance so reviewers can start with the highest-impact issues.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Validated with:

- `./mvnw -pl bootui-autoconfigure -am test -Dtest=ArchitectureScannerTests -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false -q`
- `(cd bootui-ui/src/main/frontend && npm test -- --run)`
- `./mvnw -B -ntp spotless:check -q`
- `(cd bootui-ui/src/main/frontend && npm run format:check)`
- `git --no-pager diff --check`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed