### PR TITLE
Fix broken sample app README link in docs

### DIFF
--- a/docs/TRY-SAMPLE-APP.md
+++ b/docs/TRY-SAMPLE-APP.md
@@ -29,6 +29,6 @@ In Docker-free mode most panels work normally (Configuration, Database, Spring D
 the Chat and AI Usage panels report that AI is unavailable, and Dev Services lists no containers.
 
 Want the full experience with PostgreSQL, Redis, and Ollama (a Docker-compatible engine is required)? Run the sample app
-with the `docker` profile instead — see the [sample app README](../bootui-sample-app/README.md#run-it-with-docker) for
+with the `docker` profile instead — see the [sample app README](https://github.com/jdubois/boot-ui/blob/main/bootui-sample-app/README.md#run-it-with-docker) for
 details. Note that releases published before the Docker-free default also start those Docker services under the `dev`
 profile, so building one of those older tags requires a Docker engine.


### PR DESCRIPTION
## What does this PR do?

On this page https://www.julien-dubois.com/boot-ui/try-sample-app

Link broken
<img width="310" height="59" alt="image" src="https://github.com/user-attachments/assets/c83627d3-cd09-468e-891c-5ad6ee57a96f" />

<img width="364" height="190" alt="image" src="https://github.com/user-attachments/assets/2d9498ff-7321-42c3-bc69-1a350736f94c" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
