### PR TITLE
Add cross-platform build workflow for Linux, Windows and macOS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Keep the POSIX Maven wrapper and shell scripts LF so they run correctly under
+# Git Bash on Windows (a CRLF shebang breaks ./mvnw). Windows wrapper/batch
+# scripts stay CRLF.
+mvnw text eol=lf
+*.sh text eol=lf
+mvnw.cmd text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,74 @@
+name: Cross-platform build
+
+# Verifies the full Maven build on Linux, Windows and macOS, most importantly the
+# bootui-ui module: its frontend-maven-plugin downloads platform-specific Node/npm
+# binaries and runs a Vite build that pulls in platform-specific optional
+# dependencies (esbuild/rollup). The main build (build.yml) only runs on Linux, so
+# this catches packaging/tooling regressions that are specific to a single OS.
+#
+# A 3-OS matrix is more expensive than the main build, so it runs once a day to
+# catch regressions and can also be started manually from the Actions tab.
+
+on:
+  schedule:
+    # Every day at 05:00 UTC (ahead of the native-image build at 06:00).
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    defaults:
+      run:
+        # Use bash on every runner so the ./mvnw wrapper invocation is identical.
+        # The default shell on Windows is PowerShell, where ./mvnw does not resolve.
+        shell: bash
+    steps:
+      - name: Disable Git line-ending conversion
+        # Windows runners default to core.autocrlf=true, which would rewrite the LF
+        # mvnw wrapper to CRLF and break its shebang under Git Bash. Configure this
+        # before checkout so the working tree keeps the committed LF endings.
+        run: git config --global core.autocrlf false
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Build all modules
+        # clean install builds every module, including the bootui-ui frontend
+        # (Node/npm download + npm ci with optional deps + Vite build) and runs the
+        # Java and Vitest unit tests. Node/npm are downloaded by the Maven plugin,
+        # so no separate Node setup is needed here. Invoke via `bash ./mvnw` so the
+        # build does not depend on the wrapper's executable bit being preserved on
+        # the Windows checkout.
+        run: bash ./mvnw -B -ntp clean install
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports-${{ matrix.os }}
+          path: |
+            **/target/surefire-reports/TEST-*.xml
+            bootui-ui/src/main/frontend/test-results/vitest-junit.xml
+          if-no-files-found: ignore
+          retention-days: 7

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/FlywayControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/FlywayControllerTests.java
@@ -46,7 +46,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * discovered Flyway bean whose {@code info().all()} exposes one applied and one
  * pending migration.</p>
  */
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class FlywayControllerTests {
 
     private static final String MODULITH_ACTIONS_DISABLED =

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -56,7 +56,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
             "bootui.show-banner=false",
             "bootui.overrides-file=target/bootui-test-overrides.properties"
         })
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class BootUiSampleApplicationIntegrationTests {
 
     private static final Path OVERRIDES_FILE = Paths.get("target/bootui-test-overrides.properties");


### PR DESCRIPTION
## What does this PR do?

Adds a scheduled, manually dispatchable GitHub Actions matrix that builds the project on `ubuntu-latest`, `windows-latest` and `macos-latest`.

## Why is this change needed?

The main `build.yml` pipeline only runs on Linux, but `bootui-ui` builds its frontend with `frontend-maven-plugin`, which downloads platform-specific Node/npm binaries and resolves native optional dependencies (lightningcss/rollup/esbuild) per OS. Those are exactly the things that can break on Windows or macOS without anyone noticing. This workflow exercises that real cross-platform path so single-OS packaging/tooling regressions get caught.

It runs daily plus on-demand (like `native.yml`) rather than on every PR, since a 3-OS matrix is more expensive and is meant to catch regressions rather than gate every change.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally (Testcontainers tests ran with Docker present, 0 skipped, confirming the happy path is intact)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable (annotation change on existing tests)

A few cross-platform gotchas are handled up front so the first run surfaces real issues, not avoidable noise:

- **`./mvnw` on Windows:** the job uses `shell: bash` and invokes `bash ./mvnw`, so the wrapper runs under Git Bash regardless of the executable bit.
- **Line endings:** a pre-checkout `core.autocrlf false` step plus a new `.gitattributes` (pinning `mvnw`/`*.sh` to LF, Windows scripts to CRLF) keep the wrapper shebang intact on Windows checkouts, for CI and local contributors alike.
- **Docker-backed tests:** `clean install` runs two real `@Testcontainers` PostgreSQL tests (`FlywayControllerTests`, `BootUiSampleApplicationIntegrationTests`). GitHub's Windows/macOS runners have no usable Docker daemon, so these are marked `disabledWithoutDocker = true`: they skip there but still run fully on the Linux pipeline.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no public behaviour change; auxiliary workflows are not enumerated in docs)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed