### PR TITLE
Document GraalVM native image hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ Common properties:
 | `bootui.claude-code.max-parsed-sessions` | `100`                                   | Maximum recent Claude Code JSONL files parsed and retained in memory.                    |
 | `bootui.claude-code.allow-raw-reveal`    | `false`                                 | Explicitly enable raw JSONL reveal; raw Claude Code logs can include prompts and output. |
 
+## GraalVM native images
+
+BootUI contributes Spring AOT runtime hints for the starter's own native-image needs. Applications using
+`bootui-spring-boot-starter` do not need to re-declare BootUI-specific hints for the classpath resources BootUI scans at
+runtime, BootUI DTO records serialized by Jackson, or the reflective calls used by the Heap Dump, Security, and
+Pentesting panels.
+
+The [GraalVM panel](docs/FEATURES.md#graalvm) is separate from those built-in hints: it surveys the host application and
+can generate a reviewable `reachability-metadata.json` scaffold for application code. Always validate native-image
+readiness with the GraalVM tracing agent and an actual native build.
+
 ## Runtime overrides
 
 The Configuration panel can create, update, and delete local runtime overrides. Overrides are stored in
@@ -170,6 +181,7 @@ app restarts; BootUI returns that warning with every override mutation.
 ## More docs
 
 - [Feature details](docs/FEATURES.md): panel-by-panel guide with screenshots
+- [GraalVM readiness checks](docs/GRAALVM-READINESS-CHECKS.md): native-image scan behavior and generated metadata notes
 - [Property reference](docs/PROPERTIES.md): global, per-panel, and action-gating configuration properties
 - [Sample app walkthrough](bootui-sample-app/README.md): the demo app behind the screenshots and Playwright suite
 - [CHANGELOG.md](CHANGELOG.md): release notes

--- a/docs/GRAALVM-READINESS-CHECKS.md
+++ b/docs/GRAALVM-READINESS-CHECKS.md
@@ -32,6 +32,13 @@ without an extra application dependency. The panel is available only when ArchUn
 package is resolvable from the running application. If no classes can be imported, the panel degrades to a stable, empty
 report with an explanatory reason rather than failing.
 
+Separately from the panel scan, BootUI registers Spring AOT runtime hints for its own native-image needs from
+[`BootUiRuntimeHints`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java).
+Those built-in hints cover BootUI's runtime-scanned classpath resources, BootUI DTO records used by Jackson, and the
+well-known reflective calls used by the Heap Dump, Security, and Pentesting panels. They are contributed by
+`BootUiAutoConfiguration`, so applications using the starter should not need to copy BootUI-specific hints into their own
+native-image configuration.
+
 ## What BootUI does not do
 
 - It is **not a replacement for the [GraalVM tracing agent](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/)


### PR DESCRIPTION
## What does this PR do?

Documents BootUI's built-in Spring AOT runtime hints for GraalVM native images in the README and the GraalVM readiness guide.

## Why is this change needed?

Recent commits added native-image hints for BootUI itself, but the docs only described the GraalVM panel's host-application scan. This explains that starter users get BootUI-specific hints automatically and distinguishes them from application reachability metadata.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Documentation-only change; checked the markdown diff with `git diff --check`.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed