### PR TITLE
Fix SonarCloud module-relative path deprecation for sonar.exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,10 @@
         <sonar.projectKey>jdubois_boot-ui</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/bootui-core/target/site/jacoco/jacoco.xml,${maven.multiModuleProjectDirectory}/bootui-autoconfigure/target/site/jacoco/jacoco.xml,${maven.multiModuleProjectDirectory}/bootui-sample-app/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
-        <sonar.exclusions>**/node_modules/**,**/dist/**,**/coverage/**,**/target/**</sonar.exclusions>
+        <!-- Project-relative patterns only (SonarCloud deprecates module-relative paths at project
+             level). Listing **/*.test.js here keeps the bootui-ui Vitest files out of MAIN analysis;
+             they are still indexed as tests via the module's sonar.tests + sonar.test.inclusions. -->
+        <sonar.exclusions>**/*.test.js,**/node_modules/**,**/dist/**,**/coverage/**,**/target/**</sonar.exclusions>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## What does this PR do?

Adds `**/*.test.js` to the project-level `sonar.exclusions` so SonarCloud stops emitting the "module-relative paths at project level" deprecation warning.

## Why is this change needed?

SonarCloud was warning:

> Specifying module-relative paths at project level in the property 'sonar.exclusions' is deprecated. To continue matching files like 'bootui-ui/src/main/frontend/src/utils/useServerPagedList.test.js', update this property so that patterns refer to project-relative paths.

The cause is a SonarScanner quirk, not a literal bad path. The `bootui-ui` module sets `sonar.test.inclusions=**/*.test.js` at the module level only. The scanner folds test-inclusion patterns into a module's MAIN exclusion set, but the project-level MAIN exclusion set did not contain it. So the Vitest `*.test.js` files matched only via their module-relative path (`src/main/frontend/src/...`) and not the project-relative path (`bootui-ui/src/main/frontend/src/...`), which is exactly what triggers the deprecation, misattributed to `sonar.exclusions` because the file is evaluated as a MAIN candidate.

Putting `**/*.test.js` in the project-level `sonar.exclusions` makes the scanner's project-relative check succeed first, so the warning no longer fires.

N/A (no linked issue)

Why it is safe:
- Main-source exclusion globs never touch test classification or `.java` files, so the Java modules are unaffected.
- The `.test.js` files are still indexed as tests through the `bootui-ui` module's `sonar.tests` + `sonar.test.inclusions`, so the Vitest LCOV coverage import is unchanged.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Build-config-only change (no runtime or UI behavior). Verified `xmllint` well-formedness and `./mvnw -N spotless:check` passes. The warning clears on the next CI SonarCloud run; the sample-app smoke test and unit tests are not applicable to a Sonar property change.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no docs reference the exclusion list; none needed)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed