### PR TITLE
Prime spring-boot-maven-plugin in session setup script

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -16,10 +16,18 @@ scripts:
   # root npm dependencies used by the VuePress docs. Builds into a per-worktree
   # Maven repository (.m2/ at the worktree root) so concurrent sessions never
   # clash in the shared ~/.m2 registry.
+  #
+  # The extra `spring-boot:help` invocation primes spring-boot-maven-plugin into
+  # the per-worktree .m2/. The sample app declares the plugin without executions
+  # and does not inherit spring-boot-starter-parent, so `install` never resolves
+  # it; without this online prime the later offline `spring-boot:run` in the dev
+  # server fails with "No plugin found for prefix 'spring-boot'".
   - name: Setup
     command: >-
       ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-sample-app -am
       -DskipTests install
+      && ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-sample-app
+      spring-boot:help
       && npm install
     triggers:
       - session.create


### PR DESCRIPTION
## What does this PR do?

Adds an online `spring-boot:help` prime to the Copilot session **Setup** script so the offline Dev server can resolve `spring-boot-maven-plugin` in fresh worktrees.

## Why is this change needed?

The Dev server runs `spring-boot:run` offline (`-o`) against the per-worktree `.m2/`, resolving the plugin by its `spring-boot` prefix. The sample app declares `spring-boot-maven-plugin` without executions and does not inherit `spring-boot-starter-parent`, so the Setup `install` never invokes or downloads the plugin. Offline prefix resolution then fails with `No plugin found for prefix 'spring-boot'`, and the Dev server aborts before booting.

The fix primes the plugin once, online, in the Setup script (which already runs online and exists to download everything), keeping the Dev server fast and fully offline. No production/build code changes; this only affects the local Copilot session tooling.

Closes # N/A

## How was it tested?

- [x] Reproduced the offline failure, then confirmed an online `spring-boot:help` populates `spring-boot-maven-plugin:4.0.6` into the isolated `.m2/` and makes offline resolution succeed
- [x] Ran the exact offline Dev server command end-to-end: it booted with zero plugin-prefix errors, logged `BootUI is available at .../bootui`, and both `/bootui/` and `/bootui/api/overview` returned `200`
- [ ] `./mvnw clean install` passes locally (N/A: no build/source changes, only the session Setup script)

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: tooling-only change; rationale captured in the script comment)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed