### PR TITLE
Condense README for docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,77 +8,23 @@
 
 BootUI is a **Spring Boot 4 starter** that adds an embedded, local-only developer console to your application.
 
-It is served by the host app at `/bootui/`, uses internal `/bootui/api/**` endpoints, and packages the Vue UI into the
-starter so consuming applications do not need Node.js or npm.
+Read the documentation at <https://www.julien-dubois.com/boot-ui/>.
 
-![BootUI overview](docs/images/bootui-overview.png)
-
-## Install
-
-```xml
-<dependency>
-  <groupId>com.julien-dubois.bootui</groupId>
-  <artifactId>bootui-spring-boot-starter</artifactId>
-  <version>0.5.1</version>
-</dependency>
-```
-
-Run your app with a local development profile and open <http://localhost:8080/bootui>:
-
-```bash
-./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
-```
-
-BootUI also activates automatically when `spring-boot-devtools` is on the classpath. It stays local by default: dev-only
-activation, loopback-only access, secret masking, read-only controls, and production-profile disablement.
-
-## What you get
-
-- Runtime views for health, metrics, memory, threads, heap dumps, startup timing, and JVM tuning.
-- Configuration tools for masked properties, profile diffs, runtime overrides, loggers, beans, conditions, and mappings.
-- Data and service panels for database pools, Spring Data, Hibernate, Flyway, Liquibase, caches, scheduled tasks, and dev
-  services.
-- Diagnostics and security panels for traces, logs, HTTP exchanges, local probes, architecture checks, GraalVM readiness,
-  dependency vulnerabilities, Spring Security, and security advisors.
-- Developer tooling dashboards for DevTools, GitHub, Copilot, and Claude Code local activity.
-
-Some panels depend on optional Spring, Actuator, or development infrastructure. When data is unavailable, BootUI returns
-stable empty responses or shows an actionable empty state.
-
-## Try the sample app
-
-The sample app script clones the repository, builds it, starts PostgreSQL, Redis, and Ollama with Docker Compose, then
-opens the same local BootUI console used by the screenshots.
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.sh | bash
-```
-
-```powershell
-irm https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.ps1 | iex
-```
-
-Review the scripts before running them in a trusted local development environment.
-
-## Documentation
-
-The public VuePress documentation site is <https://www.julien-dubois.com/boot-ui/>.
+## Quick links
 
 | Topic | Link |
 | ----- | ---- |
 | Setup | <https://www.julien-dubois.com/boot-ui/SETUP.html> |
-| Feature tour | <https://www.julien-dubois.com/boot-ui/FEATURES.html> |
-| Configuration properties | <https://www.julien-dubois.com/boot-ui/PROPERTIES.html> |
-| Sample app walkthrough | <https://www.julien-dubois.com/boot-ui/TRY-SAMPLE-APP.html> |
-| Repository and documentation guide | <https://www.julien-dubois.com/boot-ui/REPOSITORY.html> |
-| Product specification | <https://www.julien-dubois.com/boot-ui/SPECIFICATION.html> |
-| Roadmap | <https://www.julien-dubois.com/boot-ui/PLAN.html> |
+| Features | <https://www.julien-dubois.com/boot-ui/FEATURES.html> |
+| Properties | <https://www.julien-dubois.com/boot-ui/PROPERTIES.html> |
+| Sample app | <https://www.julien-dubois.com/boot-ui/TRY-SAMPLE-APP.html> |
+| Repository docs | <https://www.julien-dubois.com/boot-ui/REPOSITORY.html> |
 
 ## Project resources
 
-- [CHANGELOG.md](CHANGELOG.md): release notes
-- [CONTRIBUTING.md](CONTRIBUTING.md): contributor workflow, build, test, and publishing instructions
-- [SECURITY.md](SECURITY.md): threat model and security policy
+- [CHANGELOG.md](CHANGELOG.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [SECURITY.md](SECURITY.md)
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,3 +25,34 @@ features:
     details: Add one Spring Boot starter dependency and get the bundled Vue UI, REST API, and docs-backed workflow without a separate frontend deployment.
 footer: Apache-2.0 Licensed | BootUI
 ---
+
+![BootUI overview](./images/bootui-overview.png)
+
+## Start here
+
+| Goal | Documentation |
+| ---- | ------------- |
+| Add BootUI to a Spring Boot 4 app | [Setup](SETUP.md) |
+| Explore every panel | [Features](FEATURES.md) |
+| Configure activation, safety, panels, and actions | [Properties](PROPERTIES.md) |
+| Run the full demo locally | [Try the sample app](TRY-SAMPLE-APP.md) |
+| Understand the repository and docs site | [Repository and documentation](REPOSITORY.md) |
+
+## How BootUI works
+
+BootUI is served by the host application at `/bootui/`, uses internal `/bootui/api/**` endpoints, and packages the Vue UI
+into the starter so consuming applications do not need Node.js or npm.
+
+It stays local by default: development-profile activation, loopback-only access, secret masking, read-only controls, and
+production-profile disablement. Some panels depend on optional Spring, Actuator, or development infrastructure. When data
+is unavailable, BootUI returns stable empty responses or shows an actionable empty state.
+
+## What BootUI includes
+
+- Runtime views for health, metrics, memory, threads, heap dumps, startup timing, and JVM tuning.
+- Configuration tools for masked properties, profile diffs, runtime overrides, loggers, beans, conditions, and mappings.
+- Data and service panels for database pools, Spring Data, Hibernate, Flyway, Liquibase, caches, scheduled tasks, and dev
+  services.
+- Diagnostics and security panels for traces, logs, HTTP exchanges, local probes, architecture checks, GraalVM readiness,
+  dependency vulnerabilities, Spring Security, and security advisors.
+- Developer tooling dashboards for DevTools, GitHub, Copilot, and Claude Code local activity.


### PR DESCRIPTION
## What does this PR do?

Further condenses the root README into a compact GitHub entry point and moves the remaining quick-start, feature-summary, and overview screenshot content into the VuePress docs home page.

## Why is this change needed?

The README was still too large after the first refactor. This keeps GitHub visitors focused on the public documentation site at https://www.julien-dubois.com/boot-ui/ while preserving the displaced details in `docs/README.md`.

No linked issue.

## How was it tested?

- [x] `npm run docs:build`
- [x] `./mvnw -B -ntp spotless:check`
- [ ] `./mvnw clean install` passes locally (not run; docs-only change)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (not run; docs-only change)
- [ ] Added or updated tests where applicable (not applicable; docs-only change)

## Screenshots (UI changes)

Not applicable; docs-only change.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
