### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -5,9 +5,9 @@ application's own classes. This page lists every rule that ships with BootUI tod
 what to do about it.
 
 Each rule is a small class registered in
-[`ArchitectureRuleRegistry`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistry.java)
+[`ArchitectureRuleRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistry.java)
 and implemented in
-[`ArchitectureRules.java`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRules.java).
+[`ArchitectureRules.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRules.java).
 The list intentionally stays compact and reviewable; adding a new rule means adding one focused class plus a registry
 entry.
 

--- a/docs/GRAALVM-READINESS-CHECKS.md
+++ b/docs/GRAALVM-READINESS-CHECKS.md
@@ -5,9 +5,9 @@ readiness and can generate a `reachability-metadata.json` scaffold from the scan
 with BootUI today, what it inspects, when it fires, and what to do about it.
 
 Each check is a small class registered in
-[`GraalVmCheckRegistry`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmCheckRegistry.java)
+[`GraalVmCheckRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmCheckRegistry.java)
 and implemented in
-[`GraalVmChecks.java`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmChecks.java).
+[`GraalVmChecks.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmChecks.java).
 The list intentionally stays compact and reviewable; adding a new check means adding one focused class plus a registry
 entry.
 
@@ -56,7 +56,7 @@ package is resolvable from the running application. If no classes can be importe
 report with an explanatory reason rather than failing.
 
 Separately from the panel scan, BootUI registers Spring AOT runtime hints for its own native-image needs from
-[`BootUiRuntimeHints`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java).
+[`BootUiRuntimeHints`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java).
 Those built-in hints cover BootUI's runtime-scanned classpath resources, BootUI DTO records used by Jackson, and the
 well-known reflective calls used by the Heap Dump, Security, and Pentesting panels. They are contributed by
 `BootUiAutoConfiguration`, so applications using the starter should not need to copy BootUI-specific hints into their own

--- a/docs/PENTEST-CHECKS.md
+++ b/docs/PENTEST-CHECKS.md
@@ -5,9 +5,9 @@ application. This page lists every check that ships with BootUI today, what it i
 about it.
 
 Each check is a small class registered in
-[`PentestingCheckRegistry`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentesting/PentestingCheckRegistry.java)
+[`PentestingCheckRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentesting/PentestingCheckRegistry.java)
 and implemented in
-[`PentestingChecks.java`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentesting/PentestingChecks.java).
+[`PentestingChecks.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentesting/PentestingChecks.java).
 The list intentionally stays compact and reviewable; adding a new check means adding one focused class plus a registry
 entry, never adding ad-hoc HTTP traffic.
 
@@ -641,7 +641,7 @@ disclosure.
 ## Adding a new check
 
 1. Add a `final class` to
-   [`PentestingChecks.java`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentesting/PentestingChecks.java)
+   [`PentestingChecks.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentesting/PentestingChecks.java)
    extending `AbstractPentestingCheck`. Pass a `PentestingDefinition` with a unique stable ID (`PT-<category>-NNN`), title,
    OWASP 2025 category, severity, confidence, source (`SPRING_METADATA` or `HTTP_SYNTHETIC`), target, recommendation, and
    learn-more URL.
@@ -650,7 +650,7 @@ disclosure.
 3. Register the class in `PentestingCheckRegistry.ACTIVE_CHECKS`. If the new check changes what an OWASP category covers,
    update the matching `CoverageDefinition.scannedDescription`.
 4. Add a focused test in
-   [`PentestingScannerTests`](../bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/pentesting/PentestingScannerTests.java):
+   [`PentestingScannerTests`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/pentesting/PentestingScannerTests.java):
    extend the uniqueness assertion to include the new ID, and verify the check stays silent on safe defaults and fires
    on a minimal failing fixture.
 5. Append the new check to this page in the matching OWASP section so the published catalogue stays in sync.

--- a/docs/REST-API-CHECKS.md
+++ b/docs/REST-API-CHECKS.md
@@ -5,9 +5,9 @@ The REST API panel runs a fixed, zero-config ruleset against the host applicatio
 inspects, when it fires, and what to do about it.
 
 Each rule is a small class registered in
-[`RestApiRuleRegistry`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/restapi/RestApiRuleRegistry.java)
+[`RestApiRuleRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/restapi/RestApiRuleRegistry.java)
 and implemented in
-[`RestApiRules.java`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/restapi/RestApiRules.java).
+[`RestApiRules.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/restapi/RestApiRules.java).
 The list intentionally stays compact and reviewable; adding a new rule means adding one focused class plus a registry
 entry.
 


### PR DESCRIPTION
## What does this PR do?

<img width="915" height="490" alt="image" src="https://github.com/user-attachments/assets/1fac1b4a-be78-4628-8270-a03a8779411e" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
