### PR TITLE
Fix run-sample.sh failure on macOS Bash 3.2 (mapfile not found)

### DIFF
--- a/scripts/run-sample.sh
+++ b/scripts/run-sample.sh
@@ -15,7 +15,9 @@ require_command() {
 # The default selection is the most recent tag when one exists, otherwise "main".
 select_ref() {
   local -a tags=("$@")
-  local -a options=("main" "${tags[@]}")
+  # Use the `${arr[@]+...}` idiom so an empty `tags` array does not trip
+  # `set -u` ("unbound variable") on Bash 3.2 (macOS /bin/bash).
+  local -a options=("main" ${tags[@]+"${tags[@]}"})
   local default_index=0
   if (( ${#tags[@]} > 0 )); then
     default_index=1
@@ -65,8 +67,13 @@ if [[ -x "./mvnw" && -d "bootui-sample-app" ]]; then
   echo "Using existing BootUI checkout at $(pwd)."
   require_command git
 
-  mapfile -t TAGS < <(git tag --sort=-v:refname 2>/dev/null | head -5)
-  select_ref "${TAGS[@]}"
+  # Read tags into an array. Avoid `mapfile`/`readarray` (Bash 4+) so the script
+  # works under the Bash 3.2 that ships as /bin/bash on macOS.
+  TAGS=()
+  while IFS= read -r tag; do
+    TAGS+=("$tag")
+  done < <(git tag --sort=-v:refname 2>/dev/null | head -5)
+  select_ref ${TAGS[@]+"${TAGS[@]}"}
 
   echo "Checking out '$SELECTED_REF'..."
   git checkout "$SELECTED_REF"
@@ -79,8 +86,13 @@ else
     exit 1
   fi
 
-  mapfile -t TAGS < <(git ls-remote --tags --refs --sort=-v:refname "$REPO_URL" 2>/dev/null | sed 's#.*refs/tags/##' | head -5)
-  select_ref "${TAGS[@]}"
+  # Read tags into an array. Avoid `mapfile`/`readarray` (Bash 4+) so the script
+  # works under the Bash 3.2 that ships as /bin/bash on macOS.
+  TAGS=()
+  while IFS= read -r tag; do
+    TAGS+=("$tag")
+  done < <(git ls-remote --tags --refs --sort=-v:refname "$REPO_URL" 2>/dev/null | sed 's#.*refs/tags/##' | head -5)
+  select_ref ${TAGS[@]+"${TAGS[@]}"}
 
   echo "Cloning BootUI ($SELECTED_REF) into $TARGET_DIR..."
   git clone --depth 1 --branch "$SELECTED_REF" "$REPO_URL" "$TARGET_DIR"


### PR DESCRIPTION
## What does this PR do?

Makes `scripts/run-sample.sh` run on macOS by removing a Bash 4+ only feature so `curl ... | bash` no longer fails with `mapfile: command not found`.

## Why is this change needed?

The script used the `mapfile` builtin, which was introduced in Bash 4.0. macOS still ships Bash 3.2 as `/bin/bash` (for licensing reasons), and the documented `curl ... | bash` install path runs under that interpreter, so the script aborted immediately.

While fixing this I also found a second latent Bash 3.2 bug on the same code path: when a checkout has no tags, expanding an empty array with `"${TAGS[@]}"` aborts under `set -u` with "unbound variable". This would still break the script on macOS for a tag-less checkout, so it is fixed here too.

Fixes: #266

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

This is a shell-script-only change, so the items above are N/A. Instead it was validated directly against the affected interpreter (`GNU bash 3.2.57`, macOS `/bin/bash`):

- `bash -n scripts/run-sample.sh` passes and no `mapfile`/`readarray` builtins remain.
- Simulated `select_ref` end-to-end with no TTY (the `curl | bash` case): no tags defaults to `main`, a populated list defaults to the newest tag, and `BOOTUI_REF` override is honored, all with no "unbound variable" error.
- Exercised the replacement read loop for both empty (count 0) and 5-tag inputs.

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - script behaviour is unchanged; the documented invocation in `docs/TRY-SAMPLE-APP.md` still applies)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

### Approach

- Replaced both `mapfile -t TAGS < <(...)` calls with a Bash 3.2 compatible `while IFS= read -r tag; do TAGS+=("$tag"); done < <(...)` loop. Process substitution keeps the loop in the current shell, so the populated array persists exactly as before.
- Guarded the empty-array expansions (the two `select_ref` call sites and the internal `options` array) with the portable `${arr[@]+"${arr[@]}"}` idiom so a tag-less list no longer trips `set -u`.

No changes to `run-sample.ps1` (Windows/PowerShell, unaffected).