### PR TITLE
Remove empty autoconfigure packages

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/actuator/package-info.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/actuator/package-info.java
@@ -1,2 +1,0 @@
-@org.jspecify.annotations.NullMarked
-package io.github.jdubois.bootui.autoconfigure.actuator;

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/util/package-info.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/util/package-info.java
@@ -1,2 +1,0 @@
-@org.jspecify.annotations.NullMarked
-package io.github.jdubois.bootui.autoconfigure.util;


### PR DESCRIPTION
## What does this PR do?

Removes the empty `actuator` and `util` autoconfigure packages, which only contained unused `package-info.java` files.

## Why is this change needed?

These package-info-only packages no longer host Java types or references, so keeping them adds dead source directories without behavior.

N/A

## How was it tested?

Validated with:

- `./mvnw -B -ntp -pl bootui-autoconfigure -am -DskipTests compile`
- `./mvnw -B -ntp spotless:apply`
- `./mvnw -B -ntp spotless:check`

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed