### PR TITLE
Update advisor score on dismiss in panel and overview

### DIFF
--- a/bootui-sample-app/e2e/tests/advisor-dismiss.spec.js
+++ b/bootui-sample-app/e2e/tests/advisor-dismiss.spec.js
@@ -35,6 +35,16 @@ async function findingsCount(card) {
   return Number.parseInt((await card.locator('.display-6').innerText()).trim(), 10) || 0
 }
 
+/**
+ * Reads the numeric advisor score rendered by the shared AdvisorScoreCard.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<number>}
+ */
+async function scoreValue(page) {
+  return Number.parseInt((await page.locator('.advisor-score-gauge__value').innerText()).trim(), 10)
+}
+
 test.describe('Advisor rule dismiss/restore', () => {
   // The dismiss/restore mechanism is shared by every advisor panel (Architecture,
   // REST API, Spring, Hibernate, Memory, Security). It is exercised here against
@@ -63,6 +73,10 @@ test.describe('Advisor rule dismiss/restore', () => {
     // Nothing is dismissed yet, so the "N dismissed" subline is absent.
     await expect(findingsCard).not.toContainText('dismissed')
 
+    // The advisor score card renders once a scan has produced findings.
+    await expect(page.locator('.advisor-score-card')).toBeVisible()
+    const scoreBefore = await scoreValue(page)
+
     // Capture the rule id of the first active finding so we can target it precisely.
     const firstActive = activeItems.first()
     const ruleId = (await firstActive.locator('span.text-muted.small').first().innerText()).trim()
@@ -84,6 +98,15 @@ test.describe('Advisor rule dismiss/restore', () => {
     await expect(findingsCard).toContainText('1 dismissed')
     await expect.poll(async () => findingsCount(findingsCard)).toBe(before - 1)
 
+    // Dismissing a finding removes its weighted penalty. The score therefore rises or
+    // holds: the sample app's Hibernate model has enough findings to clamp the raw score
+    // at 0, so dropping a single rule can leave the displayed score unchanged. The strict
+    // "dismiss raises the score" guarantee is unit-tested in Spring.test.js against a
+    // non-clamped report; here we assert it never *decreases* and that the score card
+    // notes the exclusion. The exact-restore check below is what pins the wiring down.
+    await expect(page.getByText('excluded from this score')).toBeVisible()
+    await expect.poll(async () => scoreValue(page)).toBeGreaterThanOrEqual(scoreBefore)
+
     // The rule is no longer offered as an active (dismissible) finding.
     await expect(activeItemFor(ruleId)).toHaveCount(0)
 
@@ -92,7 +115,9 @@ test.describe('Advisor rule dismiss/restore', () => {
 
     await expect(dismissedItemFor(ruleId)).toHaveCount(0)
     await expect(findingsCard).not.toContainText('dismissed')
+    await expect(page.getByText('excluded from this score')).toHaveCount(0)
     await expect.poll(async () => findingsCount(findingsCard)).toBe(before)
+    await expect.poll(async () => scoreValue(page)).toBe(scoreBefore)
     await expect(activeItemFor(ruleId)).toHaveCount(1)
   })
 })

--- a/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.js
+++ b/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.js
@@ -3,6 +3,7 @@ import {computed, onMounted, reactive, ref} from 'vue'
 import {formatClockTime} from './format.js'
 import {describeLoadError} from './loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from './scanStatus.js'
+import {scoreBandLabel, scoreBandTone, scoreFromSeverityCounts} from './scannerScore.js'
 import {usePanelState} from './panelState.js'
 import {useDismissedRules} from './useDismissedRules.js'
 
@@ -55,6 +56,11 @@ export function useAdvisorPanel(props, options) {
   const visibleResults = computed(() => violations.value.filter((result) => !result.dismissed))
 
   const dismissedResults = computed(() => violations.value.filter((result) => result.dismissed))
+
+  // 0-100 advisor score derived from the same weighted-penalty model the Overview
+  // dashboard uses. The server recomputes severityCounts with dismissed rules excluded,
+  // so dismissing or restoring a rule (which reloads the report) updates this score too.
+  const score = computed(() => (hasScanData.value ? scoreFromSeverityCounts(report.value?.severityCounts) : null))
 
   const maxSeverityCount = computed(() => {
     if (!report.value?.severityCounts?.length) return 1
@@ -155,6 +161,9 @@ export function useAdvisorPanel(props, options) {
     dismiss,
     restore,
     hasScanData,
+    score,
+    scoreBandLabel,
+    scoreBandTone,
     visibleResults,
     dismissedResults,
     emptyRuleResultsTitle,

--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
+import AdvisorScoreCard from './components/AdvisorScoreCard.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
@@ -39,6 +40,7 @@ const panel = useAdvisorPanel(props, {
     <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
     <template v-if="panel.report">
+      <AdvisorScoreCard :score="panel.score" :dismissed-count="panel.dismissedResults.length" />
       <div class="alert alert-info">
         <strong>Heuristic architecture rules.</strong>
         {{ panel.report.disclaimer }}

--- a/bootui-ui/src/main/frontend/src/views/Hibernate.vue
+++ b/bootui-ui/src/main/frontend/src/views/Hibernate.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
+import AdvisorScoreCard from './components/AdvisorScoreCard.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
@@ -46,6 +47,7 @@ const panel = useAdvisorPanel(props, {
     <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
     <template v-if="panel.report">
+      <AdvisorScoreCard :score="panel.score" :dismissed-count="panel.dismissedResults.length" />
       <div class="alert alert-info">
         <strong>Heuristic Hibernate rules.</strong>
         {{ panel.report.disclaimer }}

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -2,6 +2,7 @@
 import {computed} from 'vue'
 import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
+import AdvisorScoreCard from './components/AdvisorScoreCard.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
@@ -62,6 +63,7 @@ function formatBytes(value) {
     <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
     <template v-if="panel.report">
+      <AdvisorScoreCard :score="panel.score" :dismissed-count="panel.dismissedResults.length" />
       <div class="alert alert-info">
         <strong>Heuristic JVM memory and thread health rules.</strong>
         {{ panel.report.disclaimer }}

--- a/bootui-ui/src/main/frontend/src/views/Overview.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Overview.test.js
@@ -1,8 +1,16 @@
 import {flushPromises, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it, vi} from 'vitest'
-import {ref} from 'vue'
+import {defineComponent, h, KeepAlive, ref} from 'vue'
 
 import Overview from './Overview.vue'
+import ScannerScoreCard from './components/ScannerScoreCard.vue'
+
+function architectureScore(wrapper) {
+  const card = wrapper
+    .findAllComponents(ScannerScoreCard)
+    .find((component) => component.props('title') === 'Architecture')
+  return card.find('.scanner-score').text()
+}
 
 function severityReport(severityCounts, status = 'SCANNED') {
   return {severityCounts, scan: {status}}
@@ -37,6 +45,26 @@ function mountOverview(panels) {
       stubs: {RouterLink: {template: '<a><slot /></a>'}}
     }
   })
+}
+
+// Mounts the dashboard inside a <KeepAlive> with a toggle, mirroring App.vue's
+// `<keep-alive include="Overview">`. Flipping `show` deactivates and re-activates
+// the cached Overview so its `onActivated` refresh runs, just like navigating away
+// to a panel and back.
+function mountKeptAlive(panels) {
+  const show = ref(true)
+  const Host = defineComponent({
+    setup() {
+      return () => h(KeepAlive, null, {default: () => (show.value ? h(Overview) : h('div', 'away'))})
+    }
+  })
+  const wrapper = mount(Host, {
+    global: {
+      provide: {panels: ref(panels)},
+      stubs: {RouterLink: {template: '<a><slot /></a>'}}
+    }
+  })
+  return {wrapper, show}
 }
 
 const allPanels = {
@@ -162,5 +190,54 @@ describe('Overview', () => {
 
     expect(wrapper.text()).toContain('Connect to GitHub to load live security metrics')
     expect(wrapper.text()).toContain('0 of 1 scanners scored')
+  })
+
+  it('refreshes a scored advisor from its report on re-activation so dismissals reflect on the dashboard', async () => {
+    // POST /scan reports one HIGH finding (score 90); the GET report (re-fetched on
+    // re-activation) reflects that finding having been dismissed server-side (clean => 100).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input, init) => {
+        const url = typeof input === 'string' ? input : input.url
+        const method = (init?.method || 'GET').toUpperCase()
+        let body = {}
+        if (url.includes('api/architecture/scan') && method === 'POST') {
+          body = severityReport([{severity: 'HIGH', count: 1}])
+        } else if (url.includes('api/architecture')) {
+          body = severityReport([])
+        }
+        return Promise.resolve(new Response(JSON.stringify(body), {status: 200}))
+      })
+    )
+
+    const {wrapper, show} = mountKeptAlive({
+      panels: [
+        {id: 'architecture', available: true},
+        {id: 'memory', available: false},
+        {id: 'rest-api', available: false},
+        {id: 'spring', available: false},
+        {id: 'hibernate', available: false},
+        {id: 'security', available: false},
+        {id: 'pentesting', available: false},
+        {id: 'vulnerabilities', available: false},
+        {id: 'github', available: false}
+      ]
+    })
+    await flushPromises()
+
+    const runButton = wrapper.findAll('button').find((button) => button.text().includes('Run scan'))
+    await runButton.trigger('click')
+    await flushPromises()
+    expect(architectureScore(wrapper)).toBe('90')
+    expect(wrapper.text()).toContain('1 high')
+
+    // Navigate away (deactivate) then back (activate) -> onActivated refresh re-reads the report.
+    show.value = false
+    await flushPromises()
+    show.value = true
+    await flushPromises()
+
+    expect(architectureScore(wrapper)).toBe('100')
+    expect(wrapper.text()).not.toContain('1 high')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -1,8 +1,8 @@
 <script setup>
 import {apiFetch} from '../api.js'
-import {computed, inject, onMounted, reactive, ref} from 'vue'
+import {computed, inject, onActivated, onMounted, reactive, ref} from 'vue'
 import {describeLoadError} from '../utils/loadError.js'
-import {scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
+import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {overallScore, scoreBandLabel, scoreBandTone, scoreFromSeverityCounts} from '../utils/scannerScore.js'
 import ScannerScoreCard from './components/ScannerScoreCard.vue'
 import OverviewHealthCard from './components/OverviewHealthCard.vue'
@@ -36,7 +36,8 @@ const scannerDefs = [
     icon: 'bi-diagram-2',
     tone: 'primary',
     to: '/architecture',
-    endpoint: 'api/architecture/scan'
+    endpoint: 'api/architecture/scan',
+    reportEndpoint: 'api/architecture'
   },
   {
     id: 'memory',
@@ -44,7 +45,8 @@ const scannerDefs = [
     icon: 'bi-clipboard2-pulse',
     tone: 'warning',
     to: '/memory',
-    endpoint: 'api/memory/scan'
+    endpoint: 'api/memory/scan',
+    reportEndpoint: 'api/memory'
   },
   {
     id: 'rest-api',
@@ -52,7 +54,8 @@ const scannerDefs = [
     icon: 'bi-signpost-split',
     tone: 'primary',
     to: '/rest-api',
-    endpoint: 'api/rest-api/scan'
+    endpoint: 'api/rest-api/scan',
+    reportEndpoint: 'api/rest-api'
   },
   {
     id: 'spring',
@@ -60,7 +63,8 @@ const scannerDefs = [
     icon: 'bi-lightbulb',
     tone: 'info',
     to: '/spring',
-    endpoint: 'api/spring/scan'
+    endpoint: 'api/spring/scan',
+    reportEndpoint: 'api/spring'
   },
   {
     id: 'hibernate',
@@ -68,7 +72,8 @@ const scannerDefs = [
     icon: 'bi-database-gear',
     tone: 'info',
     to: '/hibernate',
-    endpoint: 'api/hibernate/scan'
+    endpoint: 'api/hibernate/scan',
+    reportEndpoint: 'api/hibernate'
   },
   {
     id: 'security',
@@ -76,7 +81,8 @@ const scannerDefs = [
     icon: 'bi-shield-check',
     tone: 'success',
     to: '/security',
-    endpoint: 'api/security/scan'
+    endpoint: 'api/security/scan',
+    reportEndpoint: 'api/security'
   },
   {
     id: 'pentesting',
@@ -84,7 +90,8 @@ const scannerDefs = [
     icon: 'bi-shield-exclamation',
     tone: 'warning',
     to: '/pentesting',
-    endpoint: 'api/pentesting/scan'
+    endpoint: 'api/pentesting/scan',
+    reportEndpoint: 'api/pentesting'
   },
   {
     id: 'vulnerabilities',
@@ -102,25 +109,71 @@ function newScannerState() {
 
 const scanners = reactive(Object.fromEntries(scannerDefs.map((def) => [def.id, newScannerState()])))
 
+// Monotonic request token per scanner so a slower in-flight request (e.g. a POST scan
+// started before navigating away) can never overwrite a newer response (e.g. the GET
+// refresh that runs when the kept-alive dashboard is re-activated). Plain object, not
+// reactive: it is bookkeeping, not rendered state.
+const requestTokens = {}
+
+function nextToken(id) {
+  requestTokens[id] = (requestTokens[id] || 0) + 1
+  return requestTokens[id]
+}
+
+function applyReport(state, report) {
+  state.severityCounts = report.severityCounts ?? []
+  state.score = scoreFromSeverityCounts(state.severityCounts)
+  const status = report.scan?.status
+  state.statusLabel = scanStatusLabel(status)
+  state.statusTone = scanStatusBadgeClass(status)
+  state.state = 'done'
+  state.error = null
+}
+
 const visibleScanners = computed(() => scannerDefs.filter((def) => panelAvailable(def.id)))
 
 async function runScanner(def) {
   const state = scanners[def.id]
+  const token = nextToken(def.id)
   state.state = 'running'
   state.error = null
   try {
     const res = await apiFetch(def.endpoint, {method: 'POST'})
     if (!res.ok) throw new Error('HTTP ' + res.status)
     const report = await res.json()
-    state.severityCounts = report.severityCounts ?? []
-    state.score = scoreFromSeverityCounts(state.severityCounts)
-    const status = report.scan?.status
-    state.statusLabel = scanStatusLabel(status)
-    state.statusTone = scanStatusBadgeClass(status)
-    state.state = 'done'
+    if (token !== requestTokens[def.id]) return
+    applyReport(state, report)
   } catch (e) {
+    if (token !== requestTokens[def.id]) return
     state.state = 'error'
     state.error = describeLoadError(e, `Unable to run ${def.title}`).message
+  }
+}
+
+// The dashboard is kept alive (App.vue wraps it in <keep-alive include="Overview">), so its
+// scores survive navigation. Dismissing/restoring an advisor rule in a panel changes that
+// advisor's server-side score, which would otherwise leave the dashboard showing a stale value.
+// On re-activation we re-fetch the report (GET, never a re-scan) for advisors that have already
+// been scored here, so the score and severity counts reflect the current dismissals.
+async function refreshScanner(def) {
+  const state = scanners[def.id]
+  if (!def.reportEndpoint || state.state !== 'done') return
+  const token = nextToken(def.id)
+  try {
+    const res = await apiFetch(def.reportEndpoint)
+    if (!res.ok) return
+    const report = await res.json()
+    if (token !== requestTokens[def.id]) return
+    if (!hasScanResult(report.scan?.status)) return
+    applyReport(state, report)
+  } catch {
+    // Best-effort refresh: keep the previously computed score if the report cannot be reloaded.
+  }
+}
+
+function refreshScores() {
+  for (const def of visibleScanners.value) {
+    refreshScanner(def)
   }
 }
 
@@ -230,6 +283,7 @@ async function ensurePanels() {
 }
 
 onMounted(ensurePanels)
+onActivated(refreshScores)
 </script>
 
 <template>

--- a/bootui-ui/src/main/frontend/src/views/Pentesting.vue
+++ b/bootui-ui/src/main/frontend/src/views/Pentesting.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
+import AdvisorScoreCard from './components/AdvisorScoreCard.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
@@ -36,6 +37,7 @@ const panel = useAdvisorPanel(props, {
     <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
     <template v-if="panel.report">
+      <AdvisorScoreCard :score="panel.score" :dismissed-count="panel.dismissedResults.length" />
       <div class="alert alert-info">
         <strong>Local-only heuristics.</strong>
         {{ panel.report.disclaimer }} BootUI uses passive Spring metadata plus a synthetic app-path localhost request;

--- a/bootui-ui/src/main/frontend/src/views/RestApi.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestApi.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
+import AdvisorScoreCard from './components/AdvisorScoreCard.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
@@ -39,6 +40,7 @@ const panel = useAdvisorPanel(props, {
     <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
     <template v-if="panel.report">
+      <AdvisorScoreCard :score="panel.score" :dismissed-count="panel.dismissedResults.length" />
       <div class="alert alert-info">
         <strong>Heuristic REST API design rules.</strong>
         {{ panel.report.disclaimer }}

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
+import AdvisorScoreCard from './components/AdvisorScoreCard.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
@@ -39,6 +40,7 @@ const panel = useAdvisorPanel(props, {
     <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
     <template v-if="panel.report">
+      <AdvisorScoreCard :score="panel.score" :dismissed-count="panel.dismissedResults.length" />
       <div class="alert alert-info">
         <strong>Heuristic Spring Security rules.</strong>
         {{ panel.report.disclaimer }}

--- a/bootui-ui/src/main/frontend/src/views/Spring.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Spring.test.js
@@ -97,4 +97,61 @@ describe('Spring', () => {
     expect(wrapper.text()).toContain('No Spring Advisor findings')
     expect(wrapper.text()).not.toContain('Passing config rule')
   })
+
+  it('shows the advisor score and raises it when a finding is dismissed', async () => {
+    const dismissed = new Set()
+    const baseResults = [
+      ruleResult('SPRING-WIRING-001', 'High severity finding', 'HIGH', 'VIOLATION', 1),
+      ruleResult('SPRING-WEB-002', 'Medium severity finding', 'MEDIUM', 'VIOLATION', 1)
+    ]
+
+    function currentReport() {
+      const results = baseResults.map((result) => ({...result, dismissed: dismissed.has(result.id)}))
+      const active = results.filter((result) => result.status === 'VIOLATION' && !result.dismissed)
+      const count = (severity) => active.filter((result) => result.severity === severity).length
+      return {
+        ...advisorReport(results, active.length),
+        severityCounts: [
+          {severity: 'HIGH', count: count('HIGH')},
+          {severity: 'MEDIUM', count: count('MEDIUM')},
+          {severity: 'LOW', count: 0},
+          {severity: 'INFO', count: 0}
+        ],
+        results
+      }
+    }
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input, init) => {
+        const url = typeof input === 'string' ? input : input.url
+        const method = (init?.method || 'GET').toUpperCase()
+        if (url.includes('api/dismissed-rules/')) {
+          const id = decodeURIComponent(url.split('api/dismissed-rules/')[1])
+          if (method === 'POST') dismissed.add(id)
+          if (method === 'DELETE') dismissed.delete(id)
+          return Promise.resolve(new Response('{}', {status: 200}))
+        }
+        return Promise.resolve(new Response(JSON.stringify(currentReport()), {status: 200}))
+      })
+    )
+
+    const wrapper = mount(Spring)
+    await flushPromises()
+
+    // HIGH (10) + MEDIUM (3) penalty => 100 - 13 = 87.
+    const scoreCard = wrapper.find('.advisor-score-card')
+    expect(scoreCard.exists()).toBe(true)
+    expect(scoreCard.text()).toContain('Advisor score')
+    expect(scoreCard.text()).toContain('87')
+
+    // The first dismiss button targets the highest-importance finding (HIGH).
+    const dismissButton = wrapper.findAll('button').find((button) => button.text().includes('Dismiss'))
+    await dismissButton.trigger('click')
+    await flushPromises()
+
+    // Removing the HIGH finding drops the penalty to 3 => 97, and the exclusion is noted.
+    expect(wrapper.find('.advisor-score-card').text()).toContain('97')
+    expect(wrapper.text()).toContain('1 dismissed rule(s) excluded from this score')
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/Spring.vue
+++ b/bootui-ui/src/main/frontend/src/views/Spring.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
+import AdvisorScoreCard from './components/AdvisorScoreCard.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
@@ -39,6 +40,7 @@ const panel = useAdvisorPanel(props, {
     <div v-if="panel.actionMessage" class="alert alert-warning">{{ panel.actionMessage }}</div>
 
     <template v-if="panel.report">
+      <AdvisorScoreCard :score="panel.score" :dismissed-count="panel.dismissedResults.length" />
       <div class="alert alert-info">
         <strong>Heuristic Spring context rules.</strong>
         {{ panel.report.disclaimer }}

--- a/bootui-ui/src/main/frontend/src/views/components/AdvisorScoreCard.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/AdvisorScoreCard.test.js
@@ -1,0 +1,37 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+
+import AdvisorScoreCard from './AdvisorScoreCard.vue'
+
+describe('AdvisorScoreCard', () => {
+  it('renders the score, /100, and qualitative band when a score is provided', () => {
+    const wrapper = mount(AdvisorScoreCard, {props: {score: 90}})
+    expect(wrapper.find('.advisor-score-card').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Advisor score')
+    expect(wrapper.text()).toContain('90')
+    expect(wrapper.text()).toContain('/ 100')
+    expect(wrapper.text()).toContain('Good')
+  })
+
+  it('uses the at-risk band for low scores', () => {
+    const wrapper = mount(AdvisorScoreCard, {props: {score: 40}})
+    expect(wrapper.text()).toContain('At risk')
+    expect(wrapper.find('.advisor-score-gauge--danger').exists()).toBe(true)
+  })
+
+  it('renders nothing until a scan has produced a score', () => {
+    const wrapper = mount(AdvisorScoreCard, {props: {score: null}})
+    expect(wrapper.find('.advisor-score-card').exists()).toBe(false)
+    expect(wrapper.text()).toBe('')
+  })
+
+  it('notes how many dismissed rules are excluded from the score', () => {
+    const wrapper = mount(AdvisorScoreCard, {props: {score: 97, dismissedCount: 2}})
+    expect(wrapper.text()).toContain('2 dismissed rule(s) excluded from this score')
+  })
+
+  it('omits the dismissed note when nothing is dismissed', () => {
+    const wrapper = mount(AdvisorScoreCard, {props: {score: 100, dismissedCount: 0}})
+    expect(wrapper.text()).not.toContain('excluded from this score')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/AdvisorScoreCard.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/AdvisorScoreCard.vue
@@ -1,0 +1,86 @@
+<script setup>
+import {computed} from 'vue'
+import {scoreBandLabel, scoreBandTone} from '../../utils/scannerScore.js'
+
+const props = defineProps({
+  score: {type: Number, default: null},
+  dismissedCount: {type: Number, default: 0}
+})
+
+const hasScore = computed(() => Number.isFinite(props.score))
+const bandLabel = computed(() => (hasScore.value ? scoreBandLabel(props.score) : null))
+const bandTone = computed(() => (hasScore.value ? scoreBandTone(props.score) : 'secondary'))
+</script>
+
+<template>
+  <div v-if="hasScore" class="card advisor-score-card mb-3">
+    <div class="card-body d-flex align-items-center gap-3">
+      <div :class="['advisor-score-gauge', `advisor-score-gauge--${bandTone}`]">
+        <span class="advisor-score-gauge__value">{{ score }}</span>
+        <span class="advisor-score-gauge__max">/ 100</span>
+      </div>
+      <div class="min-w-0">
+        <div class="text-uppercase text-muted fw-bold small">Advisor score</div>
+        <span :class="['badge', `text-bg-${bandTone}`, 'fs-6', 'mt-1']">{{ bandLabel }}</span>
+        <div v-if="dismissedCount > 0" class="text-muted small mt-2">
+          <i class="bi bi-eye-slash me-1"></i>{{ dismissedCount }} dismissed rule(s) excluded from this score
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.advisor-score-card {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 1.1rem;
+  box-shadow: 0 0.5rem 1.6rem rgba(15, 23, 42, 0.06);
+}
+
+.advisor-score-gauge {
+  align-items: center;
+  border: 0.35rem solid;
+  border-radius: 50%;
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  height: 5.5rem;
+  justify-content: center;
+  width: 5.5rem;
+}
+
+.advisor-score-gauge__value {
+  font-size: 1.75rem;
+  font-weight: 850;
+  line-height: 1;
+}
+
+.advisor-score-gauge__max {
+  color: #64748b;
+  font-size: 0.68rem;
+}
+
+.advisor-score-gauge--success {
+  border-color: #198754;
+  color: #198754;
+}
+
+.advisor-score-gauge--warning {
+  border-color: #ffc107;
+  color: #997404;
+}
+
+.advisor-score-gauge--danger {
+  border-color: #dc3545;
+  color: #dc3545;
+}
+
+.advisor-score-gauge--secondary {
+  border-color: #cbd5e1;
+  color: #64748b;
+}
+
+.min-w-0 {
+  min-width: 0;
+}
+</style>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -71,15 +71,19 @@ safety threshold that skips optional sections before exhausting the core API quo
 
 BootUI's advisors run explicit, on-demand rule-based scans and surface severity-ranked findings, feeding the weighted
 score on the Overview dashboard. Each advisor inspects a different facet of the application — compiled architecture, the
-REST layer, the live Spring context, persistence, JVM memory, and security posture — and is read-only.
+REST layer, the live Spring context, persistence, JVM memory, and security posture — and is read-only. Once an advisor
+has run, its panel shows the same 0–100 score the Overview computes for it (100 minus the weighted finding penalty), so
+each panel and the dashboard always agree.
 
 Every advisor finding can be **dismissed** when it does not apply to your project. Each rule result carries a _Dismiss_
 button; dismissing a rule moves it into a collapsed "Dismissed rules" list at the bottom of the panel and excludes it
-from the panel's finding count, severity bars, and the weighted Overview score. Dismissed rules can be restored at any
-time from that list. Dismissals are applied server-side and persisted under the `dismissedRules` node of a local
-`.bootui/boot-ui.yml` configuration file (next to the runtime overrides file), so they survive restarts and stay
-consistent between each panel and the Overview dashboard. The file is developer-local and intended to be git-ignored;
-rule identifiers are globally unique across advisors, so a dismissal always targets exactly one rule.
+from the panel's finding count, severity bars, the panel's own advisor score, and the weighted Overview score. The
+panel's score recomputes immediately, and the Overview dashboard — which stays mounted in the background — re-reads the
+advisor's score when you return to it, so dismissing or restoring a finding is reflected in both places. Dismissed rules
+can be restored at any time from that list. Dismissals are applied server-side and persisted under the `dismissedRules`
+node of a local `.bootui/boot-ui.yml` configuration file (next to the runtime overrides file), so they survive restarts
+and stay consistent between each panel and the Overview dashboard. The file is developer-local and intended to be
+git-ignored; rule identifiers are globally unique across advisors, so a dismissal always targets exactly one rule.
 
 ### Architecture
 


### PR DESCRIPTION
## What does this PR do?

Surfaces a numeric advisor score on every advisor panel and keeps the Overview dashboard in sync, so dismissing (or restoring) a finding updates the score in both places.

## Why is this change needed?

Dismissing an advisor finding already recomputed the server-side severity counts, but nothing reflected the resulting score change to the user. The panels showed finding counts and severity bars but no score, and the Overview dashboard (which is kept-alive) held stale scores after a dismissal happened in a panel.

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Approach:

- Compute a per-advisor `score` in the shared `useAdvisorPanel` composable from the report's severity counts, so all seven panels (Architecture, Memory, REST API, Spring, Hibernate, Security, Pentesting) pick it up uniformly.
- Add a shared `AdvisorScoreCard` component that renders the gauge, band badge, and a note when dismissed rules are excluded from the score. Because dismiss/restore reloads the report, the score updates live.
- Fix the stale Overview: it is wrapped in `keep-alive`, so its scores did not refresh after a dismissal in a panel. Re-read already-scanned advisors on `onActivated`, using per-scanner request tokens so a slow refresh cannot clobber a newer result.

Test coverage: a non-clamped 87 -> 97 dismiss case in `Spring.test.js`, a keep-alive 90 -> 100 re-activation case in `Overview.test.js`, the `AdvisorScoreCard` unit tests, and the `advisor-dismiss` Playwright spec. Full Vitest suite: 175 pass.

One thing worth noting for review: the e2e asserts the score is non-decreasing on dismiss rather than strictly increasing. The sample app's Hibernate advisor has enough findings to clamp the raw score to 0, so dropping a single rule can leave the displayed score unchanged. The strict "dismiss raises the score" guarantee is covered by the non-clamped `Spring.test.js` unit test instead.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed