### PR TITLE
Remove HTTP Exchanges refresh button

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/HttpExchanges.test.js
+++ b/bootui-ui/src/main/frontend/src/views/HttpExchanges.test.js
@@ -65,6 +65,7 @@ describe('HTTP Exchanges', () => {
     expect(wrapper.text()).toContain('******')
     expect(wrapper.text()).not.toContain('BootUI self-request')
     expect(wrapper.findComponent(AutoRefreshToggle).exists()).toBe(true)
+    expect(wrapper.find('button[title="Refresh"]').exists()).toBe(false)
   })
 
   it('sends method and status filters to the server', async () => {

--- a/bootui-ui/src/main/frontend/src/views/HttpExchanges.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpExchanges.vue
@@ -49,7 +49,7 @@ async function refreshExchanges() {
   }
 }
 
-const {autoRefresh, loading: refreshLoading, load: refresh} = useAutoRefresh(refreshExchanges)
+const {autoRefresh, loading: refreshLoading} = useAutoRefresh(refreshExchanges)
 
 function formatTimestamp(timestamp) {
   if (!timestamp) return '—'
@@ -121,7 +121,6 @@ watch([filter, method, statusClass], scheduleReload)
       :loading="refreshLoading || loading"
       :error="error"
       :last-fetched="lastFetched"
-      @refresh="refresh"
     >
       <template #actions>
         <AutoRefreshToggle v-model="autoRefresh" />


### PR DESCRIPTION
## What does this PR do?

Removes the redundant manual refresh button from the HTTP Exchanges panel header while keeping the auto-refresh toggle.

## Why is this change needed?

The HTTP Exchanges panel had both an auto-refresh toggle and a top-right manual refresh button, unlike comparable auto-refresh log screens. Removing the extra button keeps the header consistent and avoids unnecessary UI clutter.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran focused checks:

- `(cd bootui-ui/src/main/frontend && npm test -- HttpExchanges.test.js)`
- `(cd bootui-ui/src/main/frontend && npm run format:check -- src/views/HttpExchanges.vue src/views/HttpExchanges.test.js)`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: removes an undocumented duplicate control)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed