### PR TITLE
Prepare 0.5.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [0.5.1] - 2026-06-04
+
+Patch release focused on preserving BootUI startup in applications that do not include Spring Security Core while
+keeping Security Logs support available when Spring Security authentication events are present.
+
+### Fixed
+
+- Guarded BootUI's auto-configured Spring Security audit event repository behind Spring Security authentication event
+  classes so applications without `spring-security-core` no longer fail at startup.
+
 ## [0.5.0] - 2026-06-04
 
 Fifth BootUI release, focused on repository context, servlet session inspection, database migration/advisor tooling, and
@@ -293,7 +303,8 @@ First tagged BootUI alpha. Highlights of the harden-all-visible-panels scope:
   request history, distributed tracing, multi-service orchestration, and live
   Docker Compose lifecycle control are intentionally out of scope for the alpha.
 
-[Unreleased]: https://github.com/jdubois/boot-ui/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/jdubois/boot-ui/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/jdubois/boot-ui/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jdubois/boot-ui/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jdubois/boot-ui/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/jdubois/boot-ui/compare/v0.2.0...v0.3.0


### PR DESCRIPTION
## What does this PR do?

Prepares the 0.5.1 changelog entry for the Spring Security audit repository startup fix and updates the release compare links.

## Why is this change needed?

The 0.5.1 release needs release notes documenting that BootUI no longer auto-configures the Spring Security audit event repository unless Spring Security authentication event classes are present, avoiding startup failures in applications without `spring-security-core`.

## How was it tested?

- [x] `git diff --check -- CHANGELOG.md` passes locally
- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable (N/A - changelog-only change)

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no behaviour change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed