### PR TITLE
Add SonarCloud CI analysis with unit-test coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
   build:
     name: Build (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
+    # SONAR_TOKEN is stored as a secret on the "sonar" GitHub Actions environment.
+    environment: sonar
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
   build:
     name: Build (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -26,6 +28,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # Full history lets SonarCloud assign new-code/issues to the right commits.
+          fetch-depth: 0
 
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
@@ -42,6 +47,13 @@ jobs:
           cache-dependency-path: |
             bootui-ui/src/main/frontend/package-lock.json
             bootui-sample-app/e2e/package-lock.json
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
 
       - name: Check Maven formatting
         run: ./mvnw -B -ntp spotless:check
@@ -130,3 +142,10 @@ jobs:
           path: bootui-sample-app/target/*.jar
           if-no-files-found: warn
           retention-days: 7
+
+      # Runs after the build/tests so JaCoCo XML and the Vitest LCOV report already
+      # exist on disk. No-op until the SONAR_TOKEN secret is configured (which also
+      # makes it skip forked-PR builds that have no access to the secret).
+      - name: SonarCloud analysis
+        if: ${{ env.SONAR_TOKEN != '' }}
+        run: ./mvnw -B -ntp org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ hs_err_pid*
 node/
 node_modules/
 dist/
+coverage/
 .npm/
 .eslintcache
 **/.vuepress/.cache/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist/
 node_modules/
+coverage/
 playwright-report/
 target/
 test-results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,27 @@ npm test
 Playwright can start the sample app automatically. If you already have the sample app running on port 8080, it will
 reuse that server.
 
+## Code quality and coverage
+
+[SonarCloud](https://sonarcloud.io/project/overview?id=jdubois_boot-ui) analysis runs in the `Build` workflow on pushes
+and pull requests targeting `main`. The build generates the coverage reports Sonar consumes:
+
+- **Java** — JaCoCo instruments the Surefire tests and writes `target/site/jacoco/jacoco.xml` in each module during the
+  `verify` phase of `./mvnw clean install`.
+- **Frontend** — Vitest emits `bootui-ui/src/main/frontend/coverage/lcov.info` (a `posttest` hook rewrites the report
+  paths so they resolve against the `bootui-ui` Maven module).
+
+End-to-end (Playwright) tests still run in CI but do not contribute coverage.
+
+The analysis step is a no-op until two one-time setup steps are done:
+
+1. Add a `SONAR_TOKEN` repository secret (generated from your SonarCloud account) in GitHub.
+2. In SonarCloud, disable **Automatic Analysis** (Administration → Analysis Method) — it is mutually exclusive with the
+   CI-based analysis and must be off for coverage to be imported.
+
+To reproduce the coverage reports locally, run `./mvnw clean install` (Java) and `npm test` in
+`bootui-ui/src/main/frontend` (frontend).
+
 ## Formatting
 
 Use Spotless for Java and repository whitespace checks:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build](https://github.com/jdubois/boot-ui/actions/workflows/build.yml/badge.svg)](https://github.com/jdubois/boot-ui/actions/workflows/build.yml)
 [![CodeQL](https://github.com/jdubois/boot-ui/actions/workflows/codeql.yml/badge.svg)](https://github.com/jdubois/boot-ui/actions/workflows/codeql.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jdubois_boot-ui&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=jdubois_boot-ui)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jdubois_boot-ui&metric=coverage)](https://sonarcloud.io/summary/new_code?id=jdubois_boot-ui)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.x-6db33f?logo=springboot&logoColor=white)](https://spring.io/projects/spring-boot)
 [![Java](https://img.shields.io/badge/Java-17-orange?logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/17/)

--- a/bootui-ui/pom.xml
+++ b/bootui-ui/pom.xml
@@ -18,6 +18,13 @@
         <frontend.dir>${project.basedir}/src/main/frontend</frontend.dir>
         <frontend.output.dir>${project.build.outputDirectory}/META-INF/resources/bootui</frontend.output.dir>
         <skipTests>false</skipTests>
+
+        <!-- This module has no Java sources; point Sonar at the Vue/JS frontend so it
+             is analyzed and the Vitest LCOV coverage maps onto the indexed sources. -->
+        <sonar.sources>src/main/frontend/src</sonar.sources>
+        <sonar.tests>src/main/frontend/src</sonar.tests>
+        <sonar.test.inclusions>**/*.test.js</sonar.test.inclusions>
+        <sonar.javascript.lcov.reportPaths>src/main/frontend/coverage/lcov.info</sonar.javascript.lcov.reportPaths>
     </properties>
 
     <build>

--- a/bootui-ui/src/main/frontend/.gitignore
+++ b/bootui-ui/src/main/frontend/.gitignore
@@ -1,1 +1,2 @@
 test-results/
+coverage/

--- a/bootui-ui/src/main/frontend/package-lock.json
+++ b/bootui-ui/src/main/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "6.0.7",
+        "@vitest/coverage-v8": "4.1.8",
         "@vue/server-renderer": "3.5.35",
         "@vue/test-utils": "2.4.10",
         "jsdom": "29.1.1",
@@ -181,6 +182,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -837,6 +848,37 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -1207,6 +1249,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/ast-walker-scope": {
@@ -1586,6 +1650,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -1604,6 +1678,13 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -1635,6 +1716,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -1683,6 +1803,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -2060,6 +2187,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdn-data": {
@@ -2615,6 +2770,19 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
       "engines": {
         "node": ">=8"
       }

--- a/bootui-ui/src/main/frontend/package.json
+++ b/bootui-ui/src/main/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "test": "vitest run",
+    "posttest": "node scripts/normalize-coverage-paths.mjs",
     "test:watch": "vitest",
     "preview": "vite preview",
     "format": "prettier --config ../../../../prettier.config.cjs --ignore-path ../../../../.prettierignore --write .",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "6.0.7",
+    "@vitest/coverage-v8": "4.1.8",
     "@vue/server-renderer": "3.5.35",
     "@vue/test-utils": "2.4.10",
     "jsdom": "29.1.1",

--- a/bootui-ui/src/main/frontend/scripts/normalize-coverage-paths.mjs
+++ b/bootui-ui/src/main/frontend/scripts/normalize-coverage-paths.mjs
@@ -1,0 +1,34 @@
+// Rewrites the `SF:` paths in the generated LCOV report so they are relative to
+// the `bootui-ui` Maven module base directory instead of the frontend project
+// directory. Vitest emits paths like `SF:src/App.vue`, but SonarQube analyzes the
+// `bootui-ui` module (base `bootui-ui/`) and resolves LCOV paths against that base.
+// Without this prefix the coverage would silently fail to map onto the indexed
+// `src/main/frontend/src/**` sources. Run automatically via the `posttest` hook.
+import {existsSync, readFileSync, writeFileSync} from 'node:fs'
+
+const LCOV_PATH = 'coverage/lcov.info'
+const MODULE_PREFIX = 'src/main/frontend/'
+
+if (!existsSync(LCOV_PATH)) {
+  process.exit(0)
+}
+
+const original = readFileSync(LCOV_PATH, 'utf8')
+const normalized = original
+  .split('\n')
+  .map((line) => {
+    if (!line.startsWith('SF:')) {
+      return line
+    }
+    const file = line.slice(3)
+    // Idempotent: skip lines that are already module-relative.
+    if (file.startsWith(MODULE_PREFIX)) {
+      return line
+    }
+    return `SF:${MODULE_PREFIX}${file}`
+  })
+  .join('\n')
+
+if (normalized !== original) {
+  writeFileSync(LCOV_PATH, normalized)
+}

--- a/bootui-ui/src/main/frontend/vite.config.js
+++ b/bootui-ui/src/main/frontend/vite.config.js
@@ -32,6 +32,15 @@ export default defineConfig({
     clearMocks: true,
     restoreMocks: true,
     reporters: process.env.CI ? ['default', 'junit'] : 'default',
-    outputFile: {junit: './test-results/vitest-junit.xml'}
+    outputFile: {junit: './test-results/vitest-junit.xml'},
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      reporter: ['text-summary', 'lcov'],
+      reportsDirectory: './coverage',
+      all: true,
+      include: ['src/**/*.{js,vue}'],
+      exclude: ['src/**/*.test.js', 'src/main.js']
+    }
   }
 })

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,8 @@
         <native-build-tools-plugin.version>1.1.1</native-build-tools-plugin.version>
         <archunit.version>1.4.2</archunit.version>
         <central.autoPublish>true</central.autoPublish>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+        <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
@@ -70,6 +72,14 @@
         <spotless-maven-plugin.version>3.6.0</spotless-maven-plugin.version>
         <node.version>v24.16.0</node.version>
         <npm.version>11.15.0</npm.version>
+
+        <!-- SonarCloud (CI-based) analysis. Coverage import requires CI analysis;
+             Automatic Analysis (Autoscan) must be disabled in the SonarCloud UI. -->
+        <sonar.organization>jdubois</sonar.organization>
+        <sonar.projectKey>jdubois_boot-ui</sonar.projectKey>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/bootui-core/target/site/jacoco/jacoco.xml,${maven.multiModuleProjectDirectory}/bootui-autoconfigure/target/site/jacoco/jacoco.xml,${maven.multiModuleProjectDirectory}/bootui-sample-app/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.exclusions>**/node_modules/**,**/dist/**,**/coverage/**,**/target/**</sonar.exclusions>
     </properties>
 
     <dependencyManagement>
@@ -195,9 +205,38 @@
                         <autoPublish>${central.autoPublish}</autoPublish>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>${sonar-maven-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>


### PR DESCRIPTION
## What does this PR do?

Switches the project from SonarCloud Automatic Analysis to CI-based analysis so unit-test coverage (Java + frontend) is generated during the build and imported into SonarCloud.

## Why is this change needed?

SonarCloud Automatic Analysis (the zero-config mode you get from binding the repo) runs static analysis but cannot import test coverage. To see coverage in SonarCloud you must run a CI-based analysis that produces coverage reports during the build and uploads them with the scanner. The two modes are mutually exclusive.

N/A - no linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Build-infrastructure only; no runtime/UI behavior changes. What I verified locally:

- `./mvnw -pl bootui-core verify` produces `target/site/jacoco/jacoco.xml` (JaCoCo analyzed 184 classes).
- `npm test` in the frontend emits `coverage/lcov.info`, and the `posttest` hook rewrites the `SF:` paths so they resolve against the `bootui-ui` Maven module base (confirmed the rewritten paths point at real files).
- `./mvnw spotless:check` and frontend `npm run format:check` pass.
- `sonar-maven-plugin` resolves at the pinned version `5.7.0.6970` (via `help:describe`). The scanner itself cannot run locally without a token.

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

## Approach

- **Java**: JaCoCo added to the parent build (`prepare-agent` + `report` at `verify`), so every module emits `target/site/jacoco/jacoco.xml`.
- **Frontend**: added `@vitest/coverage-v8` and enabled v8 lcov output. Because Sonar analyzes the `bootui-ui` Maven module (base `bootui-ui/`) while Vitest emits paths relative to the frontend dir, a small `posttest` script normalizes the lcov `SF:` paths to `src/main/frontend/src/...`. Without this, Sonar silently drops JS coverage.
- **Sonar config**: pom properties (organization, project key, host, JaCoCo XML paths, frontend `sonar.sources`/`tests`/lcov, exclusions) and pinned `sonar-maven-plugin`.
- **CI** (`build.yml`): full git history for new-code detection, SonarCloud cache, and an analysis step bound to the `sonar` GitHub Actions environment. The step is a no-op until `SONAR_TOKEN` is present, which also makes forked-PR builds skip it.

e2e (Playwright) tests still run but contribute no coverage (intentional).

## Required one-time setup (outside this PR)

1. Add the `SONAR_TOKEN` secret (done, on the `sonar` environment).
2. In SonarCloud, disable Automatic Analysis (Administration -> Analysis Method); it is mutually exclusive with CI analysis and must be off for coverage import to work.