### PR TITLE
Fix SonarCloud security hotspots and bug findings

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateContext.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateContext.java
@@ -152,7 +152,7 @@ record HibernateContext(
 
 record HibernateRuntimeVersion(String display, Integer major, Integer minor) {
 
-    private static final Pattern VERSION_PREFIX = Pattern.compile("^(\\d+)(?:\\.(\\d+))?.*");
+    private static final Pattern VERSION_PREFIX = Pattern.compile("^(\\d++)(?:\\.(\\d++))?.*");
 
     static HibernateRuntimeVersion detect() {
         return parse(detectedVersionString());

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateModel.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateModel.java
@@ -616,10 +616,16 @@ record HibernateRepositoryMethodModel(
         return returnType != null && java.util.stream.Stream.class.isAssignableFrom(returnType);
     }
 
+    // Optional Spring Data type: compare by class name instead of hard-referencing a class that may be absent at
+    // runtime.
+    @SuppressWarnings("java:S1872")
     boolean returnsPage() {
         return returnType != null && "org.springframework.data.domain.Page".equals(returnType.getName());
     }
 
+    // Optional Spring Data type: compare by class name instead of hard-referencing a class that may be absent at
+    // runtime.
+    @SuppressWarnings("java:S1872")
     boolean returnsSlice() {
         return returnType != null && "org.springframework.data.domain.Slice".equals(returnType.getName());
     }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateRules.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateRules.java
@@ -53,8 +53,8 @@ final class HibernateRuleModelSupport {
 
     private static final Pattern FROM_ALIAS =
             Pattern.compile("\\bfrom\\s+[\\w.$]+\\s+(?:as\\s+)?([A-Za-z_]\\w*)\\b", Pattern.CASE_INSENSITIVE);
-    private static final Pattern JOIN_FETCH =
-            Pattern.compile("\\bjoin\\s+fetch\\s+([A-Za-z_]\\w*(?:\\.[A-Za-z_]\\w*)+)\\b", Pattern.CASE_INSENSITIVE);
+    private static final Pattern JOIN_FETCH = Pattern.compile(
+            "\\bjoin\\s++fetch\\s++([A-Za-z_]\\w*+(?:\\.[A-Za-z_]\\w*+)++)\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern SELECT_CLAUSE =
             Pattern.compile("^\\s*select\\b(.*?)\\bfrom\\b", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     private static final Pattern DISTINCT_PREFIX = Pattern.compile("(?i)^distinct\\s+");
@@ -2053,6 +2053,8 @@ final class MissingForeignKeyIndexRule extends AbstractHibernateRule {
                 "https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1.html#a11145"));
     }
 
+    // Optional JPA type: compare by class name instead of hard-referencing a class that may be absent at runtime.
+    @SuppressWarnings("java:S1872")
     @Override
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
         List<String> details = new ArrayList<>();
@@ -2115,6 +2117,9 @@ final class PrimitiveIdentifierOrVersionRule extends AbstractHibernateRule {
                 "https://docs.spring.io/spring-data/jpa/reference/repositories/entity-state-detection.html"));
     }
 
+    // Optional JPA/Spring Data types: compare by class name instead of hard-referencing classes that may be absent at
+    // runtime.
+    @SuppressWarnings("java:S1872")
     @Override
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
         List<String> details = new ArrayList<>();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateRules.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateRules.java
@@ -56,7 +56,7 @@ final class HibernateRuleModelSupport {
     private static final Pattern JOIN_FETCH =
             Pattern.compile("\\bjoin\\s+fetch\\s+([A-Za-z_]\\w*(?:\\.[A-Za-z_]\\w*)+)\\b", Pattern.CASE_INSENSITIVE);
     private static final Pattern SELECT_CLAUSE =
-            Pattern.compile("^\\s*select\\s+(.*?)\\s+from\\b", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+            Pattern.compile("^\\s*select\\b(.*?)\\bfrom\\b", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
     private static final Pattern DISTINCT_PREFIX = Pattern.compile("(?i)^distinct\\s+");
     private static final Pattern OBJECT_WRAPPER = Pattern.compile("(?i)^object\\(\\s*([A-Za-z_]\\w*)\\s*\\)$");
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateScanner.java
@@ -319,6 +319,9 @@ final class HibernateScanner {
         return methods;
     }
 
+    // Optional Spring Data type: compare by class name instead of hard-referencing a class that may be absent at
+    // runtime.
+    @SuppressWarnings("java:S1872")
     private static QueryAnnotation readQueryAnnotation(Method method) {
         for (Annotation annotation : method.getAnnotations()) {
             if (!"org.springframework.data.jpa.repository.Query"
@@ -334,6 +337,9 @@ final class HibernateScanner {
         return null;
     }
 
+    // Optional Spring Data type: compare by class name instead of hard-referencing a class that may be absent at
+    // runtime.
+    @SuppressWarnings("java:S1872")
     private static ModifyingAnnotation readModifyingAnnotation(Method method) {
         for (Annotation annotation : method.getAnnotations()) {
             if (!"org.springframework.data.jpa.repository.Modifying"
@@ -356,6 +362,9 @@ final class HibernateScanner {
         }
     }
 
+    // Optional Spring Data type: compare by class name instead of hard-referencing a class that may be absent at
+    // runtime.
+    @SuppressWarnings("java:S1872")
     private static boolean hasPageableParameter(Method method) {
         for (Class<?> parameterType : method.getParameterTypes()) {
             if ("org.springframework.data.domain.Pageable".equals(parameterType.getName())) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/memory/MemoryCollector.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/memory/MemoryCollector.java
@@ -36,7 +36,8 @@ import javax.management.ObjectName;
 final class MemoryCollector {
 
     /** Matches a histogram data row: {@code   1:   12345   9876544   classname [(module)]}. */
-    private static final Pattern HISTOGRAM_ROW = Pattern.compile("^\\s*\\d+:\\s+(\\d+)\\s+(\\d+)\\s+(\\S+).*$");
+    private static final Pattern HISTOGRAM_ROW =
+            Pattern.compile("^\\s*+\\d++:\\s++(\\d++)\\s++(\\d++)\\s++(\\S++).*+$");
 
     private static final int MAX_HISTOGRAM_CLASSES = 200;
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/restapi/RestApiRules.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/restapi/RestApiRules.java
@@ -74,8 +74,6 @@ final class RestApiRuleHelp {
     static final String OPENAPI_DOCS = "https://springdoc.org/";
 
     private static final Pattern VERSION_SEGMENT = Pattern.compile("v\\d+", Pattern.CASE_INSENSITIVE);
-    private static final Pattern VERSIONED_MEDIA_TYPE =
-            Pattern.compile(".*(version=|vnd\\.).*", Pattern.CASE_INSENSITIVE);
     private static final Pattern PATH_VARIABLE_TOKEN = Pattern.compile("\\{([^}/]+)\\}");
     private static final Set<String> VERBS = Set.of(
             "get", "create", "update", "delete", "remove", "save", "add", "fetch", "insert", "modify", "post", "put",
@@ -166,16 +164,21 @@ final class RestApiRuleHelp {
             }
         }
         for (String mediaType : handler.effectiveProduces()) {
-            if (VERSIONED_MEDIA_TYPE.matcher(mediaType).matches()) {
+            if (isVersionedMediaType(mediaType)) {
                 return true;
             }
         }
         for (String mediaType : handler.effectiveConsumes()) {
-            if (VERSIONED_MEDIA_TYPE.matcher(mediaType).matches()) {
+            if (isVersionedMediaType(mediaType)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static boolean isVersionedMediaType(String mediaType) {
+        String lower = mediaType.toLowerCase(Locale.ROOT);
+        return lower.contains("version=") || lower.contains("vnd.");
     }
 
     static boolean containsWildcardMediaType(HandlerMethodModel handler) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DevServicesService.java
@@ -500,11 +500,19 @@ class DevServicesService {
     }
 
     private String slug(String value) {
-        String normalized = value == null
-                ? "service"
-                : value.toLowerCase(Locale.ROOT)
-                        .replaceAll("[^a-z0-9._-]+", "-")
-                        .replaceAll("(^-+|-+$)", "");
+        if (value == null) {
+            return "service";
+        }
+        String normalized = value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9._-]+", "-");
+        int start = 0;
+        int end = normalized.length();
+        while (start < end && normalized.charAt(start) == '-') {
+            start++;
+        }
+        while (end > start && normalized.charAt(end - 1) == '-') {
+            end--;
+        }
+        normalized = normalized.substring(start, end);
         return normalized.isBlank() ? "service" : normalized;
     }
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubTokenProvider.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubTokenProvider.java
@@ -46,6 +46,9 @@ final class DefaultGitHubTokenProvider implements GitHubTokenProvider {
     private Token ghCliToken(Duration timeout) {
         Process process = null;
         try {
+            // Resolve the GitHub CLI from the developer's PATH on purpose: BootUI is a localhost-only
+            // dev tool and must invoke whichever "gh" the developer installed (Homebrew, apt, etc.),
+            // so a fixed absolute path is intentionally not used. (Reviewed: SonarCloud S4036.)
             process = new ProcessBuilder("gh", "auth", "token")
                     .redirectError(ProcessBuilder.Redirect.DISCARD)
                     .start();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubTokenProvider.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubTokenProvider.java
@@ -48,7 +48,7 @@ final class DefaultGitHubTokenProvider implements GitHubTokenProvider {
         try {
             // Resolve the GitHub CLI from the developer's PATH on purpose: BootUI is a localhost-only
             // dev tool and must invoke whichever "gh" the developer installed (Homebrew, apt, etc.),
-            // so a fixed absolute path is intentionally not used. (Reviewed: SonarCloud S4036.)
+            // so a fixed absolute path is intentionally not used.
             process = new ProcessBuilder("gh", "auth", "token")
                     .redirectError(ProcessBuilder.Redirect.DISCARD)
                     .start();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HeapDumpService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HeapDumpService.java
@@ -37,7 +37,8 @@ public class HeapDumpService {
     private static final Pattern SAFE_NAME = Pattern.compile("[A-Za-z0-9._-]+\\.hprof");
 
     /** Matches a histogram data row: {@code   1:   12345   9876544   classname [(module)]}. */
-    private static final Pattern HISTOGRAM_ROW = Pattern.compile("^\\s*\\d+:\\s+(\\d+)\\s+(\\d+)\\s+(\\S+).*$");
+    private static final Pattern HISTOGRAM_ROW =
+            Pattern.compile("^\\s*+\\d++:\\s++(\\d++)\\s++(\\d++)\\s++(\\S++).*+$");
 
     private static final DateTimeFormatter TIMESTAMP = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangesController.java
@@ -243,7 +243,7 @@ public class HttpExchangesController {
         if (!shouldMask(name) || exposure.valueExposure() == BootUiProperties.ValueExposure.FULL) {
             return part;
         }
-        return equalsIndex >= 0 ? name + "=" + SecretMasker.MASKED_VALUE : name + "=" + SecretMasker.MASKED_VALUE;
+        return equalsIndex >= 0 ? name + "=" + SecretMasker.MASKED_VALUE : SecretMasker.MASKED_VALUE;
     }
 
     private Long responseSizeBytes(List<HttpHeaderDto> responseHeaders) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PanelsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/PanelsController.java
@@ -34,10 +34,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/bootui/api/panels")
 public class PanelsController {
 
-    // Matches both plain application-<profile>.{properties,yml,yaml} names and
-    // Spring Boot's "Config resource 'file ... application-<profile>.yml'" source names.
-    private static final Pattern PROFILE_SOURCE_PATTERN = Pattern.compile(
-            "(?:application-|Config resource 'file [^']*application-)([\\w-]+)(?:\\.properties|\\.ya?ml)");
+    // Matches the application-<profile>.{properties,yml,yaml} token in both plain source names and
+    // Spring Boot's "Config resource 'file ... application-<profile>.yml'" source names (via find()).
+    private static final Pattern PROFILE_SOURCE_PATTERN =
+            Pattern.compile("application-([\\w-]++)(?:\\.properties|\\.ya?ml)");
 
     private final ApplicationContext applicationContext;
     private final Environment environment;

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ProfileDiffController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ProfileDiffController.java
@@ -30,8 +30,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/bootui/api/profile-diff")
 public class ProfileDiffController {
 
-    private static final Pattern PROFILE_SOURCE_PATTERN = Pattern.compile(
-            "(?:application-|Config resource 'file [^']*application-)([\\w-]+)(?:\\.properties|\\.ya?ml)");
+    // Matches the application-<profile>.{properties,yml,yaml} token in both plain source names and
+    // Spring Boot's "Config resource 'file ... application-<profile>.yml'" source names (via find()).
+    private static final Pattern PROFILE_SOURCE_PATTERN =
+            Pattern.compile("application-([\\w-]++)(?:\\.properties|\\.ya?ml)");
 
     private final ConfigurableEnvironment environment;
     private final BootUiExposure exposure;

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangesControllerTests.java
@@ -120,6 +120,19 @@ class HttpExchangesControllerTests {
     }
 
     @Test
+    void masksBareSensitiveQueryParameterWithoutFabricatingEquals() {
+        HttpExchange appExchange = exchange("GET", "http://localhost/api/orders?token&page=1", 200);
+        HttpExchangesController controller =
+                new HttpExchangesController(providerOf(repositoryWith(appExchange)), new BootUiProperties());
+
+        HttpExchangesReport report = controller.exchanges(null, null, null, null, null);
+
+        HttpExchangeDto dto = report.exchanges().get(0);
+        assertThat(dto.query()).isEqualTo(SecretMasker.MASKED_VALUE + "&page=1");
+        assertThat(dto.uri()).isEqualTo("http://localhost/api/orders?" + SecretMasker.MASKED_VALUE + "&page=1");
+    }
+
+    @Test
     void filtersAndPagesOnServer() throws Exception {
         HttpExchange alpha = exchange("GET", "http://localhost/api/alpha", 200);
         HttpExchange beta = exchange("POST", "http://localhost/api/beta", 404);

--- a/bootui-ui/src/main/frontend/src/utils/loadError.js
+++ b/bootui-ui/src/main/frontend/src/utils/loadError.js
@@ -21,10 +21,12 @@ export function toErrorMessage(error, fallback = 'Request failed') {
 }
 
 export function isServerUnreachableError(error) {
-  const message = toErrorMessage(error, '')
-    .trim()
-    .toLowerCase()
-    .replace(/[.!]+$/, '')
+  const normalized = toErrorMessage(error, '').trim().toLowerCase()
+  let end = normalized.length
+  while (end > 0 && (normalized[end - 1] === '.' || normalized[end - 1] === '!')) {
+    end--
+  }
+  const message = normalized.slice(0, end)
   if (!message) return false
   if (message.startsWith(`${SERVER_UNREACHABLE_TITLE.toLowerCase()}:`)) return true
 

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -922,6 +922,12 @@ const detectedFrameworkLabel = computed(() => {
                             <details v-for="[ns, attrs] in groupedAttributes" :key="ns" class="mb-1">
                               <summary class="text-muted small">{{ ns }} ({{ attrs.length }})</summary>
                               <table class="table table-sm mt-1">
+                                <thead class="visually-hidden">
+                                  <tr>
+                                    <th scope="col">Attribute</th>
+                                    <th scope="col">Value</th>
+                                  </tr>
+                                </thead>
                                 <tbody>
                                   <tr v-for="a in attrs" :key="a.key">
                                     <td>

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -272,7 +272,10 @@ function formatTokenCount(value) {
   const unit = absolute >= 1_000_000 ? 'm' : 'k'
   const divisor = unit === 'm' ? 1_000_000 : 1000
   const truncated = Math.trunc((absolute / divisor) * 100) / 100
-  const compact = truncated.toFixed(2).replace('.', ',').replace(/,?0+$/, '')
+  const compact = truncated
+    .toFixed(2)
+    .replace('.', ',')
+    .replace(/,?0{1,2}$/, '')
   return `${numeric < 0 ? '-' : ''}${compact}${unit}`
 }
 


### PR DESCRIPTION
## What does this PR do?

Resolves the SonarCloud Cloud findings reported for `jdubois_boot-ui`: first the 11 security hotspots (regex hardening), then the actionable bug findings. The two `S5443` "publicly writable directory" vulnerabilities are intentionally left out of scope.

## Why is this change needed?

A SonarCloud analysis flagged 11 security hotspots and a set of bugs. The hotspots are mostly rule S5852 (regex vulnerable to polynomial / super-linear runtime due to backtracking), a denial-of-service risk if any of these patterns ever runs against attacker-influenced input. The goal is to eliminate the backtracking concern and fix the real bugs while preserving exact behaviour for real inputs, so there is zero functional change for users.

### Security hotspots (S5852 / S4036)

- **Possessive quantifiers** where the repeated classes are deterministic: `VERSION_PREFIX` (Hibernate version parsing) and the `HISTOGRAM_ROW` patterns in `MemoryCollector` and `HeapDumpService`.
- **Removed the catastrophic overlap** in `SELECT_CLAUSE` (HQL/JPQL parsing) by switching `\s+(.*?)\s+` to word boundaries (`select\b(.*?)\bfrom\b`). The captured group is trimmed downstream, so output is unchanged.
- **Simplified `PROFILE_SOURCE_PATTERN`** in `PanelsController` and `ProfileDiffController`. Both call sites use `find()`, so the redundant `[^']*application-` alternative (the actual backtracking source) was dropped in favour of matching the `application-<profile>.<ext>` token directly with a possessive class.
- **Dropped a regex entirely** for `VERSIONED_MEDIA_TYPE`: the `.matches()` call was only ever a substring test, so it is now a plain case-insensitive `String.contains` check for `version=` / `vnd.`.
- **Linear string trims** replacing two backtracking-prone patterns: a two-pointer dash strip in `DevServicesService.slug()` (the `-+$` case is quadratic under `replaceAll` regardless of possessive quantifiers), and a trailing-char loop in `loadError.js` (JavaScript has no possessive quantifiers).
- **Bounded quantifier** in `Copilot.vue`: `toFixed(2)` yields at most two trailing zeros, so `/,?0+$/` becomes `/,?0{1,2}$/`.
- **S4036** (resolving `gh` through `PATH` in `GitHubTokenProvider`) is intentional: BootUI is a localhost-only dev tool that must invoke whichever GitHub CLI the developer installed; a hardcoded absolute path would break portability. A code comment explains the rationale; it should be marked "Safe" in the SonarCloud UI.

### Bug findings

- **S5998** (`JOIN_FETCH` in `HibernateRules`): made the pattern possessive so it can no longer overflow the regex stack on large queries. Capture group and matches are unchanged.
- **S3923** (`HttpExchangesController.displayQueryPart`): the ternary returned an identical value on both branches. For a query token with no `=` there is no value to mask, so it now returns the masked placeholder instead of fabricating `name=******`. Added a focused unit test.
- **Web:S5256** (`Ai.vue` span-attributes table): the table had no header row. Added a visually-hidden `<thead>` with scoped column headers - satisfies accessibility with no visual change.
- **S1872 x8** (Hibernate scanner comparing Spring Data / JPA types by class name): these comparisons are deliberate. `spring-data-commons` and `jakarta.persistence-api` are `<optional>true</optional>` dependencies, so switching to `instanceof` would hard-reference classes that may be absent on the host classpath (risking `NoClassDefFoundError`) and would also change semantics by matching subtypes. Suppressed with `@SuppressWarnings("java:S1872")` plus a rationale comment rather than making an unsafe change.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Notes: Ran the `bootui-autoconfigure` backend suite and the frontend Vitest suite (168 tests), both green, plus `spotless:check` and Prettier `format:check`. Added `masksBareSensitiveQueryParameterWithoutFabricatingEquals` to cover the S3923 fix. Existing coverage (`HibernateScannerTests`, `RestApiRulesTests`, `HeapDumpServiceTests`, `loadError.test.js`) continues to pass unchanged, which is the point of the behaviour-preserving rewrites.

## Screenshots (UI changes)

N/A - the only UI change is a visually-hidden table header, which has no visible effect.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no behaviour change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
