### PR TITLE
Set up VuePress GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,8 @@ concurrency:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build:
@@ -29,11 +31,16 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
       - name: Install dependencies
         run: npm ci
 
       - name: Build VuePress site
         run: npm run docs:build
+        env:
+          VUEPRESS_BASE: /boot-ui/
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'
@@ -46,9 +53,6 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ The local development server runs at <http://127.0.0.1:8090>. Before pushing doc
 npm run docs:build
 ```
 
+GitHub Pages is deployed by `.github/workflows/pages.yml` from the `main` branch. In the repository settings, set
+**Pages > Build and deployment > Source** to **GitHub Actions**; the workflow builds VuePress with the `/boot-ui/` base
+path and publishes the site at <https://jdubois.github.io/boot-ui/>.
+
 ## Setup
 
 ### 1) Prerequisites


### PR DESCRIPTION
## What does this PR do?

Configures the VuePress documentation site for GitHub Pages deployment by explicitly running the official Pages setup action and building the site with the `/boot-ui/` base path. It also documents the required repository Pages setting and published URL in the README.

## Why is this change needed?

The newly merged VuePress site needs to be published from GitHub Pages for the `jdubois/boot-ui` repository, where generated assets resolve under `/boot-ui/` instead of the domain root.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Additional validation: `npm ci`, `VUEPRESS_BASE=/boot-ui/ npm run docs:build`, and `git diff --check`.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed