### PR TITLE
Refine database connection pools panel

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -165,7 +165,7 @@ Playwright coverage aligned for:
 - **Overview**: Overview
 - **Runtime**: Health, Metrics, Memory, Heap Dump, Startup Timeline
 - **Configuration**: Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings
-- **Services**: Scheduled Tasks, Connection Pools, Data, Cache, Security, AI Usage
+- **Services**: Scheduled Tasks, Database Connection Pools, Data, Cache, Security, AI Usage
 - **Diagnostics**: Traces, Log Tail, HTTP Probe, Architecture, Pentesting, Vulnerabilities
 - **Developer Tools**: DevTools, Dev Services, Copilot, Claude Code
 - The router order in `bootui-ui/src/main/frontend/src/main.js`, `docs/FEATURES.md`, README feature table, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.2.0] - 2026-06-01
 
 Second BootUI release, focused on local security diagnostics, three new local-only diagnostics panels — Architecture
-(ArchUnit), Heap Dump (value-free class histogram), and Database Connection Pools (HikariCP) — and safer defaults around
+(ArchUnit), Heap Dump (value-free class histogram), and Database Connection Pools — and safer defaults around
 host-application security, plus release/documentation hardening for the full visible panel surface.
 
 ### Added
@@ -45,8 +45,8 @@ host-application security, plus release/documentation hardening for the full vis
 - Heap Dump panel that captures local JVM heap dumps on demand and analyzes a value-free class histogram, including a
   `max-classes` memory cap plus big-objects and collection-bloat smart filters. Raw `.hprof` download stays disabled by
   default because dumps contain plaintext secrets.
-- Database Connection Pools panel that surfaces read-only HikariCP pool sizing, masked JDBC metadata, and a live
-  active/idle/total/pending saturation chart, failing closed when HikariCP is unavailable.
+- Database Connection Pools panel that surfaces read-only database pool sizing, masked JDBC metadata, and a live
+  active/idle/total/pending saturation chart, failing closed when pool support is unavailable.
 - Pentesting panel with explicit, local-only OWASP-aligned hygiene checks for security headers, CORS behavior, cookie
   flags, verbose errors, Spring Security wiring, actuator exposure, DevTools, H2 console, and risky configuration values.
 - BootUI Spring Security integration that keeps `/bootui/**` and `/bootui/api/**` reachable in local applications using

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ BootUI exposes these panels in the same grouped order as the application menu. S
 | Configuration   | [Conditions](docs/FEATURES.md#conditions)             | Understand why auto-configuration classes matched, did not match, or were unconditional.                      |
 | Configuration   | [Mappings](docs/FEATURES.md#mappings)                 | Review HTTP routes, handlers, methods, patterns, and produces/consumes metadata.                              |
 | Services        | [Scheduled Tasks](docs/FEATURES.md#scheduled-tasks)   | View registered scheduled tasks and their trigger metadata.                                                   |
-| Services        | [Connection Pools](docs/FEATURES.md#connection-pools) | Watch HikariCP pool sizing, masked JDBC metadata, and live active/idle/total/pending saturation.              |
+| Services        | [Database Connection Pools](docs/FEATURES.md#database-connection-pools) | Watch database pool sizing, masked JDBC metadata, and live active/idle/total/pending saturation.              |
 | Services        | [Data](docs/FEATURES.md#data)                         | Explore Spring Data repositories, domain types, IDs, and query methods.                                       |
 | Services        | [Cache](docs/FEATURES.md#cache)                       | Inspect Spring Cache managers, caches, metrics, annotations, and confirmed clear actions.                     |
 | Services        | [Security](docs/FEATURES.md#security)                 | Inspect Spring Security filter chains and best-effort endpoint rule explanations.                             |

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/panel/BootUiPanels.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/panel/BootUiPanels.java
@@ -26,7 +26,7 @@ public final class BootUiPanels {
     public static final String CONDITIONS = "conditions";
     public static final String MAPPINGS = "mappings";
     public static final String DATA = "data";
-    public static final String HIKARI = "hikari";
+    public static final String DATABASE_CONNECTION_POOLS = "database-connection-pools";
     public static final String CACHE = "cache";
     public static final String SECURITY = "security";
     public static final String AI = "ai";
@@ -55,7 +55,7 @@ public final class BootUiPanels {
             new Panel(BEANS, "Beans", false, "/beans"),
             new Panel(CONDITIONS, "Conditions", false, "/conditions"),
             new Panel(MAPPINGS, "Mappings", false, "/mappings"),
-            new Panel(HIKARI, "Connection Pools", false, "/database-connection-pools"),
+            new Panel(DATABASE_CONNECTION_POOLS, "Database Connection Pools", false, "/database-connection-pools"),
             new Panel(DATA, "Data", false, "/data"),
             new Panel(CACHE, "Cache", true, "/cache"),
             new Panel(SECURITY, "Security", false, "/security"),

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HikariController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HikariController.java
@@ -23,8 +23,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Exposes read-only HikariCP connection-pool state for {@link HikariDataSource}
- * beans declared in the current application context.
+ * Exposes read-only database connection-pool state for supported JDBC pool beans
+ * declared in the current application context.
  *
  * <p>This controller is strictly read-only: it only reads pool configuration
  * getters and the live counters published by {@link HikariPoolMXBean}. It never
@@ -34,7 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @ConditionalOnClass(HikariDataSource.class)
-@RequestMapping("/bootui/api/hikari")
+@RequestMapping("/bootui/api/database-connection-pools")
 public class HikariController {
 
     private static final Pattern URL_CREDENTIALS =

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PanelsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PanelsController.java
@@ -99,7 +99,7 @@ public class PanelsController {
                 availability(
                         classPresent("org.springframework.data.repository.Repository"),
                         "Spring Data not on the classpath");
-            case BootUiPanels.HIKARI -> availability(hikariAvailable(), hikariUnavailableReason());
+            case BootUiPanels.DATABASE_CONNECTION_POOLS -> availability(hikariAvailable(), hikariUnavailableReason());
             case BootUiPanels.CACHE ->
                 availability(beanPresent(CacheManager.class), "No CacheManager beans are available");
             case BootUiPanels.SECURITY ->
@@ -193,9 +193,9 @@ public class PanelsController {
 
     private String hikariUnavailableReason() {
         if (!classPresent("com.zaxxer.hikari.HikariDataSource")) {
-            return "HikariCP not on the classpath";
+            return "No supported JDBC connection pool implementation is available";
         }
-        return "No HikariDataSource beans are available";
+        return "No database connection pool beans are available";
     }
 
     private boolean architectureAvailable() {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HikariControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HikariControllerTests.java
@@ -75,7 +75,7 @@ class HikariControllerTests {
         MockMvc mvc = standaloneSetup(new HikariController(provider(factory), new BootUiProperties()))
                 .build();
 
-        mvc.perform(get("/bootui/api/hikari/pools"))
+        mvc.perform(get("/bootui/api/database-connection-pools/pools"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.hikariPresent").value(true))
                 .andExpect(jsonPath("$.total").value(1))
@@ -101,7 +101,7 @@ class HikariControllerTests {
         MockMvc mvc = standaloneSetup(new HikariController(provider(factory), properties))
                 .build();
 
-        mvc.perform(get("/bootui/api/hikari/pools"))
+        mvc.perform(get("/bootui/api/database-connection-pools/pools"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.pools[0].jdbcUrl").value(RAW_JDBC_URL))
                 .andExpect(jsonPath("$.pools[0].username").value("app"));
@@ -118,7 +118,7 @@ class HikariControllerTests {
         MockMvc mvc = standaloneSetup(new HikariController(provider(factory), new BootUiProperties()))
                 .build();
 
-        mvc.perform(get("/bootui/api/hikari/pools"))
+        mvc.perform(get("/bootui/api/database-connection-pools/pools"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.pools[0].available").value(false))
                 .andExpect(jsonPath("$.pools[0].unavailableReason").value("Pool is closed"))
@@ -131,7 +131,7 @@ class HikariControllerTests {
         MockMvc mvc = standaloneSetup(new HikariController(provider(factory), new BootUiProperties()))
                 .build();
 
-        mvc.perform(get("/bootui/api/hikari/pools/HikariPool-1/snapshot"))
+        mvc.perform(get("/bootui/api/database-connection-pools/pools/HikariPool-1/snapshot"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.active").value(3))
                 .andExpect(jsonPath("$.idle").value(2))
@@ -145,7 +145,8 @@ class HikariControllerTests {
         MockMvc mvc = standaloneSetup(new HikariController(provider(factory), new BootUiProperties()))
                 .build();
 
-        mvc.perform(get("/bootui/api/hikari/pools/does-not-exist/snapshot")).andExpect(status().isNotFound());
+        mvc.perform(get("/bootui/api/database-connection-pools/pools/does-not-exist/snapshot"))
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -153,7 +154,7 @@ class HikariControllerTests {
         MockMvc mvc = standaloneSetup(new HikariController(provider(null), new BootUiProperties()))
                 .build();
 
-        mvc.perform(get("/bootui/api/hikari/pools"))
+        mvc.perform(get("/bootui/api/database-connection-pools/pools"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.hikariPresent").value(true))
                 .andExpect(jsonPath("$.total").value(0));

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
@@ -87,7 +87,11 @@ class PanelsControllerTests {
                     .andExpect(jsonPath("$.panels[10].id").value("conditions"))
                     .andExpect(jsonPath("$.panels[10].available").value(false))
                     .andExpect(jsonPath("$.panels[11].id").value("mappings"))
-                    .andExpect(jsonPath("$.panels[11].available").value(false));
+                    .andExpect(jsonPath("$.panels[11].available").value(false))
+                    .andExpect(jsonPath("$.panels[12].id").value("database-connection-pools"))
+                    .andExpect(jsonPath("$.panels[12].available").value(false))
+                    .andExpect(jsonPath("$.panels[12].unavailableReason")
+                            .value("No database connection pool beans are available"));
         }
     }
 

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -359,13 +359,13 @@ public final class BootUiDtos {
             List<String> warnings) {}
 
     /**
-     * Live connection counts for one HikariCP pool at a point in time.
+     * Live connection counts for one database connection pool at a point in time.
      */
     public record HikariPoolSnapshotDto(long timestamp, int active, int idle, int total, int pending) {}
 
     /**
-     * One HikariCP {@code HikariDataSource} bean, its (masked) connection metadata,
-     * sizing and timeout settings, and the latest pool snapshot when reachable.
+     * One database connection pool bean, its (masked) connection metadata, sizing
+     * and timeout settings, and the latest pool snapshot when reachable.
      */
     public record HikariPoolDto(
             String beanName,
@@ -387,7 +387,7 @@ public final class BootUiDtos {
             HikariPoolSnapshotDto snapshot) {}
 
     /**
-     * Top-level HikariCP connection-pool report.
+     * Top-level database connection-pool report.
      */
     public record HikariPoolsReport(boolean hikariPresent, int total, List<HikariPoolDto> pools) {}
 

--- a/bootui-sample-app/README.md
+++ b/bootui-sample-app/README.md
@@ -11,7 +11,7 @@ the Playwright suite under `e2e/` exercises.
 - A PostgreSQL-backed Spring Data repository so the Data panel has data to
   show.
 - PostgreSQL and Redis Docker Compose services (`compose.yaml`) so the Data,
-  Connection Pools, Cache, and Dev Services panels have realistic infrastructure
+  Database Connection Pools, Cache, and Dev Services panels have realistic infrastructure
   to show.
 - Spring Security, scheduled tasks, custom metrics, and a small static welcome
   page so the corresponding BootUI panels are populated.
@@ -69,7 +69,7 @@ Useful URLs:
    container limits, and Heap Dump can analyze a value-free class histogram.
 8. **Data** — open `BootUiSampleRepository` to inspect its query methods and
    domain type.
-9. **Connection Pools** — inspect the HikariCP datasource metadata and live
+9. **Database Connection Pools** — inspect datasource pool metadata and live
    active / idle / total connection chart without borrowing a connection.
 10. **Cache** — verify the Redis-backed `sample-products` and
    `sample-greetings` caches are listed, inspect cache annotations, and clear a

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -15,7 +15,7 @@ const allPanelLinks = [
   {id: 'conditions', title: 'Conditions', heading: /Auto-configuration conditions/},
   {id: 'mappings', title: 'Mappings', heading: /HTTP mappings/},
   {id: 'scheduled', title: 'Scheduled Tasks', heading: /Scheduled Tasks/},
-  {id: 'hikari', title: 'Connection Pools', heading: /Connection Pools/},
+  {id: 'database-connection-pools', title: 'Database Connection Pools', heading: /Database Connection Pools/},
   {id: 'data', title: 'Data', heading: /Spring Data repositories/},
   {id: 'cache', title: 'Cache', heading: /Spring Cache/},
   {id: 'security', title: 'Security', heading: /Spring Security/},
@@ -102,7 +102,7 @@ test.describe('BootUI app shell', () => {
     await page.getByRole('button', {name: /Services\s+6/}).click()
     await expect(page.getByRole('group', {name: 'Services panels'}).locator('.bootui-nav-link__label')).toHaveText([
       'Scheduled Tasks',
-      'Connection Pools',
+      'Database Connection Pools',
       'Data',
       'Cache',
       'Security',

--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -117,9 +117,9 @@ export const routes = [
   },
   {
     path: '/database-connection-pools',
-    name: 'hikari',
+    name: 'database-connection-pools',
     component: Hikari,
-    meta: {group: groups.services, icon: 'bi-hdd-network', title: 'Connection Pools'}
+    meta: {group: groups.services, icon: 'bi-hdd-network', title: 'Database Connection Pools'}
   },
   {path: '/data', name: 'data', component: Data, meta: {group: groups.services, icon: 'bi-database', title: 'Data'}},
   {

--- a/bootui-ui/src/main/frontend/src/routes.test.js
+++ b/bootui-ui/src/main/frontend/src/routes.test.js
@@ -19,7 +19,7 @@ describe('routes', () => {
       'Conditions',
       'Mappings',
       'Scheduled Tasks',
-      'Connection Pools',
+      'Database Connection Pools',
       'Data',
       'Cache',
       'Security',

--- a/bootui-ui/src/main/frontend/src/utils/useAutoRefresh.js
+++ b/bootui-ui/src/main/frontend/src/utils/useAutoRefresh.js
@@ -1,16 +1,20 @@
-import {onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {computed, onBeforeUnmount, onMounted, ref, unref, watch} from 'vue'
 import {useRefreshState} from './useRefreshState.js'
 
 /**
  * Composable that loads immediately and refreshes while auto-refresh is enabled and the tab is visible.
  *
  * @param {Function} callback - function to call for initial, manual, interval, and visibility refreshes
- * @param {{intervalMs?: number, defaultEnabled?: boolean}} [options] - auto-refresh options
+ * @param {{intervalMs?: number, defaultEnabled?: boolean, enabled?: boolean | import('vue').Ref<boolean>, initialLoading?: boolean}} [options] - auto-refresh options
  * @returns {{ autoRefresh, intervalMs, loading, hasLoaded, initialLoading, load, refresh, startAutoRefresh, stopAutoRefresh }}
  */
-export function useAutoRefresh(callback, {intervalMs = 10_000, defaultEnabled = true} = {}) {
+export function useAutoRefresh(
+  callback,
+  {intervalMs = 10_000, defaultEnabled = true, enabled = true, initialLoading = true} = {}
+) {
   const autoRefresh = ref(defaultEnabled)
-  const {loading, hasLoaded, initialLoading, refresh} = useRefreshState(callback)
+  const refreshEnabled = computed(() => unref(enabled) !== false)
+  const {loading, hasLoaded, initialLoading: isInitialLoading, refresh} = useRefreshState(callback, {initialLoading})
   let timer = null
   let inFlight = false
 
@@ -22,6 +26,7 @@ export function useAutoRefresh(callback, {intervalMs = 10_000, defaultEnabled = 
   }
 
   async function load(...args) {
+    if (!refreshEnabled.value) return
     if (inFlight) return
     inFlight = true
     try {
@@ -33,9 +38,9 @@ export function useAutoRefresh(callback, {intervalMs = 10_000, defaultEnabled = 
 
   function startAutoRefresh() {
     stopAutoRefresh()
-    if (autoRefresh.value && document.visibilityState === 'visible') {
+    if (refreshEnabled.value && autoRefresh.value && document.visibilityState === 'visible') {
       timer = setInterval(() => {
-        if (autoRefresh.value && document.visibilityState === 'visible') {
+        if (refreshEnabled.value && autoRefresh.value && document.visibilityState === 'visible') {
           load()
         }
       }, intervalMs)
@@ -43,6 +48,10 @@ export function useAutoRefresh(callback, {intervalMs = 10_000, defaultEnabled = 
   }
 
   function onVisibilityChange() {
+    if (!refreshEnabled.value) {
+      stopAutoRefresh()
+      return
+    }
     if (document.visibilityState === 'visible') {
       startAutoRefresh()
       if (autoRefresh.value) {
@@ -53,16 +62,21 @@ export function useAutoRefresh(callback, {intervalMs = 10_000, defaultEnabled = 
     }
   }
 
-  watch(autoRefresh, () => {
-    if (autoRefresh.value) {
-      startAutoRefresh()
-    } else {
+  watch([autoRefresh, refreshEnabled], ([autoRefreshEnabled, enabledNow], [, wasEnabled]) => {
+    if (!enabledNow || !autoRefreshEnabled) {
       stopAutoRefresh()
+      return
+    }
+    startAutoRefresh()
+    if (wasEnabled === false && document.visibilityState === 'visible') {
+      load()
     }
   })
 
   onMounted(() => {
-    load()
+    if (refreshEnabled.value) {
+      load()
+    }
     startAutoRefresh()
     document.addEventListener('visibilitychange', onVisibilityChange)
   })
@@ -77,7 +91,7 @@ export function useAutoRefresh(callback, {intervalMs = 10_000, defaultEnabled = 
     intervalMs,
     loading,
     hasLoaded,
-    initialLoading,
+    initialLoading: isInitialLoading,
     load,
     refresh: load,
     startAutoRefresh,

--- a/bootui-ui/src/main/frontend/src/utils/useAutoRefresh.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/useAutoRefresh.test.js
@@ -1,14 +1,14 @@
 import {flushPromises, mount} from '@vue/test-utils'
-import {nextTick} from 'vue'
+import {nextTick, ref} from 'vue'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 
 import {useAutoRefresh} from './useAutoRefresh.js'
 
-function harness(callback) {
+function harness(callback, options) {
   let api
   const wrapper = mount({
     setup() {
-      api = useAutoRefresh(callback)
+      api = useAutoRefresh(callback, options)
       return () => null
     }
   })
@@ -107,6 +107,38 @@ describe('useAutoRefresh', () => {
     await nextTick()
     await vi.advanceTimersByTimeAsync(10_000)
     await flushPromises()
+
+    expect(callback).toHaveBeenCalledTimes(2)
+
+    wrapper.unmount()
+  })
+
+  it('waits for the enabled flag before loading or refreshing', async () => {
+    const enabled = ref(false)
+    const callback = vi.fn().mockResolvedValue()
+    const {api, wrapper} = harness(callback, {enabled, initialLoading: false})
+
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(api.initialLoading.value).toBe(false)
+
+    enabled.value = true
+    await nextTick()
+    await flushPromises()
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(api.hasLoaded.value).toBe(true)
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await flushPromises()
+
+    expect(callback).toHaveBeenCalledTimes(2)
+
+    enabled.value = false
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(10_000)
 
     expect(callback).toHaveBeenCalledTimes(2)
 

--- a/bootui-ui/src/main/frontend/src/views/Hikari.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Hikari.test.js
@@ -1,0 +1,69 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import Hikari from './Hikari.vue'
+import PanelHeader from './components/PanelHeader.vue'
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+describe('Database connection pools panel', () => {
+  let wrapper
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.defineProperty(document, 'visibilityState', {configurable: true, value: 'visible'})
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('shows an unavailable tip without calling the pool endpoint', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    wrapper = mount(Hikari, {
+      props: {
+        panel: {
+          id: 'database-connection-pools',
+          enabled: true,
+          available: false,
+          unavailableReason: 'No supported JDBC connection pool is available'
+        }
+      }
+    })
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Database connection pool metrics are unavailable')
+    expect(wrapper.text()).toContain('No supported JDBC connection pool is available')
+    expect(wrapper.findComponent(PanelHeader).props('refreshable')).toBe(false)
+  })
+
+  it('loads the generic database connection pools endpoint when available', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({total: 0, pools: []}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    wrapper = mount(Hikari, {
+      props: {
+        panel: {
+          id: 'database-connection-pools',
+          enabled: true,
+          available: true,
+          unavailableReason: null
+        }
+      }
+    })
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith('api/database-connection-pools/pools')
+    expect(wrapper.text()).toContain('No database connection pool beans were detected')
+    expect(wrapper.findComponent(PanelHeader).props('refreshable')).toBe(true)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Hikari.vue
+++ b/bootui-ui/src/main/frontend/src/views/Hikari.vue
@@ -1,10 +1,14 @@
 <script setup>
-import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
+import {computed, onBeforeUnmount, ref, watch} from 'vue'
 import {formatNumber} from '../utils/format.js'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+
+const props = defineProps({
+  panel: {type: Object, default: null}
+})
 
 const report = ref(null)
 const error = ref(null)
@@ -22,7 +26,26 @@ const SERIES = [
 
 const pools = computed(() => report.value?.pools ?? [])
 
-const selectedPool = computed(() => pools.value.find((pool) => pool.poolName === selectedName.value) || null)
+const selectedPool = computed(() => pools.value.find((pool) => poolKey(pool) === selectedName.value) || null)
+
+const panelStatusKnown = computed(() => props.panel !== null)
+const panelUnavailable = computed(() => props.panel?.enabled === false || props.panel?.available === false)
+const endpointAvailable = computed(() => panelStatusKnown.value && !panelUnavailable.value)
+const unavailableReason = computed(() => {
+  if (props.panel?.enabled === false) {
+    return 'Panel is disabled via bootui.panels.database-connection-pools.enabled=false'
+  }
+  return props.panel?.unavailableReason || 'No supported JDBC connection pool is available for this application.'
+})
+const headerSubtitle = computed(() => {
+  if (report.value) {
+    return `${pools.value.length} database pool${pools.value.length === 1 ? '' : 's'} · read-only`
+  }
+  if (panelUnavailable.value) {
+    return 'Database pool metrics unavailable for this application'
+  }
+  return 'Read-only JDBC pool metrics'
+})
 
 const chartMax = computed(() => {
   let max = 1
@@ -52,12 +75,13 @@ function poolKey(pool) {
 }
 
 async function fetchPools() {
+  if (!endpointAvailable.value) return
   error.value = null
   try {
-    const res = await fetch('api/hikari/pools')
+    const res = await fetch('api/database-connection-pools/pools')
     if (!res.ok) throw new Error('HTTP ' + res.status)
     report.value = await res.json()
-    lastUpdated.value = new Date()
+    lastUpdated.value = Date.now()
     if (!selectedPool.value && pools.value.length) {
       selectPool(poolKey(pools.value[0]))
     }
@@ -75,9 +99,9 @@ function selectPool(name) {
 
 async function pollSnapshot() {
   const pool = selectedPool.value
-  if (!pool || !pool.available || !pool.poolName) return
+  if (!endpointAvailable.value || !pool || !pool.available || !pool.poolName) return
   try {
-    const res = await fetch(`api/hikari/pools/${encodeURIComponent(pool.poolName)}/snapshot`)
+    const res = await fetch(`api/database-connection-pools/pools/${encodeURIComponent(pool.poolName)}/snapshot`)
     if (!res.ok) return
     const snapshot = await res.json()
     history.value = [
@@ -89,16 +113,24 @@ async function pollSnapshot() {
         pending: snapshot.pending
       }
     ].slice(-60)
-    lastUpdated.value = new Date()
+    lastUpdated.value = Date.now()
   } catch {
     // Transient polling failures are ignored; the next tick retries.
   }
 }
 
+function stopSnapshotPoll() {
+  if (timer) {
+    clearTimeout(timer)
+    timer = null
+  }
+}
+
 function scheduleNextPoll() {
-  if (timer) clearTimeout(timer)
+  stopSnapshotPoll()
+  if (!endpointAvailable.value) return
   timer = setTimeout(async () => {
-    if (autoRefresh.value && document.visibilityState === 'visible') {
+    if (endpointAvailable.value && autoRefresh.value && document.visibilityState === 'visible') {
       await pollSnapshot()
     }
     scheduleNextPoll()
@@ -120,37 +152,74 @@ function shortName(name) {
 
 const currentSnapshot = computed(() => history.value[history.value.length - 1] || null)
 
-onMounted(scheduleNextPoll)
-
-onBeforeUnmount(() => {
-  if (timer) clearTimeout(timer)
+const {autoRefresh, loading, initialLoading, load, stopAutoRefresh} = useAutoRefresh(fetchPools, {
+  enabled: endpointAvailable,
+  initialLoading: false
 })
 
-const {autoRefresh, loading, initialLoading, load} = useAutoRefresh(fetchPools)
+watch(
+  endpointAvailable,
+  (available) => {
+    if (available) {
+      scheduleNextPoll()
+      return
+    }
+    stopAutoRefresh()
+    stopSnapshotPoll()
+    error.value = null
+    report.value = null
+    selectedName.value = ''
+    history.value = []
+    lastUpdated.value = null
+  },
+  {immediate: true}
+)
+
+onBeforeUnmount(() => {
+  stopSnapshotPoll()
+})
 </script>
 
 <template>
   <div>
     <PanelHeader
       icon="bi-hdd-network"
-      title="Connection Pools"
-      :subtitle="report ? `${pools.length} HikariCP pool${pools.length === 1 ? '' : 's'} · read-only` : null"
-      :loading="loading"
-      :error="error"
-      :last-fetched="lastUpdated ? lastUpdated.getTime() : null"
+      title="Database Connection Pools"
+      :subtitle="headerSubtitle"
+      :loading="endpointAvailable && loading"
+      :error="endpointAvailable ? error : null"
+      :last-fetched="lastUpdated"
+      :refreshable="endpointAvailable"
       @refresh="load"
     >
       <template #actions>
-        <AutoRefreshToggle v-model="autoRefresh" />
+        <AutoRefreshToggle v-if="endpointAvailable" v-model="autoRefresh" />
       </template>
     </PanelHeader>
 
-    <PanelSkeleton v-if="initialLoading" />
+    <PanelSkeleton v-if="!panelStatusKnown || initialLoading" />
+
+    <div v-else-if="panelUnavailable" class="card border-warning-subtle mb-3">
+      <div class="card-body d-flex align-items-start gap-3">
+        <span class="text-warning fs-3"><i class="bi bi-info-circle"></i></span>
+        <div>
+          <h5 class="mb-1">Database connection pool metrics are unavailable</h5>
+          <p class="text-muted mb-2">
+            BootUI can inspect active, idle, total, and pending connection counts when the application exposes a
+            supported JDBC connection pool bean. This application does not currently provide one.
+          </p>
+          <div class="small">
+            <span class="fw-semibold">Reason:</span>
+            {{ unavailableReason }}
+          </div>
+        </div>
+      </div>
+    </div>
 
     <template v-else-if="report">
       <div v-if="!pools.length" class="alert alert-secondary">
-        No <code>HikariDataSource</code> beans were detected. Configure a HikariCP-backed datasource to inspect pool
-        saturation here.
+        No database connection pool beans were detected. Configure a JDBC datasource backed by a supported connection
+        pool to inspect saturation here.
       </div>
 
       <div v-else class="row g-3">

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.test.js
@@ -30,6 +30,20 @@ describe('PanelHeader', () => {
     wrapper.unmount()
   })
 
+  it('hides refresh controls when refresh is not available', () => {
+    const wrapper = mount(PanelHeader, {
+      props: {
+        title: 'Database Connection Pools',
+        refreshable: false,
+        onRefresh: vi.fn()
+      }
+    })
+
+    expect(wrapper.find('button[title="Refresh"]').exists()).toBe(false)
+
+    wrapper.unmount()
+  })
+
   it('keeps the relative last-fetched text current', async () => {
     const wrapper = mount(PanelHeader, {
       props: {

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
@@ -8,13 +8,14 @@ const props = defineProps({
   subtitle: {type: String, default: null},
   loading: {type: Boolean, default: false},
   error: {type: String, default: null},
-  lastFetched: {type: Number, default: null}
+  lastFetched: {type: Number, default: null},
+  refreshable: {type: Boolean, default: true}
 })
 
 const emit = defineEmits(['refresh'])
 
 const instance = getCurrentInstance()
-const hasRefresh = computed(() => typeof instance?.vnode.props?.onRefresh === 'function')
+const hasRefresh = computed(() => props.refreshable && typeof instance?.vnode.props?.onRefresh === 'function')
 const now = ref(Date.now())
 let relativeTimer = null
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -137,16 +137,16 @@ trigger metadata so background activity is visible during local development.
 
 ![BootUI Scheduled Tasks panel](images/bootui-scheduled-tasks.png)
 
-### Connection Pools
+### Database Connection Pools
 
-The Connection Pools panel inspects HikariCP `HikariDataSource` beans. It is read-only and fails closed when HikariCP is
-not on the classpath or no pool beans are present. For each pool it shows the pool identity, masked JDBC URL and
+The Database Connection Pools panel inspects supported JDBC connection pool beans. It is read-only and fails closed when
+no supported pool implementation or pool beans are present. For each pool it shows the pool identity, masked JDBC URL and
 username, driver, min/max sizing, and timeout/lifetime settings, and surfaces a clear unavailable reason for closed or
 uninitialized pools. A local live chart polls bounded snapshots of active, idle, total, and pending connections every two
 seconds so you can watch saturation trends without leaving BootUI. It never executes SQL, borrows connections, or resizes
-pools, and generic JDBC/R2DBC pools are out of scope for now.
+pools.
 
-![BootUI Connection Pools panel](images/bootui-database-connection-pools.png)
+![BootUI Database Connection Pools panel](images/bootui-database-connection-pools.png)
 
 ### Data
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -153,12 +153,12 @@ The visible-route parity check is current. The sample-app Playwright suite cover
 1. Overview.
 2. Runtime: Health, Metrics, Memory, Heap Dump, Startup Timeline.
 3. Configuration: Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings.
-4. Services: Scheduled Tasks, Connection Pools, Data, Cache, Security, AI Usage.
+4. Services: Scheduled Tasks, Database Connection Pools, Data, Cache, Security, AI Usage.
 5. Diagnostics: Traces, Log Tail, HTTP Probe, Architecture, Pentesting, Vulnerabilities.
 6. Developer tools: DevTools, Dev Services, Copilot, Claude Code.
 7. Disabled / unavailable grouping for unavailable non-overview panels.
 
-Startup, Memory, Heap Dump, Spring Data, Connection Pools, Spring Cache, HTTP Probe, Architecture, Pentesting,
+Startup, Memory, Heap Dump, Spring Data, Database Connection Pools, Spring Cache, HTTP Probe, Architecture, Pentesting,
 Profile Diff, Log Tail, Traces, AI Usage, Copilot, Claude Code, Scheduled Tasks, Security, Metrics, Vulnerabilities,
 DevTools, and Dev Services are implemented, documented, covered by sample-app Playwright tests, and part of the supported
 current release surface. Any new visible route or browser-facing behavior should update the router, README feature table,
@@ -200,7 +200,7 @@ Completed reconciliation points:
 - `bootui.enabled` uses `AUTO|ON|OFF`.
 - Runtime config overrides persist to the BootUI overrides file by default.
 - The frontend is plain JavaScript Vue 3.
-- Startup Timeline, Memory, Heap Dump, Spring Data, Connection Pools, Spring Cache, HTTP Probe, Architecture,
+- Startup Timeline, Memory, Heap Dump, Spring Data, Database Connection Pools, Spring Cache, HTTP Probe, Architecture,
   Pentesting, Profile Diff, Log Tail, Traces, AI Usage, Copilot, Claude Code, Scheduled Tasks, Security, Metrics,
   DevTools, Dev Services, and Vulnerabilities are implemented `0.2.0` surfaces, not deferred ideas.
 - Dev Services / Docker Compose / Testcontainers behavior is documented: Docker Compose entries are startup snapshots,
@@ -354,8 +354,8 @@ The candidate hardening items originally tracked for a later `v0.2` were pulled 
 The next preferred workstream is to introduce the Service Extension SPI and move service-style panels behind it. The
 current **AI Usage** panel remains the first extraction candidate because it can establish framework-neutral OTLP DTOs
 before adding LangChain4j support. LangChain4j can emit OpenTelemetry spans, so BootUI should normalize those spans
-through the same in-app OTLP path used for Spring AI while keeping the released Spring AI behavior intact. The HikariCP
-**Connection Pools** panel shipped in `0.2.0` inside `bootui-autoconfigure`; move it behind the SPI with the other
+through the same in-app OTLP path used for Spring AI while keeping the released Spring AI behavior intact. The
+**Database Connection Pools** panel shipped in `0.2.0` inside `bootui-autoconfigure`; move it behind the SPI with the other
 Services entries once the SPI exists.
 
 Scope:
@@ -364,17 +364,17 @@ Scope:
   stable DTO endpoints, documentation metadata, and optional frontend assets.
 - Extract **AI Usage** into `services/bootui-service-ai-usage` first. Preserve the existing Spring AI observation
   aggregation and add LangChain4j OpenTelemetry span support to the same panel and DTO shape where possible.
-- Move the remaining current Services menu entries behind that SPI over time: Scheduled Tasks, Connection Pools, Data,
+- Move the remaining current Services menu entries behind that SPI over time: Scheduled Tasks, Database Connection Pools, Data,
   Cache, and Security.
 - Add Elasticsearch, Flyway/Liquibase, and MongoDB service visibility after the SPI exists.
-  - HikariCP connection-pool visibility shipped (read-only **Connection Pools** panel with a live saturation chart,
+  - Database connection-pool visibility shipped (read-only **Database Connection Pools** panel with a live saturation chart,
     masked JDBC metadata, and fail-closed behavior). It currently lives in `bootui-autoconfigure` and will move behind
     the `services/` SPI with the other Services entries. Elasticsearch, Flyway/Liquibase, and MongoDB remain pending.
 - Put all first-party service extensions under a top-level `services/` Maven directory, with one Maven submodule per
   service, for example:
   - `services/bootui-service-scheduled`
   - `services/bootui-service-data`
-  - `services/bootui-service-hikari`
+  - `services/bootui-service-database-connection-pools`
   - `services/bootui-service-cache`
   - `services/bootui-service-security`
   - `services/bootui-service-ai-usage`
@@ -395,8 +395,8 @@ Design constraints:
   embedding, tool, token, latency, error, and vector-store signals when present, and degrade gracefully when a framework
   omits optional attributes. Prompt/response content must remain opt-in through captured trace attributes and continue
   to follow the existing masking/value-exposure rules.
-- HikariCP support should be read-only at first and exposed as its own **Connection Pools** panel in the Services group,
-  placed after **Data** and before **Cache**. It should discover `HikariDataSource` beans only, fail closed when HikariCP
+- Database connection-pool support should be read-only at first and exposed as its own **Database Connection Pools** panel
+  in the Services group, placed after **Data** and before **Cache**. It should fail closed when pool support
   is absent, and show pool identity, masked JDBC connection metadata, current active/idle/total/pending counts, min/max
   sizing, timeout/lifetime settings, and unavailable reasons for closed or inaccessible pools. The panel should include a
   local live chart like the Metrics panel, polling bounded snapshots for active, idle, total, and pending connections so

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -49,7 +49,7 @@ Panel settings are consistent across the UI and API:
 | Configuration | Conditions | `conditions` | `bootui.panels.conditions.enabled` | Not applicable; view-only. |
 | Configuration | Mappings | `mappings` | `bootui.panels.mappings.enabled` | Not applicable; view-only. |
 | Services | Scheduled Tasks | `scheduled` | `bootui.panels.scheduled.enabled` | Not applicable; view-only. |
-| Services | Connection Pools | `hikari` | `bootui.panels.hikari.enabled` | Not applicable; view-only. |
+| Services | Database Connection Pools | `database-connection-pools` | `bootui.panels.database-connection-pools.enabled` | Not applicable; view-only. |
 | Services | Data | `data` | `bootui.panels.data.enabled` | Not applicable; view-only. |
 | Services | Cache | `cache` | `bootui.panels.cache.enabled` | `bootui.panels.cache.read-only` |
 | Services | Security | `security` | `bootui.panels.security.enabled` | Not applicable; view-only. |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1105,9 +1105,9 @@ BootUI's current pre-1.0 release surface is complete when:
 
 - A sample Spring Boot app can add the starter and open `/bootui`.
 - The UI shows Overview, Runtime, Configuration, Services, Diagnostics, Developer tools, and Disabled / unavailable
-  navigation groups covering Health, Metrics, Memory, Heap Dump, Startup Timeline, Scheduled Tasks, Connection Pools,
-  Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings, Data, Cache, Security, AI Usage, Traces, Log Tail,
-  HTTP Probe, Architecture, Pentesting, Vulnerabilities, DevTools, Dev Services, Copilot, and Claude Code.
+  navigation groups covering Health, Metrics, Memory, Heap Dump, Startup Timeline, Scheduled Tasks, Database Connection
+  Pools, Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings, Data, Cache, Security, AI Usage, Traces, Log
+  Tail, HTTP Probe, Architecture, Pentesting, Vulnerabilities, DevTools, Dev Services, Copilot, and Claude Code.
 - Secret-like values are masked.
 - BootUI is disabled by default outside local/dev contexts.
 - Tests verify activation and safety behavior.


### PR DESCRIPTION
The connection pool panel was still exposed through Hikari-specific naming and tried to load a missing Hikari-backed endpoint when pool support was unavailable. This updates the feature to present itself as a generic Database Connection Pools panel and render a clear unavailable tip instead of a load failure.

## Summary

- Rename the panel id and route metadata to `database-connection-pools` while keeping the Hikari-backed implementation internal.
- Stop auto-loading and polling the pool API when panel availability reports the feature as unavailable.
- Expose the API only under `/bootui/api/database-connection-pools` and update docs, property reference, and tests to match the generic panel name.

## Validation

- `npm test`
- `npm run format:check`
- `./mvnw -B -ntp -pl bootui-core,bootui-autoconfigure spotless:check`
- `./mvnw -B -ntp -pl bootui-autoconfigure test -Dtest=HikariControllerTests,PanelsControllerTests`