### PR TITLE
Gate Hibernate fetch pagination rules by version

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorContext.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorContext.java
@@ -1,15 +1,35 @@
 package io.github.jdubois.bootui.autoconfigure.hibernateadvisor;
 
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.core.env.Environment;
 
 record HibernateAdvisorContext(
-        List<HibernateEntityModel> entities, List<HibernateRepositoryModel> repositories, Environment environment) {
+        List<HibernateEntityModel> entities,
+        List<HibernateRepositoryModel> repositories,
+        Environment environment,
+        HibernateRuntimeVersion hibernateVersion) {
+
+    HibernateAdvisorContext(
+            List<HibernateEntityModel> entities, List<HibernateRepositoryModel> repositories, Environment environment) {
+        this(entities, repositories, environment, HibernateRuntimeVersion.detect());
+    }
+
+    HibernateAdvisorContext(
+            List<HibernateEntityModel> entities,
+            List<HibernateRepositoryModel> repositories,
+            Environment environment,
+            String hibernateVersion) {
+        this(entities, repositories, environment, HibernateRuntimeVersion.parse(hibernateVersion));
+    }
 
     HibernateAdvisorContext {
         entities = List.copyOf(entities);
         repositories = List.copyOf(repositories);
+        hibernateVersion = hibernateVersion == null ? HibernateRuntimeVersion.unknown() : hibernateVersion;
     }
 
     boolean hasAssociations() {
@@ -107,6 +127,14 @@ record HibernateAdvisorContext(
         return false;
     }
 
+    boolean hasHibernateCollectionFetchPaginationFix() {
+        return hibernateVersion.isAfterMajorMinor(7, 4);
+    }
+
+    String hibernateVersionDisplay() {
+        return hibernateVersion.display();
+    }
+
     boolean isHibernateEnhancementEnabled() {
         return isPropertyTrue(
                         "spring.jpa.properties.hibernate.enhancer.enableLazyInitialization",
@@ -133,5 +161,66 @@ record HibernateAdvisorContext(
             }
         }
         return false;
+    }
+}
+
+record HibernateRuntimeVersion(String display, Integer major, Integer minor) {
+
+    private static final Pattern VERSION_PREFIX = Pattern.compile("^(\\d+)(?:\\.(\\d+))?.*");
+
+    static HibernateRuntimeVersion detect() {
+        return parse(detectedVersionString());
+    }
+
+    static HibernateRuntimeVersion parse(String version) {
+        if (version == null || version.isBlank()) {
+            return unknown();
+        }
+        String sanitized = version.trim();
+        Matcher matcher = VERSION_PREFIX.matcher(sanitized);
+        if (!matcher.matches()) {
+            return new HibernateRuntimeVersion(sanitized, null, null);
+        }
+        return new HibernateRuntimeVersion(sanitized, parseInteger(matcher.group(1)), parseInteger(matcher.group(2)));
+    }
+
+    static HibernateRuntimeVersion unknown() {
+        return new HibernateRuntimeVersion("unknown", null, null);
+    }
+
+    boolean isAfterMajorMinor(int targetMajor, int targetMinor) {
+        if (major == null) {
+            return false;
+        }
+        if (major > targetMajor) {
+            return true;
+        }
+        return major == targetMajor && minor != null && minor > targetMinor;
+    }
+
+    private static String detectedVersionString() {
+        try {
+            Class<?> versionType = Class.forName("org.hibernate.Version");
+            Method getVersionString = versionType.getMethod("getVersionString");
+            Object value = getVersionString.invoke(null);
+            if (value instanceof String version && !version.isBlank()) {
+                return version;
+            }
+            Package versionPackage = versionType.getPackage();
+            return versionPackage == null ? null : versionPackage.getImplementationVersion();
+        } catch (ReflectiveOperationException | RuntimeException | LinkageError ex) {
+            return null;
+        }
+    }
+
+    private static Integer parseInteger(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorRules.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorRules.java
@@ -578,6 +578,11 @@ final class CollectionJoinFetchPageableRule extends AbstractHibernateAdvisorRule
 
     @Override
     HibernateAdvisorRuleResultDto evaluateRule(HibernateAdvisorContext context) {
+        if (context.hasHibernateCollectionFetchPaginationFix()) {
+            return skipped("Hibernate "
+                    + context.hibernateVersionDisplay()
+                    + " is newer than 7.4, where pagination over collection fetch joins was fixed.");
+        }
         if (context.repositories().isEmpty()) {
             return skipped("No Spring Data repository metadata was detected.");
         }
@@ -1893,6 +1898,11 @@ final class FailOnPaginationOverCollectionFetchRule extends AbstractHibernateAdv
 
     @Override
     HibernateAdvisorRuleResultDto evaluateRule(HibernateAdvisorContext context) {
+        if (context.hasHibernateCollectionFetchPaginationFix()) {
+            return skipped("Hibernate "
+                    + context.hibernateVersionDisplay()
+                    + " is newer than 7.4, where pagination over collection fetch joins was fixed.");
+        }
         if (!context.isPropertyTrue(
                 "spring.jpa.properties.hibernate.query.fail_on_pagination_over_collection_fetch",
                 "hibernate.query.fail_on_pagination_over_collection_fetch")) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorScanner.java
@@ -42,6 +42,7 @@ final class HibernateAdvisorScanner {
             .thenComparing(HibernateAdvisorRuleResultDto::id);
 
     private final Supplier<EntityDiscovery> entityDiscoverySupplier;
+    private final Supplier<HibernateRuntimeVersion> hibernateVersionSupplier;
     private final Environment environment;
     private final Clock clock;
 
@@ -65,9 +66,31 @@ final class HibernateAdvisorScanner {
         this(() -> new EntityDiscovery(entities, repositories, List.of()), environment, clock);
     }
 
+    HibernateAdvisorScanner(
+            List<HibernateEntityModel> entities,
+            List<HibernateRepositoryModel> repositories,
+            Environment environment,
+            Clock clock,
+            String hibernateVersion) {
+        this(
+                () -> new EntityDiscovery(entities, repositories, List.of()),
+                environment,
+                clock,
+                () -> HibernateRuntimeVersion.parse(hibernateVersion));
+    }
+
     private HibernateAdvisorScanner(
             Supplier<EntityDiscovery> entityDiscoverySupplier, Environment environment, Clock clock) {
+        this(entityDiscoverySupplier, environment, clock, HibernateRuntimeVersion::detect);
+    }
+
+    private HibernateAdvisorScanner(
+            Supplier<EntityDiscovery> entityDiscoverySupplier,
+            Environment environment,
+            Clock clock,
+            Supplier<HibernateRuntimeVersion> hibernateVersionSupplier) {
         this.entityDiscoverySupplier = entityDiscoverySupplier;
+        this.hibernateVersionSupplier = hibernateVersionSupplier;
         this.environment = environment;
         this.clock = clock;
     }
@@ -92,8 +115,8 @@ final class HibernateAdvisorScanner {
             return report("DISABLED", message, clock.millis(), List.of(), 0, 0, List.of());
         }
 
-        HibernateAdvisorContext context =
-                new HibernateAdvisorContext(discovery.entities(), discovery.repositories(), environment);
+        HibernateAdvisorContext context = new HibernateAdvisorContext(
+                discovery.entities(), discovery.repositories(), environment, hibernateVersionSupplier.get());
         List<HibernateAdvisorRuleResultDto> results = HibernateAdvisorRuleRegistry.activeRules().stream()
                 .map(rule -> rule.evaluate(context))
                 .toList();

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorScannerTests.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.autoconfigure.hibernateadvisor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.HibernateAdvisorReport;
+import io.github.jdubois.bootui.core.dto.HibernateAdvisorRuleResultDto;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.CascadeType;
@@ -250,6 +251,46 @@ class HibernateAdvisorScannerTests {
     }
 
     @Test
+    void paginationOverCollectionFetchRulesStillApplyThroughHibernate74() {
+        HibernateAdvisorContext context = collectionFetchPaginationContext("7.4.9.Final");
+
+        HibernateAdvisorRuleResultDto queryResult = new CollectionJoinFetchPageableRule().evaluate(context);
+        HibernateAdvisorRuleResultDto configResult = new FailOnPaginationOverCollectionFetchRule().evaluate(context);
+
+        assertThat(queryResult.status()).isEqualTo(HibernateAdvisorRuleSupport.VIOLATION);
+        assertThat(queryResult.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("findPageWithTags", "o.tags"));
+        assertThat(configResult.status()).isEqualTo(HibernateAdvisorRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void paginationOverCollectionFetchRulesSkipAfterHibernate74() {
+        HibernateAdvisorContext context = collectionFetchPaginationContext("7.5.0.Final");
+
+        HibernateAdvisorRuleResultDto queryResult = new CollectionJoinFetchPageableRule().evaluate(context);
+        HibernateAdvisorRuleResultDto configResult = new FailOnPaginationOverCollectionFetchRule().evaluate(context);
+
+        assertThat(queryResult.status()).isEqualTo(HibernateAdvisorRuleSupport.SKIPPED);
+        assertThat(queryResult.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("Hibernate 7.5.0.Final"));
+        assertThat(configResult.status()).isEqualTo(HibernateAdvisorRuleSupport.SKIPPED);
+        assertThat(configResult.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("Hibernate 7.5.0.Final"));
+    }
+
+    @Test
+    void hibernateVersionComparisonUsesMajorMinorNumbers() {
+        assertThat(HibernateRuntimeVersion.parse("7.4.99.Final").isAfterMajorMinor(7, 4))
+                .isFalse();
+        assertThat(HibernateRuntimeVersion.parse("7.10.0.Final").isAfterMajorMinor(7, 4))
+                .isTrue();
+        assertThat(HibernateRuntimeVersion.parse("8.0.0.Final").isAfterMajorMinor(7, 4))
+                .isTrue();
+        assertThat(HibernateRuntimeVersion.parse("unknown").isAfterMajorMinor(7, 4))
+                .isFalse();
+    }
+
+    @Test
     void scanPassesWhenMappingsAndConfigurationAreSafe() {
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.jpa.open-in-view", "false")
@@ -310,7 +351,32 @@ class HibernateAdvisorScannerTests {
                         .toList(),
                 repositories,
                 environment,
-                CLOCK);
+                CLOCK,
+                "7.4.9.Final");
+    }
+
+    private HibernateAdvisorContext collectionFetchPaginationContext(String hibernateVersion) {
+        HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                "com.example.ProblemOrderRepository",
+                ProblemOrder.class,
+                List.of(new HibernateRepositoryMethodModel(
+                        "com.example.ProblemOrderRepository",
+                        "findPageWithTags",
+                        ProblemOrder.class,
+                        List.class,
+                        "select o from ProblemOrder o left join fetch o.tags where o.status = :status",
+                        false,
+                        null,
+                        true,
+                        false,
+                        false,
+                        false,
+                        List.of(Status.class))));
+        return new HibernateAdvisorContext(
+                List.of(HibernateEntityModel.fromClass(ProblemOrder.class)),
+                List.of(repository),
+                new MockEnvironment(),
+                hibernateVersion);
     }
 
     @Entity

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -53,7 +53,9 @@ includes up to a handful of sample mapped members plus a remediation link.
 
 - **Severity**: HIGH
 - **Inspects**: Spring Data JPA `@Query` methods with a `Pageable` parameter and resolvable JPQL `JOIN FETCH` paths.
-- **Fires when**: a paged repository query fetch-joins a mapped collection on the repository domain entity.
+- **Fires when**: Hibernate is 7.4 or earlier (or the runtime version cannot be detected) and a paged repository query
+  fetch-joins a mapped collection on the repository domain entity. The check is skipped for Hibernate versions newer than
+  7.4, where this pagination behavior is fixed.
 - **Why it matters**: collection fetch joins duplicate root rows, so pagination may be applied in memory or require a
   more explicit two-step query plan.
 - **Recommendation**: page root identifiers first, then fetch the required collection graph in a second query inside the
@@ -561,7 +563,9 @@ includes up to a handful of sample mapped members plus a remediation link.
 
 - **Severity**: MEDIUM
 - **Inspects**: the `hibernate.query.fail_on_pagination_over_collection_fetch` property.
-- **Fires when**: the property is absent, false, or unparseable.
+- **Fires when**: Hibernate is 7.4 or earlier (or the runtime version cannot be detected) and the property is absent,
+  false, or unparseable. The check is skipped for Hibernate versions newer than 7.4, where pagination over collection
+  fetch joins no longer needs this fail-fast guard.
 - **Why it matters**: by default, if a query uses pagination (`setMaxResults()`) and fetches a collection, Hibernate performs the pagination in memory instead of the database. This silently retrieves the entire result set, causing severe memory and performance issues in production.
 - **Recommendation**: set `spring.jpa.properties.hibernate.query.fail_on_pagination_over_collection_fetch=true` to fail fast during development rather than silently suffering memory exhaustion in production.
 


### PR DESCRIPTION
## What does this PR do?

Adds Hibernate runtime version detection to Hibernate Advisor and skips collection-fetch pagination checks for Hibernate versions newer than 7.4, while keeping them active for Hibernate 7.4 and earlier or unknown versions.

## Why is this change needed?

Hibernate fixed pagination over collection fetch joins after 7.4, so BootUI should not report legacy remediation advice against runtimes where the issue no longer applies.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional checks:

- `./mvnw -pl bootui-autoconfigure -am -Dtest=HibernateAdvisorScannerTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -B -ntp -pl bootui-autoconfigure spotless:check`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed