### PR TITLE
Fix sticky Security sidebar highlight

### DIFF
--- a/bootui-ui/src/main/frontend/src/App.test.js
+++ b/bootui-ui/src/main/frontend/src/App.test.js
@@ -1,0 +1,164 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMemoryHistory, createRouter} from 'vue-router'
+
+import {routes} from './routes.js'
+
+const TestPanel = {template: '<section />'}
+const namedRoutes = routes.filter((route) => route.name && route.meta?.title)
+
+function shellRoutes() {
+  return routes.map((route) => (route.redirect ? route : {...route, component: TestPanel}))
+}
+
+function jsonResponse(body) {
+  return {
+    ok: true,
+    json: () => Promise.resolve(body)
+  }
+}
+
+function mockShellFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url) => {
+      const requestUrl = String(url)
+      if (requestUrl === 'api/overview') {
+        return Promise.resolve(
+          jsonResponse({
+            applicationName: 'bootui-sample',
+            springBootVersion: '4.0.6',
+            javaVersion: '17',
+            activeProfiles: ['dev'],
+            activation: {enabled: true}
+          })
+        )
+      }
+
+      if (requestUrl === 'api/panels') {
+        return Promise.resolve(
+          jsonResponse({
+            panels: namedRoutes.map((route) => ({
+              id: route.name,
+              title: route.meta.title,
+              available: true,
+              enabled: true
+            }))
+          })
+        )
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch URL: ${requestUrl}`))
+    })
+  )
+}
+
+function stubLocalStorage() {
+  const storage = new Map()
+  const localStorageStub = {
+    clear: () => storage.clear(),
+    getItem: (key) => storage.get(key) ?? null,
+    removeItem: (key) => storage.delete(key),
+    setItem: (key, value) => storage.set(key, String(value))
+  }
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: localStorageStub
+  })
+  if (globalThis !== window) {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: localStorageStub
+    })
+  }
+}
+
+function restoreLocalStorage() {
+  Reflect.deleteProperty(window, 'localStorage')
+  if (globalThis !== window) {
+    Reflect.deleteProperty(globalThis, 'localStorage')
+  }
+}
+
+async function mountApp(initialPath = '/overview') {
+  const {default: App} = await import('./App.vue')
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: shellRoutes()
+  })
+
+  await router.push(initialPath)
+  await router.isReady()
+
+  const wrapper = mount(App, {
+    attachTo: document.body,
+    global: {
+      plugins: [router],
+      stubs: {
+        CommandPalette: true,
+        RouterView: {template: '<div />'}
+      }
+    }
+  })
+  await flushPromises()
+
+  return {router, wrapper}
+}
+
+function groupToggle(wrapper, title) {
+  const toggle = wrapper.findAll('.bootui-nav-group__toggle').find((button) => button.text().includes(title))
+  if (!toggle) {
+    throw new Error(`Could not find ${title} navigation group toggle`)
+  }
+  return toggle
+}
+
+describe('App sidebar navigation', () => {
+  beforeEach(() => {
+    stubLocalStorage()
+    mockShellFetch()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    restoreLocalStorage()
+    document.body.innerHTML = ''
+  })
+
+  it('moves the active group away from Security after navigating to another group', async () => {
+    const {router, wrapper} = await mountApp('/spring-security')
+
+    expect(groupToggle(wrapper, 'Security').classes()).toContain('active')
+
+    await router.push('/scheduled')
+    await flushPromises()
+
+    expect(groupToggle(wrapper, 'Security').classes()).not.toContain('active')
+    expect(groupToggle(wrapper, 'Services').classes()).toContain('active')
+  })
+
+  it('releases pointer focus from group toggles after mouse or touch activation', async () => {
+    const {wrapper} = await mountApp()
+    const securityToggle = groupToggle(wrapper, 'Security')
+    securityToggle.element.focus()
+
+    securityToggle.element.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, detail: 1}))
+    await flushPromises()
+
+    expect(securityToggle.attributes('aria-expanded')).toBe('true')
+    expect(document.activeElement).not.toBe(securityToggle.element)
+  })
+
+  it('keeps keyboard focus on group toggles after keyboard activation', async () => {
+    const {wrapper} = await mountApp()
+    const securityToggle = groupToggle(wrapper, 'Security')
+    securityToggle.element.focus()
+
+    securityToggle.element.dispatchEvent(new MouseEvent('click', {bubbles: true, cancelable: true, detail: 0}))
+    await flushPromises()
+
+    expect(securityToggle.attributes('aria-expanded')).toBe('true')
+    expect(document.activeElement).toBe(securityToggle.element)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -275,8 +275,11 @@ function isGroupExpanded(groupKey) {
   return expandedGroups[groupKey] === true
 }
 
-function toggleGroup(groupKey) {
+function toggleGroup(groupKey, event) {
   expandedGroups[groupKey] = !isGroupExpanded(groupKey)
+  if (event?.detail > 0 && event.currentTarget instanceof HTMLElement) {
+    event.currentTarget.blur()
+  }
 }
 
 watch(
@@ -370,7 +373,7 @@ function onGlobalKeydown(e) {
             :title="section.title"
             class="bootui-nav-group__toggle"
             type="button"
-            @click="toggleGroup(section.key)"
+            @click="toggleGroup(section.key, $event)"
           >
             <span class="bootui-nav-group__label">
               <i :class="['bi', section.icon]"></i>


### PR DESCRIPTION
Clicking the Security navigation group could leave the group toggle focused, making it look selected even after moving to another panel. This adjusts group toggle handling to blur only pointer-activated clicks, preserving keyboard focus for accessibility.

## Changes
- Blur mouse/touch-activated navigation group toggles after expanding or collapsing them.
- Keep keyboard activation focus intact for accessible sidebar navigation.
- Add App shell unit coverage for Security active-state transitions and pointer vs keyboard focus behavior.

## Testing
- `cd bootui-ui/src/main/frontend && npm run format:check`
- `cd bootui-ui/src/main/frontend && npm test`
- `./mvnw -B -ntp -pl bootui-sample-app -am install -DskipTests && cd bootui-sample-app/e2e && npm ci --no-audit --no-fund && npx playwright install chromium && npx playwright test tests/app-shell.spec.js`