### PR TITLE
refactor: remove unused frontend imports

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'

--- a/bootui-ui/src/main/frontend/src/views/Conditions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onBeforeUnmount, onMounted, ref, watch} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import {SERVER_PAGE_SIZE} from '../utils/useServerPagedList.js'
 import ServerListFooter from './components/ServerListFooter.vue'

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, nextTick, onMounted, ref, watch} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
 import ServerListFooter from './components/ServerListFooter.vue'

--- a/bootui-ui/src/main/frontend/src/views/Data.vue
+++ b/bootui-ui/src/main/frontend/src/views/Data.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 
 const report = ref(null)

--- a/bootui-ui/src/main/frontend/src/views/DatabaseConnectionsPools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DatabaseConnectionsPools.vue
@@ -2,7 +2,7 @@
 import {apiFetch} from '../api.js'
 import {computed, onBeforeUnmount, ref, watch} from 'vue'
 import {formatNumber, shortName} from '../utils/format.js'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'

--- a/bootui-ui/src/main/frontend/src/views/Dependencies.vue
+++ b/bootui-ui/src/main/frontend/src/views/Dependencies.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import PanelHeader from './components/PanelHeader.vue'

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, onUnmounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 

--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -5,7 +5,7 @@ import HealthNode from './HealthNode.vue'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 
 const root = ref(null)

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.vue
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -2,7 +2,7 @@
 import {apiFetch} from '../api.js'
 import {computed, ref} from 'vue'
 import {panelProps, usePanelState} from '../utils/panelState.js'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 
 const props = defineProps(panelProps)

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
-import {computed, inject, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {computed, inject, ref} from 'vue'
+import {describeLoadError} from '../utils/loadError.js'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'

--- a/bootui-ui/src/main/frontend/src/views/Pentesting.vue
+++ b/bootui-ui/src/main/frontend/src/views/Pentesting.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'

--- a/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
+++ b/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 

--- a/bootui-ui/src/main/frontend/src/views/Scheduled.vue
+++ b/bootui-ui/src/main/frontend/src/views/Scheduled.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 

--- a/bootui-ui/src/main/frontend/src/views/Startup.vue
+++ b/bootui-ui/src/main/frontend/src/views/Startup.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
-import {describeLoadError, formatLoadError} from '../utils/loadError.js'
+import {describeLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
