### PR TITLE
refactor: consolidate shared time/number format helpers

### DIFF
--- a/bootui-ui/src/main/frontend/src/utils/format.js
+++ b/bootui-ui/src/main/frontend/src/utils/format.js
@@ -11,6 +11,15 @@ export function formatTime(epochNanos) {
   return new Date(Math.floor(epochNanos / 1_000_000)).toLocaleTimeString()
 }
 
+export function formatClockTime(epochMillis) {
+  return new Date(epochMillis).toLocaleTimeString([], {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  })
+}
+
 export function formatNumber(n) {
   if (n == null) return '—'
   return Number(n).toLocaleString()

--- a/bootui-ui/src/main/frontend/src/utils/format.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/format.test.js
@@ -1,0 +1,41 @@
+import {describe, expect, it} from 'vitest'
+import {formatClockTime, formatNumber, formatRelative} from './format.js'
+
+describe('formatNumber', () => {
+  it('returns an em dash for null or undefined', () => {
+    expect(formatNumber(null)).toBe('—')
+    expect(formatNumber(undefined)).toBe('—')
+  })
+
+  it('formats numbers using locale grouping', () => {
+    expect(formatNumber(1234567)).toBe((1234567).toLocaleString())
+    expect(formatNumber(0)).toBe('0')
+  })
+})
+
+describe('formatClockTime', () => {
+  it('formats an epoch millisecond value as a 24h HH:MM:SS clock', () => {
+    // 2021-01-01T13:05:09Z expressed against the local timezone the runtime uses.
+    const millis = new Date(2021, 0, 1, 13, 5, 9).getTime()
+    expect(formatClockTime(millis)).toBe('13:05:09')
+  })
+})
+
+describe('formatRelative', () => {
+  const now = 1_000_000_000_000
+
+  it('returns an em dash for null or undefined', () => {
+    expect(formatRelative(null, now)).toBe('—')
+    expect(formatRelative(undefined, now)).toBe('—')
+  })
+
+  it('reports "just now" within five seconds', () => {
+    expect(formatRelative(now - 2_000, now)).toBe('just now')
+  })
+
+  it('reports seconds, minutes, and hours ago', () => {
+    expect(formatRelative(now - 30_000, now)).toBe('30s ago')
+    expect(formatRelative(now - 5 * 60_000, now)).toBe('5m ago')
+    expect(formatRelative(now - 2 * 3_600_000, now)).toBe('2h ago')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
+import {formatClockTime} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
@@ -82,12 +83,7 @@ function violationCountLabel(count) {
 
 function scanTime() {
   if (!report.value?.scan?.scannedAt) return ''
-  return new Date(report.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return formatClockTime(report.value.scan.scannedAt)
 }
 
 async function loadReport() {

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -2,7 +2,7 @@
 import {apiFetch} from '../api.js'
 import {computed, ref, watch} from 'vue'
 import {useRoute} from 'vue-router'
-import {formatNumber} from '../utils/format.js'
+import {formatClockTime, formatNumber} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import PanelHeader from './components/PanelHeader.vue'
@@ -212,8 +212,7 @@ const categoryBadgeClass = (category) =>
 
 function formatTime(timestamp) {
   if (timestamp === null || timestamp === undefined) return '—'
-  const date = new Date(timestamp)
-  return date.toLocaleTimeString([], {hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit'})
+  return formatClockTime(timestamp)
 }
 
 function formatBucketTime(timestamp) {

--- a/bootui-ui/src/main/frontend/src/views/Dependencies.vue
+++ b/bootui-ui/src/main/frontend/src/views/Dependencies.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
+import {formatClockTime} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
@@ -98,12 +99,7 @@ function severityWidth(count) {
 
 function scanTime() {
   if (!data.value?.scan?.scannedAt) return ''
-  return new Date(data.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return formatClockTime(data.value.scan.scannedAt)
 }
 
 async function loadDependencies() {

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, ref} from 'vue'
+import {formatClockTime} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
@@ -72,12 +73,7 @@ function statusClass(status) {
 
 function formatSnapshot(timestamp) {
   if (!timestamp) return 'unknown'
-  return new Date(timestamp).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return formatClockTime(timestamp)
 }
 
 function formatPorts(service) {

--- a/bootui-ui/src/main/frontend/src/views/GraalVm.vue
+++ b/bootui-ui/src/main/frontend/src/views/GraalVm.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed, onMounted, ref} from 'vue'
 import {apiFetch} from '../api.js'
+import {formatClockTime} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
@@ -68,12 +69,7 @@ function occurrenceCountLabel(count) {
 
 function scanTime() {
   if (!report.value?.scan?.scannedAt) return ''
-  return new Date(report.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return formatClockTime(report.value.scan.scannedAt)
 }
 
 async function loadReport() {

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.vue
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
+import {formatClockTime, formatNumber} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
@@ -81,18 +82,9 @@ function formatBytes(bytes) {
   return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`
 }
 
-function formatNumber(value) {
-  return (value ?? 0).toLocaleString()
-}
-
 function formatTime(epochMs) {
   if (!epochMs) return ''
-  return new Date(epochMs).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return formatClockTime(epochMs)
 }
 
 async function loadReport(options = {}) {

--- a/bootui-ui/src/main/frontend/src/views/HibernateAdvisor.vue
+++ b/bootui-ui/src/main/frontend/src/views/HibernateAdvisor.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
+import {formatClockTime} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
@@ -82,12 +83,7 @@ function violationCountLabel(count) {
 
 function scanTime() {
   if (!report.value?.scan?.scannedAt) return ''
-  return new Date(report.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return formatClockTime(report.value.scan.scannedAt)
 }
 
 async function loadReport() {

--- a/bootui-ui/src/main/frontend/src/views/LogTail.vue
+++ b/bootui-ui/src/main/frontend/src/views/LogTail.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {computed, nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {formatClockTime} from '../utils/format.js'
 
 const MAX_LINES = 2000
 
@@ -91,16 +92,6 @@ function clearLines() {
   lines.value = []
 }
 
-function formatTime(timestamp) {
-  const date = new Date(timestamp)
-  return date.toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
-}
-
 function levelClass(level) {
   return (
     {
@@ -172,7 +163,7 @@ onBeforeUnmount(() => disconnect(false))
       v-for="(line, index) in visibleLines"
       :key="`${line.timestamp}-${index}`"
       class="d-block"
-    ><span class="text-secondary">[{{ formatTime(line.timestamp) }}]</span> <span
+    ><span class="text-secondary">[{{ formatClockTime(line.timestamp) }}]</span> <span
       :class="levelClass(line.level)">{{ line.level }}</span> <span class="text-info-emphasis">{{ line.logger }}</span> <span
       class="text-secondary">-</span> <span class="text-light">{{ line.message }}</span></span></code><span v-else
                                                                                                             class="text-secondary">No log lines to display.</span></pre>

--- a/bootui-ui/src/main/frontend/src/views/Pentesting.vue
+++ b/bootui-ui/src/main/frontend/src/views/Pentesting.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
+import {formatClockTime} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
@@ -51,12 +52,7 @@ function severityWidth(count) {
 
 function scanTime() {
   if (!report.value?.scan?.scannedAt) return ''
-  return new Date(report.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return formatClockTime(report.value.scan.scannedAt)
 }
 
 async function loadReport() {

--- a/bootui-ui/src/main/frontend/src/views/SecurityAdvisor.vue
+++ b/bootui-ui/src/main/frontend/src/views/SecurityAdvisor.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
+import {formatClockTime} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
@@ -82,12 +83,7 @@ function violationCountLabel(count) {
 
 function scanTime() {
   if (!report.value?.scan?.scannedAt) return ''
-  return new Date(report.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
+  return formatClockTime(report.value.scan.scannedAt)
 }
 
 async function loadReport() {


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
