### PR TITLE
feat(ui): polish console shell with responsive nav and live cues

### DIFF
--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -10,6 +10,7 @@ import {
   THEME_STORAGE_KEY
 } from './utils/theme.js'
 import {describeLoadError} from './utils/loadError.js'
+import {recordRecentPanel} from './utils/recentPanels.js'
 import CommandPalette from './views/components/CommandPalette.vue'
 
 const router = useRouter()
@@ -18,17 +19,19 @@ const overview = ref(null)
 const panels = ref(null)
 const shellError = ref(null)
 const savedCollapsed = localStorage.getItem('bootui.sidebar.collapsed')
-const isMediumScreen = typeof window !== 'undefined' && window.innerWidth <= 991.98
-const sidebarCollapsed = ref(savedCollapsed !== null ? savedCollapsed === 'true' : isMediumScreen)
+const sidebarCollapsed = ref(savedCollapsed === 'true')
 
-if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
-  window.matchMedia('(max-width: 991.98px)').addEventListener('change', (e) => {
-    if (e.matches) {
-      sidebarCollapsed.value = true
-    } else if (localStorage.getItem('bootui.sidebar.collapsed') === 'false') {
-      sidebarCollapsed.value = false
-    }
-  })
+const NARROW_QUERY = '(max-width: 991.98px)'
+const narrowMediaQuery =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function' ? window.matchMedia(NARROW_QUERY) : null
+const isNarrow = ref(narrowMediaQuery?.matches === true)
+const mobileNavOpen = ref(false)
+
+function onNarrowChange(e) {
+  isNarrow.value = e.matches === true
+  if (!isNarrow.value) {
+    mobileNavOpen.value = false
+  }
 }
 
 const commandPaletteOpen = ref(false)
@@ -52,10 +55,35 @@ function openCommandPalette() {
 
 watch(sidebarCollapsed, (v) => localStorage.setItem('bootui.sidebar.collapsed', v))
 
+watch(
+  () => route.name,
+  (name) => {
+    if (name) recordRecentPanel(name)
+    mobileNavOpen.value = false
+  },
+  {immediate: true}
+)
+
 watch(resolvedTheme, syncTheme, {immediate: true})
 
 function toggleSidebar() {
   sidebarCollapsed.value = !sidebarCollapsed.value
+}
+
+function onSidebarToggle() {
+  if (isNarrow.value) {
+    mobileNavOpen.value = false
+  } else {
+    toggleSidebar()
+  }
+}
+
+function openMobileNav() {
+  mobileNavOpen.value = true
+}
+
+function closeMobileNav() {
+  mobileNavOpen.value = false
 }
 
 function syncTheme(theme) {
@@ -298,6 +326,52 @@ function toggleGroup(groupKey, event) {
   }
 }
 
+const collapsedRail = computed(() => !isNarrow.value && sidebarCollapsed.value)
+const railFlyout = ref(null)
+let flyoutCloseTimer = null
+
+function clearFlyoutTimer() {
+  if (flyoutCloseTimer) {
+    clearTimeout(flyoutCloseTimer)
+    flyoutCloseTimer = null
+  }
+}
+
+function openRailFlyout(section, event) {
+  if (!collapsedRail.value || !section.collapsible) return
+  clearFlyoutTimer()
+  const rect = event.currentTarget.getBoundingClientRect()
+  const estimatedHeight = 52 + section.routes.length * 40
+  const viewportHeight = typeof window === 'undefined' ? 0 : window.innerHeight
+  const top = Math.max(8, Math.min(rect.top, viewportHeight - estimatedHeight - 8))
+  railFlyout.value = {section, top, left: rect.right + 10}
+}
+
+function scheduleRailFlyoutClose() {
+  clearFlyoutTimer()
+  flyoutCloseTimer = setTimeout(() => {
+    railFlyout.value = null
+  }, 140)
+}
+
+function cancelRailFlyoutClose() {
+  clearFlyoutTimer()
+}
+
+function closeRailFlyout() {
+  clearFlyoutTimer()
+  railFlyout.value = null
+}
+
+function onFlyoutLinkClick(navigate, event) {
+  navigate(event)
+  closeRailFlyout()
+}
+
+watch(collapsedRail, (value) => {
+  if (!value) closeRailFlyout()
+})
+
 watch(
   activeNavigationGroupKey,
   (groupKey) => {
@@ -324,11 +398,14 @@ onMounted(() => {
   loadShellData()
   window.addEventListener('keydown', onGlobalKeydown)
   themeMediaQuery?.addEventListener?.('change', onSystemThemeChange)
+  narrowMediaQuery?.addEventListener?.('change', onNarrowChange)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onGlobalKeydown)
   themeMediaQuery?.removeEventListener?.('change', onSystemThemeChange)
+  narrowMediaQuery?.removeEventListener?.('change', onNarrowChange)
+  clearFlyoutTimer()
 })
 
 function onGlobalKeydown(e) {
@@ -348,7 +425,16 @@ function onGlobalKeydown(e) {
     <div class="ambient-orb ambient-orb-one"></div>
     <div class="ambient-orb ambient-orb-two"></div>
 
-    <aside :class="{'bootui-sidebar--collapsed': sidebarCollapsed}" class="bootui-sidebar">
+    <div v-if="isNarrow && mobileNavOpen" class="bootui-nav-backdrop" @click="closeMobileNav"></div>
+
+    <aside
+      :class="{
+        'bootui-sidebar--collapsed': collapsedRail,
+        'bootui-sidebar--drawer': isNarrow,
+        'bootui-sidebar--open': isNarrow && mobileNavOpen
+      }"
+      class="bootui-sidebar"
+    >
       <div class="brand-area">
         <router-link class="brand-card text-decoration-none" to="/overview">
           <span class="brand-mark"><i class="bi bi-cup-hot-fill"></i></span>
@@ -359,10 +445,13 @@ function onGlobalKeydown(e) {
         </router-link>
         <button
           class="sidebar-toggle"
-          :title="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
-          @click="toggleSidebar"
+          :title="isNarrow ? 'Close menu' : sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+          @click="onSidebarToggle"
         >
-          <i :class="sidebarCollapsed ? 'bi-chevron-double-right' : 'bi-chevron-double-left'" class="bi"></i>
+          <i
+            :class="isNarrow ? 'bi-x-lg' : sidebarCollapsed ? 'bi-chevron-double-right' : 'bi-chevron-double-left'"
+            class="bi"
+          ></i>
         </button>
       </div>
 
@@ -390,6 +479,10 @@ function onGlobalKeydown(e) {
             class="bootui-nav-group__toggle"
             type="button"
             @click="toggleGroup(section.key, $event)"
+            @mouseenter="openRailFlyout(section, $event)"
+            @mouseleave="scheduleRailFlyoutClose"
+            @focusin="openRailFlyout(section, $event)"
+            @focusout="scheduleRailFlyoutClose"
           >
             <span class="bootui-nav-group__label">
               <i :class="['bi', section.icon]"></i>
@@ -456,12 +549,56 @@ function onGlobalKeydown(e) {
       </div>
     </aside>
 
+    <transition name="flyout-fade">
+      <div
+        v-if="railFlyout"
+        class="bootui-nav-flyout"
+        :style="{top: railFlyout.top + 'px', left: railFlyout.left + 'px'}"
+        role="group"
+        :aria-label="`${railFlyout.section.title} panels`"
+        @mouseenter="cancelRailFlyoutClose"
+        @mouseleave="scheduleRailFlyoutClose"
+      >
+        <div class="bootui-nav-flyout__title">
+          <i :class="['bi', railFlyout.section.icon]"></i>
+          <span>{{ railFlyout.section.title }}</span>
+        </div>
+        <router-link v-for="r in railFlyout.section.routes" :key="r.name" v-slot="{href, navigate}" :to="r.path" custom>
+          <a
+            :aria-current="route.name === r.name ? 'page' : undefined"
+            :aria-label="routeAvailabilityLabel(r)"
+            :class="{
+              active: route.name === r.name,
+              'bootui-nav-link--unavailable': routeUnavailable(r)
+            }"
+            :href="href"
+            :title="routeAvailabilityLabel(r)"
+            class="nav-link bootui-nav-link bootui-nav-flyout__link"
+            @click="onFlyoutLinkClick(navigate, $event)"
+          >
+            <i :class="['bi', r.meta.icon]"></i>
+            <span class="bootui-nav-link__label">{{ r.meta.title }}</span>
+            <i
+              v-if="routeStatusIcon(r)"
+              :class="['bi', routeStatusIcon(r), 'bootui-nav-link__status']"
+              aria-hidden="true"
+            ></i>
+          </a>
+        </router-link>
+      </div>
+    </transition>
+
     <div class="bootui-workspace">
       <header class="topbar">
-        <div>
-          <div class="eyebrow">Inspecting</div>
-          <h1 class="topbar-title">{{ applicationTitle }}</h1>
-          <p class="topbar-subtitle mb-0">{{ runtimeSummary }}</p>
+        <div class="topbar-lead">
+          <button class="nav-hamburger" type="button" aria-label="Open navigation menu" @click="openMobileNav">
+            <i class="bi bi-list"></i>
+          </button>
+          <div class="topbar-heading">
+            <div class="eyebrow">Inspecting</div>
+            <h1 class="topbar-title">{{ applicationTitle }}</h1>
+            <p class="topbar-subtitle mb-0">{{ runtimeSummary }}</p>
+          </div>
         </div>
         <div class="topbar-actions">
           <button class="cp-trigger" title="Open command palette (⌘K)" @click="openCommandPalette">
@@ -862,6 +999,87 @@ function onGlobalKeydown(e) {
   width: 18rem;
 }
 
+.bootui-sidebar--drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1045;
+  height: 100vh;
+  width: min(20rem, 86vw);
+  transform: translateX(-100%);
+  transition:
+    transform 240ms ease,
+    box-shadow 240ms ease;
+}
+
+.bootui-sidebar--drawer.bootui-sidebar--open {
+  transform: translateX(0);
+  box-shadow: 1rem 0 3rem rgba(15, 23, 42, 0.35);
+}
+
+.bootui-nav-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1044;
+  background: rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(2px);
+  animation: fade-in 160ms ease both;
+}
+
+.bootui-nav-flyout {
+  position: fixed;
+  z-index: 1046;
+  width: 14rem;
+  max-height: calc(100vh - 1rem);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.6rem;
+  background: var(--bootui-surface-solid);
+  border: 1px solid var(--bootui-border);
+  border-radius: 1rem;
+  box-shadow: var(--bootui-shadow-md);
+}
+
+.bootui-nav-flyout__title {
+  align-items: center;
+  color: var(--bootui-nav-group-color);
+  display: flex;
+  font-size: 0.72rem;
+  font-weight: 800;
+  gap: 0.5rem;
+  letter-spacing: 0.06em;
+  padding: 0.35rem 0.6rem 0.5rem;
+  text-transform: uppercase;
+}
+
+.bootui-nav-flyout__link {
+  border-radius: 0.7rem;
+}
+
+.flyout-fade-enter-active,
+.flyout-fade-leave-active {
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
+}
+
+.flyout-fade-enter-from,
+.flyout-fade-leave-to {
+  opacity: 0;
+  transform: translateX(-0.4rem);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .bootui-sidebar--collapsed {
   gap: 1rem;
   padding: 1rem 0.75rem;
@@ -938,9 +1156,7 @@ function onGlobalKeydown(e) {
 }
 
 .bootui-sidebar--collapsed .bootui-nav-section:not(.bootui-nav-section--overview) .bootui-nav-group__items {
-  border-left: 0;
-  margin-left: 0;
-  padding-left: 0;
+  display: none;
 }
 
 .bootui-sidebar--collapsed .bootui-nav-link {
@@ -1204,6 +1420,37 @@ function onGlobalKeydown(e) {
   padding: 1.5rem 2rem 1rem;
 }
 
+.topbar-lead {
+  align-items: center;
+  display: flex;
+  gap: 0.85rem;
+  min-width: 0;
+}
+
+.topbar-heading {
+  min-width: 0;
+}
+
+.nav-hamburger {
+  align-items: center;
+  background: var(--bootui-surface);
+  border: 1px solid var(--bootui-border);
+  border-radius: 0.75rem;
+  color: var(--bootui-text);
+  cursor: pointer;
+  display: none;
+  flex-shrink: 0;
+  font-size: 1.2rem;
+  height: 2.6rem;
+  justify-content: center;
+  transition: background 150ms ease;
+  width: 2.6rem;
+}
+
+.nav-hamburger:hover {
+  background: var(--bootui-nav-hover-bg);
+}
+
 .topbar-title {
   font-size: clamp(1.45rem, 2vw, 2.1rem);
   font-weight: 800;
@@ -1360,32 +1607,35 @@ function onGlobalKeydown(e) {
   }
 }
 
-@media (max-width: 575.98px) {
-  .bootui-shell {
-    flex-direction: column;
-    height: auto;
-    overflow: visible;
+@media (max-width: 991.98px) {
+  .nav-hamburger {
+    display: inline-flex;
   }
 
-  .bootui-sidebar {
-    height: auto;
-    overscroll-behavior: auto;
-    position: relative;
-    width: 100%;
-  }
-
-  .bootui-workspace {
-    height: auto;
-    overflow: visible;
+  .cp-trigger-label,
+  .cp-trigger-hint,
+  .theme-toggle__label {
+    display: none;
   }
 
   .topbar {
-    align-items: flex-start;
-    flex-direction: column;
+    padding: 1.1rem 1.25rem 0.85rem;
   }
 
   .content-stage,
-  .topbar,
+  .bootui-footer {
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .topbar {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .content-stage,
   .bootui-footer {
     padding-left: 1rem;
     padding-right: 1rem;
@@ -1433,13 +1683,5 @@ function onGlobalKeydown(e) {
   border-radius: 0.3rem;
   font-size: 0.7rem;
   padding: 0.1rem 0.35rem;
-}
-
-@media (max-width: 576px) {
-  .cp-trigger-label,
-  .cp-trigger-hint,
-  .theme-toggle__label {
-    display: none;
-  }
 }
 </style>

--- a/bootui-ui/src/main/frontend/src/utils/format.js
+++ b/bootui-ui/src/main/frontend/src/utils/format.js
@@ -25,6 +25,17 @@ export function formatNumber(n) {
   return Number(n).toLocaleString()
 }
 
+export function formatBytes(bytes) {
+  if (bytes == null || bytes === '') return '—'
+  const n = Number(bytes)
+  if (Number.isNaN(n) || n < 0) return '—'
+  if (n < 1024) return `${Math.round(n)} B`
+  if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)} KB`
+  if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)} MB`
+  if (n < 1024 ** 4) return `${(n / 1024 ** 3).toFixed(2)} GB`
+  return `${(n / 1024 ** 4).toFixed(2)} TB`
+}
+
 export function shortName(name) {
   if (!name) return '—'
   const i = name.lastIndexOf('.')

--- a/bootui-ui/src/main/frontend/src/utils/format.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/format.test.js
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {formatClockTime, formatNumber, formatRelative} from './format.js'
+import {formatBytes, formatClockTime, formatNumber, formatRelative} from './format.js'
 
 describe('formatNumber', () => {
   it('returns an em dash for null or undefined', () => {
@@ -10,6 +10,28 @@ describe('formatNumber', () => {
   it('formats numbers using locale grouping', () => {
     expect(formatNumber(1234567)).toBe((1234567).toLocaleString())
     expect(formatNumber(0)).toBe('0')
+  })
+})
+
+describe('formatBytes', () => {
+  it('returns an em dash for null, undefined, empty, or negative values', () => {
+    expect(formatBytes(null)).toBe('—')
+    expect(formatBytes(undefined)).toBe('—')
+    expect(formatBytes('')).toBe('—')
+    expect(formatBytes(-1)).toBe('—')
+    expect(formatBytes('not-a-number')).toBe('—')
+  })
+
+  it('scales bytes into B, KB, MB, GB, and TB', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB')
+    expect(formatBytes(232806322176)).toBe('216.82 GB')
+    expect(formatBytes(3 * 1024 ** 4)).toBe('3.00 TB')
+  })
+
+  it('accepts numeric strings', () => {
+    expect(formatBytes('1024')).toBe('1.0 KB')
   })
 })
 

--- a/bootui-ui/src/main/frontend/src/utils/recentPanels.js
+++ b/bootui-ui/src/main/frontend/src/utils/recentPanels.js
@@ -1,0 +1,32 @@
+const STORAGE_KEY = 'bootui.recentPanels'
+export const MAX_RECENT_PANELS = 5
+
+function storage() {
+  try {
+    return typeof window !== 'undefined' ? window.localStorage : null
+  } catch {
+    return null
+  }
+}
+
+export function loadRecentPanels() {
+  try {
+    const raw = storage()?.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((name) => typeof name === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+export function recordRecentPanel(name) {
+  if (!name) return loadRecentPanels()
+  const next = [name, ...loadRecentPanels().filter((entry) => entry !== name)].slice(0, MAX_RECENT_PANELS)
+  try {
+    storage()?.setItem(STORAGE_KEY, JSON.stringify(next))
+  } catch {
+    // Ignore unavailable storage (e.g. private mode / quota); recents are best-effort.
+  }
+  return next
+}

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -259,8 +259,11 @@ async function responseMessage(res) {
                     <span :class="statusClass(service.status)" class="badge">{{ service.status }}</span>
                   </td>
                   <td class="small" data-label="Host / ports">
-                    <div>{{ service.host || '—' }}</div>
-                    <code>{{ formatPorts(service) }}</code>
+                    <template v-if="service.host || service.ports?.length">
+                      <div v-if="service.host">{{ service.host }}</div>
+                      <code v-if="service.ports?.length">{{ formatPorts(service) }}</code>
+                    </template>
+                    <span v-else class="text-muted">—</span>
                   </td>
                   <td class="text-end" data-label="Actions">
                     <div class="d-flex flex-wrap justify-content-end gap-1 service-actions">

--- a/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
+++ b/bootui-ui/src/main/frontend/src/views/HealthDetails.vue
@@ -1,9 +1,15 @@
 <script setup>
-import {isPlainObject} from '../utils/format.js'
+import {formatBytes, isPlainObject} from '../utils/format.js'
 
 defineProps({
   value: {required: false, default: null}
 })
+
+const BYTE_KEYS = new Set(['total', 'free', 'threshold', 'used', 'available', 'size'])
+
+function isByteKey(key) {
+  return BYTE_KEYS.has(String(key).toLowerCase())
+}
 
 function isScalar(value) {
   return value === null || value === undefined || ['string', 'number', 'boolean'].includes(typeof value)
@@ -21,9 +27,10 @@ function labelFor(key) {
   return label ? label.charAt(0).toUpperCase() + label.slice(1) : key
 }
 
-function formatScalar(value) {
+function formatScalar(value, key = null) {
   if (value === null || value === undefined || value === '') return '—'
   if (typeof value === 'boolean') return value ? 'Yes' : 'No'
+  if (key !== null && isByteKey(key) && typeof value === 'number') return formatBytes(value)
   return String(value)
 }
 </script>
@@ -46,7 +53,7 @@ function formatScalar(value) {
         <tr v-for="[key, item] in entries(value)" :key="key">
           <th class="text-muted fw-normal ps-0" style="width: 34%">{{ labelFor(key) }}</th>
           <td class="pe-0">
-            <code v-if="isScalar(item)">{{ formatScalar(item) }}</code>
+            <code v-if="isScalar(item)">{{ formatScalar(item, key) }}</code>
             <div v-else class="border rounded bg-light-subtle p-2">
               <HealthDetails :value="item" />
             </div>

--- a/bootui-ui/src/main/frontend/src/views/components/AutoRefreshToggle.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/AutoRefreshToggle.vue
@@ -15,8 +15,58 @@ function updateValue(event) {
 </script>
 
 <template>
-  <div class="form-check form-switch mb-0" :title="title">
-    <input :id="inputId" :checked="modelValue" class="form-check-input" type="checkbox" @change="updateValue" />
-    <label class="form-check-label small" :for="inputId">Auto-refresh</label>
+  <div class="form-check form-switch mb-0 auto-refresh-toggle" :title="title">
+    <input
+      :id="inputId"
+      :checked="modelValue"
+      class="form-check-input"
+      type="checkbox"
+      aria-label="Toggle auto-refresh"
+      @change="updateValue"
+    />
+    <label class="form-check-label small auto-refresh-label" :for="inputId">
+      <span class="auto-refresh-dot" :class="{'auto-refresh-dot--live': modelValue}" aria-hidden="true"></span>
+      Auto-refresh
+    </label>
   </div>
 </template>
+
+<style scoped>
+.auto-refresh-label {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.auto-refresh-dot {
+  background: var(--bootui-text-subtle, #94a3b8);
+  border-radius: 999px;
+  flex-shrink: 0;
+  height: 0.5rem;
+  width: 0.5rem;
+}
+
+.auto-refresh-dot--live {
+  background: var(--bootui-green, #198754);
+  box-shadow: 0 0 0 0 rgba(25, 135, 84, 0.5);
+  animation: auto-refresh-pulse 1.8s ease-out infinite;
+}
+
+@keyframes auto-refresh-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(25, 135, 84, 0.5);
+  }
+  70% {
+    box-shadow: 0 0 0 0.4rem rgba(25, 135, 84, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(25, 135, 84, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .auto-refresh-dot--live {
+    animation: none;
+  }
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
@@ -2,6 +2,7 @@
 import {computed, nextTick, ref, watch} from 'vue'
 import {useRouter} from 'vue-router'
 import {routes} from '../../routes.js'
+import {loadRecentPanels} from '../../utils/recentPanels.js'
 
 const emit = defineEmits(['close'])
 const router = useRouter()
@@ -10,6 +11,10 @@ const inputEl = ref(null)
 const activeIndex = ref(0)
 
 const searchableRoutes = routes.filter((r) => r.name && r.meta?.title)
+const recentRouteList = loadRecentPanels()
+  .map((name) => searchableRoutes.find((r) => r.name === name))
+  .filter(Boolean)
+const recentNames = new Set(recentRouteList.map((r) => r.name))
 
 function score(route, q) {
   const title = (route.meta.title || '').toLowerCase()
@@ -21,15 +26,25 @@ function score(route, q) {
   return 0
 }
 
+const showRecent = computed(() => !query.value.trim() && recentRouteList.length > 0)
+
 const results = computed(() => {
   const q = query.value.trim()
-  if (!q) return searchableRoutes
+  if (!q) {
+    if (!recentRouteList.length) return searchableRoutes
+    const rest = searchableRoutes.filter((r) => !recentNames.has(r.name))
+    return [...recentRouteList, ...rest]
+  }
   return searchableRoutes
     .map((r) => ({route: r, score: score(r, q)}))
     .filter((x) => x.score > 0)
     .sort((a, b) => b.score - a.score)
     .map((x) => x.route)
 })
+
+function isRecent(route) {
+  return showRecent.value && recentNames.has(route.name)
+}
 
 watch(query, () => {
   activeIndex.value = 0
@@ -79,6 +94,7 @@ defineExpose({focusInput})
         />
         <kbd class="cp-esc-hint">Esc</kbd>
       </div>
+      <div v-if="showRecent" class="cp-section-label">Recent</div>
       <ul v-if="results.length" class="cp-list" role="listbox">
         <li
           v-for="(r, i) in results"
@@ -92,6 +108,12 @@ defineExpose({focusInput})
         >
           <i :class="['bi', r.meta.icon, 'cp-item-icon']"></i>
           <span class="cp-item-title">{{ r.meta.title }}</span>
+          <i
+            v-if="isRecent(r)"
+            class="bi bi-clock-history cp-item-recent"
+            title="Recently viewed"
+            aria-hidden="true"
+          ></i>
           <span class="cp-item-group">{{ r.meta.group }}</span>
         </li>
       </ul>
@@ -204,6 +226,21 @@ defineExpose({focusInput})
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.cp-item-recent {
+  color: var(--bootui-green, #198754);
+  flex-shrink: 0;
+  font-size: 0.85rem;
+}
+
+.cp-section-label {
+  color: var(--bootui-text-subtle, #94a3b8);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  padding: 0.5rem 1.25rem 0;
+  text-transform: uppercase;
 }
 
 .cp-empty {


### PR DESCRIPTION
## What does this PR do?

Polishes the BootUI developer console shell with a responsive, mobile-friendly navigation and clearer live/empty-state cues across panels.

## Why is this change needed?

A UX pass over the console surfaced several rough edges: the collapsed sidebar icon rail was hard to navigate without re-expanding, the topbar crowded and wrapped on smaller widths with no mobile navigation at all, raw byte counts in Health were hard to read, "is this panel live?" was ambiguous, and jumping back to a recently used panel meant scrolling the full list. These are all polish issues in the existing shell, not new panels, so the route surface and API shapes are unchanged.

## How was it tested?

- [x] `./mvnw clean install` passes locally (full reactor build succeeds, including the frontend Vitest suite)
- [x] Started `bootui-sample-app` and verified `/bootui` loads and each change works end to end
- [x] Added or updated tests where applicable

Specifically:
- Vitest: 192/192 passing (added `formatBytes` coverage).
- Playwright e2e (Desktop Chrome 1280px): full suite 86 passed / 5 skipped / 0 failed. The `app-shell` spec confirms desktop scroll and grouping behavior is unchanged; the new drawer/responsive behavior is scoped under `max-width: 991.98px` so it does not affect desktop assertions.
- `npm run build` (production Vue/rolldown compiler) and `npm run format:check` are clean.

### Approach / what changed

- **Collapsed sidebar flyouts.** When the desktop rail is collapsed, hovering or focusing a group opens a flyout listing that group's panels. It is rendered as a `position: fixed` element positioned from the toggle's bounding rect, so it escapes the sidebar's `overflow` clipping.
- **Mobile drawer + responsive topbar.** Below 992px the sidebar becomes an off-canvas drawer with a dimming backdrop, toggled by a new hamburger button; the palette trigger and theme toggle collapse to icons. The old `<576px` column-stack layout is replaced by this overlay.
- **Human-readable bytes.** New shared `formatBytes` helper in `utils/format.js`, used in Health details so disk values render as e.g. `926.35 GB` instead of raw bytes. String values (like the disk path) pass through untouched.
- **Live auto-refresh cue.** `AutoRefreshToggle` shows a pulsing green dot when polling is active, honoring `prefers-reduced-motion`.
- **Command palette recents.** New `recentPanels.js` records visited panels in localStorage; the palette floats them into a "Recent" section when the query is empty (additive reorder, so the full list is preserved when there are no recents).
- **Dev Services empty state.** Empty host/ports cells now show a single muted dash instead of two stacked dashes.

### Note for reviewers

The production Vue compiler rejected a multi-statement inline `@click` handler that the dev compiler accepted, so the flyout link click was extracted into an `onFlyoutLinkClick(navigate, $event)` method. No docs in `docs/` needed updating since no panels were added, renamed, or reordered.

## Screenshots (UI changes)

Collapsed sidebar flyout (desktop):

![Collapsed sidebar flyout](https://github.com/user-attachments/assets/69e646fb-efe2-44e5-9e2a-755d640484a1)

Mobile overlay drawer with backdrop:

![Mobile drawer](https://github.com/user-attachments/assets/7c2b1f06-b54a-49a0-be9d-5312b8f3a5e8)

Command palette with recent panels:

![Command palette recents](https://github.com/user-attachments/assets/40b83cbf-bb5b-4f3b-b78e-dab5528893bd)

Human-readable Health disk sizes and the live auto-refresh dot:

![Health humanized bytes](https://github.com/user-attachments/assets/70b57961-fd53-40db-a251-dcac330917c5)

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no panel/API surface change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed