### PR TITLE
refactor: reuse the openView fixture across BootUI e2e specs

### DIFF
--- a/bootui-sample-app/e2e/tests/ai.spec.js
+++ b/bootui-sample-app/e2e/tests/ai.spec.js
@@ -73,16 +73,10 @@ const detail = {
 }
 
 test.describe('AI Usage view', () => {
-  test('renders AI token usage, model breakdowns, and chat detail', async ({page}) => {
+  test('renders AI token usage, model breakdowns, and chat detail', async ({openView, page}) => {
     await stubAi(page, overview)
 
-    await page.goto('/bootui/#/ai')
-    await expect(
-      page
-        .locator('main h2')
-        .filter({hasText: /AI Usage/})
-        .first()
-    ).toBeVisible()
+    await openView('ai', /AI Usage/)
     await expect(page.getByText('Spring AI detected')).toBeVisible()
     await expect(page.locator('.kpi-card-body', {hasText: 'Total tokens'}).getByText('49', {exact: true})).toBeVisible()
     await expect(page.locator('.card', {hasText: 'Usage by model'}).getByText('qwen2.5:0.5b')).toBeVisible()

--- a/bootui-sample-app/e2e/tests/dependencies.spec.js
+++ b/bootui-sample-app/e2e/tests/dependencies.spec.js
@@ -75,7 +75,7 @@ const scannedReport = {
 }
 
 test.describe('Vulnerabilities view', () => {
-  test('renders inventory and on-demand vulnerability scan results', async ({page}) => {
+  test('renders inventory and on-demand vulnerability scan results', async ({openView, page}) => {
     await page.route(
       (url) => url.pathname === '/bootui/api/dependencies',
       async (route) => {
@@ -95,13 +95,7 @@ test.describe('Vulnerabilities view', () => {
       }
     )
 
-    await page.goto('/bootui/#/vulnerabilities')
-    await expect(
-      page
-        .locator('main h2')
-        .filter({hasText: /^Vulnerabilities/})
-        .first()
-    ).toBeVisible()
+    await openView('vulnerabilities', /^Vulnerabilities/)
     await expect(page.getByText('4 of 4 dependencies')).toBeVisible()
     await expect(page.getByText('Not scanned yet')).toBeVisible()
     await expect(page.getByText('No vulnerability scan data yet')).toBeVisible()

--- a/bootui-sample-app/e2e/tests/dev-services.spec.js
+++ b/bootui-sample-app/e2e/tests/dev-services.spec.js
@@ -65,7 +65,7 @@ test.describe('Dev Services view', () => {
     await expect.poll(async () => (await emptyState.count()) + (await tableRows.count())).toBeGreaterThan(0)
   })
 
-  test('filters services, opens details, loads logs, and hides unavailable restart', async ({page}) => {
+  test('filters services, opens details, loads logs, and hides unavailable restart', async ({openView, page}) => {
     await page.route(
       (url) => url.pathname === '/bootui/api/dev-services',
       async (route) => {
@@ -90,13 +90,7 @@ test.describe('Dev Services view', () => {
       }
     )
 
-    await page.goto('/bootui/#/dev-services')
-    await expect(
-      page
-        .locator('main h2')
-        .filter({hasText: /^Dev Services/})
-        .first()
-    ).toBeVisible()
+    await openView('dev-services', /^Dev Services/)
     await expect(page.getByText('2 / 2 services')).toBeVisible()
     await expect(page.getByRole('columnheader', {name: 'Source'})).toHaveCount(0)
 

--- a/bootui-sample-app/e2e/tests/devtools.spec.js
+++ b/bootui-sample-app/e2e/tests/devtools.spec.js
@@ -16,7 +16,7 @@ test.describe('DevTools view', () => {
     await expect(page.locator('.alert-info')).toContainText('Restart interrupts the current JVM context')
   })
 
-  test('triggering LiveReload shows action feedback and keeps restart guarded', async ({page}) => {
+  test('triggering LiveReload shows action feedback and keeps restart guarded', async ({openView, page}) => {
     await page.route(
       (url) => url.pathname === '/bootui/api/devtools',
       async (route) => {
@@ -47,13 +47,7 @@ test.describe('DevTools view', () => {
       }
     )
 
-    await page.goto('/bootui/#/devtools')
-    await expect(
-      page
-        .locator('main h2')
-        .filter({hasText: /^DevTools/})
-        .first()
-    ).toBeVisible()
+    await openView('devtools', /^DevTools/)
 
     await expect(page.getByText('LiveReload port:')).toBeVisible()
     await expect(page.getByRole('button', {name: /Restart app/})).toBeDisabled()

--- a/bootui-sample-app/e2e/tests/pentesting.spec.js
+++ b/bootui-sample-app/e2e/tests/pentesting.spec.js
@@ -80,7 +80,7 @@ const scannedReport = {
 }
 
 test.describe('Pentesting view', () => {
-  test('renders the initial report and on-demand local check results', async ({page}) => {
+  test('renders the initial report and on-demand local check results', async ({openView, page}) => {
     await page.route(
       (url) => url.pathname === '/bootui/api/pentest',
       async (route) => {
@@ -100,13 +100,7 @@ test.describe('Pentesting view', () => {
       }
     )
 
-    await page.goto('/bootui/#/pentest')
-    await expect(
-      page
-        .locator('main h2')
-        .filter({hasText: /^Pentesting/})
-        .first()
-    ).toBeVisible()
+    await openView('pentest', /^Pentesting/)
 
     // Initial not-scanned state.
     await expect(page.getByText('Not scanned yet')).toBeVisible()

--- a/bootui-sample-app/e2e/tests/traces.spec.js
+++ b/bootui-sample-app/e2e/tests/traces.spec.js
@@ -61,7 +61,7 @@ const traceDetail = {
 }
 
 test.describe('Traces view', () => {
-  test('renders trace summaries and waterfall details', async ({page}) => {
+  test('renders trace summaries and waterfall details', async ({openView, page}) => {
     await stubShell(page)
     await page.route(
       (url) => url.pathname === '/bootui/api/traces',
@@ -76,13 +76,7 @@ test.describe('Traces view', () => {
       }
     )
 
-    await page.goto('/bootui/#/traces')
-    await expect(
-      page
-        .locator('main h2')
-        .filter({hasText: /^Traces/})
-        .first()
-    ).toBeVisible()
+    await openView('traces', /^Traces/)
     await expect(page.getByText('1 / 500 retained trace')).toBeVisible()
     const traceRow = page.locator('tbody tr', {hasText: 'GET /api/sample/hello'})
     await expect(traceRow).toBeVisible()


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
