### PR TITLE
Refine Hibernate batch fetch rule

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorContext.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorContext.java
@@ -18,20 +18,6 @@ record HibernateAdvisorContext(
                 .anyMatch(HibernateAttributeModel::isAssociation);
     }
 
-    int associationCount() {
-        return (int) entities.stream()
-                .flatMap(entity -> entity.attributes().stream())
-                .filter(HibernateAttributeModel::isAssociation)
-                .count();
-    }
-
-    boolean hasBatchSizeAnnotation() {
-        return entities.stream().anyMatch(HibernateEntityModel::hasBatchSizeAnnotation)
-                || entities.stream()
-                        .flatMap(entity -> entity.attributes().stream())
-                        .anyMatch(HibernateAttributeModel::hasBatchSizeAnnotation);
-    }
-
     Integer defaultBatchFetchSize() {
         for (String key : List.of(
                 "spring.jpa.properties.hibernate.default_batch_fetch_size", "hibernate.default_batch_fetch_size")) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorRules.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorRules.java
@@ -4,8 +4,10 @@ import io.github.jdubois.bootui.core.dto.HibernateAdvisorRuleResultDto;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -44,6 +46,35 @@ abstract class AbstractHibernateAdvisorRule implements HibernateAdvisorRule {
 
     HibernateAdvisorRuleResultDto violation(List<String> details) {
         return details.isEmpty() ? pass() : HibernateAdvisorRuleSupport.violation(definition, details);
+    }
+}
+
+final class HibernateAdvisorRuleModelSupport {
+
+    private HibernateAdvisorRuleModelSupport() {}
+
+    static Map<String, HibernateEntityModel> entitiesByJavaType(List<HibernateEntityModel> entities) {
+        Map<String, HibernateEntityModel> byJavaType = new LinkedHashMap<>();
+        for (HibernateEntityModel entity : entities) {
+            if (entity.javaType() != null) {
+                byJavaType.put(entity.javaType().getName(), entity);
+            }
+        }
+        return byJavaType;
+    }
+
+    static Class<?> associationTargetType(HibernateAttributeModel attribute) {
+        if (attribute.isCollectionAssociation()) {
+            java.lang.reflect.Type generic = attribute.genericType();
+            if (generic instanceof java.lang.reflect.ParameterizedType parameterized) {
+                java.lang.reflect.Type[] args = parameterized.getActualTypeArguments();
+                if (args.length > 0 && args[args.length - 1] instanceof Class<?> raw) {
+                    return raw;
+                }
+            }
+            return null;
+        }
+        return attribute.rawType();
     }
 }
 
@@ -532,11 +563,11 @@ final class MissingBatchFetchRule extends AbstractHibernateAdvisorRule {
         super(
                 new HibernateAdvisorRuleDefinition(
                         "HIB-FETCH-002",
-                        "Batch fetching should be configured for association-heavy models",
+                        "Batch fetching should cover lazy secondary-select associations",
                         HibernateAdvisorCategory.FETCHING,
                         "INFO",
-                        "Detects mapped associations with no global hibernate.default_batch_fetch_size and no @BatchSize.",
-                        "Set a bounded hibernate.default_batch_fetch_size or add @BatchSize to high-traffic associations to reduce N+1 select risk.",
+                        "Detects lazy to-one and collection associations that can initialize through secondary selects without hibernate.default_batch_fetch_size or an applicable @BatchSize.",
+                        "Set a bounded hibernate.default_batch_fetch_size or targeted @BatchSize for associations traversed across multiple owner rows; use explicit fetch plans or paged queries for a single oversized collection.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#fetching-batch"));
     }
 
@@ -545,15 +576,57 @@ final class MissingBatchFetchRule extends AbstractHibernateAdvisorRule {
         if (!context.hasAssociations()) {
             return skipped("No mapped associations were detected.");
         }
-        if (context.defaultBatchFetchSize() != null || context.hasBatchSizeAnnotation()) {
+        if (context.defaultBatchFetchSize() != null) {
             return pass();
         }
-        return HibernateAdvisorRuleSupport.result(
-                definition(),
-                HibernateAdvisorRuleSupport.VIOLATION,
-                context.associationCount(),
-                List.of(context.associationCount()
-                        + " mapped association(s) were detected without a global batch-fetch size or @BatchSize."));
+        Map<String, HibernateEntityModel> entitiesByJavaType =
+                HibernateAdvisorRuleModelSupport.entitiesByJavaType(context.entities());
+        List<String> details = new ArrayList<>();
+        for (HibernateEntityModel entity : context.entities()) {
+            for (HibernateAttributeModel attribute : entity.attributes()) {
+                if (!isBatchFetchCandidate(attribute) || isCoveredByBatchSize(attribute, entitiesByJavaType)) {
+                    continue;
+                }
+                details.add(
+                        attribute.description()
+                                + " can initialize through secondary selects without a global batch-fetch size or applicable @BatchSize.");
+            }
+        }
+        return violation(details);
+    }
+
+    private boolean isBatchFetchCandidate(HibernateAttributeModel attribute) {
+        Annotation association = attribute.associationAnnotation();
+        if (association == null || hasNonBatchFetchMode(attribute)) {
+            return false;
+        }
+        String fetch = attribute.annotationValueName(association, "fetch");
+        if ("EAGER".equals(fetch)) {
+            return false;
+        }
+        return attribute.isCollectionAssociation() || (attribute.isToOneAssociation() && "LAZY".equals(fetch));
+    }
+
+    private boolean hasNonBatchFetchMode(HibernateAttributeModel attribute) {
+        Annotation fetch = attribute.fetchAnnotation();
+        if (fetch == null) {
+            return false;
+        }
+        String mode = attribute.annotationValueName(fetch, "value");
+        return "JOIN".equals(mode) || "SUBSELECT".equals(mode);
+    }
+
+    private boolean isCoveredByBatchSize(
+            HibernateAttributeModel attribute, Map<String, HibernateEntityModel> entitiesByJavaType) {
+        if (attribute.hasBatchSizeAnnotation()) {
+            return true;
+        }
+        if (!attribute.isToOneAssociation()) {
+            return false;
+        }
+        Class<?> targetType = HibernateAdvisorRuleModelSupport.associationTargetType(attribute);
+        HibernateEntityModel target = targetType == null ? null : entitiesByJavaType.get(targetType.getName());
+        return target != null && target.hasBatchSizeAnnotation();
     }
 }
 
@@ -1796,12 +1869,8 @@ final class CacheAssociationCoverageRule extends AbstractHibernateAdvisorRule {
         if (context.entities().isEmpty()) {
             return pass();
         }
-        java.util.Map<String, HibernateEntityModel> byJavaType = new java.util.HashMap<>();
-        for (HibernateEntityModel entity : context.entities()) {
-            if (entity.javaType() != null) {
-                byJavaType.put(entity.javaType().getName(), entity);
-            }
-        }
+        Map<String, HibernateEntityModel> byJavaType =
+                HibernateAdvisorRuleModelSupport.entitiesByJavaType(context.entities());
         List<String> details = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
             if (!entity.isJpaCacheable() && !entity.hasHibernateCacheAnnotation()) {
@@ -1814,7 +1883,7 @@ final class CacheAssociationCoverageRule extends AbstractHibernateAdvisorRule {
                 if (attribute.hasHibernateCacheAnnotation()) {
                     continue;
                 }
-                Class<?> targetType = associationTargetType(attribute);
+                Class<?> targetType = HibernateAdvisorRuleModelSupport.associationTargetType(attribute);
                 if (targetType == null) {
                     continue;
                 }
@@ -1828,20 +1897,6 @@ final class CacheAssociationCoverageRule extends AbstractHibernateAdvisorRule {
             }
         }
         return violation(details);
-    }
-
-    private Class<?> associationTargetType(HibernateAttributeModel attribute) {
-        if (attribute.isCollectionAssociation()) {
-            java.lang.reflect.Type generic = attribute.genericType();
-            if (generic instanceof java.lang.reflect.ParameterizedType parameterized) {
-                java.lang.reflect.Type[] args = parameterized.getActualTypeArguments();
-                if (args.length > 0 && args[args.length - 1] instanceof Class<?> raw) {
-                    return raw;
-                }
-            }
-            return null;
-        }
-        return attribute.rawType();
     }
 }
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorScannerTests.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.autoconfigure.hibernateadvisor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.HibernateAdvisorReport;
+import io.github.jdubois.bootui.core.dto.HibernateAdvisorRuleResultDto;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.CascadeType;
@@ -38,6 +39,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.DynamicUpdate;
@@ -276,6 +278,55 @@ class HibernateAdvisorScannerTests {
     }
 
     @Test
+    void missingBatchFetchReportsLazySecondarySelectAssociations() {
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.jpa.open-in-view", "false");
+        HibernateAdvisorScanner scanner = scanner(environment, BatchFetchRiskOrder.class);
+
+        HibernateAdvisorReport report = scanner.scan();
+
+        assertThat(report.results())
+                .filteredOn(result -> result.id().equals("HIB-FETCH-002"))
+                .singleElement()
+                .satisfies(result -> {
+                    assertThat(result.violationCount()).isEqualTo(3);
+                    assertThat(result.sampleViolations())
+                            .contains(
+                                    BatchFetchRiskOrder.class.getName()
+                                            + "#customer can initialize through secondary selects without a global batch-fetch size or applicable @BatchSize.",
+                                    BatchFetchRiskOrder.class.getName()
+                                            + "#lineItems can initialize through secondary selects without a global batch-fetch size or applicable @BatchSize.",
+                                    BatchFetchRiskOrder.class.getName()
+                                            + "#tags can initialize through secondary selects without a global batch-fetch size or applicable @BatchSize.");
+                    assertThat(result.sampleViolations()).noneMatch(sample -> sample.contains("#defaultEagerCustomer"));
+                });
+    }
+
+    @Test
+    void missingBatchFetchHonorsLocalAndTargetBatchSizeAnnotations() {
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.jpa.open-in-view", "false");
+        HibernateAdvisorScanner scanner =
+                scanner(environment, List.of(), CoveredBatchFetchOrder.class, BatchSizedCustomer.class);
+
+        HibernateAdvisorReport report = scanner.scan();
+
+        assertThat(report.results())
+                .extracting(HibernateAdvisorRuleResultDto::id)
+                .doesNotContain("HIB-FETCH-002");
+    }
+
+    @Test
+    void missingBatchFetchIgnoresDefaultEagerToOneAssociations() {
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.jpa.open-in-view", "false");
+        HibernateAdvisorScanner scanner = scanner(environment, DefaultEagerToOneOrder.class);
+
+        HibernateAdvisorReport report = scanner.scan();
+
+        assertThat(report.results())
+                .extracting(HibernateAdvisorRuleResultDto::id)
+                .doesNotContain("HIB-FETCH-002");
+    }
+
+    @Test
     void scanReturnsStableDisabledReportWhenNoEntitiesAreAvailable() {
         HibernateAdvisorScanner scanner = new HibernateAdvisorScanner(List.of(), new MockEnvironment(), CLOCK);
 
@@ -424,6 +475,60 @@ class HibernateAdvisorScannerTests {
 
         @OneToMany
         List<UncachedAssociation> details;
+    }
+
+    @Entity
+    static class BatchFetchRiskOrder {
+
+        @Id
+        Long id;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        Customer customer;
+
+        @ManyToOne
+        Customer defaultEagerCustomer;
+
+        @OneToMany
+        List<LineItem> lineItems;
+
+        @ManyToMany
+        Set<Tag> tags;
+    }
+
+    @Entity
+    static class CoveredBatchFetchOrder {
+
+        @Id
+        Long id;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        BatchSizedCustomer customer;
+
+        @OneToMany
+        @BatchSize(size = 16)
+        List<LineItem> lineItems;
+    }
+
+    @Entity
+    @BatchSize(size = 32)
+    static class BatchSizedCustomer {
+
+        @Id
+        Long id;
+    }
+
+    @Entity
+    static class DefaultEagerToOneOrder {
+
+        @Id
+        Long id;
+
+        @ManyToOne
+        Customer customer;
+
+        @OneToOne
+        Profile profile;
     }
 
     @Entity

--- a/bootui-autoconfigure/src/test/java/org/hibernate/annotations/BatchSize.java
+++ b/bootui-autoconfigure/src/test/java/org/hibernate/annotations/BatchSize.java
@@ -1,0 +1,13 @@
+package org.hibernate.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
+public @interface BatchSize {
+
+    int size();
+}

--- a/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -1526,13 +1526,17 @@ const hibernateAdvisor = {
     ),
     hibernateAdvisorResult(
       'HIB-FETCH-002',
-      'Batch fetching should be configured for association-heavy models',
+      'Batch fetching should cover lazy secondary-select associations',
       'Fetching',
       'INFO',
-      'Detects mapped associations with no global hibernate.default_batch_fetch_size and no @BatchSize.',
-      4,
-      ['4 mapped association(s) were detected without a global batch-fetch size or @BatchSize.'],
-      'Set a bounded hibernate.default_batch_fetch_size or add @BatchSize to high-traffic associations to reduce N+1 select risk.'
+      'Detects lazy to-one and collection associations that can initialize through secondary selects without hibernate.default_batch_fetch_size or an applicable @BatchSize.',
+      3,
+      [
+        'io.github.jdubois.bootui.sample.SampleOrder#tags can initialize through secondary selects without a global batch-fetch size or applicable @BatchSize.',
+        'io.github.jdubois.bootui.sample.SampleOrder#invoices can initialize through secondary selects without a global batch-fetch size or applicable @BatchSize.',
+        'io.github.jdubois.bootui.sample.SampleCustomer#invoices can initialize through secondary selects without a global batch-fetch size or applicable @BatchSize.'
+      ],
+      'Set a bounded hibernate.default_batch_fetch_size or targeted @BatchSize for associations traversed across multiple owner rows; use explicit fetch plans or paged queries for a single oversized collection.'
     )
   ]
 }

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -40,14 +40,18 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Recommendation**: prefer `LAZY` associations and fetch required data explicitly with joins, entity graphs, or DTO
   projections.
 
-### HIB-FETCH-002 - Batch fetching should be configured for association-heavy models
+### HIB-FETCH-002 - Batch fetching should cover lazy secondary-select associations
 
 - **Severity**: INFO
-- **Inspects**: association mappings, `hibernate.default_batch_fetch_size` / Spring's
-  `spring.jpa.properties.hibernate.default_batch_fetch_size`, and `@org.hibernate.annotations.BatchSize`.
-- **Fires when**: associations are mapped but no global batch-fetch size or local `@BatchSize` annotation is detected.
-- **Why it matters**: lazy associations without batch fetching can produce N+1 select patterns when iterated.
-- **Recommendation**: set a bounded global batch-fetch size or apply `@BatchSize` to high-traffic associations.
+- **Inspects**: lazy to-one and collection mappings, `hibernate.default_batch_fetch_size` / Spring's
+  `spring.jpa.properties.hibernate.default_batch_fetch_size`, association-level `@org.hibernate.annotations.BatchSize`,
+  and target-entity `@BatchSize` for lazy to-one associations.
+- **Fires when**: a lazy association can initialize through secondary selects and no global or applicable local batch
+  fetch size is detected.
+- **Why it matters**: lazy associations without batch fetching can produce N+1 select patterns when the same association
+  is traversed across multiple owner rows.
+- **Recommendation**: set a bounded global batch-fetch size or targeted `@BatchSize` for associations traversed across
+  multiple owners; use explicit fetch plans or paged/filtered queries for a single oversized collection.
 
 ### HIB-FETCH-003 - Collection fetch joins should not be paged directly
 


### PR DESCRIPTION
## What does this PR do?

Refines HIB-FETCH-002 so it reports lazy secondary-select batch-fetch risks instead of flagging every mapped association.

## Why is this change needed?

The previous rule was too broad: any association without a global batch-fetch setting produced an INFO finding, while one unrelated `@BatchSize` could silence the whole rule. This narrows the advice to lazy collection and explicit lazy to-one associations that can actually initialize through secondary selects, and it keeps eager-fetch guidance owned by HIB-FETCH-001.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional local checks run:

- `./mvnw -pl bootui-autoconfigure -Dtest=HibernateAdvisorScannerTests test`
- `./mvnw -B -ntp spotless:apply spotless:check`
- `(cd bootui-sample-app/e2e && npm ci && npm run format && npm run format:check)`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed