### PR TITLE
Normalize backend-down frontend errors

### DIFF
--- a/bootui-ui/src/main/frontend/src/utils/loadError.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/loadError.test.js
@@ -24,6 +24,12 @@ describe('loadError', () => {
     expect(formatLoadError(new Error('HTTP 500'), 'Unable to load overview')).toBe('Unable to load overview: HTTP 500')
   })
 
+  it('formats browser fetch failures with the same backend-down message', () => {
+    expect(formatLoadError(new TypeError('Failed to fetch'), 'Unable to load health')).toBe(
+      'Server unreachable: BootUI could not reach the Spring Boot app. The server may have been stopped. Start it again, then retry or refresh this page.'
+    )
+  })
+
   it('normalizes non-error values', () => {
     expect(toErrorMessage('Load failed')).toBe('Load failed')
     expect(toErrorMessage(null)).toBe('Request failed')

--- a/bootui-ui/src/main/frontend/src/utils/useServerPagedList.js
+++ b/bootui-ui/src/main/frontend/src/utils/useServerPagedList.js
@@ -1,5 +1,5 @@
 import {computed, onBeforeUnmount, ref} from 'vue'
-import {toErrorMessage} from './loadError.js'
+import {formatLoadError} from './loadError.js'
 
 export const SERVER_PAGE_SIZE = 200
 
@@ -54,7 +54,7 @@ export function useServerPagedList(endpoint, itemsKey, queryParams, options = {}
             }
           : next
     } catch (e) {
-      if (id === requestId) error.value = toErrorMessage(e)
+      if (id === requestId) error.value = formatLoadError(e)
     } finally {
       if (id === requestId) targetLoading.value = false
     }

--- a/bootui-ui/src/main/frontend/src/utils/useServerPagedList.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/useServerPagedList.test.js
@@ -93,4 +93,13 @@ describe('useServerPagedList', () => {
     expect(api.error.value).toBe('HTTP 503')
     expect(api.loading.value).toBe(false)
   })
+
+  it('normalizes backend-down fetch failures', async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+    const {api} = harness('api/things', 'things', () => ({}))
+    await api.load()
+    expect(api.error.value).toBe(
+      'Server unreachable: BootUI could not reach the Spring Boot app. The server may have been stopped. Start it again, then retry or refresh this page.'
+    )
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, ref} from 'vue'
 import {formatDuration, formatNumber, formatRelative, formatTime} from '../utils/format.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {useCopyToClipboard} from '../utils/useCopyToClipboard'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import AiSetupChecklist from './components/AiSetupChecklist.vue'
@@ -35,7 +36,7 @@ async function fetchAiUsage() {
     }
     lastUpdated.value = Date.now()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load AI usage data')
   }
 }
 
@@ -94,7 +95,7 @@ async function openChat(spanId) {
     if (!res.ok) throw new Error('HTTP ' + res.status)
     detail.value = await res.json()
   } catch (e) {
-    detail.value = {error: e.message}
+    detail.value = {error: formatLoadError(e, 'Unable to load AI chat details')}
   } finally {
     detailLoading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
@@ -96,7 +97,7 @@ async function loadReport() {
     report.value = await res.json()
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load architecture report')
   }
 }
 
@@ -112,7 +113,7 @@ async function runScan() {
     report.value = await res.json()
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to run architecture checks')
   } finally {
     loading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Cache.vue
+++ b/bootui-ui/src/main/frontend/src/views/Cache.vue
@@ -2,6 +2,7 @@
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
 import {formatNumber} from '../utils/format.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
@@ -26,7 +27,7 @@ async function load() {
     report.value = await res.json()
     lastFetched.value = Date.now()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load cache report')
   } finally {
     loading.value = false
   }
@@ -148,7 +149,7 @@ async function clearCaches(payload, busyKey) {
     flash(result.message || 'Cache cleared.', 'success')
     await load()
   } catch (e) {
-    flash('Could not clear cache: ' + e.message, 'danger')
+    flash(formatLoadError(e, 'Could not clear cache'), 'danger')
   } finally {
     busy.value = null
   }

--- a/bootui-ui/src/main/frontend/src/views/Conditions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {computed, onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import {SERVER_PAGE_SIZE} from '../utils/useServerPagedList.js'
 import ServerListFooter from './components/ServerListFooter.vue'
@@ -54,7 +55,7 @@ async function load(options = {}) {
           }
         : next
   } catch (e) {
-    if (id === requestId) error.value = e.message
+    if (id === requestId) error.value = formatLoadError(e, 'Unable to load conditions')
   } finally {
     if (id === requestId) targetLoading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, nextTick, onMounted, ref, watch} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
 import ServerListFooter from './components/ServerListFooter.vue'
@@ -216,7 +217,7 @@ async function postOverride(name, value, onSuccess) {
     if (onSuccess) onSuccess()
     await load()
   } catch (e) {
-    flash('Could not save override: ' + e.message, 'danger')
+    flash(formatLoadError(e, 'Could not save override'), 'danger')
   } finally {
     saving.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -2,6 +2,7 @@
 import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
 import {useRoute} from 'vue-router'
 import {formatNumber} from '../utils/format.js'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 
@@ -240,7 +241,7 @@ async function loadDashboard() {
     dashboard.value = await res.json()
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, `Unable to load ${panelConfig.value.title} dashboard`)
   }
 }
 
@@ -258,7 +259,7 @@ async function loadSessions(window = activeSessionWindow.value) {
     sessionList.value = await res.json()
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, `Unable to load ${panelConfig.value.title} sessions`)
   } finally {
     loading.value = false
   }
@@ -293,7 +294,7 @@ async function loadDetail(sessionId) {
     detail.value = await res.json()
     rawById.value = {}
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, `Unable to load ${panelConfig.value.title} session details`)
     detail.value = null
   } finally {
     detailLoading.value = false
@@ -338,7 +339,7 @@ async function revealRaw(event) {
     const payload = await res.json()
     rawById.value = {...rawById.value, [event.id]: payload.json}
   } catch (e) {
-    rawById.value = {...rawById.value, [event.id]: 'Unable to load raw event: ' + e.message}
+    rawById.value = {...rawById.value, [event.id]: formatLoadError(e, 'Unable to load raw event')}
   } finally {
     rawLoadingId.value = null
   }

--- a/bootui-ui/src/main/frontend/src/views/DatabaseConnectionsPools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DatabaseConnectionsPools.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onBeforeUnmount, ref, watch} from 'vue'
 import {formatNumber} from '../utils/format.js'
+import {formatLoadError} from '../utils/loadError.js'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
@@ -86,7 +87,7 @@ async function fetchPools() {
       selectPool(poolKey(pools.value[0]))
     }
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load database connection pools')
   }
 }
 

--- a/bootui-ui/src/main/frontend/src/views/Dependencies.vue
+++ b/bootui-ui/src/main/frontend/src/views/Dependencies.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import PanelHeader from './components/PanelHeader.vue'
@@ -112,7 +113,7 @@ async function loadDependencies() {
     data.value = await res.json()
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load dependencies')
   }
 }
 
@@ -131,7 +132,7 @@ async function scanDependencies() {
     }
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to scan dependencies')
   } finally {
     loading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
@@ -30,7 +31,7 @@ async function load(options = {}) {
     lastFetched.value = Date.now()
     syncSelectedService()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load Dev Services')
   } finally {
     loading.value = false
   }
@@ -146,7 +147,7 @@ async function openLogs(service) {
     if (!res.ok) throw new Error(await responseMessage(res))
     logs.value = await res.json()
   } catch (e) {
-    actionMessage.value = {type: 'danger', text: e.message}
+    actionMessage.value = {type: 'danger', text: formatLoadError(e, 'Unable to load service logs')}
   } finally {
     busyService.value = null
   }
@@ -171,7 +172,7 @@ async function restart(service) {
     await load({preserveActionMessage: true})
     actionMessage.value = {type: 'success', text: result.message}
   } catch (e) {
-    actionMessage.value = {type: 'danger', text: e.message}
+    actionMessage.value = {type: 'danger', text: formatLoadError(e, 'Unable to restart service')}
   } finally {
     busyService.value = null
   }

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onMounted, onUnmounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 
@@ -25,7 +26,7 @@ async function load() {
     status.value = await res.json()
     lastFetched.value = Date.now()
   } catch (e) {
-    flash('Could not load DevTools status: ' + e.message, 'danger')
+    flash(formatLoadError(e, 'Could not load DevTools status'), 'danger')
   } finally {
     loading.value = false
   }
@@ -48,7 +49,7 @@ async function triggerLiveReload() {
     flash(result.message || 'LiveReload triggered.', 'success')
     await load()
   } catch (e) {
-    flash('Could not trigger LiveReload: ' + e.message, 'danger')
+    flash(formatLoadError(e, 'Could not trigger LiveReload'), 'danger')
   } finally {
     actionLoading.value = null
   }
@@ -79,7 +80,7 @@ async function restart() {
     flash(result.message || 'Restart scheduled.', 'success')
     pollUntilOnline()
   } catch (e) {
-    flash('Could not schedule restart: ' + e.message, 'danger')
+    flash(formatLoadError(e, 'Could not schedule restart'), 'danger')
   } finally {
     actionLoading.value = null
   }

--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -4,6 +4,7 @@ import HealthNode from './HealthNode.vue'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import {formatLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 
 const root = ref(null)
@@ -18,7 +19,7 @@ async function fetchHealth() {
     root.value = await res.json()
     lastFetched.value = Date.now()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load health')
   }
 }
 

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.vue
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 
@@ -109,7 +110,7 @@ async function loadReport(options = {}) {
     report.value = next
     error.value = null
   } catch (e) {
-    if (requestId === reportRequestId) error.value = e.message
+    if (requestId === reportRequestId) error.value = formatLoadError(e, 'Unable to load heap dump report')
   }
 }
 
@@ -130,7 +131,7 @@ async function runAction(path, body) {
     await loadReport()
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to run heap dump action')
   } finally {
     loading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Hikari.vue
+++ b/bootui-ui/src/main/frontend/src/views/Hikari.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onBeforeUnmount, ref, watch} from 'vue'
 import {formatNumber} from '../utils/format.js'
+import {formatLoadError} from '../utils/loadError.js'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
@@ -86,7 +87,7 @@ async function fetchPools() {
       selectPool(poolKey(pools.value[0]))
     }
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load database connection pools')
   }
 }
 

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -3,6 +3,7 @@ import {computed, onBeforeUnmount, ref, watch} from 'vue'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import {formatLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 
 const data = ref(null)
@@ -46,7 +47,7 @@ async function fetchMemory() {
       inputsInitialized.value = true
     }
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load memory data')
   }
 }
 

--- a/bootui-ui/src/main/frontend/src/views/Metrics.vue
+++ b/bootui-ui/src/main/frontend/src/views/Metrics.vue
@@ -3,6 +3,7 @@ import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import {formatLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 
 const data = ref(null)
@@ -124,7 +125,7 @@ async function fetchMetrics() {
       selectMeter(preferredInitialMeter(data.value.meters))
     }
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load metrics')
   }
 }
 
@@ -155,7 +156,7 @@ async function loadDetail() {
     lastUpdated.value = new Date()
     detailError.value = null
   } catch (e) {
-    detailError.value = e.message
+    detailError.value = formatLoadError(e, 'Unable to load metric details')
   } finally {
     loadingDetail = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Pentesting.vue
+++ b/bootui-ui/src/main/frontend/src/views/Pentesting.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
@@ -65,7 +66,7 @@ async function loadReport() {
     report.value = await res.json()
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load pentesting report')
   }
 }
 
@@ -81,7 +82,7 @@ async function runScan() {
     report.value = await res.json()
     error.value = null
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to run pentesting checks')
   } finally {
     loading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
+++ b/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 
@@ -18,7 +19,7 @@ async function load() {
     data.value = await res.json()
     lastFetched.value = Date.now()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load profile diff')
   } finally {
     loading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Scheduled.vue
+++ b/bootui-ui/src/main/frontend/src/views/Scheduled.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 
@@ -18,7 +19,7 @@ async function load() {
     report.value = await res.json()
     lastFetched.value = Date.now()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load scheduled tasks')
   } finally {
     loading.value = false
   }

--- a/bootui-ui/src/main/frontend/src/views/Startup.vue
+++ b/bootui-ui/src/main/frontend/src/views/Startup.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 
@@ -93,7 +94,7 @@ async function load() {
   } catch (err) {
     report.value = {steps: []}
     expandedStepIds.value = new Set()
-    error.value = err instanceof Error ? err.message : 'Unable to load startup data'
+    error.value = formatLoadError(err, 'Unable to load startup data')
   } finally {
     loading.value = false
     loaded.value = true

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -2,6 +2,7 @@
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
 import {formatDuration, formatTime} from '../utils/format.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
@@ -28,7 +29,7 @@ async function load() {
     report.value = await res.json()
     lastFetched.value = Date.now()
   } catch (e) {
-    error.value = e.message
+    error.value = formatLoadError(e, 'Unable to load traces')
   } finally {
     loading.value = false
   }
@@ -43,7 +44,7 @@ async function openTrace(traceId) {
     if (!res.ok) throw new Error('HTTP ' + res.status)
     detail.value = await res.json()
   } catch (e) {
-    banner.value = {type: 'danger', text: 'Could not load trace: ' + e.message}
+    banner.value = {type: 'danger', text: formatLoadError(e, 'Could not load trace')}
   } finally {
     detailLoading.value = false
   }
@@ -79,7 +80,7 @@ async function clearAll() {
       banner.value = null
     }, 4000)
   } catch (e) {
-    banner.value = {type: 'danger', text: 'Could not clear: ' + e.message}
+    banner.value = {type: 'danger', text: formatLoadError(e, 'Could not clear traces')}
   } finally {
     busy.value = false
   }


### PR DESCRIPTION
## What does this PR do?

Normalizes frontend request failures through the shared load-error formatter so backend-down states show the same "Server unreachable" guidance across panels, action banners, and server-paged lists.

## Why is this change needed?

When the Spring Boot app is stopped, panels previously surfaced browser-specific or context-specific raw fetch errors like "Failed to fetch". This makes the backend-down message consistent while preserving request-specific HTTP status errors for real API responses.

No linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `(cd bootui-ui/src/main/frontend && npm run format:check && npm test)`
- [x] `(cd bootui-ui/src/main/frontend && npm run build)`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: no docs cover transient backend-down error copy)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed