### PR TITLE
test: lock in advisor fail-closed rule contract with error/skip tests

### DIFF
--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureScannerTests.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.architecture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.tngtech.archunit.lang.ArchRule;
 import io.github.jdubois.bootui.core.dto.ArchitectureReport;
 import io.github.jdubois.bootui.core.dto.ArchitectureRuleResultDto;
 import java.time.Clock;
@@ -74,6 +75,88 @@ class ArchitectureScannerTests {
         assertThat(report.rulesEvaluated()).isZero();
         assertThat(report.results()).isEmpty();
         assertThat(report.violationsFound()).isZero();
+    }
+
+    @Test
+    void ruleEvaluationWrapsRuntimeExceptionAsErrorResult() {
+        ArchitectureRuleResultDto result = new ThrowingRule().evaluate(null);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.ERROR);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations()).hasSize(1);
+        assertThat(result.sampleViolations().get(0))
+                .contains("Rule could not be evaluated:")
+                .contains("boom");
+    }
+
+    @Test
+    void ruleEvaluationWrapsLinkageErrorAsErrorResult() {
+        ArchitectureRuleResultDto result = new LinkageErrorRule().evaluate(null);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.ERROR);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations().get(0)).contains("missing");
+    }
+
+    @Test
+    void ruleThatIsNotApplicableSurfacesSkippedStatus() {
+        ArchitectureRuleResultDto result = new NotApplicableRule().evaluate(null);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.SKIPPED);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations().get(0)).contains("not applicable");
+    }
+
+    @Test
+    void everyActiveRuleRoutesThroughTheFailClosedBase() {
+        assertThat(ArchitectureRuleRegistry.activeRules())
+                .allSatisfy(rule -> assertThat(rule).isInstanceOf(AbstractArchitectureRule.class));
+    }
+
+    private static ArchitectureRuleDefinition testRuleDefinition() {
+        return new ArchitectureRuleDefinition(
+                "ARCH-TEST-001",
+                "Deliberately failing test rule",
+                ArchitectureCategory.CODING_PRACTICES,
+                "LOW",
+                "Test-only rule used to exercise the fail-closed base.",
+                "No action required.");
+    }
+
+    private static final class ThrowingRule extends AbstractArchitectureRule {
+
+        ThrowingRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        ArchRule rule(ArchitectureContext context) {
+            throw new IllegalStateException("boom");
+        }
+    }
+
+    private static final class LinkageErrorRule extends AbstractArchitectureRule {
+
+        LinkageErrorRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        ArchRule rule(ArchitectureContext context) {
+            throw new NoClassDefFoundError("missing");
+        }
+    }
+
+    private static final class NotApplicableRule extends AbstractArchitectureRule {
+
+        NotApplicableRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        ArchRule rule(ArchitectureContext context) {
+            return null;
+        }
     }
 
     private static int severityRank(String severity) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmReadinessScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmReadinessScannerTests.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.graalvm;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.tngtech.archunit.lang.ArchRule;
 import io.github.jdubois.bootui.autoconfigure.graalvm.GraalVmReadinessScanner.GraalVmScanResult;
 import io.github.jdubois.bootui.core.dto.GraalVmFindingDto;
 import io.github.jdubois.bootui.core.dto.GraalVmReadinessReport;
@@ -123,6 +124,93 @@ class GraalVmReadinessScannerTests {
         assertThat(report.checksRun()).isZero();
         assertThat(report.findings()).isEmpty();
         assertThat(report.findingsFound()).isZero();
+    }
+
+    @Test
+    void checkEvaluationWrapsRuntimeExceptionAsErrorFinding() {
+        GraalVmFindingDto finding = new ThrowingCheck().evaluate(null);
+
+        assertThat(finding.status()).isEqualTo(GraalVmCheckSupport.ERROR);
+        assertThat(finding.occurrenceCount()).isZero();
+        assertThat(finding.sampleOccurrences()).hasSize(1);
+        assertThat(finding.sampleOccurrences().get(0))
+                .contains("Check could not be evaluated:")
+                .contains("boom");
+    }
+
+    @Test
+    void checkEvaluationWrapsLinkageErrorAsErrorFinding() {
+        GraalVmFindingDto finding = new LinkageErrorCheck().evaluate(null);
+
+        assertThat(finding.status()).isEqualTo(GraalVmCheckSupport.ERROR);
+        assertThat(finding.occurrenceCount()).isZero();
+        assertThat(finding.sampleOccurrences().get(0)).contains("missing");
+    }
+
+    @Test
+    void checkThatIsNotApplicableSurfacesSkippedStatus() {
+        GraalVmFindingDto finding = new NotApplicableCheck().evaluate(null);
+
+        assertThat(finding.status()).isEqualTo(GraalVmCheckSupport.SKIPPED);
+        assertThat(finding.occurrenceCount()).isZero();
+        assertThat(finding.sampleOccurrences().get(0)).contains("not applicable");
+    }
+
+    @Test
+    void directlyImplementedCheckReportsErrorInsteadOfThrowing() {
+        // SerializationCheck implements GraalVmCheck directly (not via AbstractArchUnitGraalVmCheck); a null
+        // class set forces its body to throw so the test exercises its own fail-closed try/catch.
+        GraalVmFindingDto finding = new SerializationCheck().evaluate(new GraalVmContext(null, List.of()));
+
+        assertThat(finding.status()).isEqualTo(GraalVmCheckSupport.ERROR);
+        assertThat(finding.occurrenceCount()).isZero();
+        assertThat(finding.sampleOccurrences().get(0)).contains("Check could not be evaluated:");
+    }
+
+    private static GraalVmCheckDefinition testCheckDefinition() {
+        return new GraalVmCheckDefinition(
+                "GRAAL-TEST-001",
+                "Deliberately failing test check",
+                GraalVmCategory.REFLECTION,
+                "INFO",
+                "Test-only check used to exercise the fail-closed base.",
+                "No action required.");
+    }
+
+    private static final class ThrowingCheck extends AbstractArchUnitGraalVmCheck {
+
+        ThrowingCheck() {
+            super(testCheckDefinition());
+        }
+
+        @Override
+        ArchRule rule(GraalVmContext context) {
+            throw new IllegalStateException("boom");
+        }
+    }
+
+    private static final class LinkageErrorCheck extends AbstractArchUnitGraalVmCheck {
+
+        LinkageErrorCheck() {
+            super(testCheckDefinition());
+        }
+
+        @Override
+        ArchRule rule(GraalVmContext context) {
+            throw new NoClassDefFoundError("missing");
+        }
+    }
+
+    private static final class NotApplicableCheck extends AbstractArchUnitGraalVmCheck {
+
+        NotApplicableCheck() {
+            super(testCheckDefinition());
+        }
+
+        @Override
+        ArchRule rule(GraalVmContext context) {
+            return null;
+        }
     }
 
     private static int severityRank(String severity) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernateadvisor/HibernateAdvisorScannerTests.java
@@ -404,6 +404,93 @@ class HibernateAdvisorScannerTests {
         assertThat(report.results()).isEmpty();
     }
 
+    @Test
+    void ruleEvaluationWrapsRuntimeExceptionAsErrorResult() {
+        HibernateAdvisorRuleResultDto result = new ThrowingRule().evaluate(emptyContext());
+
+        assertThat(result.status()).isEqualTo(HibernateAdvisorRuleSupport.ERROR);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations()).hasSize(1);
+        assertThat(result.sampleViolations().get(0))
+                .contains("Rule could not be evaluated:")
+                .contains("boom");
+    }
+
+    @Test
+    void ruleEvaluationWrapsLinkageErrorAsErrorResult() {
+        HibernateAdvisorRuleResultDto result = new LinkageErrorRule().evaluate(emptyContext());
+
+        assertThat(result.status()).isEqualTo(HibernateAdvisorRuleSupport.ERROR);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations().get(0)).contains("missing");
+    }
+
+    @Test
+    void skippedRuleSurfacesSkippedStatusAndReason() {
+        HibernateAdvisorRuleResultDto result = new SkippingRule().evaluate(emptyContext());
+
+        assertThat(result.status()).isEqualTo(HibernateAdvisorRuleSupport.SKIPPED);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations()).containsExactly("Not applicable in this context.");
+    }
+
+    @Test
+    void everyActiveRuleRoutesThroughTheFailClosedBase() {
+        assertThat(HibernateAdvisorRuleRegistry.activeRules())
+                .allSatisfy(rule -> assertThat(rule).isInstanceOf(AbstractHibernateAdvisorRule.class));
+    }
+
+    private static HibernateAdvisorContext emptyContext() {
+        return new HibernateAdvisorContext(List.of(), List.of(), new MockEnvironment());
+    }
+
+    private static HibernateAdvisorRuleDefinition testRuleDefinition() {
+        return new HibernateAdvisorRuleDefinition(
+                "HIB-TEST-001",
+                "Deliberately failing test rule",
+                HibernateAdvisorCategory.CONFIGURATION,
+                "LOW",
+                "Test-only rule used to exercise the fail-closed base.",
+                "No action required.",
+                null);
+    }
+
+    private static final class ThrowingRule extends AbstractHibernateAdvisorRule {
+
+        ThrowingRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        HibernateAdvisorRuleResultDto evaluateRule(HibernateAdvisorContext context) {
+            throw new IllegalStateException("boom");
+        }
+    }
+
+    private static final class LinkageErrorRule extends AbstractHibernateAdvisorRule {
+
+        LinkageErrorRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        HibernateAdvisorRuleResultDto evaluateRule(HibernateAdvisorContext context) {
+            throw new NoClassDefFoundError("missing");
+        }
+    }
+
+    private static final class SkippingRule extends AbstractHibernateAdvisorRule {
+
+        SkippingRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        HibernateAdvisorRuleResultDto evaluateRule(HibernateAdvisorContext context) {
+            return skipped("Not applicable in this context.");
+        }
+    }
+
     private HibernateAdvisorScanner scanner(MockEnvironment environment, Class<?> entityType) {
         return scanner(environment, List.of(), entityType);
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorScannerTests.java
@@ -259,6 +259,94 @@ class SecurityAdvisorScannerTests {
                 .doesNotHaveDuplicates();
     }
 
+    @Test
+    void ruleEvaluationWrapsRuntimeExceptionAsErrorResult() {
+        SecurityAdvisorRuleResultDto result = new ThrowingRule().evaluate(emptyContext());
+
+        assertThat(result.status()).isEqualTo(SecurityAdvisorRuleSupport.ERROR);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations()).hasSize(1);
+        assertThat(result.sampleViolations().get(0))
+                .contains("Rule could not be evaluated:")
+                .contains("boom");
+    }
+
+    @Test
+    void ruleEvaluationWrapsLinkageErrorAsErrorResult() {
+        SecurityAdvisorRuleResultDto result = new LinkageErrorRule().evaluate(emptyContext());
+
+        assertThat(result.status()).isEqualTo(SecurityAdvisorRuleSupport.ERROR);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations().get(0)).contains("missing");
+    }
+
+    @Test
+    void skippedRuleSurfacesSkippedStatusAndReason() {
+        SecurityAdvisorRuleResultDto result = new SkippingRule().evaluate(emptyContext());
+
+        assertThat(result.status()).isEqualTo(SecurityAdvisorRuleSupport.SKIPPED);
+        assertThat(result.violationCount()).isZero();
+        assertThat(result.sampleViolations()).containsExactly("Not applicable in this context.");
+    }
+
+    @Test
+    void everyActiveRuleRoutesThroughTheFailClosedBase() {
+        assertThat(SecurityAdvisorRuleRegistry.activeRules())
+                .allSatisfy(rule -> assertThat(rule).isInstanceOf(AbstractSecurityAdvisorRule.class));
+    }
+
+    private static SecurityAdvisorContext emptyContext() {
+        return new SecurityAdvisorContext(
+                List.of(), List.of(), List.of(), false, List.of(), false, false, false, false, new MockEnvironment());
+    }
+
+    private static SecurityAdvisorRuleDefinition testRuleDefinition() {
+        return new SecurityAdvisorRuleDefinition(
+                "SEC-TEST-001",
+                "Deliberately failing test rule",
+                SecurityAdvisorCategory.CONFIGURATION,
+                "LOW",
+                "Test-only rule used to exercise the fail-closed base.",
+                "No action required.",
+                null);
+    }
+
+    private static final class ThrowingRule extends AbstractSecurityAdvisorRule {
+
+        ThrowingRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        SecurityAdvisorRuleResultDto evaluateRule(SecurityAdvisorContext context) {
+            throw new IllegalStateException("boom");
+        }
+    }
+
+    private static final class LinkageErrorRule extends AbstractSecurityAdvisorRule {
+
+        LinkageErrorRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        SecurityAdvisorRuleResultDto evaluateRule(SecurityAdvisorContext context) {
+            throw new NoClassDefFoundError("missing");
+        }
+    }
+
+    private static final class SkippingRule extends AbstractSecurityAdvisorRule {
+
+        SkippingRule() {
+            super(testRuleDefinition());
+        }
+
+        @Override
+        SecurityAdvisorRuleResultDto evaluateRule(SecurityAdvisorContext context) {
+            return skipped("Not applicable in this context.");
+        }
+    }
+
     private static MapPropertySource bootUiActuatorDefaultsPropertySource() {
         return new MapPropertySource(
                 "bootUiActuatorEndpointDefaults",


### PR DESCRIPTION
## What

Adds negative / skip / error-path tests for the four advisor scanners (W7-4) to lock in the fail-closed rule contract: advisor rules must never propagate exceptions — the base wrapper catches `RuntimeException`/`LinkageError` and reports them as an `ERROR` result instead of aborting the scan, and a not-applicable rule yields a `SKIPPED` result with its reason.

This is a **test-only** change — no production code was modified.

## Coverage added

For each advisor, focused tests drive the production `evaluate()` fail-closed wrapper via small, deliberately-throwing/skipping test-double rules in the same package (no reflection, no new production seams):

- **Security Advisor** & **Hibernate Advisor**: a rule whose `evaluateRule` throws a `RuntimeException` → `ERROR`; throws a `LinkageError` (`NoClassDefFoundError`) → `ERROR`; returns `skipped(reason)` → `SKIPPED` with the reason. Plus a registry guard asserting every active rule extends the fail-closed base class.
- **Architecture Advisor** & **GraalVM readiness**: same pattern against the `rule()`/check seam — `rule()` throwing `RuntimeException`/`LinkageError` → `ERROR`, and `rule()` returning `null` → `SKIPPED`.
- **GraalVM**: an extra test for `SerializationCheck` (which implements `GraalVmCheck` directly rather than via `AbstractArchUnitGraalVmCheck`), confirming its own try/catch reports `ERROR` instead of throwing when handed a hostile context. Architecture/Security/Hibernate use an `instanceof` registry conformance guard; GraalVM can't (the direct implementer), so it's covered behaviorally.

## Verification

- `./mvnw -B -ntp spotless:apply` / `spotless:check` — clean
- `./mvnw -pl bootui-autoconfigure -am test` — **624 tests pass** (16 new)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>