### PR TITLE
Fix Claude Code icon

### DIFF
--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -193,7 +193,7 @@ export const routes = [
     path: '/claude-code',
     name: 'claude-code',
     component: Copilot,
-    meta: {group: groups.developerTools, icon: 'bi-stars', title: 'Claude Code'}
+    meta: {group: groups.developerTools, icon: 'bi-claude', title: 'Claude Code'}
   },
   {path: '/dependencies', redirect: '/vulnerabilities'}
 ]


### PR DESCRIPTION
## What does this PR do?

Update Claude Code icon

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

Before
<img width="143" height="35" alt="image" src="https://github.com/user-attachments/assets/502658c6-d732-43f1-8c12-debaa8ea3614" />

After
<img width="138" height="38" alt="image" src="https://github.com/user-attachments/assets/b3a759f7-3f38-4955-a1cf-6ab29404f4d9" />

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
