### PR TITLE
Serve BootUI assets even when static resource mappings are disabled

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -281,6 +281,11 @@ public class BootUiAutoConfiguration {
     }
 
     @Bean
+    public BootUiStaticResourceConfigurer bootUiStaticResourceConfigurer(Environment environment) {
+        return new BootUiStaticResourceConfigurer(environment);
+    }
+
+    @Bean
     public PanelAccessFilter bootUiPanelAccessFilter(BootUiProperties properties) {
         return new PanelAccessFilter(properties);
     }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiStaticResourceConfigurer.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiStaticResourceConfigurer.java
@@ -42,7 +42,7 @@ public class BootUiStaticResourceConfigurer implements WebMvcConfigurer {
         registry.addResourceHandler(ASSET_PATH_PATTERN).addResourceLocations(ASSET_LOCATION);
 
         if (!environment.getProperty("spring.web.resources.add-mappings", Boolean.class, true)) {
-            log.info(
+            log.warn(
                     "spring.web.resources.add-mappings is false, which disables Spring Boot's default static "
                             + "resource handling. BootUI registered its own handler for '{}' (serving {}) so the "
                             + "dashboard UI still loads.",

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiStaticResourceConfigurer.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiStaticResourceConfigurer.java
@@ -1,0 +1,53 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Serves the BootUI single-page application from a dedicated static resource handler.
+ *
+ * <p>BootUI's compiled Vue assets ship on the classpath at
+ * {@code META-INF/resources/bootui/}. Spring Boot normally serves them through its
+ * default static resource handler, but a host application can disable that handler
+ * entirely with {@code spring.web.resources.add-mappings=false}, which leaves the
+ * dashboard returning {@code 404} even though the {@code /bootui/api/**} endpoints
+ * keep working.</p>
+ *
+ * <p>Because this is a separate {@link WebMvcConfigurer} contribution, the handler it
+ * registers is added even when Spring Boot's default {@code /**} handler is
+ * suppressed. It is scoped to the fixed {@code /bootui/**} UI path &mdash; matching the
+ * SPA's Vite base and {@link BootUiIndexController}'s {@code forward:/bootui/index.html}
+ * &mdash; so it never re-exposes the host application's own static resources and keeps
+ * the dashboard reachable regardless of the host's static-resource configuration.</p>
+ */
+public class BootUiStaticResourceConfigurer implements WebMvcConfigurer {
+
+    static final String ASSET_PATH_PATTERN = "/bootui/**";
+
+    static final String ASSET_LOCATION = "classpath:/META-INF/resources/bootui/";
+
+    private static final Logger log = LoggerFactory.getLogger(BootUiStaticResourceConfigurer.class);
+
+    private final Environment environment;
+
+    public BootUiStaticResourceConfigurer(Environment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler(ASSET_PATH_PATTERN).addResourceLocations(ASSET_LOCATION);
+
+        if (!environment.getProperty("spring.web.resources.add-mappings", Boolean.class, true)) {
+            log.info(
+                    "spring.web.resources.add-mappings is false, which disables Spring Boot's default static "
+                            + "resource handling. BootUI registered its own handler for '{}' (serving {}) so the "
+                            + "dashboard UI still loads.",
+                    ASSET_PATH_PATTERN,
+                    ASSET_LOCATION);
+        }
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -1,6 +1,10 @@
 package io.github.jdubois.bootui.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import io.github.jdubois.bootui.autoconfigure.architecture.ArchitectureController;
 import io.github.jdubois.bootui.autoconfigure.config.ConfigOverrideService;
@@ -38,6 +42,10 @@ import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.handler.SimpleUrlHandlerMapping;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 class BootUiAutoConfigurationTests {
@@ -264,6 +272,50 @@ class BootUiAutoConfigurationTests {
                                     assertThat(mappingInfo.getPatternValues()).contains("/bootui/api/overview"));
                     assertThat(beanFactory.containsSingleton(overviewBeanName)).isFalse();
                 });
+    }
+
+    @Test
+    void registersBootUiResourceHandlerByDefault() {
+        webMvcRunner().withPropertyValues("bootui.enabled=ON").run(context -> {
+            assertThat(context).hasSingleBean(BootUiStaticResourceConfigurer.class);
+            assertThat(bootUiResourcePatterns(context)).contains("/bootui/**");
+        });
+    }
+
+    @Test
+    void servesBootUiAssetsEvenWhenDefaultResourceMappingsDisabled() {
+        webMvcRunner()
+                .withPropertyValues("bootui.enabled=ON", "spring.web.resources.add-mappings=false")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(BootUiStaticResourceConfigurer.class);
+                    // Spring Boot drops its default "/**" handler, but BootUI still registers its own,
+                    // so the SPA shell is actually served from the classpath rather than returning 404.
+                    MockMvc mvc = MockMvcBuilders.webAppContextSetup(
+                                    (WebApplicationContext) context.getSourceApplicationContext())
+                            .build();
+                    mvc.perform(get("/bootui/index.html"))
+                            .andExpect(status().isOk())
+                            .andExpect(content().string(containsString("bootui-test-index")));
+                });
+    }
+
+    @Test
+    void doesNotRegisterStaticResourceConfigurerWhenInactive() {
+        runner.run(context -> assertThat(context).doesNotHaveBean(BootUiStaticResourceConfigurer.class));
+    }
+
+    private static WebApplicationContextRunner webMvcRunner() {
+        return new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        DispatcherServletAutoConfiguration.class,
+                        WebMvcAutoConfiguration.class,
+                        BootUiAutoConfiguration.class));
+    }
+
+    private static java.util.Set<String> bootUiResourcePatterns(
+            org.springframework.context.ApplicationContext context) {
+        SimpleUrlHandlerMapping mapping = (SimpleUrlHandlerMapping) context.getBean("resourceHandlerMapping");
+        return mapping.getUrlMap().keySet();
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/resources/META-INF/resources/bootui/index.html
+++ b/bootui-autoconfigure/src/test/resources/META-INF/resources/bootui/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<!-- Test-only stand-in for the packaged BootUI SPA shell (real asset ships in bootui-ui). -->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>BootUI test index</title>
+  </head>
+  <body>
+    bootui-test-index
+  </body>
+</html>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -86,4 +86,4 @@ app restarts; BootUI returns that warning with every override mutation.
 | A panel is empty             | Enable the relevant Actuator endpoint or optional Spring module; BootUI degrades to stable empty DTOs when data is unavailable.         |
 | Startup Timeline is empty    | Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero, or provide your own `BufferingApplicationStartup`. |
 | Secrets are hidden           | Default exposure is `MASKED`; use `METADATA_ONLY` to hide all values or `FULL` only in trusted local sessions.                          |
-| Static resources disabled    | `spring.web.resources.add-mappings=false` no longer breaks BootUI: it registers its own `/bootui/**` handler for the dashboard assets and logs an INFO line; the host's other static resources stay disabled. |
+| Static resources disabled    | `spring.web.resources.add-mappings=false` no longer breaks BootUI: it registers its own `/bootui/**` handler for the dashboard assets and logs a WARN line; the host's other static resources stay disabled. |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -86,3 +86,4 @@ app restarts; BootUI returns that warning with every override mutation.
 | A panel is empty             | Enable the relevant Actuator endpoint or optional Spring module; BootUI degrades to stable empty DTOs when data is unavailable.         |
 | Startup Timeline is empty    | Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero, or provide your own `BufferingApplicationStartup`. |
 | Secrets are hidden           | Default exposure is `MASKED`; use `METADATA_ONLY` to hide all values or `FULL` only in trusted local sessions.                          |
+| Static resources disabled    | `spring.web.resources.add-mappings=false` no longer breaks BootUI: it registers its own `/bootui/**` handler for the dashboard assets and logs an INFO line; the host's other static resources stay disabled. |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -86,4 +86,4 @@ app restarts; BootUI returns that warning with every override mutation.
 | A panel is empty             | Enable the relevant Actuator endpoint or optional Spring module; BootUI degrades to stable empty DTOs when data is unavailable.         |
 | Startup Timeline is empty    | Leave `bootui.startup.enabled=true` and `bootui.startup.capacity` greater than zero, or provide your own `BufferingApplicationStartup`. |
 | Secrets are hidden           | Default exposure is `MASKED`; use `METADATA_ONLY` to hide all values or `FULL` only in trusted local sessions.                          |
-| Static resources disabled    | `spring.web.resources.add-mappings=false` no longer breaks BootUI: it registers its own `/bootui/**` handler for the dashboard assets and logs a WARN line; the host's other static resources stay disabled. |
+| Static resources disabled    | `spring.web.resources.add-mappings=false` is bypassed by BootUI: it registers its own `/bootui/**` handler for its Web-based dashboard assets and logs a WARN line; the host's other static resources stay disabled. |


### PR DESCRIPTION
Fixes #291

## Problem
BootUI's Vue SPA (`index.html` + JS/CSS) is served as a **static classpath resource** from `META-INF/resources/bootui/`. When a host app sets `spring.web.resources.add-mappings=false`, Spring Boot removes its default static resource handlers, so `/bootui/index.html` returns 404 and the dashboard never loads. The `/bootui/api/**` REST endpoints (real `@RequestMapping` handlers) keep working, which makes the cause non-obvious — exactly the confusion reported in the issue.

## Fix (auto-fix + log)
Add `BootUiStaticResourceConfigurer`, a `WebMvcConfigurer` that registers a dedicated resource handler for `/bootui/**` → `classpath:/META-INF/resources/bootui/`.

- Because it's a **separate** configurer contribution, the handler is added even when Spring Boot's default `/**` handler is suppressed by `add-mappings=false` — so the dashboard loads regardless of the host's static-resource configuration.
- It's scoped to the fixed `/bootui/**` UI path (matching the SPA's Vite base and `BootUiIndexController`'s `forward:/bootui/index.html`), so it never re-exposes the host's own static resources.
- When `add-mappings=false` is detected, it logs an **INFO** line noting BootUI registered its own handler.

It coexists cleanly when default mappings are enabled (the more-specific `/bootui/**` pattern wins for assets; `@RequestMapping` handlers still take precedence for the API). No exception is thrown — BootUI must never break host startup.

## Tests
- `registersBootUiResourceHandlerByDefault` — handler present with default mappings.
- `servesBootUiAssetsEvenWhenDefaultResourceMappingsDisabled` — end-to-end MockMvc `GET /bootui/index.html` returns **200** with `spring.web.resources.add-mappings=false` (uses a test-only `META-INF/resources/bootui/index.html` stand-in).
- `doesNotRegisterStaticResourceConfigurerWhenInactive` — no bean when BootUI is inactive.

Full `bootui-autoconfigure` suite (787 tests) passes; `spotless:check` is clean. Added a Troubleshooting row to `docs/SETUP.md`.