### PR TITLE
Fix dark-mode contrast on Bootstrap contextual utilities

### DIFF
--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -570,6 +570,12 @@ function onGlobalKeydown(e) {
   --bootui-nav-active-color: #ffffff;
   --bootui-nav-group-bg: rgba(255, 255, 255, 0.58);
   --bootui-nav-group-color: #64748b;
+  --bootui-nav-link-color: #334155;
+
+  /* Chart legend */
+  --bootui-chart-input: #0d6efd;
+  --bootui-chart-output: #6610f2;
+  --bootui-chart-calls: #198754;
 
   /* Skeleton loaders */
   --bootui-skeleton-base: #e2e8f0;
@@ -610,6 +616,12 @@ function onGlobalKeydown(e) {
   --bootui-nav-active-color: #ffffff;
   --bootui-nav-group-bg: rgba(30, 41, 59, 0.7);
   --bootui-nav-group-color: #94a3b8;
+  --bootui-nav-link-color: #cbd5e1;
+
+  /* Chart legend */
+  --bootui-chart-input: #6ea8fe;
+  --bootui-chart-output: #c084fc;
+  --bootui-chart-calls: #75b798;
 
   /* Skeleton loaders */
   --bootui-skeleton-base: #334155;
@@ -685,6 +697,81 @@ function onGlobalKeydown(e) {
 :global(:root[data-bootui-theme='dark'] .badge.bg-light) {
   background-color: rgba(226, 232, 240, 0.12) !important;
   color: var(--bootui-text-muted) !important;
+}
+
+/* The text-bg-light badge variant is a fixed light color; keep it muted in dark mode. */
+:global(:root[data-bootui-theme='dark'] .text-bg-light) {
+  background-color: rgba(226, 232, 240, 0.12) !important;
+  color: var(--bootui-text-muted) !important;
+}
+
+/* Bootstrap contextual table variants are not theme-aware; remap them for dark mode. */
+:global(:root[data-bootui-theme='dark'] .table-light) {
+  --bs-table-bg: var(--bootui-surface-alt);
+  --bs-table-color: var(--bootui-text);
+  --bs-table-border-color: var(--bootui-border-alt);
+}
+
+:global(:root[data-bootui-theme='dark'] .table-warning) {
+  --bs-table-color: var(--bootui-text);
+  --bs-table-bg: rgba(245, 158, 11, 0.16);
+  --bs-table-border-color: rgba(245, 158, 11, 0.28);
+  --bs-table-striped-bg: rgba(245, 158, 11, 0.2);
+  --bs-table-striped-color: var(--bootui-text);
+  --bs-table-active-bg: rgba(245, 158, 11, 0.24);
+  --bs-table-active-color: var(--bootui-text);
+  --bs-table-hover-bg: rgba(245, 158, 11, 0.22);
+  --bs-table-hover-color: var(--bootui-text);
+}
+
+:global(:root[data-bootui-theme='dark'] .table-danger) {
+  --bs-table-color: var(--bootui-text);
+  --bs-table-bg: rgba(220, 38, 38, 0.18);
+  --bs-table-border-color: rgba(220, 38, 38, 0.3);
+  --bs-table-striped-bg: rgba(220, 38, 38, 0.22);
+  --bs-table-striped-color: var(--bootui-text);
+  --bs-table-active-bg: rgba(220, 38, 38, 0.26);
+  --bs-table-active-color: var(--bootui-text);
+  --bs-table-hover-bg: rgba(220, 38, 38, 0.24);
+  --bs-table-hover-color: var(--bootui-text);
+}
+
+:global(:root[data-bootui-theme='dark'] .table-active) {
+  --bs-table-active-bg: rgba(226, 232, 240, 0.1);
+  --bs-table-active-color: var(--bootui-text);
+}
+
+/* Emphasis text utilities keep their saturated light-mode colors in Bootstrap's
+   dark theme; brighten them to the matching dark emphasis tones for contrast. */
+:global(:root[data-bootui-theme='dark'] .text-primary) {
+  color: rgba(110, 168, 254, var(--bs-text-opacity, 1)) !important;
+}
+
+:global(:root[data-bootui-theme='dark'] .text-success) {
+  color: rgba(117, 183, 152, var(--bs-text-opacity, 1)) !important;
+}
+
+:global(:root[data-bootui-theme='dark'] .text-danger) {
+  color: rgba(234, 134, 143, var(--bs-text-opacity, 1)) !important;
+}
+
+:global(:root[data-bootui-theme='dark'] .text-info) {
+  color: rgba(110, 223, 246, var(--bs-text-opacity, 1)) !important;
+}
+
+:global(:root[data-bootui-theme='dark'] .text-warning) {
+  color: rgba(255, 218, 106, var(--bs-text-opacity, 1)) !important;
+}
+
+/* Fixed light surfaces (code snippets, popovers) must darken in dark mode. */
+:global(:root[data-bootui-theme='dark'] .bg-light:not(.badge)) {
+  background-color: var(--bootui-surface-alt) !important;
+  color: var(--bootui-text) !important;
+}
+
+:global(:root[data-bootui-theme='dark'] .bg-white) {
+  background-color: var(--bootui-surface-solid) !important;
+  color: var(--bootui-text) !important;
 }
 
 :global(.card) {
@@ -933,7 +1020,7 @@ function onGlobalKeydown(e) {
 
 .bootui-nav-link {
   align-items: center;
-  color: #334155;
+  color: var(--bootui-nav-link-color);
   display: flex;
   gap: 0.75rem;
   padding: 0.62rem 0.75rem;

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -577,9 +577,9 @@ const detectedFrameworkLabel = computed(() => {
                 style="top: 0; transform: translateX(-50%); pointer-events: none; white-space: nowrap; z-index: 10"
               >
                 <div class="fw-semibold">{{ tooltipData.time }}</div>
-                <div style="color: #0d6efd">In: {{ tooltipData.input }}</div>
-                <div style="color: #6610f2">Out: {{ tooltipData.output }}</div>
-                <div style="color: #198754">Calls: {{ tooltipData.calls }}</div>
+                <div style="color: var(--bootui-chart-input)">In: {{ tooltipData.input }}</div>
+                <div style="color: var(--bootui-chart-output)">Out: {{ tooltipData.output }}</div>
+                <div style="color: var(--bootui-chart-calls)">Calls: {{ tooltipData.calls }}</div>
               </div>
             </div>
             <div class="d-flex justify-content-between text-muted small mt-1 px-1">

--- a/bootui-ui/src/main/frontend/src/views/GitHub.vue
+++ b/bootui-ui/src/main/frontend/src/views/GitHub.vue
@@ -831,8 +831,8 @@ function securitySignalUrl(signal) {
   color: inherit;
 }
 
-.metric-card-button--quota {
-  background: var(--github-quota-card-bg);
+.metric-card.metric-card-button.metric-card-button--quota {
+  background: var(--github-quota-card-bg) !important;
   border-color: var(--github-quota-card-bg) !important;
   color: var(--github-quota-card-color) !important;
 }


### PR DESCRIPTION
## What does this PR do?

Fixes low-contrast and washed-out text/surfaces that appeared across many BootUI panels in dark mode.

## Why is this change needed?

Bootstrap's contextual color utilities are not theme-adaptive: under BootUI's dark theme, classes like `.table-light` / `.table-warning` / `.table-danger` / `.table-active`, the `.text-success` / `.text-danger` / `.text-primary` / `.text-info` / `.text-warning` emphasis utilities, and the fixed `.text-bg-light` / `.bg-light` / `.bg-white` surfaces all kept their light-mode colors. That produced dark text on dark backgrounds and saturated, hard-to-read accents on several screens.

I audited all 39 panels in both light and dark themes. Light mode was already clean; every issue was in dark mode.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable (no new tests needed for CSS-only changes; existing Vitest suite passes: 131/131)

Verification done in this branch:
- Re-captured all 39 panels in dark mode after the fix and reviewed them for regressions.
- `npm test` (Vitest) green; `npm run format:check` clean.

## Approach

Most fixes are dark-theme-scoped global overrides in `App.vue`:

- Remap the non-adaptive `.table-*` contextual variants to dark-aware surfaces / translucent tints, including the full hover/striped/active state-variable family so cells stay readable in every row state.
- Brighten the `.text-*` emphasis utilities to Bootstrap's dark emphasis tones (opacity-preserving via `var(--bs-text-opacity)`).
- Darken the fixed `.text-bg-light` badges, `.bg-light` code blocks, and `.bg-white` popover/tooltip surfaces.
- Drive the sidebar inactive nav-link color from a new `--bootui-nav-link-color` variable.

Two targeted component fixes:

- `Ai.vue`: route the token-usage tooltip colors through new chart-legend CSS vars instead of hardcoded light-mode hex.
- `GitHub.vue`: raise the quota metric-card selector specificity (three-class) so its intended dark-on-green text survives the new global `.text-success` override. This was a regression the override introduced, called out here for careful review.

## Screenshots (UI changes)

Not embedded: the audit harness used to capture before/after shots was a temporary script removed before commit, and the preview server was stopped during cleanup. All 39 panels were reviewed in both themes during development.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no behaviour or API change, dark-mode CSS contrast only)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed