### PR TITLE
Add sample app quick-start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,33 +13,6 @@ UI into the starter so consuming applications do not need Node.js or npm.
 
 ![BootUI overview](docs/images/bootui-overview.png)
 
-## Try the sample app
-
-> **Security warning:** These convenience commands download a script from GitHub, clone this repository, build it, pull
-> Docker images and an Ollama model, and run a Spring Boot app on your machine. Review the script first and run it only
-> in a trusted local development environment.
-
-Prerequisites: Git, Java 17 or later, and Docker or a Docker-compatible engine for the sample app's PostgreSQL, Redis,
-and Ollama services.
-
-macOS / Linux:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.sh | bash
-```
-
-Windows PowerShell:
-
-```powershell
-irm https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.ps1 | iex
-```
-
-The scripts clone into `./boot-ui` unless that directory already exists, build with `-DskipTests`, then start
-`bootui-sample-app` with the `dev` profile. Spring Boot starts PostgreSQL, Redis, and Ollama from
-`bootui-sample-app/compose.yaml`; the first startup also pulls the small `qwen2.5:0.5b` chat model when missing. Open
-<http://localhost:8080/bootui> after startup. If you already cloned the repository, run `./scripts/run-sample.sh` or
-`.\scripts\run-sample.ps1` from its root to reuse that checkout.
-
 ## Features
 
 BootUI exposes these panels in the same grouped order as the application menu. See the
@@ -84,6 +57,33 @@ BootUI exposes these panels in the same grouped order as the application menu. S
 Some panels depend on optional Spring, Actuator, or development infrastructure. When data is unavailable, BootUI returns
 stable empty responses or shows an explanatory empty state. The sidebar also moves unavailable non-overview panels into
 a collapsed Disabled / unavailable group, and opening a dimmed panel shows the unavailable reason at the top of the page.
+
+## Try the sample app
+
+> **Security warning:** These convenience commands download a script from GitHub, clone this repository, build it, pull
+> Docker images and an Ollama model, and run a Spring Boot app on your machine. Review the script first and run it only
+> in a trusted local development environment.
+
+Prerequisites: Git, Java 17 or later, and Docker or a Docker-compatible engine for the sample app's PostgreSQL, Redis,
+and Ollama services.
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.ps1 | iex
+```
+
+The scripts clone into `./boot-ui` unless that directory already exists, build with `-DskipTests`, then start
+`bootui-sample-app` with the `dev` profile. Spring Boot starts PostgreSQL, Redis, and Ollama from
+`bootui-sample-app/compose.yaml`; the first startup also pulls the small `qwen2.5:0.5b` chat model when missing. Open
+<http://localhost:8080/bootui> after startup. If you already cloned the repository, run `./scripts/run-sample.sh` or
+`.\scripts\run-sample.ps1` from its root to reuse that checkout.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,33 @@ UI into the starter so consuming applications do not need Node.js or npm.
 
 ![BootUI overview](docs/images/bootui-overview.png)
 
+## Try the sample app
+
+> **Security warning:** These convenience commands download a script from GitHub, clone this repository, build it, pull
+> Docker images and an Ollama model, and run a Spring Boot app on your machine. Review the script first and run it only
+> in a trusted local development environment.
+
+Prerequisites: Git, Java 17 or later, and Docker or a Docker-compatible engine for the sample app's PostgreSQL, Redis,
+and Ollama services.
+
+macOS / Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.ps1 | iex
+```
+
+The scripts clone into `./boot-ui` unless that directory already exists, build with `-DskipTests`, then start
+`bootui-sample-app` with the `dev` profile. Spring Boot starts PostgreSQL, Redis, and Ollama from
+`bootui-sample-app/compose.yaml`; the first startup also pulls the small `qwen2.5:0.5b` chat model when missing. Open
+<http://localhost:8080/bootui> after startup. If you already cloned the repository, run `./scripts/run-sample.sh` or
+`.\scripts\run-sample.ps1` from its root to reuse that checkout.
+
 ## Features
 
 BootUI exposes these panels in the same grouped order as the application menu. See the

--- a/bootui-sample-app/README.md
+++ b/bootui-sample-app/README.md
@@ -10,8 +10,8 @@ the Playwright suite under `e2e/` exercises.
 - BootUI auto-activating when the `dev` profile is active.
 - A PostgreSQL-backed Spring Data repository so the Spring Data panel has data to
   show.
-- PostgreSQL and Redis Docker Compose services (`compose.yaml`) so the Spring Data,
-  Database Connection Pools, Spring Cache, and Dev Services panels have realistic infrastructure
+- PostgreSQL, Redis, and Ollama Docker Compose services (`compose.yaml`) so the Spring Data,
+  Database Connection Pools, Spring Cache, AI Usage, and Dev Services panels have realistic infrastructure
   to show.
 - Spring Security, scheduled tasks, custom metrics, and a small static welcome
   page so the corresponding BootUI panels are populated.
@@ -21,7 +21,7 @@ the Playwright suite under `e2e/` exercises.
 ## Prerequisites
 
 - Java 17 or later
-- Docker (or any Docker-compatible engine) for the Postgres and Redis containers
+- Docker (or any Docker-compatible engine) for the Postgres, Redis, and Ollama containers
 - The repository's Maven Wrapper (`./mvnw`) — no global Maven install needed
 
 ## Run it
@@ -32,8 +32,8 @@ From the repository root:
 ./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
-Spring Boot will start Docker Compose, wait for Postgres and Redis, and then
-bind the sample app to `http://localhost:8080`.
+Spring Boot will start Docker Compose, wait for Postgres, Redis, and Ollama, pull the small `qwen2.5:0.5b` chat model
+when missing, and then bind the sample app to `http://localhost:8080`.
 
 ## Visit BootUI
 

--- a/scripts/run-sample.ps1
+++ b/scripts/run-sample.ps1
@@ -1,0 +1,62 @@
+$ErrorActionPreference = "Stop"
+
+$RepositoryUrl = if ($env:BOOTUI_REPO_URL) {
+    $env:BOOTUI_REPO_URL
+} else {
+    "https://github.com/jdubois/boot-ui.git"
+}
+
+$TargetDirectory = if ($env:BOOTUI_DIR) {
+    $env:BOOTUI_DIR
+} else {
+    "boot-ui"
+}
+
+function Require-Command {
+    param([Parameter(Mandatory = $true)][string] $Name)
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "'$Name' is required to run the BootUI sample app."
+    }
+}
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)][string] $FilePath,
+        [string[]] $Arguments = @()
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+if ((Test-Path -LiteralPath ".\mvnw.cmd") -and (Test-Path -LiteralPath ".\bootui-sample-app")) {
+    Write-Host "Using existing BootUI checkout at $((Get-Location).Path)."
+} else {
+    Require-Command git
+
+    if (Test-Path -LiteralPath $TargetDirectory) {
+        throw "Target directory '$TargetDirectory' already exists. Run this script from that checkout, remove it, or set BOOTUI_DIR to another path."
+    }
+
+    Write-Host "Cloning BootUI into $TargetDirectory..."
+    Invoke-Native -FilePath "git" -Arguments @("clone", $RepositoryUrl, $TargetDirectory)
+    Set-Location -LiteralPath $TargetDirectory
+}
+
+Require-Command java
+Require-Command docker
+
+Write-Host "Building BootUI with tests skipped..."
+Invoke-Native -FilePath ".\mvnw.cmd" -Arguments @("-B", "-ntp", "install", "-DskipTests")
+
+Write-Host "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
+Write-Host "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
+Invoke-Native -FilePath ".\mvnw.cmd" -Arguments @(
+    "-pl",
+    "bootui-sample-app",
+    "spring-boot:run",
+    "-Dspring-boot.run.profiles=dev"
+)

--- a/scripts/run-sample.sh
+++ b/scripts/run-sample.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${BOOTUI_REPO_URL:-https://github.com/jdubois/boot-ui.git}"
+TARGET_DIR="${BOOTUI_DIR:-boot-ui}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' is required to run the BootUI sample app." >&2
+    exit 1
+  fi
+}
+
+if [[ -x "./mvnw" && -d "bootui-sample-app" ]]; then
+  echo "Using existing BootUI checkout at $(pwd)."
+else
+  require_command git
+
+  if [[ -e "$TARGET_DIR" ]]; then
+    echo "Error: target directory '$TARGET_DIR' already exists." >&2
+    echo "Run this script from that checkout, remove the directory, or set BOOTUI_DIR to another path." >&2
+    exit 1
+  fi
+
+  echo "Cloning BootUI into $TARGET_DIR..."
+  git clone "$REPO_URL" "$TARGET_DIR"
+  cd "$TARGET_DIR"
+fi
+
+require_command java
+require_command docker
+
+echo "Building BootUI with tests skipped..."
+./mvnw -B -ntp install -DskipTests
+
+echo "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
+echo "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
+./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev


### PR DESCRIPTION
## What does this PR do?

Adds cross-platform convenience scripts and README guidance for trying the BootUI sample application from a fresh checkout or an existing repository clone.

## Why is this change needed?

Users should have an easy, copy-pasteable way to install and run the sample app locally while clearly understanding that the flow downloads code, Docker images, and the Ollama model before starting the app.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable (N/A - documentation and scripts only)
- [x] `bash -n scripts/run-sample.sh`
- [x] `git diff --check`

PowerShell syntax parsing was not run because `pwsh` is not installed locally.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed