### PR TITLE
fix(docs): align navbar logo and sidebar toggle

### DIFF
--- a/docs/.vuepress/styles/index.css
+++ b/docs/.vuepress/styles/index.css
@@ -222,14 +222,16 @@ body {
 
 .vp-site-name {
   display: inline-flex;
+  width: fit-content;
   align-items: center;
   border: 1px solid rgba(25, 135, 84, 0.14);
   border-radius: 1.25rem;
   background: linear-gradient(135deg, rgba(25, 135, 84, 0.12), rgba(13, 110, 253, 0.1));
-  padding: 0.55rem 0.85rem 0.55rem 0.55rem;
+  padding: 0.3rem 0.85rem 0.3rem 0.55rem;
   box-shadow: none;
   font-size: 1.08rem;
   font-weight: 800;
+  line-height: 1;
   transition:
     box-shadow 180ms ease,
     transform 180ms ease;
@@ -251,10 +253,12 @@ body {
 }
 
 .vp-toggle-sidebar-button {
+  top: 50%;
   border: 1px solid var(--bootui-border);
   border-radius: 0.8rem;
   background: var(--bootui-surface);
   color: var(--bootui-text);
+  transform: translateY(-50%);
   transition:
     background 150ms ease,
     transform 150ms ease;
@@ -262,7 +266,7 @@ body {
 
 .vp-toggle-sidebar-button:hover {
   background: var(--bootui-nav-hover-bg);
-  transform: translateY(-1px);
+  transform: translateY(calc(-50% - 1px));
 }
 
 .vp-sidebar .vp-sidebar-heading {


### PR DESCRIPTION
## What does this PR do?

Before
<img width="1421" height="134" alt="image" src="https://github.com/user-attachments/assets/2c94f874-28fc-45c2-9124-83acfb0b31be" />
<img width="755" height="132" alt="image" src="https://github.com/user-attachments/assets/60300e0c-ae98-471a-9888-47c2fb6f8d21" />

After
<img width="1424" height="142" alt="image" src="https://github.com/user-attachments/assets/5433cf5a-32b3-4984-9fb6-d55b0be8c7e4" />
<img width="757" height="140" alt="image" src="https://github.com/user-attachments/assets/925c699e-c132-450a-91c3-7b5b419d8782" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
