### PR TITLE
Expand GraalVM readiness advisor from 5 to 12 checks

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmCategory.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmCategory.java
@@ -8,7 +8,9 @@ enum GraalVmCategory {
     REFLECTION("Reflection"),
     PROXIES("Dynamic proxies"),
     RESOURCES("Resources"),
+    SERVICE_LOADER("Service loading"),
     SERIALIZATION("Serialization"),
+    BUILD_TIME_INIT("Build-time initialization"),
     NATIVE_ACCESS("Native access");
 
     private final String label;

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmCheckRegistry.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmCheckRegistry.java
@@ -10,10 +10,17 @@ final class GraalVmCheckRegistry {
 
     private static final List<GraalVmCheck> ACTIVE_CHECKS = List.of(
             new ReflectionUsageCheck(),
+            new ClassLoaderUsageCheck(),
+            new DeepReflectionCheck(),
+            new AnnotationReflectionCheck(),
             new DynamicProxyCheck(),
             new ResourceAccessCheck(),
+            new ResourceBundleCheck(),
+            new ServiceLoaderCheck(),
             new SerializationCheck(),
-            new NativeAccessCheck());
+            new BuildTimeInitializationCheck(),
+            new NativeAccessCheck(),
+            new NativeMethodCheck());
 
     private GraalVmCheckRegistry() {}
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmChecks.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmChecks.java
@@ -3,9 +3,14 @@ package io.github.jdubois.bootui.autoconfigure.graalvm;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitCallTarget;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
+import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.lang.ArchRule;
 import io.github.jdubois.bootui.core.dto.GraalVmFindingDto;
 import java.util.ArrayList;
@@ -262,5 +267,305 @@ final class NativeAccessCheck extends AbstractArchUnitGraalVmCheck {
                 .dependOnClassesThat()
                 .haveFullyQualifiedName("jdk.internal.misc.Unsafe")
                 .as("Classes should not use native access without native-image configuration");
+    }
+}
+
+/**
+ * Flags dynamic class loading through {@code ClassLoader.loadClass}, which resolves types by name at
+ * run time and therefore cannot be discovered by native-image at build time.
+ */
+final class ClassLoaderUsageCheck extends AbstractArchUnitGraalVmCheck {
+
+    ClassLoaderUsageCheck() {
+        super(
+                new GraalVmCheckDefinition(
+                        "GRAAL-REFLECT-002",
+                        "Dynamic class loading may need reflection metadata",
+                        GraalVmCategory.REFLECTION,
+                        "MEDIUM",
+                        "Detects calls to ClassLoader.loadClass, which load classes by name at run time; native-image cannot discover such types statically.",
+                        "Register the dynamically loaded types under reflection in reachability-metadata.json, or replace ClassLoader.loadClass with direct class literals where possible."));
+    }
+
+    @Override
+    ArchRule rule(GraalVmContext context) {
+        return noClasses()
+                .should()
+                .callMethodWhere(new DescribedPredicate<JavaMethodCall>("ClassLoader.loadClass() is called") {
+                    @Override
+                    public boolean test(JavaMethodCall call) {
+                        MethodCallTarget target = call.getTarget();
+                        return "loadClass".equals(target.getName())
+                                && target.getOwner().isAssignableTo(ClassLoader.class);
+                    }
+                })
+                .as("Classes should not load classes by name without reflection metadata");
+    }
+}
+
+/**
+ * Flags deep reflection that bypasses access checks: {@code AccessibleObject.setAccessible} /
+ * {@code trySetAccessible} and {@code MethodHandles.privateLookupIn}. Native-image must be told about
+ * the affected members so they stay reachable and (where written) writable.
+ */
+final class DeepReflectionCheck extends AbstractArchUnitGraalVmCheck {
+
+    private static final Set<String> ACCESSIBLE_METHODS = Set.of("setAccessible", "trySetAccessible");
+
+    DeepReflectionCheck() {
+        super(
+                new GraalVmCheckDefinition(
+                        "GRAAL-REFLECT-003",
+                        "Deep reflection (setAccessible / private lookups) may need reflection metadata",
+                        GraalVmCategory.REFLECTION,
+                        "MEDIUM",
+                        "Detects deep reflection that bypasses access checks: AccessibleObject.setAccessible/trySetAccessible and MethodHandles.privateLookupIn, which native-image must be told about to keep the members reachable.",
+                        "Register the accessed members (with allowWrite where needed) under reflection in reachability-metadata.json and ensure the required module opens are configured; prefer public APIs over deep reflection."));
+    }
+
+    @Override
+    ArchRule rule(GraalVmContext context) {
+        return noClasses()
+                .should()
+                .callMethodWhere(new DescribedPredicate<JavaMethodCall>("a deep-reflection method is called") {
+                    @Override
+                    public boolean test(JavaMethodCall call) {
+                        MethodCallTarget target = call.getTarget();
+                        String owner = target.getOwner().getName();
+                        String name = target.getName();
+                        if ("java.lang.invoke.MethodHandles".equals(owner)) {
+                            return "privateLookupIn".equals(name);
+                        }
+                        return ACCESSIBLE_METHODS.contains(name)
+                                && target.getOwner().isAssignableTo("java.lang.reflect.AccessibleObject");
+                    }
+                })
+                .as("Classes should not use deep reflection without reflection metadata");
+    }
+}
+
+/**
+ * Flags reflective annotation queries on reflected members ({@code Method} / {@code Field} /
+ * {@code Constructor} / {@code Parameter}). Native-image only retains those annotations when the
+ * element is registered for reflection. Reads on {@code java.lang.Class} are intentionally ignored as
+ * too common to be actionable.
+ */
+final class AnnotationReflectionCheck extends AbstractArchUnitGraalVmCheck {
+
+    private static final Set<String> ANNOTATION_LOOKUPS = Set.of(
+            "getAnnotation",
+            "getAnnotations",
+            "getDeclaredAnnotation",
+            "getDeclaredAnnotations",
+            "getAnnotationsByType",
+            "getDeclaredAnnotationsByType",
+            "isAnnotationPresent");
+
+    AnnotationReflectionCheck() {
+        super(
+                new GraalVmCheckDefinition(
+                        "GRAAL-REFLECT-004",
+                        "Reflective annotation access may need reflection metadata",
+                        GraalVmCategory.REFLECTION,
+                        "LOW",
+                        "Detects reflective annotation queries on reflected members (Method, Field, Constructor, Parameter), whose annotations native-image only retains when the element is registered for reflection.",
+                        "Register the inspected members under reflection in reachability-metadata.json so their annotations are available at run time."));
+    }
+
+    @Override
+    ArchRule rule(GraalVmContext context) {
+        return noClasses()
+                .should()
+                .callMethodWhere(new DescribedPredicate<JavaMethodCall>("annotations are read reflectively") {
+                    @Override
+                    public boolean test(JavaMethodCall call) {
+                        MethodCallTarget target = call.getTarget();
+                        if (!ANNOTATION_LOOKUPS.contains(target.getName())) {
+                            return false;
+                        }
+                        JavaClass owner = target.getOwner();
+                        if ("java.lang.Class".equals(owner.getName())) {
+                            return false;
+                        }
+                        return owner.isAssignableTo("java.lang.reflect.AnnotatedElement");
+                    }
+                })
+                .as("Classes should not read annotations from reflected members without reflection metadata");
+    }
+}
+
+/**
+ * Flags {@code ResourceBundle.getBundle}, whose localized {@code .properties} files must be embedded
+ * in the native image (with all locale variants) to be available at run time.
+ */
+final class ResourceBundleCheck extends AbstractArchUnitGraalVmCheck {
+
+    ResourceBundleCheck() {
+        super(
+                new GraalVmCheckDefinition(
+                        "GRAAL-RES-002",
+                        "Resource bundle loading may need resource-bundle metadata",
+                        GraalVmCategory.RESOURCES,
+                        "LOW",
+                        "Detects calls to ResourceBundle.getBundle, whose localized .properties files must be registered so native-image embeds them.",
+                        "Register the bundle base names under bundles in reachability-metadata.json so native-image includes every locale variant."));
+    }
+
+    @Override
+    ArchRule rule(GraalVmContext context) {
+        return noClasses()
+                .should()
+                .callMethodWhere(new DescribedPredicate<JavaMethodCall>("ResourceBundle.getBundle() is called") {
+                    @Override
+                    public boolean test(JavaMethodCall call) {
+                        MethodCallTarget target = call.getTarget();
+                        return "getBundle".equals(target.getName())
+                                && "java.util.ResourceBundle"
+                                        .equals(target.getOwner().getName());
+                    }
+                })
+                .as("Classes should not load resource bundles without resource-bundle metadata");
+    }
+}
+
+/**
+ * Flags {@code ServiceLoader.load} / {@code loadInstalled}, which discover providers through
+ * {@code META-INF/services} and reflectively instantiate them — both must be reachable in a native
+ * image.
+ */
+final class ServiceLoaderCheck extends AbstractArchUnitGraalVmCheck {
+
+    private static final Set<String> SERVICE_LOADS = Set.of("load", "loadInstalled");
+
+    ServiceLoaderCheck() {
+        super(
+                new GraalVmCheckDefinition(
+                        "GRAAL-SERVICE-001",
+                        "Service loading may need service metadata",
+                        GraalVmCategory.SERVICE_LOADER,
+                        "LOW",
+                        "Detects calls to ServiceLoader.load, which discover providers via META-INF/services; native-image must reach the provider configuration and reflectively instantiate the implementations.",
+                        "Ensure the META-INF/services provider files are on the classpath and register the provider implementations under reflection in reachability-metadata.json."));
+    }
+
+    @Override
+    ArchRule rule(GraalVmContext context) {
+        return noClasses()
+                .should()
+                .callMethodWhere(new DescribedPredicate<JavaMethodCall>("ServiceLoader.load() is called") {
+                    @Override
+                    public boolean test(JavaMethodCall call) {
+                        MethodCallTarget target = call.getTarget();
+                        return SERVICE_LOADS.contains(target.getName())
+                                && "java.util.ServiceLoader"
+                                        .equals(target.getOwner().getName());
+                    }
+                })
+                .as("Classes should not load services without service metadata");
+    }
+}
+
+/**
+ * Flags static initializers that perform file I/O or start threads/processes directly. With
+ * build-time class initialization these side effects run during the native build, capturing
+ * build-time state or failing the build. Detection is limited to side effects emitted directly in the
+ * static initializer (helper methods and lambdas are out of scope).
+ */
+final class BuildTimeInitializationCheck extends AbstractArchUnitGraalVmCheck {
+
+    private static final Set<String> FILE_IO_TYPES = Set.of(
+            "java.io.FileInputStream",
+            "java.io.FileOutputStream",
+            "java.io.FileReader",
+            "java.io.FileWriter",
+            "java.io.RandomAccessFile");
+
+    BuildTimeInitializationCheck() {
+        super(
+                new GraalVmCheckDefinition(
+                        "GRAAL-INIT-001",
+                        "Static initializer I/O or thread starts may break build-time initialization",
+                        GraalVmCategory.BUILD_TIME_INIT,
+                        "LOW",
+                        "Detects static initializers that perform file I/O or start threads/processes directly; with build-time class initialization these run during the native build, capturing build-time state or failing the build.",
+                        "Move the side effect out of the static initializer, or initialize the class at run time (e.g. --initialize-at-run-time=<class>) so the I/O or thread starts when the application runs."));
+    }
+
+    @Override
+    ArchRule rule(GraalVmContext context) {
+        return noClasses()
+                .should()
+                .callCodeUnitWhere(
+                        new DescribedPredicate<JavaCall<?>>("a static initializer performs I/O or starts a thread") {
+                            @Override
+                            public boolean test(JavaCall<?> call) {
+                                if (!(call.getOrigin() instanceof JavaStaticInitializer)) {
+                                    return false;
+                                }
+                                CodeUnitCallTarget target = call.getTarget();
+                                JavaClass owner = target.getOwner();
+                                String ownerName = owner.getName();
+                                String name = target.getName();
+                                if ("start".equals(name) && owner.isAssignableTo(Thread.class)) {
+                                    return true;
+                                }
+                                if ("exec".equals(name) && "java.lang.Runtime".equals(ownerName)) {
+                                    return true;
+                                }
+                                if ("start".equals(name) && "java.lang.ProcessBuilder".equals(ownerName)) {
+                                    return true;
+                                }
+                                if ("java.nio.file.Files".equals(ownerName)) {
+                                    return true;
+                                }
+                                return "<init>".equals(name) && FILE_IO_TYPES.contains(ownerName);
+                            }
+                        })
+                .as("Static initializers should not perform I/O or start threads for build-time initialization");
+    }
+}
+
+/**
+ * Flags application classes that declare {@code native} methods. The JNI entry points and the backing
+ * native library must be configured for the native image.
+ */
+final class NativeMethodCheck implements GraalVmCheck {
+
+    private static final GraalVmCheckDefinition DEFINITION = new GraalVmCheckDefinition(
+            "GRAAL-NATIVE-002",
+            "Native method declarations may need JNI configuration",
+            GraalVmCategory.NATIVE_ACCESS,
+            "LOW",
+            "Detects application classes that declare native methods; the JNI entry points and their backing native library must be configured for the native image.",
+            "Provide JNI configuration under jni in reachability-metadata.json and ensure the native library is bundled with and loadable by the native image.");
+
+    @Override
+    public GraalVmCheckDefinition definition() {
+        return DEFINITION;
+    }
+
+    @Override
+    public GraalVmFindingDto evaluate(GraalVmContext context) {
+        try {
+            List<String> samples = new ArrayList<>();
+            int count = 0;
+            for (JavaClass javaClass : context.classes()) {
+                for (JavaMethod method : javaClass.getMethods()) {
+                    if (method.getModifiers().contains(JavaModifier.NATIVE)) {
+                        count++;
+                        if (samples.size() < GraalVmCheckSupport.maxSampleOccurrences()) {
+                            samples.add(GraalVmCheckSupport.detail(
+                                    javaClass.getName() + " declares native method " + method.getName() + "()"));
+                        }
+                    }
+                }
+            }
+            if (count == 0) {
+                return GraalVmCheckSupport.ok(DEFINITION);
+            }
+            return GraalVmCheckSupport.review(DEFINITION, count, samples);
+        } catch (RuntimeException | LinkageError ex) {
+            return GraalVmCheckSupport.error(DEFINITION, "Check could not be evaluated: " + ex.getMessage());
+        }
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmChecksTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmChecksTests.java
@@ -1,0 +1,93 @@
+package io.github.jdubois.bootui.autoconfigure.graalvm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import io.github.jdubois.bootui.autoconfigure.graalvm.fixtures.AnnotationReader;
+import io.github.jdubois.bootui.autoconfigure.graalvm.fixtures.CleanComponent;
+import io.github.jdubois.bootui.autoconfigure.graalvm.fixtures.DeepReflector;
+import io.github.jdubois.bootui.autoconfigure.graalvm.fixtures.DynamicClassLoader;
+import io.github.jdubois.bootui.autoconfigure.graalvm.fixtures.MessagesLoader;
+import io.github.jdubois.bootui.autoconfigure.graalvm.fixtures.NativeMethodHolder;
+import io.github.jdubois.bootui.autoconfigure.graalvm.fixtures.ServiceConsumer;
+import io.github.jdubois.bootui.autoconfigure.graalvm.fixtures.StaticInitializerComponent;
+import io.github.jdubois.bootui.core.dto.GraalVmFindingDto;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Positive and negative coverage for each curated readiness check in isolation. */
+class GraalVmChecksTests {
+
+    private GraalVmFindingDto evaluate(GraalVmCheck check, Class<?>... classes) {
+        JavaClasses imported = new ClassFileImporter().importClasses(classes);
+        return check.evaluate(new GraalVmContext(imported, List.of("io.github.jdubois.bootui")));
+    }
+
+    @Test
+    void classLoaderUsageCheckDetectsDynamicClassLoading() {
+        GraalVmFindingDto finding = evaluate(new ClassLoaderUsageCheck(), DynamicClassLoader.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-REFLECT-002");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        assertThat(finding.occurrenceCount()).isPositive();
+        assertThat(evaluate(new ClassLoaderUsageCheck(), CleanComponent.class).status())
+                .isEqualTo("OK");
+    }
+
+    @Test
+    void deepReflectionCheckDetectsSetAccessible() {
+        GraalVmFindingDto finding = evaluate(new DeepReflectionCheck(), DeepReflector.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-REFLECT-003");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        assertThat(evaluate(new DeepReflectionCheck(), CleanComponent.class).status())
+                .isEqualTo("OK");
+    }
+
+    @Test
+    void annotationReflectionCheckDetectsMemberAnnotationReads() {
+        GraalVmFindingDto finding = evaluate(new AnnotationReflectionCheck(), AnnotationReader.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-REFLECT-004");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        assertThat(evaluate(new AnnotationReflectionCheck(), CleanComponent.class)
+                        .status())
+                .isEqualTo("OK");
+    }
+
+    @Test
+    void resourceBundleCheckDetectsGetBundle() {
+        GraalVmFindingDto finding = evaluate(new ResourceBundleCheck(), MessagesLoader.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-RES-002");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        assertThat(evaluate(new ResourceBundleCheck(), CleanComponent.class).status())
+                .isEqualTo("OK");
+    }
+
+    @Test
+    void serviceLoaderCheckDetectsServiceLoad() {
+        GraalVmFindingDto finding = evaluate(new ServiceLoaderCheck(), ServiceConsumer.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-SERVICE-001");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        assertThat(evaluate(new ServiceLoaderCheck(), CleanComponent.class).status())
+                .isEqualTo("OK");
+    }
+
+    @Test
+    void buildTimeInitializationCheckDetectsStaticInitializerSideEffects() {
+        GraalVmFindingDto finding = evaluate(new BuildTimeInitializationCheck(), StaticInitializerComponent.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-INIT-001");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        assertThat(evaluate(new BuildTimeInitializationCheck(), CleanComponent.class)
+                        .status())
+                .isEqualTo("OK");
+    }
+
+    @Test
+    void nativeMethodCheckDetectsNativeDeclarations() {
+        GraalVmFindingDto finding = evaluate(new NativeMethodCheck(), NativeMethodHolder.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-NATIVE-002");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        assertThat(finding.occurrenceCount()).isEqualTo(1);
+        assertThat(evaluate(new NativeMethodCheck(), CleanComponent.class).status())
+                .isEqualTo("OK");
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmReadinessScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmReadinessScannerTests.java
@@ -53,7 +53,19 @@ class GraalVmReadinessScannerTests {
                 .allSatisfy(finding -> assertThat(finding.status()).isEqualTo("REVIEW"));
         assertThat(report.findings())
                 .extracting(GraalVmFindingDto::id)
-                .contains("GRAAL-REFLECT-001", "GRAAL-PROXY-001", "GRAAL-RES-001", "GRAAL-SER-001", "GRAAL-NATIVE-001");
+                .contains(
+                        "GRAAL-REFLECT-001",
+                        "GRAAL-REFLECT-002",
+                        "GRAAL-REFLECT-003",
+                        "GRAAL-REFLECT-004",
+                        "GRAAL-PROXY-001",
+                        "GRAAL-RES-001",
+                        "GRAAL-RES-002",
+                        "GRAAL-SERVICE-001",
+                        "GRAAL-SER-001",
+                        "GRAAL-INIT-001",
+                        "GRAAL-NATIVE-001",
+                        "GRAAL-NATIVE-002");
         assertThat(report.findings().stream().map(GraalVmFindingDto::severity).toList())
                 .isSortedAccordingTo(Comparator.comparingInt(GraalVmReadinessScannerTests::severityRank));
         assertThat(report.severityCounts()).extracting("severity").containsExactly("HIGH", "MEDIUM", "LOW", "INFO");

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/AnnotationReader.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/AnnotationReader.java
@@ -1,0 +1,11 @@
+package io.github.jdubois.bootui.autoconfigure.graalvm.fixtures;
+
+import java.lang.reflect.Method;
+
+/** Triggers GRAAL-REFLECT-004 by reading annotations from a reflected member. */
+public class AnnotationReader {
+
+    public boolean deprecated(Method method) {
+        return method.isAnnotationPresent(Deprecated.class);
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/DeepReflector.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/DeepReflector.java
@@ -1,0 +1,11 @@
+package io.github.jdubois.bootui.autoconfigure.graalvm.fixtures;
+
+import java.lang.reflect.Field;
+
+/** Triggers GRAAL-REFLECT-003 by using deep reflection (setAccessible). */
+public class DeepReflector {
+
+    public void open(Field field) {
+        field.setAccessible(true);
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/DynamicClassLoader.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/DynamicClassLoader.java
@@ -1,0 +1,9 @@
+package io.github.jdubois.bootui.autoconfigure.graalvm.fixtures;
+
+/** Triggers GRAAL-REFLECT-002 by loading a class by name through a ClassLoader. */
+public class DynamicClassLoader {
+
+    public Class<?> load(String name) throws ClassNotFoundException {
+        return getClass().getClassLoader().loadClass(name);
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/MessagesLoader.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/MessagesLoader.java
@@ -1,0 +1,11 @@
+package io.github.jdubois.bootui.autoconfigure.graalvm.fixtures;
+
+import java.util.ResourceBundle;
+
+/** Triggers GRAAL-RES-002 by loading a localized resource bundle. */
+public class MessagesLoader {
+
+    public ResourceBundle messages() {
+        return ResourceBundle.getBundle("messages");
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/NativeMethodHolder.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/NativeMethodHolder.java
@@ -1,0 +1,7 @@
+package io.github.jdubois.bootui.autoconfigure.graalvm.fixtures;
+
+/** Triggers GRAAL-NATIVE-002 by declaring a native method. */
+public class NativeMethodHolder {
+
+    public native void doNativeWork();
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/ServiceConsumer.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/ServiceConsumer.java
@@ -1,0 +1,11 @@
+package io.github.jdubois.bootui.autoconfigure.graalvm.fixtures;
+
+import java.util.ServiceLoader;
+
+/** Triggers GRAAL-SERVICE-001 by loading providers through the ServiceLoader. */
+public class ServiceConsumer {
+
+    public ServiceLoader<Runnable> services() {
+        return ServiceLoader.load(Runnable.class);
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/StaticInitializerComponent.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/fixtures/StaticInitializerComponent.java
@@ -1,0 +1,14 @@
+package io.github.jdubois.bootui.autoconfigure.graalvm.fixtures;
+
+/** Triggers GRAAL-INIT-001 by starting a thread from a static initializer. */
+public class StaticInitializerComponent {
+
+    static {
+        Thread worker = new Thread(() -> {
+            // no-op background work
+        });
+        worker.start();
+    }
+
+    private StaticInitializerComponent() {}
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -170,7 +170,8 @@ unavailable, the panel shows an empty state instead of failing.
 The GraalVM panel surveys the host application for [GraalVM native-image](https://www.graalvm.org/latest/reference-manual/native-image/)
 readiness. On demand it imports the application's own classes (bounded to the detected base package(s)) and runs a
 curated set of heuristic checks for constructs that native-image cannot resolve at build time — reflection, dynamic
-proxies, runtime resource loading, serialization, and native access. With the _Include dependencies_ toggle on (the
+class loading, deep reflection, dynamic proxies, runtime resource loading, resource bundles, service loading,
+serialization, build-time-initialization side effects, and native access. With the _Include dependencies_ toggle on (the
 default), it also surveys the classpath to report which third-party libraries already ship reachability metadata under
 `META-INF/native-image/`. From the same scan the panel generates a downloadable `reachability-metadata.json` scaffold
 (modern unified schema, with `condition.typeReached` guards) seeded with reflection/serialization candidates and the

--- a/docs/GRAALVM-READINESS-CHECKS.md
+++ b/docs/GRAALVM-READINESS-CHECKS.md
@@ -67,8 +67,9 @@ Review the generated file with the tracing agent, then place it under
 Severity reflects the worst plausible impact if the finding is real, not the likelihood:
 
 - **MEDIUM** — a construct GraalVM cannot resolve at build time that will usually fail at run time without metadata
-  (reflection, dynamic proxies).
-- **LOW** — a construct that often needs extra configuration (runtime resource loading, native access).
+  (reflection, dynamic class loading, deep reflection, dynamic proxies).
+- **LOW** — a construct that often needs extra configuration (runtime resource loading, resource bundles, service
+  loading, reflective annotation access, static-initializer side effects, native access, native methods).
 - **INFO** — an informational prompt that only matters if the type is actually used that way (serialization).
 
 The scan evaluates every registered check, but the panel only lists checks that found something to review. Findings are
@@ -87,6 +88,36 @@ detail lines.
 - **Fires when**: an application class reflectively accesses types that GraalVM cannot resolve at build time.
 - **Recommendation**: register the reflectively accessed types under `reflection` in `reachability-metadata.json`, or
   replace reflection with direct calls. Spring AOT already covers Spring-managed beans.
+
+### GRAAL-REFLECT-002 — Dynamic class loading may need reflection metadata
+
+- **Severity**: MEDIUM
+- **Inspects**: calls to `ClassLoader.loadClass`.
+- **Fires when**: an application class loads a class by name at run time, which native-image cannot resolve at build
+  time.
+- **Recommendation**: register the dynamically loaded types under `reflection` in `reachability-metadata.json`, or
+  replace `ClassLoader.loadClass` with direct class literals where possible.
+
+### GRAAL-REFLECT-003 — Deep reflection (setAccessible / private lookups) may need reflection metadata
+
+- **Severity**: MEDIUM
+- **Inspects**: `AccessibleObject.setAccessible` / `trySetAccessible` and `MethodHandles.privateLookupIn`.
+- **Fires when**: a class uses deep reflection that bypasses access checks, which native-image must be told about to keep
+  the members reachable.
+- **Recommendation**: register the accessed members (with `allowWrite` where needed) under `reflection` in
+  `reachability-metadata.json` and ensure the required module opens are configured; prefer public APIs over deep
+  reflection.
+
+### GRAAL-REFLECT-004 — Reflective annotation access may need reflection metadata
+
+- **Severity**: LOW
+- **Inspects**: reflective annotation queries (`getAnnotation`, `getDeclaredAnnotations`, `isAnnotationPresent`, …) on
+  reflected members (`Method`, `Field`, `Constructor`, `Parameter`). Reads on `java.lang.Class` are intentionally ignored
+  as too common to be actionable.
+- **Fires when**: a class reads annotations from a reflected member whose annotations native-image only retains when the
+  element is registered for reflection.
+- **Recommendation**: register the inspected members under `reflection` in `reachability-metadata.json` so their
+  annotations are available at run time.
 
 ## Proxies
 
@@ -108,6 +139,26 @@ detail lines.
 - **Recommendation**: register the loaded resource paths (as globs) under `resources` in `reachability-metadata.json` so
   native-image bundles them.
 
+### GRAAL-RES-002 — Resource bundle loading may need resource-bundle metadata
+
+- **Severity**: LOW
+- **Inspects**: calls to `ResourceBundle.getBundle`.
+- **Fires when**: a class loads a localized resource bundle whose `.properties` files must be embedded in the native
+  image.
+- **Recommendation**: register the bundle base names under `bundles` in `reachability-metadata.json` so native-image
+  includes every locale variant.
+
+## Service loading
+
+### GRAAL-SERVICE-001 — Service loading may need service metadata
+
+- **Severity**: LOW
+- **Inspects**: calls to `ServiceLoader.load` / `loadInstalled`.
+- **Fires when**: a class discovers providers through `META-INF/services`, which native-image must reach and reflectively
+  instantiate.
+- **Recommendation**: ensure the `META-INF/services` provider files are on the classpath and register the provider
+  implementations under `reflection` in `reachability-metadata.json`.
+
 ## Serialization
 
 ### GRAAL-SER-001 — Serializable types may need serialization metadata
@@ -118,6 +169,19 @@ detail lines.
   serialization metadata.
 - **Recommendation**: if these types are serialized (e.g. via the JDK serialization protocol), register them under
   `serialization` in `reachability-metadata.json`.
+
+## Build-time initialization
+
+### GRAAL-INIT-001 — Static initializer I/O or thread starts may break build-time initialization
+
+- **Severity**: LOW
+- **Inspects**: static initializers that perform file I/O (`java.nio.file.Files`, file streams) or start threads /
+  processes (`Thread.start`, `Runtime.exec`, `ProcessBuilder.start`) directly. Side effects in helper methods or lambdas
+  are out of scope.
+- **Fires when**: a class runs I/O or starts a thread from its static initializer; with build-time class initialization
+  these run during the native build, capturing build-time state or failing the build.
+- **Recommendation**: move the side effect out of the static initializer, or initialize the class at run time (e.g.
+  `--initialize-at-run-time=<class>`) so the I/O or thread starts when the application runs.
 
 ## Native access
 
@@ -130,3 +194,12 @@ detail lines.
   configuration.
 - **Recommendation**: confirm the native libraries are available to the native image and add JNI configuration if
   needed; prefer supported APIs over `Unsafe`.
+
+### GRAAL-NATIVE-002 — Native method declarations may need JNI configuration
+
+- **Severity**: LOW
+- **Inspects**: application classes that declare `native` methods.
+- **Fires when**: a class declares a `native` method whose JNI entry point and backing native library must be configured
+  for the native image.
+- **Recommendation**: provide JNI configuration under `jni` in `reachability-metadata.json` and ensure the native library
+  is bundled with and loadable by the native image.


### PR DESCRIPTION
## What

Expands the GraalVM native-image readiness advisor from 5 to **12** checks by adding 7 focused, bytecode-detectable checks. Each follows the existing ArchUnit-backed pattern: one predicate/check class + `GraalVmCheckRegistry` entry + doc entry + positive/negative tests.

## New checks

| ID | Category | Severity | Detects |
|----|----------|----------|---------|
| `GRAAL-REFLECT-002` | Reflection | MEDIUM | `ClassLoader.loadClass` (dynamic class loading) |
| `GRAAL-REFLECT-003` | Reflection | MEDIUM | Deep reflection: `setAccessible`/`trySetAccessible`, `MethodHandles.privateLookupIn` |
| `GRAAL-REFLECT-004` | Reflection | LOW | Reflective annotation reads on reflected members (`Method`/`Field`/`Constructor`/`Parameter`; `java.lang.Class` intentionally ignored as too common) |
| `GRAAL-RES-002` | Resources | LOW | `ResourceBundle.getBundle` (i18n bundle metadata) |
| `GRAAL-SERVICE-001` | Service loading *(new category)* | LOW | `ServiceLoader.load` / `loadInstalled` |
| `GRAAL-INIT-001` | Build-time initialization *(new category)* | LOW | Static-initializer file I/O or thread/process starts |
| `GRAAL-NATIVE-002` | Native access | LOW | Classes declaring `native` methods (JNI) |

## Notes

- All checks preserve the never-throw `error()`/fallback contract (ArchUnit-rule checks via `AbstractArchUnitGraalVmCheck`; the custom `NativeMethodCheck` wraps its loop in `RuntimeException | LinkageError`).
- `GRAAL-INIT-001` uses `callCodeUnitWhere` and limits detection to side effects emitted **directly** in the static initializer (helper methods/lambdas out of scope, documented as such) to avoid false positives.
- `GRAAL-REFLECT-004` excludes `java.lang.Class` annotation reads to keep noise low.
- Dropped a Log4j2-core check (not on the default Java 17 test classpath) and an FFM/`java.lang.foreign` check (package absent in Java 17) as not cleanly detectable/testable here.

## Tests & docs

- New `GraalVmChecksTests` with positive + negative coverage per new check (isolated single-class imports).
- Extended `GraalVmReadinessScannerTests` to assert all 12 rule IDs appear.
- Added 7 fixtures, each triggering exactly one new check.
- `docs/GRAALVM-READINESS-CHECKS.md`: entries for all 7 new rules (**100% doc↔code rule-ID parity verified**) + updated severity-scale examples; `docs/FEATURES.md` summary updated.

## Verification

- `./mvnw -B -ntp spotless:apply` then `spotless:check` — clean
- `./mvnw -pl bootui-autoconfigure -am test` — **615 tests pass** (16 in the GraalVM package)