### PR TITLE
docs: rename navbar label to "Try it"

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -40,7 +40,7 @@ export default defineUserConfig({
     contributors: false,
     logo: null,
     navbar: [
-      {text: 'Try sample app', link: toDocLink('TRY-SAMPLE-APP.md')},
+      {text: 'Try it', link: toDocLink('TRY-SAMPLE-APP.md')},
       {text: 'Setup', link: toDocLink('SETUP.md')},
       {text: 'Features', link: toDocLink('FEATURES.md')},
       {text: 'Properties', link: toDocLink('PROPERTIES.md')},


### PR DESCRIPTION
## What does this PR do?

Renames the VuePress docs navbar label from "Try sample app" to "Try it".

## Why is this change needed?

The shorter "Try it" label is cleaner and reads better in the navbar. This is a label-only change; the link still points to `TRY-SAMPLE-APP.md`.

Closes # N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Text-only docs navbar change, no build or test impact.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed