### PR TITLE
Remove Security Logs manual refresh

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/SecurityLogs.vue
+++ b/bootui-ui/src/main/frontend/src/views/SecurityLogs.vue
@@ -98,7 +98,6 @@ function typeBadgeClass(typeName) {
       :loading="loading"
       :error="error"
       :last-fetched="lastFetched"
-      @refresh="load"
     >
       <template #actions>
         <AutoRefreshToggle v-model="autoRefresh" />


### PR DESCRIPTION
## What does this PR do?

Removes the standalone manual refresh button from the Security Logs panel header while keeping the auto-refresh control in place.

## Why is this change needed?

The manual refresh icon is redundant on this auto-refreshing panel and creates an extra adjacent refresh control that does not add useful behavior.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable (N/A - this reuses existing PanelHeader behavior)

Additional validation: `(cd bootui-ui/src/main/frontend && npm run format:check)`

## Screenshots (UI changes)

N/A - screenshots intentionally not updated for this small control removal.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - this control is not documented)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed