### PR TITLE
Use shallow clone in sample scripts

### DIFF
--- a/scripts/run-sample.ps1
+++ b/scripts/run-sample.ps1
@@ -42,7 +42,7 @@ if ((Test-Path -LiteralPath ".\mvnw.cmd") -and (Test-Path -LiteralPath ".\bootui
     }
 
     Write-Host "Cloning BootUI into $TargetDirectory..."
-    Invoke-Native -FilePath "git" -Arguments @("clone", $RepositoryUrl, $TargetDirectory)
+    Invoke-Native -FilePath "git" -Arguments @("clone", "--depth", "1", $RepositoryUrl, $TargetDirectory)
     Set-Location -LiteralPath $TargetDirectory
 }
 

--- a/scripts/run-sample.sh
+++ b/scripts/run-sample.sh
@@ -23,7 +23,7 @@ else
   fi
 
   echo "Cloning BootUI into $TARGET_DIR..."
-  git clone "$REPO_URL" "$TARGET_DIR"
+  git clone --depth 1 "$REPO_URL" "$TARGET_DIR"
   cd "$TARGET_DIR"
 fi
 


### PR DESCRIPTION
The sample run scripts only need a working copy to build and launch the sample app, so cloning the full repository history is unnecessary. This switches both the Bash and PowerShell entry points to `git clone --depth 1` to reduce clone time and network usage while preserving the existing repository URL and target directory overrides.

Validation: `bash -n scripts/run-sample.sh`