### PR TITLE
refactor: remove unused name parameter from describeRebindCaveat

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/ConfigOverrideService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/ConfigOverrideService.java
@@ -74,7 +74,7 @@ public class ConfigOverrideService {
         String previousDisplay = previous == null ? null : displayValue(name, previous, valueExposure, maskSecrets);
         src.put(name, value);
         store.save(src.mutableSource());
-        String message = describeRebindCaveat(name);
+        String message = describeRebindCaveat();
         return new ConfigOverrideResult(
                 name, displayValue(name, value, valueExposure, maskSecrets), previousDisplay, true, message);
     }
@@ -87,7 +87,7 @@ public class ConfigOverrideService {
         Object previous = src.remove(name);
         store.save(src.mutableSource());
         String previousDisplay = previous == null ? null : displayValue(name, previous, valueExposure, maskSecrets);
-        return new ConfigOverrideResult(name, null, previousDisplay, true, describeRebindCaveat(name));
+        return new ConfigOverrideResult(name, null, previousDisplay, true, describeRebindCaveat());
     }
 
     private BootUiOverridesPropertySource source() {
@@ -116,7 +116,7 @@ public class ConfigOverrideService {
         return value == null ? null : String.valueOf(value);
     }
 
-    private String describeRebindCaveat(String name) {
+    private String describeRebindCaveat() {
         return "Override stored at " + store.file()
                 + ". Already-bound @ConfigurationProperties beans may keep their previous value until restart.";
     }


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
