### PR TITLE
Fix native sample image runtime

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
@@ -1,5 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure;
 
+import io.github.jdubois.bootui.core.BootUiDtos;
+import java.lang.reflect.Array;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -19,6 +21,8 @@ import org.springframework.aot.hint.RuntimeHintsRegistrar;
  *       the BootUI version reported as {@code unknown}.
  *   <li><b>Reflective method invocations</b> on well-known JDK and Spring Security types that BootUI
  *       discovers at runtime and calls reflectively.
+ *   <li><b>DTO binding types</b> that Jackson can synthesize while serializing BootUI records,
+ *       including array types derived from {@code List<...>} record components.
  * </ul>
  *
  * <p>The reflective sites in BootUI that operate on arbitrary user- or library-supplied types (for
@@ -56,6 +60,8 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
                 .registerPattern(CONFIGURATION_METADATA_RESOURCE)
                 .registerPattern(BOOTUI_VERSION_RESOURCE);
 
+        registerDtoBindingHints(hints);
+
         // Heap Dump panel: HeapDumpService reflectively calls HotSpotDiagnosticMXBean#dumpHeap.
         hints.reflection()
                 .registerTypeIfPresent(classLoader, HOTSPOT_DIAGNOSTIC_MXBEAN, MemberCategory.INVOKE_PUBLIC_METHODS);
@@ -67,5 +73,14 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
         hints.reflection().registerTypeIfPresent(classLoader, GRANTED_AUTHORITY, MemberCategory.INVOKE_PUBLIC_METHODS);
         hints.reflection()
                 .registerTypeIfPresent(classLoader, SIMPLE_GRANTED_AUTHORITY, MemberCategory.INVOKE_PUBLIC_METHODS);
+    }
+
+    private void registerDtoBindingHints(RuntimeHints hints) {
+        for (Class<?> dtoType : BootUiDtos.class.getDeclaredClasses()) {
+            hints.reflection()
+                    .registerType(
+                            dtoType, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS);
+            hints.reflection().registerType(Array.newInstance(dtoType, 0).getClass());
+        }
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
@@ -1,10 +1,14 @@
 package io.github.jdubois.bootui.autoconfigure;
 
-import io.github.jdubois.bootui.core.BootUiDtos;
+import java.io.IOException;
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.util.ClassUtils;
 
 /**
  * Registers the GraalVM reachability metadata that BootUI itself needs so that applications using
@@ -21,8 +25,9 @@ import org.springframework.aot.hint.RuntimeHintsRegistrar;
  *       the BootUI version reported as {@code unknown}.
  *   <li><b>Reflective method invocations</b> on well-known JDK and Spring Security types that BootUI
  *       discovers at runtime and calls reflectively.
- *   <li><b>DTO binding types</b> that Jackson can synthesize while serializing BootUI records,
- *       including array types derived from {@code List<...>} record components.
+ *   <li><b>DTO binding types</b> under {@code io.github.jdubois.bootui.core.dto} that Jackson can
+ *       synthesize while serializing BootUI records, including array types derived from
+ *       {@code List<...>} record components.
  * </ul>
  *
  * <p>The reflective sites in BootUI that operate on arbitrary user- or library-supplied types (for
@@ -40,6 +45,10 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
 
     /** Version file read by {@code BootUiInfo} (lives in bootui-core). */
     private static final String BOOTUI_VERSION_RESOURCE = "bootui-version.properties";
+
+    private static final String DTO_PACKAGE = "io.github.jdubois.bootui.core.dto";
+
+    private static final String DTO_RESOURCE_PATTERN = "classpath*:io/github/jdubois/bootui/core/dto/*.class";
 
     /** JDK MXBean invoked reflectively by {@code HeapDumpService} for heap dumps. */
     private static final String HOTSPOT_DIAGNOSTIC_MXBEAN = "com.sun.management.HotSpotDiagnosticMXBean";
@@ -60,7 +69,7 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
                 .registerPattern(CONFIGURATION_METADATA_RESOURCE)
                 .registerPattern(BOOTUI_VERSION_RESOURCE);
 
-        registerDtoBindingHints(hints);
+        registerDtoBindingHints(hints, classLoader);
 
         // Heap Dump panel: HeapDumpService reflectively calls HotSpotDiagnosticMXBean#dumpHeap.
         hints.reflection()
@@ -75,12 +84,37 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
                 .registerTypeIfPresent(classLoader, SIMPLE_GRANTED_AUTHORITY, MemberCategory.INVOKE_PUBLIC_METHODS);
     }
 
-    private void registerDtoBindingHints(RuntimeHints hints) {
-        for (Class<?> dtoType : BootUiDtos.class.getDeclaredClasses()) {
+    private void registerDtoBindingHints(RuntimeHints hints, ClassLoader classLoader) {
+        for (Class<?> dtoType : findDtoTypes(classLoader)) {
             hints.reflection()
                     .registerType(
                             dtoType, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS, MemberCategory.INVOKE_PUBLIC_METHODS);
             hints.reflection().registerType(Array.newInstance(dtoType, 0).getClass());
         }
+    }
+
+    private Class<?>[] findDtoTypes(ClassLoader classLoader) {
+        ClassLoader resourceClassLoader = classLoader != null ? classLoader : BootUiRuntimeHints.class.getClassLoader();
+        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver(resourceClassLoader);
+        try {
+            Resource[] resources = resolver.getResources(DTO_RESOURCE_PATTERN);
+            return Arrays.stream(resources)
+                    .map(Resource::getFilename)
+                    .filter(BootUiRuntimeHints::isTopLevelClassFile)
+                    .map(BootUiRuntimeHints::classNameFromResource)
+                    .map(className -> ClassUtils.resolveClassName(className, resourceClassLoader))
+                    .filter(Class::isRecord)
+                    .toArray(Class<?>[]::new);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to resolve BootUI DTO types for native-image hints", ex);
+        }
+    }
+
+    private static boolean isTopLevelClassFile(String filename) {
+        return filename != null && filename.endsWith(".class") && !filename.contains("$");
+    }
+
+    private static String classNameFromResource(String filename) {
+        return DTO_PACKAGE + '.' + filename.substring(0, filename.length() - ".class".length());
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
@@ -2,8 +2,8 @@ package io.github.jdubois.bootui.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.jdubois.bootui.core.BootUiDtos.PanelDto;
-import io.github.jdubois.bootui.core.BootUiDtos.StartupStepDto;
+import io.github.jdubois.bootui.core.dto.PanelDto;
+import io.github.jdubois.bootui.core.dto.StartupStepDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
@@ -2,6 +2,8 @@ package io.github.jdubois.bootui.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.jdubois.bootui.core.BootUiDtos.PanelDto;
+import io.github.jdubois.bootui.core.BootUiDtos.StartupStepDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -47,6 +49,18 @@ class BootUiRuntimeHintsTests {
         assertThat(RuntimeHintsPredicates.reflection()
                         .onType(TypeReference.of("org.springframework.security.core.authority.SimpleGrantedAuthority"))
                         .withMemberCategory(MemberCategory.INVOKE_PUBLIC_METHODS))
+                .accepts(hints);
+    }
+
+    @Test
+    void registersBootUiDtosAndArrayTypesForJacksonBinding() {
+        assertThat(RuntimeHintsPredicates.reflection()
+                        .onType(StartupStepDto.class)
+                        .withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS))
+                .accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(TypeReference.of(StartupStepDto[].class)))
+                .accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onType(TypeReference.of(PanelDto[].class)))
                 .accepts(hints);
     }
 }

--- a/bootui-sample-app/README.md
+++ b/bootui-sample-app/README.md
@@ -116,8 +116,10 @@ From the repository root:
 docker compose -f docker-compose-native.yml up --build
 ```
 
-Then open <http://localhost:8080/> or hit
-<http://localhost:8080/actuator/health>.
+Then open <http://localhost:8080/bootui/> or hit
+<http://localhost:8080/actuator/health>. The Compose file binds the app port to
+host loopback (`127.0.0.1`) so BootUI remains local-only while still allowing the
+browser to reach the containerized app.
 
 To build just the image:
 

--- a/docker-compose-native.yml
+++ b/docker-compose-native.yml
@@ -40,6 +40,13 @@ services:
     environment:
       SERVER_PORT: 8080
       SPRING_DOCKER_COMPOSE_ENABLED: "false"
+      # The native image is AOT-processed with BootUI enabled; keep BootUI
+      # active at runtime so its startup buffering and endpoints are available.
+      BOOTUI_ENABLED: "ON"
+      # Host browser requests arrive through Docker's bridge gateway rather
+      # than loopback from the container's point of view. The port is bound to
+      # 127.0.0.1 below, so this remains local-only on the host.
+      BOOTUI_ALLOW_NON_LOCALHOST: "true"
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/bootui_sample
       SPRING_DATASOURCE_USERNAME: bootui
       SPRING_DATASOURCE_PASSWORD: bootui
@@ -48,5 +55,5 @@ services:
       # Avoid reaching out to a (here absent) Ollama server during startup.
       SPRING_AI_OLLAMA_INIT_PULL_MODEL_STRATEGY: never
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     restart: unless-stopped


### PR DESCRIPTION
## What does this PR do?

Fixes the sample application's native-image runtime path so the Docker Compose native stack starts with BootUI enabled and can serve the BootUI console from a host browser. It also registers BootUI DTO binding hints so Jackson serialization works in the native image.

## Why is this change needed?

The new native-image workflow exposed two native runtime issues: the app could restart because BootUI was enabled during AOT but not at runtime, and the startup panel could fail in native mode because Jackson needed reflection metadata for generated DTO array types. Docker host requests also arrive through the bridge gateway, so the Compose setup now binds only to host loopback while allowing BootUI's local-only filter to accept those requests.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks run:

- `./mvnw -B -ntp -pl bootui-autoconfigure -am -Dtest=BootUiRuntimeHintsTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `docker compose -f docker-compose-native.yml up --build --detach`
- Smoke-tested `/actuator/health`, `/`, `/bootui/`, `/bootui/api/overview`, `/bootui/api/startup`, and `/bootui/api/panels`
- `./mvnw -B -ntp spotless:check`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed