### PR TITLE
refactor: remove duplicate formatDuration/formatTime in Traces.vue

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatDuration, formatTime} from '../utils/format.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 
 const props = defineProps(panelProps)
@@ -114,20 +115,6 @@ const waterfall = computed(() => {
     .sort((a, b) => a.startEpochNanos - b.startEpochNanos)
   return {spans: sorted, totalNanos}
 })
-
-function formatDuration(nanos) {
-  if (nanos == null) return '—'
-  const ms = nanos / 1_000_000
-  if (ms < 1) return (nanos / 1000).toFixed(1) + ' µs'
-  if (ms < 1000) return ms.toFixed(1) + ' ms'
-  return (ms / 1000).toFixed(2) + ' s'
-}
-
-function formatTime(epochNanos) {
-  if (!epochNanos) return '—'
-  const ms = Math.floor(epochNanos / 1_000_000)
-  return new Date(ms).toLocaleTimeString()
-}
 
 function spanColor(span) {
   if (span.statusCode === 'ERROR') return 'bg-danger'


### PR DESCRIPTION
Replace local copies with imports from utils/format.js.

## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
