### PR TITLE
Move daily workflow schedules off the top of the hour

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -11,8 +11,11 @@ name: Cross-platform build
 
 on:
   schedule:
-    # Every day at 05:00 UTC (ahead of the native-image build at 06:00).
-    - cron: '0 5 * * *'
+    # Every day at 05:17 UTC (ahead of the native-image build). Deliberately off
+    # the top of the hour: GitHub delays and, under sufficiently high load, drops
+    # scheduled events during the peak window at the start of each hour, so a
+    # ':00' cron is unreliable.
+    - cron: '17 5 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,8 +10,11 @@ name: Docker configuration
 
 on:
   schedule:
-    # Every day at 06:30 UTC (just after the native-image job).
-    - cron: '30 6 * * *'
+    # Every day at 06:47 UTC (just after the native-image job). Deliberately off
+    # the top of the hour: GitHub delays and, under sufficiently high load, drops
+    # scheduled events during the peak window at the start of each hour, so a
+    # ':00' cron is unreliable.
+    - cron: '47 6 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -9,8 +9,10 @@ name: Native image
 
 on:
   schedule:
-    # Every day at 06:00 UTC.
-    - cron: '0 6 * * *'
+    # Every day at 06:17 UTC. Deliberately off the top of the hour: GitHub
+    # delays and, under sufficiently high load, drops scheduled events during
+    # the peak window at the start of each hour, so a ':00' cron is unreliable.
+    - cron: '17 6 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Why the daily workflows didn't run

The **Native image**, **Cross-platform build** and **Docker configuration** workflows are all valid (correct cron, present on `main`, `state=active`) and Actions is healthy — `push`/`pull_request` runs fire fine. The problem is **scheduling time**:

| Workflow | Old cron | Time |
|---|---|---|
| Cross-platform build | `0 5 * * *` | 05:00 UTC |
| Native image | `0 6 * * *` | 06:00 UTC |
| Docker configuration | `30 6 * * *` | 06:30 UTC |

The **start of every hour is GitHub Actions' peak-load window**. Per GitHub's docs, scheduled events are delayed during high load and **dropped entirely** when load is high enough. Two of the three sit exactly at `:00`.

Hard evidence from this repo: CodeQL (`0 6 * * 1`) is consistently *created* ~95 minutes late (07:35 / 07:39 vs the nominal 06:00). The `0 5` / `0 6` daily events were dropped during that same peak window, so the jobs never ran.

## Fix

Shift the crons to off-peak, staggered minutes, keeping the same morning ordering and gaps:

- Cross-platform build: 05:00 → **05:17** (`17 5 * * *`)
- Native image: 06:00 → **06:17** (`17 6 * * *`)
- Docker configuration: 06:30 → **06:47** (`47 6 * * *`)

Scheduled triggers run from the **default branch** copy, so this takes effect once merged.

> Note: `codeql.yml` (`0 6 * * 1`) has the same top-of-the-hour issue and is also delayed ~95 min, but it still runs and was out of scope here — worth moving off `:00` too in a follow-up.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>