### PR TITLE
Use fast sample app launch command

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,8 +21,10 @@ read those before changing public behavior or visible panel behavior.
 # Backend-only iteration loop (skips the Vue build).
 ./mvnw -pl bootui-core,bootui-autoconfigure,bootui-spring-boot-starter,bootui-sample-app -am install
 
-# Run the sample app (smoke-test path: http://localhost:8080/bootui).
-./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
+# Fastest sample app launch (smoke-test path: http://localhost:8080/bootui).
+./mvnw -o -ntp -pl bootui-sample-app -Dmaven.test.skip=true spring-boot:run -Dspring-boot.run.profiles=dev
+# If offline mode misses a dependency, drop -o once:
+./mvnw -ntp -pl bootui-sample-app -Dmaven.test.skip=true spring-boot:run -Dspring-boot.run.profiles=dev
 
 # Single test class / single test method.
 ./mvnw -pl bootui-core test -Dtest=SecretMaskerTests
@@ -42,32 +44,33 @@ read those before changing public behavior or visible panel behavior.
 ./mvnw -B -ntp -Prelease clean deploy
 ```
 
-### Inner loop: prefer the reactor over `install`, and isolate worktrees
+### Inner loop: launch the sample app fast, and isolate worktrees
 
-When iterating against the sample app, you do **not** need to `install` the other modules into the local Maven
-repository first. Use the reactor with `-am` (also-make) so Maven builds the upstream modules in the *same* invocation
-and resolves them from their `target/` output instead of `~/.m2`:
+For the fastest sample-app launch, run only the sample module and skip test resources/compilation:
 
 ```bash
-# Run the sample app, rebuilding the modules it depends on in one reactor pass (no install step).
-./mvnw -pl bootui-sample-app -am spring-boot:run -Dspring-boot.run.profiles=dev
+./mvnw -o -ntp -pl bootui-sample-app -Dmaven.test.skip=true spring-boot:run -Dspring-boot.run.profiles=dev
+# If offline mode misses a dependency, drop -o once.
+./mvnw -ntp -pl bootui-sample-app -Dmaven.test.skip=true spring-boot:run -Dspring-boot.run.profiles=dev
+```
 
+Do **not** add `-am` to `spring-boot:run`: Maven applies the goal to every selected reactor project, including the
+parent/core/UI modules, and those modules have no main class. Use `-am` for build/test reactor work instead:
+
+```bash
 # Test the sample app the same way.
 ./mvnw -pl bootui-sample-app -am test
 ```
 
-This is faster than separate `install` runs and avoids stale-artifact bugs. Add `-o` (offline), `-T1C` (parallel
-modules), and/or `-DskipTests` to speed up the loop further; skip the `bootui-ui` frontend build when you have not
-touched the Vue app, since the npm build is the slow part regardless.
-
-When working from **multiple git worktrees in parallel**, avoid `install`: every worktree builds the same
-`com.julien-dubois.bootui:*` version, so installing overwrites the others in the shared `~/.m2/repository`. The reactor
-approach above sidesteps this because nothing is written to the local repo between modules. If you still need hard
-isolation, give each worktree its own local repository:
+When working from **multiple git worktrees in parallel**, avoid a shared `install`: every worktree builds the same
+`com.julien-dubois.bootui:*` version, so installing overwrites the others in the shared `~/.m2/repository`. If you need
+to launch the sample app against local upstream module changes, install into an isolated local repository and run from
+that same repo:
 
 ```bash
 # Per-invocation, or set in a per-worktree (git-ignored) .mvn/maven.config file: -Dmaven.repo.local=.m2
-./mvnw -Dmaven.repo.local=.m2 -pl bootui-sample-app -am spring-boot:run
+./mvnw -Dmaven.repo.local=.m2 -ntp -pl bootui-sample-app -am -DskipTests install
+./mvnw -Dmaven.repo.local=.m2 -o -ntp -pl bootui-sample-app -Dmaven.test.skip=true spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
 CI (`.github/workflows/build.yml`) runs `./mvnw -B -ntp clean install` on Java 17, which includes the frontend Vitest

--- a/scripts/run-sample.ps1
+++ b/scripts/run-sample.ps1
@@ -49,14 +49,29 @@ if ((Test-Path -LiteralPath ".\mvnw.cmd") -and (Test-Path -LiteralPath ".\bootui
 Require-Command java
 Require-Command docker
 
-Write-Host "Building BootUI with tests skipped..."
-Invoke-Native -FilePath ".\mvnw.cmd" -Arguments @("-B", "-ntp", "install", "-DskipTests")
-
-Write-Host "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
-Write-Host "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
-Invoke-Native -FilePath ".\mvnw.cmd" -Arguments @(
+$MavenRunArguments = @(
+    "-ntp",
     "-pl",
     "bootui-sample-app",
+    "-Dmaven.test.skip=true",
     "spring-boot:run",
     "-Dspring-boot.run.profiles=dev"
 )
+
+Write-Host "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
+Write-Host "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
+Write-Host "Trying the offline Maven cache first for the fastest startup."
+$OfflineArguments = @("-o") + $MavenRunArguments
+& ".\mvnw.cmd" @OfflineArguments
+$OfflineExitCode = $LASTEXITCODE
+
+if ($OfflineExitCode -eq 0) {
+    exit 0
+}
+
+if (($OfflineExitCode -eq 130) -or ($OfflineExitCode -eq -1073741510)) {
+    exit $OfflineExitCode
+}
+
+Write-Host "Offline launch failed; retrying without -o so Maven can resolve missing artifacts."
+Invoke-Native -FilePath ".\mvnw.cmd" -Arguments $MavenRunArguments

--- a/scripts/run-sample.sh
+++ b/scripts/run-sample.sh
@@ -30,9 +30,30 @@ fi
 require_command java
 require_command docker
 
-echo "Building BootUI with tests skipped..."
-./mvnw -B -ntp install -DskipTests
+MAVEN_RUN_ARGS=(
+  "-ntp"
+  "-pl"
+  "bootui-sample-app"
+  "-Dmaven.test.skip=true"
+  "spring-boot:run"
+  "-Dspring-boot.run.profiles=dev"
+)
 
 echo "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
 echo "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
-./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
+echo "Trying the offline Maven cache first for the fastest startup."
+set +e
+./mvnw -o "${MAVEN_RUN_ARGS[@]}"
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ "$status" -eq 130 || "$status" -eq 143 ]]; then
+  exit "$status"
+fi
+
+echo "Offline launch failed; retrying without -o so Maven can resolve missing artifacts."
+./mvnw "${MAVEN_RUN_ARGS[@]}"


### PR DESCRIPTION
## What does this PR do?

Updates the Copilot instructions and both sample run scripts to use the fast sample-app launch command. The scripts now try Maven offline mode first and retry without `-o` only when the local cache is missing artifacts.

## Why is this change needed?

The previous `-am spring-boot:run` guidance can make Maven run the Spring Boot goal on parent/core/UI modules that have no main class, and the sample scripts did a full `install` before launching. This keeps the default launch path faster and avoids that reactor goal failure.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally (not run; docs/scripts-only change)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (not run; no local server was reachable on port 8080)
- [ ] Added or updated tests where applicable (N/A; no production code changed)
- [x] `bash -n scripts/run-sample.sh`
- [x] `git diff --check -- .github/copilot-instructions.md scripts/run-sample.sh scripts/run-sample.ps1`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A; no product behavior change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed