### PR TITLE
ci: pin dorny/test-reporter to commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Publish Java test report
         if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
           name: Java tests (Surefire)
           path: '**/target/surefire-reports/TEST-*.xml'
@@ -95,7 +95,7 @@ jobs:
 
       - name: Publish frontend unit test report
         if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
           name: Frontend unit tests (Vitest)
           path: bootui-ui/src/main/frontend/test-results/vitest-junit.xml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Publish end-to-end test report
         if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
           name: End-to-end tests (Playwright)
           path: bootui-sample-app/e2e/test-results/junit/results.xml


### PR DESCRIPTION
## What does this PR do?

Pins all three `dorny/test-reporter@v3` references in `.github/workflows/build.yml` to the full commit SHA `a43b3a5f7366b97d083190328d2c652e1a8b6aa2` (with a `# v3` comment for readability).

## Why is this change needed?

SonarCloud flagged a security hotspot recommending that third-party GitHub Actions be pinned to a full commit SHA rather than a mutable tag like `@v3`. A floating tag can be repointed by the action's maintainer (or an attacker who compromises the repo) to malicious code, so pinning to an immutable SHA hardens the supply chain of the CI workflow.

Closes # N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

CI-only change; no application code is affected. The SHA was resolved by dereferencing the annotated `v3` tag to its underlying commit, so the workflow runs the exact same action version as before.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed