### PR TITLE
test(autoconfigure): add direct controller tests for AI, GitHub, OTLP

### DIFF
--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/AiControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/AiControllerTests.java
@@ -1,0 +1,288 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.otlp.AttributeValue;
+import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * HTTP-level tests for {@link AiController}.
+ *
+ * <p>The controller derives the AI Usage panel from the GenAI spans accumulated
+ * in {@link TelemetryStore}, so the tests seed normalized spans directly and
+ * assert the stable DTO JSON shape. They cover the aggregated overview, the
+ * disabled/empty branches, the recent-chats list (limit and ordering), the chat
+ * detail (tools and vector operations, plus the not-found path) and the token
+ * time series (window sizing and clamping).</p>
+ */
+class AiControllerTests {
+
+    private static final long ONE_MINUTE_NANOS = 60L * 1_000_000_000L;
+
+    private static long nowNanos() {
+        return System.currentTimeMillis() * 1_000_000L;
+    }
+
+    private static NormalizedSpan chatSpan(
+            String traceId,
+            String spanId,
+            long startNanos,
+            long durationNanos,
+            String provider,
+            String model,
+            long inputTokens,
+            long outputTokens,
+            boolean error) {
+        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("gen_ai.operation.name", AttributeValue.ofString("chat"));
+        attrs.put("gen_ai.system", AttributeValue.ofString(provider));
+        attrs.put("gen_ai.request.model", AttributeValue.ofString(model));
+        attrs.put("gen_ai.response.model", AttributeValue.ofString(model));
+        attrs.put("gen_ai.usage.input_tokens", AttributeValue.ofNumber(inputTokens));
+        attrs.put("gen_ai.usage.output_tokens", AttributeValue.ofNumber(outputTokens));
+        attrs.put("gen_ai.response.finish_reasons", AttributeValue.ofList(List.of("stop")));
+        return new NormalizedSpan(
+                traceId,
+                spanId,
+                null,
+                "chat " + model,
+                "CLIENT",
+                "sample",
+                "io.micrometer.observation",
+                startNanos,
+                startNanos + durationNanos,
+                error ? "ERROR" : "OK",
+                null,
+                attrs,
+                List.of());
+    }
+
+    private static NormalizedSpan toolSpan(String traceId, String spanId, String parentSpanId, String toolName) {
+        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("gen_ai.operation.name", AttributeValue.ofString("execute_tool"));
+        attrs.put("gen_ai.tool.name", AttributeValue.ofString(toolName));
+        return new NormalizedSpan(
+                traceId,
+                spanId,
+                parentSpanId,
+                "execute_tool " + toolName,
+                "INTERNAL",
+                "sample",
+                "io.micrometer.observation",
+                10L,
+                15L,
+                "OK",
+                null,
+                attrs,
+                List.of());
+    }
+
+    private static NormalizedSpan vectorSpan(String traceId, String spanId, String parentSpanId, String collection) {
+        Map<String, AttributeValue> attrs = new LinkedHashMap<>();
+        attrs.put("db.system", AttributeValue.ofString("spring_ai_vector_store"));
+        attrs.put("db.operation.name", AttributeValue.ofString("query"));
+        attrs.put("db.collection.name", AttributeValue.ofString(collection));
+        return new NormalizedSpan(
+                traceId,
+                spanId,
+                parentSpanId,
+                "db query " + collection,
+                "CLIENT",
+                "sample",
+                "io.micrometer.observation",
+                5L,
+                12L,
+                "OK",
+                null,
+                attrs,
+                List.of());
+    }
+
+    private static MockMvc mvcWith(TelemetryStore store, BootUiProperties properties) {
+        return standaloneSetup(new AiController(store, properties)).build();
+    }
+
+    @Test
+    void overviewAggregatesChatToolAndVectorSpans() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        long now = nowNanos();
+        store.add(chatSpan("trace-1", "chat-1", now, 250_000_000L, "ollama", "qwen3", 42, 8, false));
+        store.add(toolSpan("trace-1", "tool-1", "chat-1", "getWeather"));
+        store.add(vectorSpan("trace-1", "vector-1", "chat-1", "docs"));
+
+        mvcWith(store, properties)
+                .perform(get("/bootui/api/ai/overview"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.springAiDetected").value(false))
+                .andExpect(jsonPath("$.langChain4jDetected").value(false))
+                .andExpect(jsonPath("$.totalChats").value(1))
+                .andExpect(jsonPath("$.totalInputTokens").value(42))
+                .andExpect(jsonPath("$.totalOutputTokens").value(8))
+                .andExpect(jsonPath("$.tokensByModel.qwen3").value(50))
+                .andExpect(jsonPath("$.callsByModel.qwen3").value(1))
+                .andExpect(jsonPath("$.errorCount").value(0))
+                .andExpect(jsonPath("$.averageDurationNanos").value(250_000_000L))
+                .andExpect(jsonPath("$.toolCallCount").value(1))
+                .andExpect(jsonPath("$.vectorOperationCount").value(1))
+                .andExpect(jsonPath("$.embeddingCount").value(0))
+                .andExpect(jsonPath("$.recent.length()").value(1))
+                .andExpect(jsonPath("$.recent[0].provider").value("ollama"))
+                .andExpect(jsonPath("$.recent[0].requestModel").value("qwen3"))
+                .andExpect(jsonPath("$.recent[0].toolCallCount").value(1))
+                .andExpect(jsonPath("$.recent[0].vectorOperationCount").value(1));
+    }
+
+    @Test
+    void overviewReportsDisabledTelemetry() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        properties.getTelemetry().setEnabled(false);
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+
+        mvcWith(store, properties)
+                .perform(get("/bootui/api/ai/overview"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(false))
+                .andExpect(jsonPath("$.totalChats").value(0))
+                .andExpect(jsonPath("$.recent.length()").value(0));
+    }
+
+    @Test
+    void overviewIsEmptyWhenNoSpans() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+
+        mvcWith(store, properties)
+                .perform(get("/bootui/api/ai/overview"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.enabled").value(true))
+                .andExpect(jsonPath("$.totalChats").value(0))
+                .andExpect(jsonPath("$.totalInputTokens").value(0))
+                .andExpect(jsonPath("$.totalOutputTokens").value(0))
+                .andExpect(jsonPath("$.averageDurationNanos").value(0))
+                .andExpect(jsonPath("$.toolCallCount").value(0))
+                .andExpect(jsonPath("$.recent.length()").value(0));
+    }
+
+    @Test
+    void chatsRespectLimitAndAreOrderedMostRecentFirst() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        long now = nowNanos();
+        store.add(chatSpan("trace-old", "chat-old", now, 1_000_000L, "ollama", "m1", 1, 1, false));
+        store.add(chatSpan("trace-new", "chat-new", now + ONE_MINUTE_NANOS, 1_000_000L, "ollama", "m2", 2, 2, false));
+        MockMvc mvc = mvcWith(store, properties);
+
+        mvc.perform(get("/bootui/api/ai/chats"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].spanId").value("chat-new"))
+                .andExpect(jsonPath("$[1].spanId").value("chat-old"));
+
+        mvc.perform(get("/bootui/api/ai/chats").param("limit", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].spanId").value("chat-new"));
+
+        mvc.perform(get("/bootui/api/ai/chats").param("limit", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
+    }
+
+    @Test
+    void chatDetailReturnsLinkedToolsAndVectorOperations() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        long now = nowNanos();
+        store.add(chatSpan("trace-1", "chat-1", now, 100_000_000L, "ollama", "qwen3", 10, 5, false));
+        store.add(toolSpan("trace-1", "tool-1", "chat-1", "getWeather"));
+        store.add(vectorSpan("trace-1", "vector-1", "chat-1", "docs"));
+
+        mvcWith(store, properties)
+                .perform(get("/bootui/api/ai/chats/chat-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.summary.spanId").value("chat-1"))
+                .andExpect(jsonPath("$.summary.toolCallCount").value(1))
+                .andExpect(jsonPath("$.summary.vectorOperationCount").value(1))
+                .andExpect(jsonPath("$.toolCalls.length()").value(1))
+                .andExpect(jsonPath("$.toolCalls[0].name").value("getWeather"))
+                .andExpect(jsonPath("$.vectorOperations.length()").value(1))
+                .andExpect(jsonPath("$.vectorOperations[0].operation").value("query"))
+                .andExpect(jsonPath("$.vectorOperations[0].collectionName").value("docs"))
+                .andExpect(jsonPath("$.contentCaptured").value(false));
+    }
+
+    @Test
+    void chatDetailReturnsNotFoundForUnknownSpan() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+
+        mvcWith(store, properties)
+                .perform(get("/bootui/api/ai/chats/does-not-exist"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void tokensReturnsRequestedWindowAndBucketsTheChat() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        store.add(chatSpan("trace-1", "chat-1", nowNanos(), 1_000_000L, "ollama", "qwen3", 42, 8, false));
+
+        mvcWith(store, properties)
+                .perform(get("/bootui/api/ai/tokens").param("minutes", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.minutes").value(5))
+                .andExpect(jsonPath("$.buckets.length()").value(5))
+                .andExpect(jsonPath("$.buckets[?(@.inputTokens == 42 && @.outputTokens == 8 && @.callCount == 1)]")
+                        .exists());
+    }
+
+    @Test
+    void tokensClampsWindowAndFallsBackToConfiguredDefault() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        MockMvc mvc = mvcWith(store, properties);
+
+        mvc.perform(get("/bootui/api/ai/tokens").param("minutes", "1000"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.minutes").value(240));
+
+        mvc.perform(get("/bootui/api/ai/tokens").param("minutes", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.minutes").value(1));
+
+        properties.getAi().setTokenSeriesMinutes(7);
+        mvc.perform(get("/bootui/api/ai/tokens"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.minutes").value(7));
+    }
+
+    @Test
+    void chatsClampLimitToConfiguredMaximum() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        long now = nowNanos();
+        // 501 chat spans split across two traces stay under the per-trace and trace caps
+        // while exceeding the 500 response limit, so the clamp is what bounds the result.
+        for (int i = 0; i < 501; i++) {
+            String traceId = "bulk-" + (i % 2);
+            store.add(chatSpan(traceId, "chat-" + i, now + i, 1_000_000L, "ollama", "m", 1, 1, false));
+        }
+
+        mvcWith(store, properties)
+                .perform(get("/bootui/api/ai/chats").param("limit", "1000"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(500));
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubControllerTests.java
@@ -1,0 +1,226 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.dto.GitHubCopilotUsageDto;
+import io.github.jdubois.bootui.core.dto.GitHubCredentialDto;
+import io.github.jdubois.bootui.core.dto.GitHubDashboardReport;
+import io.github.jdubois.bootui.core.dto.GitHubRepositoryDto;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * HTTP-level tests for {@link GitHubController}.
+ *
+ * <p>The controller is a thin pass-through over {@link GitHubDashboardService},
+ * so the tests wire the real service with a controlled working directory and a
+ * stub {@link GitHubClient} (no network or git binary). They assert the stable
+ * {@link GitHubDashboardReport} JSON for the local-only READY dashboard, the
+ * UNAVAILABLE branch outside a GitHub repository, the api-disabled refresh
+ * branch, the connected refresh that delegates to the client, and an error
+ * report surfaced from a failed (e.g. unauthenticated) refresh.</p>
+ */
+class GitHubControllerTests {
+
+    @TempDir
+    Path tempDir;
+
+    private static MockMvc mvcFor(GitHubDashboardService service) {
+        return standaloneSetup(new GitHubController(service)).build();
+    }
+
+    private Path githubProject(String remoteUrl) throws Exception {
+        Path project = tempDir.resolve("project");
+        Path git = project.resolve(".git");
+        Files.createDirectories(git);
+        Files.writeString(git.resolve("config"), """
+                [remote "origin"]
+                    url = %s
+                [branch "main"]
+                    remote = origin
+                    merge = refs/heads/main
+                """.formatted(remoteUrl), StandardCharsets.UTF_8);
+        Files.writeString(git.resolve("HEAD"), "ref: refs/heads/main\n", StandardCharsets.UTF_8);
+        return project;
+    }
+
+    @Test
+    void dashboardReturnsLocalRepositoryState() throws Exception {
+        Path project = githubProject("https://github.com/jdubois/boot-ui.git");
+        StubGitHubClient client = new StubGitHubClient("CONNECTED", true);
+        GitHubDashboardService service = new GitHubDashboardService(new BootUiProperties(), project, client);
+
+        mvcFor(service)
+                .perform(get("/bootui/api/github"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(true))
+                .andExpect(jsonPath("$.status").value("READY"))
+                .andExpect(jsonPath("$.connected").value(false))
+                .andExpect(jsonPath("$.repository.owner").value("jdubois"))
+                .andExpect(jsonPath("$.repository.name").value("boot-ui"))
+                .andExpect(jsonPath("$.repository.fullName").value("jdubois/boot-ui"))
+                .andExpect(jsonPath("$.credential.authenticated").value(false))
+                .andExpect(jsonPath("$.copilotUsage.status").value("UNAVAILABLE"));
+
+        assertThat(client.calls).isZero();
+    }
+
+    @Test
+    void dashboardReportsUnavailableOutsideGitHubRepository() throws Exception {
+        GitHubDashboardService service =
+                new GitHubDashboardService(new BootUiProperties(), tempDir, new StubGitHubClient("CONNECTED", true));
+
+        mvcFor(service)
+                .perform(get("/bootui/api/github"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(false))
+                .andExpect(jsonPath("$.status").value("UNAVAILABLE"))
+                .andExpect(jsonPath("$.unavailableReason").value(containsString("No local git repository")))
+                .andExpect(jsonPath("$.copilotUsage.status").value("UNAVAILABLE"));
+    }
+
+    @Test
+    void refreshReportsDisabledWhenApiRefreshIsDisabled() throws Exception {
+        Path project = githubProject("https://github.com/jdubois/boot-ui.git");
+        BootUiProperties properties = new BootUiProperties();
+        properties.getGithub().setApiEnabled(false);
+        StubGitHubClient client = new StubGitHubClient("CONNECTED", true);
+        GitHubDashboardService service = new GitHubDashboardService(properties, project, client);
+
+        mvcFor(service)
+                .perform(post("/bootui/api/github/refresh"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("DISABLED"))
+                .andExpect(jsonPath("$.connected").value(false))
+                .andExpect(jsonPath("$.message").value(containsString("api-enabled")))
+                .andExpect(jsonPath("$.refreshedAt").isNumber());
+
+        assertThat(client.calls).isZero();
+    }
+
+    @Test
+    void refreshDelegatesToClientWhenApiEnabled() throws Exception {
+        Path project = githubProject("git@github.com:jdubois/boot-ui.git");
+        StubGitHubClient client = new StubGitHubClient("CONNECTED", true);
+        GitHubDashboardService service = new GitHubDashboardService(new BootUiProperties(), project, client);
+
+        mvcFor(service)
+                .perform(post("/bootui/api/github/refresh"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("CONNECTED"))
+                .andExpect(jsonPath("$.connected").value(true))
+                .andExpect(jsonPath("$.credential.authenticated").value(true))
+                .andExpect(jsonPath("$.repository.fullName").value("jdubois/boot-ui"));
+
+        assertThat(client.calls).isEqualTo(1);
+    }
+
+    @Test
+    void refreshReportsUnavailableOutsideGitHubRepository() throws Exception {
+        StubGitHubClient client = new StubGitHubClient("CONNECTED", true);
+        GitHubDashboardService service = new GitHubDashboardService(new BootUiProperties(), tempDir, client);
+
+        mvcFor(service)
+                .perform(post("/bootui/api/github/refresh"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(false))
+                .andExpect(jsonPath("$.status").value("UNAVAILABLE"));
+
+        assertThat(client.calls).isZero();
+    }
+
+    @Test
+    void refreshSurfacesClientErrorReport() throws Exception {
+        Path project = githubProject("https://github.com/jdubois/boot-ui.git");
+        StubGitHubClient client = new StubGitHubClient("ERROR", false);
+        GitHubDashboardService service = new GitHubDashboardService(new BootUiProperties(), project, client);
+
+        mvcFor(service)
+                .perform(post("/bootui/api/github/refresh"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("ERROR"))
+                .andExpect(jsonPath("$.connected").value(false))
+                .andExpect(jsonPath("$.credential.authenticated").value(false))
+                .andExpect(jsonPath("$.warnings[0]").value(containsString("token")));
+
+        assertThat(client.calls).isEqualTo(1);
+    }
+
+    /** Deterministic, no-network {@link GitHubClient} used to drive the refresh branches. */
+    private static final class StubGitHubClient implements GitHubClient {
+
+        private final String status;
+
+        private final boolean connected;
+
+        private int calls;
+
+        private StubGitHubClient(String status, boolean connected) {
+            this.status = status;
+            this.connected = connected;
+        }
+
+        @Override
+        public GitHubDashboardReport refresh(GitHubRepositoryDetector.Repository repository) {
+            calls++;
+            return new GitHubDashboardReport(
+                    true,
+                    null,
+                    connected,
+                    status,
+                    connected ? "ok" : "GitHub API call failed",
+                    Instant.now().toEpochMilli(),
+                    new GitHubRepositoryDto(
+                            repository.owner(),
+                            repository.name(),
+                            repository.fullName(),
+                            repository.host(),
+                            repository.apiBaseUri().toString(),
+                            repository.htmlUrl(),
+                            "main",
+                            repository.localBranch(),
+                            repository.upstreamBranch(),
+                            "public",
+                            false,
+                            false,
+                            false,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null),
+                    new GitHubCredentialDto(connected ? "test" : "none", connected, null, null),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    new GitHubCopilotUsageDto(
+                            "UNAVAILABLE",
+                            null,
+                            "Copilot usage report unavailable",
+                            null,
+                            null,
+                            null,
+                            "https://docs.github.com/en/rest/copilot/copilot-usage-metrics",
+                            "not refreshed"),
+                    connected ? List.of() : List.of("GitHub API call failed without a configured token"));
+        }
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverControllerTests.java
@@ -1,0 +1,206 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+import com.google.protobuf.ByteString;
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
+import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.InstrumentationScope;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.ScopeSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import io.opentelemetry.proto.trace.v1.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * HTTP-level tests for {@link OtlpReceiverController}.
+ *
+ * <p>Posts protobuf-encoded {@code ExportTraceServiceRequest} payloads to the
+ * receiver and asserts the OTLP contract: a 200 with an empty protobuf body on
+ * success, the self-span exclusion governed by {@code bootui.telemetry
+ * .exclude-self-spans}, and the disabled / empty / oversize / invalid branches.
+ * The receiver and decoder read {@link BootUiProperties} live, so each test can
+ * flip a flag after the controller is built.</p>
+ */
+class OtlpReceiverControllerTests {
+
+    private static final String TRACE_ID = "0123456789abcdef0123456789abcdef";
+
+    private static final String HOST_SPAN_ID = "1111111111111111";
+
+    private static final String SELF_SPAN_ID = "2222222222222222";
+
+    private BootUiProperties properties;
+
+    private TelemetryStore store;
+
+    private MockMvc mvc;
+
+    private static KeyValue stringAttr(String key, String value) {
+        return KeyValue.newBuilder()
+                .setKey(key)
+                .setValue(AnyValue.newBuilder().setStringValue(value).build())
+                .build();
+    }
+
+    private static ByteString bytes(String hex) {
+        byte[] out = new byte[hex.length() / 2];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return ByteString.copyFrom(out);
+    }
+
+    private static ExportTraceServiceRequest request(Span... spans) {
+        ScopeSpans.Builder scope = ScopeSpans.newBuilder()
+                .setScope(InstrumentationScope.newBuilder()
+                        .setName("io.micrometer.observation")
+                        .build());
+        for (Span span : spans) {
+            scope.addSpans(span);
+        }
+        return ExportTraceServiceRequest.newBuilder()
+                .addResourceSpans(ResourceSpans.newBuilder()
+                        .setResource(Resource.newBuilder()
+                                .addAttributes(stringAttr("service.name", "sample"))
+                                .build())
+                        .addScopeSpans(scope.build())
+                        .build())
+                .build();
+    }
+
+    private static Span hostSpan() {
+        long now = System.currentTimeMillis() * 1_000_000L;
+        return Span.newBuilder()
+                .setTraceId(bytes(TRACE_ID))
+                .setSpanId(bytes(HOST_SPAN_ID))
+                .setName("chat qwen3")
+                .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
+                .setStartTimeUnixNano(now)
+                .setEndTimeUnixNano(now + 1_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("gen_ai.operation.name", "chat"))
+                .addAttributes(stringAttr("gen_ai.system", "ollama"))
+                .build();
+    }
+
+    private static Span selfSpan() {
+        long now = System.currentTimeMillis() * 1_000_000L;
+        return Span.newBuilder()
+                .setTraceId(bytes(TRACE_ID))
+                .setSpanId(bytes(SELF_SPAN_ID))
+                .setName("http get")
+                .setKind(Span.SpanKind.SPAN_KIND_SERVER)
+                .setStartTimeUnixNano(now)
+                .setEndTimeUnixNano(now + 1_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
+                .addAttributes(stringAttr("http.route", "/bootui/api/overview"))
+                .build();
+    }
+
+    @BeforeEach
+    void setUp() {
+        properties = new BootUiProperties();
+        properties.getTelemetry().setEnabled(true);
+        store = new TelemetryStore(properties.getTelemetry());
+        OtlpSpanDecoder decoder = new OtlpSpanDecoder(properties.getTelemetry());
+        mvc = standaloneSetup(new OtlpReceiverController(store, decoder, properties))
+                .build();
+    }
+
+    @Test
+    void storesSpansFromValidPayloadAndReturnsEmptyProtobuf() throws Exception {
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(request(hostSpan()).toByteArray()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/x-protobuf"))
+                .andExpect(content().bytes(new byte[0]));
+
+        assertThat(store.retainedTraceCount()).isEqualTo(1);
+        assertThat(store.allSpansSnapshot()).hasSize(1);
+    }
+
+    @Test
+    void rejectsPayloadWhenTelemetryDisabled() throws Exception {
+        properties.getTelemetry().setEnabled(false);
+
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(request(hostSpan()).toByteArray()))
+                .andExpect(status().isServiceUnavailable());
+
+        assertThat(store.retainedTraceCount()).isZero();
+    }
+
+    @Test
+    void rejectsOversizePayload() throws Exception {
+        properties.getTelemetry().setMaxRequestBytes(8);
+
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(new byte[64]))
+                .andExpect(status().isPayloadTooLarge());
+
+        assertThat(store.retainedTraceCount()).isZero();
+    }
+
+    @Test
+    void rejectsInvalidProtobufPayload() throws Exception {
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(new byte[] {0x7F, 0x7F, 0x7F}))
+                .andExpect(status().isBadRequest());
+
+        assertThat(store.retainedTraceCount()).isZero();
+    }
+
+    @Test
+    void excludesBootUiSelfSpansByDefault() throws Exception {
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(request(selfSpan()).toByteArray()))
+                .andExpect(status().isOk());
+
+        assertThat(store.retainedTraceCount()).isZero();
+    }
+
+    @Test
+    void retainsSelfSpansWhenExclusionDisabled() throws Exception {
+        properties.getTelemetry().setExcludeSelfSpans(false);
+
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(request(selfSpan()).toByteArray()))
+                .andExpect(status().isOk());
+
+        assertThat(store.retainedTraceCount()).isEqualTo(1);
+        assertThat(store.allSpansSnapshot()).hasSize(1);
+    }
+
+    @Test
+    void dropsOnlySelfSpansFromMixedPayload() throws Exception {
+        mvc.perform(post("/bootui/api/otlp/v1/traces")
+                        .contentType("application/x-protobuf")
+                        .content(request(selfSpan(), hostSpan()).toByteArray()))
+                .andExpect(status().isOk());
+
+        assertThat(store.allSpansSnapshot()).hasSize(1);
+        assertThat(store.allSpansSnapshot().get(0).spanId()).isEqualTo(HOST_SPAN_ID);
+    }
+}


### PR DESCRIPTION
## Summary

Audit follow-up **W7-2**: add direct controller/web-slice tests for the three `bootui-autoconfigure` controllers that previously had no dedicated test class — `AiController`, `GitHubController`, and `OtlpReceiverController`.

All three use `MockMvc` `standaloneSetup`, mirroring the existing controller tests (e.g. `HikariControllerTests`, `TracesControllerTests`). Collaborators are stubbed/seeded in-memory, so the tests are fully deterministic — no real network, Docker, or git binary.

## Coverage

**`AiControllerTests`** (9 tests) — drives the panel off seeded `TelemetryStore` GenAI spans:
- `/overview` aggregation (tokens, per-model breakdown, tool/vector counts, recent chats)
- telemetry-disabled and empty-store branches
- `/chats` ordering (most-recent-first), lower clamp (`limit=0`) and upper clamp (`limit=1000` → 500)
- `/chats/{spanId}` detail with linked tool + vector operations, and the `404` branch
- `/tokens` window sizing, clamping (1..240) and configured default fallback

**`GitHubControllerTests`** (6 tests) — real `GitHubDashboardService` over a `@TempDir` working dir + a stub `GitHubClient`:
- `READY` dashboard from a detected local GitHub repo (no network)
- `UNAVAILABLE` dashboard and refresh outside a GitHub repo (client never called)
- `DISABLED` refresh when `bootui.github.api-enabled=false`
- connected refresh delegating to the client
- client `ERROR` report surfaced unchanged through the controller

**`OtlpReceiverControllerTests`** (7 tests) — posts real protobuf `ExportTraceServiceRequest` payloads:
- stores spans and returns `200` + empty protobuf body
- `503` when telemetry disabled, `413` over `max-request-bytes`, `400` on invalid protobuf
- self-span exclusion by default, retention when `exclude-self-spans=false`, and dropping only the self span from a mixed payload

## Notes
- No production code changed.
- An "empty body" receiver test was intentionally not added: a zero-length required `@RequestBody byte[]` is rejected with `400` by the framework before the handler's defensive empty-body branch runs, so it isn't reachable via a web-slice test.

## Verification
- `./mvnw -pl bootui-autoconfigure -am test` → 630 tests green
- `./mvnw -B -ntp spotless:check` → clean