### PR TITLE
Scope Maven Central release secrets to a protected environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
   maven-central:
     name: Maven Central
     runs-on: ubuntu-latest
+    environment: maven-central
     permissions:
       contents: write
     env:


### PR DESCRIPTION
## What

Adds `environment: maven-central` to the `maven-central` job in `.github/workflows/release.yml` so the release credentials are only readable by that job.

## Why

Previously the four release secrets (`GPG_PRIVATE_KEY`, `MAVEN_GPG_PASSPHRASE`, `MAVEN_CENTRAL_USERNAME`, `MAVEN_CENTRAL_PASSWORD`) were **repository-level**, meaning every workflow run — including PR builds and any future/compromised workflow — could read them. They are only ever used by the Release workflow, so scoping them to a dedicated GitHub Environment reduces the blast radius if a workflow or dependency is compromised.

## Environment configuration (already applied in repo settings)

- Secrets moved from repo-level to **environment secrets** on `maven-central`; repo-level copies deleted.
- Protection rules:
  - **Required reviewer** (`jdubois`) — secrets only unlock after manual approval.
  - **Deployment branch/tag policy** — restricted to `main` and `v*` tags (the manual `workflow_dispatch` prepare path runs from a branch, so `main` is included alongside the tag rule).

## ⚠️ Merge ordering

The repo-level secrets are already deleted, so **this must be merged before the next release** — otherwise the release job on `main` has neither repo-level secrets nor the environment declaration needed to read the environment secrets.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>