### PR TITLE
docs: fix broken CRaC source links in VuePress site

### DIFF
--- a/docs/CRAC-READINESS-CHECKS.md
+++ b/docs/CRAC-READINESS-CHECKS.md
@@ -5,9 +5,9 @@ readiness. It combines a live runtime-status view with a heuristic readiness adv
 ships with BootUI today, what it inspects, when it fires, and what to do about it.
 
 Each check is a small class registered in
-[`CracCheckRegistry`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracCheckRegistry.java)
+[`CracCheckRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracCheckRegistry.java)
 and implemented in
-[`CracChecks.java`](../bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracChecks.java).
+[`CracChecks.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracChecks.java).
 The list intentionally stays compact and reviewable; adding a new check means adding one focused class plus a registry
 entry.
 


### PR DESCRIPTION
## What does this PR do?

Fixes two broken source-code links on the CRaC readiness checks page so they resolve correctly in the published VuePress docs site.

## Why is this change needed?

A link check of the VuePress site turned up the only two internal links that 404 once published. `docs/CRAC-READINESS-CHECKS.md` referenced its registry and checks classes using repo-relative `../bootui-autoconfigure/...` paths. Those resolve outside the site base (`/boot-ui/`) because the Java sources are not part of the docs build, so they break in the rendered site.

Every other checks page (GraalVM, Architecture, Pentest, REST API, etc.) already links to its source classes via full `https://github.com/jdubois/boot-ui/blob/main/...` URLs. This change brings the CRaC page in line with that established pattern. The two target files were verified to exist at those paths.

The rest of the site checked out clean: all internal doc links and anchors, image assets, navbar/sidebar targets, and the other GitHub blob links resolve correctly.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Docs-only change. Verified via a link-resolution pass over all `docs/*.md` files (internal links, anchors, images, sidebar/navbar config targets, and GitHub `blob/main` links), and confirmed the two CRaC target Java files exist in the repo.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed