### PR TITLE
Restore sample scripts UI build

### DIFF
--- a/scripts/run-sample.ps1
+++ b/scripts/run-sample.ps1
@@ -49,29 +49,14 @@ if ((Test-Path -LiteralPath ".\mvnw.cmd") -and (Test-Path -LiteralPath ".\bootui
 Require-Command java
 Require-Command docker
 
-$MavenRunArguments = @(
-    "-ntp",
-    "-pl",
-    "bootui-sample-app",
-    "-Dmaven.test.skip=true",
-    "spring-boot:run",
-    "-Dspring-boot.run.profiles=dev"
-)
+Write-Host "Building BootUI with tests skipped..."
+Invoke-Native -FilePath ".\mvnw.cmd" -Arguments @("-B", "-ntp", "install", "-DskipTests")
 
 Write-Host "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
 Write-Host "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
-Write-Host "Trying the offline Maven cache first for the fastest startup."
-$OfflineArguments = @("-o") + $MavenRunArguments
-& ".\mvnw.cmd" @OfflineArguments
-$OfflineExitCode = $LASTEXITCODE
-
-if ($OfflineExitCode -eq 0) {
-    exit 0
-}
-
-if (($OfflineExitCode -eq 130) -or ($OfflineExitCode -eq -1073741510)) {
-    exit $OfflineExitCode
-}
-
-Write-Host "Offline launch failed; retrying without -o so Maven can resolve missing artifacts."
-Invoke-Native -FilePath ".\mvnw.cmd" -Arguments $MavenRunArguments
+Invoke-Native -FilePath ".\mvnw.cmd" -Arguments @(
+    "-pl",
+    "bootui-sample-app",
+    "spring-boot:run",
+    "-Dspring-boot.run.profiles=dev"
+)

--- a/scripts/run-sample.sh
+++ b/scripts/run-sample.sh
@@ -30,30 +30,9 @@ fi
 require_command java
 require_command docker
 
-MAVEN_RUN_ARGS=(
-  "-ntp"
-  "-pl"
-  "bootui-sample-app"
-  "-Dmaven.test.skip=true"
-  "spring-boot:run"
-  "-Dspring-boot.run.profiles=dev"
-)
+echo "Building BootUI with tests skipped..."
+./mvnw -B -ntp install -DskipTests
 
 echo "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
 echo "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
-echo "Trying the offline Maven cache first for the fastest startup."
-set +e
-./mvnw -o "${MAVEN_RUN_ARGS[@]}"
-status=$?
-set -e
-
-if [[ "$status" -eq 0 ]]; then
-  exit 0
-fi
-
-if [[ "$status" -eq 130 || "$status" -eq 143 ]]; then
-  exit "$status"
-fi
-
-echo "Offline launch failed; retrying without -o so Maven can resolve missing artifacts."
-./mvnw "${MAVEN_RUN_ARGS[@]}"
+./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev


### PR DESCRIPTION
## What does this PR do?

Restores the sample app launcher scripts so they build the full BootUI reactor before starting the sample app.

## Why is this change needed?

The scripts had been changed to run only `bootui-sample-app` in offline mode, which skipped rebuilding and reinstalling the packaged Vue/Vite UI. Building the reactor first ensures `bootui-ui` runs its frontend build and the sample app uses the freshly packaged UI assets.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Verified the restored build command with `./mvnw -B -ntp install -DskipTests`; Maven ran `bootui-ui`, including `npm run build` / `vite build`, copied the frontend build, and installed the rebuilt JAR.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed