### PR TITLE
Improve offline server UX

### DIFF
--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -9,13 +9,14 @@ import {
   THEME_QUERY,
   THEME_STORAGE_KEY
 } from './utils/theme.js'
+import {describeLoadError} from './utils/loadError.js'
 import CommandPalette from './views/components/CommandPalette.vue'
 
 const router = useRouter()
 const route = useRoute()
 const overview = ref(null)
 const panels = ref(null)
-const error = ref(null)
+const shellError = ref(null)
 const sidebarCollapsed = ref(localStorage.getItem('bootui.sidebar.collapsed') === 'true')
 const commandPaletteOpen = ref(false)
 const commandPaletteRef = ref(null)
@@ -118,14 +119,48 @@ const activePanelReadOnly = computed(() => activePanel.value?.readOnly === true 
 const activePanelReadOnlyReason = computed(() => activePanel.value?.readOnlyReason || 'This panel is read-only.')
 const applicationTitle = computed(() => overview.value?.applicationName || 'Spring Boot app')
 const runtimeSummary = computed(() => {
+  if (shellServerUnreachable.value) return 'Spring Boot app is not responding. Restart it and retry.'
+  if (shellError.value && !overview.value) return 'Unable to load BootUI runtime details.'
   if (!overview.value) return 'Loading runtime details'
   return `Spring Boot ${overview.value.springBootVersion} · Java ${overview.value.javaVersion}`
 })
 const activeProfiles = computed(() => overview.value?.activeProfiles ?? [])
-const activationLabel = computed(() => {
-  if (!overview.value?.activation) return 'Loading'
-  return overview.value.activation.enabled ? 'Active' : 'Disabled'
+const shellErrorMessage = computed(() => shellError.value?.message ?? null)
+const shellErrorTitle = computed(() => shellError.value?.title ?? 'Load failed')
+const shellServerUnreachable = computed(() => shellError.value?.serverUnreachable === true)
+const connectionState = computed(() => {
+  if (shellServerUnreachable.value) return 'unreachable'
+  if (shellError.value && !overview.value?.activation) return 'error'
+  if (!overview.value?.activation) return 'checking'
+  return overview.value.activation.enabled ? 'active' : 'disabled'
 })
+const activationLabel = computed(() => {
+  if (connectionState.value === 'unreachable') return 'Server unreachable'
+  if (connectionState.value === 'error') return 'API load failed'
+  if (connectionState.value === 'checking') return 'Checking server'
+  return connectionState.value === 'active' ? 'BootUI active' : 'BootUI disabled'
+})
+const activationIcon = computed(
+  () =>
+    ({
+      active: 'bi-broadcast-pin',
+      disabled: 'bi-slash-circle',
+      error: 'bi-exclamation-triangle',
+      checking: 'bi-hourglass-split',
+      unreachable: 'bi-wifi-off'
+    })[connectionState.value]
+)
+const activationTitle = computed(
+  () =>
+    ({
+      active: 'BootUI is active and the local API is reachable.',
+      disabled: 'BootUI answered the local API but is disabled for this application.',
+      error: 'BootUI reached the local API but could not load the shell data.',
+      checking: 'Checking the BootUI API connection.',
+      unreachable: 'BootUI cannot reach the Spring Boot app. It may have been stopped.'
+    })[connectionState.value]
+)
+const statusPillClass = computed(() => `status-pill--${connectionState.value}`)
 const githubProjectUrl = 'https://github.com/jdubois/boot-ui'
 const navigationSections = computed(() => {
   const sections = [
@@ -158,27 +193,31 @@ const activeNavigationGroupKey = computed(() => {
 })
 
 async function loadOverview() {
-  try {
-    const res = await fetch('api/overview')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    overview.value = await res.json()
-  } catch (e) {
-    error.value = 'Unable to load overview: ' + e.message
-  }
+  const res = await fetch('api/overview')
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  overview.value = await res.json()
 }
 
 async function loadPanels() {
-  try {
-    const res = await fetch('api/panels')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    panels.value = await res.json()
-  } catch (e) {
-    error.value = 'Unable to load panel availability: ' + e.message
-  }
+  const res = await fetch('api/panels')
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  panels.value = await res.json()
 }
 
 async function loadShellData() {
-  await Promise.all([loadOverview(), loadPanels()])
+  const results = await Promise.allSettled([loadOverview(), loadPanels()])
+  const failures = [
+    {result: results[0], context: 'Unable to load overview'},
+    {result: results[1], context: 'Unable to load panel availability'}
+  ].filter(({result}) => result.status === 'rejected')
+
+  if (!failures.length) {
+    shellError.value = null
+    return
+  }
+
+  const descriptions = failures.map(({result, context}) => describeLoadError(result.reason, context))
+  shellError.value = descriptions.find((description) => description.serverUnreachable) || descriptions[0]
 }
 
 function panelForRoute(r) {
@@ -420,8 +459,8 @@ function onGlobalKeydown(e) {
             <i :class="['bi', darkTheme ? 'bi-sun' : 'bi-moon-stars']"></i>
             <span class="theme-toggle__label">{{ themeToggleText }}</span>
           </button>
-          <span class="status-pill">
-            <i class="bi bi-broadcast-pin"></i>
+          <span :class="['status-pill', statusPillClass]" :title="activationTitle">
+            <i :class="['bi', activationIcon]"></i>
             {{ activationLabel }}
           </span>
           <span v-if="activeProfiles.length" class="profile-stack">
@@ -432,7 +471,18 @@ function onGlobalKeydown(e) {
       </header>
 
       <main class="content-stage">
-        <div v-if="error" class="alert alert-danger shadow-sm">{{ error }}</div>
+        <div
+          v-if="shellErrorMessage"
+          :class="['alert', shellServerUnreachable ? 'alert-warning' : 'alert-danger']"
+          class="shell-error shadow-sm"
+          role="alert"
+        >
+          <div class="shell-error__title">
+            <i :class="['bi', shellServerUnreachable ? 'bi-wifi-off' : 'bi-exclamation-triangle-fill']"></i>
+            <strong>{{ shellErrorTitle }}</strong>
+          </div>
+          <div>{{ shellErrorMessage }}</div>
+        </div>
         <div v-if="activePanelUnavailable" class="alert alert-warning panel-availability-alert shadow-sm" role="status">
           <div class="panel-availability-alert__title">
             <i class="bi bi-slash-circle"></i>
@@ -1069,6 +1119,36 @@ function onGlobalKeydown(e) {
   font-weight: 700;
   gap: 0.35rem;
   padding: 0.45rem 0.75rem;
+}
+
+.status-pill--active {
+  background: rgba(25, 135, 84, 0.12);
+  border-color: rgba(25, 135, 84, 0.22);
+  color: var(--bootui-green-dark);
+}
+
+.status-pill--disabled,
+.status-pill--checking {
+  background: rgba(100, 116, 139, 0.1);
+  color: var(--bootui-text-muted);
+}
+
+.status-pill--error,
+.status-pill--unreachable {
+  background: rgba(220, 53, 69, 0.1);
+  border-color: rgba(220, 53, 69, 0.25);
+  color: #b02a37;
+}
+
+.shell-error {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.shell-error__title {
+  align-items: center;
+  display: flex;
+  gap: 0.4rem;
 }
 
 .profile-stack {

--- a/bootui-ui/src/main/frontend/src/utils/loadError.js
+++ b/bootui-ui/src/main/frontend/src/utils/loadError.js
@@ -1,0 +1,58 @@
+export const SERVER_UNREACHABLE_TITLE = 'Server unreachable'
+export const SERVER_UNREACHABLE_MESSAGE =
+  'BootUI could not reach the Spring Boot app. The server may have been stopped. Start it again, then retry or refresh this page.'
+
+const NETWORK_ERROR_MARKERS = [
+  'failed to fetch',
+  'fetch failed',
+  'load failed',
+  'network request failed',
+  'networkerror when attempting to fetch resource',
+  'the network connection was lost'
+]
+
+export function toErrorMessage(error, fallback = 'Request failed') {
+  if (error instanceof Error && error.message) return error.message
+  if (typeof error === 'string' && error.trim()) return error
+  if (error && typeof error === 'object' && typeof error.message === 'string' && error.message.trim()) {
+    return error.message
+  }
+  return fallback
+}
+
+export function isServerUnreachableError(error) {
+  const message = toErrorMessage(error, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[.!]+$/, '')
+  if (!message) return false
+  if (message.startsWith(`${SERVER_UNREACHABLE_TITLE.toLowerCase()}:`)) return true
+
+  return NETWORK_ERROR_MARKERS.some(
+    (marker) => message === marker || message.endsWith(`: ${marker}`) || message.includes(` ${marker}`)
+  )
+}
+
+export function describeLoadError(error, context = null) {
+  const message = toErrorMessage(error)
+  const serverUnreachable = isServerUnreachableError(message)
+
+  if (serverUnreachable) {
+    return {
+      title: SERVER_UNREACHABLE_TITLE,
+      message: SERVER_UNREACHABLE_MESSAGE,
+      serverUnreachable: true
+    }
+  }
+
+  return {
+    title: 'Load failed',
+    message: context ? `${context}: ${message}` : message,
+    serverUnreachable: false
+  }
+}
+
+export function formatLoadError(error, context = null) {
+  const description = describeLoadError(error, context)
+  return description.serverUnreachable ? `${description.title}: ${description.message}` : description.message
+}

--- a/bootui-ui/src/main/frontend/src/utils/loadError.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/loadError.test.js
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest'
+
+import {describeLoadError, formatLoadError, isServerUnreachableError, toErrorMessage} from './loadError.js'
+
+describe('loadError', () => {
+  it('detects browser fetch failures as server unreachable', () => {
+    expect(isServerUnreachableError(new TypeError('Load failed'))).toBe(true)
+    expect(isServerUnreachableError('Could not load beans: Failed to fetch')).toBe(true)
+    expect(isServerUnreachableError('HTTP 503')).toBe(false)
+  })
+
+  it('describes network failures with a server-not-running tip', () => {
+    const description = describeLoadError(new TypeError('Load failed'), 'Unable to load overview')
+
+    expect(description).toEqual({
+      title: 'Server unreachable',
+      message:
+        'BootUI could not reach the Spring Boot app. The server may have been stopped. Start it again, then retry or refresh this page.',
+      serverUnreachable: true
+    })
+  })
+
+  it('keeps HTTP failures specific to the failed request', () => {
+    expect(formatLoadError(new Error('HTTP 500'), 'Unable to load overview')).toBe('Unable to load overview: HTTP 500')
+  })
+
+  it('normalizes non-error values', () => {
+    expect(toErrorMessage('Load failed')).toBe('Load failed')
+    expect(toErrorMessage(null)).toBe('Request failed')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/utils/useServerPagedList.js
+++ b/bootui-ui/src/main/frontend/src/utils/useServerPagedList.js
@@ -1,4 +1,5 @@
 import {computed, onBeforeUnmount, ref} from 'vue'
+import {toErrorMessage} from './loadError.js'
 
 export const SERVER_PAGE_SIZE = 200
 
@@ -53,7 +54,7 @@ export function useServerPagedList(endpoint, itemsKey, queryParams, options = {}
             }
           : next
     } catch (e) {
-      if (id === requestId) error.value = e.message
+      if (id === requestId) error.value = toErrorMessage(e)
     } finally {
       if (id === requestId) targetLoading.value = false
     }

--- a/bootui-ui/src/main/frontend/src/views/Data.vue
+++ b/bootui-ui/src/main/frontend/src/views/Data.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 
 const report = ref(null)
@@ -20,7 +21,7 @@ async function load() {
     if (!res.ok) throw new Error('HTTP ' + res.status)
     report.value = await res.json()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load Spring Data repositories')
   }
 }
 

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -2,6 +2,7 @@
 import {computed, ref} from 'vue'
 import {apiFetch} from '../api.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 
 const props = defineProps(panelProps)
@@ -75,7 +76,7 @@ async function sendProbe() {
       headers: {},
       body: null,
       durationMs: 0,
-      error: error.message
+      error: formatLoadError(error, 'Unable to send HTTP probe')
     }
   } finally {
     loading.value = false

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {computed, inject, onMounted, ref} from 'vue'
+import {formatLoadError} from '../utils/loadError.js'
 
 const injectedOverview = inject('overview', null)
 const data = ref(null)
@@ -85,7 +86,7 @@ async function load(force = false) {
     if (!res.ok) throw new Error('HTTP ' + res.status)
     data.value = await res.json()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load overview')
   } finally {
     loading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 
 const report = ref(null)
@@ -29,7 +30,7 @@ async function load() {
       springSecurityPresent.value = false
     }
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load Spring Security')
   }
 }
 
@@ -41,7 +42,7 @@ async function loadEndpoints() {
     if (!res.ok) throw new Error('HTTP ' + res.status)
     endpoints.value = await res.json()
   } catch (e) {
-    endpointsError.value = e.message
+    endpointsError.value = formatLoadError(e, 'Unable to load secured endpoints')
   } finally {
     endpointsLoading.value = false
   }
@@ -62,6 +63,13 @@ async function explain() {
         matcherDescription: 'Error: HTTP ' + res.status,
         filters: []
       }
+    }
+  } catch (e) {
+    explainResult.value = {
+      matched: false,
+      bestEffort: false,
+      matcherDescription: formatLoadError(e, 'Unable to explain security match'),
+      filters: []
     }
   } finally {
     explainLoading.value = false

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.test.js
@@ -61,4 +61,19 @@ describe('PanelHeader', () => {
 
     wrapper.unmount()
   })
+
+  it('shows a server-not-running tip for browser network failures', () => {
+    const wrapper = mount(PanelHeader, {
+      props: {
+        title: 'Health',
+        error: 'Load failed'
+      }
+    })
+
+    expect(wrapper.text()).toContain('Server unreachable')
+    expect(wrapper.text()).toContain('The server may have been stopped')
+    expect(wrapper.text()).not.toContain('Load failed')
+
+    wrapper.unmount()
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, getCurrentInstance, onBeforeUnmount, ref, watch} from 'vue'
 import {formatRelative} from '../../utils/format.js'
+import {describeLoadError} from '../../utils/loadError.js'
 
 const props = defineProps({
   icon: {type: String, default: null},
@@ -40,6 +41,10 @@ const lastFetchedText = computed(() => {
   if (!props.lastFetched) return null
   return formatRelative(props.lastFetched, now.value)
 })
+const loadError = computed(() => (props.error ? describeLoadError(props.error) : null))
+const retryButtonClass = computed(() =>
+  loadError.value?.serverUnreachable ? 'btn-outline-warning' : 'btn-outline-danger'
+)
 
 watch(() => props.lastFetched, startRelativeTimer, {immediate: true})
 
@@ -66,10 +71,18 @@ onBeforeUnmount(stopRelativeTimer)
       </button>
     </div>
   </div>
-  <div v-if="error" class="alert alert-danger d-flex align-items-center gap-2 mb-3" role="alert">
+  <div
+    v-if="loadError"
+    :class="['alert', loadError.serverUnreachable ? 'alert-warning' : 'alert-danger']"
+    class="d-flex align-items-start gap-2 mb-3"
+    role="alert"
+  >
     <i class="bi bi-exclamation-triangle-fill flex-shrink-0"></i>
-    <span class="flex-grow-1">{{ error }}</span>
-    <button v-if="hasRefresh" class="btn btn-sm btn-outline-danger" @click="emit('refresh')">
+    <span class="flex-grow-1">
+      <strong class="d-block">{{ loadError.title }}</strong>
+      <span class="small">{{ loadError.message }}</span>
+    </span>
+    <button v-if="hasRefresh" :class="retryButtonClass" class="btn btn-sm flex-shrink-0" @click="emit('refresh')">
       <i class="bi bi-arrow-clockwise me-1"></i>Retry
     </button>
   </div>


### PR DESCRIPTION
## What does this PR do?

Improves BootUI's offline-state UX by making the shell status explicit and replacing generic browser network failures with a server-not-running tip.

## Why is this change needed?

When the Spring Boot app is stopped while BootUI is open, panels can surface browser-specific errors such as `Load failed`, and the top-right status could still look like a normal active state. This makes the disconnected state clearer and tells developers to restart the app, then retry or refresh.

N/A

## How was it tested?

Validation run:

- `cd bootui-ui/src/main/frontend && npm run format:check && npm test && npm run build`
- `./mvnw -B -ntp install -DskipTests`

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed