### PR TITLE
Add four architecture advisor checks (ARCH-CODE-014/015, ARCH-SPRING-015/016)

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistry.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistry.java
@@ -36,7 +36,11 @@ final class ArchitectureRuleRegistry {
             new AsyncMethodsShouldHaveSupportedSignaturesRule(),
             new ScheduledMethodsShouldHaveSupportedSignaturesRule(),
             new AsyncShouldNotBeUsedInConfigurationClassesRule(),
-            new NoAopContextCurrentProxyRule());
+            new NoAopContextCurrentProxyRule(),
+            new NoPublicMutableStaticFieldsRule(),
+            new UtilityClassesShouldBeFinalWithPrivateConstructorRule(),
+            new ConfigurationPropertiesShouldBeImmutableRule(),
+            new LayeredArchitectureDirectionRule());
 
     private ArchitectureRuleRegistry() {}
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRules.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRules.java
@@ -4,10 +4,15 @@ import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predica
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
+import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
@@ -83,6 +88,8 @@ final class SpringStereotypes {
     static final String ASYNC = "org.springframework.scheduling.annotation.Async";
     static final String CACHEABLE = "org.springframework.cache.annotation.Cacheable";
     static final String SCHEDULED = "org.springframework.scheduling.annotation.Scheduled";
+    static final String CONFIGURATION_PROPERTIES =
+            "org.springframework.boot.context.properties.ConfigurationProperties";
 
     static final DescribedPredicate<CanBeAnnotated> CONTROLLER_ANNOTATED = annotatedWith(CONTROLLER)
             .or(annotatedWith(REST_CONTROLLER))
@@ -117,6 +124,9 @@ final class SpringStereotypes {
 
     static final DescribedPredicate<CanBeAnnotated> SCHEDULED_ANNOTATED =
             annotatedWith(SCHEDULED).as("annotated with @Scheduled");
+
+    static final DescribedPredicate<CanBeAnnotated> CONFIGURATION_PROPERTIES_ANNOTATED =
+            annotatedWith(CONFIGURATION_PROPERTIES).as("annotated with @ConfigurationProperties");
 
     static final DescribedPredicate<CanBeAnnotated> PROXIED_METHOD_ANNOTATED = TRANSACTIONAL_ANNOTATED
             .or(annotatedWith(ASYNC))
@@ -988,5 +998,207 @@ final class NoAopContextCurrentProxyRule extends AbstractArchitectureRule {
                     }
                 })
                 .as("Classes should not call AopContext.currentProxy()");
+    }
+}
+
+/**
+ * Flags {@code public static} fields that are not {@code final}, which expose shared, globally
+ * reachable mutable state.
+ */
+final class NoPublicMutableStaticFieldsRule extends AbstractArchitectureRule {
+
+    NoPublicMutableStaticFieldsRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-CODE-014",
+                        "Classes should not have public mutable static fields",
+                        ArchitectureCategory.CODING_PRACTICES,
+                        "MEDIUM",
+                        "Detects public static fields that are not final, which expose shared, globally reachable mutable state.",
+                        "Make the field final so it cannot be reassigned, reduce its visibility, or move the mutable state into a managed bean."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return noFields()
+                .that()
+                .areStatic()
+                .and()
+                .areNotFinal()
+                .should()
+                .bePublic()
+                .as("Classes should not have public mutable static fields")
+                .allowEmptyShould(true);
+    }
+}
+
+/**
+ * Flags utility classes (classes that expose only static members) that are not {@code final} or that
+ * allow instantiation through a non-private constructor.
+ */
+final class UtilityClassesShouldBeFinalWithPrivateConstructorRule extends AbstractArchitectureRule {
+
+    UtilityClassesShouldBeFinalWithPrivateConstructorRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-CODE-015",
+                        "Utility classes should be final with a private constructor",
+                        ArchitectureCategory.CODING_PRACTICES,
+                        "LOW",
+                        "Detects classes that expose only static members but are not final or can be instantiated through a non-private constructor.",
+                        "Make utility classes final and give them a single private constructor so they cannot be instantiated or subclassed."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return classes()
+                .should(
+                        new ArchCondition<JavaClass>(
+                                "be final with a private constructor when only static members are exposed") {
+                            @Override
+                            public void check(JavaClass javaClass, ConditionEvents events) {
+                                if (!isUtilityClass(javaClass)) {
+                                    return;
+                                }
+                                if (!javaClass.getModifiers().contains(JavaModifier.FINAL)) {
+                                    events.add(SimpleConditionEvent.violated(
+                                            javaClass, "Utility class " + javaClass.getName() + " is not final"));
+                                }
+                                for (JavaConstructor constructor : javaClass.getConstructors()) {
+                                    if (isSynthetic(constructor)) {
+                                        continue;
+                                    }
+                                    if (!constructor.getModifiers().contains(JavaModifier.PRIVATE)) {
+                                        events.add(SimpleConditionEvent.violated(
+                                                constructor,
+                                                "Utility class " + javaClass.getName()
+                                                        + " has a non-private constructor "
+                                                        + constructor.getFullName()));
+                                    }
+                                }
+                            }
+                        })
+                .as("Utility classes should be final with a private constructor");
+    }
+
+    private static boolean isUtilityClass(JavaClass javaClass) {
+        if (javaClass.isInterface()
+                || javaClass.isEnum()
+                || javaClass.isRecord()
+                || javaClass.isAnonymousClass()
+                || javaClass.isLocalClass()
+                || javaClass.getModifiers().contains(JavaModifier.ABSTRACT)) {
+            return false;
+        }
+        if (SpringStereotypes.STEREOTYPE_ANNOTATED.test(javaClass)) {
+            return false;
+        }
+        boolean hasStaticMethod = false;
+        for (JavaMethod method : javaClass.getMethods()) {
+            if (isSynthetic(method)) {
+                continue; // ignore compiler-generated methods such as lambda bodies or bridges
+            }
+            if (method.getModifiers().contains(JavaModifier.STATIC)) {
+                if (method.getName().equals("main")) {
+                    return false; // application/entry-point classes are not utility classes
+                }
+                hasStaticMethod = true;
+            } else {
+                return false; // an instance method means the class is not a pure utility holder
+            }
+        }
+        if (!hasStaticMethod) {
+            return false;
+        }
+        for (JavaField field : javaClass.getFields()) {
+            if (isSynthetic(field)) {
+                continue; // ignore compiler-generated fields such as the synthetic outer-class reference
+            }
+            if (!field.getModifiers().contains(JavaModifier.STATIC)) {
+                return false; // instance state means the class is not a pure utility holder
+            }
+        }
+        return true;
+    }
+
+    private static boolean isSynthetic(JavaMember member) {
+        return member.getModifiers().contains(JavaModifier.SYNTHETIC)
+                || member.getModifiers().contains(JavaModifier.BRIDGE);
+    }
+}
+
+/**
+ * Flags {@code @ConfigurationProperties} classes whose instance fields are not {@code final}, which
+ * makes their bound configuration mutable. Spring Boot favours immutable configuration through
+ * records or constructor binding.
+ */
+final class ConfigurationPropertiesShouldBeImmutableRule extends AbstractArchitectureRule {
+
+    ConfigurationPropertiesShouldBeImmutableRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-015",
+                        "Configuration properties classes should be immutable",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "INFO",
+                        "Detects @ConfigurationProperties classes with non-final instance fields instead of immutable constructor binding or records.",
+                        "Bind configuration through a record or constructor with final fields so configuration state is immutable; Spring Boot favours immutable @ConfigurationProperties."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return fields().that()
+                .areDeclaredInClassesThat(SpringStereotypes.CONFIGURATION_PROPERTIES_ANNOTATED)
+                .and()
+                .areNotStatic()
+                .should()
+                .beFinal()
+                .as("Configuration properties classes should be immutable")
+                .allowEmptyShould(true);
+    }
+}
+
+/**
+ * Flags dependencies among {@code @Controller} / {@code @RestController}, {@code @Service}, and
+ * {@code @Repository} beans that do not follow the canonical web -&gt; service -&gt; repository
+ * direction.
+ *
+ * <p>This is the holistic, slice-based complement to the individual stereotype dependency rules:
+ * each stereotype layer may be accessed only from itself or the layer immediately above it, so the
+ * dependency graph between the three layers stays directed and downward. Only dependencies whose
+ * source and target are both annotated stereotypes are considered, so plain classes never trigger
+ * a violation.</p>
+ */
+final class LayeredArchitectureDirectionRule extends AbstractArchitectureRule {
+
+    LayeredArchitectureDirectionRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-016",
+                        "Layered architecture dependencies should flow from web to service to repository",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "MEDIUM",
+                        "Detects dependencies among @Controller/@RestController, @Service, and @Repository beans that violate the web -> service -> repository direction.",
+                        "Keep dependencies flowing downward: controllers depend on services, services depend on repositories, and lower layers never depend on higher ones."));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return layeredArchitecture()
+                .consideringOnlyDependenciesInLayers()
+                .withOptionalLayers(true)
+                .layer("Web")
+                .definedBy(SpringStereotypes.CONTROLLER_ANNOTATED)
+                .layer("Service")
+                .definedBy(SpringStereotypes.SERVICE_ANNOTATED)
+                .layer("Persistence")
+                .definedBy(SpringStereotypes.REPOSITORY_ANNOTATED)
+                .whereLayer("Web")
+                .mayOnlyBeAccessedByLayers("Web")
+                .whereLayer("Service")
+                .mayOnlyBeAccessedByLayers("Web", "Service")
+                .whereLayer("Persistence")
+                .mayOnlyBeAccessedByLayers("Service", "Persistence")
+                .as("Layered architecture dependencies should flow from web to service to repository");
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistryTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistryTests.java
@@ -41,6 +41,10 @@ class ArchitectureRuleRegistryTests {
                         "ARCH-SPRING-011",
                         "ARCH-SPRING-012",
                         "ARCH-SPRING-013",
-                        "ARCH-SPRING-014");
+                        "ARCH-SPRING-014",
+                        "ARCH-CODE-014",
+                        "ARCH-CODE-015",
+                        "ARCH-SPRING-015",
+                        "ARCH-SPRING-016");
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRulesTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRulesTests.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.AopContext;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -237,6 +238,111 @@ class ArchitectureRulesTests {
                 .anySatisfy(sample -> assertThat(sample).contains("currentProxy"));
     }
 
+    @Test
+    void noPublicMutableStaticFieldsFlagsPublicNonFinalStaticFields() {
+        ArchitectureRuleResultDto result =
+                evaluate(new NoPublicMutableStaticFieldsRule(), PublicMutableStaticFieldHolder.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-014");
+        assertThat(result.violationCount()).isPositive();
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("counter"));
+    }
+
+    @Test
+    void noPublicMutableStaticFieldsPassesForFinalOrNonPublicStaticFields() {
+        ArchitectureRuleResultDto result = evaluate(new NoPublicMutableStaticFieldsRule(), SafeStaticFieldHolder.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void utilityClassesShouldBeFinalWithPrivateConstructorFlagsInstantiableOrSubclassableUtilities() {
+        ArchitectureRuleResultDto result = evaluate(
+                new UtilityClassesShouldBeFinalWithPrivateConstructorRule(),
+                NonFinalUtility.class,
+                UtilityWithPublicConstructor.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-015");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(
+                        sample -> assertThat(sample).contains("NonFinalUtility").contains("not final"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample)
+                        .contains("UtilityWithPublicConstructor")
+                        .contains("non-private constructor"));
+    }
+
+    @Test
+    void utilityClassesShouldBeFinalWithPrivateConstructorPassesForWellFormedUtilities() {
+        ArchitectureRuleResultDto result =
+                evaluate(new UtilityClassesShouldBeFinalWithPrivateConstructorRule(), WellFormedUtility.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void utilityClassesShouldBeFinalWithPrivateConstructorIgnoresClassesWithInstanceMembers() {
+        ArchitectureRuleResultDto result =
+                evaluate(new UtilityClassesShouldBeFinalWithPrivateConstructorRule(), NotAUtilityClass.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void utilityClassesShouldBeFinalWithPrivateConstructorIgnoresSyntheticStaticMembers() {
+        ArchitectureRuleResultDto result =
+                evaluate(new UtilityClassesShouldBeFinalWithPrivateConstructorRule(), ConstantsHolderWithLambda.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void configurationPropertiesShouldBeImmutableFlagsMutableFields() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ConfigurationPropertiesShouldBeImmutableRule(), MutableConfigurationProperties.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-015");
+        assertThat(result.violationCount()).isPositive();
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("name"));
+    }
+
+    @Test
+    void configurationPropertiesShouldBeImmutablePassesForImmutableRecord() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ConfigurationPropertiesShouldBeImmutableRule(), ImmutableConfigurationProperties.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void layeredArchitectureDirectionFlagsWebDependingDirectlyOnPersistence() {
+        ArchitectureRuleResultDto result =
+                evaluate(new LayeredArchitectureDirectionRule(), LayeredController.class, LayeredRepository.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-016");
+        assertThat(result.violationCount()).isPositive();
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("LayeredRepository"));
+    }
+
+    @Test
+    void layeredArchitectureDirectionPassesForCanonicalWebToServiceToRepositoryChain() {
+        ArchitectureRuleResultDto result = evaluate(
+                new LayeredArchitectureDirectionRule(),
+                CompliantController.class,
+                CompliantService.class,
+                CompliantRepository.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
     private static ArchitectureRuleResultDto evaluate(ArchitectureRule rule, Class<?>... classes) {
         JavaClasses importedClasses = new ClassFileImporter().importClasses(classes);
         return rule.evaluate(
@@ -370,4 +476,118 @@ class ArchitectureRulesTests {
             return AopContext.currentProxy();
         }
     }
+
+    private static class PublicMutableStaticFieldHolder {
+
+        public static int counter = 0;
+    }
+
+    private static class SafeStaticFieldHolder {
+
+        public static final int MAX = 10;
+
+        private static int internal = 0;
+
+        int read() {
+            return internal;
+        }
+    }
+
+    private static class NonFinalUtility {
+
+        private NonFinalUtility() {}
+
+        static int tripled(int value) {
+            return value * 3;
+        }
+    }
+
+    private static final class UtilityWithPublicConstructor {
+
+        public UtilityWithPublicConstructor() {}
+
+        static int doubled(int value) {
+            return value * 2;
+        }
+    }
+
+    private static final class WellFormedUtility {
+
+        private WellFormedUtility() {}
+
+        static int squared(int value) {
+            return value * value;
+        }
+    }
+
+    private static final class NotAUtilityClass {
+
+        static int helper(int value) {
+            return value;
+        }
+
+        int instanceMethod() {
+            return 0;
+        }
+    }
+
+    // Not final and has only a static constant, but a non-capturing lambda makes javac emit a synthetic static
+    // method. The rule must ignore that synthetic method so this constants holder is not treated as a utility class.
+    private static class ConstantsHolderWithLambda {
+
+        static final Runnable ACTION = () -> {};
+    }
+
+    @ConfigurationProperties(prefix = "demo.mutable")
+    private static class MutableConfigurationProperties {
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @ConfigurationProperties(prefix = "demo.immutable")
+    private record ImmutableConfigurationProperties(String name, int size) {}
+
+    @RestController
+    private static class LayeredController {
+
+        LayeredController(LayeredRepository repository) {
+            this.repository = repository;
+        }
+
+        private final LayeredRepository repository;
+    }
+
+    @Repository
+    private static class LayeredRepository {}
+
+    @RestController
+    private static class CompliantController {
+
+        CompliantController(CompliantService service) {
+            this.service = service;
+        }
+
+        private final CompliantService service;
+    }
+
+    @Service
+    private static class CompliantService {
+
+        CompliantService(CompliantRepository repository) {
+            this.repository = repository;
+        }
+
+        private final CompliantRepository repository;
+    }
+
+    @Repository
+    private static class CompliantRepository {}
 }

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -173,6 +173,26 @@ a handful of sample detail lines from ArchUnit.
 - **Recommendation**: move assertions, fixtures, containers, and test helpers to test sources; keep production classes
   independent of test APIs.
 
+### ARCH-CODE-014 — Classes should not have public mutable static fields
+
+- **Severity**: MEDIUM
+- **Inspects**: `public static` fields that are not `final`.
+- **Fires when**: a class exposes a public static field that can be reassigned, creating shared, globally reachable
+  mutable state.
+- **Why it matters**: public mutable static state is hard to reason about, is not thread-safe by default, and couples
+  unrelated code through a hidden global.
+- **Recommendation**: make the field `final` so it cannot be reassigned, reduce its visibility, or move the mutable state
+  into a managed bean.
+
+### ARCH-CODE-015 — Utility classes should be final with a private constructor
+
+- **Severity**: LOW
+- **Inspects**: classes that expose only static members (at least one static method, no instance methods, and no instance
+  fields), excluding interfaces, enums, records, abstract classes, and Spring stereotypes.
+- **Fires when**: such a utility class is not `final`, or it can be instantiated through a non-private constructor.
+- **Recommendation**: make utility classes `final` and give them a single private constructor so they cannot be
+  instantiated or subclassed.
+
 ## Spring stereotypes
 
 ### ARCH-SPRING-001 — Classes should not use field injection
@@ -306,3 +326,28 @@ a handful of sample detail lines from ArchUnit.
 - **Why it matters**: Spring documents this as a discouraged last resort because it couples application code to Spring AOP
   internals and requires proxy exposure.
 - **Recommendation**: refactor to avoid self-invocation, or inject a self-reference when a proxy call is truly required.
+
+### ARCH-SPRING-015 — Configuration properties classes should be immutable
+
+- **Severity**: INFO
+- **Inspects**: non-static instance fields declared in classes annotated with `@ConfigurationProperties`.
+- **Fires when**: a `@ConfigurationProperties` class has a non-`final` instance field, i.e. it relies on mutable setter
+  binding instead of immutable constructor binding.
+- **Why it matters**: Spring Boot favours immutable configuration bound through records or constructors; mutable
+  configuration state can be changed after binding and is harder to reason about.
+- **Recommendation**: bind configuration through a record or a constructor with `final` fields so configuration state is
+  immutable.
+
+### ARCH-SPRING-016 — Layered architecture dependencies should flow from web to service to repository
+
+- **Severity**: MEDIUM
+- **Inspects**: dependencies among `@Controller` / `@RestController` (web), `@Service` (service), and `@Repository`
+  (persistence) beans. Only dependencies whose source and target are both stereotype-annotated are considered, so plain
+  classes never trigger a violation.
+- **Fires when**: a dependency runs against the canonical `web → service → repository` direction — for example a
+  controller depending directly on a repository (skipping the service layer), a repository depending on a service, or any
+  lower layer depending on a higher one.
+- **Why it matters**: this is the holistic, slice-based complement to the individual stereotype dependency rules; keeping
+  the three stereotype layers in a single downward direction preserves a clean, testable layering.
+- **Recommendation**: keep dependencies flowing downward — controllers depend on services, services depend on
+  repositories, and lower layers never depend on higher ones.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -453,12 +453,14 @@ application's own classes at runtime. It detects the application's base package 
 configuration, imports the compiled classes from that package, and evaluates a fixed set of universally-sensible
 architecture hygiene rules: package cycles between slices, general coding practices (no standard streams, generic
 exceptions, `java.util.logging`, JodaTime, `printStackTrace`, `System.exit`, JDK-internal APIs, legacy date/time, or
-deprecated APIs, poorly named exceptions/interfaces, mutable/visible loggers, or production dependencies on test
-frameworks), and Spring stereotype/proxy heuristics (no field injection, controllers should not depend on repositories,
-repositories should not depend on controllers or services, services should not depend on controllers, services and
-repositories should stay servlet-agnostic, no self-invocation or unproxyable proxy annotations, async/scheduled method
-signatures should be supported, async should stay out of configuration classes, stereotypes should stay outside the
-default package, and code should avoid `AopContext.currentProxy()`). When BootUI is installed through
+deprecated APIs, poorly named exceptions/interfaces, mutable/visible loggers, production dependencies on test
+frameworks, public mutable static fields, or non-final utility classes), and Spring stereotype/proxy heuristics (no field
+injection, controllers should not depend on repositories, repositories should not depend on controllers or services,
+services should not depend on controllers, services and repositories should stay servlet-agnostic, no self-invocation or
+unproxyable proxy annotations, async/scheduled method signatures should be supported, async should stay out of
+configuration classes, stereotypes should stay outside the default package, `@ConfigurationProperties` classes should be
+immutable, stereotype dependencies should flow web → service → repository, and code should avoid
+`AopContext.currentProxy()`). When BootUI is installed through
 `bootui-spring-boot-starter`, ArchUnit is included transitively; the panel is available when a base package is resolvable
 and the scan runs on demand, caching the last report.
 


### PR DESCRIPTION
## Summary

Extends the curated, zero-config Architecture (ArchUnit) advisor from **28 to 32** checks. Each new rule follows the existing `ArchitectureRuleDefinition` + registry pattern, never throws (failures degrade to an `ERROR` result), and is shown only when it finds violations.

| ID | Severity | Check |
| --- | --- | --- |
| `ARCH-CODE-014` | MEDIUM | Classes should not have **public mutable static fields** (`public static`, non-`final`). |
| `ARCH-CODE-015` | LOW | **Utility classes** (only static members) should be `final` with a private constructor. |
| `ARCH-SPRING-015` | INFO | **`@ConfigurationProperties` classes should be immutable** (final fields / record binding — Boot 4 favors records). |
| `ARCH-SPRING-016` | MEDIUM | **Layered direction** `web → service → repository` as a holistic, slice-based rule complementing the existing pairwise stereotype rules. |

## Implementation notes

- `ARCH-CODE-015` detects utility classes conservatively: non-interface/enum/record/anonymous/local, non-abstract, not a Spring stereotype, ≥1 static method, no instance methods/fields. It excludes application entry points (a `static main`) and **ignores synthetic/bridge members** so a constants holder with a non-capturing lambda (which emits a synthetic static method) is not falsely flagged.
- `ARCH-SPRING-016` uses `layeredArchitecture().consideringOnlyDependenciesInLayers()` so only dependencies whose **both** endpoints are stereotype-annotated are evaluated — plain classes never trigger it. Same-layer access is allowed to avoid flagging repo→repo / service→service.
- `ARCH-SPRING-015` is `INFO` (a convention nudge): setter-binding is fully supported by Spring, so this stays low-noise.

## Tests & docs

- Added positive (violation) and compliant test cases for every new rule in `ArchitectureRulesTests`, plus a regression test for the synthetic-member handling, and extended `ArchitectureRuleRegistryTests`.
- Updated `docs/ARCHITECTURE-CHECKS.md` and `docs/FEATURES.md`, preserving exact doc↔code rule-ID parity (verified: 32 IDs in code, docs, and registry).

## Verification

- `./mvnw -B -ntp spotless:apply` / `spotless:check` — clean
- `./mvnw -pl bootui-autoconfigure -am test` — **617 tests pass** (34 in the architecture suite)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>