### PR TITLE
Prepare 1.0.0 release docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Release version to prepare, for example 0.2.0. Leave empty to publish the selected tagged ref.
+        description: Release version to prepare, for example 1.0.0. Leave empty to publish the selected tagged ref.
         required: false
         type: string
         default: ''
@@ -104,14 +104,14 @@ jobs:
             -DgenerateBackupPoms=false
 
           export CURRENT_VERSION VERSION
-          perl -0pi -e 's{(<artifactId>bootui-spring-boot-starter</artifactId>\s*<version>)\Q$ENV{CURRENT_VERSION}\E(</version>)}{$1$ENV{VERSION}$2}g' README.md
+          perl -0pi -e 's{(<artifactId>bootui-spring-boot-starter</artifactId>\s*<version>)\Q$ENV{CURRENT_VERSION}\E(</version>)}{$1$ENV{VERSION}$2}g' README.md docs/SETUP.md
 
           if [[ "$SKIP_BUILD" != "true" ]]; then
             ./mvnw -B -ntp -Prelease clean verify -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
           fi
 
           if [[ -n "$(git status --porcelain)" ]]; then
-            git add pom.xml */pom.xml README.md
+            git add pom.xml */pom.xml README.md docs/SETUP.md
             git commit -m "Release $TAG"
           else
             echo "Project files already declare version $VERSION; tagging current HEAD."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [1.0.0] - 2026-06-05
+
+First stable BootUI release, focused on promoting the current local developer-console surface to `1.0.0`, adding the
+Spring Security Advisor, and publishing the redesigned documentation site.
+
+### Added
+
+- Security Advisor panel with explicit Spring Security hardening checks for authentication, authorization, CSRF, sessions,
+  headers, CORS, method security, actuator exposure, OAuth2 resource-server validation, and security configuration hygiene,
+  plus the `docs/SECURITY-ADVISOR-CHECKS.md` rule catalogue.
+- Overview security & health scoring dashboard that can run the available Architecture, Hibernate Advisor, Security
+  Advisor, Vulnerabilities, Pentesting, and GitHub scanners individually or together.
+- VuePress documentation site, GitHub Pages workflow, repository documentation, and setup/sample-app pages for the public
+  docs at `julien-dubois.com/boot-ui`.
+
+### Changed
+
+- Copilot and Claude Code dashboards now emphasize input/output token usage charts while retaining event and failure
+  views for sanitized local agent activity.
+- Refreshed release-facing screenshots for the 1.0 surface, including Overview, Security Advisor, Copilot, and Claude Code,
+  and verified the screenshot set against the routed panel list.
+- Updated the implementation roadmap so completed 1.0 work is separated from the next workstream for trace/log/request
+  correlation, bean graph visualization, and an e-mail viewer.
+
+### Fixed
+
+- Detected proxied Hikari data sources in the Database Connection Pools panel.
+- Corrected Spring Modulith Flyway migration reporting so module-specific history tables remain visible and read-only.
+- Fixed VuePress markdown links, homepage setup navigation, GitHub Pages Node 24 configuration, and sample quick-start
+  script UI bundling.
+
 ## [0.5.1] - 2026-06-04
 
 Patch release focused on preserving BootUI startup in applications that do not include Spring Security Core while
@@ -303,7 +334,8 @@ First tagged BootUI alpha. Highlights of the harden-all-visible-panels scope:
   request history, distributed tracing, multi-service orchestration, and live
   Docker Compose lifecycle control are intentionally out of scope for the alpha.
 
-[Unreleased]: https://github.com/jdubois/boot-ui/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/jdubois/boot-ui/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/jdubois/boot-ui/compare/v0.5.1...v1.0.0
 [0.5.1]: https://github.com/jdubois/boot-ui/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/jdubois/boot-ui/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/jdubois/boot-ui/compare/v0.3.0...v0.4.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,10 +128,10 @@ to stage for manual publishing instead.
 
 To prepare and publish a release, run the **Release** GitHub Actions workflow
 from the branch you want to release, usually `main`, and enter the target version
-without the leading `v`, for example `0.5.0`. The workflow updates all Maven
-module versions, refreshes the README dependency example, optionally verifies
+without the leading `v`, for example `1.0.0`. The workflow updates all Maven
+module versions, refreshes the documentation dependency examples, optionally verifies
 with the `release` Maven profile, commits the release, creates an annotated
-`v0.5.0` tag, pushes the branch plus tag, and publishes to Maven Central in the
+`v1.0.0` tag, pushes the branch plus tag, and publishes to Maven Central in the
 same run. The selected branch must allow `github-actions[bot]` to push the
 release commit and tag.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported versions
 
-BootUI is currently pre-1.0. Only the latest released version receives
-security fixes; older releases do not.
+BootUI's latest stable release line receives security fixes; older pre-1.0
+releases do not.
 
 | Version | Supported |
 | ------- | --------- |
-| 0.5.x   | ✅        |
-| < 0.5   | ❌        |
+| 1.0.x   | ✅        |
+| < 1.0   | ❌        |
 
 ## Reporting a vulnerability
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -5,10 +5,11 @@
 BootUI ships as a **Spring Boot 4 starter** that adds a safe, local-only developer console to a running application. The
 released surface already covers runtime introspection, configuration, database migrations, services, diagnostics, project
 health, and developer tooling, including the recently shipped Threads, HTTP Exchanges, Flyway, Liquibase,
-Hibernate Advisor, HTTP Sessions, and GitHub panels. This plan describes the **next merged feature workstream**: it keeps
-the remaining roadmap items and the one capture-oriented addition chosen to close the clearest gaps against comparable
-developer dashboards (Spring Boot Admin, Quarkus Dev UI, Laravel Telescope/Pulse, Phoenix LiveDashboard, .NET Aspire,
-Symfony Web Profiler) while staying inside BootUI's read-mostly, fail-closed safety model.
+Hibernate Advisor, HTTP Sessions, GitHub, Security Advisor, and Overview scanner dashboard panels. This plan describes the
+**next merged feature workstream** after the `1.0.0` release: it keeps the remaining roadmap items and the one
+capture-oriented addition chosen to close the clearest gaps against comparable developer dashboards (Spring Boot Admin,
+Quarkus Dev UI, Laravel Telescope/Pulse, Phoenix LiveDashboard, .NET Aspire, Symfony Web Profiler) while staying inside
+BootUI's read-mostly, fail-closed safety model.
 
 The priorities for every item below remain unchanged:
 
@@ -17,6 +18,17 @@ The priorities for every item below remain unchanged:
 3. Useful runtime explanations.
 4. A polished but simple UI.
 5. Testable architecture.
+
+### Completed for 1.0.0
+
+- Promoted the current grouped sidebar surface to the stable `1.0.0` release line.
+- Added the Security Advisor panel, `/bootui/api/security-advisor` API, panel availability/read-only wiring, tests, feature
+  documentation, rule catalogue, and screenshot.
+- Redesigned Overview into an on-demand security & health scoring dashboard that aggregates the available scanner panels.
+- Added token-first activity charts to the Copilot and Claude Code dashboards and refreshed their screenshots.
+- Published the VuePress documentation site with GitHub Pages deployment, setup/sample-app pages, and fixed markdown links.
+- Fixed Spring Modulith Flyway reporting and proxied Hikari datasource discovery so the existing Database panels better
+  match real applications.
 
 Each new panel must:
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -12,7 +12,7 @@
 <dependency>
   <groupId>com.julien-dubois.bootui</groupId>
   <artifactId>bootui-spring-boot-starter</artifactId>
-  <version>0.5.1</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -19,7 +19,7 @@ BootUI currently targets:
 - Maven-based applications first.
 - Servlet web applications first.
 
-Out of scope for the current pre-1.0 line:
+Out of scope for the current 1.x line:
 
 - Spring Boot 3.x compatibility.
 - Spring Framework 6 / Boot 3 compatibility shims.
@@ -880,7 +880,7 @@ Features:
 - Skip lazy, prototype, abstract, or otherwise uninitialized service beans instead of creating them from a read-only
   panel request, and show a warning that explains why they were skipped.
 
-Status: implemented and supported for the current pre-1.0 release surface.
+Status: implemented and supported for the 1.0 release surface.
 
 Acceptance criteria:
 
@@ -916,7 +916,7 @@ Features:
 - Offer a confirmation-gated raw text thread dump download as a mutating `POST` that is blocked when the panel is
   read-only.
 
-Status: implemented and supported for the current pre-1.0 release surface.
+Status: implemented and supported for the 1.0 release surface.
 
 Acceptance criteria:
 
@@ -1062,6 +1062,7 @@ Initial endpoints:
 | Endpoint                                     | Method | Purpose                                                                                |
 | -------------------------------------------- | ------ | -------------------------------------------------------------------------------------- |
 | `/bootui/api/overview`                       | GET    | App, runtime, Spring Boot, profile, and BootUI status                                  |
+| `/bootui/api/panels`                         | GET    | Panel availability, enabled state, and read-only state                                 |
 | `/bootui/api/github`                         | GET    | Local GitHub origin metadata and the latest cached dashboard snapshot                  |
 | `/bootui/api/github/refresh`                 | POST   | Explicit bounded GitHub API refresh for project metrics and quotas                     |
 | `/bootui/api/beans`                          | GET    | Searchable bean summary                                                                |
@@ -1082,6 +1083,8 @@ Initial endpoints:
 | `/bootui/api/threads/download`               | POST   | Confirmation-gated raw text thread dump download                                       |
 | `/bootui/api/metrics`                        | GET    | Browseable Micrometer meter list                                                       |
 | `/bootui/api/metrics/detail`                 | GET    | Micrometer meter detail and live measurements                                          |
+| `/bootui/api/database-connection-pools/pools` | GET    | JDBC connection pool metadata                                                          |
+| `/bootui/api/database-connection-pools/pools/{name}/snapshot` | GET | Live connection pool utilization snapshot                                   |
 | `/bootui/api/dependencies`                   | GET    | Runtime Maven dependency inventory without external scanning                           |
 | `/bootui/api/dependencies/scan`              | POST   | Explicit on-demand OSV.dev vulnerability scan                                          |
 | `/bootui/api/devtools`                       | GET    | Spring Boot DevTools status                                                            |
@@ -1089,10 +1092,23 @@ Initial endpoints:
 | `/bootui/api/devtools/restart`               | POST   | Schedule a DevTools restart after explicit confirmation                                |
 | `/bootui/api/memory`                         | GET    | JVM memory report                                                                      |
 | `/bootui/api/tuning-advisor`                 | GET    | JVM tuning advisor report                                                              |
+| `/bootui/api/heap-dump`                      | GET    | Heap dump capture inventory and latest value-free histogram report                     |
+| `/bootui/api/heap-dump/capture`              | POST   | Capture a local heap dump after explicit confirmation                                  |
+| `/bootui/api/heap-dump/analyze`              | POST   | Analyze the latest heap dump class histogram                                           |
+| `/bootui/api/heap-dump/delete`               | POST   | Delete a retained heap dump                                                            |
+| `/bootui/api/heap-dump/download`             | GET    | Download a raw heap dump only when explicitly enabled                                  |
 | `/bootui/api/scheduled`                      | GET    | Scheduled tasks                                                                        |
 | `/bootui/api/probe`                          | POST   | Local HTTP probe                                                                       |
 | `/bootui/api/logs/recent`                    | GET    | Recent log lines                                                                       |
 | `/bootui/api/logs/stream`                    | GET    | Log stream over Server-Sent Events                                                     |
+| `/bootui/api/traces`                         | GET    | Recent local trace summaries                                                           |
+| `/bootui/api/traces/{traceId}`               | GET    | Trace waterfall detail                                                                 |
+| `/bootui/api/traces`                         | DELETE | Clear retained local traces when not read-only                                         |
+| `/bootui/api/otlp/v1/traces`                 | POST   | Embedded local OTLP/HTTP trace receiver                                                |
+| `/bootui/api/ai/overview`                    | GET    | AI telemetry summary from local spans                                                  |
+| `/bootui/api/ai/chats`                       | GET    | Recent AI chat span groups                                                             |
+| `/bootui/api/ai/chats/{spanId}`              | GET    | AI chat span detail                                                                    |
+| `/bootui/api/ai/tokens`                      | GET    | AI token usage time series                                                             |
 | `/bootui/api/profiles`                       | GET    | Profile-specific property sources                                                      |
 | `/bootui/api/dev-services`                   | GET    | Docker Compose, Testcontainers, and service connection entries                         |
 | `/bootui/api/dev-services/{id}/logs`         | GET    | Bounded log tail for a bean-backed service when available                              |
@@ -1101,6 +1117,11 @@ Initial endpoints:
 | `/bootui/api/data/repositories/{name}`       | GET    | Spring Data repository detail with query methods                                       |
 | `/bootui/api/hibernate-advisor`              | GET    | Latest Hibernate/JPA advisor report                                                    |
 | `/bootui/api/hibernate-advisor/scan`         | POST   | Run explicit read-only Hibernate/JPA advisor checks                                    |
+| `/bootui/api/architecture`                   | GET    | Latest Architecture scan report                                                        |
+| `/bootui/api/architecture/scan`              | POST   | Run explicit ArchUnit hygiene checks                                                   |
+| `/bootui/api/graalvm`                        | GET    | Latest GraalVM native-image readiness report                                           |
+| `/bootui/api/graalvm/scan`                   | POST   | Run explicit native-image readiness checks                                             |
+| `/bootui/api/graalvm/metadata`               | GET    | Download generated reachability metadata scaffold                                      |
 | `/bootui/api/flyway/migrations`              | GET    | Flyway migration state and action availability per database                            |
 | `/bootui/api/flyway/migrate`                 | POST   | Run pending Flyway migrations only when confirmed, not read-only, and not Modulith-managed |
 | `/bootui/api/flyway/clean`                   | POST   | Clean Flyway-managed schemas only when confirmed, allowed by Flyway, not read-only, and not Modulith-managed |
@@ -1112,6 +1133,8 @@ Initial endpoints:
 | `/bootui/api/spring-security/explain`        | GET    | Best-effort chain match for a method/path                                              |
 | `/bootui/api/spring-security/endpoints`      | GET    | Best-effort per-endpoint authorization report                                          |
 | `/bootui/api/security-logs`                  | GET    | Recent Spring Boot audit/security events                                               |
+| `/bootui/api/security-advisor`               | GET    | Latest Spring Security Advisor report                                                  |
+| `/bootui/api/security-advisor/scan`          | POST   | Run explicit Spring Security hardening checks                                          |
 | `/bootui/api/pentest`                        | GET    | Latest local OWASP hygiene report                                                      |
 | `/bootui/api/pentest/scan`                   | POST   | Run explicit bounded localhost OWASP hygiene checks                                    |
 | `/bootui/api/copilot/**`                     | GET    | Sanitized GitHub Copilot CLI session dashboard, token usage, explorer, raw reveal, SSE |
@@ -1356,9 +1379,9 @@ Future compatibility:
 - Masked values stay masked.
 - Empty states are readable.
 
-## 10. Acceptance criteria for the current pre-1.0 release surface
+## 10. Acceptance criteria for the 1.0 release surface
 
-BootUI's current pre-1.0 release surface is complete when:
+BootUI's 1.0 release surface is complete when:
 
 - A sample Spring Boot app can add the starter and open `/bootui`.
 - The UI shows Overview, Runtime, Configuration, Database, Security, Services, Diagnostics, Developer tools, and Disabled /
@@ -1375,11 +1398,11 @@ BootUI's current pre-1.0 release surface is complete when:
 
 ## 11. Release decisions
 
-Resolved for `0.1.0` and carried forward through `0.2.0`:
+Resolved for `1.0.0`:
 
-1. Harden every visible panel and ship the full current route set as supported local-development functionality.
+1. Harden every visible panel and ship the full current route set as supported stable local-development functionality.
 2. Publish release artifacts to Maven Central through the Release workflow so module versions, the README install
    snippet, tags, release notes, and Central publishing stay synchronized.
 3. Keep optional panels visible and show clear unavailable/empty states when their classpath or data source is absent.
-4. Continue using in-process Actuator endpoint beans and Spring-managed metadata for the pre-1.0 line; revisit broader
-   metadata abstractions after the current starter surface stabilizes.
+4. Continue using in-process Actuator endpoint beans and Spring-managed metadata for the 1.x line; revisit broader
+   metadata abstractions after the stable starter surface settles.


### PR DESCRIPTION
## What does this PR do?

Prepares the release-facing documentation and release workflow for BootUI 1.0.0.

## Why is this change needed?

The upcoming stable release needs the setup docs, roadmap, changelog, security support policy, specification, and release automation to agree on the 1.0.0 surface before tagging.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable
- [x] `npm run docs:build` passes
- [x] Rechecked the feature docs and screenshot inventory: 39 routed panels, 39 documented feature panels, and 39 screenshots at 1600x900.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed