### PR TITLE
Rename Data menu item to Spring Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ BootUI exposes these panels in the same grouped order as the application menu. S
 | Configuration   | [Mappings](docs/FEATURES.md#mappings)                 | Review HTTP routes, handlers, methods, patterns, and produces/consumes metadata.                              |
 | Services        | [Scheduled Tasks](docs/FEATURES.md#scheduled-tasks)   | View registered scheduled tasks and their trigger metadata.                                                   |
 | Services        | [Database Connection Pools](docs/FEATURES.md#database-connection-pools) | Watch database pool sizing, masked JDBC metadata, and live active/idle/total/pending saturation.              |
-| Services        | [Data](docs/FEATURES.md#data)                         | Explore Spring Data repositories, domain types, IDs, and query methods.                                       |
+| Services        | [Spring Data](docs/FEATURES.md#spring-data)            | Explore Spring Data repositories, domain types, IDs, and query methods.                                       |
 | Services        | [Cache](docs/FEATURES.md#cache)                       | Inspect Spring Cache managers, caches, metrics, annotations, and confirmed clear actions.                     |
 | Services        | [Security](docs/FEATURES.md#security)                 | Inspect Spring Security filter chains and best-effort endpoint rule explanations.                             |
 | Services        | [AI Usage](docs/FEATURES.md#ai-usage)                 | Summarize Spring AI and LangChain4j chat conversations, token usage, latency, and model details from OpenTelemetry spans.     |

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -16,7 +16,7 @@ const allPanelLinks = [
   {id: 'mappings', title: 'Mappings', heading: /HTTP mappings/},
   {id: 'scheduled', title: 'Scheduled Tasks', heading: /Scheduled Tasks/},
   {id: 'database-connection-pools', title: 'Database Connection Pools', heading: /Database Connection Pools/},
-  {id: 'data', title: 'Data', heading: /Spring Data repositories/},
+  {id: 'data', title: 'Spring Data', heading: /Spring Data repositories/},
   {id: 'cache', title: 'Cache', heading: /Spring Cache/},
   {id: 'security', title: 'Security', heading: /Spring Security/},
   {id: 'ai', title: 'AI Usage', heading: /AI Usage/},
@@ -103,7 +103,7 @@ test.describe('BootUI app shell', () => {
     await expect(page.getByRole('group', {name: 'Services panels'}).locator('.bootui-nav-link__label')).toHaveText([
       'Scheduled Tasks',
       'Database Connection Pools',
-      'Data',
+      'Spring Data',
       'Cache',
       'Security',
       'AI Usage'

--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -121,7 +121,12 @@ export const routes = [
     component: Hikari,
     meta: {group: groups.services, icon: 'bi-hdd-network', title: 'Database Connection Pools'}
   },
-  {path: '/data', name: 'data', component: Data, meta: {group: groups.services, icon: 'bi-database', title: 'Data'}},
+  {
+    path: '/data',
+    name: 'data',
+    component: Data,
+    meta: {group: groups.services, icon: 'bi-database', title: 'Spring Data'}
+  },
   {
     path: '/cache',
     name: 'cache',

--- a/bootui-ui/src/main/frontend/src/routes.test.js
+++ b/bootui-ui/src/main/frontend/src/routes.test.js
@@ -20,7 +20,7 @@ describe('routes', () => {
       'Mappings',
       'Scheduled Tasks',
       'Database Connection Pools',
-      'Data',
+      'Spring Data',
       'Cache',
       'Security',
       'AI Usage',

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -148,12 +148,12 @@ pools.
 
 ![BootUI Database Connection Pools panel](images/bootui-database-connection-pools.png)
 
-### Data
+### Spring Data
 
-The Data panel inspects Spring Data repositories. It shows repository interfaces, domain types, ID types, and query
+The Spring Data panel inspects Spring Data repositories. It shows repository interfaces, domain types, ID types, and query
 methods, and degrades to a clear empty state when Spring Data is not present or no repositories are registered.
 
-![BootUI Data panel](images/bootui-data.png)
+![BootUI Spring Data panel](images/bootui-data.png)
 
 ### Cache
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -80,7 +80,7 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - DevTools
   - Dev Services
   - Scheduled Tasks
-  - Data
+  - Spring Data
   - Cache
   - AI Usage
   - Security
@@ -153,7 +153,7 @@ The visible-route parity check is current. The sample-app Playwright suite cover
 1. Overview.
 2. Runtime: Health, Metrics, Memory, Heap Dump, Startup Timeline.
 3. Configuration: Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings.
-4. Services: Scheduled Tasks, Database Connection Pools, Data, Cache, Security, AI Usage.
+4. Services: Scheduled Tasks, Database Connection Pools, Spring Data, Cache, Security, AI Usage.
 5. Diagnostics: Traces, Log Tail, HTTP Probe, Architecture, Pentesting, Vulnerabilities.
 6. Developer tools: DevTools, Dev Services, Copilot, Claude Code.
 7. Disabled / unavailable grouping for unavailable non-overview panels.
@@ -249,7 +249,7 @@ line:
 | Strategy                       | Scope                                                                                                                                         | Trade-off                                                                                                                             |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | Harden all visible panels      | Ship every current route as supported `0.1.x` functionality.                                                                                 | Delivered for the alpha line and promoted to `0.1.0`; keep focused backend tests, docs, and release validation current.                |
-| Mark newer panels experimental | Keep all routes visible but clearly label Data, Startup, Memory, Scheduled, HTTP Probe, Log Tail, Profile Diff, and Security as experimental. | Faster release, but docs must set expectations.                                                                                       |
+| Mark newer panels experimental | Keep all routes visible but clearly label Spring Data, Startup, Memory, Scheduled, HTTP Probe, Log Tail, Profile Diff, and Security as experimental. | Faster release, but docs must set expectations.                                                                                  |
 | Hide unfinished panels         | Only expose the original MVP routes plus any fully hardened additions.                                                                        | Safest smaller surface, but requires UI gating work.                                                                                  |
 
 Delivered release stance: **harden all visible panels**.
@@ -364,7 +364,7 @@ Scope:
   stable DTO endpoints, documentation metadata, and optional frontend assets.
 - Extract **AI Usage** into `services/bootui-service-ai-usage` first. Preserve the existing Spring AI observation
   aggregation and add LangChain4j OpenTelemetry span support to the same panel and DTO shape where possible.
-- Move the remaining current Services menu entries behind that SPI over time: Scheduled Tasks, Database Connection Pools, Data,
+- Move the remaining current Services menu entries behind that SPI over time: Scheduled Tasks, Database Connection Pools, Spring Data,
   Cache, and Security.
 - Add Elasticsearch, Flyway/Liquibase, and MongoDB service visibility after the SPI exists.
   - Database connection-pool visibility shipped (read-only **Database Connection Pools** panel with a live saturation chart,
@@ -396,7 +396,7 @@ Design constraints:
   omits optional attributes. Prompt/response content must remain opt-in through captured trace attributes and continue
   to follow the existing masking/value-exposure rules.
 - Database connection-pool support should be read-only at first and exposed as its own **Database Connection Pools** panel
-  in the Services group, placed after **Data** and before **Cache**. It should fail closed when pool support
+  in the Services group, placed after **Spring Data** and before **Cache**. It should fail closed when pool support
   is absent, and show pool identity, masked JDBC connection metadata, current active/idle/total/pending counts, min/max
   sizing, timeout/lifetime settings, and unavailable reasons for closed or inaccessible pools. The panel should include a
   local live chart like the Metrics panel, polling bounded snapshots for active, idle, total, and pending connections so

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -50,7 +50,7 @@ Panel settings are consistent across the UI and API:
 | Configuration | Mappings | `mappings` | `bootui.panels.mappings.enabled` | Not applicable; view-only. |
 | Services | Scheduled Tasks | `scheduled` | `bootui.panels.scheduled.enabled` | Not applicable; view-only. |
 | Services | Database Connection Pools | `database-connection-pools` | `bootui.panels.database-connection-pools.enabled` | Not applicable; view-only. |
-| Services | Data | `data` | `bootui.panels.data.enabled` | Not applicable; view-only. |
+| Services | Spring Data | `data` | `bootui.panels.data.enabled` | Not applicable; view-only. |
 | Services | Cache | `cache` | `bootui.panels.cache.enabled` | `bootui.panels.cache.read-only` |
 | Services | Security | `security` | `bootui.panels.security.enabled` | Not applicable; view-only. |
 | Services | AI Usage | `ai` | `bootui.panels.ai.enabled` | Not applicable; view-only. |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1001,7 +1001,7 @@ Top-level navigation:
   - Mappings.
 - Services:
   - Scheduled Tasks.
-  - Data.
+  - Spring Data.
   - Cache.
   - Security.
   - AI Usage.
@@ -1106,8 +1106,8 @@ BootUI's current pre-1.0 release surface is complete when:
 - A sample Spring Boot app can add the starter and open `/bootui`.
 - The UI shows Overview, Runtime, Configuration, Services, Diagnostics, Developer tools, and Disabled / unavailable
   navigation groups covering Health, Metrics, Memory, Heap Dump, Startup Timeline, Scheduled Tasks, Database Connection
-  Pools, Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings, Data, Cache, Security, AI Usage, Traces, Log
-  Tail, HTTP Probe, Architecture, Pentesting, Vulnerabilities, DevTools, Dev Services, Copilot, and Claude Code.
+  Pools, Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings, Spring Data, Cache, Security, AI Usage, Traces, Log Tail,
+  HTTP Probe, Architecture, Pentesting, Vulnerabilities, DevTools, Dev Services, Copilot, and Claude Code.
 - Secret-like values are masked.
 - BootUI is disabled by default outside local/dev contexts.
 - Tests verify activation and safety behavior.


### PR DESCRIPTION
## What does this PR do?

Renames the Services navigation item for the repository explorer from "Data" to "Spring Data" and aligns the route metadata, app-shell assertions, and documentation labels with the new wording.

## Why is this change needed?

The panel specifically inspects Spring Data repositories, so the sidebar label should match the panel heading and avoid the generic "Data" wording.

N/A

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Also ran frontend and e2e Prettier checks.

## Screenshots (UI changes)

N/A - text-only sidebar label change covered by the app-shell test.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed