### PR TITLE
docs: lift GitHub feature heading to top level

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -37,7 +37,7 @@ gracefully when optional infrastructure is missing.
 
 ![BootUI Overview panel](./images/bootui-overview.png)
 
-### GitHub
+## GitHub
 
 The GitHub panel sits directly under Overview and summarizes the current project's GitHub state from the local `origin`
 remote. It uses BootUI's standard auto-refresh control with a one-minute interval while the tab is visible; the initial


### PR DESCRIPTION
## What does this PR do?

Promotes the GitHub section in `docs/FEATURES.md` from an H3 to an H2 so the VuePress sidebar lists "Overview" and "GitHub" as siblings under "BootUI feature details".

## Why is this change needed?

In the docs site, the auto-generated sidebar nests headings by level. Because GitHub was an `### H3`, it appeared indented under the Overview `## H2` even though it is its own top-level panel. Lifting it to `## H2` places both entries at the same level, matching the application menu where the GitHub panel sits directly under Overview rather than inside it.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Docs-only change; verified the VuePress sidebar renders Overview and GitHub at the same level. No anchor links referenced the old `#github` heading.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed