### PR TITLE
Add daily Docker Hub publish workflow for sample-app images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,9 @@ jobs:
   publish:
     name: Build and publish ${{ matrix.image }}
     runs-on: ubuntu-latest
+    # DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are stored as environment secrets,
+    # so the job must opt in to that environment to read them.
+    environment: docker-hub
     # The native build dominates the runtime; allow generous headroom.
     timeout-minutes: 90
     # Only publish from the canonical repository: forks lack the Docker Hub secrets.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,10 +13,16 @@ name: Publish Docker images
 # The images are published once a day from the main branch (scheduled events run
 # against the default branch) and can also be built on demand from the Actions tab.
 #
+# After publishing, the `prune` job deletes dated/SHA tags older than one week from
+# each repository (the rolling `latest` tag is always kept) so old daily images do
+# not accumulate, since Docker Hub has no built-in retention policy.
+#
 # Required repository secrets:
 #   DOCKERHUB_USERNAME  Docker Hub account/namespace the images are pushed to.
-#   DOCKERHUB_TOKEN     Docker Hub access token (Account Settings > Security) with
-#                       Read & Write scope; do not use the account password.
+#   DOCKERHUB_TOKEN     Docker Hub access token (Account Settings > Personal access
+#                       tokens). It must have "Read, Write, Delete" scope: Write to
+#                       push images and Delete to prune old tags. Do not use the
+#                       account password.
 
 on:
   schedule:
@@ -90,3 +96,55 @@ jobs:
           # Per-image GitHub Actions layer cache so each daily run reuses what it can.
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+
+  prune:
+    name: Prune tags older than one week
+    runs-on: ubuntu-latest
+    needs: publish
+    # Run after publishing even if one image build failed: retention is independent
+    # of today's build. Skip only on cancellation and on forks (which lack secrets).
+    if: ${{ !cancelled() && github.repository == 'jdubois/boot-ui' }}
+    environment: docker-hub
+    timeout-minutes: 10
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Tags whose last push is older than this many days are deleted.
+      MAX_AGE_DAYS: '7'
+    steps:
+      - name: Delete tags older than ${{ env.MAX_AGE_DAYS }} days
+        run: |
+          set -euo pipefail
+
+          # Exchange the access token for a short-lived Docker Hub API JWT.
+          token=$(curl -fsS -H 'Content-Type: application/json' \
+            -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
+            https://hub.docker.com/v2/users/login | jq -r '.token')
+          if [ -z "$token" ] || [ "$token" = 'null' ]; then
+            echo 'Failed to authenticate to the Docker Hub API.' >&2
+            exit 1
+          fi
+
+          cutoff=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
+
+          for repo in bootui-sample-app bootui-sample-app-crac bootui-sample-app-native; do
+            echo "::group::Pruning ${DOCKERHUB_USERNAME}/${repo}"
+            url="https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/${repo}/tags/?page_size=100"
+            while [ -n "$url" ] && [ "$url" != 'null' ]; do
+              resp=$(curl -fsS -H "Authorization: JWT ${token}" "$url")
+              while read -r name updated; do
+                # Always keep the rolling 'latest' tag.
+                [ "$name" = 'latest' ] && { echo "Keeping  ${repo}:${name} (latest)"; continue; }
+                updated_epoch=$(date -u -d "$updated" +%s)
+                if [ "$updated_epoch" -lt "$cutoff" ]; then
+                  echo "Deleting ${repo}:${name} (last updated ${updated})"
+                  curl -fsS -X DELETE -H "Authorization: JWT ${token}" \
+                    "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/${repo}/tags/${name}/"
+                else
+                  echo "Keeping  ${repo}:${name} (last updated ${updated})"
+                fi
+              done < <(echo "$resp" | jq -r '.results[] | "\(.name) \(.last_updated)"')
+              url=$(echo "$resp" | jq -r '.next')
+            done
+            echo "::endgroup::"
+          done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,89 @@
+name: Publish Docker images
+
+# Builds the three sample-app container images from the root Dockerfiles and
+# publishes them to Docker Hub:
+#
+#   Dockerfile         -> <user>/bootui-sample-app          (JVM image)
+#   Dockerfile-crac    -> <user>/bootui-sample-app-crac     (CRaC image)
+#   Dockerfile-native  -> <user>/bootui-sample-app-native   (GraalVM native image)
+#
+# Each Dockerfile copies the whole multi-module reactor and builds the sample app
+# with `-pl bootui-sample-app -am`, so the build context is the repository root.
+#
+# The images are published once a day from the main branch (scheduled events run
+# against the default branch) and can also be built on demand from the Actions tab.
+#
+# Required repository secrets:
+#   DOCKERHUB_USERNAME  Docker Hub account/namespace the images are pushed to.
+#   DOCKERHUB_TOKEN     Docker Hub access token (Account Settings > Security) with
+#                       Read & Write scope; do not use the account password.
+
+on:
+  schedule:
+    # Every day at 07:17 UTC (after the native-image and Docker-config jobs).
+    # Deliberately off the top of the hour: GitHub delays and, under sufficiently
+    # high load, drops scheduled events during the peak window at the start of each
+    # hour, so a ':00' cron is unreliable.
+    - cron: '17 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    # The native build dominates the runtime; allow generous headroom.
+    timeout-minutes: 90
+    # Only publish from the canonical repository: forks lack the Docker Hub secrets.
+    if: github.repository == 'jdubois/boot-ui'
+    strategy:
+      # Publish every image that can build, even if one variant fails.
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile
+            image: bootui-sample-app
+          - dockerfile: Dockerfile-crac
+            image: bootui-sample-app-crac
+          - dockerfile: Dockerfile-native
+            image: bootui-sample-app-native
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract image metadata (tags and labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=sha,format=short
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Per-image GitHub Actions layer cache so each daily run reuses what it can.
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}


### PR DESCRIPTION
## What does this PR do?

Adds a scheduled GitHub Actions workflow that builds the three root Dockerfiles for the sample app and publishes them to Docker Hub once a day from `main`.

## Why is this change needed?

The repo ships three sample-app container builds (`Dockerfile` JVM, `Dockerfile-crac` CRaC, `Dockerfile-native` GraalVM native) but nothing publishes them. This gives a hands-off daily publish so up-to-date images are always available on Docker Hub.

N/A (no issue)

The new `.github/workflows/docker-publish.yml`:

- Runs daily at 07:17 UTC (off-the-hour, consistent with the other scheduled workflows) plus on-demand `workflow_dispatch`. Scheduled runs execute against the default branch (`main`), as requested.
- Uses a 3-way `matrix` (`fail-fast: false`) to build each variant in parallel via `docker/build-push-action`, with the build context at the repo root since each Dockerfile copies the whole reactor.
- Pushes to three separate repos: `<user>/bootui-sample-app`, `<user>/bootui-sample-app-crac`, `<user>/bootui-sample-app-native`.
- Tags via `docker/metadata-action`: `latest`, a `YYYYMMDD` date tag on scheduled runs, and a short-SHA tag. Per-image GitHub Actions layer cache speeds up daily rebuilds.
- Reads `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` from the `docker-hub` environment (declared via `environment: docker-hub`), and is gated with `if: github.repository == 'jdubois/boot-ui'` so forks don't attempt to push. Permissions are `contents: read` only.

Note: if the `docker-hub` environment has required reviewers or a branch protection rule, scheduled runs will pause for approval; leave it unprotected for unattended publishing.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

CI-only change. Validated the workflow YAML parses and that the job/matrix/environment resolve as intended. The build/run checkboxes above are N/A for a workflow-only change.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A; CI infra only)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed (credentials read from the `docker-hub` environment secrets)