### PR TITLE
ci: add --ignore-scripts to npm ci invocations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install Playwright dependencies
         working-directory: bootui-sample-app/e2e
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Check Playwright formatting
         working-directory: bootui-sample-app/e2e

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Sync starter version in setup docs
         run: |


### PR DESCRIPTION
## Why

Sonar flags the `npm ci` steps in CI for running dependency lifecycle scripts (`preinstall`/`install`/`postinstall`). These hooks are a common supply-chain attack vector, and disabling them hardens CI against a compromised dependency executing arbitrary code on the runner.

## What

Adds `--ignore-scripts` to both `npm ci` invocations:

- `.github/workflows/build.yml` - Playwright e2e dependency install
- `.github/workflows/pages.yml` - VuePress docs site install

## Why this is safe here

I audited every dependency that declares an install script (`hasInstallScript` in the lockfiles) for both workflows:

- **`fsevents`** - macOS-only optional native module; it is never installed on the Linux CI runner, so its build script is irrelevant.
- **`@parcel/watcher`** - ships prebuilt binaries via optional dependencies (e.g. `@parcel/watcher-linux-x64-glibc`) resolved at runtime; its install script does no required work, and it is only used by the dev server, not `vuepress build`.
- **`esbuild`** - the only package doing real build work. It gets its binary from the `@esbuild/linux-x64` optional dependency (already pinned in the lockfile), not from a download script. Per the official esbuild docs, it works with `--ignore-scripts` on its own; the script is only an optimization that swaps a JS shim for the native binary. The sole break case is combining `--ignore-scripts` with `--no-optional`, which we do not do.

The one legitimate task in the e2e job, downloading Playwright browsers, is handled by the explicit `playwright install --with-deps chromium` step, which is a real CLI command rather than an npm lifecycle hook. Bin-linking of `.bin/playwright` still happens with `--ignore-scripts`.

Net effect: no functional change to either build; the only thing skipped is esbuild's bin optimization, a negligible per-invocation Node startup overhead irrelevant to a one-shot docs build.