### PR TITLE
Exclude bootui-sample-app from Sonar analysis

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,9 @@ and pull requests targeting `main`. The build generates the coverage reports Son
 - **Frontend** — Vitest emits `bootui-ui/src/main/frontend/coverage/lcov.info` (a `posttest` hook rewrites the report
   paths so they resolve against the `bootui-ui` Maven module).
 
+The `bootui-sample-app` module is a reference/demo app and is excluded from Sonar analysis via `sonar.skip=true` in its
+POM, so its sources and coverage are not reported to SonarCloud.
+
 End-to-end (Playwright) tests still run in CI but do not contribute coverage.
 
 The analysis step is a no-op until two one-time setup steps are done:

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -16,6 +16,8 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <!-- Reference/demo app: excluded from SonarCloud analysis. -->
+        <sonar.skip>true</sonar.skip>
         <spring-ai.version>2.0.0-M8</spring-ai.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <sonar.organization>jdubois</sonar.organization>
         <sonar.projectKey>jdubois_boot-ui</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/bootui-core/target/site/jacoco/jacoco.xml,${maven.multiModuleProjectDirectory}/bootui-autoconfigure/target/site/jacoco/jacoco.xml,${maven.multiModuleProjectDirectory}/bootui-sample-app/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/bootui-core/target/site/jacoco/jacoco.xml,${maven.multiModuleProjectDirectory}/bootui-autoconfigure/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
         <sonar.exclusions>**/node_modules/**,**/dist/**,**/coverage/**,**/target/**</sonar.exclusions>
     </properties>
 


### PR DESCRIPTION
## What does this PR do?

Excludes the `bootui-sample-app` module from SonarCloud analysis so the reference/demo app no longer counts toward the project's quality gate or coverage.

## Why is this change needed?

`bootui-sample-app` is a reference/demo Spring Boot app used for demos and integration testing, not a published artifact. Its sources and test coverage were being analyzed by SonarCloud and skewing the project metrics. Excluding it keeps the quality gate focused on the modules that actually ship (`bootui-core`, `bootui-autoconfigure`, `bootui-ui`).

The change is small and self-contained:

- Set `sonar.skip=true` in `bootui-sample-app/pom.xml`, the canonical way to drop a Maven module from Sonar analysis. The scanner now skips the module entirely (sources, tests, issues, and coverage).
- Remove the now-irrelevant `bootui-sample-app` JaCoCo report from `sonar.coverage.jacoco.xmlReportPaths` in the root POM, since that module is no longer analyzed.
- Document the exclusion in `CONTRIBUTING.md`.

The sample app still builds, tests, and runs exactly as before (JaCoCo and Spotless are unaffected); it is just no longer reported to SonarCloud.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Verified `./mvnw -pl bootui-sample-app validate` parses the updated POM cleanly. This is a build/config-only change with no runtime or test impact.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed