### PR TITLE
Update Pages workflow for Node 24 actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## What does this PR do?

Updates the GitHub Pages workflow to use `actions/configure-pages@v6`.

## Why is this change needed?

The current `actions/configure-pages@v5` release runs on Node.js 20, which now emits a GitHub Actions deprecation warning. Version 6 declares the Node.js 24 runtime, matching the upcoming default runner behavior.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable
- [x] Confirmed `actions/configure-pages@v6.0.0` declares `runs.using: node24`
- [x] Ran `git diff --check` for the workflow change

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed