### PR TITLE
Strengthen CRaC readiness checks (file handles, caches, config capture)

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracCategory.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracCategory.java
@@ -8,8 +8,10 @@ enum CracCategory {
     RESOURCES("Open I/O resources"),
     NETWORK("Network connections"),
     POOLS("Connection pools"),
+    CACHES("Caches"),
     THREADS("Threads & schedulers"),
     TIME("Captured time"),
+    CONFIG("Captured configuration"),
     RANDOMNESS("Randomness"),
     SECRETS("Captured secrets"),
     LIFECYCLE("CRaC lifecycle");

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracCheckRegistry.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracCheckRegistry.java
@@ -11,10 +11,13 @@ final class CracCheckRegistry {
 
     private static final List<CracCheck> ACTIVE_CHECKS = List.of(
             new OpenResourceFieldCheck(),
+            new FileHandleCheck(),
             new SocketConstructionCheck(),
             new ConnectionPoolCheck(),
+            new CacheManagerCheck(),
             new UnmanagedThreadCheck(),
             new CapturedTimeCheck(),
+            new CapturedConfigurationCheck(),
             new StaticRandomFieldCheck(),
             new CapturedSecretFieldCheck(),
             new ResourceRegistrationCheck());

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracChecks.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracChecks.java
@@ -97,6 +97,64 @@ final class SocketConstructionCheck extends AbstractArchUnitCracCheck {
 }
 
 /**
+ * Flags direct construction or opening of file handles ({@code new FileInputStream}, {@code
+ * FileReader}, {@code RandomAccessFile}, {@code ZipFile}/{@code JarFile}, and the {@code Files} /
+ * {@code FileChannel} / {@code AsynchronousFileChannel} open factory methods). An open file holds an
+ * OS file descriptor that CRaC refuses to checkpoint, so it must be closed first — otherwise the
+ * checkpoint aborts with {@code CheckpointOpenFileException}.
+ */
+final class FileHandleCheck extends AbstractArchUnitCracCheck {
+
+    private static final Set<String> FILE_TYPES = Set.of(
+            "java.io.FileInputStream",
+            "java.io.FileOutputStream",
+            "java.io.RandomAccessFile",
+            "java.io.FileReader",
+            "java.io.FileWriter",
+            "java.util.zip.ZipFile",
+            "java.util.jar.JarFile");
+
+    private static final Set<String> FILES_FACTORIES =
+            Set.of("newInputStream", "newOutputStream", "newByteChannel", "newBufferedReader", "newBufferedWriter");
+
+    private static final Set<String> CHANNEL_OPENERS =
+            Set.of("java.nio.channels.FileChannel", "java.nio.channels.AsynchronousFileChannel");
+
+    FileHandleCheck() {
+        super(new CracCheckDefinition(
+                "CRAC-FILE-001",
+                "Direct file handles must be released at checkpoint",
+                CracCategory.RESOURCES,
+                "HIGH",
+                "Detects code that opens file handles directly (new FileInputStream/FileOutputStream/RandomAccessFile/FileReader/FileWriter/ZipFile/JarFile, or the Files.newInputStream/newOutputStream/newByteChannel and FileChannel/AsynchronousFileChannel.open factory methods). An open file holds an OS file descriptor that CRaC refuses to checkpoint, so it aborts with CheckpointOpenFileException.",
+                "Close the file before the checkpoint (try-with-resources for short-lived handles, or release it in an org.crac.Resource.beforeCheckpoint() callback and reopen it in afterRestore()), or let a managed component own it so the framework closes it around the checkpoint.",
+                "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html"));
+    }
+
+    @Override
+    ArchRule rule(CracContext context) {
+        return noClasses()
+                .should()
+                .callCodeUnitWhere(new DescribedPredicate<JavaCall<?>>("a file handle is opened") {
+                    @Override
+                    public boolean test(JavaCall<?> call) {
+                        CodeUnitCallTarget target = call.getTarget();
+                        String owner = target.getOwner().getName();
+                        String name = target.getName();
+                        if ("<init>".equals(name) && FILE_TYPES.contains(owner)) {
+                            return true;
+                        }
+                        if ("java.nio.file.Files".equals(owner) && FILES_FACTORIES.contains(name)) {
+                            return true;
+                        }
+                        return "open".equals(name) && CHANNEL_OPENERS.contains(owner);
+                    }
+                })
+                .as("Classes should not open files that survive a checkpoint");
+    }
+}
+
+/**
  * Flags threads, timers, and executor pools created directly rather than through a Spring-managed
  * lifecycle. CRaC pauses Spring {@code Lifecycle} beans before a checkpoint; threads started outside
  * that lifecycle keep running and are captured mid-flight, which often deadlocks or corrupts state
@@ -209,7 +267,7 @@ final class OpenResourceFieldCheck implements CracCheck {
             "Open resources held in fields must be released at checkpoint",
             CracCategory.RESOURCES,
             "HIGH",
-            "Detects fields whose type holds an OS resource (sockets, file streams, RandomAccessFile, NIO channels, JDBC Connection) on classes that do not implement org.crac.Resource or a Spring Lifecycle. CRaC cannot snapshot live file descriptors. Auto-configured pools (a HikariCP DataSource, a Redis client) are the common case and are covered separately by CRAC-POOL-001.",
+            "Detects fields whose type holds an OS resource (sockets, file streams, FileReader/Writer, RandomAccessFile, zip/jar files, NIO channels and selectors, file locks, WatchService, Process, JDBC Connection) on classes that do not implement org.crac.Resource or a Spring Lifecycle. CRaC cannot snapshot live file descriptors. Auto-configured pools (a HikariCP DataSource, a Redis client) are the common case and are covered separately by CRAC-POOL-001.",
             "Implement org.crac.Resource and close the resource in beforeCheckpoint(), re-opening it in afterRestore(); or hold the resource in a Spring Lifecycle/SmartLifecycle bean so the framework stops it before the checkpoint. For auto-configured connection pools, see CRAC-POOL-001.",
             "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
 
@@ -220,10 +278,21 @@ final class OpenResourceFieldCheck implements CracCheck {
             "java.net.MulticastSocket",
             "java.io.FileInputStream",
             "java.io.FileOutputStream",
+            "java.io.FileReader",
+            "java.io.FileWriter",
             "java.io.RandomAccessFile",
+            "java.util.zip.ZipFile",
             "java.nio.channels.FileChannel",
+            "java.nio.channels.AsynchronousFileChannel",
             "java.nio.channels.SocketChannel",
             "java.nio.channels.ServerSocketChannel",
+            "java.nio.channels.DatagramChannel",
+            "java.nio.channels.AsynchronousSocketChannel",
+            "java.nio.channels.AsynchronousServerSocketChannel",
+            "java.nio.channels.FileLock",
+            "java.nio.channels.Selector",
+            "java.nio.file.WatchService",
+            "java.lang.Process",
             "java.sql.Connection");
 
     private static final Set<String> MANAGED_TYPES = Set.of(
@@ -330,10 +399,12 @@ final class StaticRandomFieldCheck implements CracCheck {
 }
 
 /**
- * Flags static fields whose name suggests an eagerly captured secret (token, password, API key,
- * credential). A secret loaded into a static field at startup is baked into the checkpoint image and
- * shipped with every restored process, so rotation no longer takes effect and the snapshot leaks the
- * value.
+ * Flags static fields that eagerly capture a secret: either a field whose name suggests a secret
+ * (token, password, API key, credential) holding a {@code String}/{@code char[]}/{@code byte[]}, or a
+ * field whose type is cryptographic key material ({@code SecretKey}, {@code PrivateKey}, {@code
+ * KeyStore}, {@code KeyPair}) regardless of name. A secret loaded into a static field at startup is
+ * baked into the checkpoint image and shipped with every restored process, so rotation no longer
+ * takes effect and the snapshot leaks the value.
  */
 final class CapturedSecretFieldCheck implements CracCheck {
 
@@ -342,7 +413,7 @@ final class CapturedSecretFieldCheck implements CracCheck {
             "Secrets captured in static fields are frozen into the checkpoint",
             CracCategory.SECRETS,
             "HIGH",
-            "Detects static fields whose name looks like a secret (token, password, secret, api key, credential, private key) holding a String, char[], or byte[]. Such values are captured into the checkpoint image and survive in every restored process.",
+            "Detects static fields that capture a secret: a field whose name looks like a secret (token, password, secret, api key, credential, private key) holding a String, char[], or byte[], or a field holding cryptographic key material (SecretKey, PrivateKey, KeyStore, KeyPair) regardless of name. Such values are captured into the checkpoint image and survive in every restored process.",
             "Load secrets lazily at runtime (or refresh them in an org.crac.Resource.afterRestore() callback) instead of caching them in a static field, so a checkpoint never freezes a credential.",
             "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
 
@@ -350,6 +421,9 @@ final class CapturedSecretFieldCheck implements CracCheck {
             Pattern.compile(".*(secret|password|passwd|token|apikey|api_key|credential|privatekey|private_key).*");
 
     private static final Set<String> SECRET_TYPES = Set.of("java.lang.String", "char[]", "byte[]", "[C", "[B");
+
+    private static final Set<String> KEY_TYPES = Set.of(
+            "javax.crypto.SecretKey", "java.security.PrivateKey", "java.security.KeyStore", "java.security.KeyPair");
 
     @Override
     public CracCheckDefinition definition() {
@@ -363,11 +437,7 @@ final class CapturedSecretFieldCheck implements CracCheck {
             int count = 0;
             for (JavaClass javaClass : context.classes()) {
                 for (JavaField field : javaClass.getFields()) {
-                    if (field.getModifiers().contains(JavaModifier.STATIC)
-                            && SECRET_NAME
-                                    .matcher(field.getName().toLowerCase())
-                                    .matches()
-                            && SECRET_TYPES.contains(field.getRawType().getName())) {
+                    if (field.getModifiers().contains(JavaModifier.STATIC) && isCapturedSecret(field)) {
                         count++;
                         if (samples.size() < CracCheckSupport.maxSampleOccurrences()) {
                             samples.add(CracCheckSupport.detail(javaClass.getName() + "." + field.getName() + " : "
@@ -383,6 +453,22 @@ final class CapturedSecretFieldCheck implements CracCheck {
         } catch (RuntimeException | LinkageError ex) {
             return CracCheckSupport.error(DEFINITION, "Check could not be evaluated: " + ex.getMessage());
         }
+    }
+
+    private static boolean isCapturedSecret(JavaField field) {
+        JavaClass type = field.getRawType();
+        boolean secretByName =
+                SECRET_NAME.matcher(field.getName().toLowerCase()).matches() && SECRET_TYPES.contains(type.getName());
+        return secretByName || isKeyType(type);
+    }
+
+    private static boolean isKeyType(JavaClass type) {
+        for (String keyType : KEY_TYPES) {
+            if (type.isAssignableTo(keyType)) {
+                return true;
+            }
+        }
+        return false;
     }
 }
 
@@ -432,10 +518,11 @@ final class ResourceRegistrationCheck implements CracCheck {
 }
 
 /**
- * Flags auto-configured connection pools (JDBC {@code DataSource}s, Redis connection factories) that
- * are live in the running context. Such pools hold OS sockets that CRaC refuses to checkpoint while
- * open: if a pooled connection is still established when {@code spring.context.checkpoint=onRefresh}
- * fires, CRaC aborts with a {@code CheckpointOpenSocketException}.
+ * Flags auto-configured connection pools and pooled clients (JDBC {@code DataSource}s, R2DBC/Redis/
+ * RabbitMQ/Kafka/Mongo/Cassandra/JMS connection factories and similar) that are live in the running
+ * context. Such pools hold OS sockets that CRaC refuses to checkpoint while open: if a pooled
+ * connection is still established when {@code spring.context.checkpoint=onRefresh} fires, CRaC aborts
+ * with a {@code CheckpointOpenSocketException}.
  *
  * <p>Unlike the other checks this one reads the live {@link CracRuntimeInventory} rather than the
  * imported application bytecode, because pools are contributed by Spring Boot auto-configuration and
@@ -448,7 +535,7 @@ final class ConnectionPoolCheck implements CracCheck {
             "Connection pools must hold no open connection at checkpoint",
             CracCategory.POOLS,
             "HIGH",
-            "Detects live connection pools (JDBC DataSource, Redis connection factory). A pooled connection that is still open when the checkpoint is taken holds an OS socket that CRaC refuses to snapshot, so the checkpoint aborts with CheckpointOpenSocketException. The backing service must also be reachable both when the checkpoint is taken and when it is restored.",
+            "Detects live connection pools and pooled clients (JDBC DataSource, plus R2DBC/Redis/RabbitMQ/Kafka/Mongo/Cassandra/JMS connection factories and similar). A pooled connection that is still open when the checkpoint is taken holds an OS socket that CRaC refuses to snapshot, so the checkpoint aborts with CheckpointOpenSocketException. The backing service must also be reachable both when the checkpoint is taken and when it is restored.",
             "Ensure no pooled connection is open at checkpoint time: let the pool drain to zero idle connections (for example spring.datasource.hikari.minimum-idle=0) or rely on Spring closing CRaC-aware pools before the checkpoint, and keep the database/cache reachable at both checkpoint and restore. Take the checkpoint after the context refreshes but before traffic opens a connection.",
             "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
 
@@ -475,5 +562,92 @@ final class ConnectionPoolCheck implements CracCheck {
         } catch (RuntimeException | LinkageError ex) {
             return CracCheckSupport.error(DEFINITION, "Check could not be evaluated: " + ex.getMessage());
         }
+    }
+}
+
+/**
+ * Flags live Spring {@code CacheManager} beans. Cache entries populated before the checkpoint survive
+ * into every restored process and may be stale (for example expired tokens or other time-sensitive
+ * data), because the checkpoint freezes the cache contents along with the rest of the heap.
+ *
+ * <p>Like {@link ConnectionPoolCheck} this reads the live {@link CracRuntimeInventory} rather than the
+ * imported bytecode, because cache managers are contributed by Spring's cache auto-configuration and
+ * never appear in the application's own base package.</p>
+ */
+final class CacheManagerCheck implements CracCheck {
+
+    private static final CracCheckDefinition DEFINITION = new CracCheckDefinition(
+            "CRAC-CACHE-001",
+            "In-memory caches may hold stale entries after restore",
+            CracCategory.CACHES,
+            "LOW",
+            "Detects live Spring CacheManager beans. Cache entries populated before the checkpoint are frozen into the image and survive into every restored process, where they may be stale (for example expired tokens or time-sensitive data).",
+            "Clear or refresh time-sensitive caches in an org.crac.Resource.afterRestore() callback, or use restore-aware expiry, so a restored process does not serve data captured at checkpoint time.",
+            "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
+
+    @Override
+    public CracCheckDefinition definition() {
+        return DEFINITION;
+    }
+
+    @Override
+    public CracFindingDto evaluate(CracContext context) {
+        try {
+            List<String> cacheBeans = context.runtime().cacheManagerBeans();
+            if (cacheBeans.isEmpty()) {
+                return CracCheckSupport.ok(DEFINITION);
+            }
+            List<String> samples = new ArrayList<>();
+            for (String cacheBean : cacheBeans) {
+                if (samples.size() >= CracCheckSupport.maxSampleOccurrences()) {
+                    break;
+                }
+                samples.add(CracCheckSupport.detail(cacheBean));
+            }
+            return CracCheckSupport.review(DEFINITION, cacheBeans.size(), samples);
+        } catch (RuntimeException | LinkageError ex) {
+            return CracCheckSupport.error(DEFINITION, "Check could not be evaluated: " + ex.getMessage());
+        }
+    }
+}
+
+/**
+ * Flags static initializers that read environment- or system-derived configuration ({@code
+ * System.getenv}, {@code System.getProperty}, {@code System.getProperties}). With {@code
+ * spring.context.checkpoint=onRefresh} the value is read once when the original JVM starts and frozen
+ * into the checkpoint image, so a restore-only start that changes the variable has no effect until a
+ * new checkpoint is taken.
+ */
+final class CapturedConfigurationCheck extends AbstractArchUnitCracCheck {
+
+    private static final Set<String> CONFIG_ACCESSORS = Set.of("getenv", "getProperty", "getProperties");
+
+    CapturedConfigurationCheck() {
+        super(new CracCheckDefinition(
+                "CRAC-CONFIG-001",
+                "Static initializer captures environment or system configuration",
+                CracCategory.CONFIG,
+                "MEDIUM",
+                "Detects static initializers that read environment variables or system properties (System.getenv/getProperty/getProperties). With spring.context.checkpoint=onRefresh the value is read once when the original JVM starts and frozen into the checkpoint image, so changing it for a restore-only start has no effect until a new checkpoint is taken.",
+                "Read environment- or property-derived configuration at runtime (or refresh it in an org.crac.Resource.afterRestore() callback) instead of caching it in a static field, so configuration changes take effect for a restored process.",
+                "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html"));
+    }
+
+    @Override
+    ArchRule rule(CracContext context) {
+        return noClasses()
+                .should()
+                .callCodeUnitWhere(new DescribedPredicate<JavaCall<?>>("a static initializer captures configuration") {
+                    @Override
+                    public boolean test(JavaCall<?> call) {
+                        if (!(call.getOrigin() instanceof JavaStaticInitializer)) {
+                            return false;
+                        }
+                        CodeUnitCallTarget target = call.getTarget();
+                        return "java.lang.System".equals(target.getOwner().getName())
+                                && CONFIG_ACCESSORS.contains(target.getName());
+                    }
+                })
+                .as("Static initializers should not capture environment or system configuration before a checkpoint");
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeInventory.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeInventory.java
@@ -15,21 +15,33 @@ import org.springframework.core.env.Environment;
  * connection-pool check reads this runtime inventory instead of imported classes.</p>
  *
  * @param connectionPoolBeans human-readable {@code beanName : TypeName} entries for detected pool
- *     beans (JDBC {@code DataSource}, Redis connection factory), empty when none are present
+ *     beans (JDBC {@code DataSource}, Redis/RabbitMQ/Kafka/Mongo/Cassandra/JMS/R2DBC connection
+ *     factories and similar pooled clients), empty when none are present
+ * @param cacheManagerBeans human-readable {@code beanName : TypeName} entries for detected Spring
+ *     {@code CacheManager} beans, empty when none are present
  * @param environment the live Spring {@link Environment}, or {@code null} when unavailable, used to
  *     surface pool tuning that influences checkpoint readiness (for example HikariCP idle settings)
  */
-record CracRuntimeInventory(List<String> connectionPoolBeans, Environment environment) {
+record CracRuntimeInventory(List<String> connectionPoolBeans, List<String> cacheManagerBeans, Environment environment) {
 
     CracRuntimeInventory {
         connectionPoolBeans = connectionPoolBeans == null ? List.of() : List.copyOf(connectionPoolBeans);
+        cacheManagerBeans = cacheManagerBeans == null ? List.of() : List.copyOf(cacheManagerBeans);
+    }
+
+    CracRuntimeInventory(List<String> connectionPoolBeans, Environment environment) {
+        this(connectionPoolBeans, List.of(), environment);
     }
 
     static CracRuntimeInventory empty() {
-        return new CracRuntimeInventory(List.of(), null);
+        return new CracRuntimeInventory(List.of(), List.of(), null);
     }
 
     boolean hasConnectionPools() {
         return !connectionPoolBeans.isEmpty();
+    }
+
+    boolean hasCacheManagers() {
+        return !cacheManagerBeans.isEmpty();
     }
 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeInventoryCollector.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeInventoryCollector.java
@@ -1,18 +1,23 @@
 package io.github.jdubois.bootui.autoconfigure.crac;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.util.ClassUtils;
 
 /**
- * Collects the host application's live connection-pool beans into a {@link CracRuntimeInventory}.
+ * Collects the host application's live connection-pool and cache-manager beans into a
+ * {@link CracRuntimeInventory}.
  *
  * <p>The collector inspects the running {@link ApplicationContext} for the bean types that hold the
- * OS sockets CRaC cares about — JDBC {@code DataSource}s and Redis connection factories — bounded to
- * types that are actually on the classpath so a missing optional dependency never fails the scan.
- * All access is read-only and never triggers a checkpoint.</p>
+ * OS sockets CRaC cares about — JDBC {@code DataSource}s, Redis/RabbitMQ/Kafka/Mongo/Cassandra/JMS/
+ * R2DBC connection factories and similar pooled clients — plus Spring {@code CacheManager} beans
+ * whose contents are frozen into the checkpoint. Every type is resolved lazily and bounded to types
+ * that are actually on the classpath, so a missing optional dependency never fails the scan. All
+ * access is read-only and never triggers a checkpoint.</p>
  */
 final class CracRuntimeInventoryCollector {
 
@@ -21,8 +26,28 @@ final class CracRuntimeInventoryCollector {
      * is resolved lazily so an absent optional dependency (for example Spring Data Redis) is simply
      * skipped rather than failing the scan.
      */
-    private static final List<String> POOL_TYPE_NAMES =
-            List.of("javax.sql.DataSource", "org.springframework.data.redis.connection.RedisConnectionFactory");
+    private static final List<String> POOL_TYPE_NAMES = List.of(
+            "javax.sql.DataSource",
+            "io.r2dbc.spi.ConnectionFactory",
+            "org.springframework.data.redis.connection.RedisConnectionFactory",
+            "org.springframework.amqp.rabbit.connection.ConnectionFactory",
+            "org.springframework.kafka.core.ProducerFactory",
+            "org.springframework.kafka.core.ConsumerFactory",
+            "com.mongodb.client.MongoClient",
+            "com.mongodb.reactivestreams.client.MongoClient",
+            "com.datastax.oss.driver.api.core.CqlSession",
+            "co.elastic.clients.elasticsearch.ElasticsearchClient",
+            "jakarta.jms.ConnectionFactory");
+
+    /**
+     * Spring {@code CacheManager} type whose caches are populated in-process and therefore captured
+     * into the checkpoint image. Resolved lazily so applications without the cache abstraction are
+     * skipped.
+     */
+    private static final String CACHE_MANAGER_TYPE_NAME = "org.springframework.cache.CacheManager";
+
+    /** A no-op cache manager holds no entries, so it is irrelevant to checkpoint/restore. */
+    private static final String NO_OP_CACHE_MANAGER_TYPE_NAME = "org.springframework.cache.support.NoOpCacheManager";
 
     private CracRuntimeInventoryCollector() {}
 
@@ -31,17 +56,23 @@ final class CracRuntimeInventoryCollector {
             return CracRuntimeInventory.empty();
         }
         try {
-            List<String> poolBeans = detectPoolBeans(applicationContext);
-            return new CracRuntimeInventory(poolBeans, applicationContext.getEnvironment());
+            List<String> poolBeans = detectBeans(applicationContext, POOL_TYPE_NAMES, ignored -> false);
+            List<String> cacheBeans = detectBeans(
+                    applicationContext,
+                    List.of(CACHE_MANAGER_TYPE_NAME),
+                    type -> NO_OP_CACHE_MANAGER_TYPE_NAME.equals(type.getName()));
+            return new CracRuntimeInventory(poolBeans, cacheBeans, applicationContext.getEnvironment());
         } catch (RuntimeException ex) {
             return CracRuntimeInventory.empty();
         }
     }
 
-    private static List<String> detectPoolBeans(ListableBeanFactory beanFactory) {
+    private static List<String> detectBeans(
+            ListableBeanFactory beanFactory, List<String> typeNames, java.util.function.Predicate<Class<?>> exclude) {
         ClassLoader classLoader = CracRuntimeInventoryCollector.class.getClassLoader();
         List<String> entries = new ArrayList<>();
-        for (String typeName : POOL_TYPE_NAMES) {
+        Set<String> seenBeanNames = new HashSet<>();
+        for (String typeName : typeNames) {
             if (!ClassUtils.isPresent(typeName, classLoader)) {
                 continue;
             }
@@ -52,7 +83,13 @@ final class CracRuntimeInventoryCollector {
                 continue;
             }
             for (String beanName : beanFactory.getBeanNamesForType(type, false, false)) {
+                if (!seenBeanNames.add(beanName)) {
+                    continue;
+                }
                 Class<?> beanType = beanFactory.getType(beanName);
+                if (beanType != null && exclude.test(beanType)) {
+                    continue;
+                }
                 String resolved = beanType != null ? beanType.getName() : typeName;
                 entries.add(beanName + " : " + resolved);
             }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/CracReadinessScannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/CracReadinessScannerTests.java
@@ -61,9 +61,11 @@ class CracReadinessScannerTests {
                 .extracting(CracFindingDto::id)
                 .contains(
                         "CRAC-RES-001",
+                        "CRAC-FILE-001",
                         "CRAC-NET-001",
                         "CRAC-THREAD-001",
                         "CRAC-TIME-001",
+                        "CRAC-CONFIG-001",
                         "CRAC-RANDOM-001",
                         "CRAC-SECRET-001",
                         "CRAC-LIFECYCLE-001");
@@ -124,6 +126,26 @@ class CracReadinessScannerTests {
         assertThat(pool.status()).isEqualTo("REVIEW");
         assertThat(pool.occurrenceCount()).isEqualTo(1);
         assertThat(pool.sampleOccurrences()).anyMatch(sample -> sample.contains("HikariDataSource"));
+    }
+
+    @Test
+    void scanFlagsCacheManagerWhenInventoryReportsOne() {
+        CracRuntimeInventory inventory = new CracRuntimeInventory(
+                List.of(),
+                List.of("cacheManager : org.springframework.cache.concurrent.ConcurrentMapCacheManager"),
+                null);
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES), inventory);
+
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        CracFindingDto cache = report.findings().stream()
+                .filter(finding -> "CRAC-CACHE-001".equals(finding.id()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(cache.severity()).isEqualTo("LOW");
+        assertThat(cache.status()).isEqualTo("REVIEW");
+        assertThat(cache.occurrenceCount()).isEqualTo(1);
+        assertThat(cache.sampleOccurrences()).anyMatch(sample -> sample.contains("ConcurrentMapCacheManager"));
     }
 
     private static int severityRank(String severity) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/fixtures/ConfigCapturer.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/fixtures/ConfigCapturer.java
@@ -1,0 +1,16 @@
+package io.github.jdubois.bootui.autoconfigure.crac.fixtures;
+
+/** Captures environment and system configuration in a static initializer (CRAC-CONFIG-001). */
+public class ConfigCapturer {
+
+    static final String REGION = System.getProperty("app.region");
+    static final String HOME = System.getenv("HOME");
+
+    public String region() {
+        return REGION;
+    }
+
+    public String home() {
+        return HOME;
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/fixtures/FileOpener.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/fixtures/FileOpener.java
@@ -1,0 +1,12 @@
+package io.github.jdubois.bootui.autoconfigure.crac.fixtures;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/** Opens a file handle directly (CRAC-FILE-001). */
+public class FileOpener {
+
+    public FileInputStream open() throws IOException {
+        return new FileInputStream("data.txt");
+    }
+}

--- a/docs/CRAC-READINESS-CHECKS.md
+++ b/docs/CRAC-READINESS-CHECKS.md
@@ -37,10 +37,11 @@ without an extra application dependency. The advisor is available only when Arch
 package is resolvable from the running application. If no classes can be imported, the panel degrades to a stable, empty
 report with an explanatory reason rather than failing.
 
-One check — `CRAC-POOL-001` — is different: connection pools are contributed by Spring Boot auto-configuration and never
-appear in the application's own base package, so that check reads a small read-only inventory of live pool beans (JDBC
-`DataSource`s, Redis connection factories) from the running context instead of imported bytecode. It still triggers only
-on demand and never opens, closes, or checkpoints anything.
+Two checks are different: `CRAC-POOL-001` and `CRAC-CACHE-001`. Connection pools and cache managers are
+contributed by Spring Boot auto-configuration and never appear in the application's own base package, so those checks
+read a small read-only inventory of live beans — pooled clients (JDBC `DataSource`s, plus R2DBC/Redis/RabbitMQ/Kafka/
+Mongo/Cassandra/JMS connection factories and similar) and Spring `CacheManager`s — from the running context instead of
+imported bytecode. They still trigger only on demand and never open, close, or checkpoint anything.
 
 ## What BootUI does not do
 
@@ -88,8 +89,9 @@ a handful of sample detail lines.
 ### CRAC-POOL-001 — Connection pools must hold no open connection at checkpoint
 
 - **Severity**: HIGH
-- **Inspects**: live connection pools in the running context — JDBC `DataSource`s and Redis connection factories —
-  detected from the application's beans rather than its bytecode.
+- **Inspects**: live connection pools and pooled clients in the running context — JDBC `DataSource`s, plus R2DBC/Redis/
+  RabbitMQ/Kafka/MongoDB/Cassandra/JMS connection factories and similar — detected from the application's beans rather
+  than its bytecode.
 - **Fires when**: at least one such pool bean is present. This is the most common real-world cause of a failed
   checkpoint: a pooled connection that is still open when `spring.context.checkpoint=onRefresh` fires holds an OS socket
   that CRaC refuses to snapshot, so the checkpoint aborts with `CheckpointOpenSocketException`. The backing service must
@@ -100,18 +102,45 @@ a handful of sample detail lines.
   context refreshes but before traffic opens a connection. An in-memory profile (such as H2 with no network socket)
   avoids the problem entirely.
 
+## Caches
+
+### CRAC-CACHE-001 — In-memory caches may hold stale entries after restore
+
+- **Severity**: LOW
+- **Inspects**: live Spring `CacheManager` beans in the running context, detected from the application's beans rather
+  than its bytecode. A no-op cache manager holds no entries and is ignored.
+- **Fires when**: at least one non-no-op `CacheManager` bean is present. Cache entries populated before the checkpoint
+  are frozen into the image and survive into every restored process, where they may be stale (for example expired tokens
+  or other time-sensitive data).
+- **Recommendation**: clear or refresh time-sensitive caches in an `org.crac.Resource.afterRestore()` callback, or use
+  restore-aware expiry, so a restored process does not serve data captured at checkpoint time.
+
 ## Resources
 
 ### CRAC-RES-001 — Open resources held in fields must be released at checkpoint
 
 - **Severity**: HIGH
-- **Inspects**: fields whose type holds an OS resource (sockets, file streams, `RandomAccessFile`, NIO channels, JDBC
+- **Inspects**: fields whose type holds an OS resource (sockets, file streams, `FileReader`/`FileWriter`,
+  `RandomAccessFile`, zip/jar files, NIO channels and selectors, `FileLock`, `WatchService`, `Process`, JDBC
   `Connection`) on classes that do not implement `org.crac.Resource` or a Spring `Lifecycle`.
 - **Fires when**: such a field exists on an unmanaged class. CRaC cannot snapshot live file descriptors. Auto-configured
   pools (a HikariCP `DataSource`, a Redis client) are the common case and are covered separately by `CRAC-POOL-001`.
 - **Recommendation**: implement `org.crac.Resource` and close the resource in `beforeCheckpoint()`, re-opening it in
   `afterRestore()`; or hold the resource in a Spring `Lifecycle` / `SmartLifecycle` bean so the framework stops it before
   the checkpoint. For auto-configured connection pools, see `CRAC-POOL-001`.
+
+### CRAC-FILE-001 — Direct file handles must be released at checkpoint
+
+- **Severity**: HIGH
+- **Inspects**: code that opens file handles directly (`new FileInputStream` / `FileOutputStream` / `RandomAccessFile` /
+  `FileReader` / `FileWriter` / `ZipFile` / `JarFile`, or the `Files.newInputStream` / `newOutputStream` /
+  `newByteChannel` / `newBufferedReader` / `newBufferedWriter` and `FileChannel` / `AsynchronousFileChannel.open` factory
+  methods).
+- **Fires when**: an application class opens one of those file handles. An open file holds an OS file descriptor that
+  CRaC refuses to checkpoint, so the checkpoint aborts with `CheckpointOpenFileException`.
+- **Recommendation**: close the file before the checkpoint (try-with-resources for short-lived handles, or release it in
+  an `org.crac.Resource.beforeCheckpoint()` callback and re-open it in `afterRestore()`), or let a managed component own
+  the file so the framework closes it around the checkpoint.
 
 ## Threads
 
@@ -138,6 +167,20 @@ a handful of sample detail lines.
 - **Recommendation**: read the time when it is needed at runtime instead of caching it in a static field, or refresh the
   cached value in an `org.crac.Resource.afterRestore()` callback.
 
+## Configuration
+
+### CRAC-CONFIG-001 — Static initializer captures environment or system configuration
+
+- **Severity**: MEDIUM
+- **Inspects**: static initializers that read environment variables or system properties (`System.getenv`,
+  `System.getProperty`, `System.getProperties`).
+- **Fires when**: a static initializer caches an environment- or property-derived value. With
+  `spring.context.checkpoint=onRefresh` the value is read once when the original JVM starts and frozen into the
+  checkpoint image, so changing it for a restore-only start has no effect until a new checkpoint is taken.
+- **Recommendation**: read environment- or property-derived configuration at runtime (or refresh it in an
+  `org.crac.Resource.afterRestore()` callback) instead of caching it in a static field, so configuration changes take
+  effect for a restored process.
+
 ## Randomness
 
 ### CRAC-RANDOM-001 — Static Random/SecureRandom state is frozen into the checkpoint
@@ -154,8 +197,10 @@ a handful of sample detail lines.
 ### CRAC-SECRET-001 — Secrets captured in static fields are frozen into the checkpoint
 
 - **Severity**: HIGH
-- **Inspects**: static fields whose name looks like a secret (`token`, `password`, `secret`, `api key`, `credential`,
-  `private key`) holding a `String`, `char[]`, or `byte[]`.
+- **Inspects**: static fields that capture a secret — a field whose name looks like a secret (`token`, `password`,
+  `secret`, `api key`, `credential`, `private key`) holding a `String`, `char[]`, or `byte[]`, or a field holding
+  cryptographic key material (`javax.crypto.SecretKey`, `java.security.PrivateKey`, `KeyStore`, `KeyPair`) regardless of
+  name.
 - **Fires when**: such a static field exists. The value is captured into the checkpoint image and survives in every
   restored process.
 - **Recommendation**: load secrets lazily at runtime (or refresh them in an `org.crac.Resource.afterRestore()` callback)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -372,8 +372,9 @@ CRaC or BellSoft Liberica, detected via the real CRaC implementation rather than
 `spring.context.checkpoint=onRefresh` is set, and any `-XX:CRaCCheckpointTo` / `-XX:CRaCRestoreFrom` JVM arguments (read
 from the same `RuntimeMXBean` input arguments the JVM Tuning panel uses). On demand the readiness advisor imports the
 application's own classes (bounded to the detected base package(s)) and runs a curated set of `CRaC-*` checks for
-constructs that complicate checkpoint/restore — open resources held outside Spring/CRaC lifecycle, unmanaged threads,
-captured timestamps, static random seeds, eagerly captured secrets, network listeners, and missing `org.crac.Resource`
+constructs that complicate checkpoint/restore — open resources and file handles held outside Spring/CRaC lifecycle,
+network listeners, live connection pools and cache managers, unmanaged threads, captured timestamps, captured
+environment/system configuration, static random seeds, eagerly captured secrets, and missing `org.crac.Resource`
 registrations. The checks are heuristic review aids that complement, but do not replace, an actual checkpoint/restore run
 on a CRaC-enabled JDK. See [CRAC-READINESS-CHECKS.md](CRAC-READINESS-CHECKS.md) for the full catalogue of checks and what
 each one inspects.


### PR DESCRIPTION
## What does this PR do?

Adds three new CRaC readiness checks and broadens three existing ones so the CRaC panel catches more runtime state that prevents a clean Coordinated Restore at Checkpoint.

## Why is this change needed?

The existing CRaC readiness panel covered a useful but narrow set of conditions (open resources, sockets, JDBC pools, unmanaged threads, captured time, static randomness, secrets). A review of how CRaC checkpoint/restore actually behaves surfaced several common, high-signal gaps: raw file descriptors held open across a checkpoint, in-memory cache state that goes stale on restore, configuration frozen at checkpoint time rather than restore time, and non-JDBC connection pools. These are exactly the cases that cause checkpoint failures or subtle post-restore bugs, so flagging them up front saves real debugging time. This PR implements only the strongest, lowest-risk improvements from that review.

## How was it tested?

- [x] Focused CRaC suite green: `./mvnw -pl bootui-autoconfigure test -Dtest='Crac*Tests'` (28 tests, `CracReadinessScannerTests` now 7).
- [x] Full `bootui-core` + `bootui-autoconfigure` test phase and `spotless:check` pass locally.
- [x] Added or updated tests where applicable (new `FileOpener` / `ConfigCapturer` fixtures, extended scanner tests).

Approach notes for reviewers:

- **New checks:** `CRAC-FILE-001` (HIGH) flags direct file-handle opens that pin OS file descriptors; `CRAC-CACHE-001` (LOW) flags live Spring `CacheManager` beans whose entries may be stale after restore (skips `NoOpCacheManager`); `CRAC-CONFIG-001` (MEDIUM) flags static initializers capturing `System.getenv`/`getProperty` (frozen at checkpoint, not restore, time).
- **Expansions:** `CRAC-RES-001` now matches specific OS-resource field types (zip/jar files, datagram/async channels, `FileReader`/`Writer`, `FileLock`, `WatchService`, `Selector`, `Process`) - deliberately *not* generic streams, to avoid false positives. `CRAC-SECRET-001` now matches crypto *types* (`SecretKey`/`PrivateKey`/`KeyStore`/`KeyPair`) regardless of field name, still static-only and excluding `PublicKey`. `CRAC-POOL-001` broadens the runtime inventory beyond JDBC (R2DBC, RabbitMQ, Kafka, Mongo sync+reactive, Cassandra, Elasticsearch, JMS), deduped by bean name.
- **Plumbing:** `CracRuntimeInventory` gains a `cacheManagerBeans` list with a backward-compatible 2-arg constructor so existing call sites keep compiling; new `CACHES`/`CONFIG` categories drive the UI badges. Registry now holds 11 checks.

## Screenshots (UI changes)

N/A - the Vue panel renders findings dynamically, so no UI code changed.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (`docs/CRAC-READINESS-CHECKS.md`, `docs/FEATURES.md`)
- [x] Public API kept backward compatible, or a migration note added to the PR description (`CracRuntimeInventory` keeps a backward-compatible constructor)
- [x] No secrets, tokens, or local paths committed