### PR TITLE
Update homepage setup CTA

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,8 +7,8 @@ actions:
   - text: Explore features
     link: /features
     type: primary
-  - text: View configuration
-    link: /properties
+  - text: Super easy setup
+    link: /setup
     type: secondary
 features:
   - title: Runtime observability


### PR DESCRIPTION
## What does this PR do?

Updates the VuePress homepage secondary hero action to say "Super easy setup" and link to the setup docs.

## Why is this change needed?

The homepage CTA should send new users directly into the setup flow instead of the property reference.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable
- [x] `npm run docs:build` passes locally

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed