### PR TITLE
chore: pin @vuepress/plugin-markdown-tab to an exact version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "devDependencies": {
         "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/plugin-markdown-tab": "^2.0.0-rc.130",
+        "@vuepress/plugin-markdown-tab": "2.0.0-rc.130",
         "@vuepress/theme-default": "2.0.0-rc.130",
         "bootstrap": "5.3.8",
         "bootstrap-icons": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@vuepress/bundler-vite": "2.0.0-rc.30",
-    "@vuepress/plugin-markdown-tab": "^2.0.0-rc.130",
+    "@vuepress/plugin-markdown-tab": "2.0.0-rc.130",
     "@vuepress/theme-default": "2.0.0-rc.130",
     "bootstrap": "5.3.8",
     "bootstrap-icons": "1.13.1",


### PR DESCRIPTION
## What does this PR do?

Like others dependencies

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
