### PR TITLE
chore: align npm package versions to 1.1.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -120,8 +120,10 @@ the release profile:
   without dropping the failed deployment from the Sonatype Central Portal first. The default path is to run the `Release`
   workflow with a new version so it bumps the codebase, commits, tags, and publishes in one run.
 - **Use the `Release` workflow (`.github/workflows/release.yml`) to bump versions** rather than running `versions:set` by
-  hand. It runs `versions:set` *and* updates the README install snippet, then verify-builds, commits, tags, and publishes.
-  Manual `versions:set` skips the README rewrite, leaving the install snippet pointing at a stale (and possibly
+  hand. It runs `versions:set`, updates the README install snippet, *and* bumps every npm `package.json` /
+  `package-lock.json` (root docs site, `bootui-ui` frontend, and the `bootui-sample-app/e2e` suite) via
+  `npm version --no-git-tag-version`, then verify-builds, commits, tags, and publishes. Manual `versions:set` skips the
+  README rewrite and the npm bumps, leaving the install snippet and npm package versions pointing at a stale (and possibly
   never-published) version.
 - **The sample app is excluded from release deploys** via `<maven.deploy.skip>true</maven.deploy.skip>` in
   `bootui-sample-app/pom.xml`; keep it that way — it must still be built so the central-publishing plugin sees the full

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,12 +112,23 @@ jobs:
             exit 1
           fi
 
+          for npm_dir in . bootui-ui/src/main/frontend bootui-sample-app/e2e; do
+            ( cd "$npm_dir" && npm version "$VERSION" --no-git-tag-version --allow-same-version --ignore-scripts >/dev/null )
+            if ! grep -q "\"version\": \"$VERSION\"" "$npm_dir/package.json"; then
+              echo "::error::Failed to update the npm package version in $npm_dir/package.json to $VERSION"
+              exit 1
+            fi
+          done
+
           if [[ "$SKIP_BUILD" != "true" ]]; then
             ./mvnw -B -ntp -Prelease clean verify -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
           fi
 
           if [[ -n "$(git status --porcelain)" ]]; then
-            git add pom.xml */pom.xml README.md docs/SETUP.md
+            git add pom.xml */pom.xml README.md docs/SETUP.md \
+              package.json package-lock.json \
+              bootui-ui/src/main/frontend/package.json bootui-ui/src/main/frontend/package-lock.json \
+              bootui-sample-app/e2e/package.json bootui-sample-app/e2e/package-lock.json
             git commit -m "Release $TAG"
           else
             echo "Project files already declare version $VERSION; tagging current HEAD."
@@ -158,6 +169,22 @@ jobs:
               exit 1
             fi
           fi
+
+          for npm_dir in . bootui-ui/src/main/frontend bootui-sample-app/e2e; do
+            node -e '
+              const fs = require("fs");
+              const [dir, expected] = process.argv.slice(1);
+              const pkg = JSON.parse(fs.readFileSync(dir + "/package.json", "utf8"));
+              const lock = JSON.parse(fs.readFileSync(dir + "/package-lock.json", "utf8"));
+              const found = [pkg.version, lock.version, lock.packages?.[""]?.version];
+              for (const v of found) {
+                if (v !== expected) {
+                  console.error(`::error::npm version mismatch in ${dir}: expected ${expected}, found ${v}`);
+                  process.exit(1);
+                }
+              }
+            ' "$npm_dir" "$VERSION"
+          done
 
           echo "Releasing version $VERSION"
 

--- a/bootui-sample-app/e2e/package-lock.json
+++ b/bootui-sample-app/e2e/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootui-sample-app-e2e",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bootui-sample-app-e2e",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@playwright/test": "1.60.0",
         "prettier": "3.8.3"

--- a/bootui-sample-app/e2e/package.json
+++ b/bootui-sample-app/e2e/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootui-sample-app-e2e",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.1.0",
   "description": "Playwright end-to-end integration tests that exercise the BootUI console and the sample Spring Boot application from a real browser.",
   "type": "module",
   "scripts": {

--- a/bootui-ui/src/main/frontend/package-lock.json
+++ b/bootui-ui/src/main/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootui-frontend",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bootui-frontend",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "dependencies": {
         "bootstrap": "5.3.8",
         "bootstrap-icons": "1.13.1",

--- a/bootui-ui/src/main/frontend/package.json
+++ b/bootui-ui/src/main/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootui-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootui-site",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bootui-site",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "devDependencies": {
         "@vuepress/bundler-vite": "2.0.0-rc.30",
         "@vuepress/theme-default": "2.0.0-rc.130",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootui-site",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "docs:dev": "vuepress dev docs --host 127.0.0.1 --port 8090",


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
