### PR TITLE
Reduce duplicate code flagged by SonarCloud

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AgentSessionController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AgentSessionController.java
@@ -1,0 +1,158 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
+import io.github.jdubois.bootui.core.dto.CopilotDashboardDto;
+import io.github.jdubois.bootui.core.dto.CopilotEventListDto;
+import io.github.jdubois.bootui.core.dto.CopilotRawEventDto;
+import io.github.jdubois.bootui.core.dto.CopilotSessionDetail;
+import io.github.jdubois.bootui.core.dto.CopilotSessionListDto;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * Shared read-only REST endpoints for agent activity panels (Copilot, Claude Code).
+ *
+ * <p>Both panels expose the same session/event/stream shape over an {@link AgentSessionStore};
+ * concrete subclasses only add the {@code @RestController}/{@code @RequestMapping} wiring, the
+ * backing store, and a human-readable {@code streamLabel} used in stream-limit messages.
+ *
+ * <p>Read-only by design. The default response payload contains only allowlisted, sanitized
+ * fields - never raw prompts, tool arguments, command output, or diffs. The {@code /raw} endpoint
+ * is the single opt-in escape hatch for inspecting the source JSON locally, and is gated by the
+ * per-agent {@code allow-raw-reveal} flag and the existing {@code bootui.expose-values} setting.
+ */
+public abstract class AgentSessionController {
+
+    /** Upper bound on simultaneous activity streams; this is a local dev tool, not a fan-out hub. */
+    static final int MAX_CONCURRENT_STREAMS = 20;
+
+    private final Supplier<? extends AgentSessionStore> store;
+    private final BootUiExposure exposure;
+    private final String streamLabel;
+    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    protected AgentSessionController(
+            Supplier<? extends AgentSessionStore> store, BootUiExposure exposure, String streamLabel) {
+        this.store = store;
+        this.exposure = exposure;
+        this.streamLabel = streamLabel;
+    }
+
+    @GetMapping("/sessions")
+    public CopilotSessionListDto sessions(
+            @RequestParam(name = "since", required = false) Long since,
+            @RequestParam(name = "until", required = false) Long until) {
+        return store().listSessions(since, until);
+    }
+
+    @GetMapping("/dashboard")
+    public CopilotDashboardDto dashboard() {
+        return store().dashboard();
+    }
+
+    @GetMapping("/sessions/{id}")
+    public ResponseEntity<CopilotSessionDetail> session(@PathVariable String id) {
+        CopilotSessionDetail detail = store().getSession(id);
+        if (detail == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(detail);
+    }
+
+    @GetMapping("/sessions/{id}/events")
+    public ResponseEntity<CopilotEventListDto> events(
+            @PathVariable String id,
+            @RequestParam(name = "category", required = false) String category,
+            @RequestParam(name = "since", required = false) Long since,
+            @RequestParam(name = "limit", required = false, defaultValue = "200") int limit) {
+        AgentSessionStore store = store();
+        if (store.getSession(id) == null) {
+            return ResponseEntity.notFound().build();
+        }
+        var events = store.listEvents(id, category, since, limit);
+        int total = store.totalEvents(id, category, since);
+        return ResponseEntity.ok(new CopilotEventListDto(id, total, events.size(), events));
+    }
+
+    @GetMapping("/sessions/{id}/events/{eventId}/raw")
+    public ResponseEntity<CopilotRawEventDto> raw(@PathVariable String id, @PathVariable String eventId) {
+        AgentSessionStore store = store();
+        if (!store.isRawRevealAllowed()) {
+            return ResponseEntity.notFound().build();
+        }
+        if (exposure.valueExposure() == BootUiProperties.ValueExposure.METADATA_ONLY) {
+            return ResponseEntity.notFound().build();
+        }
+        String json = store.getRawEventJson(id, eventId);
+        if (json == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(new CopilotRawEventDto(id, eventId, json));
+    }
+
+    @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter stream() {
+        AgentSessionStore store = store();
+        SseEmitter emitter = new SseEmitter(0L);
+        if (emitters.size() >= MAX_CONCURRENT_STREAMS) {
+            emitter.completeWithError(
+                    new IllegalStateException("Too many concurrent BootUI " + streamLabel + " streams"));
+            return emitter;
+        }
+        emitters.add(emitter);
+
+        AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {});
+        emitter.onCompletion(() -> cleanup(emitter, unsubscribeRef.get()));
+        emitter.onTimeout(() -> cleanup(emitter, unsubscribeRef.get()));
+        emitter.onError(error -> cleanup(emitter, unsubscribeRef.get()));
+
+        try {
+            emitter.send(SseEmitter.event().name("sessions").data(store.listSessions(), MediaType.APPLICATION_JSON));
+            emitter.send(SseEmitter.event().name("dashboard").data(store.dashboard(), MediaType.APPLICATION_JSON));
+        } catch (IOException ex) {
+            cleanup(emitter, unsubscribeRef.get());
+            emitter.completeWithError(ex);
+            return emitter;
+        }
+
+        Runnable unsubscribe = store.subscribe(refresh -> {
+            try {
+                emitter.send(
+                        SseEmitter.event().name("sessions").data(store.listSessions(), MediaType.APPLICATION_JSON));
+                emitter.send(SseEmitter.event().name("dashboard").data(store.dashboard(), MediaType.APPLICATION_JSON));
+            } catch (IOException ex) {
+                cleanup(emitter, unsubscribeRef.get());
+                emitter.completeWithError(ex);
+            }
+        });
+        unsubscribeRef.set(unsubscribe);
+
+        return emitter;
+    }
+
+    private void cleanup(SseEmitter emitter, Runnable unsubscribe) {
+        emitters.remove(emitter);
+        if (unsubscribe != null) {
+            unsubscribe.run();
+        }
+    }
+
+    // exposed only for testing
+    List<SseEmitter> emittersForTesting() {
+        return emitters;
+    }
+
+    private AgentSessionStore store() {
+        return store.get();
+    }
+}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ClaudeCodeController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ClaudeCodeController.java
@@ -2,164 +2,29 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
-import io.github.jdubois.bootui.core.dto.CopilotDashboardDto;
-import io.github.jdubois.bootui.core.dto.CopilotEventListDto;
-import io.github.jdubois.bootui.core.dto.CopilotRawEventDto;
-import io.github.jdubois.bootui.core.dto.CopilotSessionDetail;
-import io.github.jdubois.bootui.core.dto.CopilotSessionListDto;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /**
  * REST endpoints backing the BootUI Claude Code panel.
+ *
+ * <p>All endpoint behavior lives in {@link AgentSessionController}.
  */
 @RestController
 @RequestMapping("/bootui/api/claude-code")
-public class ClaudeCodeController {
-
-    private final Supplier<ClaudeCodeSessionStore> store;
-    private final BootUiExposure exposure;
-    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
-
-    /** Upper bound on simultaneous activity streams; this is a local dev tool, not a fan-out hub. */
-    static final int MAX_CONCURRENT_STREAMS = 20;
+public class ClaudeCodeController extends AgentSessionController {
 
     @Autowired
     public ClaudeCodeController(
             @Qualifier("bootUiClaudeCodeSessionStore") ObjectProvider<ClaudeCodeSessionStore> storeProvider,
-            BootUiProperties properties,
             BootUiExposure exposure) {
-        this(storeProvider::getObject, properties, exposure);
+        super(storeProvider::getObject, exposure, "Claude Code");
     }
 
     ClaudeCodeController(ClaudeCodeSessionStore store, BootUiProperties properties) {
-        this(() -> store, properties, new BootUiExposure(properties));
-    }
-
-    private ClaudeCodeController(
-            Supplier<ClaudeCodeSessionStore> store, BootUiProperties properties, BootUiExposure exposure) {
-        this.store = store;
-        this.exposure = exposure;
-    }
-
-    @GetMapping("/sessions")
-    public CopilotSessionListDto sessions(
-            @RequestParam(name = "since", required = false) Long since,
-            @RequestParam(name = "until", required = false) Long until) {
-        return store().listSessions(since, until);
-    }
-
-    @GetMapping("/dashboard")
-    public CopilotDashboardDto dashboard() {
-        return store().dashboard();
-    }
-
-    @GetMapping("/sessions/{id}")
-    public ResponseEntity<CopilotSessionDetail> session(@PathVariable String id) {
-        CopilotSessionDetail detail = store().getSession(id);
-        if (detail == null) {
-            return ResponseEntity.notFound().build();
-        }
-        return ResponseEntity.ok(detail);
-    }
-
-    @GetMapping("/sessions/{id}/events")
-    public ResponseEntity<CopilotEventListDto> events(
-            @PathVariable String id,
-            @RequestParam(name = "category", required = false) String category,
-            @RequestParam(name = "since", required = false) Long since,
-            @RequestParam(name = "limit", required = false, defaultValue = "200") int limit) {
-        ClaudeCodeSessionStore store = store();
-        if (store.getSession(id) == null) {
-            return ResponseEntity.notFound().build();
-        }
-        var events = store.listEvents(id, category, since, limit);
-        int total = store.totalEvents(id, category, since);
-        return ResponseEntity.ok(new CopilotEventListDto(id, total, events.size(), events));
-    }
-
-    @GetMapping("/sessions/{id}/events/{eventId}/raw")
-    public ResponseEntity<CopilotRawEventDto> raw(@PathVariable String id, @PathVariable String eventId) {
-        ClaudeCodeSessionStore store = store();
-        if (!store.isRawRevealAllowed()) {
-            return ResponseEntity.notFound().build();
-        }
-        if (exposure.valueExposure() == BootUiProperties.ValueExposure.METADATA_ONLY) {
-            return ResponseEntity.notFound().build();
-        }
-        String json = store.getRawEventJson(id, eventId);
-        if (json == null) {
-            return ResponseEntity.notFound().build();
-        }
-        return ResponseEntity.ok(new CopilotRawEventDto(id, eventId, json));
-    }
-
-    @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream() {
-        ClaudeCodeSessionStore store = store();
-        SseEmitter emitter = new SseEmitter(0L);
-        if (emitters.size() >= MAX_CONCURRENT_STREAMS) {
-            emitter.completeWithError(new IllegalStateException("Too many concurrent BootUI Claude Code streams"));
-            return emitter;
-        }
-        emitters.add(emitter);
-
-        AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {});
-        emitter.onCompletion(() -> cleanup(emitter, unsubscribeRef.get()));
-        emitter.onTimeout(() -> cleanup(emitter, unsubscribeRef.get()));
-        emitter.onError(error -> cleanup(emitter, unsubscribeRef.get()));
-
-        try {
-            emitter.send(SseEmitter.event().name("sessions").data(store.listSessions(), MediaType.APPLICATION_JSON));
-            emitter.send(SseEmitter.event().name("dashboard").data(store.dashboard(), MediaType.APPLICATION_JSON));
-        } catch (IOException ex) {
-            cleanup(emitter, unsubscribeRef.get());
-            emitter.completeWithError(ex);
-            return emitter;
-        }
-
-        Runnable unsubscribe = store.subscribe(refresh -> {
-            try {
-                emitter.send(
-                        SseEmitter.event().name("sessions").data(store.listSessions(), MediaType.APPLICATION_JSON));
-                emitter.send(SseEmitter.event().name("dashboard").data(store.dashboard(), MediaType.APPLICATION_JSON));
-            } catch (IOException ex) {
-                cleanup(emitter, unsubscribeRef.get());
-                emitter.completeWithError(ex);
-            }
-        });
-        unsubscribeRef.set(unsubscribe);
-
-        return emitter;
-    }
-
-    private void cleanup(SseEmitter emitter, Runnable unsubscribe) {
-        emitters.remove(emitter);
-        if (unsubscribe != null) {
-            unsubscribe.run();
-        }
-    }
-
-    // exposed only for testing
-    List<SseEmitter> emittersForTesting() {
-        return emitters;
-    }
-
-    private ClaudeCodeSessionStore store() {
-        return store.get();
+        super(() -> store, new BootUiExposure(properties), "Claude Code");
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CopilotController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/CopilotController.java
@@ -2,27 +2,11 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
-import io.github.jdubois.bootui.core.dto.CopilotDashboardDto;
-import io.github.jdubois.bootui.core.dto.CopilotEventListDto;
-import io.github.jdubois.bootui.core.dto.CopilotRawEventDto;
-import io.github.jdubois.bootui.core.dto.CopilotSessionDetail;
-import io.github.jdubois.bootui.core.dto.CopilotSessionListDto;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /**
  * REST endpoints backing the BootUI Copilot panel.
@@ -31,141 +15,22 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
  * sanitized fields - never raw prompts, tool arguments, command output, or diffs.
  * The {@code /raw} endpoint is the single opt-in escape hatch for inspecting the
  * source JSON locally, and is gated by {@code bootui.copilot.allow-raw-reveal} and
- * the existing {@code bootui.expose-values} setting.</p>
+ * the existing {@code bootui.expose-values} setting.
+ *
+ * <p>All endpoint behavior lives in {@link AgentSessionController}.
  */
 @RestController
 @RequestMapping("/bootui/api/copilot")
-public class CopilotController {
-
-    private final Supplier<CopilotSessionStore> store;
-    private final BootUiExposure exposure;
-    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
-
-    /** Upper bound on simultaneous activity streams; this is a local dev tool, not a fan-out hub. */
-    static final int MAX_CONCURRENT_STREAMS = 20;
+public class CopilotController extends AgentSessionController {
 
     @Autowired
     public CopilotController(
             @Qualifier("bootUiCopilotSessionStore") ObjectProvider<CopilotSessionStore> storeProvider,
-            BootUiProperties properties,
             BootUiExposure exposure) {
-        this(storeProvider::getObject, properties, exposure);
+        super(storeProvider::getObject, exposure, "Copilot");
     }
 
     CopilotController(CopilotSessionStore store, BootUiProperties properties) {
-        this(() -> store, properties, new BootUiExposure(properties));
-    }
-
-    private CopilotController(
-            Supplier<CopilotSessionStore> store, BootUiProperties properties, BootUiExposure exposure) {
-        this.store = store;
-        this.exposure = exposure;
-    }
-
-    @GetMapping("/sessions")
-    public CopilotSessionListDto sessions(
-            @RequestParam(name = "since", required = false) Long since,
-            @RequestParam(name = "until", required = false) Long until) {
-        return store().listSessions(since, until);
-    }
-
-    @GetMapping("/dashboard")
-    public CopilotDashboardDto dashboard() {
-        return store().dashboard();
-    }
-
-    @GetMapping("/sessions/{id}")
-    public ResponseEntity<CopilotSessionDetail> session(@PathVariable String id) {
-        CopilotSessionDetail detail = store().getSession(id);
-        if (detail == null) {
-            return ResponseEntity.notFound().build();
-        }
-        return ResponseEntity.ok(detail);
-    }
-
-    @GetMapping("/sessions/{id}/events")
-    public ResponseEntity<CopilotEventListDto> events(
-            @PathVariable String id,
-            @RequestParam(name = "category", required = false) String category,
-            @RequestParam(name = "since", required = false) Long since,
-            @RequestParam(name = "limit", required = false, defaultValue = "200") int limit) {
-        CopilotSessionStore store = store();
-        if (store.getSession(id) == null) {
-            return ResponseEntity.notFound().build();
-        }
-        var events = store.listEvents(id, category, since, limit);
-        int total = store.totalEvents(id, category, since);
-        return ResponseEntity.ok(new CopilotEventListDto(id, total, events.size(), events));
-    }
-
-    @GetMapping("/sessions/{id}/events/{eventId}/raw")
-    public ResponseEntity<CopilotRawEventDto> raw(@PathVariable String id, @PathVariable String eventId) {
-        CopilotSessionStore store = store();
-        if (!store.isRawRevealAllowed()) {
-            return ResponseEntity.notFound().build();
-        }
-        if (exposure.valueExposure() == BootUiProperties.ValueExposure.METADATA_ONLY) {
-            return ResponseEntity.notFound().build();
-        }
-        String json = store.getRawEventJson(id, eventId);
-        if (json == null) {
-            return ResponseEntity.notFound().build();
-        }
-        return ResponseEntity.ok(new CopilotRawEventDto(id, eventId, json));
-    }
-
-    @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter stream() {
-        CopilotSessionStore store = store();
-        SseEmitter emitter = new SseEmitter(0L);
-        if (emitters.size() >= MAX_CONCURRENT_STREAMS) {
-            emitter.completeWithError(new IllegalStateException("Too many concurrent BootUI Copilot streams"));
-            return emitter;
-        }
-        emitters.add(emitter);
-
-        AtomicReference<Runnable> unsubscribeRef = new AtomicReference<>(() -> {});
-        emitter.onCompletion(() -> cleanup(emitter, unsubscribeRef.get()));
-        emitter.onTimeout(() -> cleanup(emitter, unsubscribeRef.get()));
-        emitter.onError(error -> cleanup(emitter, unsubscribeRef.get()));
-
-        try {
-            emitter.send(SseEmitter.event().name("sessions").data(store.listSessions(), MediaType.APPLICATION_JSON));
-            emitter.send(SseEmitter.event().name("dashboard").data(store.dashboard(), MediaType.APPLICATION_JSON));
-        } catch (IOException ex) {
-            cleanup(emitter, unsubscribeRef.get());
-            emitter.completeWithError(ex);
-            return emitter;
-        }
-
-        Runnable unsubscribe = store.subscribe(refresh -> {
-            try {
-                emitter.send(
-                        SseEmitter.event().name("sessions").data(store.listSessions(), MediaType.APPLICATION_JSON));
-                emitter.send(SseEmitter.event().name("dashboard").data(store.dashboard(), MediaType.APPLICATION_JSON));
-            } catch (IOException ex) {
-                cleanup(emitter, unsubscribeRef.get());
-                emitter.completeWithError(ex);
-            }
-        });
-        unsubscribeRef.set(unsubscribe);
-
-        return emitter;
-    }
-
-    private void cleanup(SseEmitter emitter, Runnable unsubscribe) {
-        emitters.remove(emitter);
-        if (unsubscribe != null) {
-            unsubscribe.run();
-        }
-    }
-
-    // exposed only for testing
-    List<SseEmitter> emittersForTesting() {
-        return emitters;
-    }
-
-    private CopilotSessionStore store() {
-        return store.get();
+        super(() -> store, new BootUiExposure(properties), "Copilot");
     }
 }

--- a/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.js
+++ b/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.js
@@ -1,0 +1,171 @@
+import {apiFetch} from '../api.js'
+import {computed, onMounted, reactive, ref} from 'vue'
+import {formatClockTime} from './format.js'
+import {describeLoadError} from './loadError.js'
+import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from './scanStatus.js'
+import {usePanelState} from './panelState.js'
+import {useDismissedRules} from './useDismissedRules.js'
+
+const DEFAULT_SEVERITY_CLASSES = {
+  HIGH: 'text-bg-danger',
+  MEDIUM: 'text-bg-warning',
+  LOW: 'text-bg-info',
+  INFO: 'text-bg-secondary'
+}
+
+const DEFAULT_STATUS_CLASSES = {
+  PASS: 'text-bg-success',
+  VIOLATION: 'text-bg-danger',
+  SKIPPED: 'text-bg-secondary',
+  ERROR: 'text-bg-warning'
+}
+
+const DEFAULT_SEVERITY_ORDER = ['HIGH', 'MEDIUM', 'LOW', 'INFO']
+
+/**
+ * Shared logic for the rule-based advisor panels (Spring, REST API, Architecture,
+ * Hibernate, Security, Memory, Pentesting). Each panel renders a scan status,
+ * severity breakdown, and rule/finding results from the same advisor report shape,
+ * so the only per-panel differences are the API path and the user-facing copy passed
+ * via `options`.
+ *
+ * Returns a `reactive` object whose members are consumed directly in the template as
+ * `panel.<member>`; refs and computeds are unwrapped on access.
+ */
+export function useAdvisorPanel(props, options) {
+  const severityClasses = options.severityClasses || DEFAULT_SEVERITY_CLASSES
+  const statusClasses = options.statusClasses || DEFAULT_STATUS_CLASSES
+  const severityOrder = options.severityOrder || DEFAULT_SEVERITY_ORDER
+  const countNoun = options.countNoun || 'finding'
+
+  const {readOnly, readOnlyReason} = usePanelState(props)
+  const report = ref(null)
+  const error = ref(null)
+  const actionMessage = ref(null)
+  const loading = ref(false)
+
+  const {dismissLoading, dismiss, restore} = useDismissedRules(loadReport)
+
+  const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
+
+  const violations = computed(() =>
+    [...(report.value?.results || [])].filter((result) => result.status === 'VIOLATION').sort(compareImportance)
+  )
+
+  const visibleResults = computed(() => violations.value.filter((result) => !result.dismissed))
+
+  const dismissedResults = computed(() => violations.value.filter((result) => result.dismissed))
+
+  const maxSeverityCount = computed(() => {
+    if (!report.value?.severityCounts?.length) return 1
+    return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+  })
+
+  const emptyRuleResultsTitle = computed(() => {
+    if (!hasScanData.value) return options.emptyScanPrompt
+    if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
+    return options.emptyNoFindings
+  })
+
+  function severityClass(severity) {
+    return severityClasses[severity] || 'text-bg-light border text-dark'
+  }
+
+  function statusClass(status) {
+    return statusClasses[status] || 'text-bg-light border text-dark'
+  }
+
+  function severityWidth(count) {
+    if (count === 0) return '0%'
+    return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
+  }
+
+  function compareImportance(left, right) {
+    const severityDiff = severityRank(left.severity) - severityRank(right.severity)
+    if (severityDiff !== 0) return severityDiff
+    const countDiff = right.violationCount - left.violationCount
+    if (countDiff !== 0) return countDiff
+    return left.id.localeCompare(right.id)
+  }
+
+  function severityRank(severity) {
+    const index = severityOrder.indexOf(severity)
+    return index === -1 ? severityOrder.length : index
+  }
+
+  function pluralize(count, singular, plural = `${singular}s`) {
+    return count === 1 ? singular : plural
+  }
+
+  function violationCountLabel(count) {
+    return `${count} ${pluralize(count, countNoun)} found`
+  }
+
+  function scanTime() {
+    if (!report.value?.scan?.scannedAt) return ''
+    return formatClockTime(report.value.scan.scannedAt)
+  }
+
+  async function loadReport() {
+    try {
+      const res = await apiFetch(options.apiPath)
+      if (!res.ok) throw new Error('HTTP ' + res.status)
+      report.value = await res.json()
+      error.value = null
+    } catch (e) {
+      error.value = describeLoadError(e, options.loadErrorMessage)
+    }
+  }
+
+  async function runScan() {
+    if (readOnly.value) {
+      showReadOnlyMessage()
+      return
+    }
+    loading.value = true
+    try {
+      const res = await apiFetch(`${options.apiPath}/scan`, {method: 'POST'})
+      if (!res.ok) throw new Error('HTTP ' + res.status)
+      report.value = await res.json()
+      error.value = null
+    } catch (e) {
+      error.value = describeLoadError(e, options.scanErrorMessage)
+    } finally {
+      loading.value = false
+    }
+  }
+
+  function showReadOnlyMessage() {
+    actionMessage.value = readOnlyReason.value
+    setTimeout(() => {
+      actionMessage.value = null
+    }, 6000)
+  }
+
+  onMounted(loadReport)
+
+  return reactive({
+    readOnly,
+    readOnlyReason,
+    report,
+    error,
+    actionMessage,
+    loading,
+    dismissLoading,
+    dismiss,
+    restore,
+    hasScanData,
+    visibleResults,
+    dismissedResults,
+    emptyRuleResultsTitle,
+    severityClass,
+    statusClass,
+    severityWidth,
+    pluralize,
+    violationCountLabel,
+    scanTime,
+    runScan,
+    scanStatusBadgeClass,
+    scanStatusLabel
+  })
+}

--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -1,136 +1,18 @@
 <script setup>
-import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
-import {formatClockTime} from '../utils/format.js'
-import {describeLoadError} from '../utils/loadError.js'
-import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
-import {panelProps, usePanelState} from '../utils/panelState.js'
-import {useDismissedRules} from '../utils/useDismissedRules.js'
+import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
+import {panelProps} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
-const {readOnly, readOnlyReason} = usePanelState(props)
-const report = ref(null)
-const error = ref(null)
-const actionMessage = ref(null)
-const loading = ref(false)
-
-const {dismissLoading, dismiss, restore} = useDismissedRules(loadReport)
-
-const severityClasses = {
-  HIGH: 'text-bg-danger',
-  MEDIUM: 'text-bg-warning',
-  LOW: 'text-bg-info',
-  INFO: 'text-bg-secondary'
-}
-
-const statusClasses = {
-  PASS: 'text-bg-success',
-  VIOLATION: 'text-bg-danger',
-  SKIPPED: 'text-bg-secondary',
-  ERROR: 'text-bg-warning'
-}
-
-const severityOrder = ['HIGH', 'MEDIUM', 'LOW', 'INFO']
-
-const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
-
-const violations = computed(() =>
-  [...(report.value?.results || [])].filter((result) => result.status === 'VIOLATION').sort(compareImportance)
-)
-
-const visibleResults = computed(() => violations.value.filter((result) => !result.dismissed))
-
-const dismissedResults = computed(() => violations.value.filter((result) => result.dismissed))
-
-const maxSeverityCount = computed(() => {
-  if (!report.value?.severityCounts?.length) return 1
-  return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+const panel = useAdvisorPanel(props, {
+  apiPath: 'api/architecture',
+  loadErrorMessage: 'Unable to load architecture report',
+  scanErrorMessage: 'Unable to run architecture checks',
+  emptyScanPrompt: 'Run architecture checks to see rule violations',
+  emptyNoFindings: 'No architecture rule violations found',
+  countNoun: 'violation'
 })
-
-const emptyRuleResultsTitle = computed(() => {
-  if (!hasScanData.value) return 'Run architecture checks to see rule violations'
-  if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
-  return 'No architecture rule violations found'
-})
-
-function severityClass(severity) {
-  return severityClasses[severity] || 'text-bg-light border text-dark'
-}
-
-function statusClass(status) {
-  return statusClasses[status] || 'text-bg-light border text-dark'
-}
-
-function severityWidth(count) {
-  if (count === 0) return '0%'
-  return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
-}
-
-function compareImportance(left, right) {
-  const severityDiff = severityRank(left.severity) - severityRank(right.severity)
-  if (severityDiff !== 0) return severityDiff
-  const countDiff = right.violationCount - left.violationCount
-  if (countDiff !== 0) return countDiff
-  return left.id.localeCompare(right.id)
-}
-
-function severityRank(severity) {
-  const index = severityOrder.indexOf(severity)
-  return index === -1 ? severityOrder.length : index
-}
-
-function pluralize(count, singular, plural = `${singular}s`) {
-  return count === 1 ? singular : plural
-}
-
-function violationCountLabel(count) {
-  return `${count} ${pluralize(count, 'violation')} found`
-}
-
-function scanTime() {
-  if (!report.value?.scan?.scannedAt) return ''
-  return formatClockTime(report.value.scan.scannedAt)
-}
-
-async function loadReport() {
-  try {
-    const res = await apiFetch('api/architecture')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to load architecture report')
-  }
-}
-
-async function runScan() {
-  if (readOnly.value) {
-    showReadOnlyMessage()
-    return
-  }
-  loading.value = true
-  try {
-    const res = await apiFetch('api/architecture/scan', {method: 'POST'})
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to run architecture checks')
-  } finally {
-    loading.value = false
-  }
-}
-
-function showReadOnlyMessage() {
-  actionMessage.value = readOnlyReason.value
-  setTimeout(() => {
-    actionMessage.value = null
-  }, 6000)
-}
-
-onMounted(loadReport)
 </script>
 
 <template>
@@ -139,28 +21,28 @@ onMounted(loadReport)
       icon="bi-diagram-2"
       title="Architecture"
       subtitle="Run curated, project-agnostic ArchUnit rules against the host application's own classes."
-      :loading="loading"
-      :error="error"
+      :loading="panel.loading"
+      :error="panel.error"
     >
       <template #actions>
         <SpinnerButton
-          :loading="loading"
-          :disabled="loading || readOnly"
+          :loading="panel.loading"
+          :disabled="panel.loading || panel.readOnly"
           class="btn btn-primary"
           type="button"
           label="Run architecture checks"
           loading-label="Running..."
-          @click="runScan"
+          @click="panel.runScan"
         />
       </template>
     </PanelHeader>
-    <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>
+    <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
-    <template v-if="report">
+    <template v-if="panel.report">
       <div class="alert alert-info">
         <strong>Heuristic architecture rules.</strong>
-        {{ report.disclaimer }}
-        <span v-if="readOnly">Scanning is read-only. {{ readOnlyReason }}</span>
+        {{ panel.report.disclaimer }}
+        <span v-if="panel.readOnly">Scanning is read-only. {{ panel.readOnlyReason }}</span>
       </div>
 
       <div class="row g-3 mb-3">
@@ -169,11 +51,11 @@ onMounted(loadReport)
             <div class="card-body">
               <div class="text-muted small">Scan status</div>
               <div class="mt-2">
-                <span :class="scanStatusBadgeClass(report.scan.status)" class="badge fs-6">
-                  {{ scanStatusLabel(report.scan.status) }}
+                <span :class="panel.scanStatusBadgeClass(panel.report.scan.status)" class="badge fs-6">
+                  {{ panel.scanStatusLabel(panel.report.scan.status) }}
                 </span>
               </div>
-              <div v-if="scanTime()" class="small text-muted">Scanned at {{ scanTime() }}</div>
+              <div v-if="panel.scanTime()" class="small text-muted">Scanned at {{ panel.scanTime() }}</div>
             </div>
           </div>
         </div>
@@ -181,7 +63,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Rules evaluated</div>
-              <div class="display-6">{{ report.rulesEvaluated }}</div>
+              <div class="display-6">{{ panel.report.rulesEvaluated }}</div>
             </div>
           </div>
         </div>
@@ -189,9 +71,9 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Rule violations</div>
-              <div class="display-6">{{ report.violationsFound }}</div>
-              <div v-if="dismissedResults.length > 0" class="small text-muted">
-                {{ dismissedResults.length }} dismissed
+              <div class="display-6">{{ panel.report.violationsFound }}</div>
+              <div v-if="panel.dismissedResults.length > 0" class="small text-muted">
+                {{ panel.dismissedResults.length }} dismissed
               </div>
             </div>
           </div>
@@ -200,7 +82,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Classes analysed</div>
-              <div class="display-6">{{ report.classesAnalyzed }}</div>
+              <div class="display-6">{{ panel.report.classesAnalyzed }}</div>
             </div>
           </div>
         </div>
@@ -211,25 +93,25 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Violations by severity</div>
             <div class="card-body">
-              <div v-if="!hasScanData" class="text-center text-muted py-4">
+              <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
                 <div class="fw-semibold text-body">No architecture data yet</div>
                 <div>Run architecture checks to populate rule results.</div>
               </div>
               <div
-                v-for="item in report.severityCounts"
+                v-for="item in panel.report.severityCounts"
                 v-else
                 :key="item.severity"
                 class="row align-items-center g-2 mb-2"
               >
                 <div class="col-3">
-                  <span :class="severityClass(item.severity)" class="badge">{{ item.severity }}</span>
+                  <span :class="panel.severityClass(item.severity)" class="badge">{{ item.severity }}</span>
                 </div>
                 <div class="col">
                   <div :aria-label="`${item.severity} violations: ${item.count}`" class="progress" role="img">
                     <div
-                      :class="severityClass(item.severity)"
-                      :style="{width: severityWidth(item.count)}"
+                      :class="panel.severityClass(item.severity)"
+                      :style="{width: panel.severityWidth(item.count)}"
                       class="progress-bar"
                     ></div>
                   </div>
@@ -244,11 +126,11 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Base packages</div>
             <div class="card-body">
-              <div v-if="!report.basePackages || report.basePackages.length === 0" class="text-muted">
+              <div v-if="!panel.report.basePackages || panel.report.basePackages.length === 0" class="text-muted">
                 No application base package was detected.
               </div>
               <ul v-else class="list-unstyled mb-0">
-                <li v-for="pkg in report.basePackages" :key="pkg" class="font-monospace small">
+                <li v-for="pkg in panel.report.basePackages" :key="pkg" class="font-monospace small">
                   <i class="bi bi-box me-1"></i>{{ pkg }}
                 </li>
               </ul>
@@ -262,36 +144,36 @@ onMounted(loadReport)
           <div>
             <div class="fw-semibold">Rule results</div>
             <div class="text-muted small">
-              <template v-if="hasScanData && visibleResults.length > 0">
-                {{ visibleResults.length }} {{ pluralize(visibleResults.length, 'violating rule') }}, sorted by
-                importance
+              <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
+                {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'violating rule') }},
+                sorted by importance
               </template>
-              <template v-else>{{ visibleResults.length }} rule violation(s)</template>
+              <template v-else>{{ panel.visibleResults.length }} rule violation(s)</template>
             </div>
           </div>
           <span
-            v-if="hasScanData && visibleResults.length === 0 && dismissedResults.length === 0"
+            v-if="panel.hasScanData && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
             >No violations</span
           >
         </div>
-        <div v-if="visibleResults.length === 0" class="card-body text-center text-muted py-5">
+        <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-diagram-2 fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">{{ emptyRuleResultsTitle }}</div>
+          <div class="fw-semibold text-body">{{ panel.emptyRuleResultsTitle }}</div>
           <div>A project-specific ArchUnit suite remains the best way to enforce your own architecture.</div>
         </div>
         <div v-else class="list-group list-group-flush">
-          <div v-for="result in visibleResults" :key="result.id" class="list-group-item">
+          <div v-for="result in panel.visibleResults" :key="result.id" class="list-group-item">
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-              <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-              <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+              <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+              <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
               <span class="badge text-bg-light border">{{ result.category }}</span>
               <span class="text-muted small">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
-                :disabled="dismissLoading"
-                @click="dismiss(result.id)"
+                :disabled="panel.dismissLoading"
+                @click="panel.dismiss(result.id)"
                 title="Dismiss this rule"
               >
                 <i class="bi bi-eye-slash me-1"></i>Dismiss
@@ -301,7 +183,7 @@ onMounted(loadReport)
             <div class="small text-muted mb-2">{{ result.description }}</div>
             <div class="small mb-2">
               <strong>What happened:</strong>
-              {{ violationCountLabel(result.violationCount) }} for this rule.
+              {{ panel.violationCountLabel(result.violationCount) }} for this rule.
             </div>
             <div v-if="result.sampleViolations && result.sampleViolations.length" class="mb-2">
               <div class="small fw-semibold">
@@ -319,22 +201,23 @@ onMounted(loadReport)
             </div>
           </div>
         </div>
-        <template v-if="dismissedResults.length > 0">
+        <template v-if="panel.dismissedResults.length > 0">
           <div class="card-header text-muted small">
-            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ dismissedResults.length }}) — not counted in score
+            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ panel.dismissedResults.length }}) — not counted in
+            score
           </div>
           <div class="list-group list-group-flush">
-            <div v-for="result in dismissedResults" :key="result.id" class="list-group-item opacity-50">
+            <div v-for="result in panel.dismissedResults" :key="result.id" class="list-group-item opacity-50">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
-                <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-                <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+                <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+                <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
                 <span class="badge text-bg-light border">{{ result.category }}</span>
                 <span class="text-muted small">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"
-                  :disabled="dismissLoading"
-                  @click="restore(result.id)"
+                  :disabled="panel.dismissLoading"
+                  @click="panel.restore(result.id)"
                   title="Restore this rule"
                 >
                   <i class="bi bi-eye me-1"></i>Restore

--- a/bootui-ui/src/main/frontend/src/views/Hibernate.vue
+++ b/bootui-ui/src/main/frontend/src/views/Hibernate.vue
@@ -1,136 +1,18 @@
 <script setup>
-import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
-import {formatClockTime} from '../utils/format.js'
-import {describeLoadError} from '../utils/loadError.js'
-import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
-import {panelProps, usePanelState} from '../utils/panelState.js'
-import {useDismissedRules} from '../utils/useDismissedRules.js'
+import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
+import {panelProps} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
-const {readOnly, readOnlyReason} = usePanelState(props)
-const report = ref(null)
-const error = ref(null)
-const actionMessage = ref(null)
-const loading = ref(false)
-
-const {dismissLoading, dismiss, restore} = useDismissedRules(loadReport)
-
-const severityClasses = {
-  HIGH: 'text-bg-danger',
-  MEDIUM: 'text-bg-warning',
-  LOW: 'text-bg-info',
-  INFO: 'text-bg-secondary'
-}
-
-const statusClasses = {
-  PASS: 'text-bg-success',
-  VIOLATION: 'text-bg-danger',
-  SKIPPED: 'text-bg-secondary',
-  ERROR: 'text-bg-warning'
-}
-
-const severityOrder = ['HIGH', 'MEDIUM', 'LOW', 'INFO']
-
-const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
-
-const violations = computed(() =>
-  [...(report.value?.results || [])].filter((result) => result.status === 'VIOLATION').sort(compareImportance)
-)
-
-const visibleResults = computed(() => violations.value.filter((result) => !result.dismissed))
-
-const dismissedResults = computed(() => violations.value.filter((result) => result.dismissed))
-
-const maxSeverityCount = computed(() => {
-  if (!report.value?.severityCounts?.length) return 1
-  return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+const panel = useAdvisorPanel(props, {
+  apiPath: 'api/hibernate',
+  loadErrorMessage: 'Unable to load Hibernate Advisor report',
+  scanErrorMessage: 'Unable to run Hibernate checks',
+  emptyScanPrompt: 'Run Hibernate checks to see advisor findings',
+  emptyNoFindings: 'No Hibernate Advisor findings',
+  countNoun: 'finding'
 })
-
-const emptyRuleResultsTitle = computed(() => {
-  if (!hasScanData.value) return 'Run Hibernate checks to see advisor findings'
-  if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
-  return 'No Hibernate Advisor findings'
-})
-
-function severityClass(severity) {
-  return severityClasses[severity] || 'text-bg-light border text-dark'
-}
-
-function statusClass(status) {
-  return statusClasses[status] || 'text-bg-light border text-dark'
-}
-
-function severityWidth(count) {
-  if (count === 0) return '0%'
-  return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
-}
-
-function compareImportance(left, right) {
-  const severityDiff = severityRank(left.severity) - severityRank(right.severity)
-  if (severityDiff !== 0) return severityDiff
-  const countDiff = right.violationCount - left.violationCount
-  if (countDiff !== 0) return countDiff
-  return left.id.localeCompare(right.id)
-}
-
-function severityRank(severity) {
-  const index = severityOrder.indexOf(severity)
-  return index === -1 ? severityOrder.length : index
-}
-
-function pluralize(count, singular, plural = `${singular}s`) {
-  return count === 1 ? singular : plural
-}
-
-function violationCountLabel(count) {
-  return `${count} ${pluralize(count, 'finding')} found`
-}
-
-function scanTime() {
-  if (!report.value?.scan?.scannedAt) return ''
-  return formatClockTime(report.value.scan.scannedAt)
-}
-
-async function loadReport() {
-  try {
-    const res = await apiFetch('api/hibernate')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to load Hibernate Advisor report')
-  }
-}
-
-async function runScan() {
-  if (readOnly.value) {
-    showReadOnlyMessage()
-    return
-  }
-  loading.value = true
-  try {
-    const res = await apiFetch('api/hibernate/scan', {method: 'POST'})
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to run Hibernate checks')
-  } finally {
-    loading.value = false
-  }
-}
-
-function showReadOnlyMessage() {
-  actionMessage.value = readOnlyReason.value
-  setTimeout(() => {
-    actionMessage.value = null
-  }, 6000)
-}
-
-onMounted(loadReport)
 </script>
 
 <template>
@@ -139,18 +21,18 @@ onMounted(loadReport)
       icon="bi-database-gear"
       title="Hibernate"
       subtitle="Review mapped JPA entities with bounded Hibernate performance checks."
-      :loading="loading"
-      :error="error"
+      :loading="panel.loading"
+      :error="panel.error"
     >
       <template #actions>
         <SpinnerButton
-          :loading="loading"
-          :disabled="loading || readOnly"
+          :loading="panel.loading"
+          :disabled="panel.loading || panel.readOnly"
           class="btn btn-primary"
           type="button"
           label="Run Hibernate checks"
           loading-label="Running..."
-          @click="runScan"
+          @click="panel.runScan"
         />
       </template>
     </PanelHeader>
@@ -161,13 +43,13 @@ onMounted(loadReport)
         <a href="https://vladmihalcea.com" rel="noopener noreferrer" target="_blank">https://vladmihalcea.com</a>
       </div>
     </div>
-    <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>
+    <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
-    <template v-if="report">
+    <template v-if="panel.report">
       <div class="alert alert-info">
         <strong>Heuristic Hibernate rules.</strong>
-        {{ report.disclaimer }}
-        <span v-if="readOnly">Scanning is read-only. {{ readOnlyReason }}</span>
+        {{ panel.report.disclaimer }}
+        <span v-if="panel.readOnly">Scanning is read-only. {{ panel.readOnlyReason }}</span>
       </div>
 
       <div class="row g-3 mb-3">
@@ -176,11 +58,11 @@ onMounted(loadReport)
             <div class="card-body">
               <div class="text-muted small">Scan status</div>
               <div class="mt-2">
-                <span :class="scanStatusBadgeClass(report.scan.status)" class="badge fs-6">
-                  {{ scanStatusLabel(report.scan.status) }}
+                <span :class="panel.scanStatusBadgeClass(panel.report.scan.status)" class="badge fs-6">
+                  {{ panel.scanStatusLabel(panel.report.scan.status) }}
                 </span>
               </div>
-              <div v-if="scanTime()" class="small text-muted">Scanned at {{ scanTime() }}</div>
+              <div v-if="panel.scanTime()" class="small text-muted">Scanned at {{ panel.scanTime() }}</div>
             </div>
           </div>
         </div>
@@ -188,7 +70,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Rules evaluated</div>
-              <div class="display-6">{{ report.rulesEvaluated }}</div>
+              <div class="display-6">{{ panel.report.rulesEvaluated }}</div>
             </div>
           </div>
         </div>
@@ -196,9 +78,9 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Advisor findings</div>
-              <div class="display-6">{{ report.violationsFound }}</div>
-              <div v-if="dismissedResults.length > 0" class="small text-muted">
-                {{ dismissedResults.length }} dismissed
+              <div class="display-6">{{ panel.report.violationsFound }}</div>
+              <div v-if="panel.dismissedResults.length > 0" class="small text-muted">
+                {{ panel.dismissedResults.length }} dismissed
               </div>
             </div>
           </div>
@@ -207,7 +89,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Entities analysed</div>
-              <div class="display-6">{{ report.entitiesAnalyzed }}</div>
+              <div class="display-6">{{ panel.report.entitiesAnalyzed }}</div>
             </div>
           </div>
         </div>
@@ -218,25 +100,25 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Findings by severity</div>
             <div class="card-body">
-              <div v-if="!hasScanData" class="text-center text-muted py-4">
+              <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
                 <div class="fw-semibold text-body">No Hibernate Advisor data yet</div>
                 <div>Run Hibernate checks to populate advisor findings.</div>
               </div>
               <div
-                v-for="item in report.severityCounts"
+                v-for="item in panel.report.severityCounts"
                 v-else
                 :key="item.severity"
                 class="row align-items-center g-2 mb-2"
               >
                 <div class="col-3">
-                  <span :class="severityClass(item.severity)" class="badge">{{ item.severity }}</span>
+                  <span :class="panel.severityClass(item.severity)" class="badge">{{ item.severity }}</span>
                 </div>
                 <div class="col">
                   <div :aria-label="`${item.severity} findings: ${item.count}`" class="progress" role="img">
                     <div
-                      :class="severityClass(item.severity)"
-                      :style="{width: severityWidth(item.count)}"
+                      :class="panel.severityClass(item.severity)"
+                      :style="{width: panel.severityWidth(item.count)}"
                       class="progress-bar"
                     ></div>
                   </div>
@@ -251,11 +133,11 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Entity packages</div>
             <div class="card-body">
-              <div v-if="!report.entityPackages || report.entityPackages.length === 0" class="text-muted">
+              <div v-if="!panel.report.entityPackages || panel.report.entityPackages.length === 0" class="text-muted">
                 No mapped entity package was detected.
               </div>
               <ul v-else class="list-unstyled mb-0">
-                <li v-for="pkg in report.entityPackages" :key="pkg" class="font-monospace small">
+                <li v-for="pkg in panel.report.entityPackages" :key="pkg" class="font-monospace small">
                   <i class="bi bi-box me-1"></i>{{ pkg }}
                 </li>
               </ul>
@@ -269,36 +151,36 @@ onMounted(loadReport)
           <div>
             <div class="fw-semibold">Rule results</div>
             <div class="text-muted small">
-              <template v-if="hasScanData && visibleResults.length > 0">
-                {{ visibleResults.length }} {{ pluralize(visibleResults.length, 'violating rule') }}, sorted by
-                importance
+              <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
+                {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'violating rule') }},
+                sorted by importance
               </template>
-              <template v-else>{{ visibleResults.length }} advisor finding(s)</template>
+              <template v-else>{{ panel.visibleResults.length }} advisor finding(s)</template>
             </div>
           </div>
           <span
-            v-if="hasScanData && visibleResults.length === 0 && dismissedResults.length === 0"
+            v-if="panel.hasScanData && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
             >No findings</span
           >
         </div>
-        <div v-if="visibleResults.length === 0" class="card-body text-center text-muted py-5">
+        <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-database-gear fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">{{ emptyRuleResultsTitle }}</div>
+          <div class="fw-semibold text-body">{{ panel.emptyRuleResultsTitle }}</div>
           <div>Project-specific performance tests and query reviews remain the source of truth.</div>
         </div>
         <div v-else class="list-group list-group-flush">
-          <div v-for="result in visibleResults" :key="result.id" class="list-group-item">
+          <div v-for="result in panel.visibleResults" :key="result.id" class="list-group-item">
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-              <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-              <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+              <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+              <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
               <span class="badge text-bg-light border">{{ result.category }}</span>
               <span class="text-muted small">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
-                :disabled="dismissLoading"
-                @click="dismiss(result.id)"
+                :disabled="panel.dismissLoading"
+                @click="panel.dismiss(result.id)"
                 title="Dismiss this rule"
               >
                 <i class="bi bi-eye-slash me-1"></i>Dismiss
@@ -308,7 +190,7 @@ onMounted(loadReport)
             <div class="small text-muted mb-2">{{ result.description }}</div>
             <div class="small mb-2">
               <strong>What happened:</strong>
-              {{ violationCountLabel(result.violationCount) }} for this rule.
+              {{ panel.violationCountLabel(result.violationCount) }} for this rule.
             </div>
             <div v-if="result.sampleViolations && result.sampleViolations.length" class="mb-2">
               <div class="small fw-semibold">
@@ -335,22 +217,23 @@ onMounted(loadReport)
             </div>
           </div>
         </div>
-        <template v-if="dismissedResults.length > 0">
+        <template v-if="panel.dismissedResults.length > 0">
           <div class="card-header text-muted small">
-            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ dismissedResults.length }}) — not counted in score
+            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ panel.dismissedResults.length }}) — not counted in
+            score
           </div>
           <div class="list-group list-group-flush">
-            <div v-for="result in dismissedResults" :key="result.id" class="list-group-item opacity-50">
+            <div v-for="result in panel.dismissedResults" :key="result.id" class="list-group-item opacity-50">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
-                <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-                <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+                <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+                <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
                 <span class="badge text-bg-light border">{{ result.category }}</span>
                 <span class="text-muted small">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"
-                  :disabled="dismissLoading"
-                  @click="restore(result.id)"
+                  :disabled="panel.dismissLoading"
+                  @click="panel.restore(result.id)"
                   title="Restore this rule"
                 >
                   <i class="bi bi-eye me-1"></i>Restore

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -1,95 +1,29 @@
 <script setup>
-import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
-import {describeLoadError} from '../utils/loadError.js'
-import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
-import {panelProps, usePanelState} from '../utils/panelState.js'
-import {useDismissedRules} from '../utils/useDismissedRules.js'
+import {computed} from 'vue'
+import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
+import {panelProps} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
-const {readOnly, readOnlyReason} = usePanelState(props)
-const report = ref(null)
-const error = ref(null)
-const actionMessage = ref(null)
-const loading = ref(false)
-
-const {dismissLoading, dismiss, restore} = useDismissedRules(loadReport)
-
-const severityClasses = {
-  CRITICAL: 'text-bg-danger',
-  HIGH: 'text-bg-danger',
-  MEDIUM: 'text-bg-warning',
-  LOW: 'text-bg-info',
-  INFO: 'text-bg-secondary'
-}
-
-const statusClasses = {
-  PASS: 'text-bg-success',
-  VIOLATION: 'text-bg-danger',
-  SKIPPED: 'text-bg-secondary',
-  ERROR: 'text-bg-warning'
-}
-
-const severityOrder = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO']
-
-const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
-
-const summary = computed(() => report.value?.summary || null)
-
-const violations = computed(() =>
-  [...(report.value?.results || [])].filter((result) => result.status === 'VIOLATION').sort(compareImportance)
-)
-
-const visibleResults = computed(() => violations.value.filter((result) => !result.dismissed))
-
-const dismissedResults = computed(() => violations.value.filter((result) => result.dismissed))
-
-const maxSeverityCount = computed(() => {
-  if (!report.value?.severityCounts?.length) return 1
-  return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+const panel = useAdvisorPanel(props, {
+  apiPath: 'api/memory',
+  loadErrorMessage: 'Unable to load Memory Advisor report',
+  scanErrorMessage: 'Unable to run memory checks',
+  emptyScanPrompt: 'Run memory checks to see advisor findings',
+  emptyNoFindings: 'No Memory Advisor findings',
+  countNoun: 'observation',
+  severityClasses: {
+    CRITICAL: 'text-bg-danger',
+    HIGH: 'text-bg-danger',
+    MEDIUM: 'text-bg-warning',
+    LOW: 'text-bg-info',
+    INFO: 'text-bg-secondary'
+  },
+  severityOrder: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO']
 })
 
-const emptyRuleResultsTitle = computed(() => {
-  if (!hasScanData.value) return 'Run memory checks to see advisor findings'
-  if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
-  return 'No Memory Advisor findings'
-})
-
-function severityClass(severity) {
-  return severityClasses[severity] || 'text-bg-light border text-dark'
-}
-
-function statusClass(status) {
-  return statusClasses[status] || 'text-bg-light border text-dark'
-}
-
-function severityWidth(count) {
-  if (count === 0) return '0%'
-  return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
-}
-
-function compareImportance(left, right) {
-  const severityDiff = severityRank(left.severity) - severityRank(right.severity)
-  if (severityDiff !== 0) return severityDiff
-  const countDiff = right.violationCount - left.violationCount
-  if (countDiff !== 0) return countDiff
-  return left.id.localeCompare(right.id)
-}
-
-function severityRank(severity) {
-  const index = severityOrder.indexOf(severity)
-  return index === -1 ? severityOrder.length : index
-}
-
-function pluralize(count, singular, plural = `${singular}s`) {
-  return count === 1 ? singular : plural
-}
-
-function violationCountLabel(count) {
-  return `${count} ${pluralize(count, 'observation')} found`
-}
+const summary = computed(() => panel.report?.summary || null)
 
 function formatBytes(value) {
   if (value === null || value === undefined || value < 0) return 'n/a'
@@ -102,54 +36,6 @@ function formatBytes(value) {
   }
   return `${size.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`
 }
-
-function scanTime() {
-  if (!report.value?.scan?.scannedAt) return ''
-  return new Date(report.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
-}
-
-async function loadReport() {
-  try {
-    const res = await apiFetch('api/memory')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to load Memory Advisor report')
-  }
-}
-
-async function runScan() {
-  if (readOnly.value) {
-    showReadOnlyMessage()
-    return
-  }
-  loading.value = true
-  try {
-    const res = await apiFetch('api/memory/scan', {method: 'POST'})
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to run memory checks')
-  } finally {
-    loading.value = false
-  }
-}
-
-function showReadOnlyMessage() {
-  actionMessage.value = readOnlyReason.value
-  setTimeout(() => {
-    actionMessage.value = null
-  }, 6000)
-}
-
-onMounted(loadReport)
 </script>
 
 <template>
@@ -158,28 +44,28 @@ onMounted(loadReport)
       icon="bi-clipboard2-pulse"
       title="Memory"
       subtitle="Rule-based JVM memory, GC, and thread health findings from the live management beans."
-      :loading="loading"
-      :error="error"
+      :loading="panel.loading"
+      :error="panel.error"
     >
       <template #actions>
         <SpinnerButton
-          :loading="loading"
-          :disabled="loading || readOnly"
+          :loading="panel.loading"
+          :disabled="panel.loading || panel.readOnly"
           class="btn btn-primary"
           type="button"
           label="Run memory checks"
           loading-label="Running..."
-          @click="runScan"
+          @click="panel.runScan"
         />
       </template>
     </PanelHeader>
-    <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>
+    <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
-    <template v-if="report">
+    <template v-if="panel.report">
       <div class="alert alert-info">
         <strong>Heuristic JVM memory and thread health rules.</strong>
-        {{ report.disclaimer }}
-        <span v-if="readOnly">Scanning is read-only. {{ readOnlyReason }}</span>
+        {{ panel.report.disclaimer }}
+        <span v-if="panel.readOnly">Scanning is read-only. {{ panel.readOnlyReason }}</span>
       </div>
 
       <div class="row g-3 mb-3">
@@ -188,11 +74,11 @@ onMounted(loadReport)
             <div class="card-body">
               <div class="text-muted small">Scan status</div>
               <div class="mt-2">
-                <span :class="scanStatusBadgeClass(report.scan.status)" class="badge fs-6">
-                  {{ scanStatusLabel(report.scan.status) }}
+                <span :class="panel.scanStatusBadgeClass(panel.report.scan.status)" class="badge fs-6">
+                  {{ panel.scanStatusLabel(panel.report.scan.status) }}
                 </span>
               </div>
-              <div v-if="scanTime()" class="small text-muted">Scanned at {{ scanTime() }}</div>
+              <div v-if="panel.scanTime()" class="small text-muted">Scanned at {{ panel.scanTime() }}</div>
             </div>
           </div>
         </div>
@@ -200,7 +86,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Rules evaluated</div>
-              <div class="display-6">{{ report.rulesEvaluated }}</div>
+              <div class="display-6">{{ panel.report.rulesEvaluated }}</div>
             </div>
           </div>
         </div>
@@ -208,9 +94,9 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Advisor findings</div>
-              <div class="display-6">{{ report.violationsFound }}</div>
-              <div v-if="dismissedResults.length > 0" class="small text-muted">
-                {{ dismissedResults.length }} dismissed
+              <div class="display-6">{{ panel.report.violationsFound }}</div>
+              <div v-if="panel.dismissedResults.length > 0" class="small text-muted">
+                {{ panel.dismissedResults.length }} dismissed
               </div>
             </div>
           </div>
@@ -230,25 +116,25 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Findings by severity</div>
             <div class="card-body">
-              <div v-if="!hasScanData" class="text-center text-muted py-4">
+              <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
                 <div class="fw-semibold text-body">No Memory Advisor data yet</div>
                 <div>Run memory checks to populate advisor findings.</div>
               </div>
               <div
-                v-for="item in report.severityCounts"
+                v-for="item in panel.report.severityCounts"
                 v-else
                 :key="item.severity"
                 class="row align-items-center g-2 mb-2"
               >
                 <div class="col-3">
-                  <span :class="severityClass(item.severity)" class="badge">{{ item.severity }}</span>
+                  <span :class="panel.severityClass(item.severity)" class="badge">{{ item.severity }}</span>
                 </div>
                 <div class="col">
                   <div :aria-label="`${item.severity} findings: ${item.count}`" class="progress" role="img">
                     <div
-                      :class="severityClass(item.severity)"
-                      :style="{width: severityWidth(item.count)}"
+                      :class="panel.severityClass(item.severity)"
+                      :style="{width: panel.severityWidth(item.count)}"
                       class="progress-bar"
                     ></div>
                   </div>
@@ -300,35 +186,36 @@ onMounted(loadReport)
           <div>
             <div class="fw-semibold">Rule results</div>
             <div class="text-muted small">
-              <template v-if="hasScanData && visibleResults.length > 0">
-                {{ visibleResults.length }} {{ pluralize(visibleResults.length, 'finding') }}, sorted by importance
+              <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
+                {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'finding') }}, sorted
+                by importance
               </template>
-              <template v-else>{{ visibleResults.length }} advisor finding(s)</template>
+              <template v-else>{{ panel.visibleResults.length }} advisor finding(s)</template>
             </div>
           </div>
           <span
-            v-if="hasScanData && visibleResults.length === 0 && dismissedResults.length === 0"
+            v-if="panel.hasScanData && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
             >No findings</span
           >
         </div>
-        <div v-if="visibleResults.length === 0" class="card-body text-center text-muted py-5">
+        <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-clipboard2-pulse fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">{{ emptyRuleResultsTitle }}</div>
+          <div class="fw-semibold text-body">{{ panel.emptyRuleResultsTitle }}</div>
           <div>Validate findings against the application's workload and a profiler before acting.</div>
         </div>
         <div v-else class="list-group list-group-flush">
-          <div v-for="result in visibleResults" :key="result.id" class="list-group-item">
+          <div v-for="result in panel.visibleResults" :key="result.id" class="list-group-item">
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-              <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-              <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+              <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+              <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
               <span class="badge text-bg-light border">{{ result.category }}</span>
               <span class="text-muted small">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
-                :disabled="dismissLoading"
-                @click="dismiss(result.id)"
+                :disabled="panel.dismissLoading"
+                @click="panel.dismiss(result.id)"
                 title="Dismiss this rule"
               >
                 <i class="bi bi-eye-slash me-1"></i>Dismiss
@@ -338,7 +225,7 @@ onMounted(loadReport)
             <div class="small text-muted mb-2">{{ result.description }}</div>
             <div class="small mb-2">
               <strong>What happened:</strong>
-              {{ violationCountLabel(result.violationCount) }} for this rule.
+              {{ panel.violationCountLabel(result.violationCount) }} for this rule.
             </div>
             <div v-if="result.sampleViolations && result.sampleViolations.length" class="mb-2">
               <div class="small fw-semibold">
@@ -365,22 +252,23 @@ onMounted(loadReport)
             </div>
           </div>
         </div>
-        <template v-if="dismissedResults.length > 0">
+        <template v-if="panel.dismissedResults.length > 0">
           <div class="card-header text-muted small">
-            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ dismissedResults.length }}) — not counted in score
+            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ panel.dismissedResults.length }}) — not counted in
+            score
           </div>
           <div class="list-group list-group-flush">
-            <div v-for="result in dismissedResults" :key="result.id" class="list-group-item opacity-50">
+            <div v-for="result in panel.dismissedResults" :key="result.id" class="list-group-item opacity-50">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
-                <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-                <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+                <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+                <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
                 <span class="badge text-bg-light border">{{ result.category }}</span>
                 <span class="text-muted small">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"
-                  :disabled="dismissLoading"
-                  @click="restore(result.id)"
+                  :disabled="panel.dismissLoading"
+                  @click="panel.restore(result.id)"
                   title="Restore this rule"
                 >
                   <i class="bi bi-eye me-1"></i>Restore

--- a/bootui-ui/src/main/frontend/src/views/Pentesting.vue
+++ b/bootui-ui/src/main/frontend/src/views/Pentesting.vue
@@ -1,85 +1,15 @@
 <script setup>
-import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
-import {formatClockTime} from '../utils/format.js'
-import {describeLoadError} from '../utils/loadError.js'
-import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
-import {panelProps, usePanelState} from '../utils/panelState.js'
+import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
+import {panelProps} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
-const {readOnly, readOnlyReason} = usePanelState(props)
-const report = ref(null)
-const error = ref(null)
-const actionMessage = ref(null)
-const loading = ref(false)
-
-const severityClasses = {
-  HIGH: 'text-bg-danger',
-  MEDIUM: 'text-bg-warning',
-  LOW: 'text-bg-info',
-  INFO: 'text-bg-secondary'
-}
-
-const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
-
-const maxSeverityCount = computed(() => {
-  if (!report.value?.severityCounts?.length) return 1
-  return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+const panel = useAdvisorPanel(props, {
+  apiPath: 'api/pentesting',
+  loadErrorMessage: 'Unable to load pentesting report',
+  scanErrorMessage: 'Unable to run pentesting checks'
 })
-
-function severityClass(severity) {
-  return severityClasses[severity] || 'text-bg-light border text-dark'
-}
-
-function severityWidth(count) {
-  if (count === 0) return '0%'
-  return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
-}
-
-function scanTime() {
-  if (!report.value?.scan?.scannedAt) return ''
-  return formatClockTime(report.value.scan.scannedAt)
-}
-
-async function loadReport() {
-  try {
-    const res = await apiFetch('api/pentesting')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to load pentesting report')
-  }
-}
-
-async function runScan() {
-  if (readOnly.value) {
-    showReadOnlyMessage()
-    return
-  }
-  loading.value = true
-  try {
-    const res = await apiFetch('api/pentesting/scan', {method: 'POST'})
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to run pentesting checks')
-  } finally {
-    loading.value = false
-  }
-}
-
-function showReadOnlyMessage() {
-  actionMessage.value = readOnlyReason.value
-  setTimeout(() => {
-    actionMessage.value = null
-  }, 6000)
-}
-
-onMounted(loadReport)
 </script>
 
 <template>
@@ -88,29 +18,30 @@ onMounted(loadReport)
       icon="bi-shield-exclamation"
       title="Pentesting"
       subtitle="Run explicit local OWASP hygiene checks against the host application, not BootUI's /bootui paths."
-      :loading="loading"
-      :error="error"
+      :loading="panel.loading"
+      :error="panel.error"
     >
       <template #actions>
         <SpinnerButton
-          :loading="loading"
-          :disabled="loading || readOnly"
+          :loading="panel.loading"
+          :disabled="panel.loading || panel.readOnly"
           class="btn btn-primary"
           type="button"
           label="Run local checks"
           loading-label="Running..."
-          @click="runScan"
+          @click="panel.runScan"
         />
       </template>
     </PanelHeader>
-    <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>
+    <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
-    <template v-if="report">
+    <template v-if="panel.report">
       <div class="alert alert-info">
         <strong>Local-only heuristics.</strong>
-        {{ report.disclaimer }} BootUI uses passive Spring metadata plus a synthetic app-path localhost request; it does
-        not send exploit payloads, sweep discovered application endpoints, or store raw response bodies in this report.
-        <span v-if="readOnly">Scanning is read-only. {{ readOnlyReason }}</span>
+        {{ panel.report.disclaimer }} BootUI uses passive Spring metadata plus a synthetic app-path localhost request;
+        it does not send exploit payloads, sweep discovered application endpoints, or store raw response bodies in this
+        report.
+        <span v-if="panel.readOnly">Scanning is read-only. {{ panel.readOnlyReason }}</span>
       </div>
 
       <div class="row g-3 mb-3">
@@ -119,11 +50,11 @@ onMounted(loadReport)
             <div class="card-body">
               <div class="text-muted small">Scan status</div>
               <div class="mt-2">
-                <span :class="scanStatusBadgeClass(report.scan.status)" class="badge fs-6">
-                  {{ scanStatusLabel(report.scan.status) }}
+                <span :class="panel.scanStatusBadgeClass(panel.report.scan.status)" class="badge fs-6">
+                  {{ panel.scanStatusLabel(panel.report.scan.status) }}
                 </span>
               </div>
-              <div v-if="scanTime()" class="small text-muted">Scanned at {{ scanTime() }}</div>
+              <div v-if="panel.scanTime()" class="small text-muted">Scanned at {{ panel.scanTime() }}</div>
             </div>
           </div>
         </div>
@@ -131,7 +62,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Checks run</div>
-              <div class="display-6">{{ report.checksRun }}</div>
+              <div class="display-6">{{ panel.report.checksRun }}</div>
             </div>
           </div>
         </div>
@@ -139,7 +70,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Findings</div>
-              <div class="display-6">{{ report.findingsFound }}</div>
+              <div class="display-6">{{ panel.report.findingsFound }}</div>
             </div>
           </div>
         </div>
@@ -159,25 +90,25 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Severity breakdown</div>
             <div class="card-body">
-              <div v-if="!hasScanData" class="text-center text-muted py-4">
+              <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
                 <div class="fw-semibold text-body">No pentesting data yet</div>
                 <div>Run local checks to populate OWASP-oriented findings.</div>
               </div>
               <div
-                v-for="item in report.severityCounts"
+                v-for="item in panel.report.severityCounts"
                 v-else
                 :key="item.severity"
                 class="row align-items-center g-2 mb-2"
               >
                 <div class="col-3">
-                  <span :class="severityClass(item.severity)" class="badge">{{ item.severity }}</span>
+                  <span :class="panel.severityClass(item.severity)" class="badge">{{ item.severity }}</span>
                 </div>
                 <div class="col">
                   <div :aria-label="`${item.severity} findings: ${item.count}`" class="progress" role="img">
                     <div
-                      :class="severityClass(item.severity)"
-                      :style="{width: severityWidth(item.count)}"
+                      :class="panel.severityClass(item.severity)"
+                      :style="{width: panel.severityWidth(item.count)}"
                       class="progress-bar"
                     ></div>
                   </div>
@@ -193,21 +124,23 @@ onMounted(loadReport)
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
             <div class="fw-semibold">Findings</div>
-            <div class="text-muted small">{{ report.findingsFound }} heuristic finding(s)</div>
+            <div class="text-muted small">{{ panel.report.findingsFound }} heuristic finding(s)</div>
           </div>
-          <span v-if="hasScanData && report.findingsFound === 0" class="badge text-bg-success">No findings</span>
+          <span v-if="panel.hasScanData && panel.report.findingsFound === 0" class="badge text-bg-success"
+            >No findings</span
+          >
         </div>
-        <div v-if="report.findings.length === 0" class="card-body text-center text-muted py-5">
+        <div v-if="panel.report.findings.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-shield-check fs-2 d-block mb-2"></i>
           <div class="fw-semibold text-body">
-            {{ hasScanData ? 'No findings from local checks' : 'Run local checks to see findings' }}
+            {{ panel.hasScanData ? 'No findings from local checks' : 'Run local checks to see findings' }}
           </div>
           <div>Manual review is still required for authorization, business logic, injection, and abuse cases.</div>
         </div>
         <div v-else class="list-group list-group-flush">
-          <div v-for="finding in report.findings" :key="finding.id" class="list-group-item">
+          <div v-for="finding in panel.report.findings" :key="finding.id" class="list-group-item">
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-              <span :class="severityClass(finding.severity)" class="badge">{{ finding.severity }}</span>
+              <span :class="panel.severityClass(finding.severity)" class="badge">{{ finding.severity }}</span>
               <span class="badge text-bg-light border">{{ finding.confidence }} confidence</span>
               <span class="text-muted small">{{ finding.id }}</span>
             </div>

--- a/bootui-ui/src/main/frontend/src/views/RestApi.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestApi.vue
@@ -1,140 +1,18 @@
 <script setup>
-import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
-import {describeLoadError} from '../utils/loadError.js'
-import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
-import {panelProps, usePanelState} from '../utils/panelState.js'
-import {useDismissedRules} from '../utils/useDismissedRules.js'
+import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
+import {panelProps} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
-const {readOnly, readOnlyReason} = usePanelState(props)
-const report = ref(null)
-const error = ref(null)
-const actionMessage = ref(null)
-const loading = ref(false)
-
-const {dismissLoading, dismiss, restore} = useDismissedRules(loadReport)
-
-const severityClasses = {
-  HIGH: 'text-bg-danger',
-  MEDIUM: 'text-bg-warning',
-  LOW: 'text-bg-info',
-  INFO: 'text-bg-secondary'
-}
-
-const statusClasses = {
-  PASS: 'text-bg-success',
-  VIOLATION: 'text-bg-danger',
-  SKIPPED: 'text-bg-secondary',
-  ERROR: 'text-bg-warning'
-}
-
-const severityOrder = ['HIGH', 'MEDIUM', 'LOW', 'INFO']
-
-const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
-
-const violations = computed(() =>
-  [...(report.value?.results || [])].filter((result) => result.status === 'VIOLATION').sort(compareImportance)
-)
-
-const visibleResults = computed(() => violations.value.filter((result) => !result.dismissed))
-
-const dismissedResults = computed(() => violations.value.filter((result) => result.dismissed))
-
-const maxSeverityCount = computed(() => {
-  if (!report.value?.severityCounts?.length) return 1
-  return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+const panel = useAdvisorPanel(props, {
+  apiPath: 'api/rest-api',
+  loadErrorMessage: 'Unable to load REST API Advisor report',
+  scanErrorMessage: 'Unable to run REST API checks',
+  emptyScanPrompt: 'Run REST API checks to see rule findings',
+  emptyNoFindings: 'No REST API rule findings',
+  countNoun: 'finding'
 })
-
-const emptyRuleResultsTitle = computed(() => {
-  if (!hasScanData.value) return 'Run REST API checks to see rule findings'
-  if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
-  return 'No REST API rule findings'
-})
-
-function severityClass(severity) {
-  return severityClasses[severity] || 'text-bg-light border text-dark'
-}
-
-function statusClass(status) {
-  return statusClasses[status] || 'text-bg-light border text-dark'
-}
-
-function severityWidth(count) {
-  if (count === 0) return '0%'
-  return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
-}
-
-function compareImportance(left, right) {
-  const severityDiff = severityRank(left.severity) - severityRank(right.severity)
-  if (severityDiff !== 0) return severityDiff
-  const countDiff = right.violationCount - left.violationCount
-  if (countDiff !== 0) return countDiff
-  return left.id.localeCompare(right.id)
-}
-
-function severityRank(severity) {
-  const index = severityOrder.indexOf(severity)
-  return index === -1 ? severityOrder.length : index
-}
-
-function pluralize(count, singular, plural = `${singular}s`) {
-  return count === 1 ? singular : plural
-}
-
-function violationCountLabel(count) {
-  return `${count} ${pluralize(count, 'finding')} found`
-}
-
-function scanTime() {
-  if (!report.value?.scan?.scannedAt) return ''
-  return new Date(report.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
-}
-
-async function loadReport() {
-  try {
-    const res = await apiFetch('api/rest-api')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to load REST API Advisor report')
-  }
-}
-
-async function runScan() {
-  if (readOnly.value) {
-    showReadOnlyMessage()
-    return
-  }
-  loading.value = true
-  try {
-    const res = await apiFetch('api/rest-api/scan', {method: 'POST'})
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to run REST API checks')
-  } finally {
-    loading.value = false
-  }
-}
-
-function showReadOnlyMessage() {
-  actionMessage.value = readOnlyReason.value
-  setTimeout(() => {
-    actionMessage.value = null
-  }, 6000)
-}
-
-onMounted(loadReport)
 </script>
 
 <template>
@@ -143,28 +21,28 @@ onMounted(loadReport)
       icon="bi-signpost-split"
       title="REST API"
       subtitle="Run curated, project-agnostic REST best-practice rules against the host application's own controllers."
-      :loading="loading"
-      :error="error"
+      :loading="panel.loading"
+      :error="panel.error"
     >
       <template #actions>
         <SpinnerButton
-          :loading="loading"
-          :disabled="loading || readOnly"
+          :loading="panel.loading"
+          :disabled="panel.loading || panel.readOnly"
           class="btn btn-primary"
           type="button"
           label="Run REST API checks"
           loading-label="Running..."
-          @click="runScan"
+          @click="panel.runScan"
         />
       </template>
     </PanelHeader>
-    <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>
+    <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
-    <template v-if="report">
+    <template v-if="panel.report">
       <div class="alert alert-info">
         <strong>Heuristic REST API design rules.</strong>
-        {{ report.disclaimer }}
-        <span v-if="readOnly">Scanning is read-only. {{ readOnlyReason }}</span>
+        {{ panel.report.disclaimer }}
+        <span v-if="panel.readOnly">Scanning is read-only. {{ panel.readOnlyReason }}</span>
       </div>
 
       <div class="row g-3 mb-3">
@@ -173,11 +51,11 @@ onMounted(loadReport)
             <div class="card-body">
               <div class="text-muted small">Scan status</div>
               <div class="mt-2">
-                <span :class="scanStatusBadgeClass(report.scan.status)" class="badge fs-6">
-                  {{ scanStatusLabel(report.scan.status) }}
+                <span :class="panel.scanStatusBadgeClass(panel.report.scan.status)" class="badge fs-6">
+                  {{ panel.scanStatusLabel(panel.report.scan.status) }}
                 </span>
               </div>
-              <div v-if="scanTime()" class="small text-muted">Scanned at {{ scanTime() }}</div>
+              <div v-if="panel.scanTime()" class="small text-muted">Scanned at {{ panel.scanTime() }}</div>
             </div>
           </div>
         </div>
@@ -185,7 +63,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Rules evaluated</div>
-              <div class="display-6">{{ report.rulesEvaluated }}</div>
+              <div class="display-6">{{ panel.report.rulesEvaluated }}</div>
             </div>
           </div>
         </div>
@@ -193,9 +71,9 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Findings</div>
-              <div class="display-6">{{ report.violationsFound }}</div>
-              <div v-if="dismissedResults.length > 0" class="small text-muted">
-                {{ dismissedResults.length }} dismissed
+              <div class="display-6">{{ panel.report.violationsFound }}</div>
+              <div v-if="panel.dismissedResults.length > 0" class="small text-muted">
+                {{ panel.dismissedResults.length }} dismissed
               </div>
             </div>
           </div>
@@ -204,8 +82,8 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Controllers analysed</div>
-              <div class="display-6">{{ report.controllersAnalyzed }}</div>
-              <div class="small text-muted">{{ report.handlersAnalyzed }} handler method(s)</div>
+              <div class="display-6">{{ panel.report.controllersAnalyzed }}</div>
+              <div class="small text-muted">{{ panel.report.handlersAnalyzed }} handler method(s)</div>
             </div>
           </div>
         </div>
@@ -216,25 +94,25 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Findings by severity</div>
             <div class="card-body">
-              <div v-if="!hasScanData" class="text-center text-muted py-4">
+              <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
                 <div class="fw-semibold text-body">No REST API data yet</div>
                 <div>Run REST API checks to populate rule findings.</div>
               </div>
               <div
-                v-for="item in report.severityCounts"
+                v-for="item in panel.report.severityCounts"
                 v-else
                 :key="item.severity"
                 class="row align-items-center g-2 mb-2"
               >
                 <div class="col-3">
-                  <span :class="severityClass(item.severity)" class="badge">{{ item.severity }}</span>
+                  <span :class="panel.severityClass(item.severity)" class="badge">{{ item.severity }}</span>
                 </div>
                 <div class="col">
                   <div :aria-label="`${item.severity} findings: ${item.count}`" class="progress" role="img">
                     <div
-                      :class="severityClass(item.severity)"
-                      :style="{width: severityWidth(item.count)}"
+                      :class="panel.severityClass(item.severity)"
+                      :style="{width: panel.severityWidth(item.count)}"
                       class="progress-bar"
                     ></div>
                   </div>
@@ -249,11 +127,11 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Base packages</div>
             <div class="card-body">
-              <div v-if="!report.basePackages || report.basePackages.length === 0" class="text-muted">
+              <div v-if="!panel.report.basePackages || panel.report.basePackages.length === 0" class="text-muted">
                 No application base package was detected.
               </div>
               <ul v-else class="list-unstyled mb-0">
-                <li v-for="pkg in report.basePackages" :key="pkg" class="font-monospace small">
+                <li v-for="pkg in panel.report.basePackages" :key="pkg" class="font-monospace small">
                   <i class="bi bi-box me-1"></i>{{ pkg }}
                 </li>
               </ul>
@@ -267,35 +145,36 @@ onMounted(loadReport)
           <div>
             <div class="fw-semibold">Rule findings</div>
             <div class="text-muted small">
-              <template v-if="hasScanData && visibleResults.length > 0">
-                {{ visibleResults.length }} {{ pluralize(visibleResults.length, 'flagged rule') }}, sorted by importance
+              <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
+                {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'flagged rule') }},
+                sorted by importance
               </template>
-              <template v-else>{{ visibleResults.length }} rule finding(s)</template>
+              <template v-else>{{ panel.visibleResults.length }} rule finding(s)</template>
             </div>
           </div>
           <span
-            v-if="hasScanData && visibleResults.length === 0 && dismissedResults.length === 0"
+            v-if="panel.hasScanData && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
             >No findings</span
           >
         </div>
-        <div v-if="visibleResults.length === 0" class="card-body text-center text-muted py-5">
+        <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-signpost-split fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">{{ emptyRuleResultsTitle }}</div>
+          <div class="fw-semibold text-body">{{ panel.emptyRuleResultsTitle }}</div>
           <div>These heuristics complement, but do not replace, an API design review or contract testing.</div>
         </div>
         <div v-else class="list-group list-group-flush">
-          <div v-for="result in visibleResults" :key="result.id" class="list-group-item">
+          <div v-for="result in panel.visibleResults" :key="result.id" class="list-group-item">
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-              <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-              <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+              <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+              <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
               <span class="badge text-bg-light border">{{ result.category }}</span>
               <span class="text-muted small">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
-                :disabled="dismissLoading"
-                @click="dismiss(result.id)"
+                :disabled="panel.dismissLoading"
+                @click="panel.dismiss(result.id)"
                 title="Dismiss this rule"
               >
                 <i class="bi bi-eye-slash me-1"></i>Dismiss
@@ -305,7 +184,7 @@ onMounted(loadReport)
             <div class="small text-muted mb-2">{{ result.description }}</div>
             <div class="small mb-2">
               <strong>What happened:</strong>
-              {{ violationCountLabel(result.violationCount) }} for this rule.
+              {{ panel.violationCountLabel(result.violationCount) }} for this rule.
             </div>
             <div v-if="result.sampleViolations && result.sampleViolations.length" class="mb-2">
               <div class="small fw-semibold">
@@ -332,22 +211,23 @@ onMounted(loadReport)
             </div>
           </div>
         </div>
-        <template v-if="dismissedResults.length > 0">
+        <template v-if="panel.dismissedResults.length > 0">
           <div class="card-header text-muted small">
-            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ dismissedResults.length }}) — not counted in score
+            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ panel.dismissedResults.length }}) — not counted in
+            score
           </div>
           <div class="list-group list-group-flush">
-            <div v-for="result in dismissedResults" :key="result.id" class="list-group-item opacity-50">
+            <div v-for="result in panel.dismissedResults" :key="result.id" class="list-group-item opacity-50">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
-                <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-                <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+                <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+                <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
                 <span class="badge text-bg-light border">{{ result.category }}</span>
                 <span class="text-muted small">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"
-                  :disabled="dismissLoading"
-                  @click="restore(result.id)"
+                  :disabled="panel.dismissLoading"
+                  @click="panel.restore(result.id)"
                   title="Restore this rule"
                 >
                   <i class="bi bi-eye me-1"></i>Restore

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -1,136 +1,18 @@
 <script setup>
-import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
-import {formatClockTime} from '../utils/format.js'
-import {describeLoadError} from '../utils/loadError.js'
-import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
-import {panelProps, usePanelState} from '../utils/panelState.js'
-import {useDismissedRules} from '../utils/useDismissedRules.js'
+import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
+import {panelProps} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
-const {readOnly, readOnlyReason} = usePanelState(props)
-const report = ref(null)
-const error = ref(null)
-const actionMessage = ref(null)
-const loading = ref(false)
-
-const {dismissLoading, dismiss, restore} = useDismissedRules(loadReport)
-
-const severityClasses = {
-  HIGH: 'text-bg-danger',
-  MEDIUM: 'text-bg-warning',
-  LOW: 'text-bg-info',
-  INFO: 'text-bg-secondary'
-}
-
-const statusClasses = {
-  PASS: 'text-bg-success',
-  VIOLATION: 'text-bg-danger',
-  SKIPPED: 'text-bg-secondary',
-  ERROR: 'text-bg-warning'
-}
-
-const severityOrder = ['HIGH', 'MEDIUM', 'LOW', 'INFO']
-
-const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
-
-const violations = computed(() =>
-  [...(report.value?.results || [])].filter((result) => result.status === 'VIOLATION').sort(compareImportance)
-)
-
-const visibleResults = computed(() => violations.value.filter((result) => !result.dismissed))
-
-const dismissedResults = computed(() => violations.value.filter((result) => result.dismissed))
-
-const maxSeverityCount = computed(() => {
-  if (!report.value?.severityCounts?.length) return 1
-  return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+const panel = useAdvisorPanel(props, {
+  apiPath: 'api/security',
+  loadErrorMessage: 'Unable to load Security Advisor report',
+  scanErrorMessage: 'Unable to run security checks',
+  emptyScanPrompt: 'Run security checks to see advisor findings',
+  emptyNoFindings: 'No Security Advisor findings',
+  countNoun: 'finding'
 })
-
-const emptyRuleResultsTitle = computed(() => {
-  if (!hasScanData.value) return 'Run security checks to see advisor findings'
-  if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
-  return 'No Security Advisor findings'
-})
-
-function severityClass(severity) {
-  return severityClasses[severity] || 'text-bg-light border text-dark'
-}
-
-function statusClass(status) {
-  return statusClasses[status] || 'text-bg-light border text-dark'
-}
-
-function severityWidth(count) {
-  if (count === 0) return '0%'
-  return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
-}
-
-function compareImportance(left, right) {
-  const severityDiff = severityRank(left.severity) - severityRank(right.severity)
-  if (severityDiff !== 0) return severityDiff
-  const countDiff = right.violationCount - left.violationCount
-  if (countDiff !== 0) return countDiff
-  return left.id.localeCompare(right.id)
-}
-
-function severityRank(severity) {
-  const index = severityOrder.indexOf(severity)
-  return index === -1 ? severityOrder.length : index
-}
-
-function pluralize(count, singular, plural = `${singular}s`) {
-  return count === 1 ? singular : plural
-}
-
-function violationCountLabel(count) {
-  return `${count} ${pluralize(count, 'finding')} found`
-}
-
-function scanTime() {
-  if (!report.value?.scan?.scannedAt) return ''
-  return formatClockTime(report.value.scan.scannedAt)
-}
-
-async function loadReport() {
-  try {
-    const res = await apiFetch('api/security')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to load Security Advisor report')
-  }
-}
-
-async function runScan() {
-  if (readOnly.value) {
-    showReadOnlyMessage()
-    return
-  }
-  loading.value = true
-  try {
-    const res = await apiFetch('api/security/scan', {method: 'POST'})
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to run security checks')
-  } finally {
-    loading.value = false
-  }
-}
-
-function showReadOnlyMessage() {
-  actionMessage.value = readOnlyReason.value
-  setTimeout(() => {
-    actionMessage.value = null
-  }, 6000)
-}
-
-onMounted(loadReport)
 </script>
 
 <template>
@@ -139,28 +21,28 @@ onMounted(loadReport)
       icon="bi-shield-check"
       title="Security"
       subtitle="Review the registered Spring Security filter chains with bounded best-practice checks."
-      :loading="loading"
-      :error="error"
+      :loading="panel.loading"
+      :error="panel.error"
     >
       <template #actions>
         <SpinnerButton
-          :loading="loading"
-          :disabled="loading || readOnly"
+          :loading="panel.loading"
+          :disabled="panel.loading || panel.readOnly"
           class="btn btn-primary"
           type="button"
           label="Run security checks"
           loading-label="Running..."
-          @click="runScan"
+          @click="panel.runScan"
         />
       </template>
     </PanelHeader>
-    <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>
+    <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
-    <template v-if="report">
+    <template v-if="panel.report">
       <div class="alert alert-info">
         <strong>Heuristic Spring Security rules.</strong>
-        {{ report.disclaimer }}
-        <span v-if="readOnly">Scanning is read-only. {{ readOnlyReason }}</span>
+        {{ panel.report.disclaimer }}
+        <span v-if="panel.readOnly">Scanning is read-only. {{ panel.readOnlyReason }}</span>
       </div>
 
       <div class="row g-3 mb-3">
@@ -169,11 +51,11 @@ onMounted(loadReport)
             <div class="card-body">
               <div class="text-muted small">Scan status</div>
               <div class="mt-2">
-                <span :class="scanStatusBadgeClass(report.scan.status)" class="badge fs-6">
-                  {{ scanStatusLabel(report.scan.status) }}
+                <span :class="panel.scanStatusBadgeClass(panel.report.scan.status)" class="badge fs-6">
+                  {{ panel.scanStatusLabel(panel.report.scan.status) }}
                 </span>
               </div>
-              <div v-if="scanTime()" class="small text-muted">Scanned at {{ scanTime() }}</div>
+              <div v-if="panel.scanTime()" class="small text-muted">Scanned at {{ panel.scanTime() }}</div>
             </div>
           </div>
         </div>
@@ -181,7 +63,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Rules evaluated</div>
-              <div class="display-6">{{ report.rulesEvaluated }}</div>
+              <div class="display-6">{{ panel.report.rulesEvaluated }}</div>
             </div>
           </div>
         </div>
@@ -189,9 +71,9 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Advisor findings</div>
-              <div class="display-6">{{ report.violationsFound }}</div>
-              <div v-if="dismissedResults.length > 0" class="small text-muted">
-                {{ dismissedResults.length }} dismissed
+              <div class="display-6">{{ panel.report.violationsFound }}</div>
+              <div v-if="panel.dismissedResults.length > 0" class="small text-muted">
+                {{ panel.dismissedResults.length }} dismissed
               </div>
             </div>
           </div>
@@ -200,7 +82,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Filter chains analysed</div>
-              <div class="display-6">{{ report.filterChainsAnalyzed }}</div>
+              <div class="display-6">{{ panel.report.filterChainsAnalyzed }}</div>
             </div>
           </div>
         </div>
@@ -211,25 +93,25 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Findings by severity</div>
             <div class="card-body">
-              <div v-if="!hasScanData" class="text-center text-muted py-4">
+              <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
                 <div class="fw-semibold text-body">No Security Advisor data yet</div>
                 <div>Run security checks to populate advisor findings.</div>
               </div>
               <div
-                v-for="item in report.severityCounts"
+                v-for="item in panel.report.severityCounts"
                 v-else
                 :key="item.severity"
                 class="row align-items-center g-2 mb-2"
               >
                 <div class="col-3">
-                  <span :class="severityClass(item.severity)" class="badge">{{ item.severity }}</span>
+                  <span :class="panel.severityClass(item.severity)" class="badge">{{ item.severity }}</span>
                 </div>
                 <div class="col">
                   <div :aria-label="`${item.severity} findings: ${item.count}`" class="progress" role="img">
                     <div
-                      :class="severityClass(item.severity)"
-                      :style="{width: severityWidth(item.count)}"
+                      :class="panel.severityClass(item.severity)"
+                      :style="{width: panel.severityWidth(item.count)}"
                       class="progress-bar"
                     ></div>
                   </div>
@@ -244,11 +126,11 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Filter chains</div>
             <div class="card-body">
-              <div v-if="!report.filterChains || report.filterChains.length === 0" class="text-muted">
+              <div v-if="!panel.report.filterChains || panel.report.filterChains.length === 0" class="text-muted">
                 No Spring Security filter chain was detected.
               </div>
               <ul v-else class="list-unstyled mb-0">
-                <li v-for="(chain, index) in report.filterChains" :key="index" class="font-monospace small">
+                <li v-for="(chain, index) in panel.report.filterChains" :key="index" class="font-monospace small">
                   <i class="bi bi-link-45deg me-1"></i>{{ chain }}
                 </li>
               </ul>
@@ -262,36 +144,36 @@ onMounted(loadReport)
           <div>
             <div class="fw-semibold">Rule results</div>
             <div class="text-muted small">
-              <template v-if="hasScanData && visibleResults.length > 0">
-                {{ visibleResults.length }} {{ pluralize(visibleResults.length, 'violating rule') }}, sorted by
-                importance
+              <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
+                {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'violating rule') }},
+                sorted by importance
               </template>
-              <template v-else>{{ visibleResults.length }} advisor finding(s)</template>
+              <template v-else>{{ panel.visibleResults.length }} advisor finding(s)</template>
             </div>
           </div>
           <span
-            v-if="hasScanData && visibleResults.length === 0 && dismissedResults.length === 0"
+            v-if="panel.hasScanData && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
             >No findings</span
           >
         </div>
-        <div v-if="visibleResults.length === 0" class="card-body text-center text-muted py-5">
+        <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-shield-lock fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">{{ emptyRuleResultsTitle }}</div>
+          <div class="fw-semibold text-body">{{ panel.emptyRuleResultsTitle }}</div>
           <div>Project-specific threat modelling and penetration testing remain the source of truth.</div>
         </div>
         <div v-else class="list-group list-group-flush">
-          <div v-for="result in visibleResults" :key="result.id" class="list-group-item">
+          <div v-for="result in panel.visibleResults" :key="result.id" class="list-group-item">
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-              <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-              <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+              <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+              <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
               <span class="badge text-bg-light border">{{ result.category }}</span>
               <span class="text-muted small">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
-                :disabled="dismissLoading"
-                @click="dismiss(result.id)"
+                :disabled="panel.dismissLoading"
+                @click="panel.dismiss(result.id)"
                 title="Dismiss this rule"
               >
                 <i class="bi bi-eye-slash me-1"></i>Dismiss
@@ -301,7 +183,7 @@ onMounted(loadReport)
             <div class="small text-muted mb-2">{{ result.description }}</div>
             <div class="small mb-2">
               <strong>What happened:</strong>
-              {{ violationCountLabel(result.violationCount) }} for this rule.
+              {{ panel.violationCountLabel(result.violationCount) }} for this rule.
             </div>
             <div v-if="result.sampleViolations && result.sampleViolations.length" class="mb-2">
               <div class="small fw-semibold">
@@ -328,22 +210,23 @@ onMounted(loadReport)
             </div>
           </div>
         </div>
-        <template v-if="dismissedResults.length > 0">
+        <template v-if="panel.dismissedResults.length > 0">
           <div class="card-header text-muted small">
-            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ dismissedResults.length }}) — not counted in score
+            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ panel.dismissedResults.length }}) — not counted in
+            score
           </div>
           <div class="list-group list-group-flush">
-            <div v-for="result in dismissedResults" :key="result.id" class="list-group-item opacity-50">
+            <div v-for="result in panel.dismissedResults" :key="result.id" class="list-group-item opacity-50">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
-                <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-                <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+                <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+                <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
                 <span class="badge text-bg-light border">{{ result.category }}</span>
                 <span class="text-muted small">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"
-                  :disabled="dismissLoading"
-                  @click="restore(result.id)"
+                  :disabled="panel.dismissLoading"
+                  @click="panel.restore(result.id)"
                   title="Restore this rule"
                 >
                   <i class="bi bi-eye me-1"></i>Restore

--- a/bootui-ui/src/main/frontend/src/views/Spring.vue
+++ b/bootui-ui/src/main/frontend/src/views/Spring.vue
@@ -1,140 +1,18 @@
 <script setup>
-import {apiFetch} from '../api.js'
-import {computed, onMounted, ref} from 'vue'
-import {describeLoadError} from '../utils/loadError.js'
-import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
-import {panelProps, usePanelState} from '../utils/panelState.js'
-import {useDismissedRules} from '../utils/useDismissedRules.js'
+import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
+import {panelProps} from '../utils/panelState.js'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
-const {readOnly, readOnlyReason} = usePanelState(props)
-const report = ref(null)
-const error = ref(null)
-const actionMessage = ref(null)
-const loading = ref(false)
-
-const {dismissLoading, dismiss, restore} = useDismissedRules(loadReport)
-
-const severityClasses = {
-  HIGH: 'text-bg-danger',
-  MEDIUM: 'text-bg-warning',
-  LOW: 'text-bg-info',
-  INFO: 'text-bg-secondary'
-}
-
-const statusClasses = {
-  PASS: 'text-bg-success',
-  VIOLATION: 'text-bg-danger',
-  SKIPPED: 'text-bg-secondary',
-  ERROR: 'text-bg-warning'
-}
-
-const severityOrder = ['HIGH', 'MEDIUM', 'LOW', 'INFO']
-
-const hasScanData = computed(() => hasScanResult(report.value?.scan?.status))
-
-const violations = computed(() =>
-  [...(report.value?.results || [])].filter((result) => result.status === 'VIOLATION').sort(compareImportance)
-)
-
-const visibleResults = computed(() => violations.value.filter((result) => !result.dismissed))
-
-const dismissedResults = computed(() => violations.value.filter((result) => result.dismissed))
-
-const maxSeverityCount = computed(() => {
-  if (!report.value?.severityCounts?.length) return 1
-  return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
+const panel = useAdvisorPanel(props, {
+  apiPath: 'api/spring',
+  loadErrorMessage: 'Unable to load Spring Advisor report',
+  scanErrorMessage: 'Unable to run Spring checks',
+  emptyScanPrompt: 'Run Spring checks to see advisor findings',
+  emptyNoFindings: 'No Spring Advisor findings',
+  countNoun: 'finding'
 })
-
-const emptyRuleResultsTitle = computed(() => {
-  if (!hasScanData.value) return 'Run Spring checks to see advisor findings'
-  if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
-  return 'No Spring Advisor findings'
-})
-
-function severityClass(severity) {
-  return severityClasses[severity] || 'text-bg-light border text-dark'
-}
-
-function statusClass(status) {
-  return statusClasses[status] || 'text-bg-light border text-dark'
-}
-
-function severityWidth(count) {
-  if (count === 0) return '0%'
-  return `${Math.max(3, (count / maxSeverityCount.value) * 100)}%`
-}
-
-function compareImportance(left, right) {
-  const severityDiff = severityRank(left.severity) - severityRank(right.severity)
-  if (severityDiff !== 0) return severityDiff
-  const countDiff = right.violationCount - left.violationCount
-  if (countDiff !== 0) return countDiff
-  return left.id.localeCompare(right.id)
-}
-
-function severityRank(severity) {
-  const index = severityOrder.indexOf(severity)
-  return index === -1 ? severityOrder.length : index
-}
-
-function pluralize(count, singular, plural = `${singular}s`) {
-  return count === 1 ? singular : plural
-}
-
-function violationCountLabel(count) {
-  return `${count} ${pluralize(count, 'finding')} found`
-}
-
-function scanTime() {
-  if (!report.value?.scan?.scannedAt) return ''
-  return new Date(report.value.scan.scannedAt).toLocaleTimeString([], {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  })
-}
-
-async function loadReport() {
-  try {
-    const res = await apiFetch('api/spring')
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to load Spring Advisor report')
-  }
-}
-
-async function runScan() {
-  if (readOnly.value) {
-    showReadOnlyMessage()
-    return
-  }
-  loading.value = true
-  try {
-    const res = await apiFetch('api/spring/scan', {method: 'POST'})
-    if (!res.ok) throw new Error('HTTP ' + res.status)
-    report.value = await res.json()
-    error.value = null
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to run Spring checks')
-  } finally {
-    loading.value = false
-  }
-}
-
-function showReadOnlyMessage() {
-  actionMessage.value = readOnlyReason.value
-  setTimeout(() => {
-    actionMessage.value = null
-  }, 6000)
-}
-
-onMounted(loadReport)
 </script>
 
 <template>
@@ -143,28 +21,28 @@ onMounted(loadReport)
       icon="bi-lightbulb"
       title="Spring"
       subtitle="Review the running Spring application context with bounded configuration and best-practice checks."
-      :loading="loading"
-      :error="error"
+      :loading="panel.loading"
+      :error="panel.error"
     >
       <template #actions>
         <SpinnerButton
-          :loading="loading"
-          :disabled="loading || readOnly"
+          :loading="panel.loading"
+          :disabled="panel.loading || panel.readOnly"
           class="btn btn-primary"
           type="button"
           label="Run Spring checks"
           loading-label="Running..."
-          @click="runScan"
+          @click="panel.runScan"
         />
       </template>
     </PanelHeader>
-    <div v-if="actionMessage" class="alert alert-warning">{{ actionMessage }}</div>
+    <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
-    <template v-if="report">
+    <template v-if="panel.report">
       <div class="alert alert-info">
         <strong>Heuristic Spring context rules.</strong>
-        {{ report.disclaimer }}
-        <span v-if="readOnly">Scanning is read-only. {{ readOnlyReason }}</span>
+        {{ panel.report.disclaimer }}
+        <span v-if="panel.readOnly">Scanning is read-only. {{ panel.readOnlyReason }}</span>
       </div>
 
       <div class="row g-3 mb-3">
@@ -173,11 +51,11 @@ onMounted(loadReport)
             <div class="card-body">
               <div class="text-muted small">Scan status</div>
               <div class="mt-2">
-                <span :class="scanStatusBadgeClass(report.scan.status)" class="badge fs-6">
-                  {{ scanStatusLabel(report.scan.status) }}
+                <span :class="panel.scanStatusBadgeClass(panel.report.scan.status)" class="badge fs-6">
+                  {{ panel.scanStatusLabel(panel.report.scan.status) }}
                 </span>
               </div>
-              <div v-if="scanTime()" class="small text-muted">Scanned at {{ scanTime() }}</div>
+              <div v-if="panel.scanTime()" class="small text-muted">Scanned at {{ panel.scanTime() }}</div>
             </div>
           </div>
         </div>
@@ -185,7 +63,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Rules evaluated</div>
-              <div class="display-6">{{ report.rulesEvaluated }}</div>
+              <div class="display-6">{{ panel.report.rulesEvaluated }}</div>
             </div>
           </div>
         </div>
@@ -193,9 +71,9 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Advisor findings</div>
-              <div class="display-6">{{ report.violationsFound }}</div>
-              <div v-if="dismissedResults.length > 0" class="small text-muted">
-                {{ dismissedResults.length }} dismissed
+              <div class="display-6">{{ panel.report.violationsFound }}</div>
+              <div v-if="panel.dismissedResults.length > 0" class="small text-muted">
+                {{ panel.dismissedResults.length }} dismissed
               </div>
             </div>
           </div>
@@ -204,7 +82,7 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-body">
               <div class="text-muted small">Beans analysed</div>
-              <div class="display-6">{{ report.componentsAnalyzed }}</div>
+              <div class="display-6">{{ panel.report.componentsAnalyzed }}</div>
             </div>
           </div>
         </div>
@@ -215,25 +93,25 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Findings by severity</div>
             <div class="card-body">
-              <div v-if="!hasScanData" class="text-center text-muted py-4">
+              <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
                 <div class="fw-semibold text-body">No Spring Advisor data yet</div>
                 <div>Run Spring checks to populate advisor findings.</div>
               </div>
               <div
-                v-for="item in report.severityCounts"
+                v-for="item in panel.report.severityCounts"
                 v-else
                 :key="item.severity"
                 class="row align-items-center g-2 mb-2"
               >
                 <div class="col-3">
-                  <span :class="severityClass(item.severity)" class="badge">{{ item.severity }}</span>
+                  <span :class="panel.severityClass(item.severity)" class="badge">{{ item.severity }}</span>
                 </div>
                 <div class="col">
                   <div :aria-label="`${item.severity} findings: ${item.count}`" class="progress" role="img">
                     <div
-                      :class="severityClass(item.severity)"
-                      :style="{width: severityWidth(item.count)}"
+                      :class="panel.severityClass(item.severity)"
+                      :style="{width: panel.severityWidth(item.count)}"
                       class="progress-bar"
                     ></div>
                   </div>
@@ -248,11 +126,11 @@ onMounted(loadReport)
           <div class="card h-100">
             <div class="card-header fw-semibold">Context inspected</div>
             <div class="card-body">
-              <div v-if="!report.inspected || report.inspected.length === 0" class="text-muted">
+              <div v-if="!panel.report.inspected || panel.report.inspected.length === 0" class="text-muted">
                 No application context details were collected.
               </div>
               <ul v-else class="list-unstyled mb-0">
-                <li v-for="(item, index) in report.inspected" :key="index" class="font-monospace small">
+                <li v-for="(item, index) in panel.report.inspected" :key="index" class="font-monospace small">
                   <i class="bi bi-gear me-1"></i>{{ item }}
                 </li>
               </ul>
@@ -266,36 +144,36 @@ onMounted(loadReport)
           <div>
             <div class="fw-semibold">Rule results</div>
             <div class="text-muted small">
-              <template v-if="hasScanData && visibleResults.length > 0">
-                {{ visibleResults.length }} {{ pluralize(visibleResults.length, 'violating rule') }}, sorted by
-                importance
+              <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
+                {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'violating rule') }},
+                sorted by importance
               </template>
-              <template v-else>{{ visibleResults.length }} advisor finding(s)</template>
+              <template v-else>{{ panel.visibleResults.length }} advisor finding(s)</template>
             </div>
           </div>
           <span
-            v-if="hasScanData && visibleResults.length === 0 && dismissedResults.length === 0"
+            v-if="panel.hasScanData && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
             >No findings</span
           >
         </div>
-        <div v-if="visibleResults.length === 0" class="card-body text-center text-muted py-5">
+        <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-lightbulb fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">{{ emptyRuleResultsTitle }}</div>
+          <div class="fw-semibold text-body">{{ panel.emptyRuleResultsTitle }}</div>
           <div>These checks complement, but do not replace, project-specific review and testing.</div>
         </div>
         <div v-else class="list-group list-group-flush">
-          <div v-for="result in visibleResults" :key="result.id" class="list-group-item">
+          <div v-for="result in panel.visibleResults" :key="result.id" class="list-group-item">
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-              <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-              <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+              <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+              <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
               <span class="badge text-bg-light border">{{ result.category }}</span>
               <span class="text-muted small">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
-                :disabled="dismissLoading"
-                @click="dismiss(result.id)"
+                :disabled="panel.dismissLoading"
+                @click="panel.dismiss(result.id)"
                 title="Dismiss this rule"
               >
                 <i class="bi bi-eye-slash me-1"></i>Dismiss
@@ -305,7 +183,7 @@ onMounted(loadReport)
             <div class="small text-muted mb-2">{{ result.description }}</div>
             <div class="small mb-2">
               <strong>What happened:</strong>
-              {{ violationCountLabel(result.violationCount) }} for this rule.
+              {{ panel.violationCountLabel(result.violationCount) }} for this rule.
             </div>
             <div v-if="result.sampleViolations && result.sampleViolations.length" class="mb-2">
               <div class="small fw-semibold">
@@ -332,22 +210,23 @@ onMounted(loadReport)
             </div>
           </div>
         </div>
-        <template v-if="dismissedResults.length > 0">
+        <template v-if="panel.dismissedResults.length > 0">
           <div class="card-header text-muted small">
-            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ dismissedResults.length }}) — not counted in score
+            <i class="bi bi-eye-slash me-1"></i>Dismissed rules ({{ panel.dismissedResults.length }}) — not counted in
+            score
           </div>
           <div class="list-group list-group-flush">
-            <div v-for="result in dismissedResults" :key="result.id" class="list-group-item opacity-50">
+            <div v-for="result in panel.dismissedResults" :key="result.id" class="list-group-item opacity-50">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
-                <span :class="statusClass(result.status)" class="badge">{{ result.status }}</span>
-                <span :class="severityClass(result.severity)" class="badge">{{ result.severity }}</span>
+                <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
+                <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
                 <span class="badge text-bg-light border">{{ result.category }}</span>
                 <span class="text-muted small">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"
-                  :disabled="dismissLoading"
-                  @click="restore(result.id)"
+                  :disabled="panel.dismissLoading"
+                  @click="panel.restore(result.id)"
                   title="Restore this rule"
                 >
                   <i class="bi bi-eye me-1"></i>Restore


### PR DESCRIPTION
## What

SonarCloud's [overall analysis](https://sonarcloud.io/summary/overall?id=jdubois_boot-ui&branch=main) flagged ~2.9% duplicated code. This PR targets the two largest offenders — a structure-only refactor with **no behavior change**.

### Frontend — `useAdvisorPanel` composable
The advisor panels shared almost their entire `<script setup>`. Extracted the common logic (report/error/loading refs, scan/dismiss state, severity & status class maps, all computeds, and the load/scan handlers) into `src/utils/useAdvisorPanel.js`. Each view now supplies only its per-panel options and template; templates bind through the returned reactive `panel` object.

- Refactored: **Spring, RestApi, Architecture, Hibernate, Security, Memory, Pentesting**
- Memory keeps its local `summary` computed + `formatBytes` and passes a `CRITICAL`-aware severity map/order
- Pentesting uses a reduced option set (apiPath + load/scan error messages)

### Java — `AgentSessionController` base class
`CopilotController` and `ClaudeCodeController` were near-identical. Moved the shared endpoint logic (sessions, dashboard, session detail, events, `/raw`, bounded SSE stream) into a new abstract `AgentSessionController`. The two controllers are now thin `@RestController` subclasses that supply the store, exposure, and a stream label. Dropped the now-unused `BootUiProperties` parameter from their `@Autowired` constructors (the test-only constructor keeps it).

## Impact
- **−1041 net lines** (1419 deletions, 378 insertions)
- The Copilot/ClaudeCode SSE setup previously appeared in 3 files (incl. `LogTailController`); it's now in 2, and the remaining overlap with `LogTailController` measures sub-threshold (0 clones ≥60 tokens vs. Sonar's 100-token gate), so `LogTailController` is intentionally left untouched.

## Verification
- Frontend: `npm test` (168 passing) + `npm run format:check` + `npm run build` — all green
- Java: `bootui-autoconfigure` full suite (784 tests) + `spotless:check` — all green
- No public/visible behavior changes, so no docs updates needed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>