### PR TITLE
Fix sidebar and body scrolling together (#341)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -230,10 +230,11 @@ Playwright coverage aligned across these nine groups (current order):
 - Feature screenshots in `docs/images/bootui-*.png` should stay at the current 1600x900 px size so the feature page
   remains visually consistent. When adding or refreshing screenshots, seed the sample app or local state with realistic
   non-sensitive sample data that demonstrates how the panel works instead of capturing empty/default states.
-  **Always scroll to the top of the page before capturing** (`page.evaluate(() => window.scrollTo(0, 0))` after the
-  prepare step and before `page.screenshot()`). `waitFor` / `waitForText` helpers scroll matching elements into view,
-  which leaves the viewport at the bottom of the panel; without an explicit scroll-to-top the screenshot shows empty
-  space instead of the panel header.
+  **Always scroll to the top before capturing** — reset both the window and the `.bootui-workspace` scroll container
+  (`page.evaluate(() => { window.scrollTo(0, 0); document.querySelector('.bootui-workspace')?.scrollTo(0, 0) })`) after
+  the prepare step and before `page.screenshot()`. The main content scrolls inside `.bootui-workspace` (not the
+  document), and `waitFor` / `waitForText` helpers scroll matching elements into view, which otherwise leaves the
+  viewport at the bottom of the panel so the screenshot shows empty space instead of the panel header.
 
 ## Java conventions
 

--- a/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -2872,7 +2872,10 @@ try {
     await page.goto(`${baseUrl}/bootui/#/${route}`)
     await page.locator('main .page-panel h2').first().waitFor()
     await prepare(page)
-    await page.evaluate(() => window.scrollTo(0, 0))
+    await page.evaluate(() => {
+      window.scrollTo(0, 0)
+      document.querySelector('.bootui-workspace')?.scrollTo(0, 0)
+    })
     await page.waitForTimeout(250)
     await page.screenshot({
       path: path.join(imagesDir, fileName),

--- a/bootui-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-sample-app/e2e/tests/app-shell.spec.js
@@ -95,6 +95,48 @@ test.describe('BootUI app shell', () => {
     await expect(contributeLink.locator('.bi-github')).toBeVisible()
   })
 
+  test('main content scrolls while the sidebar stays fixed', async ({page}) => {
+    // A short viewport guarantees the main content overflows the window.
+    await page.setViewportSize({width: 1280, height: 400})
+    await page.goto('/bootui/')
+    await page.locator('main .page-panel h2').first().waitFor()
+
+    const layout = await page.evaluate(() => {
+      const shell = document.querySelector('.bootui-shell')
+      const workspace = document.querySelector('.bootui-workspace')
+      const sidebar = document.querySelector('aside.bootui-sidebar')
+      const doc = document.scrollingElement
+      return {
+        // The page itself must not scroll: scrolling lives inside the app, not the document.
+        documentScrollable: doc.scrollHeight > doc.clientHeight + 1,
+        shellOverflowY: getComputedStyle(shell).overflowY,
+        workspaceOverflowY: getComputedStyle(workspace).overflowY,
+        workspaceScrollable: workspace.scrollHeight > workspace.clientHeight,
+        sidebarOverflowY: getComputedStyle(sidebar).overflowY,
+        sidebarOverscroll: getComputedStyle(sidebar).overscrollBehaviorY
+      }
+    })
+
+    expect(layout.documentScrollable).toBe(false)
+    expect(layout.shellOverflowY).toBe('hidden')
+    expect(layout.workspaceOverflowY).toBe('auto')
+    expect(layout.workspaceScrollable).toBe(true)
+    // The sidebar is its own scroll region and never chains into the rest of the page.
+    expect(layout.sidebarOverflowY).toBe('auto')
+    expect(layout.sidebarOverscroll).toBe('contain')
+
+    // Scrolling the main content moves only the content, not the sidebar or the document.
+    const sidebar = page.locator('aside.bootui-sidebar')
+    const sidebarTopBefore = await sidebar.evaluate((el) => el.getBoundingClientRect().top)
+    const contentScrollTop = await page.locator('.bootui-workspace').evaluate((el) => {
+      el.scrollTop = el.scrollHeight
+      return el.scrollTop
+    })
+    expect(contentScrollTop).toBeGreaterThan(0)
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+    expect(await sidebar.evaluate((el) => el.getBoundingClientRect().top)).toBe(sidebarTopBefore)
+  })
+
   test('sidebar groups panels into collapsible sections', async ({page}) => {
     await mockPanelAvailability(page)
     await page.goto('/bootui/')

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -811,8 +811,9 @@ function onGlobalKeydown(e) {
 .bootui-shell {
   color: var(--bootui-text);
   display: flex;
+  height: 100vh;
   isolation: isolate;
-  overflow-x: hidden;
+  overflow: hidden;
   position: relative;
 }
 
@@ -852,12 +853,11 @@ function onGlobalKeydown(e) {
   flex-direction: column;
   flex-shrink: 0;
   gap: 1.4rem;
-  min-height: 100vh;
+  height: 100vh;
   overflow-x: hidden;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 1.25rem;
-  position: sticky;
-  top: 0;
   transition: width 220ms ease;
   width: 18rem;
 }
@@ -1191,7 +1191,9 @@ function onGlobalKeydown(e) {
   display: flex;
   flex: 1;
   flex-direction: column;
+  height: 100vh;
   min-width: 0;
+  overflow-y: auto;
 }
 
 .topbar {
@@ -1361,12 +1363,20 @@ function onGlobalKeydown(e) {
 @media (max-width: 575.98px) {
   .bootui-shell {
     flex-direction: column;
+    height: auto;
+    overflow: visible;
   }
 
   .bootui-sidebar {
-    min-height: auto;
+    height: auto;
+    overscroll-behavior: auto;
     position: relative;
     width: 100%;
+  }
+
+  .bootui-workspace {
+    height: auto;
+    overflow: visible;
   }
 
   .topbar {


### PR DESCRIPTION
## What does this PR do?

Switches the BootUI console to a standard app-shell layout so the main content scrolls on its own while the sidebar stays fixed.

## Why is this change needed?

The whole page scrolled as a single document: the sidebar used `min-height: 100vh` with a sticky position, so on a long panel the sidebar and the body content scrolled together. The expectation is that scrolling lives in the main content area, not on the sidebar/page.

The fix moves the scroll into the workspace:

- `.bootui-shell` is `height: 100vh` with `overflow: hidden`, so the document itself never scrolls.
- `.bootui-workspace` becomes the main content scroll container (`height: 100vh; overflow-y: auto`).
- `.bootui-sidebar` is a fixed full-height column. It keeps `overflow-y: auto` + `overscroll-behavior: contain` only for the rare case its own navigation overflows, and no longer needs sticky positioning.
- The mobile layout (`max-width: 575.98px`) restores normal document scrolling so the stacked sidebar and content are not clipped.

Fixes: #341

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Specifically run green: frontend Vitest (189 tests), `npm run build`, Prettier `format:check` (frontend + e2e), and the Playwright `app-shell.spec.js` suite (8 tests) against the running sample app. I did not run the full reactor `clean install`; verification was done via a targeted sample-app build plus the suites above. Also confirmed visually that scrolling the content keeps the sidebar fixed and leaves `window.scrollY` at 0.

## Screenshots (UI changes)

This is a scroll-behavior change that is best seen interactively. Before: scrolling over the sidebar dragged the body content with it (single document scroll). After: the sidebar stays put and only the main content scrolls, with the scrollbar at the window's right edge.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes <!-- updated `.github/copilot-instructions.md` and the docs screenshot script to reset the new `.bootui-workspace` scroll container before capturing -->
- [x] Public API kept backward compatible, or a migration note added to the PR description <!-- CSS-only layout change, no API impact -->
- [x] No secrets, tokens, or local paths committed