### PR TITLE
Make the sample app run Docker-free by default

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,89 @@
+name: Docker configuration
+
+# Validates the sample app's full Docker stack (the "docker" Spring profile: PostgreSQL, Redis, and
+# Ollama from bootui-sample-app/compose.yaml). It runs the full Maven test suite and then the
+# Playwright end-to-end suite against a sample app booted with the "docker" profile.
+#
+# The default CI build (build.yml) exercises the Docker-free "dev" profile, so the Docker-based path
+# is only checked once a day (and on demand from the Actions tab) to catch regressions in
+# compose.yaml, the Redis-backed cache, and the Ollama / Spring AI wiring.
+
+on:
+  schedule:
+    # Every day at 06:30 UTC (just after the native-image job).
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-config:
+    name: Validate the Docker-based configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.16.0'
+          cache: npm
+          cache-dependency-path: |
+            bootui-ui/src/main/frontend/package-lock.json
+            bootui-sample-app/e2e/package-lock.json
+
+      - name: Build all modules and run the full test suite
+        run: ./mvnw -B -ntp clean install
+
+      - name: Install Playwright dependencies
+        working-directory: bootui-sample-app/e2e
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright browsers
+        working-directory: bootui-sample-app/e2e
+        run: ./node_modules/.bin/playwright install --with-deps chromium
+
+      - name: Pre-pull the Docker Compose images
+        run: docker compose -f bootui-sample-app/compose.yaml pull
+
+      - name: Run the end-to-end suite against the Docker profile
+        working-directory: bootui-sample-app/e2e
+        env:
+          # Boot the sample app with the full Docker stack instead of the Docker-free default.
+          BOOTUI_SAMPLE_PROFILES: docker
+          # Allow extra time for Docker Compose to start and for Ollama to pull the chat model.
+          BOOTUI_WEBSERVER_TIMEOUT: '600000'
+        run: npm test
+
+      - name: Print Docker Compose logs on failure
+        if: failure()
+        run: docker compose -f bootui-sample-app/compose.yaml logs --no-color
+
+      - name: Tear down any leftover Docker Compose services
+        if: always()
+        run: docker compose -f bootui-sample-app/compose.yaml down --volumes --remove-orphans
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-docker
+          path: |
+            bootui-sample-app/e2e/playwright-report/
+            bootui-sample-app/e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -3,14 +3,14 @@ name: Native image
 # Builds the GraalVM native image of the sample app and smoke-tests it.
 #
 # The native build is slow, so it does not run on every push. Instead it runs
-# once a week to catch regressions in the native configuration (runtime hints,
+# once a day to catch regressions in the native configuration (runtime hints,
 # reachability metadata, GraalVM/Spring Boot upgrades) and can also be started
 # manually from the Actions tab.
 
 on:
   schedule:
-    # Every Monday at 06:00 UTC.
-    - cron: '0 6 * * 1'
+    # Every day at 06:00 UTC.
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- **`bootui-sample-app` now runs Docker-free by default** — the `dev` Spring profile (the default via
+  `spring.profiles.default=dev`) swaps the Docker Compose PostgreSQL, Redis, and Ollama services for an in-memory H2
+  database, a simple in-memory cache, and disabled Spring AI, so a bare `spring-boot:run` (and the Playwright e2e suite)
+  starts offline with no Docker engine. A new `docker` profile (`-Dspring-boot.run.profiles=docker`) restores the full
+  Docker experience (PostgreSQL, Redis, Ollama, and the `qwen2.5:0.5b` chat model). The `run-sample` helper scripts no
+  longer require Docker and run the Docker-free `dev` profile.
+
 ## [1.1.0] - 2026-06-07
 
 Feature release that introduces a dedicated **Advisors** workspace with three new rule-based panels (Spring, REST API,

--- a/bootui-sample-app/README.md
+++ b/bootui-sample-app/README.md
@@ -7,11 +7,11 @@ the Playwright suite under `e2e/` exercises.
 ## What it shows
 
 - The `bootui-spring-boot-starter` dependency on a real Spring Boot 4 app.
-- BootUI auto-activating when the `dev` profile is active.
-- A PostgreSQL-backed Spring Data repository so the Spring Data panel has data to
-  show.
-- PostgreSQL, Redis, and Ollama Docker Compose services (`compose.yaml`) so the Spring Data,
-  Database Connection Pools, Spring Cache, AI Usage, and Dev Services panels have realistic infrastructure
+- BootUI auto-activating in local development (the `dev`/`docker` profiles, or via `spring-boot-devtools`).
+- A relational Spring Data repository so the Spring Data panel has data to show
+  (in-memory H2 by default, PostgreSQL with the `docker` profile).
+- Optional PostgreSQL, Redis, and Ollama Docker Compose services (`compose.yaml`, enabled by the `docker` profile) so the
+  Spring Data, Database Connection Pools, Spring Cache, AI Usage, and Dev Services panels have realistic infrastructure
   to show.
 - Flyway migrations (the `catalog_*` tables) and Liquibase change sets (the separate
   `inventory_*` tables) with two pending updates each so the Flyway and Liquibase actions can be exercised manually.
@@ -23,15 +23,34 @@ the Playwright suite under `e2e/` exercises.
 ## Prerequisites
 
 - Java 17 or later
-- Docker (or any Docker-compatible engine) for the Postgres, Redis, and Ollama containers
 - The repository's Maven Wrapper (`./mvnw`) — no global Maven install needed
+- Optional: Docker (or any Docker-compatible engine) — only for the [full Docker experience](#run-it-with-docker); the
+  default run is [Docker-free](#run-it)
 
 ## Run it
 
-From the repository root:
+By default the sample app runs **Docker-free**: a bare run uses the `dev` profile, which swaps PostgreSQL, Redis, and
+Ollama for an in-memory H2 database, a simple in-memory cache, and disabled Spring AI, so no Docker engine or model
+download is needed:
 
 ```bash
-./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
+./mvnw -pl bootui-sample-app spring-boot:run
+```
+
+`dev` is the default Spring profile ([`application-dev.properties`](src/main/resources/application-dev.properties)), so
+it applies whenever no other profile is active (a bare run, the Playwright e2e suite, etc.); pass
+`-Dspring-boot.run.profiles=dev` explicitly for the same result. Most panels work normally, including Configuration,
+Database, Spring Data, Flyway, Liquibase, and Spring Cache. The Chat and AI Usage panels report that AI is unavailable,
+and Dev Services lists no containers. The [`run-sample`](../docs/TRY-SAMPLE-APP.md) helper scripts run this Docker-free
+`dev` profile.
+
+## Run it with Docker
+
+For the full experience — Postgres, Redis, Ollama, and every panel populated — activate the `docker` profile from the
+repository root:
+
+```bash
+./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=docker
 ```
 
 Spring Boot will start Docker Compose, wait for Postgres, Redis, and Ollama, pull the small `qwen2.5:0.5b` chat model
@@ -52,12 +71,16 @@ Useful URLs:
 
 ## Suggested walkthrough
 
-1. **Overview and GitHub** — confirm the activation reason is `profile=dev`,
-   localhost-only is `true`, and the local GitHub origin is detected.
+This walkthrough follows the default Docker-free `dev` mode (a bare `spring-boot:run`). The Dev Services, Spring Cache,
+and AI Usage steps note where the `docker` profile adds Postgres/Redis/Ollama-backed behavior.
+
+1. **Overview and GitHub** — confirm BootUI is active (the activation reason is `devtools` for a bare run, or
+   `profile=dev` when you pass the profile explicitly), localhost-only is `true`, and the local GitHub origin is
+   detected.
 2. **Beans** — search for `EchoScheduler` and follow the dependency graph back
    into Spring framework beans.
 3. **Conditions** — filter on `DataSourceAutoConfiguration` to see the matched
-   and skipped auto-configurations behind the Postgres datasource.
+   and skipped auto-configurations behind the H2 datasource.
 4. **Configuration** — locate `spring.datasource.password`, confirm the value is
    masked, then try toggling `bootui.expose-values` between `MASKED`,
    `METADATA_ONLY`, and `FULL` (only do `FULL` locally) and reload the panel.
@@ -79,26 +102,27 @@ Useful URLs:
 11. **Liquibase** — inspect the two applied and two pending `inventory_*` change sets
     tracked in `DATABASECHANGELOG`, on a table set fully separate from Flyway's, then
     apply the pending change sets after browser confirmation.
-12. **Spring Cache** — verify the Redis-backed `sample-products` and
-    `sample-greetings` caches are listed, inspect cache annotations, and clear a
-    cache after confirming the action.
-13. **Dev Services** — verify the Postgres and Redis Docker Compose entries are
-    present and their service-connection metadata matches the actual mapped
-    ports.
+12. **Spring Cache** — verify the in-memory (`ConcurrentHashMap`) `sample-products`
+    and `sample-greetings` caches are listed (Redis-backed with the `docker`
+    profile), inspect cache annotations, and clear a cache after confirming the action.
+13. **Dev Services** — in the default Docker-free mode no containers are listed;
+    with the `docker` profile the Postgres and Redis Docker Compose entries appear
+    and their service-connection metadata matches the actual mapped ports.
 14. **Spring Security and Security Logs** — inspect filter chains, endpoint rule explanations, and recent masked audit
     events.
 15. **Traces, Log Tail, HTTP Exchanges, Architecture, Pentesting, Vulnerabilities** — inspect local telemetry, logs,
     inbound requests, and run explicit local scans as development hygiene prompts.
 16. **HTTP Probe** — send a request to `/api/echo`, then try to send one to an
     external host and confirm it is rejected as non-loopback.
-17. **AI Usage** — exercise the sample endpoints and local AI helper
-    paths, then inspect the retained in-memory spans and token summaries.
+17. **AI Usage** — the Chat and AI Usage panels report AI is unavailable in the
+    default mode; with the `docker` profile, exercise the sample AI endpoints and
+    local AI helper paths, then inspect the retained in-memory spans and token summaries.
 18. **DevTools, Dev Services, Copilot, Claude Code** — confirm the developer-tool panels show local status, bounded service
     metadata/logs, and sanitized local agent activity.
 
 ## Stop it
 
-`Ctrl-C` the Spring Boot process. Spring Boot will stop Docker Compose.
+`Ctrl-C` the Spring Boot process. With the `docker` profile, Spring Boot also stops Docker Compose.
 
 ## Run it as a GraalVM native image
 

--- a/bootui-sample-app/e2e/playwright.config.js
+++ b/bootui-sample-app/e2e/playwright.config.js
@@ -15,6 +15,15 @@ import {defineConfig, devices} from '@playwright/test'
 const PORT = Number(process.env.BOOTUI_SAMPLE_PORT || 8080)
 const BASE_URL = process.env.BOOTUI_BASE_URL || `http://localhost:${PORT}`
 
+// Optional Spring profile(s) for the auto-started sample app. Leave unset for the default
+// Docker-free `dev` profile; set BOOTUI_SAMPLE_PROFILES=docker to boot the full Docker stack
+// (PostgreSQL, Redis, Ollama) so the same suite can validate the Docker-based configuration.
+const SAMPLE_PROFILES = process.env.BOOTUI_SAMPLE_PROFILES
+const PROFILES_ARG = SAMPLE_PROFILES ? ` -Dspring-boot.run.profiles=${SAMPLE_PROFILES}` : ''
+// Booting the Docker stack (pulling images and the Ollama model) can take much longer than the
+// Docker-free default, so allow the web-server startup timeout to be raised from the environment.
+const WEBSERVER_TIMEOUT = Number(process.env.BOOTUI_WEBSERVER_TIMEOUT || 240_000)
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: false,
@@ -49,12 +58,11 @@ export default defineConfig({
     ? undefined
     : {
         // Run from the e2e module through the root Maven Wrapper.
-        command:
-          '../../mvnw -f ../pom.xml -q spring-boot:run -Dspring-boot.run.jvmArguments=-Dspring.devtools.restart.enabled=false',
+        command: `../../mvnw -f ../pom.xml -q spring-boot:run -Dspring-boot.run.jvmArguments=-Dspring.devtools.restart.enabled=false${PROFILES_ARG}`,
         url: `${BASE_URL}/bootui/api/overview`,
         reuseExistingServer: !process.env.CI,
         stdout: 'pipe',
         stderr: 'pipe',
-        timeout: 240_000
+        timeout: WEBSERVER_TIMEOUT
       }
 })

--- a/bootui-sample-app/e2e/tests/docker-smoke.spec.js
+++ b/bootui-sample-app/e2e/tests/docker-smoke.spec.js
@@ -1,0 +1,57 @@
+// @ts-check
+import {expect, test} from '@playwright/test'
+
+// These checks only run when the sample app was booted with the full Docker stack (the `docker`
+// Spring profile, set via BOOTUI_SAMPLE_PROFILES=docker by the weekly "Docker configuration"
+// workflow). They assert the runtime genuinely uses PostgreSQL, Redis, and Ollama instead of the
+// Docker-free `dev` defaults (H2, an in-memory cache, disabled Spring AI), so a green run actually
+// proves the Docker-based configuration works rather than passing in a broadly compatible mode.
+const dockerProfileActive = (process.env.BOOTUI_SAMPLE_PROFILES || '')
+  .split(',')
+  .map((profile) => profile.trim())
+  .includes('docker')
+
+test.describe('Docker profile smoke checks', () => {
+  test.skip(!dockerProfileActive, 'Only runs when the sample app is started with the docker profile')
+
+  test('reports the docker profile as active', async ({request}) => {
+    const response = await request.get('/bootui/api/overview')
+    expect(response.ok()).toBeTruthy()
+    const overview = await response.json()
+    expect(overview.activeProfiles).toContain('docker')
+  })
+
+  test('uses a PostgreSQL datasource', async ({request}) => {
+    const response = await request.get('/actuator/health')
+    expect(response.ok()).toBeTruthy()
+    const health = await response.json()
+    expect(health.components?.db?.details?.database).toBe('PostgreSQL')
+  })
+
+  test('uses a Redis-backed Spring cache', async ({request}) => {
+    const response = await request.get('/bootui/api/spring-cache')
+    expect(response.ok()).toBeTruthy()
+    const cache = await response.json()
+    const managerTypes = (cache.managers || []).map((manager) => manager.type)
+    expect(managerTypes.some((type) => /Redis/i.test(type ?? ''))).toBeTruthy()
+  })
+
+  test('serves PostgreSQL-backed sample products', async ({request}) => {
+    const response = await request.get('/api/sample/products')
+    expect(response.ok()).toBeTruthy()
+    const products = await response.json()
+    expect(Array.isArray(products)).toBeTruthy()
+    expect(products.length).toBeGreaterThan(0)
+  })
+
+  test('answers a chat prompt through Ollama', async ({request}) => {
+    const response = await request.post('/api/chat', {
+      data: {message: 'Reply with the single word: pong.'},
+      timeout: 120_000
+    })
+    expect(response.ok(), `chat request failed: ${response.status()} ${await response.text()}`).toBeTruthy()
+    const body = await response.json()
+    expect(typeof body.reply).toBe('string')
+    expect(body.reply.length).toBeGreaterThan(0)
+  })
+})

--- a/bootui-sample-app/e2e/tests/spring-cache.spec.js
+++ b/bootui-sample-app/e2e/tests/spring-cache.spec.js
@@ -12,7 +12,9 @@ test.describe('Spring Cache view', () => {
     await expect(cacheSection).toContainText('sample-greetings')
 
     const productsRow = cacheSection.locator('tbody tr', {hasText: 'sample-products'}).first()
-    await expect(productsRow).toContainText(/Redis/)
+    // The cache provider depends on how the sample app was started: an in-memory ConcurrentHashMap in
+    // the default Docker-free (`dev`) profile, or Redis with the full Docker (`docker`) profile.
+    await expect(productsRow).toContainText(/Redis|ConcurrentHashMap/)
     await expect(productsRow.getByRole('button', {name: 'Clear'})).toBeEnabled()
 
     const operationsSection = page.locator('section', {hasText: 'Annotation operations'}).first()

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -100,6 +100,17 @@
             <version>42.7.11</version>
             <scope>runtime</scope>
         </dependency>
+        <!--
+            In-memory database used by the Docker-free "dev" profile
+            (the default; see application-dev.properties) so the sample app can
+            run without the Docker Compose PostgreSQL service. The "docker"
+            profile uses PostgreSQL via the Docker Compose connection details.
+        -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bootui-sample-app/src/main/resources/application-dev.properties
+++ b/bootui-sample-app/src/main/resources/application-dev.properties
@@ -1,0 +1,30 @@
+# Docker-free defaults for the sample app. "dev" is the DEFAULT profile
+# (spring.profiles.default=dev in application.properties), so it applies to a bare `spring-boot:run`,
+# the "try me" scripts, and the Playwright e2e suite. It swaps the Docker Compose PostgreSQL, Redis,
+# and Ollama services for an in-memory H2 database, a simple in-memory cache, and disabled Spring AI.
+# (Docker Compose is already disabled by the base config; the "docker" profile re-enables it.)
+# The Database, Spring Data, Flyway, Liquibase, and Spring Cache panels still work; the Chat / AI Usage
+# panels report AI as unavailable. Use the "docker" profile for the full Docker experience:
+#   ./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=docker
+
+# In-memory H2 database in place of the Dockerized PostgreSQL service (the H2 driver is auto-detected
+# from the jdbc:h2 URL, so an explicit driver-class-name is not needed).
+spring.datasource.url=jdbc:h2:mem:bootui_sample;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false
+spring.datasource.username=sa
+spring.datasource.password=
+
+# Simple in-memory cache in place of the Dockerized Redis service.
+spring.cache.type=simple
+
+# Disable the Redis and Spring AI / Ollama auto-configuration so the app starts
+# without those Docker services. ChatController then returns a clear "AI
+# unavailable" response instead of attempting a network call.
+spring.autoconfigure.exclude=\
+  org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration,\
+  org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration,\
+  org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration,\
+  org.springframework.boot.data.redis.autoconfigure.health.DataRedisHealthContributorAutoConfiguration,\
+  org.springframework.boot.data.redis.autoconfigure.health.DataRedisReactiveHealthContributorAutoConfiguration,\
+  org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration,\
+  org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration,\
+  org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration

--- a/bootui-sample-app/src/main/resources/application-docker.properties
+++ b/bootui-sample-app/src/main/resources/application-docker.properties
@@ -1,0 +1,27 @@
+# Full Docker experience for the sample app. Activate with -Dspring-boot.run.profiles=docker
+# (the default is the Docker-free "dev" profile). Spring Boot's docker-compose support starts the
+# PostgreSQL, Redis, and Ollama services from compose.yaml; the first startup also pulls the small
+# qwen2.5:0.5b chat model. Postgres backs JPA / Flyway / Liquibase, Redis backs Spring Cache, and
+# Ollama powers the Chat / AI Usage panels.
+
+# Start Docker Compose (compose.yaml) and wait for the services to be ready.
+spring.docker.compose.enabled=true
+
+# Clear the Docker-free profile's auto-configuration excludes so Redis, Ollama, and the ChatClient
+# auto-configuration run (also keeps -Dspring-boot.run.profiles=dev,docker working).
+spring.autoconfigure.exclude=
+
+# PostgreSQL connection details are provided by the docker-compose "postgres" service.
+
+# Redis-backed cache (the "redis" docker-compose service provides the connection details).
+spring.cache.type=redis
+spring.cache.redis.time-to-live=10m
+spring.data.redis.repositories.enabled=false
+
+# Spring AI / Ollama (the pinned "ollama" docker-compose service on port 11434).
+spring.ai.ollama.base-url=http://localhost:11434
+spring.ai.ollama.chat.model=qwen2.5:0.5b
+spring.ai.ollama.init.pull-model-strategy=when_missing
+spring.ai.ollama.init.chat.additional-models=qwen2.5:0.5b
+spring.ai.chat.client.observations.log-prompt=false
+spring.ai.chat.client.observations.log-completion=false

--- a/bootui-sample-app/src/main/resources/application.properties
+++ b/bootui-sample-app/src/main/resources/application.properties
@@ -2,12 +2,20 @@ spring.application.name=bootui-sample
 server.port=8080
 spring.threads.virtual.enabled=true
 
-spring.ai.ollama.base-url=http://localhost:11434
-spring.ai.ollama.chat.model=qwen2.5:0.5b
-spring.ai.ollama.init.pull-model-strategy=when_missing
-spring.ai.ollama.init.chat.additional-models=qwen2.5:0.5b
-spring.ai.chat.client.observations.log-prompt=false
-spring.ai.chat.client.observations.log-completion=false
+# Run Docker-free by default. The "dev" profile (application-dev.properties) is the default
+# (spring.profiles.default=dev), so a bare `spring-boot:run`, the "try me" scripts, and the
+# Playwright e2e suite all start without Docker. Activate the "docker" profile for the full
+# Docker experience (PostgreSQL, Redis, Ollama): -Dspring-boot.run.profiles=docker
+spring.profiles.default=dev
+
+# Keep the base configuration Docker-free: do not start Docker Compose (compose.yaml) even though
+# spring-boot-docker-compose is on the classpath. Only the "docker" profile turns this back on
+# (application-docker.properties), so no profile other than "docker" can ever start the containers.
+spring.docker.compose.enabled=false
+
+# Keep BootUI active under both sample profiles (dev = Docker-free, docker = full Docker), so its
+# activation reason is the profile rather than spring-boot-devtools.
+bootui.enabled-profiles=dev,local,docker
 
 # Recreate the sample schema on startup, but do not drop shared Docker Compose tables when auxiliary e2e apps stop.
 spring.jpa.hibernate.ddl-auto=create
@@ -27,10 +35,8 @@ spring.flyway.baseline-version=0
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 
-spring.data.redis.repositories.enabled=false
-spring.cache.type=redis
+# Cache names shared by both profiles (a simple in-memory cache under "dev", Redis under "docker").
 spring.cache.cache-names=sample-products,sample-greetings
-spring.cache.redis.time-to-live=10m
 
 sample.greeting=Hello
 sample.retries=3

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationDevProfileTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationDevProfileTests.java
@@ -1,0 +1,131 @@
+package io.github.jdubois.bootui.sample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Boots the sample app in the default, Docker-free {@code dev} profile (no
+ * Testcontainers, no Docker Compose) and verifies the degraded experience works:
+ * the in-memory H2 database backs JPA / Flyway / Liquibase, the simple cache
+ * replaces Redis, BootUI is active, and the AI chat endpoint reports that AI is
+ * unavailable instead of attempting a network call.
+ *
+ * <p>This is the default "try me" path (the {@code scripts/run-sample.*} helpers and
+ * the Playwright e2e suite run the {@code dev} profile), so it must keep starting
+ * cleanly without any container engine. The full Docker experience lives in the
+ * separate {@code docker} profile.
+ */
+@SpringBootTest(
+        classes = BootUiSampleApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.profiles.active=dev",
+            "bootui.show-banner=false",
+            "bootui.overrides-file=target/bootui-dev-test-overrides.properties"
+        })
+class BootUiSampleApplicationDevProfileTests {
+
+    private static final Path OVERRIDES_FILE = Paths.get("target/bootui-dev-test-overrides.properties");
+
+    @LocalServerPort
+    int port;
+
+    private RestClient client;
+
+    @BeforeAll
+    static void clearLeftoverOverridesFile() throws Exception {
+        Files.deleteIfExists(OVERRIDES_FILE);
+    }
+
+    @AfterAll
+    static void removeOverridesFile() throws Exception {
+        Files.deleteIfExists(OVERRIDES_FILE);
+    }
+
+    @Test
+    void servesSampleProductsFromInMemoryH2() {
+        ResponseEntity<List> response =
+                client().get().uri("/api/sample/products").retrieve().toEntity(List.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        // The products come from JPA (Hibernate ddl-auto) seeded by data.sql, proving H2 is wired in.
+        assertThat(response.getBody().toString()).contains("BootUI Starter");
+    }
+
+    @Test
+    void overviewReportsBootUiActiveWithoutDocker() {
+        ResponseEntity<Map> response =
+                client().get().uri("/bootui/api/overview").retrieve().toEntity(Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+    }
+
+    @Test
+    void healthIsUpWithoutRedisOrDatabaseDocker() {
+        ResponseEntity<Map> response =
+                client().get().uri("/actuator/health").retrieve().toEntity(Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().get("status")).isEqualTo("UP");
+    }
+
+    @Test
+    void chatReportsAiUnavailableWhenOllamaDisabled() {
+        ResponseEntity<Map> response = client().post()
+                .uri("/api/chat")
+                .body(Map.of("message", "Hello"))
+                .retrieve()
+                .toEntity(Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().get("error")).asString().contains("ChatClient");
+    }
+
+    private RestClient client() {
+        if (client == null) {
+            client = RestClient.builder()
+                    .baseUrl("http://localhost:" + port)
+                    .requestFactory(new JdkClientHttpRequestFactory(
+                            HttpClient.newBuilder().proxy(new NoProxySelector()).build()))
+                    // Never throw on non-2xx — tests inspect the status directly.
+                    .defaultStatusHandler(HttpStatusCode::isError, (req, res) -> {})
+                    .build();
+        }
+        return client;
+    }
+
+    private static final class NoProxySelector extends ProxySelector {
+
+        @Override
+        public List<Proxy> select(URI uri) {
+            return List.of(Proxy.NO_PROXY);
+        }
+
+        @Override
+        public void connectFailed(URI uri, java.net.SocketAddress sa, java.io.IOException ioe) {}
+    }
+}

--- a/docs/TRY-SAMPLE-APP.md
+++ b/docs/TRY-SAMPLE-APP.md
@@ -1,11 +1,11 @@
 # Try the sample app
 
-> **Security warning:** These convenience commands download a script from GitHub, clone this repository, build it, pull
-> Docker images and an Ollama model, and run a Spring Boot app on your machine. Review the script first and run it only
-> in a trusted local development environment.
+> **Security warning:** These convenience commands download a script from GitHub, clone this repository, build it, and
+> run a Spring Boot app on your machine. Review the script first and run it only in a trusted local development
+> environment.
 
-Prerequisites: Git, Java 17 or later, and Docker or a Docker-compatible engine for the sample app's PostgreSQL, Redis,
-and Ollama services.
+Prerequisites: Git and Java 17 or later. The sample app's `dev` profile runs **Docker-free** (in-memory H2 database, a
+simple in-memory cache, and disabled Spring AI), so no Docker engine is required for current releases.
 
 macOS / Linux:
 
@@ -21,8 +21,14 @@ irm https://raw.githubusercontent.com/jdubois/boot-ui/main/scripts/run-sample.ps
 
 The scripts list `main` plus the five most recent release tags and ask which version to build and run; the most recent
 tag is selected by default (press Enter to accept, or set `BOOTUI_REF` to choose non-interactively). They clone into
-`./boot-ui` unless that directory already exists, build with `-DskipTests`, then start
-`bootui-sample-app` with the `dev` profile. Spring Boot starts PostgreSQL, Redis, and Ollama from
-`bootui-sample-app/compose.yaml`; the first startup also pulls the small `qwen2.5:0.5b` chat model when missing. Open
-<http://localhost:8080/bootui> after startup. If you already cloned the repository, run `./scripts/run-sample.sh` or
-`.\scripts\run-sample.ps1` from its root to reuse that checkout.
+`./boot-ui` unless that directory already exists, build with `-DskipTests`, then start `bootui-sample-app` with the
+`dev` profile. Open <http://localhost:8080/bootui> after startup. If you already cloned the repository, run
+`./scripts/run-sample.sh` or `.\scripts\run-sample.ps1` from its root to reuse that checkout.
+
+In Docker-free mode most panels work normally (Configuration, Database, Spring Data, Flyway, Liquibase, Spring Cache);
+the Chat and AI Usage panels report that AI is unavailable, and Dev Services lists no containers.
+
+Want the full experience with PostgreSQL, Redis, and Ollama (a Docker-compatible engine is required)? Run the sample app
+with the `docker` profile instead — see the [sample app README](../bootui-sample-app/README.md#run-it-with-docker) for
+details. Note that releases published before the Docker-free default also start those Docker services under the `dev`
+profile, so building one of those older tags requires a Docker engine.

--- a/scripts/run-sample.ps1
+++ b/scripts/run-sample.ps1
@@ -91,13 +91,12 @@ if ((Test-Path -LiteralPath ".\mvnw.cmd") -and (Test-Path -LiteralPath ".\bootui
 }
 
 Require-Command java
-Require-Command docker
 
 Write-Host "Building BootUI with tests skipped..."
 Invoke-Native -FilePath ".\mvnw.cmd" -Arguments @("-B", "-ntp", "install", "-DskipTests")
 
-Write-Host "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
-Write-Host "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
+Write-Host "Starting the BootUI sample application."
+Write-Host "Open http://localhost:8080/bootui after startup."
 Invoke-Native -FilePath ".\mvnw.cmd" -Arguments @(
     "-pl",
     "bootui-sample-app",

--- a/scripts/run-sample.sh
+++ b/scripts/run-sample.sh
@@ -100,11 +100,10 @@ else
 fi
 
 require_command java
-require_command docker
 
 echo "Building BootUI with tests skipped..."
 ./mvnw -B -ntp install -DskipTests
 
-echo "Starting the BootUI sample app with PostgreSQL, Redis, and Ollama."
-echo "First startup may also pull the qwen2.5:0.5b chat model. Open http://localhost:8080/bootui after startup."
+echo "Starting the BootUI sample application."
+echo "Open http://localhost:8080/bootui after startup."
 ./mvnw -pl bootui-sample-app spring-boot:run -Dspring-boot.run.profiles=dev


### PR DESCRIPTION
## What does this PR do?

Inverts the sample-app Spring profiles so the default `dev` profile runs with no Docker engine, and adds a `docker` profile that restores the full PostgreSQL + Redis + Ollama stack.

## Why is this change needed?

The "try me" experience required a running Docker engine for the sample app's backend services (Postgres, Redis, Ollama), which is a heavy prerequisite just to evaluate BootUI. Now a bare `spring-boot:run`, the `run-sample` helper scripts, and the Playwright e2e suite all start offline. People who want the full experience opt in with `-Dspring-boot.run.profiles=docker`.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally (Java suite + frontend Vitest)
- [x] Started `bootui-sample-app` with the default `dev` profile and verified `/bootui` loads with Docker stopped (H2 datasource, in-memory cache, AI reported unavailable)
- [x] Added or updated tests where applicable (new `dev`-profile boot test; new docker-only e2e smoke spec)

Notes on the approach:

- The base `application.properties` now sets `spring.docker.compose.enabled=false`, and **only** the `docker` profile re-enables it. This is the key safety net: no profile other than `docker` can ever start the containers, so the default path is reliably offline.
- `dev` (default) swaps in H2, a simple in-memory cache, and excludes the Redis / Ollama / ChatClient auto-configuration. `docker` clears those excludes and turns Compose back on.
- `playwright.config.js` makes the webServer profile and boot timeout env-configurable (`BOOTUI_SAMPLE_PROFILES`, `BOOTUI_WEBSERVER_TIMEOUT`); defaults are unchanged so the normal CI run still exercises the Docker-free `dev` profile.
- A new `docker-smoke.spec.js` asserts the runtime genuinely uses PostgreSQL, Redis, and Ollama. It is gated by the profile flag and **skips** under `dev`, so it never affects the default build but prevents a false-green Docker run.
- New daily `Docker configuration` workflow boots the app with the `docker` profile and runs the full suite + e2e against real containers. Both this and the existing native-image workflow now run **daily instead of weekly**.

The Docker-based path could not be fully exercised locally (Docker Desktop is intentionally stopped in my environment), though the live boot confirmed the `docker` profile loads `compose.yaml`. The daily CI run on `ubuntu-latest`, where Docker is available, is the real validation.

## Screenshots (UI changes)

N/A - no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (`docs/TRY-SAMPLE-APP.md`, sample-app `README.md`, `CHANGELOG.md`)
- [x] Public API kept backward compatible, or a migration note added to the PR description (sample-app only; no published-artifact behaviour change)
- [x] No secrets, tokens, or local paths committed