### PR TITLE
Fix native image: register UnionSubclassEntityPersister constructor hint

### DIFF
--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/NativeHintsConfiguration.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/NativeHintsConfiguration.java
@@ -16,8 +16,7 @@ import org.springframework.context.annotation.ImportRuntimeHints;
  * Registers the GraalVM reachability metadata that the sample app needs but that Spring Boot's AOT
  * processing cannot infer automatically.
  *
- * <p>Two things are registered for the {@code @Cacheable} methods on {@link
- * BootUiSampleApplication.SampleCatalog}:
+ * <p>The following reachability metadata is registered:
  *
  * <ul>
  *   <li><b>SpEL reflection</b> — {@code unless = "#result.isEmpty()"} on {@link
@@ -28,6 +27,11 @@ import org.springframework.context.annotation.ImportRuntimeHints;
  *   <li><b>JDK serialization</b> — the default Redis cache serializer serializes cached values with
  *       {@link java.io.ObjectOutputStream}. The cached {@code List<ProductSummary>} graph (the
  *       record, its element wrappers and the immutable list type) is registered for serialization.
+ *   <li><b>Hibernate persister reflection</b> — the {@code SampleBillingDocument}/{@code
+ *       SampleReceipt} {@code @Inheritance(TABLE_PER_CLASS)} hierarchy is loaded through Hibernate's
+ *       {@code UnionSubclassEntityPersister}, which Hibernate instantiates reflectively via its
+ *       public 4-arg constructor. Neither Hibernate 7.2 nor Spring Boot's AOT hints register that
+ *       constructor, so its public constructors are registered here.
  * </ul>
  */
 @Configuration(proxyBeanMethods = false)
@@ -70,6 +74,18 @@ class NativeHintsConfiguration {
             for (Class<?> type : serializable) {
                 hints.reflection().registerJavaSerialization(type);
             }
+
+            // Hibernate resolves the entity persister for the TABLE_PER_CLASS demo hierarchy
+            // (SampleBillingDocument / SampleReceipt) reflectively through the public
+            // UnionSubclassEntityPersister(PersistentClass, EntityDataAccess, NaturalIdDataAccess,
+            // RuntimeModelCreationContext) constructor. Spring Boot's AOT processing does not infer
+            // this, so without the hint the native image fails to build the SessionFactory with a
+            // NoSuchMethodException.
+            hints.reflection()
+                    .registerTypeIfPresent(
+                            classLoader,
+                            "org.hibernate.persister.entity.UnionSubclassEntityPersister",
+                            MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
         }
 
         private static Class<?> serializationProxyClass() {


### PR DESCRIPTION
## Problem

The scheduled **Native image** workflow ([run 27122921119](https://github.com/jdubois/boot-ui/actions/runs/27122921119)) started failing. The native binary crashed at startup, never bound port 8080, and the smoke test timed out after 60 attempts.

The "Print application logs on failure" step showed:

```
org.hibernate.MappingException: Could not find appropriate constructor for
  org.hibernate.persister.entity.UnionSubclassEntityPersister
Caused by: java.lang.NoSuchMethodException: ...UnionSubclassEntityPersister.<init>(
  PersistentClass, EntityDataAccess, NaturalIdDataAccess, RuntimeModelCreationContext)
```

## Root cause

PR #209 (Hibernate Advisor panel), merged after the last green native run, added the demo entity `SampleBillingDocument` (`@Inheritance(strategy = TABLE_PER_CLASS)`) and concrete subclass `SampleReceipt` — intentionally an anti-pattern to trigger the HIB-MAP-007 advisor rule.

Hibernate loads `TABLE_PER_CLASS` entities through `UnionSubclassEntityPersister`, which `PersisterFactoryImpl` instantiates **reflectively** via its public 4-arg constructor (`Class.getConstructor(...)`). Spring Boot's AOT hints register naming strategies and the single-table persister, but not the union variant — so in the native image that constructor's reflection metadata is absent. The error is `NoSuchMethodException` (not `ClassNotFoundException`), confirming the class is in the image and only the reflection hint is missing.

## Fix

Register the persister's public constructors in the sample app's existing `NativeHintsConfiguration` — the documented home for reachability metadata Spring Boot's AOT cannot infer:

```java
hints.reflection().registerTypeIfPresent(
    classLoader,
    "org.hibernate.persister.entity.UnionSubclassEntityPersister",
    MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
```

The hint lives in the sample app (not BootUI autoconfigure) because this is a generic Hibernate-on-native limitation tied to the sample's demo entity, not BootUI runtime behavior, and only the sample app builds a native image.

## Verification

- `bootui-sample-app` compiles; `spotless:check` passes.
- Full native build can't run locally (needs Docker + GraalVM); the Native image workflow has been dispatched on this branch to confirm green.