### PR TITLE
Harden native image: distroless base + mostly-static binary

### DIFF
--- a/Dockerfile-native
+++ b/Dockerfile-native
@@ -33,6 +33,13 @@ WORKDIR /app
 COPY . .
 RUN chmod +x mvnw
 
+# Build a "mostly static" native image: statically link everything (including zlib) except glibc,
+# so the runtime image only needs a glibc base and no extra shared libraries. The native-image tool
+# honors this via the NATIVE_IMAGE_OPTIONS environment variable, so it needs no pom changes and does
+# not affect a local, host `-Pnative` build. The GraalVM build image already ships the static zlib
+# (libz.a) this requires.
+ENV NATIVE_IMAGE_OPTIONS="-H:+StaticExecutableWithDynamicLibC"
+
 # Build the native executable for the sample app and its reactor dependencies.
 # The `native` profile (declared in bootui-sample-app/pom.xml) runs Spring
 # Boot's process-aot goal, downloads GraalVM reachability metadata and then
@@ -49,29 +56,24 @@ RUN if [ -f bootui-sample-app/target/bootui-sample-app ]; then \
       else echo "ERROR: Native executable not found"; ls -laR bootui-sample-app/target | head -40; exit 1; fi; \
     fi
 
-# Runtime stage with Debian slim (includes glibc + zlib needed by the binary)
-FROM debian:12-slim
-
-# Install curl for healthchecks
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
-# Create a non-root user
-RUN useradd -m -u 1001 springboot
+# Runtime stage: Google "distroless" base. It ships glibc (and the dynamic loader) but no shell,
+# package manager, curl, perl or tar - which removes the bulk of the OS-package CVEs that a full
+# Debian base otherwise carries (those are unfixed upstream and cannot be patched away). The native
+# binary above is built "mostly static", so glibc is the only shared library it needs and this base
+# provides it. The :nonroot tag runs as an unprivileged user (uid 65532).
+FROM gcr.io/distroless/base-debian12:nonroot
 
 WORKDIR /app
 
 # Copy the native executable from the build stage
-COPY --from=build --chown=springboot:springboot /app/native-app native-app
+COPY --from=build --chown=nonroot:nonroot /app/native-app native-app
 
-USER springboot
+USER nonroot
 
 EXPOSE 8080
 
-# Health check using Spring Boot Actuator
-HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:${SERVER_PORT:-8080}/actuator/health || exit 1
+# No Docker HEALTHCHECK: the distroless base has no shell or curl to run a probe. Probe the web
+# server (or /actuator/health) from your orchestrator's liveness/readiness checks instead.
 
 # Run the native application
 ENTRYPOINT ["./native-app"]

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmDockerfileGenerator.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmDockerfileGenerator.java
@@ -96,6 +96,13 @@ final class GraalVmDockerfileGenerator {
 
                 %3$s
 
+                # Build a "mostly static" native image: statically link everything (including zlib)
+                # except glibc, so the runtime image only needs a glibc base and no extra shared
+                # libraries. The native-image tool honors this via the NATIVE_IMAGE_OPTIONS environment
+                # variable, so it needs no build-file changes and leaves a local, host native build
+                # untouched.
+                ENV NATIVE_IMAGE_OPTIONS="-H:+StaticExecutableWithDynamicLibC"
+
                 # Build the native executable. This runs Spring Boot's AOT processing, downloads the
                 # GraalVM reachability metadata and then compiles the native image.
                 RUN %4$s
@@ -109,31 +116,25 @@ final class GraalVmDockerfileGenerator {
                       else echo "ERROR: Native executable not found"; ls -laR %5$s | head -40; exit 1; fi; \\
                     fi
 
-                # Runtime stage with Debian slim (includes glibc + zlib needed by the binary)
-                FROM debian:12-slim
-
-                # Install curl for healthchecks
-                RUN apt-get update && \\
-                    apt-get install -y --no-install-recommends curl && \\
-                    rm -rf /var/lib/apt/lists/*
-
-                # Create a non-root user
-                RUN useradd -m -u 1001 springboot
+                # Runtime stage: Google "distroless" base. It ships glibc (and the dynamic loader) but
+                # no shell, package manager, curl, perl or tar - which removes the bulk of the
+                # OS-package CVEs a full Debian base otherwise carries. The binary above is built
+                # "mostly static", so glibc is the only shared library it needs and this base provides
+                # it. The :nonroot tag runs as an unprivileged user (uid 65532).
+                FROM gcr.io/distroless/base-debian12:nonroot
 
                 WORKDIR /app
 
                 # Copy the native executable from the build stage
-                COPY --from=build --chown=springboot:springboot /app/native-app native-app
+                COPY --from=build --chown=nonroot:nonroot /app/native-app native-app
 
-                USER springboot
+                USER nonroot
 
                 EXPOSE 8080
 
-                # Liveness check: succeeds once the embedded web server accepts connections and returns
-                # any HTTP response. It does not require Spring Boot Actuator to be on the classpath, so it
-                # stays green even when the management endpoints are not web-exposed.
-                HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \\
-                    CMD curl -s -o /dev/null http://localhost:${SERVER_PORT:-8080}/ || exit 1
+                # No Docker HEALTHCHECK: the distroless base has no shell or curl to run a probe. Probe
+                # the web server (or /actuator/health) from your orchestrator's liveness/readiness
+                # checks instead.
 
                 # Run the native application
                 ENTRYPOINT ["./native-app"]

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmDockerfileGeneratorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmDockerfileGeneratorTests.java
@@ -30,12 +30,17 @@ class GraalVmDockerfileGeneratorTests {
     }
 
     @Test
-    void healthcheckDoesNotDependOnActuator() {
+    void runtimeStageIsDistrolessWithoutCurlHealthcheck() {
         String dockerfile = generator.generate("my-service");
 
-        // A liveness probe that succeeds on any HTTP response, so it stays green without Actuator.
-        assertThat(dockerfile).contains("curl -s -o /dev/null http://localhost:${SERVER_PORT:-8080}/ || exit 1");
-        assertThat(dockerfile).doesNotContain("/actuator/health");
+        // Minimal-attack-surface runtime: distroless ships glibc but no shell/curl/perl/tar, which
+        // keeps the runtime's OS-package CVE surface near zero.
+        assertThat(dockerfile).contains("FROM gcr.io/distroless/base-debian12:nonroot");
+        // A "mostly static" binary links only glibc dynamically, so the glibc base needs no zlib.
+        assertThat(dockerfile).contains("NATIVE_IMAGE_OPTIONS=\"-H:+StaticExecutableWithDynamicLibC\"");
+        // No Docker HEALTHCHECK directive and no curl probe (distroless has neither shell nor curl).
+        assertThat(dockerfile).doesNotContain("HEALTHCHECK --");
+        assertThat(dockerfile).doesNotContain("curl -s -o /dev/null");
     }
 
     @Test

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -346,8 +346,10 @@ did not generate. Alongside the metadata scaffold the panel also generates a tai
 **`Dockerfile-native`** that builds a GraalVM native image of the host application. It detects the project's build
 system — Maven or Gradle, with or without the wrapper — and uses the matching native build command (`./mvnw`/`mvn
 -Pnative -DskipTests clean native:compile`, or `./gradlew`/`gradle nativeCompile`), then packages the resulting executable —
-named after the resolved `artifactId` — into a minimal Debian runtime image (installing a known, pinned Maven/Gradle
-release in the build stage when the project has no wrapper). It can be downloaded, or written directly to the project root under the
+named after the resolved `artifactId` — into a minimal, distroless runtime image (`gcr.io/distroless/base-debian12:nonroot`,
+which runs as a non-root user and carries no shell/curl/perl/tar, keeping the OS-package CVE surface near zero; the binary
+is built *mostly static* so it needs only glibc, and the build stage installs a known, pinned Maven/Gradle
+release when the project has no wrapper). It can be downloaded, or written directly to the project root under the
 same exploded-build constraint and the same fail-closed guard (BootUI never overwrites a `Dockerfile-native` it did not
 generate). The metadata scaffold and the `Dockerfile-native` are presented in a three-drawer accordion whose default,
 top drawer is an **All files** action that generates and writes both artifacts into the project's source tree in a

--- a/docs/GRAALVM-READINESS-CHECKS.md
+++ b/docs/GRAALVM-READINESS-CHECKS.md
@@ -38,8 +38,11 @@ In addition to the checks, the scan does two things:
 - **Generates a tailored `Dockerfile-native`** for the host application — a multi-stage build that detects the project's
   build system (Maven or Gradle, with or without the wrapper) and compiles a GraalVM native image with the matching
   command (`./mvnw`/`mvn -Pnative -DskipTests clean native:compile`, or `./gradlew`/`gradle nativeCompile`), then packages the
-  resulting executable (named after the resolved `artifactId`) into a minimal Debian runtime image with a non-root user
-  and an HTTP liveness healthcheck (it probes the web server for any response, so it does not require Actuator). When
+  resulting executable (named after the resolved `artifactId`) into a minimal, distroless runtime image
+  (`gcr.io/distroless/base-debian12:nonroot`). That base runs as a non-root user and ships glibc but no shell, package
+  manager, curl, perl or tar, so the runtime's OS-package CVE surface stays near zero; the native image is built *mostly
+  static* (only glibc is linked dynamically) so it needs no extra libraries. Because distroless has no shell or curl
+  there is no Docker `HEALTHCHECK` - probe `/actuator/health` (or the web root) from your orchestrator instead. When
   the project carries no wrapper, the build stage installs a known, pinned
   Maven/Gradle release (declared as a constant in the generator and exposed as a Docker `ARG`) so the image is
   self-contained. You can download it, or — under the same exploded-build constraint as the scaffold install — write it


### PR DESCRIPTION
## What does this PR do?

Switches the GraalVM `Dockerfile-native` runtime to a distroless base and builds the binary "mostly static", taking the native image from 2 HIGH / 3 MEDIUM / 42 LOW CVEs down to 0.

## Why is this change needed?

The native runtime shipped on `debian:12-slim` plus `curl`, which carried **2 HIGH / 3 MEDIUM / 42 LOW** CVEs (in `perl-base`, `tar`, `gnutls`, `gcc-12`, `shadow`, ...). Every one is **unfixed upstream** in Debian bookworm, so patching or pinning could not clear them. The native binary itself contributes no OS-package CVEs, so the right fix is to shrink the runtime base.

The change has two parts:

- Build the native image **mostly static** (`-H:+StaticExecutableWithDynamicLibC`, passed via the `NATIVE_IMAGE_OPTIONS` env var so there is no pom change and a local host `-Pnative` build is unaffected). glibc becomes the only shared library the binary needs. The GraalVM build image already ships the static `libz.a` this requires.
- Switch the runtime stage to `gcr.io/distroless/base-debian12:nonroot`, which ships glibc but no shell, package manager, curl, perl or tar. The `apt-get install curl` and `useradd` steps go away (distroless provides the `nonroot` uid 65532).

The curl-based `HEALTHCHECK` is removed because distroless has neither shell nor curl; orchestrators should probe `/actuator/health` (or the web root) directly. `docker-compose-native.yml` does not gate on the app's health, so nothing depends on it.

Applied identically to the **BootUI-generated** `Dockerfile-native` (`GraalVmDockerfileGenerator`) and its unit tests, and the `docs/` descriptions were updated to match.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally (ran the affected `GraalVmDockerfileGeneratorTests` and `spotless:check`)
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Verified the full native path end-to-end: `docker build -f Dockerfile-native` succeeds (mostly-static linking with `libz.a`), the container boots in ~700ms, `/actuator/health` returns UP, and `/` and `/bootui` return 200. `docker scout cves` on the final image reports **0C / 0H / 0M / 0L** (down from 2H / 3M / 42L).

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed