### PR TITLE
Standardize empty/unavailable panel state with a shared component

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Data.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Data.test.js
@@ -1,0 +1,70 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import Data from './Data.vue'
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+function repositoriesReport() {
+  return {
+    total: 1,
+    repositories: [
+      {
+        beanName: 'userRepository',
+        repositoryInterface: 'com.example.UserRepository',
+        domainType: 'com.example.User',
+        idType: 'java.lang.Long',
+        storeModule: 'JPA',
+        queryMethodCount: 2,
+        fragmentCount: 0
+      }
+    ]
+  }
+}
+
+describe('Data', () => {
+  let wrapper
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    vi.unstubAllGlobals()
+  })
+
+  it('shows a shared unavailable reason when Spring Data is not on the classpath', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(null, false, 404)))
+
+    wrapper = mount(Data)
+    await flushPromises()
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert-info')
+    expect(alert.text()).toContain('Spring Data is not on the classpath')
+    expect(alert.find('code').text()).toBe('spring-boot-starter-data-jpa')
+  })
+
+  it('reports when Spring Data is present but no repositories are detected', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({total: 0, repositories: []})))
+
+    wrapper = mount(Data)
+    await flushPromises()
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert-secondary')
+    expect(alert.text()).toContain('no repository beans were detected')
+  })
+
+  it('renders repositories when repository beans are present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(repositoriesReport())))
+
+    wrapper = mount(Data)
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledWith('api/data/repositories', expect.anything())
+    expect(wrapper.text()).not.toContain('not on the classpath')
+    expect(wrapper.text()).toContain('UserRepository')
+    expect(wrapper.text()).toContain('1 / 1 repositories')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Data.vue
+++ b/bootui-ui/src/main/frontend/src/views/Data.vue
@@ -3,6 +3,7 @@ import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
 import {describeLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
+import UnavailableState from './components/UnavailableState.vue'
 
 const report = ref(null)
 const detail = ref(null)
@@ -94,14 +95,14 @@ onMounted(load)
   <div>
     <PanelHeader icon="bi-database" title="Spring Data repositories" :error="error" />
 
-    <div v-if="!springDataPresent" class="alert alert-info">
+    <UnavailableState v-if="!springDataPresent" variant="info">
       Spring Data is not on the classpath of this application. Add a Spring Data starter (e.g.
       <code>spring-boot-starter-data-jpa</code>) to see repositories here.
-    </div>
+    </UnavailableState>
 
-    <div v-else-if="report && report.total === 0" class="alert alert-secondary">
+    <UnavailableState v-else-if="report && report.total === 0">
       Spring Data is on the classpath, but no repository beans were detected in the application context.
-    </div>
+    </UnavailableState>
 
     <template v-else-if="report">
       <div class="row g-2 mb-3">

--- a/bootui-ui/src/main/frontend/src/views/DevTools.test.js
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.test.js
@@ -1,0 +1,58 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+import DevTools from './DevTools.vue'
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+function devToolsStatus() {
+  return {
+    restartAvailable: false,
+    restartPending: false,
+    restartUnavailableReason: 'Spring Boot DevTools is not on the classpath.',
+    liveReloadAvailable: false,
+    liveReloadPort: null,
+    liveReloadUnavailableReason: 'Spring Boot DevTools is not on the classpath.'
+  }
+}
+
+describe('DevTools', () => {
+  let wrapper
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    Object.defineProperty(document, 'visibilityState', {configurable: true, value: 'visible'})
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('shows a shared unavailable state when the status cannot be loaded', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Failed to fetch')))
+
+    wrapper = mount(DevTools)
+    await flushPromises()
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert-secondary')
+    expect(alert.text()).toContain('DevTools status is unavailable')
+  })
+
+  it('renders the action cards when the status loads', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(devToolsStatus())))
+
+    wrapper = mount(DevTools)
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledWith('api/devtools', expect.anything())
+    expect(wrapper.text()).toContain('Trigger LiveReload')
+    expect(wrapper.text()).toContain('Restart application')
+    expect(wrapper.text()).not.toContain('DevTools status is unavailable')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -5,6 +5,7 @@ import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import PanelHeader from './components/PanelHeader.vue'
+import UnavailableState from './components/UnavailableState.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -243,6 +244,11 @@ onUnmounted(clearReconnectTimer)
         </div>
       </div>
     </div>
+
+    <UnavailableState
+      v-else
+      message="DevTools status is unavailable. The app may be restarting or unreachable — retry or refresh this panel."
+    />
   </div>
 </template>
 

--- a/bootui-ui/src/main/frontend/src/views/Flyway.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Flyway.test.js
@@ -1,0 +1,80 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import Flyway from './Flyway.vue'
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+function flywayReport() {
+  return {
+    total: 1,
+    databases: [
+      {
+        name: 'dataSource',
+        currentVersion: '1',
+        applied: 1,
+        pending: 0,
+        migrateEnabled: true,
+        cleanEnabled: false,
+        migrations: [
+          {
+            version: '1',
+            description: 'init schema',
+            script: 'V1__init.sql',
+            type: 'SQL',
+            state: 'Success',
+            installedOn: '2026-01-01',
+            executionTime: 12
+          }
+        ]
+      }
+    ]
+  }
+}
+
+describe('Flyway', () => {
+  let wrapper
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    vi.unstubAllGlobals()
+  })
+
+  it('shows a shared unavailable reason when Flyway is not on the classpath', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(null, false, 404)))
+
+    wrapper = mount(Flyway)
+    await flushPromises()
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert-info')
+    expect(alert.text()).toContain('Flyway is not on the classpath')
+    expect(alert.find('code').text()).toBe('flyway-core')
+  })
+
+  it('reports when Flyway is present but no beans are detected', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({total: 0, databases: []})))
+
+    wrapper = mount(Flyway)
+    await flushPromises()
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert-secondary')
+    expect(alert.text()).toContain('no Flyway beans were detected')
+  })
+
+  it('renders migrations when Flyway beans are present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(flywayReport())))
+
+    wrapper = mount(Flyway)
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledWith('api/flyway/migrations', expect.anything())
+    expect(wrapper.text()).not.toContain('not on the classpath')
+    expect(wrapper.text()).toContain('migration(s) across')
+    expect(wrapper.text()).toContain('V1__init.sql')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Flyway.vue
+++ b/bootui-ui/src/main/frontend/src/views/Flyway.vue
@@ -4,6 +4,7 @@ import {computed, onMounted, ref} from 'vue'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import UnavailableState from './components/UnavailableState.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -111,14 +112,14 @@ onMounted(load)
       <button class="btn-close" @click="banner = null"></button>
     </div>
 
-    <div v-if="!flywayPresent" class="alert alert-info">
+    <UnavailableState v-if="!flywayPresent" variant="info">
       Flyway is not on the classpath of this application. Add the <code>flyway-core</code> dependency to see schema
       migrations here.
-    </div>
+    </UnavailableState>
 
-    <div v-else-if="report && report.databases.length === 0" class="alert alert-secondary">
+    <UnavailableState v-else-if="report && report.databases.length === 0">
       Flyway is on the classpath, but no Flyway beans were detected in the application context.
-    </div>
+    </UnavailableState>
 
     <template v-else-if="report">
       <div v-if="readOnly" class="alert alert-warning small">

--- a/bootui-ui/src/main/frontend/src/views/Liquibase.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Liquibase.test.js
@@ -1,0 +1,78 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import Liquibase from './Liquibase.vue'
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {ok, status, json: () => Promise.resolve(body)}
+}
+
+function liquibaseReport() {
+  return {
+    total: 1,
+    databases: [
+      {
+        name: 'dataSource',
+        applied: 1,
+        pending: 0,
+        updateEnabled: true,
+        changeSets: [
+          {
+            id: 'create-users',
+            author: 'dev',
+            changeLog: 'db/changelog.xml',
+            execType: 'EXECUTED',
+            orderExecuted: 1,
+            dateExecuted: '2026-01-01',
+            description: 'create users table'
+          }
+        ]
+      }
+    ]
+  }
+}
+
+describe('Liquibase', () => {
+  let wrapper
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    vi.unstubAllGlobals()
+  })
+
+  it('shows a shared unavailable reason when Liquibase is not on the classpath', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(null, false, 404)))
+
+    wrapper = mount(Liquibase)
+    await flushPromises()
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert-info')
+    expect(alert.text()).toContain('Liquibase is not on the classpath')
+    expect(alert.find('code').text()).toBe('liquibase-core')
+  })
+
+  it('reports when Liquibase is present but no beans are detected', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({total: 0, databases: []})))
+
+    wrapper = mount(Liquibase)
+    await flushPromises()
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert-secondary')
+    expect(alert.text()).toContain('no Liquibase beans were detected')
+  })
+
+  it('renders change sets when Liquibase beans are present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(liquibaseReport())))
+
+    wrapper = mount(Liquibase)
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledWith('api/liquibase/changesets', expect.anything())
+    expect(wrapper.text()).not.toContain('not on the classpath')
+    expect(wrapper.text()).toContain('change set(s) across')
+    expect(wrapper.text()).toContain('create-users')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Liquibase.vue
+++ b/bootui-ui/src/main/frontend/src/views/Liquibase.vue
@@ -4,6 +4,7 @@ import {computed, onMounted, ref} from 'vue'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import UnavailableState from './components/UnavailableState.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -109,14 +110,14 @@ onMounted(load)
       <button class="btn-close" @click="banner = null"></button>
     </div>
 
-    <div v-if="!liquibasePresent" class="alert alert-info">
+    <UnavailableState v-if="!liquibasePresent" variant="info">
       Liquibase is not on the classpath of this application. Add the <code>liquibase-core</code> dependency to see
       change sets here.
-    </div>
+    </UnavailableState>
 
-    <div v-else-if="report && report.databases.length === 0" class="alert alert-secondary">
+    <UnavailableState v-else-if="report && report.databases.length === 0">
       Liquibase is on the classpath, but no Liquibase beans were detected in the application context.
-    </div>
+    </UnavailableState>
 
     <template v-else-if="report">
       <div v-if="readOnly" class="alert alert-warning small">

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -1,6 +1,7 @@
 <script setup>
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import UnavailableState from './components/UnavailableState.vue'
 import {formatBytes, memoryProgressClass, useMemoryReport} from '../utils/memoryReport.js'
 
 const {data, error, lastUpdated, autoRefresh, loading, initialLoading, load} = useMemoryReport()
@@ -148,6 +149,6 @@ const {data, error, lastUpdated, autoRefresh, loading, initialLoading, load} = u
       </div>
     </template>
 
-    <div v-else-if="!error" class="text-muted">Loading…</div>
+    <UnavailableState v-else-if="!error" message="Live memory data is unavailable. Retry or refresh this panel." />
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/TuningAdvisor.vue
+++ b/bootui-ui/src/main/frontend/src/views/TuningAdvisor.vue
@@ -2,6 +2,7 @@
 import {computed} from 'vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import UnavailableState from './components/UnavailableState.vue'
 import {useCopyToClipboard} from '../utils/useCopyToClipboard.js'
 import {confidenceBadgeClass, formatBytes, useMemoryReport} from '../utils/memoryReport.js'
 
@@ -397,7 +398,7 @@ async function copyKubernetesYaml() {
       </div>
     </template>
 
-    <div v-else-if="!error" class="text-muted">Loading…</div>
+    <UnavailableState v-else-if="!error" message="Tuning advisor data is unavailable. Retry or refresh this panel." />
   </div>
 </template>
 

--- a/bootui-ui/src/main/frontend/src/views/components/UnavailableState.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/UnavailableState.test.js
@@ -1,0 +1,38 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+
+import UnavailableState from './UnavailableState.vue'
+
+describe('UnavailableState', () => {
+  it('renders the message with the default secondary variant and info icon', () => {
+    const wrapper = mount(UnavailableState, {props: {message: 'Nothing here yet.'}})
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert')
+    expect(alert.classes()).toContain('alert-secondary')
+    expect(alert.text()).toBe('Nothing here yet.')
+    expect(wrapper.find('i.bi.bi-info-circle').exists()).toBe(true)
+  })
+
+  it('applies the requested variant and icon', () => {
+    const wrapper = mount(UnavailableState, {
+      props: {message: 'Add the dependency.', variant: 'info', icon: 'bi-plug'}
+    })
+
+    const alert = wrapper.get('[role="alert"]')
+    expect(alert.classes()).toContain('alert-info')
+    expect(alert.classes()).not.toContain('alert-secondary')
+    expect(wrapper.find('i.bi.bi-plug').exists()).toBe(true)
+  })
+
+  it('prefers default slot content over the message prop', () => {
+    const wrapper = mount(UnavailableState, {
+      props: {message: 'fallback message'},
+      slots: {default: '<code>flyway-core</code> required'}
+    })
+
+    expect(wrapper.find('code').exists()).toBe(true)
+    expect(wrapper.text()).toContain('flyway-core required')
+    expect(wrapper.text()).not.toContain('fallback message')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/UnavailableState.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/UnavailableState.vue
@@ -1,0 +1,13 @@
+<script setup>
+defineProps({
+  message: {type: String, default: ''},
+  icon: {type: String, default: 'bi-info-circle'},
+  variant: {type: String, default: 'secondary'}
+})
+</script>
+
+<template>
+  <div :class="['alert', `alert-${variant}`]" role="alert">
+    <i :class="['bi', icon, 'me-2']"></i><slot>{{ message }}</slot>
+  </div>
+</template>


### PR DESCRIPTION
## What & why

Audit follow-up (W4-1). Some panels rendered an explicit "unavailable + reason" state (e.g. `Threads.vue`, `HttpSessions.vue`, `Health.vue`, the advisor scan-status views), while others fell back to a generic `Loading…` or showed no explicit reason. This PR introduces one shared component and adopts it so every optional-dependency panel shows a clear reason when its backing library/endpoint is absent.

## Shared component

`src/views/components/UnavailableState.vue` — a Bootstrap alert (`role="alert"`) with an icon + reason, matching the existing good-example idiom:

```html
<div class="alert alert-secondary" role="alert">
  <i class="bi bi-info-circle me-2"></i>{{ reason }}
</div>
```

Props: `message` (simple-text path), `icon` (default `bi-info-circle`), `variant` (default `secondary`). A default slot overrides `message` for rich content (e.g. `<code>` dependency names).

> Note: placed in `src/views/components/` to match the existing shared components (`PanelHeader`, `PanelSkeleton`, `ServerListFooter`) rather than the task's example `src/components/` path.

## Adopting views

- **Flyway / Liquibase / Data** — replaced the ad-hoc "not on classpath" (`info`) and "present but no beans detected" (`secondary`) alerts with `UnavailableState`, preserving each existing condition and variant.
- **Memory / TuningAdvisor** — replaced the misleading generic `Loading…` fallback (only reachable after the initial load, never during refresh) with an explicit unavailable reason. Normal data rendering is unchanged.
- **DevTools** — added an explicit unavailable fallback for when the status can't load (previously left a blank panel after the error banner auto-dismissed).

API calls remain relative; no backend or DTO changes.

## Tests

- `UnavailableState.test.js` — message prop, slot override, icon/variant classes, `role="alert"`.
- New smoke tests for `Flyway`, `Liquibase`, `Data`, and `DevTools` covering the absent, empty, and populated branches so every edited view is exercised.
- Existing `Memory` / `TuningAdvisor` tests still pass (data path unchanged).

Vitest: **131 passed** (was 117). `npm run format:check` clean.