### PR TITLE
Detect proxied Hikari data sources

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HikariController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HikariController.java
@@ -10,7 +10,6 @@ import io.github.jdubois.bootui.core.dto.HikariPoolDto;
 import io.github.jdubois.bootui.core.dto.HikariPoolSnapshotDto;
 import io.github.jdubois.bootui.core.dto.HikariPoolsReport;
 import jakarta.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -62,7 +61,7 @@ public class HikariController {
 
     @GetMapping("/pools")
     public HikariPoolsReport pools() {
-        List<PoolEntry> entries = discover();
+        List<HikariDataSourceDiscovery.PoolEntry> entries = discover();
         List<HikariPoolDto> pools = entries.stream()
                 .map(this::toDto)
                 .sorted(Comparator.comparing(HikariPoolDto::poolName, Comparator.nullsLast(String::compareTo)))
@@ -72,7 +71,7 @@ public class HikariController {
 
     @GetMapping("/pools/{name}/snapshot")
     public ResponseEntity<HikariPoolSnapshotDto> snapshot(@PathVariable String name) {
-        for (PoolEntry entry : discover()) {
+        for (HikariDataSourceDiscovery.PoolEntry entry : discover()) {
             if (matches(entry, name)) {
                 HikariPoolSnapshotDto snapshot = snapshotOf(entry.dataSource());
                 if (snapshot == null) {
@@ -84,26 +83,15 @@ public class HikariController {
         return ResponseEntity.notFound().build();
     }
 
-    private List<PoolEntry> discover() {
+    private List<HikariDataSourceDiscovery.PoolEntry> discover() {
         ListableBeanFactory factory = beanFactoryProvider.getIfAvailable();
         if (factory == null) {
             return List.of();
         }
-        String[] beanNames = factory.getBeanNamesForType(HikariDataSource.class);
-        List<PoolEntry> entries = new ArrayList<>(beanNames.length);
-        for (String beanName : beanNames) {
-            HikariDataSource dataSource;
-            try {
-                dataSource = factory.getBean(beanName, HikariDataSource.class);
-            } catch (Exception ex) {
-                continue;
-            }
-            entries.add(new PoolEntry(strip(beanName), dataSource));
-        }
-        return entries;
+        return HikariDataSourceDiscovery.discover(factory);
     }
 
-    private boolean matches(PoolEntry entry, String name) {
+    private boolean matches(HikariDataSourceDiscovery.PoolEntry entry, String name) {
         if (name == null) {
             return false;
         }
@@ -117,7 +105,7 @@ public class HikariController {
         }
     }
 
-    private HikariPoolDto toDto(PoolEntry entry) {
+    private HikariPoolDto toDto(HikariDataSourceDiscovery.PoolEntry entry) {
         HikariDataSource dataSource = entry.dataSource();
         String poolName = safeString(dataSource::getPoolName);
         String jdbcUrl = maskUrl(safeString(dataSource::getJdbcUrl));
@@ -255,10 +243,4 @@ public class HikariController {
             return false;
         }
     }
-
-    private String strip(String beanName) {
-        return beanName.startsWith("&") ? beanName.substring(1) : beanName;
-    }
-
-    private record PoolEntry(String beanName, HikariDataSource dataSource) {}
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HikariDataSourceDiscovery.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HikariDataSourceDiscovery.java
@@ -1,0 +1,147 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import javax.sql.DataSource;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.util.ClassUtils;
+
+final class HikariDataSourceDiscovery {
+
+    private HikariDataSourceDiscovery() {}
+
+    static boolean hasAny(ListableBeanFactory factory) {
+        return !discover(factory).isEmpty();
+    }
+
+    static List<PoolEntry> discover(ListableBeanFactory factory) {
+        List<PoolEntry> entries = new ArrayList<>();
+        Set<String> seenBeanNames = new HashSet<>();
+        Set<HikariDataSource> seenDataSources = Collections.newSetFromMap(new IdentityHashMap<>());
+        addDirectHikariBeans(factory, entries, seenBeanNames, seenDataSources);
+        addDataSourceBeans(factory, entries, seenBeanNames, seenDataSources);
+        return entries;
+    }
+
+    private static void addDirectHikariBeans(
+            ListableBeanFactory factory,
+            List<PoolEntry> entries,
+            Set<String> seenBeanNames,
+            Set<HikariDataSource> seenDataSources) {
+        for (String beanName : beanNamesForType(factory, HikariDataSource.class)) {
+            HikariDataSource dataSource = bean(factory, beanName, HikariDataSource.class);
+            add(entries, seenBeanNames, seenDataSources, beanName, dataSource);
+        }
+    }
+
+    private static void addDataSourceBeans(
+            ListableBeanFactory factory,
+            List<PoolEntry> entries,
+            Set<String> seenBeanNames,
+            Set<HikariDataSource> seenDataSources) {
+        for (String beanName : beanNamesForType(factory, DataSource.class)) {
+            DataSource dataSource = bean(factory, beanName, DataSource.class);
+            if (dataSource == null) {
+                continue;
+            }
+            add(entries, seenBeanNames, seenDataSources, beanName, hikariTarget(dataSource));
+        }
+    }
+
+    private static <T> T bean(ListableBeanFactory factory, String beanName, Class<T> type) {
+        try {
+            return factory.getBean(beanName, type);
+        } catch (BeansException ex) {
+            return null;
+        }
+    }
+
+    private static HikariDataSource hikariTarget(DataSource dataSource) {
+        if (dataSource instanceof HikariDataSource hikariDataSource) {
+            return hikariDataSource;
+        }
+        HikariDataSource advisedTarget = advisedTarget(dataSource);
+        if (advisedTarget != null) {
+            return advisedTarget;
+        }
+        return wrapperTarget(dataSource);
+    }
+
+    private static HikariDataSource advisedTarget(DataSource dataSource) {
+        ClassLoader classLoader = HikariDataSourceDiscovery.class.getClassLoader();
+        if (!ClassUtils.isPresent("org.springframework.aop.framework.Advised", classLoader)) {
+            return null;
+        }
+        try {
+            Class<?> advisedType = ClassUtils.forName("org.springframework.aop.framework.Advised", classLoader);
+            if (!advisedType.isInstance(dataSource)) {
+                return null;
+            }
+            Object targetSource = advisedType.getMethod("getTargetSource").invoke(dataSource);
+            if (targetSource == null) {
+                return null;
+            }
+            Class<?> targetSourceType = ClassUtils.forName("org.springframework.aop.TargetSource", classLoader);
+            Object target = targetSourceType.getMethod("getTarget").invoke(targetSource);
+            if (target == dataSource || !(target instanceof DataSource targetDataSource)) {
+                return null;
+            }
+            return hikariTarget(targetDataSource);
+        } catch (ReflectiveOperationException | LinkageError | RuntimeException ex) {
+            return null;
+        }
+    }
+
+    private static HikariDataSource wrapperTarget(DataSource dataSource) {
+        try {
+            if (dataSource.isWrapperFor(HikariDataSource.class)) {
+                return dataSource.unwrap(HikariDataSource.class);
+            }
+        } catch (SQLException ex) {
+            // Try unwrap below; some proxies only implement one side of Wrapper.
+        }
+        try {
+            return dataSource.unwrap(HikariDataSource.class);
+        } catch (SQLException ex) {
+            return null;
+        }
+    }
+
+    private static void add(
+            List<PoolEntry> entries,
+            Set<String> seenBeanNames,
+            Set<HikariDataSource> seenDataSources,
+            String beanName,
+            HikariDataSource dataSource) {
+        if (dataSource == null) {
+            return;
+        }
+        String normalizedBeanName = strip(beanName);
+        if (!seenBeanNames.add(normalizedBeanName) || !seenDataSources.add(dataSource)) {
+            return;
+        }
+        entries.add(new PoolEntry(normalizedBeanName, dataSource));
+    }
+
+    private static String[] beanNamesForType(ListableBeanFactory factory, Class<?> type) {
+        try {
+            String[] beanNames = factory.getBeanNamesForType(type);
+            return beanNames == null ? new String[0] : beanNames;
+        } catch (BeansException ex) {
+            return new String[0];
+        }
+    }
+
+    private static String strip(String beanName) {
+        return beanName.startsWith("&") ? beanName.substring(1) : beanName;
+    }
+
+    record PoolEntry(String beanName, HikariDataSource dataSource) {}
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PanelsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PanelsController.java
@@ -235,17 +235,8 @@ public class PanelsController {
     }
 
     private boolean hikariAvailable() {
-        return classPresent("com.zaxxer.hikari.HikariDataSource") && hikariDataSourceBeanPresent();
-    }
-
-    private boolean hikariDataSourceBeanPresent() {
-        try {
-            Class<?> type = ClassUtils.forName(
-                    "com.zaxxer.hikari.HikariDataSource", getClass().getClassLoader());
-            return beanPresent(type);
-        } catch (ClassNotFoundException ex) {
-            return false;
-        }
+        return classPresent("com.zaxxer.hikari.HikariDataSource")
+                && HikariDataSourceDiscovery.hasAny(applicationContext);
     }
 
     private String hikariUnavailableReason() {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HikariControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HikariControllerTests.java
@@ -11,7 +11,9 @@ import com.zaxxer.hikari.HikariDataSource;
 import com.zaxxer.hikari.HikariPoolMXBean;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties.ValueExposure;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.test.web.servlet.MockMvc;
@@ -44,6 +46,14 @@ class HikariControllerTests {
         return factory;
     }
 
+    private static ListableBeanFactory beanFactoryWithProxiedDataSource(String beanName, DataSource dataSource) {
+        ListableBeanFactory factory = mock(ListableBeanFactory.class);
+        when(factory.getBeanNamesForType(HikariDataSource.class)).thenReturn(new String[0]);
+        when(factory.getBeanNamesForType(DataSource.class)).thenReturn(new String[] {beanName});
+        when(factory.getBean(beanName, DataSource.class)).thenReturn(dataSource);
+        return factory;
+    }
+
     private static HikariDataSource runningDataSource() {
         HikariDataSource dataSource = mock(HikariDataSource.class);
         when(dataSource.getPoolName()).thenReturn("HikariPool-1");
@@ -69,6 +79,13 @@ class HikariControllerTests {
         return dataSource;
     }
 
+    private static DataSource proxyFor(HikariDataSource target) {
+        ProxyFactory proxyFactory = new ProxyFactory();
+        proxyFactory.setInterfaces(DataSource.class);
+        proxyFactory.setTarget(target);
+        return (DataSource) proxyFactory.getProxy();
+    }
+
     @Test
     void poolsReturnsMaskedMetadataAndSnapshot() throws Exception {
         ListableBeanFactory factory = beanFactoryWith("dataSource", runningDataSource());
@@ -91,6 +108,27 @@ class HikariControllerTests {
                 .andExpect(jsonPath("$.pools[0].snapshot.idle").value(2))
                 .andExpect(jsonPath("$.pools[0].snapshot.total").value(5))
                 .andExpect(jsonPath("$.pools[0].snapshot.pending").value(1));
+    }
+
+    @Test
+    void poolsDiscoverWrappedHikariDataSourceProxy() throws Exception {
+        HikariDataSource target = runningDataSource();
+        ListableBeanFactory factory = beanFactoryWithProxiedDataSource("dataSource", proxyFor(target));
+        MockMvc mvc = standaloneSetup(new HikariController(provider(factory), new BootUiProperties()))
+                .build();
+
+        mvc.perform(get("/bootui/api/database-connection-pools/pools"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hikariPresent").value(true))
+                .andExpect(jsonPath("$.total").value(1))
+                .andExpect(jsonPath("$.pools[0].beanName").value("dataSource"))
+                .andExpect(jsonPath("$.pools[0].poolName").value("HikariPool-1"))
+                .andExpect(jsonPath("$.pools[0].available").value(true))
+                .andExpect(jsonPath("$.pools[0].snapshot.active").value(3));
+
+        mvc.perform(get("/bootui/api/database-connection-pools/pools/HikariPool-1/snapshot"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.active").value(3));
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
@@ -1,16 +1,20 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
+import com.zaxxer.hikari.HikariDataSource;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.panel.BootUiPanels;
 import io.github.jdubois.bootui.core.dto.PanelDto;
 import java.util.List;
+import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -159,6 +163,28 @@ class PanelsControllerTests {
                             .value(false))
                     .andExpect(jsonPath(panelPath(BootUiPanels.LIQUIBASE) + ".unavailableReason")
                             .value("No Liquibase beans are available"));
+        }
+    }
+
+    @Test
+    void panelsMarksDatabaseConnectionPoolsAvailableForProxiedHikariDataSource() throws Exception {
+        HikariDataSource target = mock(HikariDataSource.class);
+        ProxyFactory proxyFactory = new ProxyFactory();
+        proxyFactory.setInterfaces(DataSource.class);
+        proxyFactory.setTarget(target);
+        DataSource proxy = (DataSource) proxyFactory.getProxy();
+
+        try (GenericApplicationContext context = new GenericApplicationContext()) {
+            context.registerBean("dataSource", DataSource.class, () -> proxy);
+            context.refresh();
+            MockMvc mvc = standaloneSetup(
+                            new PanelsController(context, context.getEnvironment(), new BootUiProperties()))
+                    .build();
+
+            mvc.perform(get("/bootui/api/panels"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath(panelPath(BootUiPanels.DATABASE_CONNECTION_POOLS) + ".available")
+                            .value(true));
         }
     }
 


### PR DESCRIPTION
DataSource proxy libraries can hide `HikariDataSource` from Spring bean type lookups, which disabled the Database Connection Pools panel and left the pools API empty even when the target pool was Hikari.

This adds shared Hikari discovery for direct Hikari beans, Spring AOP proxy targets, and JDBC `Wrapper` unwraps. `PanelsController` and `HikariController` now use the same discovery path so panel availability and API results stay in sync.

Tests:
- `./mvnw -ntp -pl bootui-autoconfigure test -Dtest=HikariControllerTests,PanelsControllerTests`
- `./mvnw -ntp -pl bootui-autoconfigure spotless:check`

Fixes: #230