### PR TITLE
Add build/run instructions to CRaC and native Dockerfiles

### DIFF
--- a/Dockerfile-crac
+++ b/Dockerfile-crac
@@ -15,6 +15,15 @@
 # build stage and the sample app is built together with the modules it depends on
 # (`-pl bootui-sample-app -am`). For a JVM image see Dockerfile, for a GraalVM
 # native image see Dockerfile-native.
+#
+# Build and run (CRIU needs extra privileges; the named volume keeps the checkpoint
+# between restarts, and -p publishes the port so the app is reachable from the host):
+#   docker build -f Dockerfile-crac -t bootui-sample-app-crac .
+#   docker run --rm -p 8080:8080 \
+#     --cap-add=CHECKPOINT_RESTORE --cap-add=SYS_PTRACE --cap-add=SYS_ADMIN \
+#     -v bootui-sample-app-crac:/opt/crac/checkpoint bootui-sample-app-crac
+#
+# Or use docker-compose-crac.yml (docker compose -f docker-compose-crac.yml up --build).
 
 # Build stage (a plain JDK is enough; CRaC only matters at runtime).
 FROM eclipse-temurin:21-jdk-noble AS build
@@ -28,7 +37,7 @@ RUN chmod +x mvnw
 # Build the sample app and its reactor dependencies. The sample app binds the
 # spring-boot-maven-plugin "repackage" goal, so this produces a runnable Spring
 # Boot jar (with BOOT-INF and a Main-Class) alongside the thin *.jar.original.
-RUN ./mvnw -DskipTests -pl bootui-sample-app -am clean package
+RUN ./mvnw -Pcrac -DskipTests -pl bootui-sample-app -am clean package
 
 # Runtime stage with a CRaC-enabled JDK (BellSoft Liberica with CRaC support).
 FROM bellsoft/liberica-runtime-container:jdk-21-crac-slim-glibc

--- a/Dockerfile-native
+++ b/Dockerfile-native
@@ -5,6 +5,9 @@
 # depends on (`-pl bootui-sample-app -am`).
 #
 # Requires GraalVM 25+ for Spring Boot 4 (GraalVM 25 = JDK 25).
+# Build and run:
+#   docker build -f Dockerfile-native -t bootui-sample-app-native .
+#   docker run --rm -p 8080:8080 bootui-sample-app-native
 
 # Build stage with GraalVM 25 (includes the native-image toolchain, JDK 25)
 FROM ghcr.io/graalvm/graalvm-community:25 AS build

--- a/bootui-sample-app/pom.xml
+++ b/bootui-sample-app/pom.xml
@@ -78,23 +78,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
-
-        <!--
-            CRaC (Coordinated Restore at Checkpoint) adapter. Required on the
-            classpath for spring.context.checkpoint=onRefresh to work on a
-            CRaC-enabled JVM. See the "Run it with CRaC" section in README.md
-            and Dockerfile-crac. The version is managed by the Spring Boot BOM.
-        -->
-        <dependency>
-            <groupId>org.crac</groupId>
-            <artifactId>crac</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-starter-model-ollama</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
@@ -122,7 +109,6 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -287,6 +273,21 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>crac</id>
+            <dependencies>
+                <!--
+                    CRaC (Coordinated Restore at Checkpoint) adapter. Required on the
+                    classpath for spring.context.checkpoint=onRefresh to work on a
+                    CRaC-enabled JVM. See the "Run it with CRaC" section in README.md
+                    and Dockerfile-crac. The version is managed by the Spring Boot BOM.
+                -->
+                <dependency>
+                    <groupId>org.crac</groupId>
+                    <artifactId>crac</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## What does this PR do?

Documents how to build and run the CRaC and native container images, and moves the CRaC adapter dependency behind a dedicated Maven profile.

## Why is this change needed?

The panel-generated `Dockerfile-crac` (from `CracDockerfileGenerator`) includes a "Build and run" header block with the exact `docker build` / `docker run` commands, but the hand-written root `Dockerfile-crac` did not. This aligns the root file with the generated one so anyone reading it knows how to build the image and which CRIU privileges/volume are required, without digging through the README.

The two files stay intentionally similar; the remaining differences are the expected multi-module ones (the reactor build with `-pl bootui-sample-app -am`, the `bootui-sample-app/target` paths, and `SPRING_PROFILES_ACTIVE=dev`).

## Approach

- **`Dockerfile-crac`**: added the build/run header block (image name `bootui-sample-app-crac`, capabilities, checkpoint volume) plus a pointer to `docker-compose-crac.yml`. The reactor build now runs with `-Pcrac`.
- **`Dockerfile-native`**: added a matching short build/run block for consistency.
- **`bootui-sample-app/pom.xml`**: moved the `org.crac:crac` adapter out of the always-on dependencies into a new `crac` profile, so it is only on the classpath when building the CRaC image (`-Pcrac`). This keeps the JVM and native builds free of the CRaC adapter they don't need.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed