### PR TITLE
Update footer GitHub link

### DIFF
--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -455,7 +455,11 @@ function onGlobalKeydown(e) {
         </router-view>
       </main>
 
-      <footer class="bootui-footer">BootUI · embedded in your Spring Boot app · no external service required</footer>
+      <footer class="bootui-footer">
+        <a :href="githubProjectUrl" rel="noopener noreferrer" target="_blank">
+          BootUI - The missing developer UI for Spring Boot!
+        </a>
+      </footer>
     </div>
   </div>
 </template>
@@ -1117,6 +1121,14 @@ function onGlobalKeydown(e) {
   font-size: 0.82rem;
   padding: 0 2rem 1.25rem;
   text-align: center;
+}
+
+.bootui-footer a {
+  color: inherit;
+}
+
+.bootui-footer a:hover {
+  color: var(--bootui-green-dark);
 }
 
 .page-slide-enter-active,


### PR DESCRIPTION
The footer should make BootUI's positioning clearer and give users a direct path to the project source.

This replaces the static footer copy with the requested tagline and links it to the existing GitHub project URL used elsewhere in the app. The link keeps the footer's muted styling by default and uses the BootUI green hover color for consistency.

Validation: `npm run format:check && npm test`