### PR TITLE
refactor: remove duplicate shortName/isPlainObject helpers

### DIFF
--- a/bootui-ui/src/main/frontend/src/utils/format.js
+++ b/bootui-ui/src/main/frontend/src/utils/format.js
@@ -16,6 +16,16 @@ export function formatNumber(n) {
   return Number(n).toLocaleString()
 }
 
+export function shortName(name) {
+  if (!name) return '—'
+  const i = name.lastIndexOf('.')
+  return i < 0 ? name : name.substring(i + 1)
+}
+
+export function isPlainObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]'
+}
+
 export function formatRelative(epochMillis, nowMillis = Date.now()) {
   if (epochMillis == null) return '—'
   const diff = nowMillis - epochMillis

--- a/bootui-ui/src/main/frontend/src/views/Cache.vue
+++ b/bootui-ui/src/main/frontend/src/views/Cache.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
-import {formatNumber} from '../utils/format.js'
+import {formatNumber, shortName} from '../utils/format.js'
 import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
@@ -68,12 +68,6 @@ const filteredOperations = computed(() => {
       (operation.caches || []).join(' ').toLowerCase().includes(value)
   )
 })
-
-function shortName(name) {
-  if (!name) return '—'
-  const i = name.lastIndexOf('.')
-  return i < 0 ? name : name.substring(i + 1)
-}
 
 function formatRatio(value) {
   if (value === null || value === undefined) return '—'

--- a/bootui-ui/src/main/frontend/src/views/DatabaseConnectionsPools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DatabaseConnectionsPools.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {computed, onBeforeUnmount, ref, watch} from 'vue'
-import {formatNumber} from '../utils/format.js'
+import {formatNumber, shortName} from '../utils/format.js'
 import {formatLoadError} from '../utils/loadError.js'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
@@ -143,12 +143,6 @@ function formatMillis(value) {
   if (value === 0) return 'disabled'
   if (value >= 1000) return `${(value / 1000).toLocaleString(undefined, {maximumFractionDigits: 1})} s`
   return `${value} ms`
-}
-
-function shortName(name) {
-  if (!name) return '—'
-  const i = name.lastIndexOf('.')
-  return i < 0 ? name : name.substring(i + 1)
 }
 
 const currentSnapshot = computed(() => history.value[history.value.length - 1] || null)

--- a/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
@@ -1,11 +1,9 @@
 <script setup>
+import {isPlainObject} from '../utils/format.js'
+
 defineProps({
   value: {required: false, default: null}
 })
-
-function isPlainObject(value) {
-  return Object.prototype.toString.call(value) === '[object Object]'
-}
 
 function isScalar(value) {
   return value === null || value === undefined || ['string', 'number', 'boolean'].includes(typeof value)

--- a/bootui-ui/src/main/frontend/src/views/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthNode.vue
@@ -1,4 +1,5 @@
 <script setup>
+import {isPlainObject} from '../utils/format.js'
 import HealthDetails from './HealthDetails.vue'
 
 const props = defineProps({
@@ -25,10 +26,6 @@ const statusIcon = (s) =>
   })[s] || 'bi-question-circle-fill text-secondary'
 
 const childCount = (node) => (node.components || []).length
-
-function isPlainObject(value) {
-  return Object.prototype.toString.call(value) === '[object Object]'
-}
 
 function hasDetailValue(value) {
   if (value === null || value === undefined || value === '') return false


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
