### PR TITLE
Standardize panel auto-refresh controls

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/DatabaseConnectionsPools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DatabaseConnectionsPools.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {apiFetch} from '../api.js'
-import {computed, onBeforeUnmount, ref, watch} from 'vue'
+import {computed, ref, watch} from 'vue'
 import {formatNumber, shortName} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
@@ -17,7 +17,6 @@ const error = ref(null)
 const selectedName = ref('')
 const history = ref([])
 const lastUpdated = ref(null)
-let timer = null
 
 const SERIES = [
   {key: 'active', label: 'Active', color: '#dc3545'},
@@ -84,22 +83,32 @@ async function fetchPools() {
     if (!res.ok) throw new Error('HTTP ' + res.status)
     report.value = await res.json()
     lastUpdated.value = Date.now()
-    if (!selectedPool.value && pools.value.length) {
-      selectPool(poolKey(pools.value[0]))
+    if (!pools.value.length) {
+      selectedName.value = ''
+      history.value = []
+      return
     }
+    if (!selectedPool.value) {
+      resetSelectedPool(poolKey(pools.value[0]))
+    }
+    await loadSnapshot()
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load database connection pools')
   }
 }
 
-function selectPool(name) {
-  if (selectedName.value === name) return
+function resetSelectedPool(name) {
   selectedName.value = name
   history.value = []
-  pollSnapshot()
 }
 
-async function pollSnapshot() {
+function selectPool(name) {
+  if (selectedName.value === name) return
+  resetSelectedPool(name)
+  loadSnapshot()
+}
+
+async function loadSnapshot() {
   const pool = selectedPool.value
   if (!endpointAvailable.value || !pool || !pool.available || !pool.poolName) return
   try {
@@ -121,24 +130,6 @@ async function pollSnapshot() {
   }
 }
 
-function stopSnapshotPoll() {
-  if (timer) {
-    clearTimeout(timer)
-    timer = null
-  }
-}
-
-function scheduleNextPoll() {
-  stopSnapshotPoll()
-  if (!endpointAvailable.value) return
-  timer = setTimeout(async () => {
-    if (endpointAvailable.value && autoRefresh.value && document.visibilityState === 'visible') {
-      await pollSnapshot()
-    }
-    scheduleNextPoll()
-  }, 2000)
-}
-
 function formatMillis(value) {
   if (value === null || value === undefined || value < 0) return '—'
   if (value === 0) return 'disabled'
@@ -157,11 +148,9 @@ watch(
   endpointAvailable,
   (available) => {
     if (available) {
-      scheduleNextPoll()
       return
     }
     stopAutoRefresh()
-    stopSnapshotPoll()
     error.value = null
     report.value = null
     selectedName.value = ''
@@ -170,10 +159,6 @@ watch(
   },
   {immediate: true}
 )
-
-onBeforeUnmount(() => {
-  stopSnapshotPoll()
-})
 </script>
 
 <template>
@@ -271,7 +256,7 @@ onBeforeUnmount(() => {
                       {{ series.label }}: {{ formatNumber(currentSnapshot?.[series.key]) }}
                     </span>
                   </div>
-                  <div class="small text-muted mt-2">Sampled every 2 seconds (last 60 points).</div>
+                  <div class="small text-muted mt-2">Sampled on each auto-refresh (last 60 points).</div>
                 </div>
                 <div class="col-md-8">
                   <div class="chart-box">

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -1,14 +1,15 @@
 <script setup>
 import {apiFetch} from '../api.js'
-import {computed, onMounted, onUnmounted, ref} from 'vue'
+import {computed, onUnmounted, ref} from 'vue'
 import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
+import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
 const status = ref(null)
-const loading = ref(true)
 const actionLoading = ref(null)
 const banner = ref(null)
 const restarting = ref(false)
@@ -17,9 +18,9 @@ let reconnectTimer = null
 
 const restartReady = computed(() => status.value?.restartAvailable && !status.value?.restartPending)
 const liveReloadReady = computed(() => status.value?.liveReloadAvailable)
+const autoRefreshEnabled = computed(() => !restarting.value)
 
-async function load() {
-  loading.value = true
+async function fetchStatus() {
   try {
     const res = await apiFetch('api/devtools')
     if (!res.ok) throw new Error('HTTP ' + res.status)
@@ -27,8 +28,6 @@ async function load() {
     lastFetched.value = Date.now()
   } catch (e) {
     flash(formatLoadError(e, 'Could not load DevTools status'), 'danger')
-  } finally {
-    loading.value = false
   }
 }
 
@@ -93,6 +92,7 @@ function pollUntilOnline() {
       const res = await apiFetch('api/devtools', {cache: 'no-store'})
       if (res.ok) {
         status.value = await res.json()
+        lastFetched.value = Date.now()
         restarting.value = false
         flash('Application is available again.', 'success')
         return
@@ -122,7 +122,8 @@ function showReadOnlyMessage() {
   flash(readOnlyReason.value, 'warning')
 }
 
-onMounted(load)
+const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: autoRefreshEnabled})
+
 onUnmounted(clearReconnectTimer)
 </script>
 
@@ -135,7 +136,11 @@ onUnmounted(clearReconnectTimer)
       :loading="loading || restarting"
       :last-fetched="lastFetched"
       @refresh="load"
-    />
+    >
+      <template #actions>
+        <AutoRefreshToggle v-model="autoRefresh" />
+      </template>
+    </PanelHeader>
 
     <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
       <div>

--- a/bootui-ui/src/main/frontend/src/views/Metrics.vue
+++ b/bootui-ui/src/main/frontend/src/views/Metrics.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {apiFetch} from '../api.js'
-import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
+import {computed, ref} from 'vue'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
@@ -18,7 +18,6 @@ const selectedTags = ref([])
 const selectedStatistic = ref('')
 const history = ref([])
 const lastUpdated = ref(null)
-let timer = null
 let loadingDetail = false
 
 const filteredMeters = computed(() => {
@@ -80,13 +79,17 @@ function resetHistory() {
   history.value = []
 }
 
-function selectMeter(name) {
-  if (selectedName.value === name) return
+function resetSelection(name) {
   selectedName.value = name
   selectedTags.value = []
   selectedStatistic.value = ''
   detail.value = null
   resetHistory()
+}
+
+function selectMeter(name) {
+  if (selectedName.value === name) return
+  resetSelection(name)
   loadDetail()
 }
 
@@ -123,10 +126,18 @@ async function fetchMetrics() {
     data.value = await res.json()
     error.value = null
     if (!selectedName.value && data.value.meters.length) {
-      selectMeter(preferredInitialMeter(data.value.meters))
+      resetSelection(preferredInitialMeter(data.value.meters))
     }
+    return true
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load metrics')
+    return false
+  }
+}
+
+async function refreshMetrics() {
+  if (await fetchMetrics()) {
+    await loadDetail()
   }
 }
 
@@ -168,23 +179,7 @@ function appendHistoryPoint() {
   history.value = [...history.value, {timestamp: Date.now(), value: selectedMeasurement.value.value}].slice(-60)
 }
 
-function scheduleNextPoll() {
-  if (timer) clearTimeout(timer)
-  timer = setTimeout(async () => {
-    if (autoRefresh.value && document.visibilityState === 'visible') {
-      await loadDetail()
-    }
-    scheduleNextPoll()
-  }, 2000)
-}
-
-onMounted(scheduleNextPoll)
-
-onBeforeUnmount(() => {
-  if (timer) clearTimeout(timer)
-})
-
-const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh(fetchMetrics)
+const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh(refreshMetrics)
 </script>
 
 <template>
@@ -192,7 +187,7 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
     <PanelHeader
       icon="bi-activity"
       title="Metrics"
-      subtitle="Browse meters, filter tag sets, and watch live values update every 2 seconds."
+      subtitle="Browse meters, filter tag sets, and watch live values update automatically."
       :loading="loading"
       :error="error"
       :last-fetched="lastUpdated ? lastUpdated.getTime() : null"

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -1,9 +1,11 @@
 <script setup>
 import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
+import {computed, ref} from 'vue'
 import {formatDuration, formatTime} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
+import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 
@@ -11,7 +13,6 @@ const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
 const report = ref(null)
 const detail = ref(null)
-const loading = ref(true)
 const error = ref(null)
 const banner = ref(null)
 const filter = ref('')
@@ -20,8 +21,7 @@ const detailLoading = ref(false)
 const busy = ref(false)
 const lastFetched = ref(null)
 
-async function load() {
-  loading.value = true
+async function fetchTraces() {
   error.value = null
   try {
     const res = await apiFetch('api/traces')
@@ -30,8 +30,6 @@ async function load() {
     lastFetched.value = Date.now()
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load traces')
-  } finally {
-    loading.value = false
   }
 }
 
@@ -134,7 +132,7 @@ function shortId(id) {
   return id.length > 8 ? id.substring(0, 8) : id
 }
 
-onMounted(load)
+const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
 </script>
 
 <template>
@@ -148,9 +146,9 @@ onMounted(load)
       :loading="loading"
       :error="error"
       :last-fetched="lastFetched"
-      @refresh="load"
     >
       <template #actions>
+        <AutoRefreshToggle v-model="autoRefresh" />
         <button
           :disabled="!report || readOnly || report.retained === 0 || busy"
           class="btn btn-sm btn-outline-danger"


### PR DESCRIPTION
## What does this PR do?

Refactors Metrics, Database Connection Pools, DevTools, and Traces so panels with periodic refresh behavior consistently use the shared `useAutoRefresh` composable and `AutoRefreshToggle` control.

## Why is this change needed?

Auto-refresh behavior was inconsistent across panels: Metrics and Database Connection Pools had extra custom polling loops, DevTools had only manual refresh plus restart polling, and Traces showed the header refresh icon instead of the shared auto-refresh toggle. This makes the refresh UX coherent while keeping DevTools restart recovery polling as a separate one-off path.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable
- [x] `npm run format:check` passes
- [x] `npm test` passes

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: no docs describe per-panel refresh controls)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed