### PR TITLE
Fix two SonarCloud reliability issues (connection leak, cache instanceof)

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LiquibaseController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LiquibaseController.java
@@ -329,11 +329,9 @@ public class LiquibaseController {
         }
 
         private LiquibaseActionResult updateInScope(String beanName, SpringLiquibase source) throws Exception {
-            Liquibase liquibase = null;
-            try {
-                Connection connection = source.getDataSource().getConnection();
-                BootUiSpringLiquibase runner = BootUiSpringLiquibase.from(source, changeLogParameters(source));
-                liquibase = runner.create(connection);
+            BootUiSpringLiquibase runner = BootUiSpringLiquibase.from(source, changeLogParameters(source));
+            try (Connection connection = source.getDataSource().getConnection();
+                    Liquibase liquibase = runner.create(connection)) {
                 Contexts contexts = new Contexts(source.getContexts());
                 LabelExpression labelExpression = new LabelExpression(source.getLabelFilter());
                 int before =
@@ -352,10 +350,6 @@ public class LiquibaseController {
                 return new LiquibaseActionResult("success", message, beanName, before, after, applied, List.of());
             } catch (SQLException ex) {
                 throw new DatabaseException(ex);
-            } finally {
-                if (liquibase != null) {
-                    liquibase.close();
-                }
             }
         }
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SpringCacheService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SpringCacheService.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.interceptor.*;
+import org.springframework.cache.support.NoOpCacheManager;
 import org.springframework.core.BridgeMethodResolver;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -314,7 +315,7 @@ class SpringCacheService {
     }
 
     private boolean isNoOp(CacheManager manager) {
-        return manager.getClass().getName().equals("org.springframework.cache.support.NoOpCacheManager");
+        return manager instanceof NoOpCacheManager;
     }
 
     private Map<MetricKey, CacheMetricsAccumulator> cacheMetrics() {


### PR DESCRIPTION
## What does this PR do?

Fixes the two genuinely safe, obvious SonarCloud reliability (type=BUG) issues in the codebase: a JDBC connection leak in the Liquibase update path, and a class-name string comparison in the cache service.

## Why is this change needed?

SonarCloud reports 408 reliability issues, but the vast majority are systematic fallout of the project's JSpecify `@NullMarked` adoption (S2637/S2583, 373 issues) or intentional patterns, and aren't safe to touch in isolation. This PR addresses the two that are unambiguous bugs in production code:

- **`java:S2095` (BLOCKER) - JDBC connection leak.** In `LiquibaseController.updateInScope`, the JDBC `Connection` was opened, then `runner.create(connection)` was called on the next line. If that call threw (it throws `LiquibaseException`), `liquibase` stayed null and the `finally` closed nothing, leaking the open connection. The fix uses try-with-resources for both the `Connection` and the `Liquibase` handle, so the connection is always closed even when `create` fails. Closing order is unchanged in practice (`liquibase.close()` first, which closes the underlying connection; the subsequent `connection.close()` is an idempotent no-op), matching the sibling `readPendingChangeSetsInScope` method's intent.

- **`java:S1872` (MAJOR) - compare by name.** `SpringCacheService.isNoOp` matched the fully-qualified class name string against `NoOpCacheManager`. Replaced with `instanceof NoOpCacheManager`, which is more robust (also handles subclasses) and safe here because `NoOpCacheManager` is a core spring-context class that is always present when a `CacheManager` bean exists.

### Deliberately left alone

The other reliability findings are not "easy and obvious" fixes: S2583 flags intentional defensive null-checks as "always false" (removing them would reduce reliability), the remaining S1872 cases in `SecurityScanner`/`HibernateRules` deliberately use string comparison to avoid hard dependencies on optional libraries (Spring Security, Spring Data), S3077 targets correct `volatile` snapshot caches, S5841 covers test assertions where empty results are valid, and S7184 is an intentional negative test fixture.

## How was it tested?

- [x] `LiquibaseControllerTests` and `SpringCacheControllerTests` pass (14 tests) and the `bootui-autoconfigure` module compiles cleanly
- [x] `./mvnw spotless:check` passes for the touched module
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] No new tests needed; existing tests cover both code paths

## Screenshots (UI changes)

N/A - backend-only change.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no behaviour change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed