### PR TITLE
Refactor: extract shared FlashBanner, SpinnerButton, ReadOnlyNotice

### DIFF
--- a/bootui-ui/src/main/frontend/src/utils/useFlashMessage.js
+++ b/bootui-ui/src/main/frontend/src/utils/useFlashMessage.js
@@ -1,0 +1,47 @@
+import {onBeforeUnmount, ref} from 'vue'
+
+/**
+ * Shared transient "flash" banner state used by panels that surface action results.
+ *
+ * Holds a single `{text, type}` message. `flash()` shows it and auto-dismisses after
+ * `timeoutMs`; `show()` displays it until cleared (for sticky errors); `clear()` removes
+ * it immediately. The pending dismiss timer is always cleared on unmount.
+ *
+ * @param {number} timeoutMs default auto-dismiss delay for `flash`
+ * @returns {{message: import('vue').Ref<{text: string, type: string}|null>, flash: Function, show: Function, clear: Function}}
+ */
+export function useFlashMessage(timeoutMs = 6000) {
+  const message = ref(null)
+  let timer = null
+
+  function cancelTimer() {
+    if (timer) {
+      clearTimeout(timer)
+      timer = null
+    }
+  }
+
+  function clear() {
+    cancelTimer()
+    message.value = null
+  }
+
+  function show(text, type = 'info') {
+    cancelTimer()
+    message.value = {text, type}
+  }
+
+  function flash(text, type = 'info', {timeout = timeoutMs} = {}) {
+    show(text, type)
+    if (timeout > 0) {
+      timer = setTimeout(() => {
+        message.value = null
+        timer = null
+      }, timeout)
+    }
+  }
+
+  onBeforeUnmount(cancelTimer)
+
+  return {message, flash, show, clear}
+}

--- a/bootui-ui/src/main/frontend/src/utils/useFlashMessage.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/useFlashMessage.test.js
@@ -1,0 +1,71 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {mount} from '@vue/test-utils'
+
+import {useFlashMessage} from './useFlashMessage.js'
+
+function harness(timeoutMs) {
+  let api
+  const wrapper = mount({
+    setup() {
+      api = useFlashMessage(timeoutMs)
+      return () => null
+    }
+  })
+  return {wrapper, api}
+}
+
+describe('useFlashMessage', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('flashes a message and auto-dismisses after the default timeout', () => {
+    const {api} = harness()
+    api.flash('Saved', 'success')
+    expect(api.message.value).toEqual({text: 'Saved', type: 'success'})
+    vi.advanceTimersByTime(5999)
+    expect(api.message.value).not.toBeNull()
+    vi.advanceTimersByTime(1)
+    expect(api.message.value).toBeNull()
+  })
+
+  it('honours a per-instance timeout', () => {
+    const {api} = harness(8000)
+    api.flash('Hi')
+    vi.advanceTimersByTime(6000)
+    expect(api.message.value).not.toBeNull()
+    vi.advanceTimersByTime(2000)
+    expect(api.message.value).toBeNull()
+  })
+
+  it('defaults the type to info', () => {
+    const {api} = harness()
+    api.flash('Hello')
+    expect(api.message.value).toEqual({text: 'Hello', type: 'info'})
+  })
+
+  it('show() keeps the message until cleared (no auto-dismiss)', () => {
+    const {api} = harness()
+    api.show('Boom', 'danger')
+    vi.advanceTimersByTime(60_000)
+    expect(api.message.value).toEqual({text: 'Boom', type: 'danger'})
+    api.clear()
+    expect(api.message.value).toBeNull()
+  })
+
+  it('replacing a flashed message cancels the previous timer', () => {
+    const {api} = harness()
+    api.flash('first', 'info')
+    vi.advanceTimersByTime(3000)
+    api.show('second', 'danger')
+    vi.advanceTimersByTime(10_000)
+    // The first timer must not wipe the persistent second message.
+    expect(api.message.value).toEqual({text: 'second', type: 'danger'})
+  })
+
+  it('clears the pending timer on unmount', () => {
+    const {wrapper, api} = harness()
+    api.flash('bye')
+    wrapper.unmount()
+    expect(() => vi.advanceTimersByTime(6000)).not.toThrow()
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -6,6 +6,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -135,10 +136,15 @@ onMounted(loadReport)
       :error="error"
     >
       <template #actions>
-        <button :disabled="loading || readOnly" class="btn btn-primary" type="button" @click="runScan">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Running...' : 'Run architecture checks' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          type="button"
+          label="Run architecture checks"
+          loading-label="Running..."
+          @click="runScan"
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -4,6 +4,8 @@ import {computed, nextTick, onMounted, ref, watch} from 'vue'
 import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
+import {useFlashMessage} from '../utils/useFlashMessage.js'
+import FlashBanner from './components/FlashBanner.vue'
 import ServerListFooter from './components/ServerListFooter.vue'
 import PanelHeader from './components/PanelHeader.vue'
 
@@ -24,7 +26,7 @@ const newRowValue = ref('')
 const newRowError = ref(null)
 const newNameInput = ref(null)
 const editInput = ref(null)
-const banner = ref(null)
+const {message: banner, flash, clear} = useFlashMessage(8000)
 
 const {
   data,
@@ -249,13 +251,6 @@ async function removeOverride(name) {
   }
 }
 
-function flash(text, type) {
-  banner.value = {text, type}
-  setTimeout(() => {
-    banner.value = null
-  }, 8000)
-}
-
 function showReadOnlyMessage() {
   flash(readOnlyReason.value, 'warning')
 }
@@ -302,13 +297,7 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
       </div>
     </div>
 
-    <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
-      <div>
-        <i :class="banner.type === 'danger' ? 'bi-exclamation-triangle-fill' : 'bi-check-circle-fill'" class="bi"></i>
-        <span class="ms-2">{{ banner.text }}</span>
-      </div>
-      <button class="btn-close" @click="banner = null"></button>
-    </div>
+    <FlashBanner :message="banner" with-icon @dismiss="clear" />
 
     <div class="row g-2 mb-3">
       <div class="col-md-6">

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -4,14 +4,18 @@ import {computed, onUnmounted, ref} from 'vue'
 import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import {useFlashMessage} from '../utils/useFlashMessage.js'
+import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 import UnavailableState from './components/UnavailableState.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
 const status = ref(null)
 const actionLoading = ref(null)
-const banner = ref(null)
+const {message: banner, flash, clear} = useFlashMessage(8000)
 const restarting = ref(false)
 const lastFetched = ref(null)
 let reconnectTimer = null
@@ -111,13 +115,6 @@ function clearReconnectTimer() {
   }
 }
 
-function flash(text, type) {
-  banner.value = {text, type}
-  setTimeout(() => {
-    banner.value = null
-  }, 8000)
-}
-
 function showReadOnlyMessage() {
   flash(readOnlyReason.value, 'warning')
 }
@@ -139,18 +136,9 @@ onUnmounted(clearReconnectTimer)
       @refresh="load"
     />
 
-    <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
-      <div>
-        <i :class="banner.type === 'danger' ? 'bi-exclamation-triangle-fill' : 'bi-info-circle-fill'" class="bi"></i>
-        <span class="ms-2">{{ banner.text }}</span>
-      </div>
-      <button class="btn-close" @click="banner = null"></button>
-    </div>
+    <FlashBanner :message="banner" with-icon @dismiss="clear" />
 
-    <div v-if="readOnly" class="alert alert-warning small">
-      <i class="bi bi-lock me-1"></i>
-      DevTools actions are read-only. {{ readOnlyReason }}
-    </div>
+    <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">DevTools actions are read-only.</ReadOnlyNotice>
 
     <div v-if="restarting" class="alert alert-primary d-flex align-items-start gap-3">
       <div class="spinner-border spinner-border-sm mt-1" role="status"></div>
@@ -190,15 +178,15 @@ onUnmounted(clearReconnectTimer)
               <span v-else>{{ status.liveReloadUnavailableReason || 'No LiveReload port reported.' }}</span>
             </div>
 
-            <button
+            <SpinnerButton
+              :loading="actionLoading === 'livereload'"
               :disabled="readOnly || !liveReloadReady || actionLoading"
               class="btn btn-primary"
+              icon="bi-broadcast"
+              label="Trigger LiveReload"
+              spinner-class="me-2"
               @click="triggerLiveReload"
-            >
-              <span v-if="actionLoading === 'livereload'" class="spinner-border spinner-border-sm me-2"></span>
-              <i v-else class="bi bi-broadcast me-1"></i>
-              Trigger LiveReload
-            </button>
+            />
           </div>
         </div>
       </div>
@@ -223,15 +211,15 @@ onUnmounted(clearReconnectTimer)
               {{ status.restartUnavailableReason || 'Spring Boot DevTools restart is initialized.' }}
             </div>
 
-            <button
+            <SpinnerButton
+              :loading="actionLoading === 'restart'"
               :disabled="readOnly || !restartReady || actionLoading || restarting"
               class="btn btn-warning"
+              icon="bi-arrow-clockwise"
+              label="Restart app"
+              spinner-class="me-2"
               @click="restart"
-            >
-              <span v-if="actionLoading === 'restart'" class="spinner-border spinner-border-sm me-2"></span>
-              <i v-else class="bi bi-arrow-clockwise me-1"></i>
-              Restart app
-            </button>
+            />
           </div>
         </div>
       </div>

--- a/bootui-ui/src/main/frontend/src/views/Flyway.vue
+++ b/bootui-ui/src/main/frontend/src/views/Flyway.vue
@@ -3,7 +3,11 @@ import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
+import {useFlashMessage} from '../utils/useFlashMessage.js'
+import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 import UnavailableState from './components/UnavailableState.vue'
 
 const props = defineProps(panelProps)
@@ -12,7 +16,7 @@ const report = ref(null)
 const error = ref(null)
 const flywayPresent = ref(true)
 const filter = ref('')
-const banner = ref(null)
+const {message: banner, flash, clear} = useFlashMessage()
 const busy = ref(null)
 
 async function load() {
@@ -27,13 +31,6 @@ async function load() {
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load Flyway migrations')
   }
-}
-
-function flash(text, type = 'info') {
-  banner.value = {text, type}
-  setTimeout(() => {
-    banner.value = null
-  }, 6000)
 }
 
 function actionKey(db, action) {
@@ -53,7 +50,7 @@ async function runAction(db, action) {
 
   const key = actionKey(db, action)
   busy.value = key
-  banner.value = null
+  clear()
   try {
     const res = await apiFetch(`api/flyway/${action}`, {
       method: 'POST',
@@ -107,10 +104,7 @@ onMounted(load)
   <div>
     <PanelHeader icon="bi-arrow-up-right-circle" title="Flyway migrations" :error="error" />
 
-    <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
-      <div>{{ banner.text }}</div>
-      <button class="btn-close" @click="banner = null"></button>
-    </div>
+    <FlashBanner :message="banner" @dismiss="clear" />
 
     <UnavailableState v-if="!flywayPresent" variant="info">
       Flyway is not on the classpath of this application. Add the <code>flyway-core</code> dependency to see schema
@@ -122,10 +116,7 @@ onMounted(load)
     </UnavailableState>
 
     <template v-else-if="report">
-      <div v-if="readOnly" class="alert alert-warning small">
-        <i class="bi bi-lock me-1"></i>
-        Flyway actions are read-only. {{ readOnlyReason }}
-      </div>
+      <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Flyway actions are read-only.</ReadOnlyNotice>
 
       <div class="row g-2 mb-3">
         <div class="col-md-6">
@@ -151,26 +142,24 @@ onMounted(load)
         </div>
         <div class="card-body border-bottom">
           <div class="d-flex flex-wrap gap-2">
-            <button
+            <SpinnerButton
+              :loading="busy === actionKey(db, 'migrate')"
               :disabled="readOnly || busy || !db.migrateEnabled"
               :title="db.migrateDisabledReason || 'Run pending Flyway migrations'"
               class="btn btn-sm btn-outline-primary"
+              icon="bi-play-circle"
+              label="Migrate"
               @click="runAction(db, 'migrate')"
-            >
-              <span v-if="busy === actionKey(db, 'migrate')" class="spinner-border spinner-border-sm me-1"></span>
-              <i v-else class="bi bi-play-circle me-1"></i>
-              Migrate
-            </button>
-            <button
+            />
+            <SpinnerButton
+              :loading="busy === actionKey(db, 'clean')"
               :disabled="readOnly || busy || !db.cleanEnabled"
               :title="db.cleanDisabledReason || 'Clean Flyway-managed schemas'"
               class="btn btn-sm btn-outline-danger"
+              icon="bi-trash"
+              label="Clean"
               @click="runAction(db, 'clean')"
-            >
-              <span v-if="busy === actionKey(db, 'clean')" class="spinner-border spinner-border-sm me-1"></span>
-              <i v-else class="bi bi-trash me-1"></i>
-              Clean
-            </button>
+            />
           </div>
           <div class="small text-muted mt-2">
             <div v-if="db.migrateDisabledReason"><strong>Migrate:</strong> {{ db.migrateDisabledReason }}</div>

--- a/bootui-ui/src/main/frontend/src/views/GraalVm.vue
+++ b/bootui-ui/src/main/frontend/src/views/GraalVm.vue
@@ -6,6 +6,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -131,10 +132,15 @@ onMounted(loadReport)
           />
           <label class="form-check-label small" for="graalvm-include-dependencies">Include dependencies</label>
         </div>
-        <button :disabled="loading || readOnly" class="btn btn-primary" type="button" @click="runScan">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Running...' : 'Run readiness checks' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          type="button"
+          label="Run readiness checks"
+          loading-label="Running..."
+          @click="runScan"
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.vue
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.vue
@@ -5,6 +5,7 @@ import {formatClockTime, formatNumber} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -182,19 +183,23 @@ onBeforeUnmount(() => {
       :error="error"
     >
       <template #actions>
-        <button :disabled="loading || readOnly" class="btn btn-outline-primary" type="button" @click="analyzeHeap">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          Analyze live heap
-        </button>
-        <button
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-outline-primary"
+          type="button"
+          label="Analyze live heap"
+          @click="analyzeHeap"
+        />
+        <SpinnerButton
+          :loading="loading"
           :disabled="loading || readOnly || report?.captureEnabled === false || report?.hotspotAvailable === false"
           class="btn btn-primary"
           type="button"
+          label="Capture heap dump"
+          loading-label="Working..."
           @click="captureDump"
-        >
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Working...' : 'Capture heap dump' }}
-        </button>
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/Hibernate.vue
+++ b/bootui-ui/src/main/frontend/src/views/Hibernate.vue
@@ -6,6 +6,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -135,10 +136,15 @@ onMounted(loadReport)
       :error="error"
     >
       <template #actions>
-        <button :disabled="loading || readOnly" class="btn btn-primary" type="button" @click="runScan">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Running...' : 'Run Hibernate checks' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          type="button"
+          label="Run Hibernate checks"
+          loading-label="Running..."
+          @click="runScan"
+        />
       </template>
     </PanelHeader>
     <div class="alert alert-info d-flex align-items-start gap-2">

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -4,6 +4,8 @@ import {computed, ref} from 'vue'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -109,18 +111,20 @@ function clearForm() {
         <button :disabled="loading" class="btn btn-outline-secondary" @click="clearForm">
           <i class="bi bi-x-circle me-1"></i>Clear
         </button>
-        <button :disabled="loading || readOnly" class="btn btn-primary" @click="sendProbe">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-2"></span>
-          <i v-else class="bi bi-send me-1"></i>
-          {{ loading ? 'Sending…' : 'Send' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          icon="bi-send"
+          label="Send"
+          loading-label="Sending…"
+          spinner-class="me-2"
+          @click="sendProbe"
+        />
       </template>
     </PanelHeader>
 
-    <div v-if="readOnly" class="alert alert-warning small">
-      <i class="bi bi-lock me-1"></i>
-      HTTP probes are read-only. {{ readOnlyReason }}
-    </div>
+    <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">HTTP probes are read-only.</ReadOnlyNotice>
 
     <div class="card mb-4">
       <div class="card-body">

--- a/bootui-ui/src/main/frontend/src/views/HttpSessions.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpSessions.vue
@@ -5,15 +5,19 @@ import {formatNumber, shortName} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import {useFlashMessage} from '../utils/useFlashMessage.js'
+import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
 
 const report = ref(null)
 const error = ref(null)
-const banner = ref(null)
+const {message: banner, flash, clear} = useFlashMessage()
 const busy = ref(null)
 const expanded = ref(new Set())
 const lastFetched = ref(null)
@@ -113,7 +117,7 @@ async function destroySession(session) {
 
 async function mutateSession(session, action, label) {
   busy.value = `${session.sessionKey}:${action}`
-  banner.value = null
+  clear()
   try {
     const res = await apiFetch(`api/http-sessions/${encodeURIComponent(session.sessionKey)}/${action}`, {
       method: 'POST',
@@ -141,13 +145,6 @@ function actionBusy(session, action) {
 function showReadOnlyMessage() {
   flash(readOnly.value ? readOnlyReason.value : 'HTTP session actions are disabled.', 'warning')
 }
-
-function flash(text, type) {
-  banner.value = {text, type}
-  setTimeout(() => {
-    banner.value = null
-  }, 6000)
-}
 </script>
 
 <template>
@@ -163,10 +160,7 @@ function flash(text, type) {
       @refresh="load"
     />
 
-    <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
-      <div>{{ banner.text }}</div>
-      <button class="btn-close" @click="banner = null"></button>
-    </div>
+    <FlashBanner :message="banner" @dismiss="clear" />
 
     <PanelSkeleton v-if="initialLoading" />
 
@@ -176,10 +170,7 @@ function flash(text, type) {
       </div>
 
       <template v-else>
-        <div v-if="readOnly" class="alert alert-warning small">
-          <i class="bi bi-lock me-1"></i>
-          HTTP session actions are read-only. {{ readOnlyReason }}
-        </div>
+        <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">HTTP session actions are read-only.</ReadOnlyNotice>
 
         <div v-if="report.limited" class="alert alert-info small">
           Showing the first {{ formatNumber(report.limit) }} active sessions. Increase
@@ -242,27 +233,20 @@ function flash(text, type) {
                         ></i>
                         {{ isExpanded(session.sessionKey) ? 'Hide' : 'Details' }}
                       </button>
-                      <button
+                      <SpinnerButton
+                        :loading="actionBusy(session, 'clear')"
                         :disabled="actionsDisabled"
                         class="btn btn-outline-warning"
-                        type="button"
+                        label="Clear"
                         @click="clearSession(session)"
-                      >
-                        <span v-if="actionBusy(session, 'clear')" class="spinner-border spinner-border-sm me-1"></span>
-                        Clear
-                      </button>
-                      <button
+                      />
+                      <SpinnerButton
+                        :loading="actionBusy(session, 'invalidate')"
                         :disabled="actionsDisabled"
                         class="btn btn-outline-danger"
-                        type="button"
+                        label="Destroy"
                         @click="destroySession(session)"
-                      >
-                        <span
-                          v-if="actionBusy(session, 'invalidate')"
-                          class="spinner-border spinner-border-sm me-1"
-                        ></span>
-                        Destroy
-                      </button>
+                      />
                     </div>
                   </td>
                 </tr>

--- a/bootui-ui/src/main/frontend/src/views/Liquibase.vue
+++ b/bootui-ui/src/main/frontend/src/views/Liquibase.vue
@@ -3,7 +3,11 @@ import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
+import {useFlashMessage} from '../utils/useFlashMessage.js'
+import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 import UnavailableState from './components/UnavailableState.vue'
 
 const props = defineProps(panelProps)
@@ -12,7 +16,7 @@ const report = ref(null)
 const error = ref(null)
 const liquibasePresent = ref(true)
 const filter = ref('')
-const banner = ref(null)
+const {message: banner, flash, clear} = useFlashMessage()
 const busy = ref(null)
 
 async function load() {
@@ -29,13 +33,6 @@ async function load() {
   }
 }
 
-function flash(text, type = 'info') {
-  banner.value = {text, type}
-  setTimeout(() => {
-    banner.value = null
-  }, 6000)
-}
-
 function actionKey(db, action) {
   return `${db.name}:${action}`
 }
@@ -49,7 +46,7 @@ async function runUpdate(db) {
 
   const key = actionKey(db, 'update')
   busy.value = key
-  banner.value = null
+  clear()
   try {
     const res = await apiFetch('api/liquibase/update', {
       method: 'POST',
@@ -105,10 +102,7 @@ onMounted(load)
   <div>
     <PanelHeader icon="bi-droplet" title="Liquibase change sets" :error="error" />
 
-    <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
-      <div>{{ banner.text }}</div>
-      <button class="btn-close" @click="banner = null"></button>
-    </div>
+    <FlashBanner :message="banner" @dismiss="clear" />
 
     <UnavailableState v-if="!liquibasePresent" variant="info">
       Liquibase is not on the classpath of this application. Add the <code>liquibase-core</code> dependency to see
@@ -120,10 +114,7 @@ onMounted(load)
     </UnavailableState>
 
     <template v-else-if="report">
-      <div v-if="readOnly" class="alert alert-warning small">
-        <i class="bi bi-lock me-1"></i>
-        Liquibase actions are read-only. {{ readOnlyReason }}
-      </div>
+      <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Liquibase actions are read-only.</ReadOnlyNotice>
 
       <div class="row g-2 mb-3">
         <div class="col-md-6">
@@ -150,16 +141,15 @@ onMounted(load)
         </div>
         <div class="card-body border-bottom">
           <div class="d-flex flex-wrap gap-2">
-            <button
+            <SpinnerButton
+              :loading="busy === actionKey(db, 'update')"
               :disabled="readOnly || busy || !db.updateEnabled"
               :title="db.updateDisabledReason || 'Apply pending Liquibase change sets'"
               class="btn btn-sm btn-outline-primary"
+              icon="bi-play-circle"
+              label="Update"
               @click="runUpdate(db)"
-            >
-              <span v-if="busy === actionKey(db, 'update')" class="spinner-border spinner-border-sm me-1"></span>
-              <i v-else class="bi bi-play-circle me-1"></i>
-              Update
-            </button>
+            />
           </div>
           <div class="small text-muted mt-2">
             <div v-if="db.updateDisabledReason"><strong>Update:</strong> {{ db.updateDisabledReason }}</div>

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -5,6 +5,7 @@ import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
 import ServerListFooter from './components/ServerListFooter.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -79,10 +80,7 @@ watch(filter, scheduleReload)
 <template>
   <div>
     <PanelHeader icon="bi-journal-text" title="Loggers" :error="error" />
-    <div v-if="readOnly" class="alert alert-warning small">
-      <i class="bi bi-lock me-1"></i>
-      Logger levels are read-only. {{ readOnlyReason }}
-    </div>
+    <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Logger levels are read-only.</ReadOnlyNotice>
     <div v-if="message" :class="'alert-' + messageType" class="alert">{{ message }}</div>
     <input v-model="filter" class="form-control mb-3" placeholder="Filter loggers by name…" />
     <p v-if="data" class="small text-muted">{{ matchedCount }} of {{ totalCount }} loggers matched</p>

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -5,6 +5,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -154,10 +155,15 @@ onMounted(loadReport)
       :error="error"
     >
       <template #actions>
-        <button :disabled="loading || readOnly" class="btn btn-primary" type="button" @click="runScan">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Running...' : 'Run memory checks' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          type="button"
+          label="Run memory checks"
+          loading-label="Running..."
+          @click="runScan"
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -7,6 +7,7 @@ import {overallScore, scoreBandLabel, scoreBandTone, scoreFromSeverityCounts} fr
 import ScannerScoreCard from './components/ScannerScoreCard.vue'
 import OverviewHealthCard from './components/OverviewHealthCard.vue'
 import OverviewMemoryCard from './components/OverviewMemoryCard.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const injectedPanels = inject('panels', null)
 const githubProjectUrl = 'https://github.com/jdubois/boot-ui'
@@ -317,10 +318,15 @@ onMounted(ensurePanels)
             </div>
 
             <div class="flex-shrink-0 mt-3 mt-lg-0 min-w-0">
-              <button class="btn btn-primary" type="button" :disabled="anyRunning || totalCount === 0" @click="runAll">
-                <span v-if="anyRunning" class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
-                {{ anyRunning ? 'Running scanners…' : 'Run all scanners' }}
-              </button>
+              <SpinnerButton
+                :loading="anyRunning"
+                :disabled="anyRunning || totalCount === 0"
+                class="btn btn-primary"
+                type="button"
+                label="Run all scanners"
+                loading-label="Running scanners…"
+                @click="runAll"
+              />
             </div>
           </div>
         </div>
@@ -385,20 +391,16 @@ onMounted(ensurePanels)
           </template>
 
           <template #actions>
-            <button
+            <SpinnerButton
+              :loading="github.state === 'running'"
               class="btn btn-sm btn-primary"
               type="button"
+              icon="bi-github"
               :disabled="github.state === 'running'"
               @click="connectGithub"
             >
-              <span
-                v-if="github.state === 'running'"
-                class="spinner-border spinner-border-sm me-1"
-                aria-hidden="true"
-              ></span>
-              <i v-else class="bi bi-github me-1"></i>
               {{ githubScored ? 'Refresh' : 'Connect to GitHub' }}
-            </button>
+            </SpinnerButton>
             <router-link to="/github" class="btn btn-sm btn-outline-secondary ms-auto">
               Open GitHub<i class="bi bi-arrow-right-short"></i>
             </router-link>

--- a/bootui-ui/src/main/frontend/src/views/Pentesting.vue
+++ b/bootui-ui/src/main/frontend/src/views/Pentesting.vue
@@ -6,6 +6,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -91,10 +92,15 @@ onMounted(loadReport)
       :error="error"
     >
       <template #actions>
-        <button :disabled="loading || readOnly" class="btn btn-primary" type="button" @click="runScan">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Running...' : 'Run local checks' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          type="button"
+          label="Run local checks"
+          loading-label="Running..."
+          @click="runScan"
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/RestApi.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestApi.vue
@@ -5,6 +5,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -139,10 +140,15 @@ onMounted(loadReport)
       :error="error"
     >
       <template #actions>
-        <button :disabled="loading || readOnly" class="btn btn-primary" type="button" @click="runScan">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Running...' : 'Run REST API checks' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          type="button"
+          label="Run REST API checks"
+          loading-label="Running..."
+          @click="runScan"
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -6,6 +6,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -135,10 +136,15 @@ onMounted(loadReport)
       :error="error"
     >
       <template #actions>
-        <button :disabled="loading || readOnly" class="btn btn-primary" type="button" @click="runScan">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Running...' : 'Run security checks' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          type="button"
+          label="Run security checks"
+          loading-label="Running..."
+          @click="runScan"
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/SecurityLogs.vue
+++ b/bootui-ui/src/main/frontend/src/views/SecurityLogs.vue
@@ -4,6 +4,7 @@ import {computed, ref} from 'vue'
 import {describeLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 
 const report = ref(null)
@@ -151,10 +152,13 @@ function typeBadgeClass(typeName) {
           </select>
         </div>
         <div class="col-md-auto">
-          <button :disabled="loading" class="btn btn-sm btn-primary" @click="load(true)">
-            <span v-if="loading" class="spinner-border spinner-border-sm me-1"></span>
-            Apply
-          </button>
+          <SpinnerButton
+            :loading="loading"
+            :disabled="loading"
+            class="btn btn-sm btn-primary"
+            label="Apply"
+            @click="load(true)"
+          />
         </div>
       </div>
 

--- a/bootui-ui/src/main/frontend/src/views/Spring.vue
+++ b/bootui-ui/src/main/frontend/src/views/Spring.vue
@@ -5,6 +5,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -139,10 +140,15 @@ onMounted(loadReport)
       :error="error"
     >
       <template #actions>
-        <button :disabled="loading || readOnly" class="btn btn-primary" type="button" @click="runScan">
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          {{ loading ? 'Running...' : 'Run Spring checks' }}
-        </button>
+        <SpinnerButton
+          :loading="loading"
+          :disabled="loading || readOnly"
+          class="btn btn-primary"
+          type="button"
+          label="Run Spring checks"
+          loading-label="Running..."
+          @click="runScan"
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/SpringCache.vue
+++ b/bootui-ui/src/main/frontend/src/views/SpringCache.vue
@@ -5,14 +5,18 @@ import {formatNumber, shortName} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import {useFlashMessage} from '../utils/useFlashMessage.js'
+import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
 const report = ref(null)
 const error = ref(null)
-const banner = ref(null)
+const {message: banner, flash, clear} = useFlashMessage()
 const cacheFilter = ref('')
 const operationFilter = ref('')
 const busy = ref(null)
@@ -127,7 +131,7 @@ async function clearCaches(payload, busyKey) {
     return
   }
   busy.value = busyKey
-  banner.value = null
+  clear()
   try {
     const res = await apiFetch('api/spring-cache/clear', {
       method: 'POST',
@@ -146,13 +150,6 @@ async function clearCaches(payload, busyKey) {
   } finally {
     busy.value = null
   }
-}
-
-function flash(text, type) {
-  banner.value = {text, type}
-  setTimeout(() => {
-    banner.value = null
-  }, 6000)
 }
 
 function showReadOnlyMessage() {
@@ -179,22 +176,18 @@ function showReadOnlyMessage() {
       @refresh="load"
     >
       <template #actions>
-        <button
+        <SpinnerButton
+          :loading="busy === '__all__'"
           :disabled="!report || readOnly || !report.clearEnabled || report.cacheCount === 0 || busy"
           class="btn btn-sm btn-outline-danger ms-2"
+          icon="bi-trash"
+          label="Clear all"
           @click="clearAll"
-        >
-          <span v-if="busy === '__all__'" class="spinner-border spinner-border-sm me-1"></span>
-          <i v-else class="bi bi-trash me-1"></i>
-          Clear all
-        </button>
+        />
       </template>
     </PanelHeader>
 
-    <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
-      <div>{{ banner.text }}</div>
-      <button class="btn-close" @click="banner = null"></button>
-    </div>
+    <FlashBanner :message="banner" @dismiss="clear" />
 
     <PanelSkeleton v-if="initialLoading && !report" />
 
@@ -203,10 +196,7 @@ function showReadOnlyMessage() {
         {{ warning }}
       </div>
 
-      <div v-if="readOnly" class="alert alert-warning small">
-        <i class="bi bi-lock me-1"></i>
-        Cache clearing is read-only. {{ readOnlyReason }}
-      </div>
+      <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Cache clearing is read-only.</ReadOnlyNotice>
 
       <div v-if="!report.clearEnabled" class="alert alert-info small">
         Cache clearing has been disabled by configuration. Set <code>bootui.cache.clear-enabled=true</code>
@@ -270,14 +260,13 @@ function showReadOnlyMessage() {
                   <span v-else class="text-muted small">No cache metrics registered</span>
                 </td>
                 <td class="text-end">
-                  <button
+                  <SpinnerButton
+                    :loading="busy === cacheKey(cache)"
                     :disabled="readOnly || !report.clearEnabled || busy"
                     class="btn btn-sm btn-outline-danger"
+                    label="Clear"
                     @click="clearOne(cache)"
-                  >
-                    <span v-if="busy === cacheKey(cache)" class="spinner-border spinner-border-sm me-1"></span>
-                    Clear
-                  </button>
+                  />
                 </td>
               </tr>
             </tbody>

--- a/bootui-ui/src/main/frontend/src/views/SpringSecurity.vue
+++ b/bootui-ui/src/main/frontend/src/views/SpringSecurity.vue
@@ -3,6 +3,7 @@ import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const report = ref(null)
 const error = ref(null)
@@ -254,10 +255,13 @@ onMounted(() => {
       <h5 class="mt-4 mb-2">
         Endpoints
         <span v-if="endpoints" class="badge bg-secondary">{{ endpoints.total }}</span>
-        <button :disabled="endpointsLoading" class="btn btn-sm btn-outline-secondary ms-2" @click="loadEndpoints">
-          <span v-if="endpointsLoading" class="spinner-border spinner-border-sm me-1"></span>
-          Reload
-        </button>
+        <SpinnerButton
+          :loading="endpointsLoading"
+          :disabled="endpointsLoading"
+          class="btn btn-sm btn-outline-secondary ms-2"
+          label="Reload"
+          @click="loadEndpoints"
+        />
       </h5>
       <p class="text-muted small">
         Per-endpoint authorization rule resolved by matching each Spring MVC mapping against the configured filter
@@ -345,10 +349,13 @@ onMounted(() => {
           />
         </div>
         <div class="col-auto">
-          <button :disabled="explainLoading" class="btn btn-sm btn-primary" @click="explain">
-            <span v-if="explainLoading" class="spinner-border spinner-border-sm me-1"></span>
-            Explain
-          </button>
+          <SpinnerButton
+            :loading="explainLoading"
+            :disabled="explainLoading"
+            class="btn btn-sm btn-primary"
+            label="Explain"
+            @click="explain"
+          />
         </div>
       </div>
 

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -5,15 +5,19 @@ import {formatDuration, formatTime} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import {useFlashMessage} from '../utils/useFlashMessage.js'
+import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
 const report = ref(null)
 const detail = ref(null)
 const error = ref(null)
-const banner = ref(null)
+const {message: banner, flash, show, clear} = useFlashMessage(4000)
 const filter = ref('')
 const selectedTraceId = ref(null)
 const detailLoading = ref(false)
@@ -41,7 +45,7 @@ async function openTrace(traceId) {
     if (!res.ok) throw new Error('HTTP ' + res.status)
     detail.value = await res.json()
   } catch (e) {
-    banner.value = {type: 'danger', text: formatLoadError(e, 'Could not load trace')}
+    show(formatLoadError(e, 'Could not load trace'), 'danger')
   } finally {
     detailLoading.value = false
   }
@@ -72,22 +76,16 @@ async function clearAll() {
     if (!res.ok && res.status !== 204) throw new Error('HTTP ' + res.status)
     closeDrawer()
     await load()
-    banner.value = {type: 'success', text: 'Cleared retained traces.'}
-    setTimeout(() => {
-      banner.value = null
-    }, 4000)
+    flash('Cleared retained traces.', 'success')
   } catch (e) {
-    banner.value = {type: 'danger', text: formatLoadError(e, 'Could not clear traces')}
+    show(formatLoadError(e, 'Could not clear traces'), 'danger')
   } finally {
     busy.value = false
   }
 }
 
 function showReadOnlyMessage() {
-  banner.value = {type: 'warning', text: readOnlyReason.value}
-  setTimeout(() => {
-    banner.value = null
-  }, 4000)
+  flash(readOnlyReason.value, 'warning')
 }
 
 const filteredTraces = computed(() => {
@@ -149,21 +147,18 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
       @refresh="load"
     >
       <template #actions>
-        <button
+        <SpinnerButton
+          :loading="busy"
           :disabled="!report || readOnly || report.retained === 0 || busy"
           class="btn btn-sm btn-outline-danger"
+          icon="bi-trash"
+          label="Clear"
           @click="clearAll"
-        >
-          <span v-if="busy" class="spinner-border spinner-border-sm me-1"></span>
-          <i v-else class="bi bi-trash me-1"></i>Clear
-        </button>
+        />
       </template>
     </PanelHeader>
 
-    <div v-if="banner" :class="'alert-' + banner.type" class="alert d-flex justify-content-between align-items-center">
-      <div>{{ banner.text }}</div>
-      <button class="btn-close" @click="banner = null"></button>
-    </div>
+    <FlashBanner :message="banner" @dismiss="clear" />
 
     <PanelSkeleton v-if="loading && !report" />
 
@@ -174,10 +169,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
         <span v-if="report.retained > 0">Showing spans retained before telemetry was disabled.</span>
       </div>
 
-      <div v-if="readOnly" class="alert alert-warning small">
-        <i class="bi bi-lock me-1"></i>
-        Trace clearing is read-only. {{ readOnlyReason }}
-      </div>
+      <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Trace clearing is read-only.</ReadOnlyNotice>
 
       <div v-if="report.enabled && report.retained === 0" class="alert alert-secondary">
         No traces received yet. With the BootUI starter on the classpath, local application spans are captured

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -6,6 +6,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import PanelHeader from './components/PanelHeader.vue'
+import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
@@ -154,15 +155,14 @@ onMounted(loadDependencies)
       :error="error"
     >
       <template #actions>
-        <button
+        <SpinnerButton
+          :loading="loading"
           :disabled="loading || readOnly || data?.scanningEnabled === false"
           class="btn btn-primary"
           type="button"
+          label="Scan with OSV.dev"
           @click="scanDependencies"
-        >
-          <span v-if="loading" aria-hidden="true" class="spinner-border spinner-border-sm me-1"></span>
-          Scan with OSV.dev
-        </button>
+        />
       </template>
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>

--- a/bootui-ui/src/main/frontend/src/views/components/FlashBanner.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/FlashBanner.test.js
@@ -1,0 +1,34 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+
+import FlashBanner from './FlashBanner.vue'
+
+describe('FlashBanner', () => {
+  it('renders nothing when there is no message', () => {
+    const wrapper = mount(FlashBanner, {props: {message: null}})
+    expect(wrapper.find('.alert').exists()).toBe(false)
+  })
+
+  it('renders the message text with the type-specific alert class', () => {
+    const wrapper = mount(FlashBanner, {props: {message: {text: 'Saved', type: 'success'}}})
+    const alert = wrapper.get('.alert')
+    expect(alert.classes()).toContain('alert-success')
+    expect(alert.text()).toContain('Saved')
+  })
+
+  it('omits the icon by default', () => {
+    const wrapper = mount(FlashBanner, {props: {message: {text: 'Hi', type: 'info'}}})
+    expect(wrapper.find('i.bi').exists()).toBe(false)
+  })
+
+  it('shows a type-specific icon when withIcon is set', () => {
+    const wrapper = mount(FlashBanner, {props: {message: {text: 'Oops', type: 'danger'}, withIcon: true}})
+    expect(wrapper.find('i.bi.bi-exclamation-triangle-fill').exists()).toBe(true)
+  })
+
+  it('emits dismiss when the close button is clicked', async () => {
+    const wrapper = mount(FlashBanner, {props: {message: {text: 'Saved', type: 'success'}}})
+    await wrapper.get('button.btn-close').trigger('click')
+    expect(wrapper.emitted('dismiss')).toHaveLength(1)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/FlashBanner.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/FlashBanner.vue
@@ -1,0 +1,34 @@
+<script setup>
+import {computed} from 'vue'
+
+const props = defineProps({
+  // Transient message: {text, type}. When null the banner renders nothing.
+  message: {type: Object, default: null},
+  // When true, prefix the text with a contextual icon chosen from the message type.
+  withIcon: {type: Boolean, default: false}
+})
+
+defineEmits(['dismiss'])
+
+const TYPE_ICONS = {
+  success: 'bi-check-circle-fill',
+  danger: 'bi-exclamation-triangle-fill',
+  warning: 'bi-exclamation-triangle-fill',
+  info: 'bi-info-circle-fill'
+}
+
+const iconClass = computed(() => {
+  if (!props.withIcon || !props.message) return null
+  return TYPE_ICONS[props.message.type] || 'bi-info-circle-fill'
+})
+</script>
+
+<template>
+  <div v-if="message" :class="'alert-' + message.type" class="alert d-flex justify-content-between align-items-center">
+    <div>
+      <i v-if="iconClass" :class="['bi', iconClass]"></i>
+      <span :class="{'ms-2': iconClass}">{{ message.text }}</span>
+    </div>
+    <button class="btn-close" type="button" aria-label="Dismiss" @click="$emit('dismiss')"></button>
+  </div>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/components/ReadOnlyNotice.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/ReadOnlyNotice.test.js
@@ -1,0 +1,25 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+
+import ReadOnlyNotice from './ReadOnlyNotice.vue'
+
+describe('ReadOnlyNotice', () => {
+  it('renders the lock icon, slot text and reason', () => {
+    const wrapper = mount(ReadOnlyNotice, {
+      props: {reason: 'BootUI is read-only'},
+      slots: {default: 'Flyway actions are read-only.'}
+    })
+    const alert = wrapper.get('div')
+    expect(alert.classes()).toContain('alert')
+    expect(alert.classes()).toContain('alert-warning')
+    expect(alert.classes()).toContain('small')
+    expect(wrapper.find('i.bi.bi-lock').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Flyway actions are read-only.')
+    expect(wrapper.text()).toContain('BootUI is read-only')
+  })
+
+  it('renders without a reason', () => {
+    const wrapper = mount(ReadOnlyNotice, {slots: {default: 'Actions are read-only.'}})
+    expect(wrapper.text()).toContain('Actions are read-only.')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/ReadOnlyNotice.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ReadOnlyNotice.vue
@@ -1,0 +1,14 @@
+<script setup>
+defineProps({
+  // The reason this panel is read-only, appended after the slot text.
+  reason: {type: String, default: ''}
+})
+</script>
+
+<template>
+  <div class="alert alert-warning small">
+    <i class="bi bi-lock me-1"></i>
+    <slot></slot>
+    {{ reason }}
+  </div>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {computed} from 'vue'
 import {scoreBandLabel, scoreBandTone} from '../../utils/scannerScore.js'
+import SpinnerButton from './SpinnerButton.vue'
 
 const props = defineProps({
   title: {type: String, required: true},
@@ -100,15 +101,15 @@ function onRun() {
 
       <div class="d-flex gap-2 mt-3">
         <slot name="actions">
-          <button
+          <SpinnerButton
+            :loading="state === 'running'"
             class="btn btn-sm btn-primary"
             type="button"
             :disabled="runDisabled || state === 'running'"
             @click="onRun"
           >
-            <span v-if="state === 'running'" class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
             {{ state === 'idle' ? runLabel : rerunLabel }}
-          </button>
+          </SpinnerButton>
           <router-link v-if="to" :to="to" class="btn btn-sm btn-outline-secondary ms-auto">
             {{ openLabel }}<i class="bi bi-arrow-right-short"></i>
           </router-link>

--- a/bootui-ui/src/main/frontend/src/views/components/SpinnerButton.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/SpinnerButton.test.js
@@ -1,0 +1,57 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+
+import SpinnerButton from './SpinnerButton.vue'
+
+describe('SpinnerButton', () => {
+  it('defaults to type="button" and renders the label', () => {
+    const wrapper = mount(SpinnerButton, {props: {label: 'Run checks'}})
+    const button = wrapper.get('button')
+    expect(button.attributes('type')).toBe('button')
+    expect(button.text()).toBe('Run checks')
+    expect(button.find('.spinner-border').exists()).toBe(false)
+  })
+
+  it('shows the spinner and swaps to the loading label while loading', () => {
+    const wrapper = mount(SpinnerButton, {
+      props: {loading: true, label: 'Run checks', loadingLabel: 'Running...'}
+    })
+    expect(wrapper.find('.spinner-border').exists()).toBe(true)
+    expect(wrapper.text()).toBe('Running...')
+  })
+
+  it('keeps the label constant while loading when no loadingLabel is given', () => {
+    const wrapper = mount(SpinnerButton, {props: {loading: true, label: 'Scan'}})
+    expect(wrapper.text()).toBe('Scan')
+  })
+
+  it('renders the idle icon when not loading and hides it while loading', async () => {
+    const wrapper = mount(SpinnerButton, {props: {icon: 'bi-play-circle', label: 'Migrate'}})
+    expect(wrapper.find('i.bi.bi-play-circle').exists()).toBe(true)
+    await wrapper.setProps({loading: true})
+    expect(wrapper.find('i.bi.bi-play-circle').exists()).toBe(false)
+    expect(wrapper.find('.spinner-border').exists()).toBe(true)
+  })
+
+  it('forwards class, disabled, title and click to the root button', async () => {
+    const wrapper = mount(SpinnerButton, {
+      attrs: {class: 'btn btn-primary', disabled: true, title: 'tip'},
+      props: {label: 'Go'}
+    })
+    const button = wrapper.get('button')
+    expect(button.classes()).toContain('btn')
+    expect(button.classes()).toContain('btn-primary')
+    expect(button.attributes('disabled')).toBeDefined()
+    expect(button.attributes('title')).toBe('tip')
+  })
+
+  it('prefers default slot content over the label prop', () => {
+    const wrapper = mount(SpinnerButton, {props: {label: 'fallback'}, slots: {default: 'Slotted'}})
+    expect(wrapper.text()).toBe('Slotted')
+  })
+
+  it('uses the requested spinner spacing class', () => {
+    const wrapper = mount(SpinnerButton, {props: {loading: true, label: 'Send', spinnerClass: 'me-2'}})
+    expect(wrapper.find('.spinner-border').classes()).toContain('me-2')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/SpinnerButton.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/SpinnerButton.vue
@@ -1,0 +1,22 @@
+<script setup>
+defineProps({
+  // While true, show a spinner in place of the idle icon and (optionally) swap the label.
+  loading: {type: Boolean, default: false},
+  // Bootstrap icon class shown when not loading (e.g. "bi-play-circle").
+  icon: {type: String, default: null},
+  // Text rendered when no default slot content is provided.
+  label: {type: String, default: null},
+  // Optional text shown instead of `label` while loading.
+  loadingLabel: {type: String, default: null},
+  // Spacing utility for the spinner; matches the surrounding markup ("me-1" or "me-2").
+  spinnerClass: {type: String, default: 'me-1'}
+})
+</script>
+
+<template>
+  <button type="button">
+    <span v-if="loading" aria-hidden="true" :class="['spinner-border spinner-border-sm', spinnerClass]"></span>
+    <i v-else-if="icon" :class="['bi', icon, 'me-1']"></i>
+    <slot>{{ loading && loadingLabel !== null ? loadingLabel : label }}</slot>
+  </button>
+</template>


### PR DESCRIPTION
## What does this PR do?

Extracts three patterns that were copy-pasted across ~25 panel views into shared, unit-tested components/composables, and converts every call site to use them.

## Why is this change needed?

The dev console has ~50 similar panels, and the same flash-banner state, spinner-button markup, and read-only notice were duplicated inline in view after view. That made the screens drift apart visually and meant any tweak had to be made in many places. Centralizing these gives a single source of truth, more coherent screens, and easier maintenance. The old inline flash implementations also leaked their dismiss `setTimeout` on unmount; the new composable fixes that.

## How it works

- `utils/useFlashMessage.js` - composable exposing `flash` / `show` / `clear` with a per-instance timeout that auto-dismisses and clears its timer on unmount.
- `components/FlashBanner.vue` - dismissible Bootstrap alert with an optional per-type icon.
- `components/SpinnerButton.vue` - button with a loading spinner, optional idle icon, and `label` / `loading-label`; relies on Vue attribute fallthrough so callers keep passing `class`, `:disabled`, `type`, and `@click`.
- `components/ReadOnlyNotice.vue` - lock-icon read-only alert taking a slot plus a `reason`.

Converted flash banners (7 views), read-only notices (8 views), and spinner buttons (~20 sites, including the shared `ScannerScoreCard` action button). Behavior is preserved at each call site.

A couple of non-obvious points for review: per-view flash timeouts differ (4000/6000/8000 ms) and are passed into the composable; `SpinnerButton` always sets `type="button"` on its root, which is safe here because there are no `<form>` elements in the frontend.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Frontend Vitest suite passes (163 tests, 20 new covering the shared pieces), prettier `format:check` is clean, and a production `vite build` succeeds.

## Screenshots (UI changes)

N/A - this is an internal refactor with no intended visual or behavioral change.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no behaviour change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed