### PR TITLE
Require formatting checks before commits and PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,10 +47,10 @@ suite through Maven, installs Playwright Chromium, and runs `bootui-sample-app/e
 Java/Kotlin and JavaScript/TypeScript when code scanning is enabled. The release workflow (`.github/workflows/release.yml`)
 publishes `v*` tags to Maven Central through the `release` Maven profile and the Sonatype Central Publishing plugin.
 
-## Formatting before PRs
+## Formatting before commits and PRs
 
-- Before marking a PR ready or creating one, run the formatters for the areas touched by the change; after broad
-  AI-generated edits, run all of them:
+- Before committing, pushing, creating/updating a PR, or marking a PR ready, run the formatters for the areas touched by
+  the change; after broad AI-generated edits, run all of them:
 
 ```bash
 ./mvnw -B -ntp spotless:apply
@@ -58,7 +58,7 @@ publishes `v*` tags to Maven Central through the `release` Maven profile and the
 (cd bootui-sample-app/e2e && npm run format)
 ```
 
-- Validate with the same formatting checks CI uses:
+- Do not commit or create/update a PR until the same formatting checks CI uses pass:
 
 ```bash
 ./mvnw -B -ntp spotless:check


### PR DESCRIPTION
## What does this PR do?

Updates `.github/copilot-instructions.md` so Copilot agents are told to run formatters and CI-equivalent formatting checks before commits, pushes, PR creation, PR updates, or marking a PR ready.

## Why is this change needed?

AI-generated PRs can otherwise reach CI with avoidable formatting failures. Making the requirement explicit in the agent instructions catches those issues before the branch is committed or reviewed.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

`./mvnw -B -ntp spotless:check` passes locally.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed