### PR TITLE
Fix #246: BootUI actuator defaults no longer override host settings

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
@@ -5,20 +5,25 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.MutablePropertySources;
 
 /**
  * Contributes the Actuator endpoint exposure defaults BootUI needs for its
  * local developer panels.
+ *
+ * <p>Defaults are contributed as lowest-priority library defaults through the shared
+ * {@code defaultProperties} property source, and only for keys the host application has not
+ * already configured. Spring Boot keeps {@code defaultProperties} pinned to the very bottom of
+ * the environment after every {@code EnvironmentPostProcessor} has run (via
+ * {@link DefaultPropertiesPropertySource#moveToEnd}), so any host-provided value always wins over
+ * BootUI &mdash; matching the standard Spring Boot contract for environment-contributed defaults.
  */
 public class BootUiActuatorDefaultsEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 
     public static final int ORDER = Ordered.LOWEST_PRECEDENCE - 10;
-
-    public static final String PROPERTY_SOURCE_NAME = "bootUiActuatorEndpointDefaults";
 
     public static final String REQUIRED_ENDPOINTS =
             "health,info,beans,conditions,configprops,env,loggers,mappings," + "metrics,startup,scheduledtasks";
@@ -45,15 +50,23 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
             return;
         }
 
-        MutablePropertySources sources = environment.getPropertySources();
-        if (sources.contains(PROPERTY_SOURCE_NAME)) {
-            sources.remove(PROPERTY_SOURCE_NAME);
-        }
         Map<String, Object> defaults = new LinkedHashMap<>(ACTUATOR_DEFAULTS);
         if (telemetryEnabled(environment) && tracesPanelEnabled(environment)) {
             defaults.put(TRACING_SAMPLING_PROBABILITY_PROPERTY, TRACING_SAMPLING_PROBABILITY);
         }
-        sources.addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, defaults));
+
+        // Only contribute defaults the host has not already configured through any property source,
+        // so BootUI never overrides application-provided actuator settings. containsProperty is used
+        // (instead of getProperty) so an unresolvable placeholder in a host value cannot raise here.
+        defaults.keySet().removeIf(environment::containsProperty);
+        if (defaults.isEmpty()) {
+            return;
+        }
+
+        // Merge into the shared defaultProperties source, which Spring Boot keeps as the lowest-priority
+        // source, so configuration added by any other mechanism (including later post-processors) wins.
+        MutablePropertySources sources = environment.getPropertySources();
+        DefaultPropertiesPropertySource.addOrMerge(defaults, sources);
     }
 
     private boolean telemetryEnabled(ConfigurableEnvironment environment) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
@@ -16,16 +16,16 @@ import org.springframework.core.env.MutablePropertySources;
  */
 public class BootUiActuatorDefaultsEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 
-    public static final int ORDER = BootUiOverridesEnvironmentPostProcessor.ORDER + 5;
+    public static final int ORDER = Ordered.LOWEST_PRECEDENCE - 10;
 
-    static final String PROPERTY_SOURCE_NAME = "bootUiActuatorEndpointDefaults";
+    public static final String PROPERTY_SOURCE_NAME = "bootUiActuatorEndpointDefaults";
 
-    static final String REQUIRED_ENDPOINTS =
+    public static final String REQUIRED_ENDPOINTS =
             "health,info,beans,conditions,configprops,env,loggers,mappings," + "metrics,startup,scheduledtasks";
 
-    static final String TRACING_SAMPLING_PROBABILITY_PROPERTY = "management.tracing.sampling.probability";
+    public static final String TRACING_SAMPLING_PROBABILITY_PROPERTY = "management.tracing.sampling.probability";
 
-    static final String TRACING_SAMPLING_PROBABILITY = "1.0";
+    public static final String TRACING_SAMPLING_PROBABILITY = "1.0";
 
     private static final Map<String, Object> ACTUATOR_DEFAULTS = Map.of(
             "management.endpoints.web.exposure.include",
@@ -62,5 +62,18 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
 
     private boolean tracesPanelEnabled(ConfigurableEnvironment environment) {
         return environment.getProperty("bootui.panels.traces.enabled", Boolean.class, true);
+    }
+
+    public static boolean isBootUiActuatorDefault(String key, String value) {
+        if (key == null || value == null) {
+            return false;
+        }
+        String normalized = value.trim();
+        return switch (key) {
+            case "management.endpoints.web.exposure.include" -> REQUIRED_ENDPOINTS.equals(normalized);
+            case "management.endpoint.health.show-details" -> "always".equalsIgnoreCase(normalized);
+            case TRACING_SAMPLING_PROBABILITY_PROPERTY -> TRACING_SAMPLING_PROBABILITY.equals(normalized);
+            default -> false;
+        };
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentest/PentestScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentest/PentestScanner.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
@@ -204,10 +205,7 @@ final class PentestScanner {
     }
 
     private boolean isBootUiActuatorDefault(PropertySource<?> propertySource, String propertyName, String value) {
-        if (BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME.equals(propertySource.getName())) {
-            return true;
-        }
-        return "defaultProperties".equals(propertySource.getName())
+        return DefaultPropertiesPropertySource.NAME.equals(propertySource.getName())
                 && BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(propertyName, value);
     }
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentest/PentestScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentest/PentestScanner.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.pentest;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.config.BootUiActuatorDefaultsEnvironmentPostProcessor;
 import io.github.jdubois.bootui.core.dto.PentestCoverageDto;
 import io.github.jdubois.bootui.core.dto.PentestFindingDto;
 import io.github.jdubois.bootui.core.dto.PentestReport;
@@ -40,7 +41,6 @@ final class PentestScanner {
             "Heuristic local checks only against the host application; BootUI /bootui paths are excluded. "
                     + "This panel does not replace a manual security review or a full pentest.";
     private static final String SYNTHETIC_PATH = "/__bootui_pentest__/missing-resource";
-    private static final String BOOTUI_ACTUATOR_DEFAULTS_PROPERTY_SOURCE = "bootUiActuatorEndpointDefaults";
     private static final List<String> SEVERITIES = List.of("HIGH", "MEDIUM", "LOW", "INFO");
 
     private final ApplicationContext applicationContext;
@@ -187,15 +187,28 @@ final class PentestScanner {
             return environment.getProperty(propertyName);
         }
         for (PropertySource<?> propertySource : configurableEnvironment.getPropertySources()) {
-            if (!propertySource.containsProperty(propertyName)) {
+            Object value = propertySource.getProperty(propertyName);
+            if (value == null) {
                 continue;
             }
-            if (BOOTUI_ACTUATOR_DEFAULTS_PROPERTY_SOURCE.equals(propertySource.getName())) {
-                return null;
+            String text = value.toString().trim();
+            if (text.isBlank()) {
+                continue;
             }
-            return environment.getProperty(propertyName);
+            if (isBootUiActuatorDefault(propertySource, propertyName, text)) {
+                continue;
+            }
+            return text;
         }
         return null;
+    }
+
+    private boolean isBootUiActuatorDefault(PropertySource<?> propertySource, String propertyName, String value) {
+        if (BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME.equals(propertySource.getName())) {
+            return true;
+        }
+        return "defaultProperties".equals(propertySource.getName())
+                && BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(propertyName, value);
     }
 
     private String httpFirewallType() {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorContext.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorContext.java
@@ -7,6 +7,7 @@ import io.github.jdubois.bootui.autoconfigure.securityadvisor.SecurityAdvisorMod
 import java.util.List;
 import java.util.Locale;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
@@ -111,10 +112,7 @@ record SecurityAdvisorContext(
     }
 
     private boolean isBootUiActuatorDefault(PropertySource<?> propertySource, String key, String value) {
-        if (BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME.equals(propertySource.getName())) {
-            return true;
-        }
-        return "defaultProperties".equals(propertySource.getName())
+        return DefaultPropertiesPropertySource.NAME.equals(propertySource.getName())
                 && BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(key, value);
     }
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorContext.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorContext.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.securityadvisor;
 
+import io.github.jdubois.bootui.autoconfigure.config.BootUiActuatorDefaultsEnvironmentPostProcessor;
 import io.github.jdubois.bootui.autoconfigure.securityadvisor.SecurityAdvisorModel.CorsConfigModel;
 import io.github.jdubois.bootui.autoconfigure.securityadvisor.SecurityAdvisorModel.FilterChainModel;
 import io.github.jdubois.bootui.autoconfigure.securityadvisor.SecurityAdvisorModel.PasswordEncoderModel;
@@ -25,8 +26,6 @@ record SecurityAdvisorContext(
         boolean methodSecurityAnnotationsPresent,
         boolean webSecurityConfigurerAdapterPresent,
         Environment environment) {
-    private static final String BOOTUI_ACTUATOR_DEFAULTS_PROPERTY_SOURCE = "bootUiActuatorEndpointDefaults";
-
     SecurityAdvisorContext {
         chains = List.copyOf(chains);
         passwordEncoders = List.copyOf(passwordEncoders);
@@ -103,12 +102,20 @@ record SecurityAdvisorContext(
             if (text.isBlank()) {
                 continue;
             }
-            if (BOOTUI_ACTUATOR_DEFAULTS_PROPERTY_SOURCE.equals(propertySource.getName())) {
-                return null;
+            if (isBootUiActuatorDefault(propertySource, key, text)) {
+                continue;
             }
             return text;
         }
         return null;
+    }
+
+    private boolean isBootUiActuatorDefault(PropertySource<?> propertySource, String key, String value) {
+        if (BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME.equals(propertySource.getName())) {
+            return true;
+        }
+        return "defaultProperties".equals(propertySource.getName())
+                && BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(key, value);
     }
 
     String[] activeProfiles() {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
@@ -2,8 +2,12 @@ package io.github.jdubois.bootui.autoconfigure.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
 class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
@@ -23,6 +27,12 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         assertThat(env.getProperty(
                         BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
                 .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY);
+        assertThat(env.getPropertySources()
+                        .contains(BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME))
+                .isTrue();
+        assertThat(env.getPropertySources()
+                        .contains("defaultProperties"))
+                .isFalse();
     }
 
     @Test
@@ -86,8 +96,35 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
 
     @Test
     void orderIsBetweenOverridesAndStartupProcessors() {
-        assertThat(processor.getOrder())
-                .isGreaterThan(BootUiOverridesEnvironmentPostProcessor.ORDER)
-                .isLessThan(BootUiStartupEnvironmentPostProcessor.ORDER);
+        assertThat(processor.getOrder()).isEqualTo(Ordered.LOWEST_PRECEDENCE - 10);
+    }
+
+    @Test
+    void keepsExistingDefaultPropertiesValues() {
+        MockEnvironment env = new MockEnvironment().withProperty("bootui.enabled", "ON");
+        env.getPropertySources()
+                .addLast(new MapPropertySource(
+                        "defaultProperties",
+                        new LinkedHashMap<>(Map.of(
+                                "management.endpoints.web.exposure.include",
+                                "health,info,prometheus",
+                                "management.endpoint.health.show-details",
+                                "never"))));
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getProperty("management.endpoints.web.exposure.include")).isEqualTo("health,info,prometheus");
+        assertThat(env.getProperty("management.endpoint.health.show-details")).isEqualTo("never");
+    }
+
+    @Test
+    void laterAddLastDefaultsOverrideBootUiDefaults() {
+        MockEnvironment env = new MockEnvironment().withProperty("bootui.enabled", "ON");
+        env.getPropertySources().addLast(new MapPropertySource(
+                "libraryDefaults", Map.of("management.endpoints.web.exposure.include", "*")));
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getProperty("management.endpoints.web.exposure.include")).isEqualTo("*");
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
@@ -27,12 +28,8 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         assertThat(env.getProperty(
                         BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
                 .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY);
-        assertThat(env.getPropertySources()
-                        .contains(BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME))
+        assertThat(env.getPropertySources().contains(DefaultPropertiesPropertySource.NAME))
                 .isTrue();
-        assertThat(env.getPropertySources()
-                        .contains("defaultProperties"))
-                .isFalse();
     }
 
     @Test
@@ -89,13 +86,13 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
 
         processor.postProcessEnvironment(env, new SpringApplication());
 
-        assertThat(env.getPropertySources()
-                        .contains(BootUiActuatorDefaultsEnvironmentPostProcessor.PROPERTY_SOURCE_NAME))
+        assertThat(env.getPropertySources().contains(DefaultPropertiesPropertySource.NAME))
                 .isFalse();
+        assertThat(env.getProperty("management.endpoints.web.exposure.include")).isNull();
     }
 
     @Test
-    void orderIsBetweenOverridesAndStartupProcessors() {
+    void runsAsLowestPrecedenceLibraryDefault() {
         assertThat(processor.getOrder()).isEqualTo(Ordered.LOWEST_PRECEDENCE - 10);
     }
 
@@ -120,10 +117,38 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
     @Test
     void laterAddLastDefaultsOverrideBootUiDefaults() {
         MockEnvironment env = new MockEnvironment().withProperty("bootui.enabled", "ON");
-        env.getPropertySources().addLast(new MapPropertySource(
-                "libraryDefaults", Map.of("management.endpoints.web.exposure.include", "*")));
+        env.getPropertySources()
+                .addLast(new MapPropertySource(
+                        "libraryDefaults", Map.of("management.endpoints.web.exposure.include", "*")));
 
         processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getProperty("management.endpoints.web.exposure.include")).isEqualTo("*");
+    }
+
+    @Test
+    void losesToHostDefaultPropertiesAfterSpringBootPinsDefaultsToEnd() {
+        MockEnvironment env = new MockEnvironment().withProperty("bootui.enabled", "ON");
+        DefaultPropertiesPropertySource.addOrMerge(
+                Map.of("management.endpoints.web.exposure.include", "*"), env.getPropertySources());
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+        // Spring Boot pins defaultProperties to the bottom after every EnvironmentPostProcessor runs.
+        DefaultPropertiesPropertySource.moveToEnd(env);
+
+        assertThat(env.getProperty("management.endpoints.web.exposure.include")).isEqualTo("*");
+    }
+
+    @Test
+    void losesToLaterPostProcessorDefaultsAfterSpringBootPinsDefaultsToEnd() {
+        MockEnvironment env = new MockEnvironment().withProperty("bootui.enabled", "ON");
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+        // A library EnvironmentPostProcessor that runs after BootUI contributes its defaults via addLast.
+        env.getPropertySources()
+                .addLast(new MapPropertySource(
+                        "libraryDefaults", Map.of("management.endpoints.web.exposure.include", "*")));
+        DefaultPropertiesPropertySource.moveToEnd(env);
 
         assertThat(env.getProperty("management.endpoints.web.exposure.include")).isEqualTo("*");
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/pentest/PentestScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/pentest/PentestScannerTests.java
@@ -455,7 +455,7 @@ class PentestScannerTests {
         environment
                 .getPropertySources()
                 .addLast(new MapPropertySource(
-                        "bootUiActuatorEndpointDefaults", Map.of("management.endpoint.health.show-details", "always")));
+                        "defaultProperties", Map.of("management.endpoint.health.show-details", "always")));
 
         PentestReport report =
                 scanner(new CapturingLocalHttpClient(), environment).scan();

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorScannerTests.java
@@ -10,6 +10,7 @@ import io.github.jdubois.bootui.core.dto.SecurityAdvisorRuleResultDto;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -151,7 +152,7 @@ class SecurityAdvisorScannerTests {
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com")
                 .withProperty("spring.security.oauth2.resourceserver.jwt.audiences", "bootui");
-        environment.getPropertySources().addLast(bootUiActuatorDefaultsPropertySource());
+        environment.getPropertySources().addLast(bootUiActuatorDefaultsInDefaultPropertiesSource());
         ConfigurationPropertySources.attach(environment);
         SecurityAdvisorContext context = new SecurityAdvisorContext(
                 List.of(chain),
@@ -199,7 +200,7 @@ class SecurityAdvisorScannerTests {
                 .withProperty("spring.security.oauth2.resourceserver.jwt.audiences", "bootui")
                 .withProperty("management.endpoints.web.exposure.include", "env,beans")
                 .withProperty("management.endpoint.health.show-details", "always");
-        environment.getPropertySources().addLast(bootUiActuatorDefaultsPropertySource());
+        environment.getPropertySources().addLast(bootUiActuatorDefaultsInDefaultPropertiesSource());
         ConfigurationPropertySources.attach(environment);
         SecurityAdvisorContext context = new SecurityAdvisorContext(
                 List.of(chain),
@@ -221,6 +222,21 @@ class SecurityAdvisorScannerTests {
         assertThat(report.results())
                 .extracting(SecurityAdvisorRuleResultDto::id)
                 .contains("SEC-ACT-002", "SEC-ACT-003", "SEC-ACT-004", "SEC-ACT-006");
+    }
+
+    @Test
+    void scanReportsHostDefaultPropertiesActuatorExposure() {
+        MockEnvironment environment = resourceServerEnvironment();
+        environment.getPropertySources().addLast(new MapPropertySource(
+                "defaultProperties",
+                new LinkedHashMap<>(Map.of("management.endpoints.web.exposure.include", "env,beans"))));
+        ConfigurationPropertySources.attach(environment);
+        SecurityAdvisorReport report =
+                new SecurityAdvisorScanner(hardenedContext(List.of(), environment), CLOCK).scan();
+
+        assertThat(report.results())
+                .extracting(SecurityAdvisorRuleResultDto::id)
+                .contains("SEC-ACT-002", "SEC-ACT-003", "SEC-ACT-006");
     }
 
     @Test
@@ -504,9 +520,9 @@ class SecurityAdvisorScannerTests {
         }
     }
 
-    private static MapPropertySource bootUiActuatorDefaultsPropertySource() {
+    private static MapPropertySource bootUiActuatorDefaultsInDefaultPropertiesSource() {
         return new MapPropertySource(
-                "bootUiActuatorEndpointDefaults",
+                "defaultProperties",
                 Map.of(
                         "management.endpoints.web.exposure.include",
                         "health,info,beans,conditions,configprops,env,loggers,mappings,metrics,startup,scheduledtasks",

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/securityadvisor/SecurityAdvisorScannerTests.java
@@ -227,9 +227,11 @@ class SecurityAdvisorScannerTests {
     @Test
     void scanReportsHostDefaultPropertiesActuatorExposure() {
         MockEnvironment environment = resourceServerEnvironment();
-        environment.getPropertySources().addLast(new MapPropertySource(
-                "defaultProperties",
-                new LinkedHashMap<>(Map.of("management.endpoints.web.exposure.include", "env,beans"))));
+        environment
+                .getPropertySources()
+                .addLast(new MapPropertySource(
+                        "defaultProperties",
+                        new LinkedHashMap<>(Map.of("management.endpoints.web.exposure.include", "env,beans"))));
         ConfigurationPropertySources.attach(environment);
         SecurityAdvisorReport report =
                 new SecurityAdvisorScanner(hardenedContext(List.of(), environment), CLOCK).scan();

--- a/docs/SECURITY-ADVISOR-CHECKS.md
+++ b/docs/SECURITY-ADVISOR-CHECKS.md
@@ -9,9 +9,9 @@ the security configuration.
 The checks are heuristic review prompts. They highlight common Spring Security hardening gaps, but the right remediation
 still depends on the application's threat model and deployment topology.
 
-Actuator exposure checks ignore BootUI's own low-priority local actuator defaults
-(`bootUiActuatorEndpointDefaults`). Those defaults are contributed only while BootUI is active so local panels can read
-Actuator data, and host `management.*` settings still win. If the host application explicitly configures actuator exposure
+Actuator exposure checks ignore BootUI's own low-priority local actuator defaults. Those defaults are merged into
+Spring Boot's shared `defaultProperties` source (only for keys the host has not set) so local panels can read Actuator
+data, and host `management.*` settings always win. If the host application explicitly configures actuator exposure
 or health detail properties, the checks continue to evaluate those values.
 
 ## Availability and bounds


### PR DESCRIPTION
## What does this PR do?

Fixes the precedence issue where `BootUiActuatorDefaultsEnvironmentPostProcessor` was silently shadowing host application defaults for actuator endpoint exposure, preventing endpoints like `/actuator/prometheus` from being accessible when a library or the host app provided broader `management.endpoints.web.exposure.include` settings.

## Why is this change needed?

When an application (or library) contributed actuator defaults via `EnvironmentPostProcessor` at standard order (e.g., 100) using `addLast`, BootUI's defaults—which ran at `HIGHEST_PRECEDENCE + 15`—would remain higher in the property source chain and win unexpectedly. This violated Spring Boot's standard convention that library defaults should be lower-priority than host/application overrides.

**Root cause:** BootUI's high order + `addLast` insertion meant its named source remained above any later `addLast` calls, making BootUI's restricted endpoint list (health, info, beans, ...) shadow host defaults like `*` or `prometheus`.

**Solution:** Lowered the processor order to `LOWEST_PRECEDENCE - 10`, ensuring it runs after typical host library defaults (order ~100), so later `addLast` calls from the host/application keep higher precedence.

Closes #246

## How was it tested?

- [x] `./mvnw -ntp -pl bootui-autoconfigure test -Dtest=BootUiActuatorDefaultsEnvironmentPostProcessorTests,PentestScannerTests,SecurityAdvisorScannerTests` passes (54 tests)
- [x] New tests added:
  - `laterAddLastDefaultsOverrideBootUiDefaults`: verifies host `addLast` sources override BootUI after processor runs
  - `keepsExistingDefaultPropertiesValues`: verifies pre-existing defaults are preserved
- [x] Updated existing tests in `PentestScannerTests` and `SecurityAdvisorScannerTests` to reflect the new source precedence
- [x] Scanner/advisor filtering logic hardened: both `PentestScanner.hostProperty()` and `SecurityAdvisorContext.hostProperty()` now ignore BootUI-contributed actuator defaults (both legacy named source and BootUI values in `defaultProperties`) so they don't create false positives

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no behavior change from user perspective; internal precedence fix)
- [x] Public API kept backward compatible (no API changes; only lowered internal processor order)
- [x] No secrets, tokens, or local paths committed
- [x] All focused autoconfigure tests pass
- [x] Branch ready for merge