### PR TITLE
Guard security audit repository classpath

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -205,7 +205,11 @@ public class BootUiAutoConfiguration {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @ConditionalOnClass(name = "org.springframework.boot.actuate.audit.AuditEventRepository")
+    @ConditionalOnClass(
+            name = {
+                "org.springframework.boot.actuate.audit.AuditEventRepository",
+                "org.springframework.security.authentication.event.AbstractAuthenticationEvent"
+            })
     @ConditionalOnProperty(name = "management.auditevents.enabled", havingValue = "true", matchIfMissing = true)
     @ConditionalOnProperty(prefix = "bootui.panels.security-logs", name = "enabled", matchIfMissing = true)
     static class SecurityAuditRepositoryConfiguration {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -332,6 +332,19 @@ class BootUiAutoConfigurationTests {
     }
 
     @Test
+    void missingSpringSecurityCoreDoesNotCreateAuditEventRepository() {
+        new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(BootUiAutoConfiguration.class, AuditAutoConfiguration.class))
+                .withClassLoader(new FilteredClassLoader(
+                        "org.springframework.security.authentication.event.AbstractAuthenticationEvent"))
+                .withPropertyValues("bootui.enabled=ON")
+                .run(context -> {
+                    assertThat(context.getStartupFailure()).isNull();
+                    assertThat(context).doesNotHaveBean(AuditEventRepository.class);
+                });
+    }
+
+    @Test
     void disabledSpringBootAuditEventsDoesNotCreateAuditEventRepository() {
         new WebApplicationContextRunner()
                 .withConfiguration(AutoConfigurations.of(BootUiAutoConfiguration.class, AuditAutoConfiguration.class))


### PR DESCRIPTION
## What does this PR do?

Adds a Spring Security authentication event classpath guard before BootUI contributes its in-memory audit event repository.

## Why is this change needed?

BootUI 0.5.0 can trigger Spring Boot's security audit listeners in applications without `spring-security-core`. Those listeners resolve `AbstractAuthenticationEvent` during web server startup, causing a `TypeNotPresentException` and preventing the host app from starting.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran:

- `./mvnw -B -ntp -pl bootui-autoconfigure test -Dtest=BootUiAutoConfigurationTests`
- `./mvnw -B -ntp -pl bootui-autoconfigure spotless:apply spotless:check`
- `./mvnw -B -ntp -pl bootui-autoconfigure test`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (not needed for this internal startup fix)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed