### PR TITLE
ci: redeploy docs site after a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
     environment: maven-central
     permissions:
       contents: write
+      actions: write
     env:
       CENTRAL_AUTO_PUBLISH: ${{ github.event_name != 'workflow_dispatch' || inputs.auto_publish }}
     steps:
@@ -203,3 +204,12 @@ jobs:
           ./mvnw -B -ntp -Prelease clean deploy \
             -Dcentral.autoPublish="${CENTRAL_AUTO_PUBLISH}" \
             -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
+
+      - name: Redeploy documentation site
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The release commit is pushed to main with GITHUB_TOKEN, which does not
+          # trigger the Pages workflow. Dispatch it explicitly so the docs site
+          # rebuilds with the released version's setup instructions.
+          gh workflow run pages.yml --ref main


### PR DESCRIPTION
## What failed

The 1.2.0 release left the published Setup page on the docs site still showing `1.1.0`.

Root cause: the `Release v1.2.0` commit that bumps `pom.xml` / `docs/SETUP.md` is created and pushed to `main` **by the Release workflow itself**, using the default `GITHUB_TOKEN`. GitHub deliberately does **not** trigger other workflows for pushes made with `GITHUB_TOKEN` (recursion guard), so the `Pages` workflow never re-ran for that commit. The last Pages deploy was for the merge of the prepare-release PR (#314), where the version was still `1.1.0`, and the Pages "Sync starter version" step derives the version from `pom.xml` at build time — so it baked in `1.1.0`.

Nothing errored; the deploy simply never happened.

## Fix

- **Live site**: manually dispatched the `Pages` workflow on `main` to redeploy — the published Setup page now shows `1.2.0`.
- **Recurrence**: this PR adds a final step to the Release job that explicitly dispatches the `Pages` workflow (`gh workflow run pages.yml --ref main`) after publishing, plus the `actions: write` permission it needs. A `workflow_dispatch` triggered via the API/CLI is not subject to the `GITHUB_TOKEN` recursion guard, so the docs site will rebuild with the released version automatically from now on.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>