### PR TITLE
Prefer Math.max() and Math.max() to simplify ternary expressions

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -108,8 +108,8 @@ const filteredTraces = computed(() => {
 const waterfall = computed(() => {
   if (!detail.value || !detail.value.spans || detail.value.spans.length === 0) return null
   const spans = [...detail.value.spans]
-  const minStart = spans.reduce((m, s) => (s.startEpochNanos < m ? s.startEpochNanos : m), spans[0].startEpochNanos)
-  const maxEnd = spans.reduce((m, s) => (s.endEpochNanos > m ? s.endEpochNanos : m), spans[0].endEpochNanos)
+  const minStart = spans.reduce((m, s) => Math.min(s.startEpochNanos, m), spans[0].startEpochNanos)
+  const maxEnd = spans.reduce((m, s) => Math.max(s.endEpochNanos, m), spans[0].endEpochNanos)
   const totalNanos = Math.max(maxEnd - minStart, 1)
   const sorted = spans
     .map((s) => ({


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
