### PR TITLE
Add Kubernetes memory sizing guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ BootUI exposes these panels in the same grouped order as the application menu. S
 | Overview        | [Overview](docs/FEATURES.md#overview)                 | See runtime identity, versions, ports, active profiles, activation reason, and safety state.                  |
 | Runtime         | [Health](docs/FEATURES.md#health)                     | Explore the Actuator health tree and contributor details, with setup guidance when health is unavailable or only defaults are reported. |
 | Runtime         | [Metrics](docs/FEATURES.md#metrics)                   | Browse Micrometer meters, tags, measurements, and a local live chart for selected metrics.                    |
-| Runtime         | [Memory](docs/FEATURES.md#memory)                     | Review JVM heap, non-heap, memory pools, garbage collectors, and suggested JVM options.                       |
+| Runtime         | [Memory](docs/FEATURES.md#memory)                     | Review JVM heap, non-heap, memory pools, JVM options, and Kubernetes request/limit sizing.                    |
 | Runtime         | [Heap Dump](docs/FEATURES.md#heap-dump)               | Capture local JVM heap dumps on demand and analyze a value-free class histogram of memory usage.             |
 | Runtime         | [Startup Timeline](docs/FEATURES.md#startup-timeline) | Inspect Spring Boot startup steps and durations when startup data is available.                               |
 | Configuration   | [Configuration](docs/FEATURES.md#configuration)       | Inspect effective configuration values, metadata, masking, and local runtime overrides.                       |

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ContainerMemoryLimitDetector.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ContainerMemoryLimitDetector.java
@@ -1,0 +1,71 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.OptionalLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class ContainerMemoryLimitDetector {
+
+    private static final Logger log = LoggerFactory.getLogger(ContainerMemoryLimitDetector.class);
+    private static final long CGROUP_V1_UNLIMITED_SENTINEL_FLOOR = Long.MAX_VALUE / 2;
+
+    private static final List<Path> STANDARD_CGROUP_LIMIT_FILES =
+            List.of(Path.of("/sys/fs/cgroup/memory.max"), Path.of("/sys/fs/cgroup/memory/memory.limit_in_bytes"));
+
+    private final List<Path> limitFiles;
+
+    private ContainerMemoryLimitDetector(List<Path> limitFiles) {
+        this.limitFiles = List.copyOf(limitFiles);
+    }
+
+    static ContainerMemoryLimitDetector standard() {
+        return new ContainerMemoryLimitDetector(STANDARD_CGROUP_LIMIT_FILES);
+    }
+
+    static ContainerMemoryLimitDetector disabled() {
+        return new ContainerMemoryLimitDetector(List.of());
+    }
+
+    OptionalLong detectLimit() {
+        for (Path limitFile : limitFiles) {
+            OptionalLong limit = readLimit(limitFile);
+            if (limit.isPresent()) {
+                return limit;
+            }
+        }
+        return OptionalLong.empty();
+    }
+
+    private OptionalLong readLimit(Path limitFile) {
+        if (!Files.isRegularFile(limitFile)) {
+            return OptionalLong.empty();
+        }
+        try {
+            return parseLimit(Files.readString(limitFile));
+        } catch (IOException ex) {
+            log.debug("Could not read cgroup memory limit from {}", limitFile, ex);
+            return OptionalLong.empty();
+        }
+    }
+
+    static OptionalLong parseLimit(String rawLimit) {
+        String value = rawLimit == null ? "" : rawLimit.trim();
+        if (value.isEmpty() || "max".equals(value)) {
+            return OptionalLong.empty();
+        }
+        try {
+            long parsed = Long.parseLong(value);
+            if (parsed <= 0 || parsed >= CGROUP_V1_UNLIMITED_SENTINEL_FLOOR) {
+                return OptionalLong.empty();
+            }
+            return OptionalLong.of(parsed);
+        } catch (NumberFormatException ex) {
+            log.debug("Could not parse cgroup memory limit '{}'", value, ex);
+            return OptionalLong.empty();
+        }
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MemoryController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MemoryController.java
@@ -1,11 +1,13 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import io.github.jdubois.bootui.core.BootUiDtos.KubernetesMemoryRecommendationDto;
 import io.github.jdubois.bootui.core.BootUiDtos.MemoryCalculationDto;
 import io.github.jdubois.bootui.core.BootUiDtos.MemoryPoolDto;
 import io.github.jdubois.bootui.core.BootUiDtos.MemoryReport;
 import java.lang.management.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.OptionalLong;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,13 +18,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemoryController {
 
     private final MemoryCalculator calculator;
+    private final ContainerMemoryLimitDetector containerMemoryLimitDetector;
 
     public MemoryController() {
-        this(new MemoryCalculator());
+        this(new MemoryCalculator(), ContainerMemoryLimitDetector.standard());
     }
 
     MemoryController(MemoryCalculator calculator) {
+        this(calculator, ContainerMemoryLimitDetector.standard());
+    }
+
+    MemoryController(MemoryCalculator calculator, ContainerMemoryLimitDetector containerMemoryLimitDetector) {
         this.calculator = calculator;
+        this.containerMemoryLimitDetector = containerMemoryLimitDetector;
     }
 
     @GetMapping
@@ -52,21 +60,31 @@ public class MemoryController {
 
         int liveThreads = threadBean.getThreadCount();
         int liveClasses = classBean.getLoadedClassCount();
+        OptionalLong detectedContainerMemoryLimit = containerMemoryLimitDetector.detectLimit();
 
         long resolvedTotalBytes = totalMemoryMb != null
                 ? totalMemoryMb * 1024L * 1024L
-                : calculator.defaultTotalMemoryBytes(
+                : detectedContainerMemoryLimit.orElseGet(() -> calculator.defaultTotalMemoryBytes(
                         heapUsage.getCommitted(),
                         nonHeapUsage.getCommitted(),
                         MemoryCalculator.defaultThreadCount(liveThreads),
-                        liveClasses);
+                        liveClasses));
         int resolvedThreads = threadCount != null ? threadCount : MemoryCalculator.defaultThreadCount(liveThreads);
         int resolvedHeadRoom = headRoomPercent != null ? headRoomPercent : 0;
 
         MemoryCalculationDto calculation = calculator.calculate(
                 resolvedTotalBytes, resolvedThreads, liveClasses, resolvedHeadRoom, liveThreads, liveClasses);
+        Long detectedContainerMemoryLimitBytes =
+                detectedContainerMemoryLimit.isPresent() ? detectedContainerMemoryLimit.getAsLong() : null;
+        KubernetesMemoryRecommendationDto kubernetes = MemoryKubernetesSizer.recommend(
+                calculation,
+                heapUsage.getCommitted(),
+                nonHeapUsage.getCommitted(),
+                directBufferMemoryUsedBytes(),
+                nativeMemoryTrackingEnabled(inputArgs),
+                detectedContainerMemoryLimitBytes);
 
-        return new MemoryReport(heap, nonHeap, pools, inputArgs, calculation.jvmOptions(), calculation);
+        return new MemoryReport(heap, nonHeap, pools, inputArgs, calculation.jvmOptions(), calculation, kubernetes);
     }
 
     private MemoryPoolDto toDto(String name, MemoryUsage usage) {
@@ -75,5 +93,24 @@ public class MemoryController {
         long max = usage.getMax();
         int pct = (max > 0) ? (int) (used * 100L / max) : (committed > 0 ? (int) (used * 100L / committed) : 0);
         return new MemoryPoolDto(name, used, committed, max, pct);
+    }
+
+    private long directBufferMemoryUsedBytes() {
+        long usedBytes = 0;
+        for (BufferPoolMXBean bufferPool : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
+            if ("direct".equalsIgnoreCase(bufferPool.getName())) {
+                usedBytes += Math.max(0, bufferPool.getMemoryUsed());
+            }
+        }
+        return usedBytes;
+    }
+
+    private boolean nativeMemoryTrackingEnabled(List<String> inputArgs) {
+        for (String inputArg : inputArgs) {
+            if (inputArg.startsWith("-XX:NativeMemoryTracking=") && !inputArg.endsWith("=off")) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MemoryKubernetesSizer.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MemoryKubernetesSizer.java
@@ -1,0 +1,194 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.core.BootUiDtos.KubernetesMemoryRecommendationDto;
+import io.github.jdubois.bootui.core.BootUiDtos.MemoryCalculationDto;
+import java.util.ArrayList;
+import java.util.List;
+
+final class MemoryKubernetesSizer {
+
+    static final int RECOMMENDED_MIN_HEADROOM_PERCENT = 10;
+    static final int RECOMMENDED_MAX_HEADROOM_PERCENT = 15;
+
+    private static final long MB = 1024L * 1024L;
+    private static final long MIN_BURSTABLE_REQUEST_BYTES = 128L * MB;
+    private static final long REQUEST_GRANULARITY_BYTES = 64L * MB;
+    private static final long MIN_SNAPSHOT_MARGIN_BYTES = 64L * MB;
+    private static final double SNAPSHOT_MARGIN_FACTOR = 0.15;
+
+    private MemoryKubernetesSizer() {}
+
+    static KubernetesMemoryRecommendationDto recommend(
+            MemoryCalculationDto calculation,
+            long heapCommittedBytes,
+            long nonHeapCommittedBytes,
+            long directBufferMemoryUsedBytes,
+            boolean nativeMemoryTrackingEnabled,
+            Long detectedContainerLimitBytes) {
+
+        long currentSnapshotBytes = estimateCurrentSnapshotBytes(
+                calculation, heapCommittedBytes, nonHeapCommittedBytes, directBufferMemoryUsedBytes);
+        String detectedContainerLimitMemory =
+                detectedContainerLimitBytes == null ? null : formatMi(detectedContainerLimitBytes);
+
+        if (!calculation.valid()) {
+            List<String> warnings = new ArrayList<>();
+            warnings.add(calculation.error());
+            return new KubernetesMemoryRecommendationDto(
+                    0,
+                    calculation.totalMemoryBytes(),
+                    0,
+                    currentSnapshotBytes,
+                    detectedContainerLimitBytes,
+                    "",
+                    formatMi(calculation.totalMemoryBytes()),
+                    "",
+                    formatMi(currentSnapshotBytes),
+                    detectedContainerLimitMemory,
+                    "Unavailable",
+                    "Low",
+                    List.copyOf(warnings),
+                    "");
+        }
+
+        long limitBytes = calculation.totalMemoryBytes();
+        long requestBytes = limitBytes;
+        long burstableRequestBytes = estimateBurstableRequestBytes(limitBytes, currentSnapshotBytes);
+        List<String> warnings = buildWarnings(
+                calculation,
+                nativeMemoryTrackingEnabled,
+                detectedContainerLimitBytes,
+                burstableRequestBytes,
+                limitBytes);
+        String confidence = confidence(calculation, nativeMemoryTrackingEnabled, detectedContainerLimitBytes);
+        String yaml = buildYaml(formatMi(requestBytes), formatMi(limitBytes), calculation.jvmOptions());
+
+        return new KubernetesMemoryRecommendationDto(
+                requestBytes,
+                limitBytes,
+                burstableRequestBytes,
+                currentSnapshotBytes,
+                detectedContainerLimitBytes,
+                formatMi(requestBytes),
+                formatMi(limitBytes),
+                formatMi(burstableRequestBytes),
+                formatMi(currentSnapshotBytes),
+                detectedContainerLimitMemory,
+                "Guaranteed",
+                confidence,
+                List.copyOf(warnings),
+                yaml);
+    }
+
+    private static long estimateCurrentSnapshotBytes(
+            MemoryCalculationDto calculation,
+            long heapCommittedBytes,
+            long nonHeapCommittedBytes,
+            long directBufferMemoryUsedBytes) {
+
+        long liveStackBytes = calculation.stackBytesPerThread() * Math.max(0L, calculation.liveThreadCount());
+        return nonNegative(heapCommittedBytes)
+                + nonNegative(nonHeapCommittedBytes)
+                + nonNegative(directBufferMemoryUsedBytes)
+                + liveStackBytes;
+    }
+
+    private static long estimateBurstableRequestBytes(long limitBytes, long currentSnapshotBytes) {
+        long marginBytes =
+                Math.max(MIN_SNAPSHOT_MARGIN_BYTES, Math.round(currentSnapshotBytes * SNAPSHOT_MARGIN_FACTOR));
+        long rounded = roundUpTo(Math.max(MIN_BURSTABLE_REQUEST_BYTES, currentSnapshotBytes + marginBytes));
+        return Math.min(limitBytes, rounded);
+    }
+
+    private static List<String> buildWarnings(
+            MemoryCalculationDto calculation,
+            boolean nativeMemoryTrackingEnabled,
+            Long detectedContainerLimitBytes,
+            long burstableRequestBytes,
+            long limitBytes) {
+
+        List<String> warnings = new ArrayList<>();
+        warnings.add(
+                "Request equals limit for Kubernetes Guaranteed QoS; use the burstable request only in clusters that intentionally overcommit memory.");
+        if (detectedContainerLimitBytes != null && detectedContainerLimitBytes.longValue() != limitBytes) {
+            warnings.add("Detected cgroup memory limit is "
+                    + formatMi(detectedContainerLimitBytes)
+                    + ", which differs from the calculator total "
+                    + formatMi(limitBytes)
+                    + "; update the total memory input if you want the manifest to match the live container limit.");
+        }
+        if (calculation.headRoomPercent() < RECOMMENDED_MIN_HEADROOM_PERCENT) {
+            warnings.add("Headroom below "
+                    + RECOMMENDED_MIN_HEADROOM_PERCENT
+                    + "% leaves little room for native allocations; Kubernetes deployments usually start at "
+                    + RECOMMENDED_MIN_HEADROOM_PERCENT
+                    + "-"
+                    + RECOMMENDED_MAX_HEADROOM_PERCENT
+                    + "% unless measured otherwise.");
+        }
+        if (!nativeMemoryTrackingEnabled) {
+            warnings.add(
+                    "Native Memory Tracking is not enabled, so native overhead is estimated from JVM pools and runtime defaults.");
+        }
+        if (calculation.threadCount() < calculation.liveThreadCount()) {
+            warnings.add(
+                    "Thread budget is below the current live thread count; increase it before applying these limits.");
+        }
+        if (calculation.heapBytes() * 100.0 / limitBytes > 75.0) {
+            warnings.add("Heap is above 75% of the container limit; verify native memory under representative load.");
+        }
+        if (burstableRequestBytes < limitBytes) {
+            warnings.add(
+                    "The burstable request is based on the current committed-memory snapshot and can be too low after warmup.");
+        }
+        return warnings;
+    }
+
+    private static String confidence(
+            MemoryCalculationDto calculation, boolean nativeMemoryTrackingEnabled, Long detectedContainerLimitBytes) {
+        if (!calculation.valid()) {
+            return "Low";
+        }
+        if (detectedContainerLimitBytes != null
+                && detectedContainerLimitBytes.longValue() == calculation.totalMemoryBytes()
+                && nativeMemoryTrackingEnabled
+                && calculation.headRoomPercent() >= RECOMMENDED_MIN_HEADROOM_PERCENT) {
+            return "High";
+        }
+        return "Medium";
+    }
+
+    private static String buildYaml(String requestMemory, String limitMemory, String jvmOptions) {
+        String escapedJvmOptions = jvmOptions.replace("\\", "\\\\").replace("\"", "\\\"");
+        return "resources:\n"
+                + "  requests:\n"
+                + "    memory: \""
+                + requestMemory
+                + "\"\n"
+                + "  limits:\n"
+                + "    memory: \""
+                + limitMemory
+                + "\"\n"
+                + "env:\n"
+                + "  - name: JAVA_TOOL_OPTIONS\n"
+                + "    value: \""
+                + escapedJvmOptions
+                + "\"";
+    }
+
+    private static long nonNegative(long value) {
+        return Math.max(0, value);
+    }
+
+    private static long roundUpTo(long value) {
+        if (value <= 0) {
+            return REQUEST_GRANULARITY_BYTES;
+        }
+        return ((value + REQUEST_GRANULARITY_BYTES - 1) / REQUEST_GRANULARITY_BYTES) * REQUEST_GRANULARITY_BYTES;
+    }
+
+    static String formatMi(long bytes) {
+        long mebibytes = Math.max(0, (bytes + MB - 1) / MB);
+        return mebibytes + "Mi";
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MemoryControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MemoryControllerTests.java
@@ -41,7 +41,8 @@ class MemoryControllerTests {
                 .andExpect(jsonPath("$.pools").isArray())
                 .andExpect(jsonPath("$.jvmInputArguments").isArray())
                 .andExpect(jsonPath("$.suggestedJvmOptions").isString())
-                .andExpect(jsonPath("$.calculation").isMap());
+                .andExpect(jsonPath("$.calculation").isMap())
+                .andExpect(jsonPath("$.kubernetes").isMap());
     }
 
     @Test
@@ -123,5 +124,23 @@ class MemoryControllerTests {
                 .andExpect(jsonPath("$.calculation.liveThreadCount").value(org.hamcrest.Matchers.greaterThan(0)))
                 // liveLoadedClassCount must be at least 1
                 .andExpect(jsonPath("$.calculation.liveLoadedClassCount").value(org.hamcrest.Matchers.greaterThan(0)));
+    }
+
+    @Test
+    void kubernetesRecommendationReportsGuaranteedResources() throws Exception {
+        MockMvc mvc = standaloneSetup(
+                        new MemoryController(new MemoryCalculator(JDK_25), ContainerMemoryLimitDetector.disabled()))
+                .build();
+
+        long expectedBytes = 1024L * 1024L * 1024L;
+        mvc.perform(get("/bootui/api/memory")
+                        .param("totalMemoryMb", "1024")
+                        .param("headRoomPercent", "10")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.kubernetes.requestMemoryBytes").value(expectedBytes))
+                .andExpect(jsonPath("$.kubernetes.limitMemoryBytes").value(expectedBytes))
+                .andExpect(jsonPath("$.kubernetes.qosClass").value("Guaranteed"))
+                .andExpect(jsonPath("$.kubernetes.yaml").value(org.hamcrest.Matchers.containsString("resources:")));
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MemoryKubernetesSizerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MemoryKubernetesSizerTests.java
@@ -1,0 +1,83 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.web.MemoryCalculator.JdkVersion;
+import io.github.jdubois.bootui.core.BootUiDtos.KubernetesMemoryRecommendationDto;
+import io.github.jdubois.bootui.core.BootUiDtos.MemoryCalculationDto;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+
+class MemoryKubernetesSizerTests {
+
+    private static final long MB = 1024L * 1024L;
+    private static final JdkVersion JDK_24 = () -> 24;
+
+    private final MemoryCalculator calculator = new MemoryCalculator(JDK_24);
+
+    @Test
+    void recommendsGuaranteedQosByDefault() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation =
+                MemoryKubernetesSizer.recommend(calculation, 256 * MB, 128 * MB, 8 * MB, true, 1024 * MB);
+
+        assertThat(recommendation.requestMemoryBytes()).isEqualTo(1024 * MB);
+        assertThat(recommendation.limitMemoryBytes()).isEqualTo(1024 * MB);
+        assertThat(recommendation.requestMemory()).isEqualTo("1024Mi");
+        assertThat(recommendation.limitMemory()).isEqualTo("1024Mi");
+        assertThat(recommendation.qosClass()).isEqualTo("Guaranteed");
+        assertThat(recommendation.confidence()).isEqualTo("High");
+        assertThat(recommendation.detectedContainerLimitMemory()).isEqualTo("1024Mi");
+        assertThat(recommendation.yaml())
+                .startsWith("resources:\n  requests:\n    memory: \"1024Mi\"\n  limits:\n    memory: \"1024Mi\"")
+                .contains("JAVA_TOOL_OPTIONS");
+    }
+
+    @Test
+    void burstableRequestUsesLiveSnapshotRatherThanFixedRegionCaps() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 10, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation =
+                MemoryKubernetesSizer.recommend(calculation, 64 * MB, 64 * MB, 0, false, null);
+
+        assertThat(recommendation.currentSnapshotBytes()).isEqualTo(138 * MB);
+        assertThat(recommendation.burstableRequestMemoryBytes()).isEqualTo(256 * MB);
+        assertThat(recommendation.burstableRequestMemory()).isEqualTo("256Mi");
+    }
+
+    @Test
+    void reportsLowConfidenceAndNoYamlWhenCalculationIsInvalid() {
+        MemoryCalculationDto calculation = calculator.calculate(256 * MB, 5_000, 100_000, 0, 10, 100_000);
+
+        KubernetesMemoryRecommendationDto recommendation =
+                MemoryKubernetesSizer.recommend(calculation, 64 * MB, 64 * MB, 0, false, null);
+
+        assertThat(recommendation.confidence()).isEqualTo("Low");
+        assertThat(recommendation.requestMemoryBytes()).isZero();
+        assertThat(recommendation.yaml()).isEmpty();
+        assertThat(recommendation.warnings()).contains(calculation.error());
+    }
+
+    @Test
+    void warnsWhenHeadroomIsBelowKubernetesRecommendation() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 0, 10, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation =
+                MemoryKubernetesSizer.recommend(calculation, 64 * MB, 64 * MB, 0, true, null);
+
+        assertThat(recommendation.warnings())
+                .anySatisfy(warning -> assertThat(warning).contains("Headroom below 10%"));
+    }
+
+    @Test
+    void parsesCgroupLimitsAndIgnoresUnlimitedValues() {
+        assertThat(ContainerMemoryLimitDetector.parseLimit("1073741824")).isEqualTo(OptionalLong.of(1024 * MB));
+        assertThat(ContainerMemoryLimitDetector.parseLimit(String.valueOf(128L * 1024 * MB)))
+                .isEqualTo(OptionalLong.of(128L * 1024 * MB));
+        assertThat(ContainerMemoryLimitDetector.parseLimit("max")).isEmpty();
+        assertThat(ContainerMemoryLimitDetector.parseLimit(String.valueOf(Long.MAX_VALUE)))
+                .isEmpty();
+        assertThat(ContainerMemoryLimitDetector.parseLimit("not-a-number")).isEmpty();
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiDtos.java
@@ -691,7 +691,8 @@ public final class BootUiDtos {
             List<MemoryPoolDto> pools,
             List<String> jvmInputArguments,
             String suggestedJvmOptions,
-            MemoryCalculationDto calculation) {}
+            MemoryCalculationDto calculation,
+            KubernetesMemoryRecommendationDto kubernetes) {}
 
     /**
      * Result of the Paketo-style memory calculator.
@@ -720,6 +721,26 @@ public final class BootUiDtos {
             String jvmOptions,
             boolean valid,
             String error) {}
+
+    /**
+     * Kubernetes resource recommendation derived from the JVM memory
+     * calculator and the current runtime snapshot.
+     */
+    public record KubernetesMemoryRecommendationDto(
+            long requestMemoryBytes,
+            long limitMemoryBytes,
+            long burstableRequestMemoryBytes,
+            long currentSnapshotBytes,
+            Long detectedContainerLimitBytes,
+            String requestMemory,
+            String limitMemory,
+            String burstableRequestMemory,
+            String currentSnapshotMemory,
+            String detectedContainerLimitMemory,
+            String qosClass,
+            String confidence,
+            List<String> warnings,
+            String yaml) {}
 
     /**
      * One captured heap dump file on local disk.

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -179,7 +179,7 @@ test.describe('BootUI app shell', () => {
     await expandAllSidebarGroups(page)
 
     for (const link of allPanelLinks) {
-      await page.locator('aside .nav-link', {hasText: link.title}).click()
+      await page.getByRole('link', {name: link.title, exact: true}).click()
       await expect(page.locator('main h2').filter({hasText: link.heading}).first()).toBeVisible({timeout: 15_000})
     }
   })

--- a/bootui-sample-app/e2e/tests/memory.spec.js
+++ b/bootui-sample-app/e2e/tests/memory.spec.js
@@ -15,15 +15,20 @@ test.describe('Memory view', () => {
 
     await openView('memory', 'Memory')
 
-    await expect(page.locator('.card', {hasText: 'Recommended JVM Options'}).first()).toBeVisible()
+    const jvmOptionsCard = page.locator('.card', {hasText: 'Recommended JVM Options'}).first()
+    const kubernetesCard = page.locator('.card', {hasText: 'Kubernetes sizing'}).first()
+    await expect(jvmOptionsCard).toBeVisible()
+    await expect(kubernetesCard).toBeVisible()
+    await expect(kubernetesCard).toContainText('Guaranteed')
+    await expect(kubernetesCard.locator('.options-box code')).toContainText('JAVA_TOOL_OPTIONS')
     await expect(page.locator('.card', {hasText: 'Heap Memory'}).first()).toBeVisible()
     await expect(page.locator('.card', {hasText: /Non[- ]?Heap/i}).first()).toBeVisible()
 
-    const optionsBlock = page.locator('.options-box code')
+    const optionsBlock = jvmOptionsCard.locator('.options-box code')
     await expect(optionsBlock).toContainText(/-Xmx|-XX:/)
 
     // The copy button gives feedback after being clicked.
-    const copyButton = page.getByRole('button', {name: /Copy/})
+    const copyButton = jvmOptionsCard.getByRole('button', {name: /Copy/})
     await copyButton.click()
     await expect(page.getByRole('button', {name: /Copied!/})).toBeVisible({timeout: 5_000})
   })
@@ -46,13 +51,14 @@ test.describe('Memory view', () => {
     await openView('memory', 'Memory')
 
     const calculatorCard = page.locator('.card', {hasText: 'JVM memory calculator'})
+    const jvmOptionsCard = page.locator('.card', {hasText: 'Recommended JVM Options'}).first()
     await expect(calculatorCard).toBeVisible()
 
     const totalInput = calculatorCard.locator('input[type="number"]').first()
     await expect(totalInput).toBeVisible()
     await expect(totalInput).not.toHaveValue('')
 
-    const optionsBlock = page.locator('.options-box code')
+    const optionsBlock = jvmOptionsCard.locator('.options-box code')
     // Capture the current -Xmx value before editing
     const before = await optionsBlock.innerText()
     const beforeMatch = before.match(/-Xmx(\d+)m/)

--- a/bootui-ui/src/main/frontend/src/views/Memory.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Memory.test.js
@@ -84,6 +84,22 @@ describe('Memory', () => {
     await flushPromises()
 
     expect(fetch).toHaveBeenCalledWith('api/memory')
+    const renderedText = wrapper.text()
+    const panelOrder = [
+      'Heap Memory',
+      'Non-Heap Memory',
+      'Memory Pools',
+      'Current JVM Arguments',
+      'JVM memory calculator',
+      'Recommended JVM Options',
+      'Kubernetes sizing'
+    ]
+    const panelPositions = panelOrder.map((label) => {
+      const position = renderedText.indexOf(label)
+      expect(position).toBeGreaterThanOrEqual(0)
+      return position
+    })
+    expect(panelPositions).toEqual([...panelPositions].sort((a, b) => a - b))
     expect(wrapper.text()).toContain('Kubernetes sizing')
     expect(wrapper.text()).toContain('1024Mi')
     expect(wrapper.text()).toContain('Guaranteed')

--- a/bootui-ui/src/main/frontend/src/views/Memory.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Memory.test.js
@@ -1,0 +1,96 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import Memory from './Memory.vue'
+
+const MB = 1024 * 1024
+
+function memoryReport() {
+  return {
+    heap: {name: 'Heap', usedBytes: 128 * MB, committedBytes: 256 * MB, maxBytes: 512 * MB, usedPercent: 25},
+    nonHeap: {name: 'Non-Heap', usedBytes: 64 * MB, committedBytes: 128 * MB, maxBytes: -1, usedPercent: 50},
+    pools: [{name: 'G1 Eden Space', usedBytes: 32 * MB, committedBytes: 64 * MB, maxBytes: 128 * MB, usedPercent: 25}],
+    jvmInputArguments: [],
+    suggestedJvmOptions: '-Xms512m -Xmx512m -XX:+UseG1GC',
+    calculation: {
+      totalMemoryBytes: 1024 * MB,
+      heapBytes: 512 * MB,
+      metaspaceBytes: 64 * MB,
+      codeCacheBytes: 240 * MB,
+      directMemoryBytes: 10 * MB,
+      stackBytesPerThread: MB,
+      stackBytesTotal: 250 * MB,
+      headRoomBytes: 102 * MB,
+      fixedRegionsBytes: 564 * MB,
+      threadCount: 250,
+      loadedClasses: 5000,
+      liveThreadCount: 40,
+      liveLoadedClassCount: 5000,
+      headRoomPercent: 10,
+      jvmOptions: '-Xms512m -Xmx512m -XX:+UseG1GC',
+      valid: true,
+      error: null
+    },
+    kubernetes: {
+      requestMemoryBytes: 1024 * MB,
+      limitMemoryBytes: 1024 * MB,
+      burstableRequestMemoryBytes: 512 * MB,
+      currentSnapshotBytes: 432 * MB,
+      detectedContainerLimitBytes: 1024 * MB,
+      requestMemory: '1024Mi',
+      limitMemory: '1024Mi',
+      burstableRequestMemory: '512Mi',
+      currentSnapshotMemory: '432Mi',
+      detectedContainerLimitMemory: '1024Mi',
+      qosClass: 'Guaranteed',
+      confidence: 'High',
+      warnings: ['Request equals limit for Kubernetes Guaranteed QoS.'],
+      yaml:
+        'resources:\n' +
+        '  requests:\n' +
+        '    memory: "1024Mi"\n' +
+        '  limits:\n' +
+        '    memory: "1024Mi"\n' +
+        'env:\n' +
+        '  - name: JAVA_TOOL_OPTIONS\n' +
+        '    value: "-Xms512m -Xmx512m -XX:+UseG1GC"'
+    }
+  }
+}
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+describe('Memory', () => {
+  let wrapper
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.defineProperty(document, 'visibilityState', {configurable: true, value: 'visible'})
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('renders Kubernetes sizing recommendations from the memory report', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(memoryReport())))
+
+    wrapper = mount(Memory)
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledWith('api/memory')
+    expect(wrapper.text()).toContain('Kubernetes sizing')
+    expect(wrapper.text()).toContain('1024Mi')
+    expect(wrapper.text()).toContain('Guaranteed')
+    expect(wrapper.text()).toContain('Burstable alternative')
+    expect(wrapper.text()).toContain('512Mi')
+    expect(wrapper.text()).toContain('High confidence')
+    expect(wrapper.text()).toContain('Request equals limit')
+    expect(wrapper.html()).toContain('JAVA_TOOL_OPTIONS')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -164,215 +164,6 @@ onBeforeUnmount(() => {
     <PanelSkeleton v-if="initialLoading" />
 
     <template v-else-if="data">
-      <!-- Memory Calculator Panel -->
-      <div v-if="data.calculation" class="card mb-4 border-primary">
-        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
-          <span><i class="bi bi-calculator me-2"></i>JVM memory calculator</span>
-          <small class="text-white-50">Plan a container memory limit</small>
-        </div>
-        <div class="card-body">
-          <p class="text-muted small mb-3">
-            Inspired by the Paketo <code>libjvm</code> memory calculator. Heap is whatever is left after subtracting
-            metaspace (sized from currently loaded classes × 1.25 safety factor), code cache, direct memory, thread
-            stacks, and headroom from your target memory.
-          </p>
-
-          <div class="row g-3 mb-3">
-            <div class="col-md-5">
-              <label class="form-label small fw-semibold">Total container memory (MB)</label>
-              <div class="input-group input-group-sm">
-                <button aria-label="Decrease" class="btn btn-outline-secondary" type="button" @click="stepTotal(-64)">
-                  −
-                </button>
-                <input
-                  v-model.number="totalMemoryMb"
-                  class="form-control text-center"
-                  max="65536"
-                  min="128"
-                  step="64"
-                  type="number"
-                />
-                <button aria-label="Increase" class="btn btn-outline-secondary" type="button" @click="stepTotal(64)">
-                  +
-                </button>
-                <span class="input-group-text">MB</span>
-              </div>
-            </div>
-            <div class="col-md-4">
-              <label class="form-label small fw-semibold">
-                Thread count
-                <span class="text-muted fw-normal"> (currently {{ data.calculation.liveThreadCount }}) </span>
-              </label>
-              <input
-                v-model.number="threadCount"
-                class="form-control form-control-sm"
-                max="10000"
-                min="1"
-                step="10"
-                type="number"
-              />
-            </div>
-            <div class="col-md-3">
-              <label class="form-label small fw-semibold">Headroom (%)</label>
-              <input
-                v-model.number="headRoomPercent"
-                class="form-control form-control-sm"
-                max="30"
-                min="0"
-                step="1"
-                type="number"
-              />
-            </div>
-          </div>
-
-          <div v-if="!data.calculation.valid" class="alert alert-warning small mb-3">
-            <i class="bi bi-exclamation-triangle me-1"></i>{{ data.calculation.error }}
-          </div>
-
-          <template v-else>
-            <div aria-label="Memory breakdown" class="progress breakdown-bar mb-2" role="img" style="height: 24px">
-              <div
-                v-for="seg in breakdown"
-                :key="seg.key"
-                :style="{width: seg.percent + '%', backgroundColor: seg.color}"
-                :title="seg.label + ': ' + formatBytes(seg.bytes)"
-                class="progress-bar"
-              >
-                <span v-if="seg.percent >= 8" class="small">{{ seg.label }}</span>
-              </div>
-            </div>
-            <div class="d-flex flex-wrap gap-3 small mb-2">
-              <div v-for="seg in breakdown" :key="'leg-' + seg.key" class="d-flex align-items-center">
-                <span :style="{backgroundColor: seg.color}" class="legend-swatch me-1"></span>
-                <span class="text-muted me-1">{{ seg.label }}:</span>
-                <span class="fw-semibold">{{ formatBytes(seg.bytes) }}</span>
-              </div>
-            </div>
-            <div class="small text-muted">
-              Currently {{ data.calculation.liveLoadedClassCount.toLocaleString() }} classes loaded · metaspace sized
-              for {{ data.calculation.loadedClasses.toLocaleString() }} classes × 1.25 safety factor
-            </div>
-          </template>
-        </div>
-      </div>
-
-      <!-- Kubernetes sizing -->
-      <div v-if="data.kubernetes" class="card mb-4 border-success">
-        <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
-          <span><i class="bi bi-box-seam me-2"></i>Kubernetes sizing</span>
-          <span :class="['badge', confidenceBadgeClass(data.kubernetes.confidence)]">
-            {{ data.kubernetes.confidence }} confidence
-          </span>
-        </div>
-        <div class="card-body">
-          <p class="text-muted small mb-3">
-            Uses the calculator total as the hard Kubernetes memory limit. The generated manifest sets
-            <code>requests.memory == limits.memory</code> for Guaranteed QoS because JVM memory is not throttled when a
-            pod crosses its limit.
-          </p>
-
-          <div v-if="data.kubernetes.detectedContainerLimitMemory" class="alert alert-light border small mb-3">
-            <i class="bi bi-hdd-network me-1"></i>
-            Detected cgroup memory limit:
-            <strong>{{ data.kubernetes.detectedContainerLimitMemory }}</strong>
-          </div>
-
-          <div class="row g-3 mb-3">
-            <div class="col-md-3">
-              <div class="border rounded p-3 h-100">
-                <div class="text-muted small">Request memory</div>
-                <div class="fs-5 fw-semibold">{{ data.kubernetes.requestMemory || '—' }}</div>
-                <div class="text-muted small">Guaranteed scheduling request</div>
-              </div>
-            </div>
-            <div class="col-md-3">
-              <div class="border rounded p-3 h-100">
-                <div class="text-muted small">Limit memory</div>
-                <div class="fs-5 fw-semibold">{{ data.kubernetes.limitMemory }}</div>
-                <div class="text-muted small">Container OOM boundary</div>
-              </div>
-            </div>
-            <div class="col-md-3">
-              <div class="border rounded p-3 h-100">
-                <div class="text-muted small">QoS class</div>
-                <div class="fs-5 fw-semibold">{{ data.kubernetes.qosClass }}</div>
-                <div class="text-muted small">Recommended default</div>
-              </div>
-            </div>
-            <div class="col-md-3">
-              <div class="border rounded p-3 h-100">
-                <div class="text-muted small">Current snapshot</div>
-                <div class="fs-5 fw-semibold">{{ data.kubernetes.currentSnapshotMemory }}</div>
-                <div class="text-muted small">Committed JVM memory + live stacks</div>
-              </div>
-            </div>
-          </div>
-
-          <div v-if="data.kubernetes.burstableRequestMemory" class="alert alert-info small mb-3">
-            <i class="bi bi-info-circle me-1"></i>
-            Burstable alternative:
-            <strong>{{ data.kubernetes.burstableRequestMemory }}</strong>
-            request with
-            <strong>{{ data.kubernetes.limitMemory }}</strong>
-            limit. Use only when your cluster intentionally overcommits memory and you have representative load data.
-          </div>
-
-          <div v-if="data.kubernetes.warnings?.length" class="alert alert-warning small mb-3">
-            <div class="fw-semibold mb-1"><i class="bi bi-exclamation-triangle me-1"></i>Sizing notes</div>
-            <ul class="mb-0 ps-3">
-              <li v-for="warning in data.kubernetes.warnings" :key="warning">{{ warning }}</li>
-            </ul>
-          </div>
-
-          <div class="d-flex justify-content-between align-items-center mb-2">
-            <div class="small fw-semibold">Deployment snippet</div>
-            <button
-              :class="{'btn-success': copiedKubernetes}"
-              :disabled="!data.kubernetes.yaml"
-              class="btn btn-sm btn-outline-success"
-              @click="copyKubernetesYaml"
-            >
-              <i :class="['bi', copiedKubernetes ? 'bi-check-lg' : 'bi-clipboard', 'me-1']"></i>
-              {{ copiedKubernetes ? 'Copied!' : 'Copy YAML' }}
-            </button>
-          </div>
-          <pre
-            :class="{'opacity-50': !data.kubernetes.yaml}"
-            class="bg-dark text-light rounded p-3 mb-0 options-box"
-          ><code>{{ data.kubernetes.yaml || 'Adjust calculator inputs until a valid heap is available.' }}</code></pre>
-        </div>
-      </div>
-
-      <!-- Recommended JVM Options -->
-      <div class="card mb-4 border-primary">
-        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
-          <span><i class="bi bi-rocket-takeoff me-2"></i>Recommended JVM Options</span>
-          <button
-            :class="{'btn-success': copied}"
-            :disabled="!data.calculation || !data.calculation.valid"
-            class="btn btn-sm btn-light"
-            @click="copyOptions"
-          >
-            <i :class="['bi', copied ? 'bi-check-lg' : 'bi-clipboard', 'me-1']"></i>
-            {{ copied ? 'Copied!' : 'Copy' }}
-          </button>
-        </div>
-        <div class="card-body">
-          <p class="text-muted small mb-2">
-            Generated from your calculator inputs. <code>-Xms == -Xmx</code> for predictable container startup; GC
-            picked automatically (G1 below 4 GB, ZGC above).
-          </p>
-          <pre
-            :class="{'opacity-50': data.calculation && !data.calculation.valid}"
-            class="bg-dark text-light rounded p-3 mb-0 options-box"
-          ><code>{{ data.suggestedJvmOptions || '—' }}</code></pre>
-          <div class="mt-2">
-            <span class="badge text-bg-secondary me-1"><i class="bi bi-shield-check me-1"></i>OOM protection</span>
-            <span class="badge text-bg-secondary me-1"><i class="bi bi-gear me-1"></i>GC tuned</span>
-          </div>
-        </div>
-      </div>
-
       <!-- Heap & Non-Heap summary cards -->
       <div class="row g-3 mb-4">
         <div class="col-md-6">
@@ -501,7 +292,7 @@ onBeforeUnmount(() => {
       </div>
 
       <!-- Current JVM Arguments -->
-      <div v-if="data.jvmInputArguments && data.jvmInputArguments.length" class="card">
+      <div v-if="data.jvmInputArguments && data.jvmInputArguments.length" class="card mb-4">
         <div class="card-header"><i class="bi bi-terminal me-2"></i>Current JVM Arguments</div>
         <div class="card-body">
           <div v-if="data.jvmInputArguments.length === 0" class="text-muted small">
@@ -514,9 +305,218 @@ onBeforeUnmount(() => {
           </ul>
         </div>
       </div>
-      <div v-else class="card">
+      <div v-else class="card mb-4">
         <div class="card-header"><i class="bi bi-terminal me-2"></i>Current JVM Arguments</div>
         <div class="card-body text-muted small">No explicit JVM arguments were passed at startup.</div>
+      </div>
+
+      <!-- Memory Calculator Panel -->
+      <div v-if="data.calculation" class="card mb-4 border-primary">
+        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+          <span><i class="bi bi-calculator me-2"></i>JVM memory calculator</span>
+          <small class="text-white-50">Plan a container memory limit</small>
+        </div>
+        <div class="card-body">
+          <p class="text-muted small mb-3">
+            Inspired by the Paketo <code>libjvm</code> memory calculator. Heap is whatever is left after subtracting
+            metaspace (sized from currently loaded classes × 1.25 safety factor), code cache, direct memory, thread
+            stacks, and headroom from your target memory.
+          </p>
+
+          <div class="row g-3 mb-3">
+            <div class="col-md-5">
+              <label class="form-label small fw-semibold">Total container memory (MB)</label>
+              <div class="input-group input-group-sm">
+                <button aria-label="Decrease" class="btn btn-outline-secondary" type="button" @click="stepTotal(-64)">
+                  −
+                </button>
+                <input
+                  v-model.number="totalMemoryMb"
+                  class="form-control text-center"
+                  max="65536"
+                  min="128"
+                  step="64"
+                  type="number"
+                />
+                <button aria-label="Increase" class="btn btn-outline-secondary" type="button" @click="stepTotal(64)">
+                  +
+                </button>
+                <span class="input-group-text">MB</span>
+              </div>
+            </div>
+            <div class="col-md-4">
+              <label class="form-label small fw-semibold">
+                Thread count
+                <span class="text-muted fw-normal"> (currently {{ data.calculation.liveThreadCount }}) </span>
+              </label>
+              <input
+                v-model.number="threadCount"
+                class="form-control form-control-sm"
+                max="10000"
+                min="1"
+                step="10"
+                type="number"
+              />
+            </div>
+            <div class="col-md-3">
+              <label class="form-label small fw-semibold">Headroom (%)</label>
+              <input
+                v-model.number="headRoomPercent"
+                class="form-control form-control-sm"
+                max="30"
+                min="0"
+                step="1"
+                type="number"
+              />
+            </div>
+          </div>
+
+          <div v-if="!data.calculation.valid" class="alert alert-warning small mb-3">
+            <i class="bi bi-exclamation-triangle me-1"></i>{{ data.calculation.error }}
+          </div>
+
+          <template v-else>
+            <div aria-label="Memory breakdown" class="progress breakdown-bar mb-2" role="img" style="height: 24px">
+              <div
+                v-for="seg in breakdown"
+                :key="seg.key"
+                :style="{width: seg.percent + '%', backgroundColor: seg.color}"
+                :title="seg.label + ': ' + formatBytes(seg.bytes)"
+                class="progress-bar"
+              >
+                <span v-if="seg.percent >= 8" class="small">{{ seg.label }}</span>
+              </div>
+            </div>
+            <div class="d-flex flex-wrap gap-3 small mb-2">
+              <div v-for="seg in breakdown" :key="'leg-' + seg.key" class="d-flex align-items-center">
+                <span :style="{backgroundColor: seg.color}" class="legend-swatch me-1"></span>
+                <span class="text-muted me-1">{{ seg.label }}:</span>
+                <span class="fw-semibold">{{ formatBytes(seg.bytes) }}</span>
+              </div>
+            </div>
+            <div class="small text-muted">
+              Currently {{ data.calculation.liveLoadedClassCount.toLocaleString() }} classes loaded · metaspace sized
+              for {{ data.calculation.loadedClasses.toLocaleString() }} classes × 1.25 safety factor
+            </div>
+          </template>
+        </div>
+      </div>
+
+      <!-- Recommended JVM Options -->
+      <div class="card mb-4 border-primary">
+        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+          <span><i class="bi bi-rocket-takeoff me-2"></i>Recommended JVM Options</span>
+          <button
+            :class="{'btn-success': copied}"
+            :disabled="!data.calculation || !data.calculation.valid"
+            class="btn btn-sm btn-light"
+            @click="copyOptions"
+          >
+            <i :class="['bi', copied ? 'bi-check-lg' : 'bi-clipboard', 'me-1']"></i>
+            {{ copied ? 'Copied!' : 'Copy' }}
+          </button>
+        </div>
+        <div class="card-body">
+          <p class="text-muted small mb-2">
+            Generated from your calculator inputs. <code>-Xms == -Xmx</code> for predictable container startup; GC
+            picked automatically (G1 below 4 GB, ZGC above).
+          </p>
+          <pre
+            :class="{'opacity-50': data.calculation && !data.calculation.valid}"
+            class="bg-dark text-light rounded p-3 mb-0 options-box"
+          ><code>{{ data.suggestedJvmOptions || '—' }}</code></pre>
+          <div class="mt-2">
+            <span class="badge text-bg-secondary me-1"><i class="bi bi-shield-check me-1"></i>OOM protection</span>
+            <span class="badge text-bg-secondary me-1"><i class="bi bi-gear me-1"></i>GC tuned</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Kubernetes sizing -->
+      <div v-if="data.kubernetes" class="card mb-4 border-success">
+        <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
+          <span><i class="bi bi-box-seam me-2"></i>Kubernetes sizing</span>
+          <span :class="['badge', confidenceBadgeClass(data.kubernetes.confidence)]">
+            {{ data.kubernetes.confidence }} confidence
+          </span>
+        </div>
+        <div class="card-body">
+          <p class="text-muted small mb-3">
+            Uses the calculator total as the hard Kubernetes memory limit. The generated manifest sets
+            <code>requests.memory == limits.memory</code> for Guaranteed QoS because JVM memory is not throttled when a
+            pod crosses its limit.
+          </p>
+
+          <div v-if="data.kubernetes.detectedContainerLimitMemory" class="alert alert-light border small mb-3">
+            <i class="bi bi-hdd-network me-1"></i>
+            Detected cgroup memory limit:
+            <strong>{{ data.kubernetes.detectedContainerLimitMemory }}</strong>
+          </div>
+
+          <div class="row g-3 mb-3">
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Request memory</div>
+                <div class="fs-5 fw-semibold">{{ data.kubernetes.requestMemory || '—' }}</div>
+                <div class="text-muted small">Guaranteed scheduling request</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Limit memory</div>
+                <div class="fs-5 fw-semibold">{{ data.kubernetes.limitMemory }}</div>
+                <div class="text-muted small">Container OOM boundary</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">QoS class</div>
+                <div class="fs-5 fw-semibold">{{ data.kubernetes.qosClass }}</div>
+                <div class="text-muted small">Recommended default</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Current snapshot</div>
+                <div class="fs-5 fw-semibold">{{ data.kubernetes.currentSnapshotMemory }}</div>
+                <div class="text-muted small">Committed JVM memory + live stacks</div>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="data.kubernetes.burstableRequestMemory" class="alert alert-info small mb-3">
+            <i class="bi bi-info-circle me-1"></i>
+            Burstable alternative:
+            <strong>{{ data.kubernetes.burstableRequestMemory }}</strong>
+            request with
+            <strong>{{ data.kubernetes.limitMemory }}</strong>
+            limit. Use only when your cluster intentionally overcommits memory and you have representative load data.
+          </div>
+
+          <div v-if="data.kubernetes.warnings?.length" class="alert alert-warning small mb-3">
+            <div class="fw-semibold mb-1"><i class="bi bi-exclamation-triangle me-1"></i>Sizing notes</div>
+            <ul class="mb-0 ps-3">
+              <li v-for="warning in data.kubernetes.warnings" :key="warning">{{ warning }}</li>
+            </ul>
+          </div>
+
+          <div class="d-flex justify-content-between align-items-center mb-2">
+            <div class="small fw-semibold">Deployment snippet</div>
+            <button
+              :class="{'btn-success': copiedKubernetes}"
+              :disabled="!data.kubernetes.yaml"
+              class="btn btn-sm btn-outline-success"
+              @click="copyKubernetesYaml"
+            >
+              <i :class="['bi', copiedKubernetes ? 'bi-check-lg' : 'bi-clipboard', 'me-1']"></i>
+              {{ copiedKubernetes ? 'Copied!' : 'Copy YAML' }}
+            </button>
+          </div>
+          <pre
+            :class="{'opacity-50': !data.kubernetes.yaml}"
+            class="bg-dark text-light rounded p-3 mb-0 options-box"
+          ><code>{{ data.kubernetes.yaml || 'Adjust calculator inputs until a valid heap is available.' }}</code></pre>
+        </div>
       </div>
     </template>
 

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -10,6 +10,7 @@ const data = ref(null)
 const error = ref(null)
 const lastUpdated = ref(null)
 const copied = ref(false)
+const copiedKubernetes = ref(false)
 let debounceHandle = null
 
 const totalMemoryMb = ref(null)
@@ -71,26 +72,42 @@ function progressClass(pct) {
   return 'bg-success'
 }
 
-async function copyOptions() {
-  if (!data.value) return
+function confidenceBadgeClass(confidence) {
+  if (confidence === 'High') return 'text-bg-success'
+  if (confidence === 'Medium') return 'text-bg-warning'
+  if (confidence === 'Low') return 'text-bg-secondary'
+  return 'text-bg-secondary'
+}
+
+function markCopied(copiedRef) {
+  copiedRef.value = true
+  setTimeout(() => {
+    copiedRef.value = false
+  }, 2000)
+}
+
+async function copyText(text, copiedRef) {
+  if (!text) return
   try {
-    await navigator.clipboard.writeText(data.value.suggestedJvmOptions)
-    copied.value = true
-    setTimeout(() => {
-      copied.value = false
-    }, 2000)
+    await navigator.clipboard.writeText(text)
+    markCopied(copiedRef)
   } catch {
     const ta = document.createElement('textarea')
-    ta.value = data.value.suggestedJvmOptions
+    ta.value = text
     document.body.appendChild(ta)
     ta.select()
     document.execCommand('copy')
     document.body.removeChild(ta)
-    copied.value = true
-    setTimeout(() => {
-      copied.value = false
-    }, 2000)
+    markCopied(copiedRef)
   }
+}
+
+async function copyOptions() {
+  await copyText(data.value?.suggestedJvmOptions, copied)
+}
+
+async function copyKubernetesYaml() {
+  await copyText(data.value?.kubernetes?.yaml, copiedKubernetes)
 }
 
 const breakdown = computed(() => {
@@ -113,7 +130,7 @@ const breakdown = computed(() => {
 })
 
 function stepTotal(delta) {
-  const next = Math.max(128, Math.min(8192, (totalMemoryMb.value || 0) + delta))
+  const next = Math.max(128, Math.min(65536, (totalMemoryMb.value || 0) + delta))
   totalMemoryMb.value = next
 }
 
@@ -170,7 +187,7 @@ onBeforeUnmount(() => {
                 <input
                   v-model.number="totalMemoryMb"
                   class="form-control text-center"
-                  max="8192"
+                  max="65536"
                   min="128"
                   step="64"
                   type="number"
@@ -236,6 +253,93 @@ onBeforeUnmount(() => {
               for {{ data.calculation.loadedClasses.toLocaleString() }} classes × 1.25 safety factor
             </div>
           </template>
+        </div>
+      </div>
+
+      <!-- Kubernetes sizing -->
+      <div v-if="data.kubernetes" class="card mb-4 border-success">
+        <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
+          <span><i class="bi bi-box-seam me-2"></i>Kubernetes sizing</span>
+          <span :class="['badge', confidenceBadgeClass(data.kubernetes.confidence)]">
+            {{ data.kubernetes.confidence }} confidence
+          </span>
+        </div>
+        <div class="card-body">
+          <p class="text-muted small mb-3">
+            Uses the calculator total as the hard Kubernetes memory limit. The generated manifest sets
+            <code>requests.memory == limits.memory</code> for Guaranteed QoS because JVM memory is not throttled when a
+            pod crosses its limit.
+          </p>
+
+          <div v-if="data.kubernetes.detectedContainerLimitMemory" class="alert alert-light border small mb-3">
+            <i class="bi bi-hdd-network me-1"></i>
+            Detected cgroup memory limit:
+            <strong>{{ data.kubernetes.detectedContainerLimitMemory }}</strong>
+          </div>
+
+          <div class="row g-3 mb-3">
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Request memory</div>
+                <div class="fs-5 fw-semibold">{{ data.kubernetes.requestMemory || '—' }}</div>
+                <div class="text-muted small">Guaranteed scheduling request</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Limit memory</div>
+                <div class="fs-5 fw-semibold">{{ data.kubernetes.limitMemory }}</div>
+                <div class="text-muted small">Container OOM boundary</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">QoS class</div>
+                <div class="fs-5 fw-semibold">{{ data.kubernetes.qosClass }}</div>
+                <div class="text-muted small">Recommended default</div>
+              </div>
+            </div>
+            <div class="col-md-3">
+              <div class="border rounded p-3 h-100">
+                <div class="text-muted small">Current snapshot</div>
+                <div class="fs-5 fw-semibold">{{ data.kubernetes.currentSnapshotMemory }}</div>
+                <div class="text-muted small">Committed JVM memory + live stacks</div>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="data.kubernetes.burstableRequestMemory" class="alert alert-info small mb-3">
+            <i class="bi bi-info-circle me-1"></i>
+            Burstable alternative:
+            <strong>{{ data.kubernetes.burstableRequestMemory }}</strong>
+            request with
+            <strong>{{ data.kubernetes.limitMemory }}</strong>
+            limit. Use only when your cluster intentionally overcommits memory and you have representative load data.
+          </div>
+
+          <div v-if="data.kubernetes.warnings?.length" class="alert alert-warning small mb-3">
+            <div class="fw-semibold mb-1"><i class="bi bi-exclamation-triangle me-1"></i>Sizing notes</div>
+            <ul class="mb-0 ps-3">
+              <li v-for="warning in data.kubernetes.warnings" :key="warning">{{ warning }}</li>
+            </ul>
+          </div>
+
+          <div class="d-flex justify-content-between align-items-center mb-2">
+            <div class="small fw-semibold">Deployment snippet</div>
+            <button
+              :class="{'btn-success': copiedKubernetes}"
+              :disabled="!data.kubernetes.yaml"
+              class="btn btn-sm btn-outline-success"
+              @click="copyKubernetesYaml"
+            >
+              <i :class="['bi', copiedKubernetes ? 'bi-check-lg' : 'bi-clipboard', 'me-1']"></i>
+              {{ copiedKubernetes ? 'Copied!' : 'Copy YAML' }}
+            </button>
+          </div>
+          <pre
+            :class="{'opacity-50': !data.kubernetes.yaml}"
+            class="bg-dark text-light rounded p-3 mb-0 options-box"
+          ><code>{{ data.kubernetes.yaml || 'Adjust calculator inputs until a valid heap is available.' }}</code></pre>
         </div>
       </div>
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -43,8 +43,10 @@ available measurements, and render a local live chart for a selected metric/tag 
 ### Memory
 
 The Memory panel summarizes JVM heap and non-heap usage, memory pools, garbage collectors, and selected runtime memory
-settings. It also suggests JVM options that are useful during local development when memory pressure or startup behavior
-needs tuning.
+settings. It includes a Paketo-style JVM memory calculator, suggested JVM options, and a Kubernetes sizing card that
+turns the calculated process budget into copyable `requests.memory`, `limits.memory`, and `JAVA_TOOL_OPTIONS` snippets.
+The Kubernetes recommendation keeps request and limit equal by default for Guaranteed QoS and labels any smaller
+current-snapshot request as a Burstable alternative that should be validated under representative load.
 
 ![BootUI Memory panel](images/bootui-memory.png)
 


### PR DESCRIPTION
## What does this PR do?

Adds Kubernetes-aware memory sizing guidance to the Memory panel, including backend DTOs that expose JVM/container limits and Vue UI recommendations.

## Why is this change needed?

When BootUI runs in a container, developers need concrete guidance for aligning Kubernetes memory requests and limits with JVM heap and native overhead. This surfaces a local recommendation from the current runtime memory data.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Focused checks run:

- `./mvnw -B -ntp -pl bootui-autoconfigure -am test -Dtest=MemoryControllerTests,MemoryKubernetesSizerTests -Dsurefire.failIfNoSpecifiedTests=false`
- `(cd bootui-ui/src/main/frontend && npm install --no-audit --no-fund && npm test -- Memory.test.js --run)`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed