### PR TITLE
docs: feature Advisors dashboard on welcome page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,8 @@ actions:
 features:
   - title: Runtime observability
     details: Inspect health, metrics, memory, threads, heap dumps, startup timing, and JVM sizing from the running Spring Boot app.
-  - title: Configuration intelligence
-    details: Browse masked configuration, profile differences, loggers, beans, conditions, and mappings with stable BootUI DTOs.
+  - title: Advisors dashboard
+    details: Analyse and score your application with advanced advisors for architecture, REST API, Spring, Hibernate, JVM memory, Spring Security, pentesting, and vulnerabilities.
   - title: Diagnostics toolbox
     details: Review traces, log tail, HTTP exchanges, local probes, architecture checks, GraalVM readiness, and dependency vulnerabilities.
   - title: Data and services visibility


### PR DESCRIPTION
## What does this PR do?

Replaces the "Configuration intelligence" feature card on the VuePress home page (`docs/README.md`) with an "Advisors dashboard" card.

## Why is this change needed?

The Advisors dashboard is now a flagship part of BootUI, but the welcome page still led with configuration browsing. Promoting the advisors on the landing page better reflects what the console offers: on-demand, read-only analysis across architecture, REST API, Spring, Hibernate, JVM memory, Spring Security, pentesting, and vulnerabilities, with severity-ranked findings feeding a weighted Overview score.

Closes # N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Docs-only change to the home page front matter; verified locally via the VuePress dev server.

## Screenshots (UI changes)

N/A - documentation home page copy only.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed