### PR TITLE
Add Hibernate Advisor Vlad Mihalcea note

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/HibernateAdvisor.test.js
+++ b/bootui-ui/src/main/frontend/src/views/HibernateAdvisor.test.js
@@ -65,6 +65,17 @@ describe('HibernateAdvisor', () => {
     vi.unstubAllGlobals()
   })
 
+  it('shows the Vlad Mihalcea best-practices note under the title', async () => {
+    const wrapper = await mountWithReport(advisorReport([]))
+    const link = wrapper.get('a[href="https://vladmihalcea.com"]')
+
+    expect(wrapper.text()).toContain(
+      'Many of those rules are best practices from Vlad Mihalcea, who reviewed the code himself - join him at'
+    )
+    expect(link.text()).toBe('https://vladmihalcea.com')
+    expect(link.attributes('target')).toBe('_blank')
+  })
+
   it('shows only advisor findings sorted by importance', async () => {
     const wrapper = await mountWithReport(
       advisorReport([

--- a/bootui-ui/src/main/frontend/src/views/HibernateAdvisor.vue
+++ b/bootui-ui/src/main/frontend/src/views/HibernateAdvisor.vue
@@ -145,6 +145,13 @@ onMounted(loadReport)
         </button>
       </template>
     </PanelHeader>
+    <div class="alert alert-info d-flex align-items-start gap-2">
+      <i class="bi bi-info-circle flex-shrink-0" aria-hidden="true"></i>
+      <div>
+        Many of those rules are best practices from Vlad Mihalcea, who reviewed the code himself - join him at
+        <a href="https://vladmihalcea.com" rel="noopener noreferrer" target="_blank">https://vladmihalcea.com</a>
+      </div>
+    </div>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>
 
     <template v-if="report">


### PR DESCRIPTION
Adds a small info note beneath the Hibernate Advisor title so users understand that many checks reflect best practices from Vlad Mihalcea and can follow the linked site for more context.

## Summary
- Show a persistent info alert under the Hibernate Advisor panel header with the requested Vlad Mihalcea message and external link.
- Add focused Vitest coverage for the new visible copy and link behavior.

## Validation
- `npm test -- src/views/HibernateAdvisor.test.js`