### PR TITLE
Aggregate tasks from all ScheduledTaskHolder beans

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ScheduledController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ScheduledController.java
@@ -4,10 +4,10 @@ import io.github.jdubois.bootui.autoconfigure.monitoring.BootUiSelfDataFilter;
 import io.github.jdubois.bootui.core.dto.ScheduledReport;
 import io.github.jdubois.bootui.core.dto.ScheduledTaskDto;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
-import org.springframework.beans.factory.ObjectProvider;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.scheduling.config.*;
@@ -20,36 +20,33 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/bootui/api/scheduled")
 public class ScheduledController {
 
-    private final ObjectProvider<ScheduledTaskHolder> scheduledTaskHolderProvider;
+    private final List<ScheduledTaskHolder> scheduledTaskHolders;
 
     private final BootUiSelfDataFilter selfDataFilter;
 
-    public ScheduledController(ObjectProvider<ScheduledTaskHolder> scheduledTaskHolderProvider) {
-        this(scheduledTaskHolderProvider, BootUiSelfDataFilter.defaults());
+    public ScheduledController(List<ScheduledTaskHolder> scheduledTaskHolders) {
+        this(scheduledTaskHolders, BootUiSelfDataFilter.defaults());
     }
 
     @Autowired
-    public ScheduledController(
-            ObjectProvider<ScheduledTaskHolder> scheduledTaskHolderProvider, BootUiSelfDataFilter selfDataFilter) {
-        this.scheduledTaskHolderProvider = scheduledTaskHolderProvider;
+    public ScheduledController(List<ScheduledTaskHolder> scheduledTaskHolders, BootUiSelfDataFilter selfDataFilter) {
+        this.scheduledTaskHolders = scheduledTaskHolders;
         this.selfDataFilter = selfDataFilter;
     }
 
     @GetMapping
     public ScheduledReport scheduled() {
-        ScheduledTaskHolder holder = scheduledTaskHolderProvider.getIfAvailable();
-        if (holder == null) {
+        if (scheduledTaskHolders.isEmpty()) {
             return new ScheduledReport(false, 0, List.of());
         }
-        Set<ScheduledTask> scheduledTasks = holder.getScheduledTasks();
-        List<ScheduledTaskDto> tasks = scheduledTasks == null
-                ? List.of()
-                : scheduledTasks.stream()
-                        .map(this::toDto)
-                        .filter(task -> selfDataFilter.shouldIncludeScheduledTask(task.runnable()))
-                        .sorted(Comparator.comparing(
-                                ScheduledTaskDto::runnable, Comparator.nullsLast(String::compareTo)))
-                        .toList();
+        List<ScheduledTaskDto> tasks = scheduledTaskHolders.stream()
+                .map(ScheduledTaskHolder::getScheduledTasks)
+                .filter(Objects::nonNull)
+                .flatMap(Collection::stream)
+                .map(this::toDto)
+                .filter(task -> selfDataFilter.shouldIncludeScheduledTask(task.runnable()))
+                .sorted(Comparator.comparing(ScheduledTaskDto::runnable, Comparator.nullsLast(String::compareTo)))
+                .toList();
         return new ScheduledReport(true, tasks.size(), tasks);
     }
 

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MissingActuatorEndpointsTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MissingActuatorEndpointsTests.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.condition.ConditionsReportEndpoint;
@@ -16,7 +17,6 @@ import org.springframework.boot.actuate.startup.StartupEndpoint;
 import org.springframework.boot.actuate.web.mappings.MappingsEndpoint;
 import org.springframework.boot.health.actuate.endpoint.HealthEndpoint;
 import org.springframework.mock.env.MockEnvironment;
-import org.springframework.scheduling.config.ScheduledTaskHolder;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.FilterChainProxy;
@@ -145,8 +145,7 @@ class MissingActuatorEndpointsTests {
 
     @Test
     void scheduledControllerReturnsAbsentSchedulingReportWhenHolderMissing() throws Exception {
-        ObjectProvider<ScheduledTaskHolder> provider = emptyProvider();
-        MockMvc mvc = standaloneSetup(new ScheduledController(provider)).build();
+        MockMvc mvc = standaloneSetup(new ScheduledController(List.of())).build();
 
         mvc.perform(get("/bootui/api/scheduled"))
                 .andExpect(status().isOk())

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ScheduledControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/ScheduledControllerTests.java
@@ -7,10 +7,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockMakers;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.MediaType;
 import org.springframework.scheduling.config.*;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,12 +18,12 @@ import org.springframework.test.web.servlet.MockMvc;
 /**
  * Controller-level tests for {@link ScheduledController}.
  *
- * <p>Covers three infrastructure states: absent holder (scheduling not
- * present), present holder with no tasks, and present holder with tasks
- * of various trigger types. {@link ScheduledTask} is {@code final} with a
- * package-private constructor and is mocked via {@link MockMakers#INLINE}.
- * {@link ScheduledTaskHolder} is an interface and uses the default mock
- * maker.</p>
+ * <p>Covers infrastructure states: no holder beans (scheduling not present),
+ * a present holder with no tasks, a present holder with tasks of various
+ * trigger types, and multiple holder beans whose tasks are aggregated.
+ * {@link ScheduledTask} is {@code final} with a package-private constructor
+ * and is mocked via {@link MockMakers#INLINE}. {@link ScheduledTaskHolder}
+ * is an interface and uses the default mock maker.</p>
  */
 class ScheduledControllerTests {
 
@@ -31,23 +31,15 @@ class ScheduledControllerTests {
         return mock(cls, withSettings().mockMaker(MockMakers.INLINE));
     }
 
-    @SuppressWarnings("unchecked")
-    private static ObjectProvider<ScheduledTaskHolder> providerOf(ScheduledTaskHolder holder) {
-        ObjectProvider<ScheduledTaskHolder> provider = mock(ObjectProvider.class);
-        when(provider.getIfAvailable()).thenReturn(holder);
-        return provider;
-    }
-
-    @SuppressWarnings("unchecked")
-    private static ObjectProvider<ScheduledTaskHolder> emptyProvider() {
-        ObjectProvider<ScheduledTaskHolder> provider = mock(ObjectProvider.class);
-        when(provider.getIfAvailable()).thenReturn(null);
-        return provider;
+    private static ScheduledTaskHolder holderOf(Set<ScheduledTask> tasks) {
+        ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
+        when(holder.getScheduledTasks()).thenReturn(tasks);
+        return holder;
     }
 
     @Test
-    void scheduledReturnsAbsentWhenHolderUnavailable() throws Exception {
-        MockMvc mvc = standaloneSetup(new ScheduledController(emptyProvider())).build();
+    void scheduledReturnsAbsentWhenNoHolderBeans() throws Exception {
+        MockMvc mvc = standaloneSetup(new ScheduledController(List.of())).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -59,11 +51,9 @@ class ScheduledControllerTests {
 
     @Test
     void scheduledReturnsEmptyListWhenNoTasksRegistered() throws Exception {
-        ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
-        when(holder.getScheduledTasks()).thenReturn(Set.of());
+        ScheduledTaskHolder holder = holderOf(Set.of());
 
-        MockMvc mvc =
-                standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc = standaloneSetup(new ScheduledController(List.of(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -80,11 +70,9 @@ class ScheduledControllerTests {
         ScheduledTask scheduledTask = inlineMock(ScheduledTask.class);
         when(scheduledTask.getTask()).thenReturn(cronTask);
 
-        ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
-        when(holder.getScheduledTasks()).thenReturn(Set.of(scheduledTask));
+        ScheduledTaskHolder holder = holderOf(Set.of(scheduledTask));
 
-        MockMvc mvc =
-                standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc = standaloneSetup(new ScheduledController(List.of(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -96,16 +84,33 @@ class ScheduledControllerTests {
     }
 
     @Test
+    void scheduledAggregatesTasksFromMultipleHolders() throws Exception {
+        ScheduledTask annotationTask = scheduledCronTask(new NamedRunnable("com.example.AnnotatedJob#run"));
+        ScheduledTask programmaticTask = scheduledCronTask(new NamedRunnable("com.example.ProgrammaticTimer"));
+
+        ScheduledTaskHolder annotationHolder = holderOf(Set.of(annotationTask));
+        ScheduledTaskHolder programmaticHolder = holderOf(Set.of(programmaticTask));
+
+        MockMvc mvc = standaloneSetup(new ScheduledController(List.of(annotationHolder, programmaticHolder)))
+                .build();
+
+        mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.schedulingPresent").value(true))
+                .andExpect(jsonPath("$.total").value(2))
+                .andExpect(jsonPath("$.tasks[0].runnable").value("com.example.AnnotatedJob#run"))
+                .andExpect(jsonPath("$.tasks[1].runnable").value("com.example.ProgrammaticTimer"));
+    }
+
+    @Test
     void scheduledFiltersBootUiTasksByDefault() throws Exception {
         ScheduledTask bootUiTask = scheduledCronTask(
                 new NamedRunnable("io.github.jdubois.bootui.autoconfigure.web.BootUiMaintenanceTask"));
         ScheduledTask applicationTask = scheduledCronTask(new NamedRunnable("com.example.MyJob#executeJob"));
 
-        ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
-        when(holder.getScheduledTasks()).thenReturn(Set.of(bootUiTask, applicationTask));
+        ScheduledTaskHolder holder = holderOf(Set.of(bootUiTask, applicationTask));
 
-        MockMvc mvc =
-                standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc = standaloneSetup(new ScheduledController(List.of(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -121,11 +126,9 @@ class ScheduledControllerTests {
         ScheduledTask scheduledTask = inlineMock(ScheduledTask.class);
         when(scheduledTask.getTask()).thenReturn(fixedRateTask);
 
-        ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
-        when(holder.getScheduledTasks()).thenReturn(Set.of(scheduledTask));
+        ScheduledTaskHolder holder = holderOf(Set.of(scheduledTask));
 
-        MockMvc mvc =
-                standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc = standaloneSetup(new ScheduledController(List.of(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -143,11 +146,9 @@ class ScheduledControllerTests {
         ScheduledTask scheduledTask = inlineMock(ScheduledTask.class);
         when(scheduledTask.getTask()).thenReturn(fixedDelayTask);
 
-        ScheduledTaskHolder holder = mock(ScheduledTaskHolder.class);
-        when(holder.getScheduledTasks()).thenReturn(Set.of(scheduledTask));
+        ScheduledTaskHolder holder = holderOf(Set.of(scheduledTask));
 
-        MockMvc mvc =
-                standaloneSetup(new ScheduledController(providerOf(holder))).build();
+        MockMvc mvc = standaloneSetup(new ScheduledController(List.of(holder))).build();
 
         mvc.perform(get("/bootui/api/scheduled").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## What does this PR do?

Makes the Scheduled Tasks panel collect tasks from every `ScheduledTaskHolder` bean instead of requiring exactly one.

## Why is this change needed?

When a host app registers its own `ScheduledTaskHolder` (for example to expose timers created programmatically) alongside Spring's built-in `internalScheduledAnnotationProcessor`, the context contains two beans of that type. `ScheduledController` injected a single `ObjectProvider<ScheduledTaskHolder>` and called `getIfAvailable()`, which throws `NoUniqueBeanDefinitionException` when more than one holder is present. The panel then failed with a 500 error.

The fix injects `List<ScheduledTaskHolder>` and flat-maps the scheduled tasks across all holders, so programmatically registered tasks show up next to `@Scheduled` ones. An empty list still produces an absent report (`schedulingPresent=false`), preserving the previous "no scheduling" behavior. This is the approach suggested by the issue author.

Closes #288

Fixes: #288

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran `ScheduledControllerTests` and `MissingActuatorEndpointsTests` (16 tests, all green), including a new `scheduledAggregatesTasksFromMultipleHolders` regression test that feeds two holder beans and asserts both tasks are returned. `spotless:check` passes on the touched module.

## Screenshots (UI changes)

N/A - no UI changes. The DTO and `/bootui/api/scheduled` response shape are unchanged.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no doc change needed; existing docs describe generic Spring scheduling infrastructure with no single-holder limitation)
- [x] Public API kept backward compatible, or a migration note added to the PR description (constructor signature changed from `ObjectProvider<ScheduledTaskHolder>` to `List<ScheduledTaskHolder>`; this is internal autoconfiguration wiring, not part of the consumer-facing API)
- [x] No secrets, tokens, or local paths committed