### PR TITLE
Shrink sample-app Docker image from 739MB to 338MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,18 @@
 # the build stage and the sample app is built together with the modules it
 # depends on (`-pl bootui-sample-app -am`).
 #
+# This image is deliberately kept small with three techniques:
+#   1. The repackaged Spring Boot jar is exploded into its layers
+#      (`-Djarmode=tools ... extract --layers`) and run via the JarLauncher, so
+#      the large, rarely-changing dependency layer is cached/re-pushed less often
+#      and there is no second copy of the fat jar baked into the image.
+#   2. A custom, minimal Java runtime is assembled with `jlink` (only the JDK
+#      modules the app needs, with debug symbols/man-pages/headers stripped),
+#      replacing the full ~200 MB JRE.
+#   3. The final stage is a bare Alpine base (no bundled JDK/JRE) and brings the
+#      application in with `COPY --chown` instead of a `RUN chown -R` layer that
+#      would otherwise duplicate every copied file.
+#
 # For a GraalVM native image, see Dockerfile-native.
 # For a JVM image using CRaC, see Dockerfile-crac.
 #
@@ -27,7 +39,11 @@
 #     -e SPRING_FLYWAY_ENABLED=true -e SPRING_LIQUIBASE_ENABLED=true \
 #     bootui-sample-app
 
-# Build stage
+# ---------------------------------------------------------------------------
+# Build stage: compile the reactor and explode the Spring Boot jar into layers.
+# A glibc JDK (Ubuntu "noble") is used so the frontend-maven-plugin's downloaded
+# Node.js binaries (glibc-linked) run while building the bundled Vue UI.
+# ---------------------------------------------------------------------------
 FROM eclipse-temurin:25-jdk-noble AS build
 
 WORKDIR /app
@@ -45,21 +61,69 @@ RUN chmod +x mvnw
 # Build the sample app and its reactor dependencies.
 RUN ./mvnw -DskipTests -pl bootui-sample-app -am clean package
 
-# Runtime stage (Alpine-based JRE for a smaller image)
-FROM eclipse-temurin:25-jre-alpine
+# Explode the repackaged Spring Boot jar into its layers (dependencies,
+# spring-boot-loader, snapshot-dependencies, application). These are copied
+# separately into the runtime stage so the large, rarely-changing dependency
+# layer is reused from cache across rebuilds, and the app runs exploded via the
+# JarLauncher rather than re-copying the whole fat jar.
+RUN cp bootui-sample-app/target/bootui-sample-app-*.jar app.jar && \
+    java -Djarmode=tools -jar app.jar extract --layers --launcher --destination extracted
 
-# Install curl for healthchecks
-RUN apk add --no-cache curl
+# ---------------------------------------------------------------------------
+# JRE stage: assemble a minimal custom Java runtime with jlink. Built on the
+# Alpine (musl) JDK so the produced runtime's libc matches the Alpine runtime
+# base below.
+# ---------------------------------------------------------------------------
+FROM eclipse-temurin:25-jdk-alpine AS jre-build
 
-# Create a non-root user
-RUN adduser -D -u 1001 springboot
+# Deliberate superset of the JDK modules the sample app and BootUI use - several
+# are loaded reflectively, so the set cannot be derived reliably with jdeps:
+#   - JDBC / JPA / Hibernate: java.sql, java.sql.rowset, java.naming, java.transaction.xa
+#   - Spring bean introspection (java.beans): java.desktop
+#   - TLS + BootUI OSV scanning over HTTPS: java.net.http, jdk.crypto.ec, jdk.crypto.cryptoki
+#   - Security / SASL / JAAS: java.security.jgss, java.security.sasl, jdk.security.auth
+#   - AspectJ load-time weaving / agents: java.instrument
+#   - XML config (Liquibase, Spring): java.xml, java.xml.crypto
+#   - BootUI diagnostics: heap dumps (jdk.management), JFR startup timeline (jdk.jfr),
+#     JMX metrics (java.management[.rmi], jdk.management.agent), attach (jdk.attach)
+#   - Misc runtime needs: java.logging, java.scripting, java.compiler, java.rmi,
+#     java.prefs, jdk.unsupported, jdk.charsets, jdk.net, jdk.zipfs
+RUN "$JAVA_HOME/bin/jlink" \
+      --add-modules java.base,java.logging,java.naming,java.management,java.management.rmi,java.instrument,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,java.desktop,java.security.jgss,java.security.sasl,java.scripting,java.compiler,java.net.http,java.rmi,java.prefs,jdk.unsupported,jdk.crypto.ec,jdk.crypto.cryptoki,jdk.jfr,jdk.management,jdk.management.agent,jdk.attach,jdk.zipfs,jdk.charsets,jdk.net,jdk.security.auth \
+      --strip-debug --no-man-pages --no-header-files --compress=zip-6 \
+      --output /javaruntime
+
+# ---------------------------------------------------------------------------
+# Runtime stage: a bare Alpine base (no bundled JDK/JRE) plus the custom jlink
+# runtime. alpine:3.23 matches the Temurin Alpine images above so the jlink
+# runtime's musl libc lines up.
+# ---------------------------------------------------------------------------
+FROM alpine:3.23
+
+# Custom Java runtime assembled by jlink above.
+ENV JAVA_HOME=/opt/java
+ENV PATH="$JAVA_HOME/bin:$PATH"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+# Create a non-root user and an application directory it owns. Making /app itself
+# springboot-owned (not just its contents) lets BootUI write its runtime state -
+# heap dumps and config overrides under /app/.bootui - at runtime. The chown is
+# non-recursive (an empty dir here), so it adds a negligible layer rather than
+# duplicating the copied application below.
+RUN adduser -D -u 1001 springboot && \
+    mkdir -p /app && \
+    chown springboot:springboot /app
 
 WORKDIR /app
 
-# Copy the repackaged Spring Boot jar from the build stage
-COPY --from=build /app/bootui-sample-app/target/bootui-sample-app-*.jar app.jar
-
-RUN chown -R springboot:springboot /app
+# Copy the exploded application layers, ordered least- to most-frequently
+# changing so Docker's layer cache is reused across rebuilds. COPY --chown sets
+# ownership inline, avoiding a `RUN chown -R` layer that would otherwise
+# duplicate every copied file in a fresh layer.
+COPY --from=build --chown=springboot:springboot /app/extracted/dependencies/ ./
+COPY --from=build --chown=springboot:springboot /app/extracted/spring-boot-loader/ ./
+COPY --from=build --chown=springboot:springboot /app/extracted/snapshot-dependencies/ ./
+COPY --from=build --chown=springboot:springboot /app/extracted/application/ ./
 
 USER springboot
 
@@ -84,11 +148,12 @@ ENV JAVA_OPTS="-Xms200m -Xmx200m -XX:MaxMetaspaceSize=171m -XX:ReservedCodeCache
 
 EXPOSE 8080
 
-# Health check using Spring Boot Actuator
+# Health check using Spring Boot Actuator. The bare Alpine base ships BusyBox wget (no curl), which
+# exits non-zero on a non-2xx response - so a 503 from a DOWN actuator health endpoint fails the check.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:${SERVER_PORT:-8080}/actuator/health || exit 1
+    CMD wget -q -O /dev/null "http://localhost:${SERVER_PORT:-8080}/actuator/health" || exit 1
 
-# Launch with the JVM tuning flags above. `sh -c ... exec java` keeps java as PID 1 so it still
-# receives SIGTERM from `docker stop` for Spring Boot's graceful shutdown, while letting the shell
-# word-split $JAVA_OPTS.
-ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]
+# Launch the exploded application via the Spring Boot JarLauncher. `sh -c ... exec java` keeps java as
+# PID 1 (so it still receives SIGTERM from `docker stop` for Spring Boot's graceful shutdown) while
+# letting the shell word-split $JAVA_OPTS.
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## Summary

Reworks the root `Dockerfile` to cut the `bootui-sample-app` JVM image from **739MB to 338MB (−54%)**, with no change to runtime behavior.

## What changed

The image is now built in three stages with three complementary size techniques:

1. **Layered jar extract** — the repackaged Spring Boot jar is exploded into its layers (`-Djarmode=tools ... extract --layers --launcher`) and run via the `JarLauncher`. This removes the second copy of the fat jar that the old image baked in, and orders the layers least- to most-frequently-changing so Docker caches the large dependency layer across rebuilds.
2. **Custom jlink runtime** — a minimal Java runtime is assembled with `jlink` (curated module set, `--strip-debug --no-man-pages --no-header-files --compress=zip-6`), replacing the full ~200MB JRE. It's built on the Alpine JDK so its musl libc matches the final base. The build stage stays on the glibc `noble` JDK so the `frontend-maven-plugin`'s downloaded Node.js binaries still run.
3. **Bare Alpine final stage + `COPY --chown`** — `alpine:3.23` with no bundled JDK/JRE; the app is brought in with `COPY --chown` instead of a `RUN chown -R` layer that previously duplicated every copied file. The healthcheck uses BusyBox `wget` so no extra package (curl) is installed.

`/app` is made `springboot`-owned (non-recursively, negligible layer) so BootUI can still write its runtime state under `/app/.bootui` (heap dumps, config overrides).

## Behavior preserved

`dev` profile active, Flyway/Liquibase disabled by default, non-root user, JVM tuning flags, graceful shutdown (java stays PID 1), and the actuator healthcheck.

## Verification

- Image size: **338MB** (down from 739MB)
- Health endpoint UP; all BootUI panels return 200
- Heap dump capture succeeds (exercises `jdk.management`)
- OSV vulnerability scan succeeds (exercises `java.net.http` + TLS)
- `wget` healthcheck reports the container `healthy`

## Notes / considered but skipped

- **CDS / AOT cache** was prototyped for faster startup but rejected: the only variant with a real startup win (full dynamic CDS, ~1.2s / 26% faster) costs **+128MB**, which would erase most of the size savings. The base-only archive (+15MB) gave a startup gain within noise. Not worth it for a local-dev image.
- A follow-up opportunity (not in this PR): excluding `netty-codec-http3` QUIC natives (~11.5MB) is a pure size win that would benefit all three published images.

CI (`docker-publish.yml`) and `docker-smoke.spec.js` remain compatible — same build context/file, same smoke-test endpoints.