### PR TITLE
Restore sample app button that triggers the Exceptions panel demo

### DIFF
--- a/bootui-sample-app/src/main/resources/static/index.html
+++ b/bootui-sample-app/src/main/resources/static/index.html
@@ -289,6 +289,11 @@
           <p>Calls the same secured endpoint with <code>developer/developer</code> to produce a forbidden response.</p>
           <small>Inspect: Spring Security, Security Logs, Pentesting</small>
         </article>
+        <article class="test-action">
+          <button class="button" id="exception-button" type="button">Trigger an exception</button>
+          <p>Calls <code>GET /api/sample/boom</code>, which throws on purpose to record a server-side failure.</p>
+          <small>Inspect: Exceptions, Log Tail, Traces</small>
+        </article>
       </div>
       <div class="form-row">
         <span aria-live="polite" class="chat-status" id="sample-action-status" role="status"></span>
@@ -330,6 +335,7 @@
   const publicApiButton = document.getElementById('public-api-button')
   const secureAdminButton = document.getElementById('secure-admin-button')
   const secureUserButton = document.getElementById('secure-user-button')
+  const exceptionButton = document.getElementById('exception-button')
   const sessionDataButton = document.getElementById('session-data-button')
   const sessionDataStatus = document.getElementById('session-data-status')
   const sampleActionStatus = document.getElementById('sample-action-status')
@@ -506,6 +512,20 @@
       showSampleResult(
         `Developer access returned HTTP ${response.status}`,
         `${text}\n\nThis forbidden response is useful in Spring Security, Security Logs, and Pentesting.`
+      )
+    })
+  )
+
+  exceptionButton.addEventListener('click', () =>
+    runSampleAction(exceptionButton, 'Triggering a sample exception...', async () => {
+      const response = await fetch('/api/sample/boom', {
+        headers: {Accept: 'application/json'}
+      })
+      await response.text()
+      showSampleResult(
+        `Triggered a sample exception (HTTP ${response.status})`,
+        'The server threw an IllegalStateException on purpose.\n\n' +
+          'Open BootUI Exceptions to inspect the captured stack trace and masked details.'
       )
     })
   )


### PR DESCRIPTION
## What does this PR do?

Adds a "Trigger an exception" action card to the sample app welcome page that calls `GET /api/sample/boom` to exercise the Exceptions panel from the browser.

## Why is this change needed?

The `/api/sample/boom` endpoint (which throws an `IllegalStateException` on purpose) already exists and is used by the `exceptions.spec.js` e2e test via a direct HTTP request, but no UI button to invoke it was ever committed to any branch. That left the Exceptions panel demo with no way to trigger it from the welcome page. This wires a button to the existing endpoint, matching the existing sample action lab pattern, so the panel can be exercised interactively.

The click handler treats the expected HTTP 500 as the intended demo outcome (it does not surface it as a failure) and points the user to the Exceptions panel.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally (built `bootui-sample-app` and its upstream modules into an isolated local repo)
- [x] Started `bootui-sample-app` and verified the welcome page renders the new button and `GET /api/sample/boom` returns HTTP 500 with the expected `IllegalStateException`
- [ ] Added or updated tests where applicable (existing `exceptions.spec.js` already triggers `/api/sample/boom` directly; no new test needed)

## Screenshots (UI changes)

N/A - the change is on the sample app welcome page (static HTML), not the Vue console UI.

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no public BootUI behaviour change; sample app only)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed