### PR TITLE
Change Spring panel icon from lightbulb to leaf

### DIFF
--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -82,7 +82,7 @@ export const routes = [
     path: '/spring',
     name: 'spring',
     component: Spring,
-    meta: {group: groups.advisors, icon: 'bi-lightbulb', title: 'Spring'}
+    meta: {group: groups.advisors, icon: 'bi-leaf', title: 'Spring'}
   },
   {
     path: '/hibernate',

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -60,7 +60,7 @@ const scannerDefs = [
   {
     id: 'spring',
     title: 'Spring',
-    icon: 'bi-lightbulb',
+    icon: 'bi-leaf',
     tone: 'info',
     to: '/spring',
     endpoint: 'api/spring/scan',

--- a/bootui-ui/src/main/frontend/src/views/Spring.vue
+++ b/bootui-ui/src/main/frontend/src/views/Spring.vue
@@ -19,7 +19,7 @@ const panel = useAdvisorPanel(props, {
 <template>
   <div>
     <PanelHeader
-      icon="bi-lightbulb"
+      icon="bi-leaf"
       title="Spring"
       subtitle="Review the running Spring application context with bounded configuration and best-practice checks."
       :loading="panel.loading"


### PR DESCRIPTION
## What does this PR do?

Swaps the Spring advisor panel's icon from a lightbulb (`bi-lightbulb`) to a leaf (`bi-leaf`).

## Why is this change needed?

The leaf better reflects Spring's own branding (its logo is a leaf) and makes the panel easier to recognize at a glance in the sidebar and overview.

Closes #

## How was it tested?

Icon-only UI change. Updated the three places that carry the Spring identity icon so they stay consistent:

- `routes.js` - sidebar/route icon
- `views/Spring.vue` - panel header icon
- `views/Overview.vue` - Spring advisor card icon

`bi-leaf` exists in bootstrap-icons 1.13.1. Verified via the Vite dev server. The generic empty-state "tip" lightbulb inside `Spring.vue` was intentionally left untouched since it is decorative and not the Spring identity icon.

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed