### PR TITLE
Remove dead frontend code and unused imports

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/GraalVm.vue
+++ b/bootui-ui/src/main/frontend/src/views/GraalVm.vue
@@ -21,8 +21,6 @@ const severityClasses = {
   INFO: 'text-bg-secondary'
 }
 
-const severityOrder = ['HIGH', 'MEDIUM', 'LOW', 'INFO']
-
 const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
 
 const maxSeverityCount = computed(() => {

--- a/bootui-ui/src/main/frontend/src/views/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthNode.vue
@@ -2,7 +2,7 @@
 import {isPlainObject} from '../utils/format.js'
 import HealthDetails from './HealthDetails.vue'
 
-const props = defineProps({
+defineProps({
   node: {type: Object, required: true},
   depth: {type: Number, default: 0}
 })

--- a/bootui-ui/src/main/frontend/src/views/Scheduled.vue
+++ b/bootui-ui/src/main/frontend/src/views/Scheduled.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
+import {computed, ref} from 'vue'
 import {describeLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import PanelHeader from './components/PanelHeader.vue'

--- a/bootui-ui/src/main/frontend/src/views/SpringCache.vue
+++ b/bootui-ui/src/main/frontend/src/views/SpringCache.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
+import {computed, ref} from 'vue'
 import {formatNumber, shortName} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'


### PR DESCRIPTION
## What does this PR do?

Removes four pieces of confirmed dead code in the Vue frontend that an audit of the whole codebase surfaced.

## Why is this change needed?

The frontend has no ESLint `no-unused-vars`/import check (unlike Java, where Spotless `removeUnusedImports` already keeps imports clean), so a few unused bindings had accumulated. They add noise and can mislead readers into thinking they are wired up. This is a small, behavior-neutral cleanup.

The removals are:

- `Scheduled.vue` and `SpringCache.vue`: dropped the unused `onMounted` import from `vue`.
- `GraalVm.vue`: removed the unused `severityOrder` constant.
- `HealthNode.vue`: dropped the unused `props` binding so it is now a bare `defineProps({...})`. The `node` and `depth` props are referenced directly in the template, so nothing read the `props` variable.

No related issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Frontend Vitest suite (`npm test`) passes 131/131 and `npm run format:check` is clean. The change is pure removal of unreferenced bindings, so no new tests were needed and existing component tests still cover the affected views. Backend was untouched.

## Screenshots (UI changes)

N/A. These removals do not change any rendered output.

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed