### PR TITLE
Publish multi-arch (amd64 + arm64) Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,7 +1,7 @@
 name: Publish Docker images
 
 # Builds the three sample-app container images from the root Dockerfiles and
-# publishes them to Docker Hub:
+# publishes them to Docker Hub as multi-arch images (linux/amd64 + linux/arm64):
 #
 #   Dockerfile         -> <user>/bootui-sample-app          (JVM image)
 #   Dockerfile-crac    -> <user>/bootui-sample-app-crac     (CRaC image)
@@ -9,6 +9,14 @@ name: Publish Docker images
 #
 # Each Dockerfile copies the whole multi-module reactor and builds the sample app
 # with `-pl bootui-sample-app -am`, so the build context is the repository root.
+#
+# Multi-arch is produced by building each image once per platform on a *native*
+# runner (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) and then merging the
+# per-platform digests into a single manifest list. Native runners (rather than
+# QEMU emulation) are required because GraalVM cannot cross-compile a native image
+# and emulated native-image / Maven builds would not fit the time budget. The
+# `build` job pushes each platform image by digest (no tags); the `merge` job then
+# stitches those digests together and applies the `latest`/date/SHA tags.
 #
 # The images are published once a day from the main branch (scheduled events run
 # against the default branch) and can also be built on demand from the Actions tab.
@@ -41,9 +49,11 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    name: Build and publish ${{ matrix.image }}
-    runs-on: ubuntu-latest
+  build:
+    name: Build ${{ matrix.image }} (${{ matrix.platform }})
+    # Build each platform on a native runner: arm64 on GitHub's hosted arm64
+    # runners, everything else (amd64) on the standard x86_64 runners.
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     # DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are stored as environment secrets,
     # so the job must opt in to that environment to read them.
     environment: docker-hub
@@ -52,17 +62,30 @@ jobs:
     # Only publish from the canonical repository: forks lack the Docker Hub secrets.
     if: github.repository == 'jdubois/boot-ui'
     strategy:
-      # Publish every image that can build, even if one variant fails.
+      # Publish every image/platform that can build, even if one combination fails.
       fail-fast: false
       matrix:
+        image:
+          - bootui-sample-app
+          - bootui-sample-app-crac
+          - bootui-sample-app-native
+        platform:
+          - linux/amd64
+          - linux/arm64
         include:
-          - dockerfile: Dockerfile
-            image: bootui-sample-app
-          - dockerfile: Dockerfile-crac
-            image: bootui-sample-app-crac
-          - dockerfile: Dockerfile-native
-            image: bootui-sample-app-native
+          - image: bootui-sample-app
+            dockerfile: Dockerfile
+          - image: bootui-sample-app-crac
+            dockerfile: Dockerfile-crac
+          - image: bootui-sample-app-native
+            dockerfile: Dockerfile-native
     steps:
+      - name: Prepare
+        run: |
+          platform='${{ matrix.platform }}'
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+          echo "REGISTRY_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}" >> "$GITHUB_ENV"
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -75,32 +98,101 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Extract image labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+
+      - name: Build and push image by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Push the per-platform image by digest only (no tags): the merge job
+          # assembles the tagged manifest list from these digests.
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Per-image, per-platform GitHub Actions layer cache so each daily run
+          # reuses what it can without the two platforms clobbering each other.
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ env.PLATFORM_PAIR }}
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest='${{ steps.build.outputs.digest }}'
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ matrix.image }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge ${{ matrix.image }} manifests
+    runs-on: ubuntu-latest
+    needs: build
+    # Merge each image independently: if one image (or one of its platforms) failed
+    # to build, still publish the others. Skip only on cancellation and on forks.
+    if: ${{ !cancelled() && github.repository == 'jdubois/boot-ui' }}
+    environment: docker-hub
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - bootui-sample-app
+          - bootui-sample-app-crac
+          - bootui-sample-app-native
+    steps:
+      - name: Prepare
+        run: echo "REGISTRY_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@v7
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract image metadata (tags and labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=raw,value=latest
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=sha,format=short
 
-      - name: Build and push image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Per-image GitHub Actions layer cache so each daily run reuses what it can.
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect "${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}"
 
   prune:
     name: Prune tags older than one week
     runs-on: ubuntu-latest
-    needs: publish
+    needs: merge
     # Run after publishing even if one image build failed: retention is independent
     # of today's build. Skip only on cancellation and on forks (which lack secrets).
     if: ${{ !cancelled() && github.repository == 'jdubois/boot-ui' }}


### PR DESCRIPTION
## What does this PR do?

Makes the daily `docker-publish` workflow publish all three sample-app images as multi-arch manifests covering both `linux/amd64` and `linux/arm64`.

## Why is this change needed?

The workflow built the three images on `ubuntu-latest` (amd64) with no `platforms:` set, so only `linux/amd64` manifests were pushed. Pulling them on arm64 hosts (such as Apple Silicon Macs) fails with:

```
no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found
```

### Approach

Restructured `docker-publish.yml` into the canonical multi-platform CI pattern:

- **`build`** matrix of 3 images x 2 platforms (6 jobs). Each job builds for a single platform on its **native** runner (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64) and pushes the image **by digest** (no tags), uploading the digest as an artifact.
- **`merge`** matrix of 3 images. Downloads that image's per-platform digests and stitches them into one tagged manifest list (`latest` + date + short-SHA), then inspects the result.
- **`prune`** is unchanged except it now depends on `merge`.

Native per-platform runners are used instead of QEMU emulation because GraalVM cannot cross-compile a native image, and emulated native-image / Maven builds would not fit the 90-minute budget. GitHub's hosted `ubuntu-24.04-arm` runners are free for public repos. `fail-fast: false` is preserved, so one variant failing still publishes the rest.

I verified that every base image already publishes both architectures: Temurin 25/21 (incl. the Alpine JRE), BellSoft Liberica CRaC, GraalVM Community 25, and `debian:12-slim`.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

CI workflow change (no Java/UI code touched), so the items above are N/A. Validated instead with `actionlint` (no issues) and confirmed the matrix resolves to the expected 6 build / 3 merge jobs. End-to-end behavior is exercised by the scheduled run / manual `Run workflow` dispatch.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no docs reference image architecture; workflow header comments updated)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed