### PR TITLE
Add worktree dev server scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ target/
 *.ear
 *.log
 hs_err_pid*
+.m2/
 
 # Node / Vue
 node/

--- a/bootui-sample-app/compose.yaml
+++ b/bootui-sample-app/compose.yaml
@@ -14,7 +14,7 @@ services:
   ollama:
     image: ollama/ollama:latest
     ports:
-      - "${BOOTUI_OLLAMA_PORT:-11434}:11434"
+      - "11434"
     healthcheck:
       test: [ "CMD", "ollama", "--version" ]
       interval: 10s

--- a/bootui-sample-app/compose.yaml
+++ b/bootui-sample-app/compose.yaml
@@ -10,11 +10,11 @@ services:
   redis:
     image: redis:8-alpine
     ports:
-      - "6379:6379"
+      - "6379"
   ollama:
     image: ollama/ollama:latest
     ports:
-      - "11434:11434"
+      - "11434"
     healthcheck:
       test: [ "CMD", "ollama", "--version" ]
       interval: 10s

--- a/bootui-sample-app/compose.yaml
+++ b/bootui-sample-app/compose.yaml
@@ -14,7 +14,7 @@ services:
   ollama:
     image: ollama/ollama:latest
     ports:
-      - "11434"
+      - "${BOOTUI_OLLAMA_PORT:-11434}:11434"
     healthcheck:
       test: [ "CMD", "ollama", "--version" ]
       interval: 10s

--- a/bootui-sample-app/src/main/resources/application.properties
+++ b/bootui-sample-app/src/main/resources/application.properties
@@ -2,7 +2,6 @@ spring.application.name=bootui-sample
 server.port=8080
 spring.threads.virtual.enabled=true
 
-spring.ai.ollama.base-url=http://localhost:11434
 spring.ai.ollama.chat.model=qwen2.5:0.5b
 spring.ai.ollama.init.pull-model-strategy=when_missing
 spring.ai.ollama.init.chat.additional-models=qwen2.5:0.5b

--- a/scripts/dev-server.ps1
+++ b/scripts/dev-server.ps1
@@ -1,0 +1,109 @@
+$ErrorActionPreference = "Stop"
+
+function Require-Command {
+    param([Parameter(Mandatory = $true)][string] $Name)
+
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "'$Name' is required to run the BootUI sample app."
+    }
+}
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)][string] $FilePath,
+        [string[]] $Arguments = @()
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+}
+
+function Get-StableHash {
+    param([Parameter(Mandatory = $true)][string] $Value)
+
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes($Value)
+        $hash = $sha256.ComputeHash($bytes)
+        return [BitConverter]::ToUInt32($hash, 0)
+    } finally {
+        $sha256.Dispose()
+    }
+}
+
+function Resolve-Port {
+    param(
+        [Parameter(Mandatory = $true)][string] $Name,
+        [string] $Value,
+        [Parameter(Mandatory = $true)][int] $Default
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $Default
+    }
+
+    [int] $parsed = 0
+    if (-not [int]::TryParse($Value, [ref] $parsed) -or $parsed -lt 1 -or $parsed -gt 65535) {
+        throw "$Name must be a TCP port between 1 and 65535."
+    }
+
+    return $parsed
+}
+
+$ScriptDirectory = Split-Path -Parent $PSCommandPath
+$RootDirectory = (Resolve-Path -LiteralPath (Join-Path $ScriptDirectory "..")).Path
+$MavenWrapper = Join-Path $RootDirectory "mvnw.cmd"
+$SampleAppDirectory = Join-Path $RootDirectory "bootui-sample-app"
+$MavenRepository = if ($env:BOOTUI_MAVEN_REPO) {
+    $env:BOOTUI_MAVEN_REPO
+} else {
+    Join-Path $RootDirectory ".m2\repository"
+}
+
+if (-not (Test-Path -LiteralPath $MavenWrapper) -or -not (Test-Path -LiteralPath $SampleAppDirectory)) {
+    throw "This script must live in the scripts directory of a BootUI checkout."
+}
+
+Require-Command java
+Require-Command docker
+
+$hash = Get-StableHash -Value $RootDirectory
+$AppPort = Resolve-Port -Name "BOOTUI_PORT" -Value $env:BOOTUI_PORT -Default (10000 + ($hash % 10000))
+$ComposeProjectName = if ($env:BOOTUI_COMPOSE_PROJECT_NAME) {
+    $env:BOOTUI_COMPOSE_PROJECT_NAME
+} elseif ($env:COMPOSE_PROJECT_NAME) {
+    $env:COMPOSE_PROJECT_NAME
+} else {
+    "bootui-$hash"
+}
+
+$env:COMPOSE_PROJECT_NAME = $ComposeProjectName
+
+Set-Location -LiteralPath $RootDirectory
+
+Write-Host "Using Maven repository: $MavenRepository"
+Write-Host "Using Docker Compose project: $ComposeProjectName"
+Write-Host "Building BootUI with tests skipped..."
+
+Invoke-Native -FilePath $MavenWrapper -Arguments @(
+    "-B",
+    "-ntp",
+    "-Dmaven.repo.local=$MavenRepository",
+    "-DskipTests",
+    "install"
+)
+
+Write-Host "Starting the BootUI sample app at http://localhost:$AppPort/bootui"
+
+Invoke-Native -FilePath $MavenWrapper -Arguments @(
+    "-B",
+    "-ntp",
+    "-Dmaven.repo.local=$MavenRepository",
+    "-pl",
+    "bootui-sample-app",
+    "spring-boot:run",
+    "-Dspring-boot.run.profiles=dev",
+    "-Dspring-boot.run.arguments=--server.port=$AppPort"
+)

--- a/scripts/dev-server.ps1
+++ b/scripts/dev-server.ps1
@@ -71,7 +71,6 @@ Require-Command docker
 
 $hash = Get-StableHash -Value $RootDirectory
 $AppPort = Resolve-Port -Name "BOOTUI_PORT" -Value $env:BOOTUI_PORT -Default (10000 + ($hash % 10000))
-$OllamaPort = Resolve-Port -Name "BOOTUI_OLLAMA_PORT" -Value $env:BOOTUI_OLLAMA_PORT -Default (30000 + ($hash % 10000))
 $ComposeProjectName = if ($env:BOOTUI_COMPOSE_PROJECT_NAME) {
     $env:BOOTUI_COMPOSE_PROJECT_NAME
 } elseif ($env:COMPOSE_PROJECT_NAME) {
@@ -80,14 +79,12 @@ $ComposeProjectName = if ($env:BOOTUI_COMPOSE_PROJECT_NAME) {
     "bootui-$hash"
 }
 
-$env:BOOTUI_OLLAMA_PORT = [string] $OllamaPort
 $env:COMPOSE_PROJECT_NAME = $ComposeProjectName
 
 Set-Location -LiteralPath $RootDirectory
 
 Write-Host "Using Maven repository: $MavenRepository"
 Write-Host "Using Docker Compose project: $ComposeProjectName"
-Write-Host "Using Ollama port: $OllamaPort"
 Write-Host "Building BootUI with tests skipped..."
 
 Invoke-Native -FilePath $MavenWrapper -Arguments @(
@@ -108,5 +105,5 @@ Invoke-Native -FilePath $MavenWrapper -Arguments @(
     "bootui-sample-app",
     "spring-boot:run",
     "-Dspring-boot.run.profiles=dev",
-    "-Dspring-boot.run.arguments=--server.port=$AppPort --spring.ai.ollama.base-url=http://localhost:$OllamaPort"
+    "-Dspring-boot.run.arguments=--server.port=$AppPort"
 )

--- a/scripts/dev-server.ps1
+++ b/scripts/dev-server.ps1
@@ -71,6 +71,7 @@ Require-Command docker
 
 $hash = Get-StableHash -Value $RootDirectory
 $AppPort = Resolve-Port -Name "BOOTUI_PORT" -Value $env:BOOTUI_PORT -Default (10000 + ($hash % 10000))
+$OllamaPort = Resolve-Port -Name "BOOTUI_OLLAMA_PORT" -Value $env:BOOTUI_OLLAMA_PORT -Default (30000 + ($hash % 10000))
 $ComposeProjectName = if ($env:BOOTUI_COMPOSE_PROJECT_NAME) {
     $env:BOOTUI_COMPOSE_PROJECT_NAME
 } elseif ($env:COMPOSE_PROJECT_NAME) {
@@ -79,12 +80,14 @@ $ComposeProjectName = if ($env:BOOTUI_COMPOSE_PROJECT_NAME) {
     "bootui-$hash"
 }
 
+$env:BOOTUI_OLLAMA_PORT = [string] $OllamaPort
 $env:COMPOSE_PROJECT_NAME = $ComposeProjectName
 
 Set-Location -LiteralPath $RootDirectory
 
 Write-Host "Using Maven repository: $MavenRepository"
 Write-Host "Using Docker Compose project: $ComposeProjectName"
+Write-Host "Using Ollama port: $OllamaPort"
 Write-Host "Building BootUI with tests skipped..."
 
 Invoke-Native -FilePath $MavenWrapper -Arguments @(
@@ -105,5 +108,5 @@ Invoke-Native -FilePath $MavenWrapper -Arguments @(
     "bootui-sample-app",
     "spring-boot:run",
     "-Dspring-boot.run.profiles=dev",
-    "-Dspring-boot.run.arguments=--server.port=$AppPort"
+    "-Dspring-boot.run.arguments=--server.port=$AppPort --spring.ai.ollama.base-url=http://localhost:$OllamaPort"
 )

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -33,16 +33,20 @@ require_command docker
 HASH="$(printf '%s' "$ROOT_DIR" | cksum | awk '{print $1}')"
 
 APP_PORT="${BOOTUI_PORT:-$((10000 + HASH % 10000))}"
+OLLAMA_PORT="${BOOTUI_OLLAMA_PORT:-$((30000 + HASH % 10000))}"
 COMPOSE_PROJECT_NAME="${BOOTUI_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME:-bootui-$HASH}}"
 
 validate_port BOOTUI_PORT "$APP_PORT"
+validate_port BOOTUI_OLLAMA_PORT "$OLLAMA_PORT"
 
+export BOOTUI_OLLAMA_PORT="$OLLAMA_PORT"
 export COMPOSE_PROJECT_NAME
 
 cd "$ROOT_DIR"
 
 echo "Using Maven repository: $MAVEN_REPO"
 echo "Using Docker Compose project: $COMPOSE_PROJECT_NAME"
+echo "Using Ollama port: $BOOTUI_OLLAMA_PORT"
 echo "Building BootUI with tests skipped..."
 
 ./mvnw -B -ntp \
@@ -57,4 +61,4 @@ echo "Starting the BootUI sample app at http://localhost:$APP_PORT/bootui"
   -pl bootui-sample-app \
   spring-boot:run \
   -Dspring-boot.run.profiles=dev \
-  -Dspring-boot.run.arguments="--server.port=$APP_PORT"
+  -Dspring-boot.run.arguments="--server.port=$APP_PORT --spring.ai.ollama.base-url=http://localhost:$OLLAMA_PORT"

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -33,20 +33,16 @@ require_command docker
 HASH="$(printf '%s' "$ROOT_DIR" | cksum | awk '{print $1}')"
 
 APP_PORT="${BOOTUI_PORT:-$((10000 + HASH % 10000))}"
-OLLAMA_PORT="${BOOTUI_OLLAMA_PORT:-$((30000 + HASH % 10000))}"
 COMPOSE_PROJECT_NAME="${BOOTUI_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME:-bootui-$HASH}}"
 
 validate_port BOOTUI_PORT "$APP_PORT"
-validate_port BOOTUI_OLLAMA_PORT "$OLLAMA_PORT"
 
-export BOOTUI_OLLAMA_PORT="$OLLAMA_PORT"
 export COMPOSE_PROJECT_NAME
 
 cd "$ROOT_DIR"
 
 echo "Using Maven repository: $MAVEN_REPO"
 echo "Using Docker Compose project: $COMPOSE_PROJECT_NAME"
-echo "Using Ollama port: $BOOTUI_OLLAMA_PORT"
 echo "Building BootUI with tests skipped..."
 
 ./mvnw -B -ntp \
@@ -61,4 +57,4 @@ echo "Starting the BootUI sample app at http://localhost:$APP_PORT/bootui"
   -pl bootui-sample-app \
   spring-boot:run \
   -Dspring-boot.run.profiles=dev \
-  -Dspring-boot.run.arguments="--server.port=$APP_PORT --spring.ai.ollama.base-url=http://localhost:$OLLAMA_PORT"
+  -Dspring-boot.run.arguments="--server.port=$APP_PORT"

--- a/scripts/dev-server.sh
+++ b/scripts/dev-server.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MAVEN_REPO="${BOOTUI_MAVEN_REPO:-$ROOT_DIR/.m2/repository}"
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' is required to run the BootUI sample app." >&2
+    exit 1
+  fi
+}
+
+validate_port() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]] || ((value < 1 || value > 65535)); then
+    echo "Error: $name must be a TCP port between 1 and 65535." >&2
+    exit 1
+  fi
+}
+
+if [[ ! -x "$ROOT_DIR/mvnw" || ! -d "$ROOT_DIR/bootui-sample-app" ]]; then
+  echo "Error: this script must live in the scripts directory of a BootUI checkout." >&2
+  exit 1
+fi
+
+require_command java
+require_command docker
+
+HASH="$(printf '%s' "$ROOT_DIR" | cksum | awk '{print $1}')"
+
+APP_PORT="${BOOTUI_PORT:-$((10000 + HASH % 10000))}"
+COMPOSE_PROJECT_NAME="${BOOTUI_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME:-bootui-$HASH}}"
+
+validate_port BOOTUI_PORT "$APP_PORT"
+
+export COMPOSE_PROJECT_NAME
+
+cd "$ROOT_DIR"
+
+echo "Using Maven repository: $MAVEN_REPO"
+echo "Using Docker Compose project: $COMPOSE_PROJECT_NAME"
+echo "Building BootUI with tests skipped..."
+
+./mvnw -B -ntp \
+  -Dmaven.repo.local="$MAVEN_REPO" \
+  -DskipTests \
+  install
+
+echo "Starting the BootUI sample app at http://localhost:$APP_PORT/bootui"
+
+./mvnw -B -ntp \
+  -Dmaven.repo.local="$MAVEN_REPO" \
+  -pl bootui-sample-app \
+  spring-boot:run \
+  -Dspring-boot.run.profiles=dev \
+  -Dspring-boot.run.arguments="--server.port=$APP_PORT"


### PR DESCRIPTION
## What does this PR do?

Adds cross-platform dev-server scripts that build and run the BootUI sample app from the current worktree using a worktree-local Maven repository and a stable per-worktree application port.

## Why is this change needed?

Running multiple BootUI worktrees with the default Maven repository and fixed application port can cause SNAPSHOT artifact conflicts and local port collisions. The new scripts isolate Maven artifacts under the checkout and keep each worktree's browser URL stable. PostgreSQL, Redis, and Ollama now all use Docker Compose dynamic host port mapping consistently, with Spring Boot Docker Compose service connections providing the mapped service ports to the app.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable
- [x] `bash -n scripts/dev-server.sh`
- [x] `git diff --check`
- [x] `docker compose -f bootui-sample-app/compose.yaml config --quiet`
- [x] Sample app startup smoke: `./mvnw -pl bootui-sample-app spring-boot:run ... --server.port=19091`, then `GET /bootui/api/overview`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes, or not applicable
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
