### PR TITLE
Refactor README for VuePress docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,118 +8,12 @@
 
 BootUI is a **Spring Boot 4 starter** that adds an embedded, local-only developer console to your application.
 
-It is served by the host application at `/bootui/`, uses internal `/bootui/api/**` endpoints, and packages the browser
-UI into the starter so consuming applications do not need Node.js or npm.
+It is served by the host app at `/bootui/`, uses internal `/bootui/api/**` endpoints, and packages the Vue UI into the
+starter so consuming applications do not need Node.js or npm.
 
 ![BootUI overview](docs/images/bootui-overview.png)
 
-## Features
-
-BootUI exposes these panels in the same grouped order as the application menu. See the
-[feature details guide](docs/FEATURES.md) for explanations and screenshots for every panel.
-
-| Group           | Feature                                                                 | What it helps with                                                                                                                                       |
-| --------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Overview        | [Overview](docs/FEATURES.md#overview)                                   | See runtime identity, versions, ports, active profiles, activation reason, and safety state.                                                             |
-| Overview        | [GitHub](docs/FEATURES.md#github)                                       | Inspect the local GitHub origin with one-minute metric drawers for PRs, issues, workflows, quotas, security signals, and Copilot usage.                  |
-| Runtime         | [Health](docs/FEATURES.md#health)                                       | Explore the Actuator health tree and contributor details, with setup guidance when health is unavailable or only defaults are reported.                  |
-| Runtime         | [HTTP Sessions](docs/FEATURES.md#http-sessions)                         | Inspect bounded local Tomcat HTTP sessions, masked attributes, and confirmation-gated clear/destroy actions.                                             |
-| Runtime         | [Metrics](docs/FEATURES.md#metrics)                                     | Browse Micrometer meters, tags, measurements, and a local live chart for selected metrics.                                                               |
-| Runtime         | [Memory](docs/FEATURES.md#memory)                                       | Review live JVM heap, non-heap, and memory pool usage.                                                                                                   |
-| Runtime         | [Tuning Advisor](docs/FEATURES.md#tuning-advisor)                       | Calculate fixed bare-metal JVM options, percentage-based Kubernetes JVM settings, probes, and detected virtual-thread sizing from live JVM context.      |
-| Runtime         | [Heap Dump](docs/FEATURES.md#heap-dump)                                 | Capture local JVM heap dumps on demand and analyze a value-free class histogram of memory usage.                                                         |
-| Runtime         | [Threads](docs/FEATURES.md#threads)                                     | Inspect a live in-process thread snapshot with per-state counts, deadlock detection, virtual-thread context, and a confirmation-gated raw dump download. |
-| Runtime         | [Startup Timeline](docs/FEATURES.md#startup-timeline)                   | Inspect Spring Boot startup steps and durations when startup data is available.                                                                          |
-| Runtime         | [GraalVM](docs/FEATURES.md#graalvm)                                     | Survey the host app for GraalVM native-image readiness and generate a reachability-metadata.json scaffold.                                               |
-| Configuration   | [Configuration](docs/FEATURES.md#configuration)                         | Inspect effective configuration values, metadata, masking, and local runtime overrides.                                                                  |
-| Configuration   | [Profile Diff](docs/FEATURES.md#profile-diff)                           | Compare profile-specific property sources and values while preserving secret masking.                                                                    |
-| Configuration   | [Loggers](docs/FEATURES.md#loggers)                                     | Inspect and change logger levels at runtime through the Actuator loggers endpoint.                                                                       |
-| Configuration   | [Beans](docs/FEATURES.md#beans)                                         | Search Spring beans by name, type, and BootUI classification with server-side paging.                                                                    |
-| Configuration   | [Conditions](docs/FEATURES.md#conditions)                               | Understand why auto-configuration classes matched, did not match, or were unconditional.                                                                 |
-| Configuration   | [Mappings](docs/FEATURES.md#mappings)                                   | Review HTTP routes, handlers, methods, patterns, and produces/consumes metadata.                                                                         |
-| Database        | [Database Connection Pools](docs/FEATURES.md#database-connection-pools) | Watch database pool sizing, masked JDBC metadata, and live active/idle/total/pending saturation.                                                         |
-| Database        | [Spring Data](docs/FEATURES.md#spring-data)                             | Explore Spring Data repositories, domain types, IDs, and query methods.                                                                                  |
-| Database        | [Hibernate Advisor](docs/FEATURES.md#hibernate-advisor)                 | Run curated Hibernate/JPA mapping, configuration, and repository-query checks.                                                                           |
-| Database        | [Flyway](docs/FEATURES.md#flyway)                                       | Inspect Flyway schema migrations, current version, and applied/pending migrations; optionally migrate or clean after confirmation.                       |
-| Database        | [Liquibase](docs/FEATURES.md#liquibase)                                 | Inspect applied/pending Liquibase change sets and optionally apply pending change sets after confirmation.                                               |
-| Security        | [Spring Security](docs/FEATURES.md#spring-security)                     | Inspect Spring Security filter chains and best-effort endpoint rule explanations.                                                                        |
-| Security        | [Security Logs](docs/FEATURES.md#security-logs)                         | Review recent Spring Boot audit/security events from the host repository or BootUI's in-memory default.                                                  |
-| Security        | [Security Advisor](docs/FEATURES.md#security-advisor)                   | Run read-only Spring Security hardening checks against filter chains, security beans, and relevant configuration.                                        |
-| Security        | [Pentesting](docs/FEATURES.md#pentesting)                               | Run explicit host-app OWASP Top 10 2025 hygiene checks without testing BootUI paths or sending exploit payloads.                                         |
-| Security        | [Vulnerabilities](docs/FEATURES.md#vulnerabilities)                     | Review dependency inventory and severity-ordered local OSV vulnerability scan results.                                                                   |
-| Services        | [Scheduled Tasks](docs/FEATURES.md#scheduled-tasks)                     | View registered scheduled tasks and their trigger metadata.                                                                                              |
-| Services        | [Spring Cache](docs/FEATURES.md#spring-cache)                           | Inspect Spring Cache managers, caches, metrics, annotations, and confirmed clear actions.                                                                |
-| Services        | [AI Usage](docs/FEATURES.md#ai-usage)                                   | Summarize Spring AI and LangChain4j chat conversations, token usage, latency, and model details from OpenTelemetry spans.                                |
-| Diagnostics     | [Traces](docs/FEATURES.md#traces)                                       | Inspect local spans captured automatically by the starter, plus OTLP spans from cooperating services.                                                    |
-| Diagnostics     | [Log Tail](docs/FEATURES.md#log-tail)                                   | Read recent application logs and stream new local log events from the running process.                                                                   |
-| Diagnostics     | [HTTP Exchanges](docs/FEATURES.md#http-exchanges)                       | Review recent inbound application requests with masked headers, timings, status, and trace identifiers.                                                  |
-| Diagnostics     | [HTTP Probe](docs/FEATURES.md#http-probe)                               | Send local-only HTTP requests to the app and inspect response status, headers, and body.                                                                 |
-| Diagnostics     | [Architecture](docs/FEATURES.md#architecture)                           | Run a curated, zero-config ArchUnit ruleset against the host app's own classes for architecture hygiene.                                                 |
-| Developer tools | [DevTools](docs/FEATURES.md#devtools)                                   | Check Spring Boot DevTools status, LiveReload availability, and restart controls.                                                                        |
-| Developer tools | [Dev Services](docs/FEATURES.md#dev-services)                           | Inspect Docker Compose snapshots, safe Testcontainers beans, service connection metadata, and bounded logs.                                              |
-| Developer tools | [Copilot](docs/FEATURES.md#copilot)                                     | Dashboard sanitized local GitHub Copilot CLI sessions: activity trends, tool mix, MCP, hooks, skills, errors.                                            |
-| Developer tools | [Claude Code](docs/FEATURES.md#claude-code)                             | Dashboard sanitized local Claude Code project logs: activity trends, tool mix, models, and failures.                                                     |
-
-Some panels depend on optional Spring, Actuator, or development infrastructure. When data is unavailable, BootUI returns
-stable empty responses or shows an explanatory empty state. The sidebar also moves unavailable non-overview panels into
-a collapsed Disabled / unavailable group, and opening a dimmed panel shows the unavailable reason at the top of the page.
-
-## Try the sample app
-
-> **Security warning:** These convenience commands download a script from GitHub, clone this repository, build it, pull
-> Docker images and an Ollama model, and run a Spring Boot app on your machine. Review the script first and run it only
-> in a trusted local development environment.
-
-Prerequisites: Git, Java 17 or later, and Docker or a Docker-compatible engine for the sample app's PostgreSQL, Redis,
-and Ollama services.
-
-macOS / Linux:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.sh | bash
-```
-
-Windows PowerShell:
-
-```powershell
-irm https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.ps1 | iex
-```
-
-The scripts clone into `./boot-ui` unless that directory already exists, build with `-DskipTests`, then start
-`bootui-sample-app` with the `dev` profile. Spring Boot starts PostgreSQL, Redis, and Ollama from
-`bootui-sample-app/compose.yaml`; the first startup also pulls the small `qwen2.5:0.5b` chat model when missing. Open
-<http://localhost:8080/bootui> after startup. If you already cloned the repository, run `./scripts/run-sample.sh` or
-`.\scripts\run-sample.ps1` from its root to reuse that checkout.
-
-## Documentation website
-
-The GitHub Pages website is built with VuePress from the markdown files in `docs/`, so the repository documentation stays
-the source of truth for the published site.
-
-```bash
-npm install
-npm run docs:dev
-```
-
-The local development server runs at <http://127.0.0.1:8090>. Before pushing documentation changes, run:
-
-```bash
-npm run docs:build
-```
-
-GitHub Pages is deployed by `.github/workflows/pages.yml` from the `main` branch. In the repository settings, set
-**Pages > Build and deployment > Source** to **GitHub Actions**; the workflow builds VuePress with the `/boot-ui/` base
-path and publishes the site at <https://jdubois.github.io/boot-ui/>.
-
-## Setup
-
-### 1) Prerequisites
-
-- Java 17 or later
-- Spring Boot 4.x application
-- Maven or your application's Maven Wrapper
-
-### 2) Add the starter dependency
+## Install
 
 ```xml
 <dependency>
@@ -129,125 +23,62 @@ path and publishes the site at <https://jdubois.github.io/boot-ui/>.
 </dependency>
 ```
 
-### 3) Run your app in development mode
+Run your app with a local development profile and open <http://localhost:8080/bootui>:
 
 ```bash
 ./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
 ```
 
-BootUI also activates automatically when `spring-boot-devtools` is on the classpath. To force it on or off:
+BootUI also activates automatically when `spring-boot-devtools` is on the classpath. It stays local by default: dev-only
+activation, loopback-only access, secret masking, read-only controls, and production-profile disablement.
 
-```properties
-bootui.enabled=AUTO
-bootui.enabled=ON
-bootui.enabled=OFF
+## What you get
+
+- Runtime views for health, metrics, memory, threads, heap dumps, startup timing, and JVM tuning.
+- Configuration tools for masked properties, profile diffs, runtime overrides, loggers, beans, conditions, and mappings.
+- Data and service panels for database pools, Spring Data, Hibernate, Flyway, Liquibase, caches, scheduled tasks, and dev
+  services.
+- Diagnostics and security panels for traces, logs, HTTP exchanges, local probes, architecture checks, GraalVM readiness,
+  dependency vulnerabilities, Spring Security, and security advisors.
+- Developer tooling dashboards for DevTools, GitHub, Copilot, and Claude Code local activity.
+
+Some panels depend on optional Spring, Actuator, or development infrastructure. When data is unavailable, BootUI returns
+stable empty responses or shows an actionable empty state.
+
+## Try the sample app
+
+The sample app script clones the repository, builds it, starts PostgreSQL, Redis, and Ollama with Docker Compose, then
+opens the same local BootUI console used by the screenshots.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.sh | bash
 ```
 
-`prod` and `production` profiles disable BootUI unless `bootui.enabled=ON` is set. Invalid `bootui.enabled` values fail
-closed and keep BootUI disabled.
+```powershell
+irm https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.ps1 | iex
+```
 
-### 4) Open BootUI
+Review the scripts before running them in a trusted local development environment.
 
-Visit: <http://localhost:8080/bootui>
+## Documentation
 
-## Configuration and safety
+The public VuePress documentation site is <https://www.julien-dubois.com/boot-ui/>.
 
-BootUI is intended for local development only. By default it:
+| Topic | Link |
+| ----- | ---- |
+| Setup | <https://www.julien-dubois.com/boot-ui/SETUP.html> |
+| Feature tour | <https://www.julien-dubois.com/boot-ui/FEATURES.html> |
+| Configuration properties | <https://www.julien-dubois.com/boot-ui/PROPERTIES.html> |
+| Sample app walkthrough | <https://www.julien-dubois.com/boot-ui/TRY-SAMPLE-APP.html> |
+| Repository and documentation guide | <https://www.julien-dubois.com/boot-ui/REPOSITORY.html> |
+| Product specification | <https://www.julien-dubois.com/boot-ui/SPECIFICATION.html> |
+| Roadmap | <https://www.julien-dubois.com/boot-ui/PLAN.html> |
 
-- activates in `AUTO` mode only for `dev` / `local` profiles or DevTools
-- rejects non-loopback requests
-- permits `/bootui/**` through Spring Security when Spring Security is present, with a startup warning, so the local
-  console remains directly reachable while the loopback-only filter still applies
-- masks secret-like configuration values
-- exposes the local Actuator endpoints used by BootUI panels when BootUI is active
-- captures local application spans for the Traces panel when telemetry and the panel are enabled
-- disables itself for `prod` / `production` profiles
-- stores runtime configuration overrides in `.bootui/application-bootui.properties`, not in your source config files
+## Project resources
 
-Every visible panel can be disabled with `bootui.panels.<panel-id>.enabled=false`. Panels with mutating browser actions
-can also be made read-only with `bootui.panels.<panel-id>.read-only=true`, and `bootui.read-only=true` makes the whole
-BootUI application read-only. See the [property reference](docs/PROPERTIES.md) for the full panel list.
-
-Common properties:
-
-| Property                                 | Default                                 | Description                                                                              |
-| ---------------------------------------- | --------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `bootui.enabled`                         | `AUTO`                                  | `AUTO`, `ON`, or `OFF`.                                                                  |
-| `bootui.enabled-profiles`                | `dev,local`                             | Profiles that activate BootUI in auto mode.                                              |
-| `bootui.disabled-profiles`               | `prod,production`                       | Profiles that disable BootUI unless forced on.                                           |
-| `bootui.allow-non-localhost`             | `false`                                 | Explicit opt-out of loopback-only protection.                                            |
-| `bootui.expose-values`                   | `MASKED`                                | `MASKED`, `METADATA_ONLY`, or `FULL`; `FULL` can disclose secrets and should stay local. |
-| `bootui.read-only`                       | `false`                                 | Disable all browser-triggered actions while keeping read-only panel data visible.        |
-| `bootui.overrides-file`                  | `.bootui/application-bootui.properties` | Runtime override persistence file.                                                       |
-| `bootui.startup.enabled`                 | `true`                                  | Auto-install startup buffering for the Startup Timeline panel while BootUI is active.    |
-| `bootui.startup.capacity`                | `4096`                                  | Maximum startup steps retained by BootUI's auto-installed startup buffer.                |
-| `bootui.cache.clear-enabled`             | `true`                                  | Enables Spring Cache clear actions after explicit browser confirmation.                  |
-| `bootui.http-sessions.max-sessions`      | `50`                                    | Maximum Tomcat HTTP sessions listed by the HTTP Sessions panel.                          |
-| `bootui.http-exchanges.max-exchanges`    | `200`                                   | Maximum recent HTTP exchanges retained in memory for the HTTP Exchanges panel.           |
-| `bootui.security-logs.max-logs`          | `500`                                   | Maximum recent audit events returned by the Security Logs panel.                         |
-| `bootui.dev-services.restart-enabled`    | `false`                                 | Enables restart controls for bean-backed Testcontainers services. Disabled by default.   |
-| `bootui.dev-services.log-tail-bytes`     | `65536`                                 | Maximum bytes returned by one Dev Services log request.                                  |
-| `bootui.telemetry.enabled`               | `true`                                  | Enables local in-memory trace capture and the OTLP receiver used by Traces and AI Usage. |
-| `bootui.copilot.enabled`                 | `AUTO`                                  | Enable the Copilot panel. `AUTO` activates when `~/.copilot/session-state/` exists.      |
-| `bootui.copilot.session-state-dir`       | `~/.copilot/session-state`              | Directory scanned for Copilot CLI session directories and `events.jsonl` files.          |
-| `bootui.copilot.max-sessions`            | `100`                                   | Maximum recent sessions returned by the Copilot session explorer.                        |
-| `bootui.copilot.max-parsed-sessions`     | `100`                                   | Maximum recent Copilot session files parsed and retained in memory.                      |
-| `bootui.copilot.allow-raw-reveal`        | `true`                                  | When `false`, the opt-in raw-event reveal endpoint returns 404 even on loopback.         |
-| `bootui.claude-code.enabled`             | `AUTO`                                  | Enable the Claude Code panel. `AUTO` activates when `~/.claude/projects/` exists.        |
-| `bootui.claude-code.session-state-dir`   | `~/.claude/projects`                    | Directory scanned for Claude Code project JSONL logs.                                    |
-| `bootui.claude-code.max-sessions`        | `100`                                   | Maximum recent sessions returned by the Claude Code session explorer.                    |
-| `bootui.claude-code.max-parsed-sessions` | `100`                                   | Maximum recent Claude Code JSONL files parsed and retained in memory.                    |
-| `bootui.claude-code.allow-raw-reveal`    | `false`                                 | Explicitly enable raw JSONL reveal; raw Claude Code logs can include prompts and output. |
-
-## GraalVM native images
-
-BootUI contributes Spring AOT runtime hints for the starter's own native-image needs. Applications using
-`bootui-spring-boot-starter` do not need to re-declare BootUI-specific hints for the classpath resources BootUI scans at
-runtime, BootUI DTO records serialized by Jackson, or the reflective calls used by the Heap Dump, Security, and
-Pentesting panels.
-
-The [GraalVM panel](docs/FEATURES.md#graalvm) is separate from those built-in hints: it surveys the host application and
-can generate a reviewable `reachability-metadata.json` scaffold for application code. Always validate native-image
-readiness with the GraalVM tracing agent and an actual native build.
-
-## Runtime overrides
-
-The Configuration panel can create, update, and delete local runtime overrides. Overrides are stored in
-`.bootui/application-bootui.properties` by default, loaded at high precedence on the next startup, and never modify your
-application source configuration. Already-bound `@ConfigurationProperties` beans may keep their previous value until the
-app restarts; BootUI returns that warning with every override mutation.
-
-## Troubleshooting
-
-| Symptom                      | Check                                                                                                                                   |
-| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `/bootui` returns 404        | Use the `dev` or `local` profile, add DevTools, or set `bootui.enabled=ON`.                                                             |
-| BootUI is disabled in `prod` | This is intentional; only `bootui.enabled=ON` can force activation with a disabled profile.                                             |
-| Browser is rejected          | BootUI accepts loopback callers by default. Use `bootui.allow-non-localhost=true` only for a trusted local network.                     |
-| Spring Security blocks UI    | BootUI auto-registers a `/bootui/**` permit-all chain when Spring Security is active; check for a custom higher-priority chain.         |
-| A panel is empty             | Enable the relevant Actuator endpoint or optional Spring module; BootUI degrades to stable empty DTOs when data is unavailable.         |
-| Startup Timeline is empty    | Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero, or provide your own `BufferingApplicationStartup`. |
-| Secrets are hidden           | Default exposure is `MASKED`; use `METADATA_ONLY` to hide all values or `FULL` only in trusted local sessions.                          |
-
-## Repository modules
-
-- `bootui-spring-boot-starter`: dependency to add to your app
-- `bootui-autoconfigure`: Spring Boot auto-configuration
-- `bootui-ui`: Vue 3 frontend packaged into the starter
-- `bootui-core`: shared DTOs and core helpers
-- `bootui-sample-app`: demo and integration sample app
-
-## More docs
-
-- [Feature details](docs/FEATURES.md): panel-by-panel guide with screenshots
-- [GraalVM readiness checks](docs/GRAALVM-READINESS-CHECKS.md): native-image scan behavior and generated metadata notes
-- [Property reference](docs/PROPERTIES.md): global, per-panel, and action-gating configuration properties
-- [Sample app walkthrough](bootui-sample-app/README.md): the demo app behind the screenshots and Playwright suite
 - [CHANGELOG.md](CHANGELOG.md): release notes
 - [CONTRIBUTING.md](CONTRIBUTING.md): contributor workflow, build, test, and publishing instructions
 - [SECURITY.md](SECURITY.md): threat model and security policy
-- [docs/SPECIFICATION.md](docs/SPECIFICATION.md): full product and technical specification
-- [docs/PLAN.md](docs/PLAN.md): implementation roadmap
 
 ## License
 

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -4,7 +4,15 @@ import {fileURLToPath} from 'node:url'
 
 const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const hiddenDocs = ['README.md']
-const coreDocs = ['TRY-SAMPLE-APP.md', 'SETUP.md', 'FEATURES.md', 'PROPERTIES.md', 'SPECIFICATION.md', 'PLAN.md']
+const coreDocs = [
+  'TRY-SAMPLE-APP.md',
+  'SETUP.md',
+  'FEATURES.md',
+  'PROPERTIES.md',
+  'REPOSITORY.md',
+  'SPECIFICATION.md',
+  'PLAN.md'
+]
 const checkDocs = [
   'ARCHITECTURE-CHECKS.md',
   'GRAALVM-READINESS-CHECKS.md',

--- a/docs/REPOSITORY.md
+++ b/docs/REPOSITORY.md
@@ -1,0 +1,29 @@
+# Repository and documentation
+
+## Modules
+
+- `bootui-spring-boot-starter`: dependency to add to your app.
+- `bootui-autoconfigure`: Spring Boot auto-configuration, REST controllers, and safety filter.
+- `bootui-ui`: Vue 3 frontend packaged into the starter at `META-INF/resources/bootui/`.
+- `bootui-core`: shared DTOs, secret masking, and core helpers.
+- `bootui-sample-app`: demo and integration sample app used for screenshots and Playwright coverage.
+
+## Documentation website
+
+The public documentation website is <https://www.julien-dubois.com/boot-ui/>. It is built with VuePress from the
+markdown files in `docs/`, so repository documentation stays the source of truth for the published site.
+
+```bash
+npm install
+npm run docs:dev
+```
+
+The local development server runs at <http://127.0.0.1:8090>. Before pushing documentation changes, run:
+
+```bash
+npm run docs:build
+```
+
+GitHub Pages is deployed by `.github/workflows/pages.yml` from the `main` branch. In the repository settings, set
+**Pages > Build and deployment > Source** to **GitHub Actions**. The workflow builds VuePress with the `/boot-ui/` base
+path and publishes the site at <https://www.julien-dubois.com/boot-ui/>.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -36,3 +36,40 @@ closed and keep BootUI disabled.
 ## 4) Open BootUI
 
 Visit: <http://localhost:8080/bootui>
+
+## Safety defaults
+
+BootUI is intended for local development only. By default it:
+
+- Activates in `AUTO` mode only for the `dev` / `local` profiles or DevTools.
+- Rejects non-loopback requests.
+- Permits `/bootui/**` through Spring Security when Spring Security is present, with a startup warning, so the local
+  console remains directly reachable while the loopback-only filter still applies.
+- Masks secret-like configuration values.
+- Exposes the local Actuator endpoints used by BootUI panels when BootUI is active.
+- Captures local application spans for the Traces panel when telemetry and the panel are enabled.
+- Disables itself for `prod` / `production` profiles.
+- Stores runtime configuration overrides in `.bootui/application-bootui.properties`, not in your source config files.
+
+Every visible panel can be disabled with `bootui.panels.<panel-id>.enabled=false`. Panels with mutating browser actions
+can also be made read-only with `bootui.panels.<panel-id>.read-only=true`, and `bootui.read-only=true` makes the whole
+BootUI application read-only. See the [property reference](PROPERTIES.md) for the full panel list.
+
+## Runtime overrides
+
+The Configuration panel can create, update, and delete local runtime overrides. Overrides are stored in
+`.bootui/application-bootui.properties` by default, loaded at high precedence on the next startup, and never modify your
+application source configuration. Already-bound `@ConfigurationProperties` beans may keep their previous value until the
+app restarts; BootUI returns that warning with every override mutation.
+
+## Troubleshooting
+
+| Symptom                      | Check                                                                                                                                   |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `/bootui` returns 404        | Use the `dev` or `local` profile, add DevTools, or set `bootui.enabled=ON`.                                                             |
+| BootUI is disabled in `prod` | This is intentional; only `bootui.enabled=ON` can force activation with a disabled profile.                                             |
+| Browser is rejected          | BootUI accepts loopback callers by default. Use `bootui.allow-non-localhost=true` only for a trusted local network.                     |
+| Spring Security blocks UI    | BootUI auto-registers a `/bootui/**` permit-all chain when Spring Security is active; check for a custom higher-priority chain.         |
+| A panel is empty             | Enable the relevant Actuator endpoint or optional Spring module; BootUI degrades to stable empty DTOs when data is unavailable.         |
+| Startup Timeline is empty    | Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero, or provide your own `BufferingApplicationStartup`. |
+| Secrets are hidden           | Default exposure is `MASKED`; use `METADATA_ONLY` to hide all values or `FULL` only in trusted local sessions.                          |


### PR DESCRIPTION
## What does this PR do?

Refactors the root README into a concise GitHub landing page now that the VuePress docs are published at https://www.julien-dubois.com/boot-ui/.

## Why is this change needed?

The README had grown into long-form documentation that now belongs on the VuePress site. This keeps GitHub entry points short while preserving README-only details in `docs/SETUP.md` and `docs/REPOSITORY.md`.

No linked issue.

## How was it tested?

- [x] `npm run docs:build`
- [x] `./mvnw -B -ntp spotless:check`
- [ ] `./mvnw clean install` passes locally (not run; docs-only change)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (not run; docs-only change)
- [ ] Added or updated tests where applicable (not applicable; docs-only change)

## Screenshots (UI changes)

Not applicable; docs-only change.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
