### PR TITLE
Fix AI Usage telemetry KPIs

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiController.java
@@ -97,6 +97,8 @@ public class AiController {
         List<NormalizedSpan> chats = chatSpansSorted();
         long totalIn = 0;
         long totalOut = 0;
+        long totalDuration = 0;
+        int errorCount = 0;
         Map<String, Long> tokensByModel = new LinkedHashMap<>();
         Map<String, Integer> callsByModel = new LinkedHashMap<>();
         for (NormalizedSpan chat : chats) {
@@ -104,6 +106,10 @@ public class AiController {
             Long out = AiSpanRecognizer.outputTokens(chat);
             totalIn += in == null ? 0 : in;
             totalOut += out == null ? 0 : out;
+            totalDuration += chat.durationNanos();
+            if (chat.isError()) {
+                errorCount++;
+            }
             String model = preferredModel(chat);
             long modelTokens = (in == null ? 0 : in) + (out == null ? 0 : out);
             tokensByModel.merge(model, modelTokens, Long::sum);
@@ -144,6 +150,8 @@ public class AiController {
                 totalOut,
                 topLongEntries(tokensByModel),
                 topIntegerEntries(callsByModel),
+                errorCount,
+                chats.isEmpty() ? 0 : totalDuration / chats.size(),
                 toolCount,
                 vectorCount,
                 embeddingCount,

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiSpanRecognizer.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AiSpanRecognizer.java
@@ -14,7 +14,8 @@ import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
  *   <li>Chat: {@code gen_ai.operation.name=chat} and {@code gen_ai.system=<provider>}.</li>
  *   <li>Embeddings: {@code gen_ai.operation.name=embeddings}.</li>
  *   <li>Tool execution: {@code gen_ai.operation.name=execute_tool} or {@code spring.ai.tool}.</li>
- *   <li>Vector store: {@code db.system=spring_ai_vector_store} or scope contains "vectorstore".</li>
+ *   <li>Vector store/retrieval: {@code spring.ai.kind=vector_store}, {@code gen_ai.operation.name=retrieval},
+ *       {@code db.system=spring_ai_vector_store}, or scope contains "vectorstore".</li>
  * </ul>
  *
  * <p>Spring-AI-specific attributes (such as {@code spring.ai.tool.name}) are kept as
@@ -54,6 +55,14 @@ public final class AiSpanRecognizer {
     }
 
     public static boolean isVectorOperation(NormalizedSpan span) {
+        String springAiKind = stringAttr(span, "spring.ai.kind");
+        if (springAiKind != null && "vector_store".equalsIgnoreCase(springAiKind)) {
+            return true;
+        }
+        String genAiOperation = stringAttr(span, "gen_ai.operation.name");
+        if (genAiOperation != null && "retrieval".equalsIgnoreCase(genAiOperation)) {
+            return true;
+        }
         String dbSystem = stringAttr(span, "db.system");
         if (dbSystem != null && (dbSystem.startsWith("spring_ai") || dbSystem.contains("vector"))) {
             return true;
@@ -141,6 +150,9 @@ public final class AiSpanRecognizer {
     public static String toolName(NormalizedSpan span) {
         String name = stringAttr(span, "gen_ai.tool.name");
         if (name == null) {
+            name = stringAttr(span, "spring.ai.tool.definition.name");
+        }
+        if (name == null) {
             name = stringAttr(span, "spring.ai.tool.name");
         }
         if (name == null && span.name() != null) {
@@ -158,6 +170,9 @@ public final class AiSpanRecognizer {
         if (c == null) {
             c = stringAttr(span, "spring.ai.vectorstore.collection.name");
         }
+        if (c == null) {
+            c = stringAttr(span, "db.namespace");
+        }
         return c;
     }
 
@@ -165,6 +180,9 @@ public final class AiSpanRecognizer {
         String op = stringAttr(span, "db.operation.name");
         if (op == null) {
             op = stringAttr(span, "spring.ai.vectorstore.operation");
+        }
+        if (op == null && isVectorOperation(span)) {
+            op = stringAttr(span, "gen_ai.operation.name");
         }
         return op;
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverEndToEndTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverEndToEndTests.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 
 import com.google.protobuf.ByteString;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
 import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
 import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
@@ -117,6 +118,8 @@ class OtlpReceiverEndToEndTests {
                 .andExpect(jsonPath("$.totalChats").value(1))
                 .andExpect(jsonPath("$.totalInputTokens").value(42))
                 .andExpect(jsonPath("$.totalOutputTokens").value(7))
+                .andExpect(jsonPath("$.errorCount").value(0))
+                .andExpect(jsonPath("$.averageDurationNanos").value(250_000_000))
                 .andExpect(jsonPath("$.toolCallCount").value(1))
                 .andExpect(jsonPath("$.vectorOperationCount").value(1))
                 .andExpect(jsonPath("$.recent[0].requestModel").value("qwen3:0.6b"))
@@ -183,6 +186,37 @@ class OtlpReceiverEndToEndTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalChats").value(1))
                 .andExpect(jsonPath("$.recent.length()").value(0));
+    }
+
+    @Test
+    void aiOverviewAggregatesErrorsAndFrameworkTelemetryBeyondRecentLimit() throws Exception {
+        properties.getAi().setMaxRecentChats(1);
+        for (NormalizedSpan span : decode(mixedFrameworkTelemetryRequest())) {
+            store.add(span);
+        }
+
+        mvc.perform(get("/bootui/api/ai/overview"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalChats").value(2))
+                .andExpect(jsonPath("$.recent.length()").value(1))
+                .andExpect(jsonPath("$.errorCount").value(1))
+                .andExpect(jsonPath("$.averageDurationNanos").value(200_000_000))
+                .andExpect(jsonPath("$.toolCallCount").value(2))
+                .andExpect(jsonPath("$.vectorOperationCount").value(2));
+
+        mvc.perform(get("/bootui/api/ai/chats/aaaaaaaaaaaaaaaa"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.summary.toolCallCount").value(1))
+                .andExpect(jsonPath("$.summary.vectorOperationCount").value(1))
+                .andExpect(jsonPath("$.toolCalls[0].name").value("lookupWeather"))
+                .andExpect(jsonPath("$.vectorOperations[0].operation").value("query"))
+                .andExpect(jsonPath("$.vectorOperations[0].collectionName").value("documents"));
+
+        mvc.perform(get("/bootui/api/ai/chats/bbbbbbbbbbbbbbbb"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.summary.toolCallCount").value(1))
+                .andExpect(jsonPath("$.summary.vectorOperationCount").value(1))
+                .andExpect(jsonPath("$.vectorOperations[0].operation").value("retrieval"));
     }
 
     @Test
@@ -260,6 +294,132 @@ class OtlpReceiverEndToEndTests {
                 .addSpans(chat)
                 .addSpans(tool)
                 .addSpans(vector)
+                .build();
+
+        ResourceSpans resourceSpans = ResourceSpans.newBuilder()
+                .setResource(Resource.newBuilder()
+                        .addAttributes(stringAttr("service.name", "sample"))
+                        .build())
+                .addScopeSpans(scopeSpans)
+                .build();
+
+        return ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(resourceSpans)
+                .build();
+    }
+
+    private ExportTraceServiceRequest mixedFrameworkTelemetryRequest() {
+        long now = System.currentTimeMillis() * 1_000_000L;
+        ByteString springTraceId = ByteString.copyFrom(hexToBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        ByteString langChainTraceId = ByteString.copyFrom(hexToBytes("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"));
+
+        Span springChat = Span.newBuilder()
+                .setTraceId(springTraceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes("aaaaaaaaaaaaaaaa")))
+                .setName("chat spring")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now)
+                .setEndTimeUnixNano(now + 100_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "chat"))
+                .addAttributes(stringAttr("gen_ai.system", "spring_ai"))
+                .addAttributes(stringAttr("gen_ai.request.model", "test-spring-model"))
+                .build();
+
+        Span springTool = Span.newBuilder()
+                .setTraceId(springTraceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes("aaaaaaaaaaaaaaa1")))
+                .setParentSpanId(ByteString.copyFrom(hexToBytes("aaaaaaaaaaaaaaaa")))
+                .setName("spring.ai.tool")
+                .setKind(Span.SpanKind.SPAN_KIND_INTERNAL)
+                .setStartTimeUnixNano(now + 10_000_000L)
+                .setEndTimeUnixNano(now + 20_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "execute_tool"))
+                .addAttributes(stringAttr("gen_ai.system", "spring_ai"))
+                .addAttributes(stringAttr("spring.ai.kind", "tool_call"))
+                .addAttributes(stringAttr("spring.ai.tool.definition.name", "lookupWeather"))
+                .addAttributes(stringAttr("spring.ai.tool.type", "function"))
+                .addAttributes(stringAttr("spring.ai.tool.call.id", "call-1"))
+                .build();
+
+        Span springVector = Span.newBuilder()
+                .setTraceId(springTraceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes("aaaaaaaaaaaaaaa2")))
+                .setParentSpanId(ByteString.copyFrom(hexToBytes("aaaaaaaaaaaaaaaa")))
+                .setName("redis query")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now + 30_000_000L)
+                .setEndTimeUnixNano(now + 40_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("spring.ai.kind", "vector_store"))
+                .addAttributes(stringAttr("db.system", "redis"))
+                .addAttributes(stringAttr("db.operation.name", "query"))
+                .addAttributes(stringAttr("db.collection.name", "documents"))
+                .build();
+
+        Span langChainChat = Span.newBuilder()
+                .setTraceId(langChainTraceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes("bbbbbbbbbbbbbbbb")))
+                .setName("completion gpt-4o-mini")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now + 1_000_000_000L)
+                .setEndTimeUnixNano(now + 1_300_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_ERROR)
+                        .build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "chat"))
+                .addAttributes(stringAttr("gen_ai.provider.name", "openai"))
+                .addAttributes(stringAttr("gen_ai.request.model", "gpt-4o-mini"))
+                .build();
+
+        Span langChainTool = Span.newBuilder()
+                .setTraceId(langChainTraceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes("bbbbbbbbbbbbbbb1")))
+                .setParentSpanId(ByteString.copyFrom(hexToBytes("bbbbbbbbbbbbbbbb")))
+                .setName("langchain4j.tools.getWeather")
+                .setKind(Span.SpanKind.SPAN_KIND_INTERNAL)
+                .setStartTimeUnixNano(now + 1_010_000_000L)
+                .setEndTimeUnixNano(now + 1_020_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "execute_tool"))
+                .addAttributes(stringAttr("gen_ai.tool.name", "getWeather"))
+                .addAttributes(stringAttr("gen_ai.tool.type", "function"))
+                .build();
+
+        Span langChainRetrieval = Span.newBuilder()
+                .setTraceId(langChainTraceId)
+                .setSpanId(ByteString.copyFrom(hexToBytes("bbbbbbbbbbbbbbb2")))
+                .setParentSpanId(ByteString.copyFrom(hexToBytes("bbbbbbbbbbbbbbbb")))
+                .setName("retrieval documents")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now + 1_030_000_000L)
+                .setEndTimeUnixNano(now + 1_050_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "retrieval"))
+                .addAttributes(stringAttr("gen_ai.provider.name", "langchain4j"))
+                .build();
+
+        ScopeSpans scopeSpans = ScopeSpans.newBuilder()
+                .setScope(InstrumentationScope.newBuilder()
+                        .setName("io.micrometer.observation")
+                        .build())
+                .addSpans(springChat)
+                .addSpans(springTool)
+                .addSpans(springVector)
+                .addSpans(langChainChat)
+                .addSpans(langChainTool)
+                .addSpans(langChainRetrieval)
                 .build();
 
         ResourceSpans resourceSpans = ResourceSpans.newBuilder()

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiOverviewDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiOverviewDto.java
@@ -15,6 +15,8 @@ public record AiOverviewDto(
         long totalOutputTokens,
         Map<String, Long> tokensByModel,
         Map<String, Integer> callsByModel,
+        int errorCount,
+        long averageDurationNanos,
         int toolCallCount,
         int vectorOperationCount,
         int embeddingCount,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiToolCallDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiToolCallDto.java
@@ -1,6 +1,6 @@
 package io.github.jdubois.bootui.core.dto;
 
 /**
- * Tool call (function call) emitted by Spring AI advisors.
+ * Tool call emitted by AI framework telemetry.
  */
 public record AiToolCallDto(String spanId, String name, long startEpochNanos, long durationNanos, String statusCode) {}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiVectorOpDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiVectorOpDto.java
@@ -1,7 +1,7 @@
 package io.github.jdubois.bootui.core.dto;
 
 /**
- * Vector store operation linked to the same trace.
+ * Vector store or retrieval operation linked to the same trace.
  */
 public record AiVectorOpDto(
         String spanId,

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -373,17 +373,13 @@ function onChartMouseleave() {
 }
 
 const avgLatency = computed(() => {
-  const recent = overview.value && overview.value.recent
-  if (!recent || recent.length === 0) return null
-  const sum = recent.reduce((s, c) => s + (c.durationNanos || 0), 0)
-  return sum / recent.length
+  if (!overview.value || !overview.value.totalChats) return null
+  return overview.value.averageDurationNanos ?? null
 })
 
 const errorRate = computed(() => {
-  const recent = overview.value && overview.value.recent
-  if (!recent || recent.length === 0) return null
-  const errors = recent.filter((c) => c.statusCode === 'ERROR').length
-  return (errors / recent.length) * 100
+  if (!overview.value || !overview.value.totalChats) return null
+  return ((overview.value.errorCount || 0) / overview.value.totalChats) * 100
 })
 
 const hasAnyData = computed(() => overview.value && overview.value.totalChats > 0)


### PR DESCRIPTION
## What does this PR do?

Fixes the AI Usage KPI row so error rate and average latency come from full retained chat telemetry, and broadens tool/vector recognition for current Spring AI and GenAI telemetry shapes.

## Why is this change needed?

The panel mixed global backend counters with frontend calculations based on the bounded `recent` chat list. That made Error rate (and the neighboring average latency KPI) incorrect when recent chats were limited, and it could report no data even while retained chat telemetry existed.

The recognizer also missed some valid framework spans: Spring AI tool calls expose `spring.ai.tool.definition.name`, Spring AI vector observations can use concrete `db.system` values with `spring.ai.kind=vector_store`, and vendor-neutral GenAI retrieval spans should appear as vector/retrieval operations.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `./mvnw -B -ntp -pl bootui-autoconfigure -am test -Dtest=OtlpReceiverEndToEndTests -Dsurefire.failIfNoSpecifiedTests=false`
- [x] `(cd bootui-ui/src/main/frontend && npm test -- --run && npm run format:check)`
- [x] `./mvnw -B -ntp spotless:check`

## Screenshots (UI changes)

N/A - KPI calculations changed, but there is no visual layout change.

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed