### PR TITLE
Make Copilot app dev server self-healing for cold worktree .m2

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -16,34 +16,33 @@ scripts:
   # root npm dependencies used by the VuePress docs. Builds into a per-worktree
   # Maven repository (.m2/ at the worktree root) so concurrent sessions never
   # clash in the shared ~/.m2 registry.
-  #
-  # The extra `spring-boot:help` invocation primes spring-boot-maven-plugin into
-  # the per-worktree .m2/. The sample app declares the plugin without executions
-  # and does not inherit spring-boot-starter-parent, so `install` never resolves
-  # it; without this online prime the later offline `spring-boot:run` in the dev
-  # server fails with "No plugin found for prefix 'spring-boot'".
   - name: Setup
     command: >-
       ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-sample-app -am
       -DskipTests install
-      && ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-sample-app
-      spring-boot:help
       && npm install
     triggers:
       - session.create
 
   # Spring Boot sample app: the full, bundled BootUI console at /bootui.
-  # Rebuilds the core/autoconfigure/ui/starter modules first (from the
+  # Rebuilds the core/autoconfigure/ui/starter modules first (into the
   # per-worktree .m2/) so the app always reflects local changes, then launches
   # on $COPILOT_PORT -- a free port unique to this session -- so concurrent
   # sessions never collide on the HTTP port. Requires Docker (Spring Boot
   # auto-starts the Postgres/Redis/Ollama Compose services). On startup it logs
   # "BootUI is available at http://localhost:<port>/bootui", which is auto-opened.
+  #
+  # Runs online (no -o) so it is self-healing: if the "Setup" script has not yet
+  # finished populating the per-worktree .m2/ (e.g. launched during or before
+  # Setup, or in a worktree where Setup never ran), Maven downloads whatever is
+  # missing -- such as the spring-boot-dependencies BOM or spring-boot-maven-plugin
+  # -- instead of failing with "Cannot access central in offline mode".
+  # -Dmaven.repo.local=.m2 still keeps the build isolated from the shared ~/.m2.
   - name: Dev server (sample app)
     command: >-
-      ./mvnw -o -ntp -Dmaven.repo.local=.m2 -pl bootui-sample-app -am
+      ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-sample-app -am
       -DskipTests install
-      && ./mvnw -o -ntp -Dmaven.repo.local=.m2 -pl bootui-sample-app
+      && ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-sample-app
       -Dmaven.test.skip=true spring-boot:run -Dspring-boot.run.profiles=dev
       -Dspring-boot.run.arguments=--server.port=$COPILOT_PORT
 


### PR DESCRIPTION
## What does this PR do?

Makes the GitHub Copilot app "Dev server (sample app)" script in `.github/github-app.yml` build online so it self-heals when the per-worktree `.m2/` has not been fully populated yet.

## Why is this change needed?

The "Dev server (sample app)" script built offline (`-o`), assuming the `session.create` "Setup" script had already populated the per-worktree `.m2/`. When the dev server ran before/while Setup finished, in a worktree where Setup never ran, or when Setup did not complete, the offline build failed at "Scanning for projects" with:

```
Non-resolvable import POM: ... org.springframework.boot:spring-boot-dependencies:pom:4.0.6
(absent): Cannot access central in offline mode and the artifact ... has not been downloaded
from it before.
```

Dropping `-o` lets Maven download whatever is missing (the `spring-boot-dependencies` BOM, the `spring-boot` plugin) into the isolated per-worktree repo. `-Dmaven.repo.local=.m2` still keeps the build isolated from the shared `~/.m2`. Because an online `spring-boot:run` resolves the plugin prefix itself, the Setup `spring-boot:help` prime is no longer needed and is removed, which also speeds up session creation. `-B` was added for non-interactive consistency.

This is config-only; no production code, public API, or UI changes.

Closes # N/A (no tracking issue)

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Validated the actual fix against an isolated empty repo (`-Dmaven.repo.local=/tmp/...`):

- The old offline command reproduced the reported error (missing `spring-boot-dependencies:4.0.6` BOM at `pom.xml` line 77).
- The new online command on the same empty repo returned `BUILD SUCCESS`, downloading both the BOM and `spring-boot-maven-plugin` into the isolated repo, confirming the plugin prefix self-heals without the prime and that worktree isolation still holds.
- Each step is a single command, so stopping the server does not trigger a restart and compile errors fail once (no offline-then-online double build).

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (in-file comments in `github-app.yml` updated; no `docs/` impact)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed