### PR TITLE
Add ArchUnit to BootUI starter

### DIFF
--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -38,11 +38,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.tngtech.archunit</groupId>
-            <artifactId>archunit</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>

--- a/bootui-spring-boot-starter/pom.xml
+++ b/bootui-spring-boot-starter/pom.xml
@@ -23,6 +23,10 @@
             <groupId>com.julien-dubois.bootui</groupId>
             <artifactId>bootui-ui</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -20,9 +20,10 @@ application's own base package(s) — never the entire classpath — and runs on
 invoked, caching the last report in the controller. When several base packages are detected, all of them are imported
 and analysed together.
 
-The panel is available only when:
+When BootUI is installed through `bootui-spring-boot-starter`, ArchUnit is included transitively so the panel works
+without an extra application dependency. The panel is available only when:
 
-- ArchUnit is on the classpath (it ships as an `optional` dependency of `bootui-autoconfigure`), and
+- ArchUnit is on the classpath, and
 - a base package is resolvable from the running application.
 
 If no classes can be imported (for example in some fat-jar or DevTools restart-classloader situations), the panel

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -231,9 +231,9 @@ architecture hygiene rules: package cycles between slices, general coding practi
 exceptions, `java.util.logging`, JodaTime, `printStackTrace`, `System.exit`, JDK-internal APIs, legacy date/time, or
 deprecated APIs, poorly named exceptions/interfaces, or mutable/visible loggers), and Spring stereotype heuristics (no
 field injection, controllers should not depend on repositories, repositories/services should not depend on controllers,
-no self-invocation of proxied methods, and stereotypes outside the default package). The panel is
-available only when a base package is resolvable and ArchUnit is on the classpath; the scan runs on demand and caches
-the last report.
+no self-invocation of proxied methods, and stereotypes outside the default package). When BootUI is installed through
+`bootui-spring-boot-starter`, ArchUnit is included transitively; the panel is available when a base package is
+resolvable and the scan runs on demand, caching the last report.
 
 Generic rules are necessarily less powerful than project-authored ArchUnit tests, so the panel is positioned as a
 starting-point and review aid that complements — rather than replaces — a project-specific ArchUnit test suite. Each


### PR DESCRIPTION
## What does this PR do?

Adds ArchUnit as a normal transitive dependency of `bootui-spring-boot-starter` so the Architecture panel works out of the box for starter users. The sample app now relies on the starter-provided dependency instead of declaring ArchUnit directly.

## Why is this change needed?

The Architecture panel uses ArchUnit's class importer at runtime. Without ArchUnit on the host application classpath, users who only add the BootUI starter see the panel unavailable unless they manually add a separate dependency.

N/A

## How was it tested?

- [x] `./mvnw -B -ntp -pl bootui-spring-boot-starter,bootui-sample-app -am install` passes locally
- [x] `./mvnw -B -ntp -pl bootui-sample-app dependency:tree -Dscope=runtime -Dincludes=com.tngtech.archunit` shows ArchUnit coming through the starter
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable (N/A - dependency wiring/docs only)

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed