### PR TITLE
Fix two GraalVM native-image issues in the BootUI starter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the entrypoint is exec-form, and the Docker `HEALTHCHECK` was dropped (probe `/actuator/health` from your orchestrator
   instead, as the native image already documents).
 
+### Fixed
+
+- **GraalVM native image: the Mappings panel no longer fails.** `GET /bootui/api/mappings` (the compatibility
+  endpoint that returns Actuator's raw mappings descriptor) threw a `MissingReflectionRegistrationError` in a native
+  image because Jackson reflectively instantiates the array forms of Actuator's nested `MediaTypeExpressionDescription`
+  / `NameValueExpressionDescription` types while serializing them. BootUI's `RuntimeHints` now register those types and
+  their array forms, so consumers of the starter no longer need to declare the hints themselves.
+- **GraalVM native image: BootUI no longer self-reports as "Disabled" while running.** In a native image the activation
+  condition is frozen at AOT build time, but the `BootUiActivation` bean recomputed it against the live runtime
+  environment (where the build-time `dev` profile / `bootui.enabled=ON` no longer apply), so the Overview panel and the
+  startup log claimed BootUI was disabled even though it was serving. When running AOT-generated artifacts, BootUI now
+  trusts the frozen build-time decision and reports the accurate enabled state.
+
 ## [1.3.0] - 2026-06-11
 
 Feature release headlined by two new GraalVM/CRaC capabilities — a new **CRaC (Coordinated Restore at Checkpoint)

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.aot.AotDetector;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
@@ -294,6 +295,16 @@ public class BootUiAutoConfiguration {
     public BootUiActivation bootUiActivation(Environment environment) {
         BootUiActivation activation =
                 BootUiActivationCondition.resolve(environment, getClass().getClassLoader());
+        if (!activation.enabled() && AotDetector.useGeneratedArtifacts()) {
+            // In a native image (or any AOT-generated context) BootUiAutoConfiguration's activation
+            // condition is frozen from build time: this bean only exists because the condition
+            // matched then. The live runtime environment may no longer match (for example the
+            // build-time 'dev' profile is not active at runtime), so resolve() would mis-report
+            // BootUI as disabled even though it is wired into the image and serving. Trust the frozen
+            // build-time decision so the Overview panel and startup log reflect reality. A runtime
+            // bootui.enabled=OFF cannot remove the baked-in beans, so it does not change this.
+            activation = new BootUiActivation(true, "Enabled at build time (AOT/native image)", activation.warnings());
+        }
         log.info("BootUI activation: {}", activation.reason());
         for (String warning : activation.warnings()) {
             log.warn("BootUI activation warning: {}", warning);

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
@@ -66,6 +66,15 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
     private static final String MODULITH_APPLICATION_MODULE_IDENTIFIERS =
             "org.springframework.modulith.core.ApplicationModuleIdentifiers";
 
+    /**
+     * Web MVC actuator mapping-condition description types whose array forms Jackson reflectively
+     * instantiates while serializing the raw descriptor returned by {@code MappingsController#mappings()}.
+     */
+    private static final String[] MAPPINGS_EXPRESSION_DESCRIPTIONS = {
+        "org.springframework.boot.webmvc.actuate.web.mappings.RequestMappingConditionsDescription$MediaTypeExpressionDescription",
+        "org.springframework.boot.webmvc.actuate.web.mappings.RequestMappingConditionsDescription$NameValueExpressionDescription"
+    };
+
     @Override
     public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
         hints.resources()
@@ -93,6 +102,25 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
         hints.reflection()
                 .registerTypeIfPresent(
                         classLoader, MODULITH_APPLICATION_MODULE_IDENTIFIERS, MemberCategory.INVOKE_PUBLIC_METHODS);
+
+        // Mappings panel: the /bootui/api/mappings compatibility endpoint serializes Actuator's raw
+        // ApplicationMappingsDescriptor. While introspecting the nested media-type / name-value
+        // expression descriptions, Jackson reflectively instantiates their array types; GraalVM
+        // requires those array types to be registered or the endpoint fails at runtime with a
+        // MissingReflectionRegistrationError. registerTypeIfPresent keeps this harmless when the
+        // Web MVC actuator mappings support is absent (e.g. a WebFlux-only application).
+        for (String descriptionType : MAPPINGS_EXPRESSION_DESCRIPTIONS) {
+            registerTypeAndArrayIfPresent(hints, classLoader, descriptionType);
+        }
+    }
+
+    private void registerTypeAndArrayIfPresent(RuntimeHints hints, ClassLoader classLoader, String className) {
+        if (!ClassUtils.isPresent(className, classLoader)) {
+            return;
+        }
+        Class<?> type = ClassUtils.resolveClassName(className, classLoader);
+        hints.reflection().registerType(type, MemberCategory.INVOKE_PUBLIC_METHODS);
+        hints.reflection().registerType(Array.newInstance(type, 0).getClass());
     }
 
     private void registerDtoBindingHints(RuntimeHints hints, ClassLoader classLoader) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.aot.AotDetector;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
@@ -44,6 +45,8 @@ import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.core.SpringProperties;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -89,6 +92,27 @@ class BootUiAutoConfigurationTests {
     void activatesOnEnabledProfile() {
         runner.withPropertyValues("spring.profiles.active=dev")
                 .run(context -> assertThat(context).hasSingleBean(BootUiAutoConfiguration.class));
+    }
+
+    @Test
+    void reportsEnabledInAotModeWhenRuntimeEnvironmentNoLongerMatches() {
+        // In a native image the activation condition is frozen at AOT build time, so this bean only
+        // exists because BootUI was enabled then. Simulate that with the AOT flag plus a bare
+        // environment that resolve() would otherwise report as disabled (no enabling profile / devtools).
+        SpringProperties.setProperty(AotDetector.AOT_ENABLED, "true");
+        try {
+            BootUiActivation activation = new BootUiAutoConfiguration().bootUiActivation(new MockEnvironment());
+            assertThat(activation.enabled()).isTrue();
+            assertThat(activation.reason()).contains("build time");
+        } finally {
+            SpringProperties.setProperty(AotDetector.AOT_ENABLED, null);
+        }
+    }
+
+    @Test
+    void reportsResolvedStateOutsideAotModeWhenEnvironmentDoesNotMatch() {
+        BootUiActivation activation = new BootUiAutoConfiguration().bootUiActivation(new MockEnvironment());
+        assertThat(activation.enabled()).isFalse();
     }
 
     @Test

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
@@ -63,4 +63,20 @@ class BootUiRuntimeHintsTests {
         assertThat(RuntimeHintsPredicates.reflection().onType(TypeReference.of(PanelDto[].class)))
                 .accepts(hints);
     }
+
+    @Test
+    void registersActuatorMappingsExpressionDescriptionArrayTypesForJacksonSerialization() {
+        String mediaType =
+                "org.springframework.boot.webmvc.actuate.web.mappings.RequestMappingConditionsDescription$MediaTypeExpressionDescription";
+        String nameValue =
+                "org.springframework.boot.webmvc.actuate.web.mappings.RequestMappingConditionsDescription$NameValueExpressionDescription";
+        for (String descriptionType : new String[] {mediaType, nameValue}) {
+            assertThat(RuntimeHintsPredicates.reflection()
+                            .onType(TypeReference.of(descriptionType))
+                            .withMemberCategory(MemberCategory.INVOKE_PUBLIC_METHODS))
+                    .accepts(hints);
+            assertThat(RuntimeHintsPredicates.reflection().onType(TypeReference.of(descriptionType + "[]")))
+                    .accepts(hints);
+        }
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes two native-image-only defects in the BootUI starter so the developer console works cleanly when the host app is compiled with GraalVM.

## Why is this change needed?

While testing the starter end-to-end as a GraalVM native image (via the sample app's Docker native build), two issues surfaced that only manifest under AOT/native, not on the JVM:

1. **Mappings panel crashed.** `GET /bootui/api/mappings` (the compatibility endpoint that returns Actuator's raw mappings descriptor) threw a `MissingReflectionRegistrationError`. Jackson reflectively instantiates the array forms of Actuator's nested `MediaTypeExpressionDescription` / `NameValueExpressionDescription` types while serializing the descriptor, and those array types were not registered for reflection. `BootUiRuntimeHints` now registers those types and their array forms, so consumers of the starter get the hints for free.

2. **BootUI self-reported as "Disabled" while running.** In a native image the `@Conditional` activation decision is frozen at AOT build time, but the `bootUiActivation` bean recomputed `resolve()` against the live runtime environment (where the build-time `dev` profile / `bootui.enabled=ON` no longer apply). The Overview panel and startup log therefore claimed BootUI was disabled even though it was wired into the image and serving. When running AOT-generated artifacts, BootUI now trusts the frozen build-time decision and reports the accurate enabled state. A runtime `bootui.enabled=OFF` cannot remove the baked-in beans, so this stays honest.

Both fixes live entirely in the starter, so downstream native apps need no extra hints of their own.

## How was it tested?

- [x] `./mvnw clean install` passes locally (full `bootui-autoconfigure` suite: 1143 tests, 0 failures; `spotless:check` clean)
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additionally verified against a rebuilt GraalVM **native image** (Docker native build of the sample app):

- 54/56 GET endpoints return 200 (the 2 non-200s are expected 400s: `metrics/detail` needs a `name` param, `heap-dump/download` needs a prior dump).
- All 8 advisor `/scan` POST actions return 200 with real reflection-based data.
- `/bootui/api/mappings` now returns 200, and the Overview API reports `activation.enabled: true` ("Enabled at build time (AOT/native image)").
- Zero reflection/resource/proxy errors in the container logs after exercising the full surface.

## Screenshots (UI changes)

N/A - no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (CHANGELOG.md `Unreleased` updated; no behavioural docs affected)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed