### PR TITLE
Align agent panels with auto refresh

### DIFF
--- a/bootui-sample-app/e2e/README.md
+++ b/bootui-sample-app/e2e/README.md
@@ -36,8 +36,8 @@ flow) exposed by the sample app:
 | `dependencies.spec.js` | Vulnerability inventory, severity ordering, OSV scan states, and read-only behavior                                   |
 | `devtools.spec.js`     | DevTools LiveReload / restart status cards and guarded action feedback                                                |
 | `dev-services.spec.js` | Dev Services snapshot, filtering, details, log viewing, and disabled restart controls                                 |
-| `copilot.spec.js`      | Copilot dashboard, session explorer, sanitized events, raw reveal gating, and live refresh                            |
-| `claude-code.spec.js`  | Claude Code dashboard, project-log parsing, sanitized events, raw reveal gating, and polling refresh                  |
+| `copilot.spec.js`      | Copilot dashboard, session explorer, sanitized events, raw reveal gating, and auto-refresh controls                   |
+| `claude-code.spec.js`  | Claude Code dashboard, project-log parsing, sanitized events, raw reveal gating, and auto-refresh controls            |
 | `read-only.spec.js`    | Global and per-panel read-only properties block unsafe APIs and lock mutating browser controls                        |
 | `sample-api.spec.js`   | Sample REST API (`/api/hello`, `/api/secure`, `/api/sample/hello`, `/api/sample/products`) and basic-auth on `/admin` |
 

--- a/bootui-sample-app/e2e/tests/claude-code.spec.js
+++ b/bootui-sample-app/e2e/tests/claude-code.spec.js
@@ -134,6 +134,9 @@ test.describe('Claude Code panel', () => {
 
     await page.goto('/bootui/#/claude-code')
 
+    await expect(page.getByLabel('Auto-refresh')).toBeChecked()
+    await expect(page.getByTitle('Refresh', {exact: true})).toBeVisible()
+    await expect(page.locator('.panel-header__actions .badge').filter({hasText: 'Live'})).toHaveCount(0)
     await expect(page.getByRole('heading', {name: 'Claude Code activity overview'})).toBeVisible()
     await expect(page.getByText('/home/dev/.claude/projects')).toBeVisible()
     await expect(page.getByText('bootui.claude-code.max-sessions')).toBeVisible()

--- a/bootui-sample-app/e2e/tests/copilot.spec.js
+++ b/bootui-sample-app/e2e/tests/copilot.spec.js
@@ -151,6 +151,9 @@ test.describe('Copilot panel', () => {
 
     await page.goto('/bootui/#/copilot')
 
+    await expect(page.getByLabel('Auto-refresh')).toBeChecked()
+    await expect(page.getByTitle('Refresh', {exact: true})).toBeVisible()
+    await expect(page.locator('.panel-header__actions .badge').filter({hasText: 'Live'})).toHaveCount(0)
     await expect(page.getByRole('heading', {name: 'Copilot activity overview'})).toBeVisible()
     await expect(page.getByRole('link', {name: 'copilot-mission-control'})).toHaveAttribute(
       'href',

--- a/bootui-ui/src/main/frontend/src/views/Copilot.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.test.js
@@ -1,0 +1,119 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import Copilot from './Copilot.vue'
+import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
+
+const route = vi.hoisted(() => ({name: 'copilot'}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => route
+}))
+
+function dashboard(overrides = {}) {
+  return {
+    available: true,
+    sessionStateDir: '/home/dev/.copilot/session-state',
+    sessionCount: 1,
+    eventCount: 2,
+    turnCount: 1,
+    errorCount: 0,
+    activeLast24Hours: 1,
+    activeLast7Days: 1,
+    sessionsWithSchemaDrift: 0,
+    lastActivityEpochMillis: Date.now() - 60_000,
+    categoryCounts: [],
+    modelCounts: [],
+    topTools: [],
+    otherToolEventCount: 0,
+    activityBuckets: [],
+    dailyActivityBuckets: [],
+    recentSessions: [],
+    warnings: [],
+    ...overrides
+  }
+}
+
+function sessionList(overrides = {}) {
+  return {
+    available: true,
+    sessionStateDir: '/home/dev/.copilot/session-state',
+    total: 0,
+    returned: 0,
+    maxSessions: 100,
+    sessions: [],
+    warnings: [],
+    ...overrides
+  }
+}
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+function fetchForPanel(apiBase, dashboardPayload = dashboard(), sessionPayload = sessionList()) {
+  return vi.fn((url) => {
+    if (url === `${apiBase}/dashboard`) return Promise.resolve(jsonResponse(dashboardPayload))
+    if (url === `${apiBase}/sessions`) return Promise.resolve(jsonResponse(sessionPayload))
+    return Promise.resolve(jsonResponse({}, false, 404))
+  })
+}
+
+describe('Copilot', () => {
+  let wrapper
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.defineProperty(document, 'visibilityState', {configurable: true, value: 'visible'})
+    route.name = 'copilot'
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('uses the shared auto-refresh controls instead of the live status badge', async () => {
+    const eventSource = vi.fn()
+    vi.stubGlobal('EventSource', eventSource)
+    vi.stubGlobal('fetch', fetchForPanel('api/copilot'))
+
+    wrapper = mount(Copilot)
+    await flushPromises()
+
+    expect(wrapper.findComponent(AutoRefreshToggle).exists()).toBe(true)
+    expect(wrapper.get('button[title="Refresh"]').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Auto-refresh')
+    expect(wrapper.text()).not.toContain('Live')
+    expect(eventSource).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledWith('api/copilot/dashboard')
+    expect(fetch).toHaveBeenCalledWith('api/copilot/sessions')
+    expect(fetch).toHaveBeenCalledTimes(4)
+  })
+
+  it('loads Claude Code through the same auto-refresh mechanism', async () => {
+    route.name = 'claude-code'
+    vi.stubGlobal(
+      'fetch',
+      fetchForPanel(
+        'api/claude-code',
+        dashboard({sessionStateDir: '/home/dev/.claude/projects'}),
+        sessionList({sessionStateDir: '/home/dev/.claude/projects'})
+      )
+    )
+
+    wrapper = mount(Copilot)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Claude Code')
+    expect(wrapper.findComponent(AutoRefreshToggle).exists()).toBe(true)
+    expect(fetch).toHaveBeenCalledWith('api/claude-code/dashboard')
+    expect(fetch).toHaveBeenCalledWith('api/claude-code/sessions')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -1,8 +1,10 @@
 <script setup>
-import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
+import {computed, ref, watch} from 'vue'
 import {useRoute} from 'vue-router'
 import {formatNumber} from '../utils/format.js'
 import {formatLoadError} from '../utils/loadError.js'
+import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 
@@ -43,13 +45,11 @@ const categoryFilter = ref('ALL')
 const textFilter = ref('')
 const activeDetailTab = ref('activity')
 const activeSessionWindow = ref(null)
-const loading = ref(true)
 const detailLoading = ref(false)
 const error = ref(null)
-const status = ref('Loading')
+const lastFetched = ref(null)
 const rawById = ref({})
 const rawLoadingId = ref(null)
-let eventSource = null
 
 const categories = [
   'ALL',
@@ -126,16 +126,6 @@ const dashboardCards = computed(() => [
 const categoryRows = computed(() => addPercent(dashboard.value?.categoryCounts ?? [], totalEvents.value))
 const topToolRows = computed(() => addPercent(dashboard.value?.topTools ?? [], dashboard.value?.eventCount ?? 0))
 const modelRows = computed(() => addPercent(dashboard.value?.modelCounts ?? [], dashboard.value?.sessionCount ?? 0))
-
-const statusClass = computed(
-  () =>
-    ({
-      Live: 'text-bg-success',
-      Loading: 'text-bg-secondary',
-      Disconnected: 'text-bg-danger',
-      Unavailable: 'text-bg-warning'
-    })[status.value] || 'text-bg-secondary'
-)
 
 const filteredEvents = computed(() => {
   const events = detail.value?.recentEvents ?? []
@@ -235,33 +225,65 @@ function bucketWindowLabel(bucket, granularity) {
 }
 
 async function loadDashboard() {
-  try {
-    const res = await fetch(`${panelConfig.value.apiBase}/dashboard`)
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    dashboard.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = formatLoadError(e, `Unable to load ${panelConfig.value.title} dashboard`)
-  }
+  const res = await fetch(`${panelConfig.value.apiBase}/dashboard`)
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  dashboard.value = await res.json()
 }
 
 async function loadSessions(window = activeSessionWindow.value) {
+  let url = `${panelConfig.value.apiBase}/sessions`
+  if (window) {
+    const params = new URLSearchParams()
+    params.set('since', window.since)
+    params.set('until', window.until)
+    url += `?${params.toString()}`
+  }
+  const res = await fetch(url)
+  if (!res.ok) throw new Error('HTTP ' + res.status)
+  sessionList.value = await res.json()
+}
+
+async function refreshSessions(window = activeSessionWindow.value) {
   try {
-    let url = `${panelConfig.value.apiBase}/sessions`
-    if (window) {
-      const params = new URLSearchParams()
-      params.set('since', window.since)
-      params.set('until', window.until)
-      url += `?${params.toString()}`
-    }
-    const res = await fetch(url)
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    sessionList.value = await res.json()
+    await loadSessions(window)
+    lastFetched.value = Date.now()
     error.value = null
   } catch (e) {
     error.value = formatLoadError(e, `Unable to load ${panelConfig.value.title} sessions`)
-  } finally {
-    loading.value = false
+  }
+}
+
+async function refreshPanel() {
+  const jobs = [
+    {
+      run: loadSessions,
+      message: `Unable to load ${panelConfig.value.title} sessions`
+    },
+    {
+      run: loadDashboard,
+      message: `Unable to load ${panelConfig.value.title} dashboard`
+    }
+  ]
+  const results = await Promise.all(
+    jobs.map(async (job) => {
+      try {
+        await job.run()
+        return null
+      } catch (e) {
+        return formatLoadError(e, job.message)
+      }
+    })
+  )
+  const firstError = results.find(Boolean)
+  if (firstError) {
+    error.value = firstError
+    return
+  }
+
+  error.value = null
+  lastFetched.value = Date.now()
+  if (selectedSessionId.value) {
+    await loadDetail(selectedSessionId.value)
   }
 }
 
@@ -274,12 +296,12 @@ async function selectActivityWindow(bucket, granularity) {
   }
   selectedSessionId.value = null
   detail.value = null
-  await loadSessions(activeSessionWindow.value)
+  await refreshSessions(activeSessionWindow.value)
 }
 
 async function clearActivityWindow() {
   activeSessionWindow.value = null
-  await loadSessions(null)
+  await refreshSessions(null)
 }
 
 async function loadDetail(sessionId) {
@@ -293,6 +315,7 @@ async function loadDetail(sessionId) {
     if (!res.ok) throw new Error('HTTP ' + res.status)
     detail.value = await res.json()
     rawById.value = {}
+    error.value = null
   } catch (e) {
     error.value = formatLoadError(e, `Unable to load ${panelConfig.value.title} session details`)
     detail.value = null
@@ -359,55 +382,30 @@ function pickSession(sessionId, options = {}) {
   loadDetail(sessionId)
 }
 
-function connectStream() {
-  disconnect()
-  eventSource = new EventSource(`${panelConfig.value.apiBase}/stream`)
-  eventSource.addEventListener('sessions', async (event) => {
-    try {
-      if (activeSessionWindow.value) {
-        await loadSessions(activeSessionWindow.value)
-      } else {
-        sessionList.value = JSON.parse(event.data)
-      }
-      status.value = sessionList.value?.available === false ? 'Unavailable' : 'Live'
-      // refresh detail if the selected session changed
-      if (selectedSessionId.value) {
-        await loadDetail(selectedSessionId.value)
-      }
-    } catch (e) {
-      // ignore parse errors
-    }
-  })
-  eventSource.addEventListener('dashboard', (event) => {
-    try {
-      dashboard.value = JSON.parse(event.data)
-    } catch (e) {
-      // ignore parse errors
-    }
-  })
-  eventSource.onerror = () => {
-    status.value = 'Disconnected'
-  }
+function resetPanelState() {
+  sessionList.value = null
+  dashboard.value = null
+  selectedSessionId.value = null
+  detail.value = null
+  categoryFilter.value = 'ALL'
+  textFilter.value = ''
+  activeDetailTab.value = 'activity'
+  activeSessionWindow.value = null
+  error.value = null
+  lastFetched.value = null
+  rawById.value = {}
+  rawLoadingId.value = null
 }
 
-function disconnect() {
-  if (eventSource) {
-    eventSource.close()
-    eventSource = null
-  }
-}
+const {autoRefresh, loading, initialLoading, load} = useAutoRefresh(refreshPanel)
 
-onMounted(async () => {
-  await Promise.all([loadSessions(), loadDashboard()])
-  if (sessionList.value?.available !== false) {
-    status.value = 'Live'
-    connectStream()
-  } else {
-    status.value = 'Unavailable'
+watch(
+  () => route.name,
+  () => {
+    resetPanelState()
+    load()
   }
-})
-
-onBeforeUnmount(disconnect)
+)
 </script>
 
 <template>
@@ -418,13 +416,15 @@ onBeforeUnmount(disconnect)
       :subtitle="panelConfig.description"
       :loading="loading"
       :error="error"
+      :last-fetched="lastFetched"
+      @refresh="load"
     >
       <template #actions>
-        <span :class="statusClass" class="badge">{{ status }}</span>
+        <AutoRefreshToggle v-model="autoRefresh" />
       </template>
     </PanelHeader>
 
-    <PanelSkeleton v-if="loading" />
+    <PanelSkeleton v-if="initialLoading" />
     <div v-else-if="!available" class="card border-info">
       <div class="card-body">
         <h5 class="card-title"><i class="bi bi-info-circle me-2"></i>{{ panelConfig.emptyTitle }}</h5>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -318,8 +318,8 @@ Each event row shows only an allowlisted summary - raw prompts, tool arguments, 
 excluded. The per-event "Reveal raw" action is an explicit, local-only escape hatch that returns the source JSON; it can
 be disabled with `bootui.copilot.allow-raw-reveal=false` and is also blocked when `bootui.expose-values=METADATA_ONLY`.
 The sidebar dims the panel when no session-state directory is found. Data is read-only - BootUI never modifies anything
-under `~/.copilot/`. The panel watches the directory through a Java NIO `WatchService` thread and pushes live updates via
-Server-Sent Events. Inspired by
+under `~/.copilot/`. The panel uses the same header refresh button and visibility-aware auto-refresh toggle as the other
+live data panels, while the backend watches the directory through a Java NIO `WatchService` thread. Inspired by
 [copilot-mission-control](https://github.com/DanWahlin/copilot-mission-control), which pioneered this dashboarding of
 Copilot CLI session state.
 
@@ -337,6 +337,6 @@ retained in JVM heap. The raw JSONL reveal endpoint is disabled by default with 
 enabling it is an explicit local-only escape hatch and is still blocked when `bootui.expose-values=METADATA_ONLY`. The
 sidebar dims the panel when no Claude Code projects directory is found. Data is read-only - BootUI never modifies anything
 under `~/.claude/`. Because Claude Code writes sessions inside per-project subdirectories, BootUI refreshes this panel
-through bounded polling rather than relying on root-directory file-system events.
+through the shared visibility-aware auto-refresh polling used by the other live data panels.
 
 ![BootUI Claude Code panel](images/bootui-claude-code.png)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -56,8 +56,8 @@ The project has moved beyond the original skeleton and the initial MVP panel set
   - Micrometer metrics
   - dependency inventory and OSV vulnerability scan
   - DevTools reload/restart
-  - Copilot session dashboard, session explorer, and live SSE stream
-  - Claude Code project-log dashboard, session explorer, and live refresh stream
+  - Copilot session dashboard, session explorer, and shared auto-refresh UI
+  - Claude Code project-log dashboard, session explorer, and shared auto-refresh UI
   - OTLP traces receiver (`/bootui/api/otlp/v1/traces`), Traces panel API, and AI Usage panel API
 - Vue 3 UI shell with routes for:
   - Overview
@@ -288,8 +288,8 @@ Already implemented beyond the original MVP surface:
 - Micrometer metrics browser with live values.
 - DevTools reload/restart controls.
 - In-app OTLP/HTTP traces receiver, Traces panel, and AI Usage panel.
-- Copilot panel for sanitized GitHub Copilot CLI session dashboarding and live SSE updates.
-- Claude Code panel for sanitized local Claude Code project-log dashboarding and live refresh updates.
+- Copilot panel for sanitized GitHub Copilot CLI session dashboarding and shared auto-refresh updates.
+- Claude Code panel for sanitized local Claude Code project-log dashboarding and shared auto-refresh updates.
 
 Added in the late alpha line and included in `0.1.0`:
 
@@ -311,8 +311,8 @@ Added for the final `0.1.0` release after `0.1.0-alpha.5`:
   `~/.copilot/session-state/` and presents a sanitized activity dashboard: session count, total events, failures,
   24-hour and 7-day activity charts, event category mix, top tools, and model usage. The session explorer lets you
   drill into individual sessions with a turn-by-turn story, recent events, and failure list, while a configurable
-  parsed-session cap bounds heap usage for large local histories. Raw event JSON is opt-in and local-only. Live updates
-  are pushed via SSE. Inspired by
+  parsed-session cap bounds heap usage for large local histories. Raw event JSON is opt-in and local-only. The browser
+  refreshes through BootUI's shared visibility-aware auto-refresh control. Inspired by
   [copilot-mission-control](https://github.com/DanWahlin/copilot-mission-control).
 - **Claude Code panel**. Reads Claude Code JSONL project logs under `~/.claude/projects/` and presents the same
   sanitized session dashboard shape for local Claude Code usage. Normal responses only expose tool names, categories,


### PR DESCRIPTION
Copilot and Claude Code still used a panel-specific live status badge, while the rest of the live data views use the shared auto-refresh affordance. This makes those developer-tool panels consistent with Memory and the other screens.

## Summary

- Replace the Copilot/Claude Code header live badge with the shared `AutoRefreshToggle`, manual refresh button, and last-fetched timestamp.
- Refresh dashboard and session explorer data through the shared visibility-aware auto-refresh composable, including selected-session details when present.
- Add focused Vitest coverage plus Playwright assertions for both panels, and update docs/e2e README wording from live/SSE polling language to the shared auto-refresh behavior.

## Tests

- `cd bootui-ui/src/main/frontend && npm test -- Copilot.test.js useAutoRefresh.test.js`
- `cd bootui-ui/src/main/frontend && npm test`
- `./mvnw -B -ntp -pl bootui-ui install`
- `cd bootui-sample-app/e2e && npm test -- tests/copilot.spec.js tests/claude-code.spec.js`