### PR TITLE
Clarify Health availability guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ BootUI exposes these panels in the same grouped order as the application menu. S
 | Group           | Feature                                               | What it helps with                                                                                            |
 | --------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Overview        | [Overview](docs/FEATURES.md#overview)                 | See runtime identity, versions, ports, active profiles, activation reason, and safety state.                  |
-| Runtime         | [Health](docs/FEATURES.md#health)                     | Explore the Actuator health tree and contributor details, with setup guidance when health is unavailable.     |
+| Runtime         | [Health](docs/FEATURES.md#health)                     | Explore the Actuator health tree and contributor details, with setup guidance when health is unavailable or only defaults are reported. |
 | Runtime         | [Metrics](docs/FEATURES.md#metrics)                   | Browse Micrometer meters, tags, measurements, and a local live chart for selected metrics.                    |
 | Runtime         | [Memory](docs/FEATURES.md#memory)                     | Review JVM heap, non-heap, memory pools, garbage collectors, and suggested JVM options.                       |
 | Runtime         | [Heap Dump](docs/FEATURES.md#heap-dump)               | Capture local JVM heap dumps on demand and analyze a value-free class histogram of memory usage.             |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ BootUI exposes these panels in the same grouped order as the application menu. S
 | Group           | Feature                                               | What it helps with                                                                                            |
 | --------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | Overview        | [Overview](docs/FEATURES.md#overview)                 | See runtime identity, versions, ports, active profiles, activation reason, and safety state.                  |
-| Runtime         | [Health](docs/FEATURES.md#health)                     | Explore the Actuator health tree and contributor details.                                                     |
+| Runtime         | [Health](docs/FEATURES.md#health)                     | Explore the Actuator health tree and contributor details, with setup guidance when health is unavailable.     |
 | Runtime         | [Metrics](docs/FEATURES.md#metrics)                   | Browse Micrometer meters, tags, measurements, and a local live chart for selected metrics.                    |
 | Runtime         | [Memory](docs/FEATURES.md#memory)                     | Review JVM heap, non-heap, memory pools, garbage collectors, and suggested JVM options.                       |
 | Runtime         | [Heap Dump](docs/FEATURES.md#heap-dump)               | Capture local JVM heap dumps on demand and analyze a value-free class histogram of memory usage.             |

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HealthController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HealthController.java
@@ -25,9 +25,6 @@ public class HealthController {
     private static final String DEFAULT_CONTRIBUTORS_REASON =
             "Only Spring Boot default health indicators are available";
 
-    private static final String DEFAULT_CONTRIBUTOR_NODE_REASON =
-            "Default Spring Boot health indicator; add application or dependency contributors to make health actionable";
-
     private static final Set<String> DEFAULT_HEALTH_CONTRIBUTORS =
             Set.of("diskSpace", "livenessState", "readinessState", "ping", "ssl");
 
@@ -84,8 +81,7 @@ public class HealthController {
         }
         HealthNodeDto root = toNode("application", he.health());
         if (hasOnlyDefaultContributors(root)) {
-            return disabledRoot(
-                    DEFAULT_CONTRIBUTORS_REASON, DEFAULT_CONTRIBUTOR_SETUP, disableNodes(root.components()));
+            return withGuidance(root, DEFAULT_CONTRIBUTORS_REASON, DEFAULT_CONTRIBUTOR_SETUP);
         }
         return root;
     }
@@ -114,7 +110,12 @@ public class HealthController {
     }
 
     private HealthNodeDto disabledRoot(String reason, List<HealthSetupStepDto> setup, List<HealthNodeDto> components) {
-        return new HealthNodeDto("application", "DISABLED", null, components, false, reason, setup);
+        return new HealthNodeDto("application", "DISABLED", null, components, false, reason, null, setup);
+    }
+
+    private HealthNodeDto withGuidance(HealthNodeDto root, String reason, List<HealthSetupStepDto> setup) {
+        return new HealthNodeDto(
+                root.name(), root.status(), root.details(), root.components(), true, null, reason, setup);
     }
 
     private boolean hasOnlyDefaultContributors(HealthNodeDto root) {
@@ -138,20 +139,5 @@ public class HealthController {
 
     private boolean isHealthyDefaultStatus(HealthNodeDto node) {
         return "UP".equals(node.status()) || "UNKNOWN".equals(node.status());
-    }
-
-    private List<HealthNodeDto> disableNodes(List<HealthNodeDto> nodes) {
-        return nodes.stream().map(this::disabledNode).toList();
-    }
-
-    private HealthNodeDto disabledNode(HealthNodeDto node) {
-        return new HealthNodeDto(
-                node.name(),
-                "DISABLED",
-                node.details(),
-                disableNodes(node.components()),
-                false,
-                DEFAULT_CONTRIBUTOR_NODE_REASON,
-                List.of());
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HealthController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HealthController.java
@@ -1,9 +1,12 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.BootUiDtos.HealthNodeDto;
+import io.github.jdubois.bootui.core.BootUiDtos.HealthSetupStepDto;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.health.actuate.endpoint.CompositeHealthDescriptor;
 import org.springframework.boot.health.actuate.endpoint.HealthDescriptor;
@@ -17,6 +20,56 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/bootui/api/health")
 public class HealthController {
 
+    private static final String ACTUATOR_UNAVAILABLE_REASON = "Spring Boot Actuator health endpoint is not available";
+
+    private static final String DEFAULT_CONTRIBUTORS_REASON =
+            "Only Spring Boot default health indicators are available";
+
+    private static final String DEFAULT_CONTRIBUTOR_NODE_REASON =
+            "Default Spring Boot health indicator; add application or dependency contributors to make health actionable";
+
+    private static final Set<String> DEFAULT_HEALTH_CONTRIBUTORS =
+            Set.of("diskSpace", "livenessState", "readinessState", "ping", "ssl");
+
+    private static final List<HealthSetupStepDto> ACTUATOR_SETUP = List.of(
+            new HealthSetupStepDto(
+                    "Add Spring Boot Actuator",
+                    "Use bootui-spring-boot-starter, or add spring-boot-starter-actuator alongside"
+                            + " bootui-autoconfigure so Spring creates the HealthEndpoint bean.",
+                    List.of("org.springframework.boot:spring-boot-starter-actuator")),
+            new HealthSetupStepDto(
+                    "Expose health details locally",
+                    "BootUI can render contributors and details when the local Actuator health endpoint exposes them.",
+                    List.of(
+                            "management.endpoints.web.exposure.include=health,info",
+                            "management.endpoint.health.show-details=always")),
+            new HealthSetupStepDto(
+                    "Enable availability probes when you need them",
+                    "Keep probes enabled and point your runtime platform at the liveness and readiness health groups.",
+                    List.of("management.endpoint.health.probes.enabled=true")),
+            new HealthSetupStepDto(
+                    "Configure SSL certificate health intentionally",
+                    "Configure Spring SSL bundles when you want certificate checks, or disable the SSL indicator when"
+                            + " the application has no SSL bundles to validate.",
+                    List.of("spring.ssl.bundle.*", "management.health.ssl.enabled=false")));
+
+    private static final List<HealthSetupStepDto> DEFAULT_CONTRIBUTOR_SETUP = List.of(
+            new HealthSetupStepDto(
+                    "Add application health contributors",
+                    "Create a HealthIndicator bean or add starters that provide dependency indicators, such as JDBC,"
+                            + " Redis, RabbitMQ, or other services your app depends on.",
+                    List.of("class MyHealthIndicator implements HealthIndicator")),
+            new HealthSetupStepDto(
+                    "Keep availability probes explicit",
+                    "Use liveness and readiness for platform probes, but do not treat them as dependency health until"
+                            + " application-specific contributors are present.",
+                    List.of("management.endpoint.health.probes.enabled=true")),
+            new HealthSetupStepDto(
+                    "Configure or disable SSL certificate health",
+                    "Configure Spring SSL bundles when certificate health matters, or disable the SSL indicator for"
+                            + " applications without SSL bundles.",
+                    List.of("spring.ssl.bundle.*", "management.health.ssl.enabled=false")));
+
     private final ObjectProvider<HealthEndpoint> endpoint;
 
     public HealthController(ObjectProvider<HealthEndpoint> endpoint) {
@@ -27,9 +80,14 @@ public class HealthController {
     public HealthNodeDto health() {
         HealthEndpoint he = endpoint.getIfAvailable();
         if (he == null) {
-            return new HealthNodeDto("application", "UNKNOWN", null, List.of());
+            return disabledRoot(ACTUATOR_UNAVAILABLE_REASON, ACTUATOR_SETUP, List.of());
         }
-        return toNode("application", he.health());
+        HealthNodeDto root = toNode("application", he.health());
+        if (hasOnlyDefaultContributors(root)) {
+            return disabledRoot(
+                    DEFAULT_CONTRIBUTORS_REASON, DEFAULT_CONTRIBUTOR_SETUP, disableNodes(root.components()));
+        }
+        return root;
     }
 
     private HealthNodeDto toNode(String name, HealthDescriptor descriptor) {
@@ -53,5 +111,47 @@ public class HealthController {
             return new HealthNodeDto(name, status, indicated.getDetails(), List.of());
         }
         return new HealthNodeDto(name, status, null, List.of());
+    }
+
+    private HealthNodeDto disabledRoot(String reason, List<HealthSetupStepDto> setup, List<HealthNodeDto> components) {
+        return new HealthNodeDto("application", "DISABLED", null, components, false, reason, setup);
+    }
+
+    private boolean hasOnlyDefaultContributors(HealthNodeDto root) {
+        List<HealthNodeDto> components = new ArrayList<>();
+        collectComponents(root.components(), components);
+        Set<String> componentNames = components.stream()
+                .map(HealthNodeDto::name)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        return isHealthyDefaultStatus(root)
+                && !components.isEmpty()
+                && DEFAULT_HEALTH_CONTRIBUTORS.containsAll(componentNames)
+                && components.stream().allMatch(this::isHealthyDefaultStatus);
+    }
+
+    private void collectComponents(List<HealthNodeDto> nodes, List<HealthNodeDto> components) {
+        for (HealthNodeDto node : nodes) {
+            components.add(node);
+            collectComponents(node.components(), components);
+        }
+    }
+
+    private boolean isHealthyDefaultStatus(HealthNodeDto node) {
+        return "UP".equals(node.status()) || "UNKNOWN".equals(node.status());
+    }
+
+    private List<HealthNodeDto> disableNodes(List<HealthNodeDto> nodes) {
+        return nodes.stream().map(this::disabledNode).toList();
+    }
+
+    private HealthNodeDto disabledNode(HealthNodeDto node) {
+        return new HealthNodeDto(
+                node.name(),
+                "DISABLED",
+                node.details(),
+                disableNodes(node.components()),
+                false,
+                DEFAULT_CONTRIBUTOR_NODE_REASON,
+                List.of());
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HealthControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HealthControllerTests.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
@@ -21,7 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 /**
  * Controller-level tests for {@link HealthController}.
  *
- * <p>Covers the missing-actuator UNKNOWN root, a simple indicated UP health,
+ * <p>Covers the missing-actuator disabled root, a simple indicated UP health,
  * a DOWN health with details, and a composite health with child components.
  * {@link IndicatedHealthDescriptor} is {@code final} and uses
  * {@link MockMakers#INLINE}; {@link CompositeHealthDescriptor} is non-final
@@ -44,13 +45,17 @@ class HealthControllerTests {
     }
 
     @Test
-    void healthReturnsUnknownWhenActuatorUnavailable() throws Exception {
+    void healthReturnsDisabledWhenActuatorUnavailable() throws Exception {
         MockMvc mvc = standaloneSetup(new HealthController(emptyProvider())).build();
 
         mvc.perform(get("/bootui/api/health"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("application"))
-                .andExpect(jsonPath("$.status").value("UNKNOWN"))
+                .andExpect(jsonPath("$.status").value("DISABLED"))
+                .andExpect(jsonPath("$.available").value(false))
+                .andExpect(
+                        jsonPath("$.unavailableReason").value("Spring Boot Actuator health endpoint is not available"))
+                .andExpect(jsonPath("$.setup[0].title").value("Add Spring Boot Actuator"))
                 .andExpect(jsonPath("$.components").isArray())
                 .andExpect(jsonPath("$.components").isEmpty());
     }
@@ -72,8 +77,81 @@ class HealthControllerTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("application"))
                 .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.available").value(true))
+                .andExpect(jsonPath("$.setup").isEmpty())
                 .andExpect(jsonPath("$.components").isArray())
                 .andExpect(jsonPath("$.components").isEmpty());
+    }
+
+    @Test
+    void healthReturnsDisabledWhenOnlyDefaultIndicatorsArePresent() throws Exception {
+        IndicatedHealthDescriptor liveness =
+                mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        when(liveness.getStatus()).thenReturn(Status.UP);
+        when(liveness.getDetails()).thenReturn(Map.of("livenessState", "CORRECT"));
+
+        IndicatedHealthDescriptor readiness =
+                mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        when(readiness.getStatus()).thenReturn(Status.UP);
+        when(readiness.getDetails()).thenReturn(Map.of("readinessState", "ACCEPTING_TRAFFIC"));
+
+        IndicatedHealthDescriptor ssl =
+                mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        when(ssl.getStatus()).thenReturn(Status.UP);
+        when(ssl.getDetails()).thenReturn(Map.of("validChains", List.of()));
+
+        CompositeHealthDescriptor composite = mock(CompositeHealthDescriptor.class);
+        when(composite.getStatus()).thenReturn(Status.UP);
+        when(composite.getComponents())
+                .thenReturn(Map.of(
+                        "livenessState", liveness,
+                        "readinessState", readiness,
+                        "ssl", ssl));
+
+        HealthEndpoint endpoint = mock(HealthEndpoint.class);
+        when(endpoint.health()).thenReturn(composite);
+
+        MockMvc mvc =
+                standaloneSetup(new HealthController(providerOf(endpoint))).build();
+
+        mvc.perform(get("/bootui/api/health").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DISABLED"))
+                .andExpect(jsonPath("$.available").value(false))
+                .andExpect(jsonPath("$.unavailableReason")
+                        .value("Only Spring Boot default health indicators are available"))
+                .andExpect(jsonPath("$.setup[0].title").value("Add application health contributors"))
+                .andExpect(jsonPath("$.components.length()").value(3))
+                .andExpect(jsonPath("$.components[?(@.name=='livenessState')].status")
+                        .value("DISABLED"))
+                .andExpect(jsonPath("$.components[?(@.name=='readinessState')].status")
+                        .value("DISABLED"))
+                .andExpect(jsonPath("$.components[?(@.name=='ssl')].status").value("DISABLED"));
+    }
+
+    @Test
+    void healthKeepsDefaultIndicatorFailuresVisible() throws Exception {
+        IndicatedHealthDescriptor disk =
+                mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
+        when(disk.getStatus()).thenReturn(Status.DOWN);
+        when(disk.getDetails()).thenReturn(Map.of("error", "Disk space below threshold"));
+
+        CompositeHealthDescriptor composite = mock(CompositeHealthDescriptor.class);
+        when(composite.getStatus()).thenReturn(Status.DOWN);
+        when(composite.getComponents()).thenReturn(Map.of("diskSpace", disk));
+
+        HealthEndpoint endpoint = mock(HealthEndpoint.class);
+        when(endpoint.health()).thenReturn(composite);
+
+        MockMvc mvc =
+                standaloneSetup(new HealthController(providerOf(endpoint))).build();
+
+        mvc.perform(get("/bootui/api/health").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DOWN"))
+                .andExpect(jsonPath("$.available").value(true))
+                .andExpect(
+                        jsonPath("$.components[?(@.name=='diskSpace')].status").value("DOWN"));
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HealthControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HealthControllerTests.java
@@ -84,7 +84,7 @@ class HealthControllerTests {
     }
 
     @Test
-    void healthReturnsDisabledWhenOnlyDefaultIndicatorsArePresent() throws Exception {
+    void healthAddsGuidanceWhenOnlyDefaultIndicatorsArePresent() throws Exception {
         IndicatedHealthDescriptor liveness =
                 mock(IndicatedHealthDescriptor.class, withSettings().mockMaker(MockMakers.INLINE));
         when(liveness.getStatus()).thenReturn(Status.UP);
@@ -116,17 +116,18 @@ class HealthControllerTests {
 
         mvc.perform(get("/bootui/api/health").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("DISABLED"))
-                .andExpect(jsonPath("$.available").value(false))
-                .andExpect(jsonPath("$.unavailableReason")
-                        .value("Only Spring Boot default health indicators are available"))
+                .andExpect(jsonPath("$.status").value("UP"))
+                .andExpect(jsonPath("$.available").value(true))
+                .andExpect(jsonPath("$.unavailableReason").doesNotExist())
+                .andExpect(
+                        jsonPath("$.guidanceReason").value("Only Spring Boot default health indicators are available"))
                 .andExpect(jsonPath("$.setup[0].title").value("Add application health contributors"))
                 .andExpect(jsonPath("$.components.length()").value(3))
                 .andExpect(jsonPath("$.components[?(@.name=='livenessState')].status")
-                        .value("DISABLED"))
+                        .value("UP"))
                 .andExpect(jsonPath("$.components[?(@.name=='readinessState')].status")
-                        .value("DISABLED"))
-                .andExpect(jsonPath("$.components[?(@.name=='ssl')].status").value("DISABLED"));
+                        .value("UP"))
+                .andExpect(jsonPath("$.components[?(@.name=='ssl')].status").value("UP"));
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MissingActuatorEndpointsTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MissingActuatorEndpointsTests.java
@@ -88,14 +88,17 @@ class MissingActuatorEndpointsTests {
     }
 
     @Test
-    void healthControllerReturnsUnknownRootWhenEndpointMissing() throws Exception {
+    void healthControllerReturnsDisabledRootWhenEndpointMissing() throws Exception {
         ObjectProvider<HealthEndpoint> provider = emptyProvider();
         MockMvc mvc = standaloneSetup(new HealthController(provider)).build();
 
         mvc.perform(get("/bootui/api/health"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value("application"))
-                .andExpect(jsonPath("$.status").value("UNKNOWN"))
+                .andExpect(jsonPath("$.status").value("DISABLED"))
+                .andExpect(jsonPath("$.available").value(false))
+                .andExpect(jsonPath("$.setup[0].snippets[0]")
+                        .value("org.springframework.boot:spring-boot-starter-actuator"))
                 .andExpect(jsonPath("$.components").isEmpty());
     }
 

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -205,7 +205,21 @@ public final class BootUiDtos {
     /**
      * Health node, possibly nested.
      */
-    public record HealthNodeDto(String name, String status, Object details, List<HealthNodeDto> components) {}
+    public record HealthNodeDto(
+            String name,
+            String status,
+            Object details,
+            List<HealthNodeDto> components,
+            boolean available,
+            String unavailableReason,
+            List<HealthSetupStepDto> setup) {
+
+        public HealthNodeDto(String name, String status, Object details, List<HealthNodeDto> components) {
+            this(name, status, details, components, true, null, List.of());
+        }
+    }
+
+    public record HealthSetupStepDto(String title, String description, List<String> snippets) {}
 
     public record LoggerDto(String name, String configuredLevel, String effectiveLevel) {}
 

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -212,10 +212,11 @@ public final class BootUiDtos {
             List<HealthNodeDto> components,
             boolean available,
             String unavailableReason,
+            String guidanceReason,
             List<HealthSetupStepDto> setup) {
 
         public HealthNodeDto(String name, String status, Object details, List<HealthNodeDto> components) {
-            this(name, status, details, components, true, null, List.of());
+            this(name, status, details, components, true, null, null, List.of());
         }
     }
 

--- a/bootui-sample-app/e2e/tests/health.spec.js
+++ b/bootui-sample-app/e2e/tests/health.spec.js
@@ -9,7 +9,7 @@ test.describe('Health view', () => {
     await expect(page.getByText('Component tree')).toBeVisible()
     const rootCard = page.locator('main .card').first()
     await expect(rootCard).toBeVisible()
-    await expect(rootCard.locator('.badge')).toHaveText(/UP|DOWN|UNKNOWN|OUT_OF_SERVICE/)
+    await expect(rootCard.locator('.badge')).toHaveText(/UP|DOWN|UNKNOWN|OUT_OF_SERVICE|DISABLED/)
     await expect(page.locator('main pre')).toHaveCount(0)
   })
 

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -203,7 +203,7 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
         assertThat(body).isNotNull();
-        assertThat(body.get("status")).isIn("UP", "DOWN", "UNKNOWN", "OUT_OF_SERVICE");
+        assertThat(body.get("status")).isIn("UP", "DOWN", "UNKNOWN", "OUT_OF_SERVICE", "DISABLED");
     }
 
     @Test

--- a/bootui-ui/src/main/frontend/src/views/Health.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Health.test.js
@@ -1,0 +1,118 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import Health from './Health.vue'
+
+function jsonResponse(body) {
+  return Promise.resolve(new Response(JSON.stringify(body), {status: 200}))
+}
+
+async function mountWithHealth(body) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => jsonResponse(body))
+  )
+  const wrapper = mount(Health)
+  await flushPromises()
+  return wrapper
+}
+
+describe('Health', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows setup guidance when Actuator health is unavailable', async () => {
+    const wrapper = await mountWithHealth({
+      name: 'application',
+      status: 'DISABLED',
+      details: null,
+      components: [],
+      available: false,
+      unavailableReason: 'Spring Boot Actuator health endpoint is not available',
+      setup: [
+        {
+          title: 'Add Spring Boot Actuator',
+          description: 'Add the Actuator starter.',
+          snippets: ['org.springframework.boot:spring-boot-starter-actuator']
+        },
+        {
+          title: 'Enable availability probes when you need them',
+          description: 'Expose liveness and readiness groups.',
+          snippets: ['management.endpoint.health.probes.enabled=true']
+        }
+      ]
+    })
+
+    expect(fetch).toHaveBeenCalledWith('api/health')
+    expect(wrapper.text()).toContain('DISABLED')
+    expect(wrapper.text()).toContain('Spring Boot Actuator health endpoint is not available')
+    expect(wrapper.text()).toContain('Set up Spring Boot Actuator health')
+    expect(wrapper.text()).toContain('org.springframework.boot:spring-boot-starter-actuator')
+    expect(wrapper.text()).toContain('management.endpoint.health.probes.enabled=true')
+    expect(wrapper.text()).not.toContain('Component tree')
+  })
+
+  it('shows default health contributors as disabled while setup guidance is visible', async () => {
+    const wrapper = await mountWithHealth({
+      name: 'application',
+      status: 'DISABLED',
+      details: null,
+      available: false,
+      unavailableReason: 'Only Spring Boot default health indicators are available',
+      setup: [
+        {
+          title: 'Add application health contributors',
+          description: 'Create a HealthIndicator bean.',
+          snippets: ['class MyHealthIndicator implements HealthIndicator']
+        }
+      ],
+      components: [
+        {
+          name: 'livenessState',
+          status: 'DISABLED',
+          details: {livenessState: 'CORRECT'},
+          components: [],
+          available: false
+        },
+        {
+          name: 'readinessState',
+          status: 'DISABLED',
+          details: {readinessState: 'ACCEPTING_TRAFFIC'},
+          components: [],
+          available: false
+        },
+        {
+          name: 'ssl',
+          status: 'DISABLED',
+          details: {validChains: []},
+          components: [],
+          available: false
+        }
+      ]
+    })
+
+    expect(wrapper.text()).toContain('Only Spring Boot default health indicators are available')
+    expect(wrapper.text()).toContain('Add application health contributors')
+    expect(wrapper.text()).toContain('Component tree')
+    expect(wrapper.text()).toContain('livenessState')
+    expect(wrapper.text()).toContain('readinessState')
+    expect(wrapper.text()).toContain('ssl')
+  })
+
+  it('renders the component tree when health data is available', async () => {
+    const wrapper = await mountWithHealth({
+      name: 'application',
+      status: 'UP',
+      details: null,
+      components: [{name: 'diskSpace', status: 'UP', details: {free: '128 GB'}, components: [], available: true}],
+      available: true,
+      setup: []
+    })
+
+    expect(wrapper.text()).toContain('All reported components are healthy')
+    expect(wrapper.text()).toContain('Component tree')
+    expect(wrapper.text()).toContain('diskSpace')
+    expect(wrapper.text()).not.toContain('Set up Spring Boot Actuator health')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Health.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Health.test.js
@@ -94,6 +94,9 @@ describe('Health', () => {
 
     expect(wrapper.text()).toContain('Only Spring Boot default health indicators are available')
     expect(wrapper.text()).toContain('Add application health contributors')
+    expect(wrapper.text()).toContain('Actuator health is present')
+    expect(wrapper.text()).toContain('Spring Boot default health indicators: livenessState, readinessState, ssl')
+    expect(wrapper.text()).toContain('The SSL indicator only appears when Spring has SSL bundles to validate.')
     expect(wrapper.text()).toContain('Component tree')
     expect(wrapper.text()).toContain('livenessState')
     expect(wrapper.text()).toContain('readinessState')

--- a/bootui-ui/src/main/frontend/src/views/Health.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Health.test.js
@@ -53,13 +53,13 @@ describe('Health', () => {
     expect(wrapper.text()).not.toContain('Component tree')
   })
 
-  it('shows default health contributors as disabled while setup guidance is visible', async () => {
+  it('shows default health contributors as live with setup guidance', async () => {
     const wrapper = await mountWithHealth({
       name: 'application',
-      status: 'DISABLED',
+      status: 'UP',
       details: null,
-      available: false,
-      unavailableReason: 'Only Spring Boot default health indicators are available',
+      available: true,
+      guidanceReason: 'Only Spring Boot default health indicators are available',
       setup: [
         {
           title: 'Add application health contributors',
@@ -70,31 +70,32 @@ describe('Health', () => {
       components: [
         {
           name: 'livenessState',
-          status: 'DISABLED',
+          status: 'UP',
           details: {livenessState: 'CORRECT'},
           components: [],
-          available: false
+          available: true
         },
         {
           name: 'readinessState',
-          status: 'DISABLED',
+          status: 'UP',
           details: {readinessState: 'ACCEPTING_TRAFFIC'},
           components: [],
-          available: false
+          available: true
         },
         {
           name: 'ssl',
-          status: 'DISABLED',
+          status: 'UP',
           details: {validChains: []},
           components: [],
-          available: false
+          available: true
         }
       ]
     })
 
+    expect(wrapper.text()).toContain('UP')
     expect(wrapper.text()).toContain('Only Spring Boot default health indicators are available')
     expect(wrapper.text()).toContain('Add application health contributors')
-    expect(wrapper.text()).toContain('Actuator health is present')
+    expect(wrapper.text()).toContain('Actuator health is available')
     expect(wrapper.text()).toContain('Spring Boot default health indicators: livenessState, readinessState, ssl')
     expect(wrapper.text()).toContain('The SSL indicator only appears when Spring has SSL bundles to validate.')
     expect(wrapper.text()).toContain('Component tree')
@@ -106,15 +107,15 @@ describe('Health', () => {
   it('does not render empty detail sections for contributors', async () => {
     const wrapper = await mountWithHealth({
       name: 'application',
-      status: 'DISABLED',
+      status: 'UP',
       details: null,
-      available: false,
-      unavailableReason: 'Only Spring Boot default health indicators are available',
+      available: true,
+      guidanceReason: 'Only Spring Boot default health indicators are available',
       setup: [],
       components: [
-        {name: 'livenessState', status: 'DISABLED', details: {}, components: [], available: false},
-        {name: 'ping', status: 'DISABLED', details: {}, components: [], available: false},
-        {name: 'readinessState', status: 'DISABLED', details: {}, components: [], available: false}
+        {name: 'livenessState', status: 'UP', details: {}, components: [], available: true},
+        {name: 'ping', status: 'UP', details: {}, components: [], available: true},
+        {name: 'readinessState', status: 'UP', details: {}, components: [], available: true}
       ]
     })
 

--- a/bootui-ui/src/main/frontend/src/views/Health.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Health.test.js
@@ -100,6 +100,28 @@ describe('Health', () => {
     expect(wrapper.text()).toContain('ssl')
   })
 
+  it('does not render empty detail sections for contributors', async () => {
+    const wrapper = await mountWithHealth({
+      name: 'application',
+      status: 'DISABLED',
+      details: null,
+      available: false,
+      unavailableReason: 'Only Spring Boot default health indicators are available',
+      setup: [],
+      components: [
+        {name: 'livenessState', status: 'DISABLED', details: {}, components: [], available: false},
+        {name: 'ping', status: 'DISABLED', details: {}, components: [], available: false},
+        {name: 'readinessState', status: 'DISABLED', details: {}, components: [], available: false}
+      ]
+    })
+
+    expect(wrapper.text()).toContain('livenessState')
+    expect(wrapper.text()).toContain('ping')
+    expect(wrapper.text()).toContain('readinessState')
+    expect(wrapper.findAll('h6').filter((heading) => heading.text() === 'Details')).toHaveLength(0)
+    expect(wrapper.text()).not.toContain('0 details')
+  })
+
   it('renders the component tree when health data is available', async () => {
     const wrapper = await mountWithHealth({
       name: 'application',

--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -37,12 +37,19 @@ const componentCount = computed(() => Math.max(nodes.value.length - 1, 0))
 const healthUnavailable = computed(() => root.value?.available === false)
 const setupSteps = computed(() => root.value?.setup || [])
 const hasHealthComponents = computed(() => componentCount.value > 0)
+const defaultOnlyHealth = computed(
+  () => root.value?.unavailableReason === 'Only Spring Boot default health indicators are available'
+)
+const defaultContributorNames = computed(() =>
+  (root.value?.components || []).map((component) => component.name).join(', ')
+)
+const setupTitle = computed(() =>
+  defaultOnlyHealth.value ? 'Add application health contributors' : 'Set up Spring Boot Actuator health'
+)
 const setupIntro = computed(() => {
-  if (hasHealthComponents.value) {
-    return (
-      'Actuator is present, but BootUI only found Spring Boot default probe and SSL indicators. Add application or ' +
-      'dependency health contributors so this panel reflects your app instead of framework defaults.'
-    )
+  if (defaultOnlyHealth.value) {
+    const contributors = defaultContributorNames.value ? `: ${defaultContributorNames.value}` : ''
+    return `Actuator health is present, but BootUI only found Spring Boot default health indicators${contributors}. These framework checks are useful, but they do not prove that your application dependencies are healthy. The SSL indicator only appears when Spring has SSL bundles to validate.`
   }
   return (
     'The Health panel is disabled until a Spring Boot Actuator HealthEndpoint is available. Once it is configured, ' +
@@ -153,7 +160,7 @@ onMounted(load)
         <div class="card-body">
           <h5 class="card-title d-flex align-items-center gap-2">
             <i class="bi bi-info-circle text-info"></i>
-            Set up Spring Boot Actuator health
+            {{ setupTitle }}
           </h5>
           <p class="text-muted mb-3">
             {{ setupIntro }}

--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -34,13 +34,36 @@ function flatten(node) {
 
 const nodes = computed(() => flatten(root.value))
 const componentCount = computed(() => Math.max(nodes.value.length - 1, 0))
-const problemNodes = computed(() => nodes.value.filter((node) => !['UP', 'UNKNOWN'].includes(node.status)))
+const healthUnavailable = computed(() => root.value?.available === false)
+const setupSteps = computed(() => root.value?.setup || [])
+const hasHealthComponents = computed(() => componentCount.value > 0)
+const setupIntro = computed(() => {
+  if (hasHealthComponents.value) {
+    return (
+      'Actuator is present, but BootUI only found Spring Boot default probe and SSL indicators. Add application or ' +
+      'dependency health contributors so this panel reflects your app instead of framework defaults.'
+    )
+  }
+  return (
+    'The Health panel is disabled until a Spring Boot Actuator HealthEndpoint is available. Once it is configured, ' +
+    'BootUI will render the application status, liveness/readiness probes, SSL certificate checks, and any dependency ' +
+    'contributors reported by Actuator.'
+  )
+})
+const problemNodes = computed(() =>
+  nodes.value.filter((node) => node.available !== false && !['UP', 'UNKNOWN', 'DISABLED'].includes(node.status))
+)
 const detailsHidden = computed(
-  () => root.value && !root.value.details && (!root.value.components || root.value.components.length === 0)
+  () =>
+    root.value &&
+    !healthUnavailable.value &&
+    !root.value.details &&
+    (!root.value.components || root.value.components.length === 0)
 )
 
 const statusMessage = computed(() => {
   if (!root.value) return ''
+  if (healthUnavailable.value) return root.value.unavailableReason || 'Actuator health data is unavailable'
   if (problemNodes.value.length) {
     return (
       problemNodes.value.length + ' component' + (problemNodes.value.length === 1 ? ' needs' : 's need') + ' attention'
@@ -126,8 +149,31 @@ onMounted(load)
         <code>management.endpoint.health.show-details=always</code> to show component details.
       </div>
 
-      <h5 class="mb-2">Component tree</h5>
-      <HealthNode :node="root" />
+      <div v-if="healthUnavailable" class="card border-info mb-3">
+        <div class="card-body">
+          <h5 class="card-title d-flex align-items-center gap-2">
+            <i class="bi bi-info-circle text-info"></i>
+            Set up Spring Boot Actuator health
+          </h5>
+          <p class="text-muted mb-3">
+            {{ setupIntro }}
+          </p>
+          <ol v-if="setupSteps.length" class="mb-0 ps-3">
+            <li v-for="step in setupSteps" :key="step.title" class="mb-3">
+              <div class="fw-semibold">{{ step.title }}</div>
+              <div class="text-muted small mb-2">{{ step.description }}</div>
+              <div v-if="step.snippets?.length" class="d-flex flex-column gap-1">
+                <code v-for="snippet in step.snippets" :key="snippet" class="small">{{ snippet }}</code>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </div>
+
+      <template v-if="!healthUnavailable || hasHealthComponents">
+        <h5 class="mb-2">Component tree</h5>
+        <HealthNode :node="root" />
+      </template>
     </template>
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -38,7 +38,10 @@ const healthUnavailable = computed(() => root.value?.available === false)
 const setupSteps = computed(() => root.value?.setup || [])
 const hasHealthComponents = computed(() => componentCount.value > 0)
 const defaultOnlyHealth = computed(
-  () => root.value?.unavailableReason === 'Only Spring Boot default health indicators are available'
+  () => root.value?.guidanceReason === 'Only Spring Boot default health indicators are available'
+)
+const healthGuidance = computed(
+  () => healthUnavailable.value || Boolean(root.value?.guidanceReason) || setupSteps.value.length > 0
 )
 const defaultContributorNames = computed(() =>
   (root.value?.components || []).map((component) => component.name).join(', ')
@@ -49,7 +52,7 @@ const setupTitle = computed(() =>
 const setupIntro = computed(() => {
   if (defaultOnlyHealth.value) {
     const contributors = defaultContributorNames.value ? `: ${defaultContributorNames.value}` : ''
-    return `Actuator health is present, but BootUI only found Spring Boot default health indicators${contributors}. These framework checks are useful, but they do not prove that your application dependencies are healthy. The SSL indicator only appears when Spring has SSL bundles to validate.`
+    return `Actuator health is available, but the reported tree contains only Spring Boot default health indicators${contributors}. These framework checks are useful, but they do not prove that your application dependencies are healthy. The SSL indicator only appears when Spring has SSL bundles to validate.`
   }
   return (
     'The Health panel is disabled until a Spring Boot Actuator HealthEndpoint is available. Once it is configured, ' +
@@ -71,6 +74,7 @@ const detailsHidden = computed(
 const statusMessage = computed(() => {
   if (!root.value) return ''
   if (healthUnavailable.value) return root.value.unavailableReason || 'Actuator health data is unavailable'
+  if (root.value.guidanceReason) return root.value.guidanceReason
   if (problemNodes.value.length) {
     return (
       problemNodes.value.length + ' component' + (problemNodes.value.length === 1 ? ' needs' : 's need') + ' attention'
@@ -156,7 +160,7 @@ onMounted(load)
         <code>management.endpoint.health.show-details=always</code> to show component details.
       </div>
 
-      <div v-if="healthUnavailable" class="card border-info mb-3">
+      <div v-if="healthGuidance" class="card border-info mb-3">
         <div class="card-body">
           <h5 class="card-title d-flex align-items-center gap-2">
             <i class="bi bi-info-circle text-info"></i>

--- a/bootui-ui/src/main/frontend/src/views/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthNode.vue
@@ -11,7 +11,8 @@ const statusClass = (s) =>
     UP: 'bg-success',
     DOWN: 'bg-danger',
     OUT_OF_SERVICE: 'bg-warning text-dark',
-    UNKNOWN: 'bg-secondary'
+    UNKNOWN: 'bg-secondary',
+    DISABLED: 'bg-secondary'
   })[s] || 'bg-secondary'
 
 const statusIcon = (s) =>
@@ -19,7 +20,8 @@ const statusIcon = (s) =>
     UP: 'bi-check-circle-fill text-success',
     DOWN: 'bi-x-circle-fill text-danger',
     OUT_OF_SERVICE: 'bi-exclamation-triangle-fill text-warning',
-    UNKNOWN: 'bi-question-circle-fill text-secondary'
+    UNKNOWN: 'bi-question-circle-fill text-secondary',
+    DISABLED: 'bi-slash-circle-fill text-secondary'
   })[s] || 'bi-question-circle-fill text-secondary'
 
 const childCount = (node) => (node.components || []).length

--- a/bootui-ui/src/main/frontend/src/views/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthNode.vue
@@ -26,10 +26,25 @@ const statusIcon = (s) =>
 
 const childCount = (node) => (node.components || []).length
 
-const detailCount = (node) => {
-  if (!node.details || typeof node.details !== 'object' || Array.isArray(node.details)) return node.details ? 1 : 0
-  return Object.keys(node.details).length
+function isPlainObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]'
 }
+
+function hasDetailValue(value) {
+  if (value === null || value === undefined || value === '') return false
+  if (Array.isArray(value)) return value.some(hasDetailValue)
+  if (isPlainObject(value)) return Object.values(value).some(hasDetailValue)
+  return true
+}
+
+const detailCount = (node) => {
+  if (!hasDetailValue(node.details)) return 0
+  if (Array.isArray(node.details)) return node.details.filter(hasDetailValue).length
+  if (isPlainObject(node.details)) return Object.values(node.details).filter(hasDetailValue).length
+  return 1
+}
+
+const hasDetails = (node) => detailCount(node) > 0
 </script>
 
 <template>
@@ -41,21 +56,21 @@ const detailCount = (node) => {
         <span v-if="childCount(node)" class="text-muted small">
           {{ childCount(node) }} {{ childCount(node) === 1 ? 'component' : 'components' }}
         </span>
-        <span v-if="detailCount(node)" class="text-muted small">
+        <span v-if="hasDetails(node)" class="text-muted small">
           {{ detailCount(node) }} {{ detailCount(node) === 1 ? 'detail' : 'details' }}
         </span>
       </span>
       <span :class="statusClass(node.status)" class="badge">{{ node.status }}</span>
     </summary>
 
-    <div v-if="childCount(node) || node.details" class="card-body">
-      <section v-if="node.details" class="mb-3">
+    <div v-if="childCount(node) || hasDetails(node)" class="card-body">
+      <section v-if="hasDetails(node)" class="mb-3">
         <h6 class="text-muted text-uppercase small mb-2">Details</h6>
         <HealthDetails :value="node.details" />
       </section>
 
       <section v-if="childCount(node)">
-        <h6 v-if="node.details" class="text-muted text-uppercase small mb-2">Components</h6>
+        <h6 v-if="hasDetails(node)" class="text-muted text-uppercase small mb-2">Components</h6>
         <HealthNode v-for="c in node.components" :key="c.name" :depth="depth + 1" :node="c" />
       </section>
     </div>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -28,7 +28,8 @@ first place to confirm whether BootUI is active for the reason you expect.
 The Health panel displays the Actuator health tree, including nested contributors and detailed status information when
 the host app exposes it. It keeps unavailable health data separate from unhealthy application state so missing Actuator
 infrastructure is clear, and shows setup guidance instead of a healthy-looking status when the Actuator health endpoint
-is not available or only Spring Boot's default health indicators are present.
+is not available. When Actuator health is present but only Spring Boot's default indicators are reported, it keeps the
+live statuses visible and shows guidance for adding application or dependency health contributors.
 
 ![BootUI Health panel](images/bootui-health.png)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -27,7 +27,8 @@ first place to confirm whether BootUI is active for the reason you expect.
 
 The Health panel displays the Actuator health tree, including nested contributors and detailed status information when
 the host app exposes it. It keeps unavailable health data separate from unhealthy application state so missing Actuator
-infrastructure is clear.
+infrastructure is clear, and shows setup guidance instead of a healthy-looking status when the Actuator health endpoint
+is not available or only Spring Boot's default probe/SSL indicators are present.
 
 ![BootUI Health panel](images/bootui-health.png)
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -28,7 +28,7 @@ first place to confirm whether BootUI is active for the reason you expect.
 The Health panel displays the Actuator health tree, including nested contributors and detailed status information when
 the host app exposes it. It keeps unavailable health data separate from unhealthy application state so missing Actuator
 infrastructure is clear, and shows setup guidance instead of a healthy-looking status when the Actuator health endpoint
-is not available or only Spring Boot's default probe/SSL indicators are present.
+is not available or only Spring Boot's default health indicators are present.
 
 ![BootUI Health panel](images/bootui-health.png)
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -294,7 +294,7 @@ Features:
 - Show details when available.
 - Explain when details are hidden by Actuator configuration.
 - Show a disabled state with setup guidance when the Actuator health endpoint is not available.
-- Treat a tree made only of Spring Boot default health indicators as not yet application-health-ready.
+- Show guidance, without changing reported statuses, when a tree is made only of Spring Boot default health indicators.
 
 Acceptance criteria:
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -294,7 +294,7 @@ Features:
 - Show details when available.
 - Explain when details are hidden by Actuator configuration.
 - Show a disabled state with setup guidance when the Actuator health endpoint is not available.
-- Treat a tree made only of Spring Boot default probe/SSL indicators as not yet application-health-ready.
+- Treat a tree made only of Spring Boot default health indicators as not yet application-health-ready.
 
 Acceptance criteria:
 
@@ -1041,7 +1041,7 @@ Examples:
   - "Health details are hidden. In local development, set `management.endpoint.health.show-details=always`."
 - No Actuator health endpoint:
   - "The Health panel is disabled until a Spring Boot Actuator `HealthEndpoint` is available."
-- Only default probe/SSL health contributors:
+- Only default health contributors:
   - "Only Spring Boot default health indicators are available. Add application or dependency health contributors."
 - No startup timeline:
   - "Startup data is unavailable. Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero,

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -293,6 +293,8 @@ Features:
 - Highlight failing contributors.
 - Show details when available.
 - Explain when details are hidden by Actuator configuration.
+- Show a disabled state with setup guidance when the Actuator health endpoint is not available.
+- Treat a tree made only of Spring Boot default probe/SSL indicators as not yet application-health-ready.
 
 Acceptance criteria:
 
@@ -1037,6 +1039,10 @@ Examples:
 
 - No Actuator health details:
   - "Health details are hidden. In local development, set `management.endpoint.health.show-details=always`."
+- No Actuator health endpoint:
+  - "The Health panel is disabled until a Spring Boot Actuator `HealthEndpoint` is available."
+- Only default probe/SSL health contributors:
+  - "Only Spring Boot default health indicators are available. Add application or dependency health contributors."
 - No startup timeline:
   - "Startup data is unavailable. Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero,
     or provide your own `BufferingApplicationStartup`."


### PR DESCRIPTION
## What does this PR do?

Updates the Health panel so unavailable Actuator health is shown as disabled with setup guidance, while Spring Boot default health contributors keep their real statuses and details. When BootUI only sees default contributors such as `diskSpace`, `ping`, liveness, readiness, or SSL, it now shows an advisory panel instead of rewriting the tree to `DISABLED`.

## Why is this change needed?

The Health panel could previously make a minimal app look fully application-health-ready, or later make valid default contributors look disabled even though Actuator was present and returning real data. This change separates three states: missing Actuator health, default-only Actuator health, and actual application/dependency health contributors.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional validation run:

- `./mvnw -B -ntp -pl bootui-core,bootui-autoconfigure -Dtest=HealthControllerTests,MissingActuatorEndpointsTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `(cd bootui-ui/src/main/frontend && npm run format && npm test -- --run src/views/Health.test.js)`
- `./mvnw -B -ntp spotless:check`
- `(cd bootui-ui/src/main/frontend && npm run format:check && npm test)`
- `(cd bootui-sample-app/e2e && npx playwright test tests/health.spec.js)`

Note: the full sample-app e2e suite currently has an unrelated failure in `tests/ai.spec.js` for the AI Usage unavailable-mode text; the Health spec passes.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed