### PR TITLE
Redesign VuePress documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Read the documentation at <https://www.julien-dubois.com/boot-ui/>.
 
 | Topic | Link |
 | ----- | ---- |
-| Setup | <https://www.julien-dubois.com/boot-ui/SETUP.html> |
-| Features | <https://www.julien-dubois.com/boot-ui/FEATURES.html> |
-| Properties | <https://www.julien-dubois.com/boot-ui/PROPERTIES.html> |
-| Sample app | <https://www.julien-dubois.com/boot-ui/TRY-SAMPLE-APP.html> |
-| Repository docs | <https://www.julien-dubois.com/boot-ui/REPOSITORY.html> |
+| Setup | <https://www.julien-dubois.com/boot-ui/setup> |
+| Features | <https://www.julien-dubois.com/boot-ui/features> |
+| Properties | <https://www.julien-dubois.com/boot-ui/properties> |
+| Sample app | <https://www.julien-dubois.com/boot-ui/try-sample-app> |
+| Repository docs | <https://www.julien-dubois.com/boot-ui/repository> |
 
 ## Project resources
 

--- a/docs/.vuepress/client.js
+++ b/docs/.vuepress/client.js
@@ -1,6 +1,238 @@
-import {defineClientConfig} from 'vuepress/client'
+import {nextTick, onMounted, onUnmounted, watch} from 'vue'
+import {defineClientConfig, onContentUpdated, useRoute} from 'vuepress/client'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap-icons/font/bootstrap-icons.css'
 import './styles/index.css'
 
-export default defineClientConfig({})
+export default defineClientConfig({
+  setup() {
+    const route = useRoute()
+    let scheduleSidebarSync = () => {}
+    let cleanupSidebarSync = () => {}
+    let refreshSidebarLinkToggles = () => {}
+    let cleanupSidebarLinkToggles = () => {}
+
+    const syncAfterDomUpdate = () => {
+      void nextTick(() => {
+        refreshSidebarLinkToggles()
+        scheduleSidebarSync()
+      })
+    }
+
+    onMounted(() => {
+      const sidebarSync = setupSidebarScrollSync()
+      scheduleSidebarSync = sidebarSync.schedule
+      cleanupSidebarSync = sidebarSync.cleanup
+      const sidebarLinkToggles = setupSidebarLinkToggles(() => scheduleSidebarSync())
+      refreshSidebarLinkToggles = sidebarLinkToggles.refresh
+      cleanupSidebarLinkToggles = sidebarLinkToggles.cleanup
+      refreshSidebarLinkToggles()
+      scheduleSidebarSync()
+    })
+
+    onContentUpdated(syncAfterDomUpdate)
+    watch(() => route.fullPath, syncAfterDomUpdate)
+
+    onUnmounted(() => {
+      cleanupSidebarSync()
+      cleanupSidebarLinkToggles()
+    })
+  }
+})
+
+function setupSidebarLinkToggles(scheduleSidebarSync) {
+  const onClick = (event) => {
+    if (!isPlainLeftClick(event)) {
+      return
+    }
+
+    if (!(event.target instanceof Element)) {
+      return
+    }
+
+    const link = event.target.closest('.vp-sidebar .vp-sidebar-item.auto-link[href]')
+    if (!link || !isCurrentSidebarLink(link)) {
+      return
+    }
+
+    const children = getToggleChildren(link)
+    if (!children) {
+      return
+    }
+
+    event.preventDefault()
+    toggleSidebarLinkChildren(link, children)
+    scheduleSidebarSync()
+  }
+
+  document.addEventListener('click', onClick)
+
+  return {
+    refresh: refreshSidebarLinkToggles,
+    cleanup() {
+      document.removeEventListener('click', onClick)
+    }
+  }
+}
+
+function refreshSidebarLinkToggles() {
+  document.querySelectorAll('.vp-sidebar .vp-sidebar-item.auto-link[href]').forEach((link) => {
+    const children = getToggleChildren(link)
+    link.classList.toggle('bootui-sidebar-link-toggle', Boolean(children))
+
+    if (children) {
+      syncSidebarLinkToggleState(link, children)
+    } else {
+      link.classList.remove('bootui-sidebar-link-toggle--collapsed')
+      link.removeAttribute('aria-expanded')
+    }
+  })
+}
+
+function isPlainLeftClick(event) {
+  return event.button === 0 && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey
+}
+
+function isCurrentSidebarLink(link) {
+  const url = toUrl(link)
+  if (!url || normalizePathname(url.pathname) !== normalizePathname(window.location.pathname)) {
+    return false
+  }
+
+  return !url.hash || url.hash === window.location.hash
+}
+
+function getToggleChildren(link) {
+  const sibling = link.nextElementSibling
+  return sibling?.classList.contains('vp-sidebar-children') ? sibling : null
+}
+
+function toggleSidebarLinkChildren(link, children) {
+  children.hidden = !children.hidden
+  syncSidebarLinkToggleState(link, children)
+}
+
+function syncSidebarLinkToggleState(link, children) {
+  const expanded = !children.hidden
+  link.classList.toggle('bootui-sidebar-link-toggle--collapsed', !expanded)
+  link.setAttribute('aria-expanded', String(expanded))
+}
+
+function setupSidebarScrollSync() {
+  let frame = 0
+
+  const schedule = () => {
+    if (frame) {
+      return
+    }
+
+    frame = window.requestAnimationFrame(() => {
+      frame = 0
+      scrollSidebarToCurrentSection()
+    })
+  }
+
+  const cleanup = () => {
+    window.removeEventListener('scroll', schedule)
+    window.removeEventListener('resize', schedule)
+
+    if (frame) {
+      window.cancelAnimationFrame(frame)
+    }
+  }
+
+  window.addEventListener('scroll', schedule, {passive: true})
+  window.addEventListener('resize', schedule)
+
+  return {schedule, cleanup}
+}
+
+function scrollSidebarToCurrentSection() {
+  const sidebar = document.querySelector('.vp-sidebar')
+  if (!sidebar) {
+    return
+  }
+
+  const target = findCurrentSidebarLink()
+  if (!target) {
+    return
+  }
+
+  keepElementVisible(sidebar, target)
+}
+
+function findCurrentSidebarLink() {
+  const links = Array.from(document.querySelectorAll('.vp-sidebar .vp-sidebar-item.auto-link[href]')).filter(
+    isElementVisible
+  )
+  const currentPath = normalizePathname(window.location.pathname)
+  const pageLinks = []
+  const headingLinks = []
+
+  links.forEach((link) => {
+    const url = toUrl(link)
+    if (!url || normalizePathname(url.pathname) !== currentPath) {
+      return
+    }
+
+    if (url.hash) {
+      headingLinks.push({link, id: decodeHash(url.hash)})
+    } else {
+      pageLinks.push(link)
+    }
+  })
+
+  const headingTargets = headingLinks
+    .map(({link, id}) => ({link, element: document.getElementById(id)}))
+    .filter(({element}) => element)
+  const activeHeading = findActiveHeading(headingTargets)
+
+  return activeHeading?.link ?? pageLinks[0] ?? headingTargets[0]?.link
+}
+
+function findActiveHeading(headingTargets) {
+  const topOffset = getScrollTopOffset()
+  let activeHeading = null
+
+  headingTargets.forEach((headingTarget) => {
+    if (headingTarget.element.getBoundingClientRect().top <= topOffset) {
+      activeHeading = headingTarget
+    }
+  })
+
+  return activeHeading
+}
+
+function getScrollTopOffset() {
+  const navbar = document.querySelector('.vp-navbar')
+  return (navbar?.getBoundingClientRect().height ?? 0) + 32
+}
+
+function keepElementVisible(container, element) {
+  const containerRect = container.getBoundingClientRect()
+  const elementRect = element.getBoundingClientRect()
+  const margin = 56
+
+  if (elementRect.top < containerRect.top + margin) {
+    container.scrollTop += elementRect.top - containerRect.top - margin
+  } else if (elementRect.bottom > containerRect.bottom - margin) {
+    container.scrollTop += elementRect.bottom - containerRect.bottom + margin
+  }
+}
+
+function isElementVisible(element) {
+  return element.getClientRects().length > 0
+}
+
+function toUrl(link) {
+  const href = link.getAttribute('href')
+  return href ? new URL(href, window.location.href) : null
+}
+
+function normalizePathname(pathname) {
+  return pathname.endsWith('/') ? `${pathname}index.html` : pathname
+}
+
+function decodeHash(hash) {
+  return decodeURIComponent(hash.slice(1))
+}

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,9 +1,12 @@
+import path from 'node:path'
 import {viteBundler} from '@vuepress/bundler-vite'
 import {defaultTheme} from '@vuepress/theme-default'
 import {defineUserConfig} from 'vuepress'
+import {toDocLink} from './doc-links.js'
 import {createDocsSidebar} from './sidebar.js'
 
 const siteBase = normalizeBase(process.env.VUEPRESS_BASE || (process.argv.includes('dev') ? '/' : '/boot-ui/'))
+const publicSiteUrl = 'https://www.julien-dubois.com/boot-ui'
 
 export default defineUserConfig({
   base: siteBase,
@@ -17,7 +20,14 @@ export default defineUserConfig({
     ['meta', {property: 'og:description', content: 'A local-only developer console for Spring Boot 4 applications.'}]
   ],
   bundler: viteBundler(),
+  plugins: [cleanDocsPermalinksPlugin()],
   theme: defaultTheme({
+    hostname: 'https://www.julien-dubois.com',
+    themePlugins: {
+      seo: {
+        canonical: toCanonicalUrl
+      }
+    },
     repo: 'jdubois/boot-ui',
     docsRepo: 'https://github.com/jdubois/boot-ui',
     docsBranch: 'main',
@@ -27,12 +37,12 @@ export default defineUserConfig({
     contributors: false,
     logo: null,
     navbar: [
-      {text: 'Try sample app', link: '/TRY-SAMPLE-APP.html'},
-      {text: 'Setup', link: '/SETUP.html'},
-      {text: 'Features', link: '/FEATURES.html'},
-      {text: 'Properties', link: '/PROPERTIES.html'},
-      {text: 'Specification', link: '/SPECIFICATION.html'},
-      {text: 'Roadmap', link: '/PLAN.html'}
+      {text: 'Try sample app', link: toDocLink('TRY-SAMPLE-APP.md')},
+      {text: 'Setup', link: toDocLink('SETUP.md')},
+      {text: 'Features', link: toDocLink('FEATURES.md')},
+      {text: 'Properties', link: toDocLink('PROPERTIES.md')},
+      {text: 'Specification', link: toDocLink('SPECIFICATION.md')},
+      {text: 'Roadmap', link: toDocLink('PLAN.md')}
     ],
     sidebar: createDocsSidebar()
   })
@@ -44,4 +54,39 @@ function normalizeBase(value) {
   }
   const prefixed = value.startsWith('/') ? value : `/${value}`
   return prefixed.endsWith('/') ? prefixed : `${prefixed}/`
+}
+
+function toCanonicalUrl(page) {
+  return page.path === '/' ? `${publicSiteUrl}/` : `${publicSiteUrl}${page.path}`
+}
+
+function cleanDocsPermalinksPlugin() {
+  return {
+    name: 'bootui-clean-docs-permalinks',
+    extendsPageOptions(options, app) {
+      if (!options.filePath) {
+        return
+      }
+
+      const filePathRelative = path.relative(app.dir.source(), options.filePath)
+      if (filePathRelative.startsWith('..') || !filePathRelative.endsWith('.md')) {
+        return
+      }
+
+      options.frontmatter = {
+        permalink: toDocLink(filePathRelative),
+        ...options.frontmatter
+      }
+    },
+    extendsPage(page) {
+      if (!page.filePathRelative?.endsWith('.md')) {
+        return
+      }
+
+      const cleanPath = toDocLink(page.filePathRelative)
+      if (cleanPath !== '/') {
+        page.pathInferred = `${cleanPath}.html`
+      }
+    }
+  }
 }

--- a/docs/.vuepress/doc-links.js
+++ b/docs/.vuepress/doc-links.js
@@ -1,0 +1,16 @@
+const markdownExtension = /\.md$/i
+const readmeFile = 'README.md'
+
+export function toDocLink(file) {
+  const normalized = file.replaceAll('\\', '/')
+
+  if (normalized === readmeFile) {
+    return '/'
+  }
+
+  if (normalized.endsWith(`/${readmeFile}`)) {
+    return `/${normalized.slice(0, -readmeFile.length - 1).toLowerCase()}`
+  }
+
+  return `/${normalized.replace(markdownExtension, '').toLowerCase()}`
+}

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import {fileURLToPath} from 'node:url'
+import {toDocLink} from './doc-links.js'
 
 const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const hiddenDocs = ['README.md']
@@ -17,6 +18,7 @@ const checkDocs = [
   'ARCHITECTURE-CHECKS.md',
   'GRAALVM-READINESS-CHECKS.md',
   'HIBERNATE-CHECKS.md',
+  'SECURITY-ADVISOR-CHECKS.md',
   'PENTEST-CHECKS.md'
 ]
 
@@ -33,16 +35,19 @@ export function createDocsSidebar() {
   return [
     {
       text: 'Project documentation',
+      collapsible: true,
       children: coreDocs.filter((file) => markdownFiles.includes(file)).map(toSidebarItem)
     },
     {
       text: 'Diagnostic checks',
-      children: checkDocs.filter((file) => markdownFiles.includes(file)).map(toSidebarItem)
+      collapsible: true,
+      children: checkDocs.filter((file) => markdownFiles.includes(file)).map(toDiagnosticSidebarItem)
     },
     ...(remainingDocs.length
       ? [
           {
             text: 'Additional docs',
+            collapsible: true,
             children: remainingDocs.map(toSidebarItem)
           }
         ]
@@ -53,7 +58,15 @@ export function createDocsSidebar() {
 function toSidebarItem(file) {
   return {
     text: readTitle(file),
-    link: file === 'README.md' ? '/' : `/${file.replace(/\.md$/, '.html')}`
+    link: toDocLink(file)
+  }
+}
+
+function toDiagnosticSidebarItem(file) {
+  const item = toSidebarItem(file)
+  return {
+    ...item,
+    text: item.text.replace(/\s+checks$/i, '')
   }
 }
 

--- a/docs/.vuepress/styles/index.css
+++ b/docs/.vuepress/styles/index.css
@@ -36,8 +36,10 @@
   --vp-c-text: var(--bootui-text);
   --vp-c-text-mute: var(--bootui-text-muted);
   --vp-c-text-subtle: var(--bootui-text-subtle);
-  --vp-navbar-height: 4.75rem;
-  --vp-sidebar-width: 18rem;
+  --navbar-height: 4.75rem;
+  --sidebar-width: 20rem;
+  --content-width: 52rem;
+  --homepage-width: 76rem;
   --vp-font: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
@@ -274,6 +276,41 @@ body {
   text-transform: uppercase;
 }
 
+.vp-sidebar .vp-sidebar-heading.collapsible {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.vp-sidebar .vp-sidebar-heading .arrow {
+  flex: 0 0 auto;
+  opacity: 0.72;
+}
+
+.vp-sidebar .bootui-sidebar-link-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.vp-sidebar .bootui-sidebar-link-toggle::after {
+  width: 0.5rem;
+  height: 0.5rem;
+  flex: 0 0 auto;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  content: '';
+  opacity: 0.72;
+  transform: rotate(45deg);
+  transition: transform 160ms ease;
+}
+
+.vp-sidebar .bootui-sidebar-link-toggle--collapsed::after {
+  transform: rotate(-45deg);
+}
+
 .vp-sidebar .vp-sidebar-children {
   margin-left: 0.85rem;
   padding-left: 0.5rem;
@@ -347,7 +384,7 @@ body {
 
 .vp-hero {
   order: 1;
-  max-width: 68rem;
+  width: 100%;
   margin-top: 2rem;
   padding: 3rem;
   overflow: hidden;
@@ -413,7 +450,7 @@ body {
 
 .vp-features {
   gap: 1rem;
-  order: 3;
+  order: 2;
 }
 
 .vp-feature {
@@ -551,13 +588,14 @@ body {
 }
 
 .vp-home > [vp-content] > div > p:first-child {
-  order: 2;
+  order: 3;
+  width: 100%;
   margin: 2rem 0 0;
 }
 
 .vp-home > [vp-content] > div > p:first-child img[src*='bootui-overview'] {
-  width: min(100%, 58rem);
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   box-shadow: var(--bootui-shadow-md);
 }
 
@@ -583,6 +621,108 @@ body {
 .vp-page-meta,
 .vp-page-nav {
   border-color: var(--bootui-border);
+}
+
+.vp-page-meta {
+  margin-top: 1.75rem;
+  border: 1px solid var(--bootui-border);
+  border-radius: 1.1rem;
+  background: var(--bootui-surface);
+  box-shadow: var(--bootui-shadow-sm);
+  gap: 0.75rem;
+}
+
+.vp-page-meta .edit-link .label {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: var(--bootui-nav-hover-bg);
+  padding: 0.5rem 0.75rem;
+  color: var(--bootui-nav-hover-color);
+  font-weight: 800;
+}
+
+.vp-page-meta .git-info {
+  color: var(--bootui-text-muted);
+}
+
+.vp-page-meta .meta-item-label {
+  color: var(--bootui-text-subtle);
+  font-weight: 700;
+}
+
+.vp-page-meta .meta-item-info {
+  color: var(--bootui-text-muted);
+  font-weight: 600;
+}
+
+.vp-page-nav {
+  gap: 1rem;
+  margin-top: 1rem;
+  padding: 0;
+  border-top: 0;
+}
+
+.vp-page-nav .auto-link {
+  display: flex;
+  min-width: min(100%, 18rem);
+  flex: 1 1 18rem;
+  flex-direction: column;
+  margin: 0;
+  border: 1px solid var(--bootui-border);
+  border-radius: 1.1rem;
+  background: var(--bootui-surface);
+  padding: 1rem 1.15rem;
+  box-shadow: var(--bootui-shadow-sm);
+  color: var(--bootui-text);
+  transition:
+    border-color 180ms ease,
+    background 180ms ease,
+    box-shadow 180ms ease,
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.vp-page-nav .auto-link:hover {
+  border-color: rgba(25, 135, 84, 0.2);
+  background:
+    linear-gradient(135deg, rgba(25, 135, 84, 0.08), rgba(13, 110, 253, 0.06)),
+    var(--bootui-surface);
+  box-shadow: var(--bootui-shadow-md);
+  color: var(--bootui-text);
+  transform: translateY(-2px);
+}
+
+.vp-page-nav .auto-link .hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.35rem;
+  color: var(--bootui-text-subtle);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.vp-page-nav .auto-link .link {
+  color: var(--bootui-text);
+  font-size: 1.05rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.vp-page-nav .auto-link:hover .link {
+  color: var(--bootui-green-dark);
+}
+
+.vp-page-nav .next {
+  align-items: flex-end;
+}
+
+.vp-page-nav .next .hint {
+  justify-content: flex-end;
 }
 
 .vp-page-title h1 {
@@ -634,6 +774,22 @@ html[data-theme='dark'] [vp-content] code {
   .vp-hero {
     margin-top: 1rem;
     padding: 2rem;
+  }
+}
+
+@media (min-width: 1200px) {
+  :root {
+    --sidebar-width: 22rem;
+    --content-width: 58rem;
+    --homepage-width: 82rem;
+  }
+}
+
+@media (min-width: 1680px) {
+  :root {
+    --sidebar-width: 24rem;
+    --content-width: 64rem;
+    --homepage-width: 90rem;
   }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,10 @@ heroText: BootUI
 tagline: A local-only developer console for Spring Boot 4 applications.
 actions:
   - text: Explore features
-    link: /FEATURES.html
+    link: /features
     type: primary
   - text: View configuration
-    link: /PROPERTIES.html
+    link: /properties
     type: secondary
 features:
   - title: Runtime observability

--- a/docs/SECURITY-ADVISOR-CHECKS.md
+++ b/docs/SECURITY-ADVISOR-CHECKS.md
@@ -1,4 +1,4 @@
-# Security Advisor checks
+# Spring Security Advisor checks
 
 The Security Advisor panel runs a fixed, on-demand ruleset against the host application's Spring Security configuration.
 It introspects the registered `SecurityFilterChain` beans and their filter lists, simulates an anonymous authorization


### PR DESCRIPTION
## What does this PR do?

Redesigns the VuePress documentation site with wider desktop layout, cleaner sidebar interactions, clean lowercase docs URLs, and polished homepage/footer styling.

## Why is this change needed?

The docs site was cramped on wide screens, used uppercase `.html` URLs, and had navigation areas that felt inconsistent with the BootUI visual style. This updates the site so the docs are easier to scan, easier to share, and more consistent with the product UI.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable
- [x] `npm run docs:build` passes locally
- [x] Verified clean VuePress routes, sidebar behavior, homepage alignment, and footer styling in a local docs preview

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed