### PR TITLE
Show open issue list in GitHub panel and fix dark-mode quota card

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubApiClient.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubApiClient.java
@@ -67,6 +67,7 @@ final class GitHubApiClient implements GitHubClient {
                     List.of(),
                     List.of(),
                     List.of(),
+                    List.of(),
                     unavailableCopilotUsage("GitHub API host is not allowed"),
                     List.of());
         }
@@ -79,6 +80,7 @@ final class GitHubApiClient implements GitHubClient {
         List<GitHubWorkflowRunDto> workflowRuns = new ArrayList<>();
         List<GitHubWorkflowDto> workflows = new ArrayList<>();
         List<GitHubIssueBucketDto> issueBuckets = new ArrayList<>();
+        List<GitHubIssueDto> issues = new ArrayList<>();
         List<GitHubSecuritySignalDto> securitySignals = new ArrayList<>();
 
         try {
@@ -92,6 +94,7 @@ final class GitHubApiClient implements GitHubClient {
                         refreshedAt,
                         null,
                         credential(token, rateLimit.headers(), null),
+                        List.of(),
                         List.of(),
                         List.of(),
                         List.of(),
@@ -125,6 +128,7 @@ final class GitHubApiClient implements GitHubClient {
                         workflowRuns,
                         workflows,
                         issueBuckets,
+                        issues,
                         securitySignals,
                         copilotUsage,
                         warnings);
@@ -157,6 +161,7 @@ final class GitHubApiClient implements GitHubClient {
                     "issues");
             if (issuesResponse.success()) {
                 issueBuckets.addAll(issueBuckets(issuesResponse.json()));
+                issues.addAll(issues(issuesResponse.json()));
             } else {
                 warnings.add(issuesResponse.safeMessage());
             }
@@ -241,6 +246,7 @@ final class GitHubApiClient implements GitHubClient {
                     workflowRuns,
                     workflows,
                     issueBuckets,
+                    issues,
                     securitySignals,
                     copilotUsage,
                     warnings);
@@ -491,6 +497,28 @@ final class GitHubApiClient implements GitHubClient {
                 new GitHubIssueBucketDto("With labels", labeled, "info"),
                 new GitHubIssueBucketDto("No label", unlabeled, "warning"),
                 new GitHubIssueBucketDto("Stale 30d+", stale, stale > 0 ? "warning" : "success"));
+    }
+
+    private List<GitHubIssueDto> issues(JsonNode root) {
+        if (!root.isArray()) {
+            return List.of();
+        }
+        List<GitHubIssueDto> issues = new ArrayList<>();
+        for (JsonNode item : root) {
+            if (!item.path("pull_request").isMissingNode()) {
+                continue;
+            }
+            issues.add(new GitHubIssueDto(
+                    item.path("number").asInt(),
+                    text(item, "title"),
+                    text(item.path("user"), "login"),
+                    text(item, "html_url"),
+                    instantMillis(text(item, "created_at")),
+                    instantMillis(text(item, "updated_at")),
+                    item.path("comments").asInt(0),
+                    labels(item.path("labels"))));
+        }
+        return issues;
     }
 
     private void addSecuritySignal(
@@ -804,6 +832,7 @@ final class GitHubApiClient implements GitHubClient {
             List<GitHubWorkflowRunDto> workflowRuns,
             List<GitHubWorkflowDto> workflows,
             List<GitHubIssueBucketDto> issueBuckets,
+            List<GitHubIssueDto> issues,
             List<GitHubSecuritySignalDto> securitySignals,
             GitHubCopilotUsageDto copilotUsage,
             List<String> warnings) {
@@ -822,6 +851,7 @@ final class GitHubApiClient implements GitHubClient {
                 List.copyOf(workflowRuns),
                 List.copyOf(workflows),
                 List.copyOf(issueBuckets),
+                List.copyOf(issues),
                 List.copyOf(securitySignals),
                 copilotUsage,
                 List.copyOf(warnings));
@@ -840,6 +870,7 @@ final class GitHubApiClient implements GitHubClient {
                 refreshedAt,
                 null,
                 credential(token, null, null),
+                List.of(),
                 List.of(),
                 List.of(),
                 List.of(),

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubDashboardService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubDashboardService.java
@@ -78,6 +78,7 @@ class GitHubDashboardService {
                     report.workflowRuns(),
                     report.workflows(),
                     report.issueBuckets(),
+                    report.issues(),
                     report.securitySignals(),
                     report.copilotUsage(),
                     report.warnings());
@@ -101,6 +102,7 @@ class GitHubDashboardService {
                 null,
                 null,
                 new GitHubCredentialDto("none", false, null, null),
+                List.of(),
                 List.of(),
                 List.of(),
                 List.of(),
@@ -142,6 +144,7 @@ class GitHubDashboardService {
                         null,
                         null),
                 new GitHubCredentialDto("not connected", false, null, null),
+                List.of(),
                 List.of(),
                 List.of(),
                 List.of(),

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubApiClientTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubApiClientTests.java
@@ -38,7 +38,7 @@ class GitHubApiClientTests {
                 [{"number":42,"title":"Add dashboard","draft":false,"html_url":"https://github.com/jdubois/boot-ui/pull/42","updated_at":"2026-06-04T08:30:00Z","user":{"login":"alice"},"labels":[{"name":"feature"}]}]
                 """);
         json("/repos/jdubois/boot-ui/issues", """
-                [{"number":7,"title":"Bug","updated_at":"2026-04-01T08:30:00Z","labels":[]},{"number":8,"pull_request":{},"labels":[]}]
+                [{"number":7,"title":"Bug","user":{"login":"carol"},"comments":3,"html_url":"https://github.com/jdubois/boot-ui/issues/7","created_at":"2026-03-30T08:00:00Z","updated_at":"2026-04-01T08:30:00Z","labels":[]},{"number":8,"pull_request":{},"labels":[]}]
                 """);
         json("/repos/jdubois/boot-ui/actions/runs", """
                 {"workflow_runs":[{"id":9,"workflow_id":100,"name":"Build","display_title":"Run tests","run_number":41,"event":"push","status":"completed","conclusion":"failure","head_branch":"main","triggering_actor":{"login":"alice"},"html_url":"https://github.com/jdubois/boot-ui/actions/runs/9","created_at":"2026-06-04T07:00:00Z","run_started_at":"2026-06-04T07:01:00Z","updated_at":"2026-06-04T07:05:00Z"},{"id":10,"workflow_id":100,"name":"Build","display_title":"Run tests","run_number":42,"event":"push","status":"completed","conclusion":"success","head_branch":"main","triggering_actor":{"login":"alice"},"html_url":"https://github.com/jdubois/boot-ui/actions/runs/10","created_at":"2026-06-04T08:00:00Z","run_started_at":"2026-06-04T08:01:00Z","updated_at":"2026-06-04T08:05:00Z"},{"id":11,"workflow_id":200,"name":"Build","display_title":"Manual release","run_number":9,"event":"workflow_dispatch","status":"completed","conclusion":"timed_out","head_branch":"main","actor":{"login":"bob"},"html_url":"https://github.com/jdubois/boot-ui/actions/runs/11","created_at":"2026-06-03T08:00:00Z","run_started_at":"2026-06-03T08:01:00Z","updated_at":"2026-06-03T08:20:00Z"},{"id":12,"workflow_id":200,"name":"Build","display_title":"Feature branch scan","run_number":8,"event":"push","status":"completed","conclusion":"failure","head_branch":"feature/github-dashboard","actor":{"login":"bob"},"html_url":"https://github.com/jdubois/boot-ui/actions/runs/12","created_at":"2026-06-02T08:00:00Z","run_started_at":"2026-06-02T08:01:00Z","updated_at":"2026-06-02T08:20:00Z"}]}
@@ -110,6 +110,13 @@ class GitHubApiClientTests {
                 .singleElement()
                 .extracting("count")
                 .isEqualTo(1);
+        assertThat(report.issues()).singleElement().satisfies(issue -> {
+            assertThat(issue.number()).isEqualTo(7);
+            assertThat(issue.title()).isEqualTo("Bug");
+            assertThat(issue.author()).isEqualTo("carol");
+            assertThat(issue.comments()).isEqualTo(3);
+            assertThat(issue.htmlUrl()).isEqualTo("https://github.com/jdubois/boot-ui/issues/7");
+        });
         assertThat(report.quotas())
                 .extracting("key")
                 .contains(

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubControllerTests.java
@@ -211,6 +211,7 @@ class GitHubControllerTests {
                     List.of(),
                     List.of(),
                     List.of(),
+                    List.of(),
                     new GitHubCopilotUsageDto(
                             "UNAVAILABLE",
                             null,

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubDashboardServiceTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubDashboardServiceTests.java
@@ -127,6 +127,7 @@ class GitHubDashboardServiceTests {
                     List.of(),
                     List.of(),
                     List.of(),
+                    List.of(),
                     new GitHubCopilotUsageDto(
                             "UNAVAILABLE",
                             null,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubDashboardReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubDashboardReport.java
@@ -21,6 +21,7 @@ public record GitHubDashboardReport(
         List<GitHubWorkflowRunDto> workflowRuns,
         List<GitHubWorkflowDto> workflows,
         List<GitHubIssueBucketDto> issueBuckets,
+        List<GitHubIssueDto> issues,
         List<GitHubSecuritySignalDto> securitySignals,
         GitHubCopilotUsageDto copilotUsage,
         List<String> warnings) {}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubIssueDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubIssueDto.java
@@ -1,0 +1,17 @@
+package io.github.jdubois.bootui.core.dto;
+
+import java.util.List;
+
+/**
+ * Bounded open issue summary for the current repository. Pull requests returned by
+ * the GitHub issues endpoint are excluded.
+ */
+public record GitHubIssueDto(
+        int number,
+        String title,
+        String author,
+        String htmlUrl,
+        Long createdAt,
+        Long updatedAt,
+        int comments,
+        List<String> labels) {}

--- a/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -202,6 +202,38 @@ const github = {
     {label: 'Enhancement', count: 5, tone: 'info'},
     {label: 'Documentation', count: 2, tone: 'success'}
   ],
+  issues: [
+    {
+      number: 188,
+      title: 'Flaky Playwright run on slow CI agents',
+      author: 'julien',
+      htmlUrl: 'https://github.com/jdubois/boot-ui/issues/188',
+      createdAt: nowMillis - 3 * 24 * 60 * 60 * 1000,
+      updatedAt: nowMillis - 35 * 60 * 1000,
+      comments: 4,
+      labels: ['bug', 'ci']
+    },
+    {
+      number: 184,
+      title: 'Document the GitHub issues drawer',
+      author: 'octocat',
+      htmlUrl: 'https://github.com/jdubois/boot-ui/issues/184',
+      createdAt: nowMillis - 5 * 24 * 60 * 60 * 1000,
+      updatedAt: nowMillis - 4 * 60 * 60 * 1000,
+      comments: 1,
+      labels: ['docs']
+    },
+    {
+      number: 179,
+      title: 'Add metric for stale issues older than 90 days',
+      author: 'contributor',
+      htmlUrl: 'https://github.com/jdubois/boot-ui/issues/179',
+      createdAt: nowMillis - 12 * 24 * 60 * 60 * 1000,
+      updatedAt: nowMillis - 2 * 24 * 60 * 60 * 1000,
+      comments: 0,
+      labels: ['enhancement']
+    }
+  ],
   securitySignals: [
     {label: 'Dependabot alerts', status: 'AVAILABLE', count: 0, unavailableReason: null},
     {label: 'Code scanning alerts', status: 'AVAILABLE', count: 1, unavailableReason: null},

--- a/bootui-sample-app/e2e/tests/github.spec.js
+++ b/bootui-sample-app/e2e/tests/github.spec.js
@@ -72,6 +72,28 @@ function connectedDashboard() {
       {label: 'Open issues', count: 9, tone: 'primary'},
       {label: 'Bug', count: 2, tone: 'danger'}
     ],
+    issues: [
+      {
+        number: 188,
+        title: 'Flaky Playwright run on slow CI agents',
+        author: 'julien',
+        htmlUrl: 'https://github.com/jdubois/boot-ui/issues/188',
+        createdAt: now - 3 * 24 * 60 * 60 * 1000,
+        updatedAt: now - 35 * 60 * 1000,
+        comments: 4,
+        labels: ['bug', 'ci']
+      },
+      {
+        number: 184,
+        title: 'Document the GitHub issues drawer',
+        author: 'octocat',
+        htmlUrl: 'https://github.com/jdubois/boot-ui/issues/184',
+        createdAt: now - 5 * 24 * 60 * 60 * 1000,
+        updatedAt: now - 4 * 60 * 60 * 1000,
+        comments: 1,
+        labels: ['docs']
+      }
+    ],
     securitySignals: [
       {label: 'Dependabot alerts', status: 'AVAILABLE', count: 0, unavailableReason: null},
       {label: 'Code scanning alerts', status: 'AVAILABLE', count: 1, unavailableReason: null},
@@ -132,6 +154,12 @@ test.describe('GitHub view', () => {
     await expect(drawer).toContainText('Open pull requests')
     await expect(drawer).toContainText('#211 Update implementation plan roadmap')
     await expect(drawer).toContainText('#210 Update GitHub Actions execution drawer')
+
+    // The issues card opens a drawer that lists the actual open issues.
+    await page.getByRole('button', {name: /Open issues/}).click()
+    await expect(drawer).toContainText('Open issues')
+    await expect(drawer).toContainText('#188 Flaky Playwright run on slow CI agents')
+    await expect(drawer).toContainText('#184 Document the GitHub issues drawer')
 
     // The trusted panel reached the live data through the POST refresh endpoint.
     expect(refreshMethod).toBe('POST')

--- a/bootui-ui/src/main/frontend/src/views/GitHub.test.js
+++ b/bootui-ui/src/main/frontend/src/views/GitHub.test.js
@@ -223,6 +223,18 @@ function connectedReport() {
       }
     ],
     issueBuckets: [{label: 'Open issues', count: 2, tone: 'primary'}],
+    issues: [
+      {
+        number: 7,
+        title: 'Investigate flaky test',
+        author: 'carol',
+        htmlUrl: 'https://github.com/jdubois/boot-ui/issues/7',
+        createdAt: 1780300000000,
+        updatedAt: 1780561800000,
+        comments: 3,
+        labels: ['bug']
+      }
+    ],
     securitySignals: [
       {label: 'Dependabot alerts', status: 'AVAILABLE', count: 0, unavailableReason: null},
       {label: 'Code scanning alerts', status: 'AVAILABLE', count: 1, unavailableReason: null},
@@ -355,6 +367,16 @@ describe('GitHub', () => {
     await flushPromises()
 
     expect(wrapper.find('.details-drawer').exists()).toBe(false)
+
+    await metricButton(wrapper, 'Open issues').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.details-drawer').text()).toContain('1 issue returned by this refresh')
+    expect(wrapper.find('.details-drawer').text()).toContain('#7 Investigate flaky test')
+    expect(wrapper.find('.details-drawer a.github-link-chip').attributes('href')).toBe(
+      'https://github.com/jdubois/boot-ui/issues/7'
+    )
+    expect(wrapper.find('.details-drawer').text()).not.toContain('#42 Add dashboard')
 
     await metricButton(wrapper, 'Workflow failures').trigger('click')
     await flushPromises()

--- a/bootui-ui/src/main/frontend/src/views/GitHub.vue
+++ b/bootui-ui/src/main/frontend/src/views/GitHub.vue
@@ -874,7 +874,7 @@ function securitySignalUrl(signal) {
 }
 
 .metric-card-button--quota {
-  background: var(--github-quota-card-bg);
+  background: var(--github-quota-card-bg) !important;
   border-color: var(--github-quota-card-bg) !important;
   color: var(--github-quota-card-color) !important;
 }

--- a/bootui-ui/src/main/frontend/src/views/GitHub.vue
+++ b/bootui-ui/src/main/frontend/src/views/GitHub.vue
@@ -600,11 +600,11 @@ function securitySignalUrl(signal) {
 
         <template v-else-if="activeDrawer === 'issues'">
           <div v-if="issueBuckets.length" class="card-body pb-0">
-            <div class="row g-3">
-              <div v-for="bucket in issueBuckets" :key="bucket.label" class="col-sm-6 col-lg-3">
-                <div class="border rounded p-3 h-100">
+            <div class="row g-2">
+              <div v-for="bucket in issueBuckets" :key="bucket.label" class="col-6 col-lg-3">
+                <div class="border rounded px-3 py-2 h-100">
                   <div class="text-muted small">{{ bucket.label }}</div>
-                  <div class="display-6">{{ formatNumber(bucket.count) }}</div>
+                  <div class="fs-5 fw-semibold">{{ formatNumber(bucket.count) }}</div>
                 </div>
               </div>
             </div>

--- a/bootui-ui/src/main/frontend/src/views/GitHub.vue
+++ b/bootui-ui/src/main/frontend/src/views/GitHub.vue
@@ -33,6 +33,7 @@ const pullRequests = computed(() => data.value?.pullRequests ?? [])
 const workflowRuns = computed(() => data.value?.workflowRuns ?? [])
 const workflows = computed(() => data.value?.workflows ?? [])
 const issueBuckets = computed(() => data.value?.issueBuckets ?? [])
+const issues = computed(() => data.value?.issues ?? [])
 const securitySignals = computed(() => data.value?.securitySignals ?? [])
 const warnings = computed(() => data.value?.warnings ?? [])
 const repository = computed(() => data.value?.repository)
@@ -384,7 +385,9 @@ const drawerSubtitle = computed(() => {
   return (
     {
       pullRequests: `${pullRequests.value.length} pull request${pullRequests.value.length === 1 ? '' : 's'} returned by this refresh`,
-      issues: 'Issue buckets from the bounded live refresh',
+      issues: issues.value.length
+        ? `${issues.value.length} issue${issues.value.length === 1 ? '' : 's'} returned by this refresh`
+        : 'Issue buckets from the bounded live refresh',
       workflows: visibleWorkflowRuns.value.length
         ? `Latest ${visibleWorkflowRuns.value.length} GitHub Actions execution${visibleWorkflowRuns.value.length === 1 ? '' : 's'} returned by this refresh`
         : 'No GitHub Actions executions were returned by this refresh',
@@ -596,7 +599,7 @@ function securitySignalUrl(signal) {
         </template>
 
         <template v-else-if="activeDrawer === 'issues'">
-          <div v-if="issueBuckets.length" class="card-body">
+          <div v-if="issueBuckets.length" class="card-body pb-0">
             <div class="row g-3">
               <div v-for="bucket in issueBuckets" :key="bucket.label" class="col-sm-6 col-lg-3">
                 <div class="border rounded p-3 h-100">
@@ -606,7 +609,46 @@ function securitySignalUrl(signal) {
               </div>
             </div>
           </div>
-          <div v-else class="card-body text-muted">No issue buckets were returned by this refresh.</div>
+          <div v-if="issues.length" class="table-responsive mt-3">
+            <table class="table table-sm align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Issue</th>
+                  <th>Author</th>
+                  <th>Labels</th>
+                  <th class="text-end">Comments</th>
+                  <th class="text-end">Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="issue in issues" :key="issue.number">
+                  <td>
+                    <a
+                      v-if="issue.htmlUrl"
+                      :href="issue.htmlUrl"
+                      class="github-link-chip"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      #{{ issue.number }} {{ issue.title }}
+                      <i class="bi bi-box-arrow-up-right"></i>
+                    </a>
+                    <span v-else class="fw-semibold">#{{ issue.number }} {{ issue.title }}</span>
+                  </td>
+                  <td>{{ issue.author || '—' }}</td>
+                  <td>
+                    <span v-for="label in issue.labels" :key="label" class="badge text-bg-light me-1">{{ label }}</span>
+                    <span v-if="!issue.labels?.length" class="text-muted small">—</span>
+                  </td>
+                  <td class="text-end">{{ formatNumber(issue.comments ?? 0) }}</td>
+                  <td class="text-end">{{ issue.updatedAt ? formatRelative(issue.updatedAt) : '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div v-else-if="!issueBuckets.length" class="card-body text-muted">
+            No open issues were returned by this refresh.
+          </div>
         </template>
 
         <template v-else-if="activeDrawer === 'workflows'">

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -44,8 +44,11 @@ remote. It uses BootUI's standard auto-refresh control with a one-minute interva
 refresh and each interval are bounded and blocked by the panel's read-only settings.
 
 The panel shows repository metadata and an eight-card summary grid with click-through detail drawers for open pull
-requests, issue buckets, the latest GitHub Actions executions, quotas, Copilot usage report availability, and the three
-security signals. GitHub Actions execution rows link to the matching run, show the workflow, branch, event, status, and
+requests, open issues, the latest GitHub Actions executions, quotas, Copilot usage report availability, and the three
+security signals. The open-issues drawer summarizes the label/staleness buckets and then lists the bounded set of open
+issues returned by the refresh, linking each to its issue page with its author, labels, comment count, and last-updated
+time (pull requests returned by the issues endpoint are excluded). GitHub Actions execution rows link to the matching
+run, show the workflow, branch, event, status, and
 duration, and mirror the recent-run list from the GitHub Actions page. The workflow failure count only considers the
 latest execution for each workflow and branch, so older failures drop out once a later run fixes that workflow on that
 branch; security signal drawers link to the matching GitHub alert pages.

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -104,7 +104,7 @@ Panel settings are consistent across the UI and API:
 | `bootui.github.api-enabled`            | `true`           | Additional action gate for outbound GitHub API calls during live refresh.            |
 | `bootui.github.request-timeout`        | `5s`             | Timeout for each GitHub API request and local `gh auth token` lookup.                |
 | `bootui.github.max-pull-requests`      | `10`             | Maximum open pull requests returned in one refresh.                                  |
-| `bootui.github.max-issues`             | `25`             | Maximum open issues fetched for issue buckets in one refresh.                        |
+| `bootui.github.max-issues`             | `25`             | Maximum open issues fetched for the issue buckets and open issue list in one refresh. |
 | `bootui.github.max-workflow-runs`      | `20`             | Maximum recent workflow runs returned in one refresh.                                |
 | `bootui.github.quota-safety-threshold` | `10`             | Skip optional API calls when remaining core quota is at or below this value.         |
 | `bootui.github.max-api-calls`          | `17`             | Maximum GitHub API requests issued by one refresh.                                   |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -167,8 +167,8 @@ Data sources:
 Features:
 
 - Show repository identity, visibility, default branch, local branch, stars, forks, watchers, and recent push time.
-- Show bounded open pull requests, issue buckets, latest GitHub Actions executions, configured workflow links, and
-  permission-aware security signals.
+- Show bounded open pull requests, issue buckets and the bounded open issue list, latest GitHub Actions executions,
+  configured workflow links, and permission-aware security signals.
 - Render every resource returned by `/rate_limit` dynamically, plus best-effort repository/owner quota cards when
   authorized.
 - Skip optional sections when remaining core API quota is at or below the safety threshold.
@@ -1177,7 +1177,7 @@ Initial properties:
 | `bootui.github.api-enabled`                  | `true`                                  | Allow GitHub panel refresh calls to GitHub APIs.                                                  |
 | `bootui.github.request-timeout`              | `5s`                                    | Timeout for each GitHub API request and local `gh auth token` lookup.                             |
 | `bootui.github.max-pull-requests`            | `10`                                    | Maximum open pull requests returned in one GitHub refresh.                                        |
-| `bootui.github.max-issues`                   | `25`                                    | Maximum open issues fetched for GitHub issue buckets.                                             |
+| `bootui.github.max-issues`                   | `25`                                    | Maximum open issues fetched for the issue buckets and open issue list.                            |
 | `bootui.github.max-workflow-runs`            | `20`                                    | Maximum recent workflow runs returned in one GitHub refresh.                                      |
 | `bootui.github.quota-safety-threshold`       | `10`                                    | Skip optional GitHub calls when remaining core quota is at or below this value.                   |
 | `bootui.github.max-api-calls`                | `17`                                    | Maximum GitHub API calls issued by one refresh.                                                   |


### PR DESCRIPTION
## What does this PR do?

Makes the GitHub panel's "Open issues" metric card open a drawer that lists the actual open issues, shrinks the issue bucket summary cards, and fixes the quota metric card rendering invisible text in dark mode.

## Why is this change needed?

The "Open issues" card previously only showed aggregated count buckets, while the sibling "Open pull requests" card already listed the underlying PRs. This brings issues to parity so you can see which issues are open without leaving the console. Separately, the quota metric card was reported as unreadable in dark mode.

The approach:

- **Issue list:** The backend already fetched issues for the count buckets; this threads a sanitized `GitHubIssueDto` list (number, title, author, url, timestamps, comments, labels) through `GitHubApiClient` -> `GitHubDashboardReport` and exposes it to the UI. The GitHub `/issues` endpoint also returns PRs, so nodes carrying a `pull_request` field are filtered out (same rule the buckets use). The drawer keeps the bucket summary on top and adds an issue table below.
- **Smaller bucket cards:** The issue count buckets were visually competing with the new issue list, so they were made more compact (tighter grid gap, two-up on small screens, reduced padding, smaller count font) to read as a secondary summary.
- **Dark-mode quota card fix:** The quota card colors its background and text from a quota-health scale via inline CSS variables. In dark mode the global `:root[data-bootui-theme='dark'] .card` rule (specificity 0,3,0) overrode the scoped `.metric-card-button--quota` background (0,2,0), so the card fell back to the dark surface color while the scoped `color` (dark text) still won via `!important` -- dark text on a dark background. Adding `!important` to the quota background makes the health color win in both themes, matching the `!important` already on `border-color` and `color`.

Issue titles and authors are intentionally left unmasked, consistent with the existing unmasked PR table.

N/A (no tracking issue)

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran the GitHub backend tests (12 passing), the frontend Vitest suite (GitHub view + full run), and `spotless:check` / prettier checks. Verified the dark-mode fix live by confirming the served CSS chunk applies the quota background with `!important`. Updated backend client/service/controller tests, the Vue unit test, the Playwright `github.spec.js` fixtures, and the docs screenshot seed data.

## Screenshots (UI changes)

The "Open issues" card now opens a drawer with the compacted bucket summary plus a table of open issues (Issue / Author / Labels / Comments / Updated). The quota card renders its health color with readable text in dark mode instead of dark-on-dark.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

`GitHubDashboardReport` gains a new `issues` field; existing consumers constructing it were updated, and JSON deserialization remains backward compatible.