### PR TITLE
test(e2e): add Playwright specs for five routed panels

### DIFF
--- a/bootui-sample-app/e2e/tests/flyway.spec.js
+++ b/bootui-sample-app/e2e/tests/flyway.spec.js
@@ -1,0 +1,27 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Flyway view', () => {
+  test('lists the catalog migrations and filters them by script', async ({openView, page}) => {
+    await openView('flyway', 'Flyway migrations')
+
+    // The sample app exposes a single `flyway` bean managing the catalog schema.
+    await expect(page.locator('code', {hasText: /^flyway$/})).toBeVisible()
+    await expect(page.locator('main')).toContainText(/migration\(s\) across \d+ database\(s\)/)
+    await expect(page.getByRole('button', {name: /Migrate/})).toBeVisible()
+
+    // The four catalog migrations are always resolved, regardless of applied/pending state
+    // (the persistent sample database may already have later migrations applied).
+    await expect(page.getByText('V1__create_catalog.sql')).toBeVisible()
+    await expect(page.getByText('V2__seed_catalog.sql')).toBeVisible()
+    await expect(page.getByText('V3__add_catalog_tags.sql')).toBeVisible()
+    await expect(page.getByText('V4__classify_catalog_books.sql')).toBeVisible()
+
+    // Filtering by script narrows the table to the single matching migration.
+    const flywayCard = page.locator('.card', {has: page.locator('.card-header code', {hasText: /^flyway$/})})
+    await page.getByPlaceholder(/Filter by version/).fill('tags')
+    await expect(flywayCard.locator('tbody tr')).toHaveCount(1)
+    await expect(page.getByText('V3__add_catalog_tags.sql')).toBeVisible()
+    await expect(page.getByText('V1__create_catalog.sql')).toHaveCount(0)
+  })
+})

--- a/bootui-sample-app/e2e/tests/github.spec.js
+++ b/bootui-sample-app/e2e/tests/github.spec.js
@@ -1,0 +1,139 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+// A connected GitHub dashboard cannot be reproduced deterministically in CI (it depends
+// on an authenticated token and live GitHub responses), so this spec mocks the bounded
+// GitHub API the same way the documentation screenshot generator does and asserts that
+// the panel renders the repository, credential, metrics, and an interactive drawer.
+function connectedDashboard() {
+  const now = Date.now()
+  return {
+    available: true,
+    unavailableReason: null,
+    connected: true,
+    status: 'CONNECTED',
+    message: null,
+    refreshedAt: now - 45_000,
+    repository: {
+      owner: 'jdubois',
+      name: 'boot-ui',
+      fullName: 'jdubois/boot-ui',
+      host: 'github.com',
+      apiBaseUrl: 'https://api.github.com/',
+      htmlUrl: 'https://github.com/jdubois/boot-ui',
+      defaultBranch: 'main',
+      localBranch: 'jdubois/panel-e2e-coverage',
+      upstreamBranch: 'main',
+      visibility: 'public',
+      privateRepository: false,
+      fork: false,
+      archived: false,
+      pushedAt: now - 18 * 60 * 1000,
+      stars: 128,
+      forks: 14,
+      watchers: 11,
+      openIssues: 9,
+      latestRelease: 'v0.4.0'
+    },
+    credential: {source: 'GITHUB_TOKEN', authenticated: true, login: 'local-dev', scopes: 'repo, workflow'},
+    metrics: [
+      {label: 'Open pull requests', value: '2', detail: 'Bounded live queue', tone: 'primary'},
+      {label: 'Open issues', value: '9', detail: 'Grouped by label and age', tone: 'info'},
+      {label: 'Workflow failures', value: '1', detail: 'Latest run per workflow', tone: 'danger'}
+    ],
+    quotas: [],
+    pullRequests: [
+      {
+        number: 211,
+        title: 'Update implementation plan roadmap',
+        author: 'julien',
+        draft: false,
+        htmlUrl: 'https://github.com/jdubois/boot-ui/pull/211',
+        updatedAt: now - 20 * 60 * 1000,
+        reviewDecision: 'APPROVED',
+        checksConclusion: 'success',
+        labels: ['docs']
+      },
+      {
+        number: 210,
+        title: 'Update GitHub Actions execution drawer',
+        author: 'julien',
+        draft: false,
+        htmlUrl: 'https://github.com/jdubois/boot-ui/pull/210',
+        updatedAt: now - 90 * 60 * 1000,
+        reviewDecision: null,
+        checksConclusion: 'success',
+        labels: ['github']
+      }
+    ],
+    workflowRuns: [],
+    workflows: [],
+    issueBuckets: [
+      {label: 'Open issues', count: 9, tone: 'primary'},
+      {label: 'Bug', count: 2, tone: 'danger'}
+    ],
+    securitySignals: [
+      {label: 'Dependabot alerts', status: 'AVAILABLE', count: 0, unavailableReason: null},
+      {label: 'Code scanning alerts', status: 'AVAILABLE', count: 1, unavailableReason: null},
+      {label: 'Secret scanning alerts', status: 'AVAILABLE', count: 0, unavailableReason: null}
+    ],
+    copilotUsage: null,
+    warnings: []
+  }
+}
+
+test.describe('GitHub view', () => {
+  test('renders the connected dashboard and opens the pull-request drawer', async ({openView, page}) => {
+    const payload = JSON.stringify(connectedDashboard())
+    let refreshMethod = null
+    // Trusted localhost sessions refresh via POST on mount; the GET endpoint is the read-only
+    // fallback. Both are mocked, and the refresh method is captured so the spec can confirm the
+    // panel used the POST refresh path.
+    await page.route(
+      (url) => url.pathname === '/bootui/api/github/refresh',
+      async (route) => {
+        refreshMethod = route.request().method()
+        await route.fulfill({contentType: 'application/json', body: payload})
+      }
+    )
+    await page.route(
+      (url) => url.pathname === '/bootui/api/github',
+      async (route) => {
+        await route.fulfill({contentType: 'application/json', body: payload})
+      }
+    )
+
+    await openView('github', 'GitHub')
+
+    // Repository summary card.
+    await expect(page.getByRole('link', {name: 'jdubois/boot-ui'})).toBeVisible()
+    await expect(page.locator('.badge', {hasText: 'CONNECTED'})).toBeVisible()
+    const repositoryCard = page.locator('.card', {hasText: 'Repository'}).first()
+    await expect(repositoryCard).toContainText('128')
+    await expect(repositoryCard).toContainText('14')
+
+    // Credential card confirms the token stayed server-side but reports the authenticated source.
+    const credentialCard = page.locator('.card', {hasText: 'Credential'}).first()
+    await expect(credentialCard).toContainText('Authenticated')
+    await expect(credentialCard).toContainText('GITHUB_TOKEN')
+
+    // Summary metric and security-signal cards render the mocked values.
+    const openPrsCard = page.getByRole('button', {name: /Open pull requests/})
+    await expect(openPrsCard).toBeVisible()
+    await expect(openPrsCard.locator('.display-6')).toHaveText('2')
+    const codeScanningCard = page.getByRole('button', {name: /Code scanning alerts/})
+    await expect(codeScanningCard).toBeVisible()
+    await expect(codeScanningCard.locator('.display-6')).toHaveText('1')
+
+    // Opening the pull-request drawer is a meaningful read interaction.
+    await page.getByRole('button', {name: /Open pull requests/}).click()
+    const drawer = page.locator('.details-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(drawer).toContainText('Open pull requests')
+    await expect(drawer).toContainText('#211 Update implementation plan roadmap')
+    await expect(drawer).toContainText('#210 Update GitHub Actions execution drawer')
+
+    // The trusted panel reached the live data through the POST refresh endpoint.
+    expect(refreshMethod).toBe('POST')
+  })
+})

--- a/bootui-sample-app/e2e/tests/graalvm.spec.js
+++ b/bootui-sample-app/e2e/tests/graalvm.spec.js
@@ -1,0 +1,38 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('GraalVM view', () => {
+  test('runs the native-image readiness scan and reports analysed classes', async ({openView, page}) => {
+    // The native-image readiness scan can take a while on slower CI hardware.
+    test.setTimeout(120_000)
+
+    await openView('graalvm', 'GraalVM')
+
+    // The read-only disclaimer renders once the report loads. The pre-scan empty state is not
+    // asserted because the readiness report caches the last scan, so a reused or retried
+    // server may already have scan data on mount.
+    await expect(page.locator('main')).toContainText('Heuristic readiness checks.')
+
+    await page.getByRole('button', {name: 'Run readiness checks'}).click()
+
+    // The scan surveys the host application's own classes, so the empty state clears.
+    await expect(page.getByText('No readiness data yet')).toHaveCount(0, {timeout: 45_000})
+
+    const checksRun = page.locator('.card', {hasText: 'Checks run'}).locator('.display-6')
+    await expect
+      .poll(async () => Number.parseInt((await checksRun.innerText()).trim(), 10) || 0, {timeout: 15_000})
+      .toBeGreaterThan(0)
+
+    const classesAnalyzed = page.locator('.card', {hasText: 'Classes analysed'}).locator('.display-6')
+    await expect
+      .poll(async () => Number.parseInt((await classesAnalyzed.innerText()).trim(), 10) || 0)
+      .toBeGreaterThan(0)
+
+    // The scan-status card surfaces a status badge once the scan completes.
+    const scanStatusCard = page.locator('.card', {hasText: 'Scan status'}).first()
+    await expect(scanStatusCard.locator('.badge').first()).toBeVisible()
+
+    // The readiness-concerns section renders once the scan completes.
+    await expect(page.getByText('Readiness concerns')).toBeVisible()
+  })
+})

--- a/bootui-sample-app/e2e/tests/liquibase.spec.js
+++ b/bootui-sample-app/e2e/tests/liquibase.spec.js
@@ -1,0 +1,26 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Liquibase view', () => {
+  test('lists inventory change sets with applied/pending state and filters by id', async ({openView, page}) => {
+    await openView('liquibase', 'Liquibase change sets')
+
+    // The sample app exposes a single `liquibase` bean managing the inventory schema.
+    await expect(page.locator('code', {hasText: /^liquibase$/})).toBeVisible()
+    await expect(page.locator('main')).toContainText(/change set\(s\) across \d+ database\(s\)/)
+    await expect(page.getByRole('button', {name: /Update/})).toBeVisible()
+
+    // All four inventory change sets are always listed (applied history + pending changelog),
+    // regardless of how many have been applied against the persistent sample database.
+    const liquibaseCard = page.locator('.card', {has: page.locator('.card-header code', {hasText: /^liquibase$/})})
+    await expect(liquibaseCard.locator('tbody tr')).toHaveCount(4)
+    await expect(liquibaseCard.locator('tbody td code', {hasText: /^1$/})).toBeVisible()
+    await expect(liquibaseCard.locator('tbody td code', {hasText: /^4$/})).toBeVisible()
+
+    // Filtering by change-set id narrows the table to the single matching change set.
+    await page.getByPlaceholder(/Filter by id/).fill('3')
+    await expect(liquibaseCard.locator('tbody tr')).toHaveCount(1)
+    await expect(liquibaseCard.locator('tbody td code', {hasText: /^3$/})).toBeVisible()
+    await expect(liquibaseCard.locator('tbody td code', {hasText: /^1$/})).toHaveCount(0)
+  })
+})

--- a/bootui-sample-app/e2e/tests/security-advisor.spec.js
+++ b/bootui-sample-app/e2e/tests/security-advisor.spec.js
@@ -1,0 +1,43 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Security Advisor view', () => {
+  test('runs the read-only scan and reports rules, chains, and findings', async ({openView, page}) => {
+    await openView('security-advisor', 'Security Advisor')
+
+    // The read-only disclaimer renders once the report loads. The pre-scan empty state is not
+    // asserted because the advisor caches the last scan, so a reused or retried server may
+    // already have scan data on mount.
+    await expect(page.locator('main')).toContainText('Heuristic Spring Security rules.')
+
+    await page.getByRole('button', {name: 'Run security checks'}).click()
+
+    // After the scan the severity card is populated and the empty state disappears.
+    await expect(page.getByText('No Security Advisor data yet')).toHaveCount(0, {timeout: 30_000})
+
+    const rulesEvaluated = page.locator('.card', {hasText: 'Rules evaluated'}).locator('.display-6')
+    await expect
+      .poll(async () => Number.parseInt((await rulesEvaluated.innerText()).trim(), 10) || 0, {timeout: 15_000})
+      .toBeGreaterThan(0)
+
+    const filterChainsAnalyzed = page.locator('.card', {hasText: 'Filter chains analysed'}).locator('.display-6')
+    await expect
+      .poll(async () => Number.parseInt((await filterChainsAnalyzed.innerText()).trim(), 10) || 0)
+      .toBeGreaterThan(0)
+
+    // The Spring Security filter chains discovered by the scan are listed (the
+    // summary "Filter chains analysed" card is excluded via its display number).
+    const filterChainsCard = page
+      .locator('.card', {hasText: 'Filter chains'})
+      .filter({hasNot: page.locator('.display-6')})
+    await expect(filterChainsCard.locator('li.font-monospace').first()).toBeVisible()
+    await expect(filterChainsCard).toContainText('/api/secure')
+
+    // The scan-status card surfaces a status badge for the completed scan.
+    const scanStatusCard = page.locator('.card', {hasText: 'Scan status'}).first()
+    await expect(scanStatusCard.locator('.badge').first()).toBeVisible()
+
+    // The rule-results section renders once the scan completes.
+    await expect(page.getByText('Rule results')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## What

Audit follow-up **W7-1**: add focused Playwright e2e specs for routed panels that previously had no dedicated per-panel spec. Each spec navigates to the route, asserts the panel header/structure renders, and exercises a meaningful read interaction — following the existing conventions in `bootui-sample-app/e2e/tests` (the `openView(route, heading)` fixture, scoped Playwright locators).

## New specs

- **`security-advisor.spec.js`** — runs the read-only scan and asserts rules evaluated > 0, filter chains analysed > 0, the discovered filter chains list (contains `/api/secure`), the scan-status badge, and the rule-results section.
- **`graalvm.spec.js`** — runs the native-image readiness scan and asserts checks run > 0, classes analysed > 0, the scan-status badge, and the readiness-concerns section.
- **`github.spec.js`** — mocks the bounded GitHub API (`GET api/github` + `POST api/github/refresh`) with a connected dashboard, since a real connected/authenticated state is token-dependent and non-deterministic locally/CI. Asserts the repository link + `CONNECTED` badge, stars/forks, the authenticated `GITHUB_TOKEN` credential, metric and security-signal card values, opens the pull-request drawer, and confirms the trusted panel used the POST refresh path.
- **`flyway.spec.js`** — lists the catalog migrations (`V1`–`V4`) and filters them by script (`tags` → only `V3`).
- **`liquibase.spec.js`** — lists the inventory change sets (4 rows) and filters them by id (`3` → single row).

## Determinism notes

- **Flyway/Liquibase** run against the sample app's persistent Postgres (docker-compose), whose applied-vs-pending state mutates across runs. The specs therefore avoid asserting applied/pending counts and instead assert the always-present facts (the db bean card, the full migration/change-set catalog is listed, and that the filter input narrows the table). Row counts are scoped to the specific `flyway`/`liquibase` database card.
- **security-advisor/graalvm** run the real read-only scans and assert structural outcomes (non-zero counters, sections render) rather than specific findings. They do not assume a pre-scan empty state, so they stay green on a reused/retried server that already has a cached scan.
- **github** is fully mocked per-test (`page.route`), so it is independent of any token or live GitHub responses.

## Verification

- `cd bootui-sample-app/e2e && npm ci && npx playwright install --with-deps chromium && npm test` → **82 passed** (full suite, including the 5 new specs).
- `npm run format` + `npm run format:check` → clean.

No sample-app Java/config changes — spec-only PR.