### PR TITLE
docs: sync ARCH-CODE-011 title with rule definition

### DIFF
--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -161,7 +161,7 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Fires when**: an exception type's simple class name does not end with `Exception`.
 - **Recommendation**: rename exception classes to end with `Exception` so their purpose is immediately clear.
 
-### ARCH-CODE-011 — Interfaces should not have names ending with Interface
+### ARCH-CODE-011 — Interfaces should not have names ending with 'Interface'
 
 - **Severity**: LOW
 - **Inspects**: Java interfaces.


### PR DESCRIPTION
## What does this PR do?

Fixes a single documentation drift: the `ARCH-CODE-011` heading in `docs/ARCHITECTURE-CHECKS.md` now matches the rule name in `ArchitectureRules.java` exactly.

## Why is this change needed?

I ran a full audit checking that all docs, the specification, the Copilot instructions, the `*-CHECKS.md` catalogues, and the properties reference are in sync with the code. I extracted IDs/titles/severities directly from the code and diffed them against the docs across every surface:

- `PROPERTIES.md` vs `BootUiProperties` + the four env post-processors
- Panel surface across `routes.js`, `BootUiPanels.java`, `PROPERTIES.md`, and `FEATURES.md`
- All eight advisor `*-CHECKS.md` files vs their rule registries (Spring, Hibernate, Memory, Security, Architecture, REST API, GraalVM, Pentesting)
- `SPECIFICATION.md` API endpoint table vs controller `@RequestMapping`s
- `FEATURES.md` scoring weights/bands vs `scannerScore.js`
- `copilot-instructions.md` version/topology claims vs `pom.xml` and registration files

Everything was already in sync except one rule title: the doc heading had dropped the single quotes around `'Interface'` that the code uses in the rule's name. This restores them so the documented title matches the code.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Verified `prettier --check docs/ARCHITECTURE-CHECKS.md` passes; re-ran the code-vs-docs comparison and confirmed zero remaining mismatches

Docs-only change, so no build or runtime behaviour is affected.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed