### PR TITLE
Expand Architecture panel checks

### DIFF
--- a/bootui-autoconfigure/pom.xml
+++ b/bootui-autoconfigure/pom.xml
@@ -107,6 +107,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-tx</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistry.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistry.java
@@ -22,12 +22,21 @@ final class ArchitectureRuleRegistry {
             new NoFieldInjectionRule(),
             new ControllersShouldNotDependOnRepositoriesRule(),
             new RepositoriesShouldNotDependOnControllersRule(),
+            new RepositoriesShouldNotDependOnServicesRule(),
             new ServicesShouldNotDependOnControllersRule(),
             new NoSelfInvocationOfProxiedMethodsRule(),
             new StereotypesShouldNotResideInDefaultPackageRule(),
             new ExceptionsShouldBeNamedExceptionRule(),
             new InterfacesShouldNotHaveInterfaceSuffixRule(),
-            new LoggersShouldBePrivateStaticFinalRule());
+            new LoggersShouldBePrivateStaticFinalRule(),
+            new NoTestFrameworkDependenciesRule(),
+            new ServicesAndRepositoriesShouldNotDependOnServletTypesRule(),
+            new TransactionalAnnotationsShouldNotBeDeclaredOnInterfacesRule(),
+            new ProxiedMethodsShouldNotBePrivateOrStaticRule(),
+            new AsyncMethodsShouldHaveSupportedSignaturesRule(),
+            new ScheduledMethodsShouldHaveSupportedSignaturesRule(),
+            new AsyncShouldNotBeUsedInConfigurationClassesRule(),
+            new NoAopContextCurrentProxyRule());
 
     private ArchitectureRuleRegistry() {}
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRules.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRules.java
@@ -7,16 +7,23 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.properties.CanBeAnnotated;
+import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.EvaluationResult;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.library.GeneralCodingRules;
 import com.tngtech.archunit.library.ProxyRules;
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition;
 import io.github.jdubois.bootui.core.BootUiDtos.ArchitectureRuleResultDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Base class for curated architecture rules backed by a single ArchUnit {@link ArchRule}.
@@ -72,8 +79,10 @@ final class SpringStereotypes {
     static final String CONFIGURATION = "org.springframework.context.annotation.Configuration";
 
     static final String TRANSACTIONAL = "org.springframework.transaction.annotation.Transactional";
+    static final String JAKARTA_TRANSACTIONAL = "jakarta.transaction.Transactional";
     static final String ASYNC = "org.springframework.scheduling.annotation.Async";
     static final String CACHEABLE = "org.springframework.cache.annotation.Cacheable";
+    static final String SCHEDULED = "org.springframework.scheduling.annotation.Scheduled";
 
     static final DescribedPredicate<CanBeAnnotated> CONTROLLER_ANNOTATED = annotatedWith(CONTROLLER)
             .or(annotatedWith(REST_CONTROLLER))
@@ -85,6 +94,12 @@ final class SpringStereotypes {
     static final DescribedPredicate<CanBeAnnotated> SERVICE_ANNOTATED =
             annotatedWith(SERVICE).as("annotated with @Service");
 
+    static final DescribedPredicate<CanBeAnnotated> SERVICE_OR_REPOSITORY_ANNOTATED =
+            annotatedWith(SERVICE).or(annotatedWith(REPOSITORY)).as("annotated with @Service or @Repository");
+
+    static final DescribedPredicate<CanBeAnnotated> CONFIGURATION_ANNOTATED =
+            annotatedWith(CONFIGURATION).as("annotated with @Configuration");
+
     static final DescribedPredicate<CanBeAnnotated> STEREOTYPE_ANNOTATED = annotatedWith(COMPONENT)
             .or(annotatedWith(SERVICE))
             .or(annotatedWith(REPOSITORY))
@@ -93,7 +108,17 @@ final class SpringStereotypes {
             .or(annotatedWith(CONFIGURATION))
             .as("annotated with a Spring stereotype");
 
-    static final DescribedPredicate<CanBeAnnotated> PROXIED_METHOD_ANNOTATED = annotatedWith(TRANSACTIONAL)
+    static final DescribedPredicate<CanBeAnnotated> TRANSACTIONAL_ANNOTATED = annotatedWith(TRANSACTIONAL)
+            .or(annotatedWith(JAKARTA_TRANSACTIONAL))
+            .as("annotated with @Transactional");
+
+    static final DescribedPredicate<CanBeAnnotated> ASYNC_ANNOTATED =
+            annotatedWith(ASYNC).as("annotated with @Async");
+
+    static final DescribedPredicate<CanBeAnnotated> SCHEDULED_ANNOTATED =
+            annotatedWith(SCHEDULED).as("annotated with @Scheduled");
+
+    static final DescribedPredicate<CanBeAnnotated> PROXIED_METHOD_ANNOTATED = TRANSACTIONAL_ANNOTATED
             .or(annotatedWith(ASYNC))
             .or(annotatedWith(CACHEABLE))
             .as("annotated with @Transactional, @Async, or @Cacheable");
@@ -589,5 +614,379 @@ final class LoggersShouldBePrivateStaticFinalRule extends AbstractArchitectureRu
                 .andShould()
                 .beFinal()
                 .allowEmptyShould(true);
+    }
+}
+
+/**
+ * Flags accidental dependencies from application classes to test-only APIs.
+ */
+final class NoTestFrameworkDependenciesRule extends AbstractArchitectureRule {
+
+    NoTestFrameworkDependenciesRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-CODE-013",
+                        "Application classes should not depend on test frameworks",
+                        ArchitectureCategory.CODING_PRACTICES,
+                        "MEDIUM",
+                        "Detects dependencies from application classes to common test-only APIs such as JUnit, Mockito, AssertJ, Spring Test, Hamcrest, or Testcontainers.",
+                        "Move test helpers and assertions to test sources; production code should not depend on test frameworks."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return noClasses()
+                .should()
+                .dependOnClassesThat()
+                .resideInAnyPackage(
+                        "org.junit..",
+                        "org.mockito..",
+                        "org.assertj..",
+                        "org.hamcrest..",
+                        "org.springframework.boot.test..",
+                        "org.springframework.test..",
+                        "org.testcontainers..");
+    }
+}
+
+/**
+ * Flags repository beans that depend on service beans, which reverses the usual persistence-to-
+ * domain dependency direction.
+ */
+final class RepositoriesShouldNotDependOnServicesRule extends AbstractArchitectureRule {
+
+    RepositoriesShouldNotDependOnServicesRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-007",
+                        "Repositories should not depend on services",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "MEDIUM",
+                        "Detects @Repository beans that depend directly on @Service beans, coupling persistence code back to business services.",
+                        "Keep repository beans focused on persistence concerns; dependencies should flow from services toward repositories, not back."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return noClasses()
+                .that(SpringStereotypes.REPOSITORY_ANNOTATED)
+                .should()
+                .dependOnClassesThat(SpringStereotypes.SERVICE_ANNOTATED);
+    }
+}
+
+/**
+ * Flags service and repository beans that depend on servlet request/response infrastructure.
+ */
+final class ServicesAndRepositoriesShouldNotDependOnServletTypesRule extends AbstractArchitectureRule {
+
+    ServicesAndRepositoriesShouldNotDependOnServletTypesRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-008",
+                        "Services and repositories should not depend on servlet types",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "MEDIUM",
+                        "Detects @Service or @Repository beans that depend on servlet or Spring web request types.",
+                        "Extract request data in the web layer and pass plain application values into services and repositories."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return noClasses()
+                .that(SpringStereotypes.SERVICE_OR_REPOSITORY_ANNOTATED)
+                .should()
+                .dependOnClassesThat()
+                .resideInAnyPackage(
+                        "jakarta.servlet..", "javax.servlet..", "org.springframework.web.context.request..");
+    }
+}
+
+/**
+ * Flags transaction annotations on interfaces, which Spring recommends avoiding because behaviour
+ * differs between proxy modes and can be silently ignored with AspectJ weaving.
+ */
+final class TransactionalAnnotationsShouldNotBeDeclaredOnInterfacesRule extends AbstractArchitectureRule {
+
+    TransactionalAnnotationsShouldNotBeDeclaredOnInterfacesRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-009",
+                        "Transactional annotations should not be declared on interfaces",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "MEDIUM",
+                        "Detects @Transactional on interfaces or interface methods.",
+                        "Declare transaction semantics on concrete implementation classes or methods so proxy and weaving modes behave consistently."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return classes()
+                .should(new ArchCondition<JavaClass>("not declare @Transactional on interfaces") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        if (!javaClass.isInterface()) {
+                            return;
+                        }
+                        if (hasTransactionalAnnotation(javaClass)) {
+                            events.add(SimpleConditionEvent.violated(
+                                    javaClass,
+                                    "Interface " + javaClass.getName() + " is annotated with @Transactional"));
+                        }
+                        for (JavaMethod method : javaClass.getMethods()) {
+                            if (hasTransactionalAnnotation(method)) {
+                                events.add(SimpleConditionEvent.violated(
+                                        method,
+                                        "Interface method " + method.getFullName()
+                                                + " is annotated with @Transactional"));
+                            }
+                        }
+                    }
+                })
+                .as("Transactional annotations should not be declared on interfaces");
+    }
+
+    private static boolean hasTransactionalAnnotation(CanBeAnnotated annotated) {
+        return annotated.isAnnotatedWith(SpringStereotypes.TRANSACTIONAL)
+                || annotated.isAnnotatedWith(SpringStereotypes.JAKARTA_TRANSACTIONAL);
+    }
+}
+
+/**
+ * Flags private or static methods annotated with proxy-driven Spring annotations. Such methods
+ * cannot be invoked through the Spring proxy and the annotation is therefore misleading.
+ */
+final class ProxiedMethodsShouldNotBePrivateOrStaticRule extends AbstractArchitectureRule {
+
+    ProxiedMethodsShouldNotBePrivateOrStaticRule() {
+        super(new ArchitectureRuleDefinition(
+                "ARCH-SPRING-010",
+                "Proxy-driven methods should not be private or static",
+                ArchitectureCategory.SPRING_STEREOTYPES,
+                "MEDIUM",
+                "Detects private or static methods annotated with @Transactional, @Async, or @Cacheable.",
+                "Move the annotation to an instance method that can be invoked through a Spring proxy."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return classes()
+                .should(new ArchCondition<JavaClass>("not declare private or static proxy-driven methods") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        for (JavaMethod method : javaClass.getMethods()) {
+                            if (SpringStereotypes.PROXIED_METHOD_ANNOTATED.test(method) && isPrivateOrStatic(method)) {
+                                events.add(SimpleConditionEvent.violated(
+                                        method,
+                                        "Method " + method.getFullName()
+                                                + " is annotated with a proxy-driven Spring annotation but is "
+                                                + visibilityProblem(method)));
+                            }
+                        }
+                    }
+                })
+                .as("Proxy-driven methods should not be private or static");
+    }
+
+    private static boolean isPrivateOrStatic(JavaMethod method) {
+        Set<JavaModifier> modifiers = method.getModifiers();
+        return modifiers.contains(JavaModifier.PRIVATE) || modifiers.contains(JavaModifier.STATIC);
+    }
+
+    private static String visibilityProblem(JavaMethod method) {
+        Set<JavaModifier> modifiers = method.getModifiers();
+        if (modifiers.contains(JavaModifier.PRIVATE) && modifiers.contains(JavaModifier.STATIC)) {
+            return "private and static";
+        }
+        if (modifiers.contains(JavaModifier.PRIVATE)) {
+            return "private";
+        }
+        return "static";
+    }
+}
+
+/**
+ * Flags {@code @Async} methods with unsupported return types.
+ */
+final class AsyncMethodsShouldHaveSupportedSignaturesRule extends AbstractArchitectureRule {
+
+    AsyncMethodsShouldHaveSupportedSignaturesRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-011",
+                        "Async methods should return void or Future",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "MEDIUM",
+                        "Detects @Async methods that return a value type other than java.util.concurrent.Future.",
+                        "Use void for fire-and-forget async work, or return Future/CompletableFuture when callers need a result."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return classes()
+                .should(new ArchCondition<JavaClass>("declare only supported @Async method signatures") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        boolean asyncClass = SpringStereotypes.ASYNC_ANNOTATED.test(javaClass);
+                        for (JavaMethod method : javaClass.getMethods()) {
+                            if ((asyncClass || SpringStereotypes.ASYNC_ANNOTATED.test(method))
+                                    && !returnsVoidOrFuture(method)) {
+                                events.add(SimpleConditionEvent.violated(
+                                        method,
+                                        "Async method " + method.getFullName()
+                                                + " returns "
+                                                + method.getRawReturnType().getName()
+                                                + " instead of void or java.util.concurrent.Future"));
+                            }
+                        }
+                    }
+                })
+                .as("Async methods should return void or Future");
+    }
+
+    private static boolean returnsVoidOrFuture(JavaMethod method) {
+        JavaClass returnType = method.getRawReturnType();
+        return returnType.isEquivalentTo(void.class) || returnType.isAssignableTo(java.util.concurrent.Future.class);
+    }
+}
+
+/**
+ * Flags scheduled methods with parameters or unsupported return types.
+ */
+final class ScheduledMethodsShouldHaveSupportedSignaturesRule extends AbstractArchitectureRule {
+
+    ScheduledMethodsShouldHaveSupportedSignaturesRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-012",
+                        "Scheduled methods should have supported signatures",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "MEDIUM",
+                        "Detects @Scheduled methods that accept parameters or return non-void, non-reactive values that Spring ignores.",
+                        "Declare scheduled methods without parameters and return void unless using a supported deferred reactive Publisher type."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return classes()
+                .should(new ArchCondition<JavaClass>("declare only supported @Scheduled method signatures") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        for (JavaMethod method : javaClass.getMethods()) {
+                            if (SpringStereotypes.SCHEDULED_ANNOTATED.test(method)) {
+                                checkParameters(method, events);
+                                checkReturnType(method, events);
+                            }
+                        }
+                    }
+                })
+                .as("Scheduled methods should have supported signatures");
+    }
+
+    private static void checkParameters(JavaMethod method, ConditionEvents events) {
+        if (!method.getRawParameterTypes().isEmpty()) {
+            events.add(SimpleConditionEvent.violated(
+                    method,
+                    "Scheduled method " + method.getFullName()
+                            + " declares parameters, but Spring invokes @Scheduled methods without arguments"));
+        }
+    }
+
+    private static void checkReturnType(JavaMethod method, ConditionEvents events) {
+        JavaClass returnType = method.getRawReturnType();
+        if (returnType.isEquivalentTo(void.class) || isKnownReactiveReturnType(returnType)) {
+            return;
+        }
+        events.add(SimpleConditionEvent.violated(
+                method,
+                "Scheduled method " + method.getFullName()
+                        + " returns " + returnType.getName()
+                        + "; synchronous @Scheduled return values are ignored"));
+    }
+
+    private static boolean isKnownReactiveReturnType(JavaClass returnType) {
+        String name = returnType.getName();
+        return returnType.isAssignableTo("org.reactivestreams.Publisher")
+                || name.startsWith("reactor.core.publisher.")
+                || name.equals("kotlinx.coroutines.flow.Flow")
+                || name.equals("kotlinx.coroutines.Deferred")
+                || name.startsWith("io.reactivex.")
+                || name.startsWith("io.reactivex.rxjava3.");
+    }
+}
+
+/**
+ * Flags {@code @Async} usage in configuration classes, which Spring explicitly does not support.
+ */
+final class AsyncShouldNotBeUsedInConfigurationClassesRule extends AbstractArchitectureRule {
+
+    AsyncShouldNotBeUsedInConfigurationClassesRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-013",
+                        "Async should not be used in configuration classes",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "MEDIUM",
+                        "Detects @Async on @Configuration classes or methods declared within them.",
+                        "Move asynchronous work to a regular Spring bean; @Async is not supported on methods declared in @Configuration classes."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return classes()
+                .should(new ArchCondition<JavaClass>("not use @Async in @Configuration classes") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        if (!SpringStereotypes.CONFIGURATION_ANNOTATED.test(javaClass)) {
+                            return;
+                        }
+                        if (SpringStereotypes.ASYNC_ANNOTATED.test(javaClass)) {
+                            events.add(SimpleConditionEvent.violated(
+                                    javaClass,
+                                    "Configuration class " + javaClass.getName() + " is annotated with @Async"));
+                        }
+                        for (JavaMethod method : javaClass.getMethods()) {
+                            if (SpringStereotypes.ASYNC_ANNOTATED.test(method)) {
+                                events.add(SimpleConditionEvent.violated(
+                                        method,
+                                        "Configuration method " + method.getFullName() + " is annotated with @Async"));
+                            }
+                        }
+                    }
+                })
+                .as("Async should not be used in configuration classes");
+    }
+}
+
+/**
+ * Flags use of {@code AopContext.currentProxy()}, which couples application code directly to
+ * Spring AOP internals and requires exposing proxies.
+ */
+final class NoAopContextCurrentProxyRule extends AbstractArchitectureRule {
+
+    NoAopContextCurrentProxyRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-014",
+                        "Classes should not call AopContext.currentProxy",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "LOW",
+                        "Detects calls to AopContext.currentProxy(), which couples code to Spring AOP proxy internals.",
+                        "Prefer refactoring to avoid self-invocation, or inject a self-reference when a proxy call is truly required."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return noClasses()
+                .should()
+                .callMethodWhere(new DescribedPredicate<JavaMethodCall>("AopContext.currentProxy() is called") {
+                    @Override
+                    public boolean test(JavaMethodCall call) {
+                        MethodCallTarget target = call.getTarget();
+                        return target.getName().equals("currentProxy")
+                                && target.getOwner().getName().equals("org.springframework.aop.framework.AopContext");
+                    }
+                })
+                .as("Classes should not call AopContext.currentProxy()");
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistryTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistryTests.java
@@ -28,6 +28,19 @@ class ArchitectureRuleRegistryTests {
     void activeRulesIncludeTheAdditionalSpringAndCodingPracticeChecks() {
         assertThat(ArchitectureRuleRegistry.activeRules())
                 .extracting(rule -> rule.definition().id())
-                .contains("ARCH-SPRING-006", "ARCH-CODE-010", "ARCH-CODE-011", "ARCH-CODE-012");
+                .contains(
+                        "ARCH-CODE-010",
+                        "ARCH-CODE-011",
+                        "ARCH-CODE-012",
+                        "ARCH-CODE-013",
+                        "ARCH-SPRING-006",
+                        "ARCH-SPRING-007",
+                        "ARCH-SPRING-008",
+                        "ARCH-SPRING-009",
+                        "ARCH-SPRING-010",
+                        "ARCH-SPRING-011",
+                        "ARCH-SPRING-012",
+                        "ARCH-SPRING-013",
+                        "ARCH-SPRING-014");
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRulesTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRulesTests.java
@@ -5,11 +5,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import io.github.jdubois.bootui.core.BootUiDtos.ArchitectureRuleResultDto;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 class ArchitectureRulesTests {
@@ -99,6 +108,135 @@ class ArchitectureRulesTests {
         assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
     }
 
+    @Test
+    void noTestFrameworkDependenciesFlagsMainCodeUsingTestApis() {
+        ArchitectureRuleResultDto result = evaluate(new NoTestFrameworkDependenciesRule(), TestFrameworkUser.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-013");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("org.junit"));
+    }
+
+    @Test
+    void repositoriesShouldNotDependOnServicesFlagsPersistenceDependingOnBusinessLayer() {
+        ArchitectureRuleResultDto result = evaluate(
+                new RepositoriesShouldNotDependOnServicesRule(),
+                RepositoryDependingOnService.class,
+                ExampleService.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-007");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample)
+                        .contains("RepositoryDependingOnService")
+                        .contains("ExampleService"));
+    }
+
+    @Test
+    void servicesAndRepositoriesShouldNotDependOnServletTypesFlagsHttpRequestDependencies() {
+        ArchitectureRuleResultDto result = evaluate(
+                new ServicesAndRepositoriesShouldNotDependOnServletTypesRule(), ServiceUsingServletRequest.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-008");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("HttpServletRequest"));
+    }
+
+    @Test
+    void transactionalAnnotationsShouldNotBeDeclaredOnInterfacesFlagsInterfaceAnnotations() {
+        ArchitectureRuleResultDto result = evaluate(
+                new TransactionalAnnotationsShouldNotBeDeclaredOnInterfacesRule(),
+                TransactionalInterface.class,
+                TransactionalMethodInterface.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-009");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("TransactionalInterface"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("TransactionalMethodInterface"));
+    }
+
+    @Test
+    void proxiedMethodsShouldNotBePrivateOrStaticFlagsUnproxyableMethods() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ProxiedMethodsShouldNotBePrivateOrStaticRule(), BadProxyAnnotationComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-010");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("private"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("static"));
+    }
+
+    @Test
+    void asyncMethodsShouldHaveSupportedSignaturesFlagsUnsupportedReturnTypes() {
+        ArchitectureRuleResultDto result =
+                evaluate(new AsyncMethodsShouldHaveSupportedSignaturesRule(), BadAsyncComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-011");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("java.lang.String"));
+    }
+
+    @Test
+    void asyncMethodsShouldHaveSupportedSignaturesPassesForFutureReturnTypes() {
+        ArchitectureRuleResultDto result =
+                evaluate(new AsyncMethodsShouldHaveSupportedSignaturesRule(), GoodAsyncComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void scheduledMethodsShouldHaveSupportedSignaturesFlagsArgumentsAndIgnoredReturnValues() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ScheduledMethodsShouldHaveSupportedSignaturesRule(), BadScheduledComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-012");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("declares parameters"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("returns java.lang.String"));
+    }
+
+    @Test
+    void scheduledMethodsShouldHaveSupportedSignaturesPassesForVoidMethodsWithoutArguments() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ScheduledMethodsShouldHaveSupportedSignaturesRule(), GoodScheduledComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void asyncShouldNotBeUsedInConfigurationClassesFlagsConfigurationUsage() {
+        ArchitectureRuleResultDto result =
+                evaluate(new AsyncShouldNotBeUsedInConfigurationClassesRule(), AsyncConfiguration.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-013");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("AsyncConfiguration"));
+    }
+
+    @Test
+    void noAopContextCurrentProxyFlagsDirectProxyLookup() {
+        ArchitectureRuleResultDto result =
+                evaluate(new NoAopContextCurrentProxyRule(), AopContextCurrentProxyUser.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-014");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("currentProxy"));
+    }
+
     private static ArchitectureRuleResultDto evaluate(ArchitectureRule rule, Class<?>... classes) {
         JavaClasses importedClasses = new ClassFileImporter().importClasses(classes);
         return rule.evaluate(
@@ -107,6 +245,9 @@ class ArchitectureRulesTests {
 
     @RestController
     private static class ExampleController {}
+
+    @Service
+    private static class ExampleService {}
 
     @Service
     private static class ServiceDependingOnController {
@@ -140,5 +281,93 @@ class ArchitectureRulesTests {
     private static class WellFormedLoggerComponent {
 
         private static final Logger LOGGER = LoggerFactory.getLogger(WellFormedLoggerComponent.class);
+    }
+
+    private static class TestFrameworkUser {
+
+        private final org.junit.jupiter.api.TestInfo testInfo = null;
+    }
+
+    @Repository
+    private static class RepositoryDependingOnService {
+
+        private final ExampleService service;
+
+        RepositoryDependingOnService(ExampleService service) {
+            this.service = service;
+        }
+    }
+
+    @Service
+    private static class ServiceUsingServletRequest {
+
+        String userAgent(HttpServletRequest request) {
+            return request.getHeader("User-Agent");
+        }
+    }
+
+    @Transactional
+    private interface TransactionalInterface {}
+
+    private interface TransactionalMethodInterface {
+
+        @Transactional
+        void save();
+    }
+
+    private static class BadProxyAnnotationComponent {
+
+        @Transactional
+        private void privateTransactional() {}
+
+        @Async
+        static void staticAsync() {}
+    }
+
+    private static class BadAsyncComponent {
+
+        @Async
+        String unsupportedReturnType() {
+            return "bad";
+        }
+    }
+
+    private static class GoodAsyncComponent {
+
+        @Async
+        Future<String> supportedReturnType() {
+            return CompletableFuture.completedFuture("ok");
+        }
+    }
+
+    private static class BadScheduledComponent {
+
+        @Scheduled(fixedDelay = 1000)
+        void withArgument(String ignored) {}
+
+        @Scheduled(fixedDelay = 1000)
+        String ignoredReturnValue() {
+            return "ignored";
+        }
+    }
+
+    private static class GoodScheduledComponent {
+
+        @Scheduled(fixedDelay = 1000)
+        void run() {}
+    }
+
+    @Configuration
+    private static class AsyncConfiguration {
+
+        @Async
+        void configureAsync() {}
+    }
+
+    private static class AopContextCurrentProxyUser {
+
+        Object currentProxy() {
+            return AopContext.currentProxy();
+        }
     }
 }

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -162,6 +162,17 @@ a handful of sample detail lines from ArchUnit.
 - **Recommendation**: make logger fields `private static final` to avoid accidental external access and per-instance
   logger allocations.
 
+### ARCH-CODE-013 — Application classes should not depend on test frameworks
+
+- **Severity**: MEDIUM
+- **Inspects**: dependencies on common test-only APIs such as JUnit, Mockito, AssertJ, Hamcrest, Spring Test, Spring Boot
+  Test, or Testcontainers.
+- **Fires when**: an application class references a test framework type.
+- **Why it matters**: production code that depends on test frameworks is usually an accidental source-set leak and can
+  pull unnecessary or unavailable test libraries into runtime code.
+- **Recommendation**: move assertions, fixtures, containers, and test helpers to test sources; keep production classes
+  independent of test APIs.
+
 ## Spring stereotypes
 
 ### ARCH-SPRING-001 — Classes should not use field injection
@@ -216,3 +227,82 @@ a handful of sample detail lines from ArchUnit.
 - **Fires when**: service-layer code references web-layer classes, coupling business logic back to HTTP concerns.
 - **Recommendation**: keep service beans free of controller dependencies; web dependencies should flow from controllers
   toward services, not back.
+
+### ARCH-SPRING-007 — Repositories should not depend on services
+
+- **Severity**: MEDIUM
+- **Inspects**: `@Repository` beans that depend directly on `@Service` beans.
+- **Fires when**: persistence code references business services, inverting the usual service-to-repository dependency
+  direction.
+- **Recommendation**: keep repository beans focused on persistence concerns; dependencies should flow from services
+  toward repositories, not back.
+
+### ARCH-SPRING-008 — Services and repositories should not depend on servlet types
+
+- **Severity**: MEDIUM
+- **Inspects**: `@Service` and `@Repository` beans that depend on `jakarta.servlet`, `javax.servlet`, or Spring web
+  request types.
+- **Fires when**: business or persistence code accepts, stores, or otherwise references servlet request/response
+  infrastructure.
+- **Why it matters**: service and repository code should be transport-agnostic so it can be reused from HTTP
+  controllers, CLI runners, scheduled jobs, tests, and message consumers.
+- **Recommendation**: extract request data in the controller and pass plain application values into services and
+  repositories.
+
+### ARCH-SPRING-009 — Transactional annotations should not be declared on interfaces
+
+- **Severity**: MEDIUM
+- **Inspects**: Spring or Jakarta `@Transactional` annotations on interfaces and interface methods.
+- **Fires when**: an interface or one of its methods declares transaction metadata.
+- **Why it matters**: Spring recommends annotating concrete classes or methods because interface-declared annotations can
+  behave differently across proxy modes and may be silently ignored with AspectJ weaving.
+- **Recommendation**: move transaction annotations to concrete implementation classes or methods.
+
+### ARCH-SPRING-010 — Proxy-driven methods should not be private or static
+
+- **Severity**: MEDIUM
+- **Inspects**: private or static methods annotated with `@Transactional`, `@Async`, or `@Cacheable`.
+- **Fires when**: a proxy-driven Spring annotation is applied to a method that cannot be invoked through a Spring proxy.
+- **Why it matters**: Spring AOP is proxy-based; private and static methods are not intercepted like normal bean method
+  calls, so the annotation is misleading or ineffective.
+- **Recommendation**: move the annotation to an instance method that is invoked through a Spring proxy.
+
+### ARCH-SPRING-011 — Async methods should return void or Future
+
+- **Severity**: MEDIUM
+- **Inspects**: methods annotated with `@Async`, and methods declared on `@Async` classes.
+- **Fires when**: an async method returns a value type that is neither `void` nor assignable to
+  `java.util.concurrent.Future`.
+- **Why it matters**: Spring supports async methods with `void` return values or `Future`/`CompletableFuture` handles;
+  other return values do not provide the caller a valid asynchronous result.
+- **Recommendation**: use `void` for fire-and-forget async work, or return `Future` / `CompletableFuture` when callers
+  need a result.
+
+### ARCH-SPRING-012 — Scheduled methods should have supported signatures
+
+- **Severity**: MEDIUM
+- **Inspects**: methods annotated with `@Scheduled`.
+- **Fires when**: a scheduled method declares parameters, or returns a non-`void`, non-reactive value type whose result
+  Spring will ignore.
+- **Why it matters**: Spring invokes scheduled methods without arguments; synchronous return values are discarded, which
+  often indicates a misunderstood job contract.
+- **Recommendation**: declare scheduled methods without parameters and return `void` unless using a supported deferred
+  reactive `Publisher` type.
+
+### ARCH-SPRING-013 — Async should not be used in configuration classes
+
+- **Severity**: MEDIUM
+- **Inspects**: `@Async` on `@Configuration` classes or methods declared inside `@Configuration` classes.
+- **Fires when**: configuration code is annotated for asynchronous execution.
+- **Why it matters**: Spring's `@Async` Javadoc explicitly states that it is not supported on methods declared within
+  `@Configuration` classes.
+- **Recommendation**: move asynchronous work to a regular Spring bean and call it through that bean's proxy.
+
+### ARCH-SPRING-014 — Classes should not call AopContext.currentProxy
+
+- **Severity**: LOW
+- **Inspects**: calls to `org.springframework.aop.framework.AopContext.currentProxy()`.
+- **Fires when**: application code looks up the current Spring AOP proxy directly.
+- **Why it matters**: Spring documents this as a discouraged last resort because it couples application code to Spring AOP
+  internals and requires proxy exposure.
+- **Recommendation**: refactor to avoid self-invocation, or inject a self-reference when a proxy call is truly required.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -238,11 +238,14 @@ application's own classes at runtime. It detects the application's base package 
 configuration, imports the compiled classes from that package, and evaluates a fixed set of universally-sensible
 architecture hygiene rules: package cycles between slices, general coding practices (no standard streams, generic
 exceptions, `java.util.logging`, JodaTime, `printStackTrace`, `System.exit`, JDK-internal APIs, legacy date/time, or
-deprecated APIs, poorly named exceptions/interfaces, or mutable/visible loggers), and Spring stereotype heuristics (no
-field injection, controllers should not depend on repositories, repositories/services should not depend on controllers,
-no self-invocation of proxied methods, and stereotypes outside the default package). When BootUI is installed through
-`bootui-spring-boot-starter`, ArchUnit is included transitively; the panel is available when a base package is
-resolvable and the scan runs on demand, caching the last report.
+deprecated APIs, poorly named exceptions/interfaces, mutable/visible loggers, or production dependencies on test
+frameworks), and Spring stereotype/proxy heuristics (no field injection, controllers should not depend on repositories,
+repositories should not depend on controllers or services, services should not depend on controllers, services and
+repositories should stay servlet-agnostic, no self-invocation or unproxyable proxy annotations, async/scheduled method
+signatures should be supported, async should stay out of configuration classes, stereotypes should stay outside the
+default package, and code should avoid `AopContext.currentProxy()`). When BootUI is installed through
+`bootui-spring-boot-starter`, ArchUnit is included transitively; the panel is available when a base package is resolvable
+and the scan runs on demand, caching the last report.
 
 Generic rules are necessarily less powerful than project-authored ArchUnit tests, so the panel is positioned as a
 starting-point and review aid that complements — rather than replaces — a project-specific ArchUnit test suite. Each


### PR DESCRIPTION
## What does this PR do?

Adds nine zero-config Architecture panel checks for Spring proxy usage, async and scheduled method signatures, repository/service layering, servlet coupling, test-framework leakage, and direct `AopContext.currentProxy()` usage.

## Why is this change needed?

The Architecture panel already catches broad ArchUnit hygiene issues. These additions capture more project-agnostic Spring and ArchUnit best-practice opportunities that can reveal silent misconfigurations without requiring package conventions or app-specific architecture definitions.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks run:

- `./mvnw -pl bootui-autoconfigure test`
- `./mvnw -B -ntp spotless:check`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed