### PR TITLE
Refactor sample app into clean feature packages

### DIFF
--- a/bootui-sample-app/e2e/tests/data.spec.js
+++ b/bootui-sample-app/e2e/tests/data.spec.js
@@ -17,7 +17,7 @@ test.describe('Data (Spring Data repositories) view', () => {
     // Open the detail panel.
     await productRepoEntry.click()
     const detailCard = page.locator('main .col-md-7 .card')
-    await expect(detailCard).toContainText('io.github.jdubois.bootui.sample.ProductRepository')
+    await expect(detailCard).toContainText('io.github.jdubois.bootui.sample.catalog.ProductRepository')
     await expect(detailCard).toContainText('searchByName')
     await expect(detailCard).toContainText('select p from Product p')
     await expect(detailCard.locator('.badge', {hasText: 'ANNOTATED'}).first()).toBeVisible()

--- a/bootui-sample-app/e2e/tests/exceptions.spec.js
+++ b/bootui-sample-app/e2e/tests/exceptions.spec.js
@@ -23,7 +23,7 @@ test.describe('Exceptions view', () => {
     const drawer = page.locator('.exception-drawer')
     await expect(drawer).toBeVisible()
     await expect(drawer).toContainText('Caused by: java.lang.NumberFormatException')
-    await expect(drawer.locator('.stack-pane')).toContainText('BootUiSampleApplication')
+    await expect(drawer.locator('.stack-pane')).toContainText('SampleController')
     await expect(drawer).toContainText('Recent occurrences')
   })
 

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/BootUiSampleApplication.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/BootUiSampleApplication.java
@@ -1,52 +1,27 @@
 package io.github.jdubois.bootui.sample;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
-import java.io.Serializable;
+import io.github.jdubois.bootui.sample.catalog.SampleSettings;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.sql.DataSource;
-import liquibase.integration.spring.SpringLiquibase;
-import org.flywaydb.core.Flyway;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.flyway.autoconfigure.FlywayMigrationStrategy;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.event.EventListener;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
 @EnableCaching
 @EnableScheduling
-@EnableConfigurationProperties(BootUiSampleApplication.SampleSettings.class)
+@EnableConfigurationProperties(SampleSettings.class)
 public class BootUiSampleApplication {
 
     private static final Logger log = LoggerFactory.getLogger(BootUiSampleApplication.class);
-
-    private static final String FLYWAY_STARTUP_TARGET = "2";
-    private static final String LIQUIBASE_BASE_CHANGELOG = "classpath:db/changelog/db.changelog-base.xml";
-    private static final String LIQUIBASE_MASTER_CHANGELOG = "classpath:db/changelog/db.changelog-master.xml";
 
     public static void main(String[] args) {
         SpringApplication application = new SpringApplication(BootUiSampleApplication.class);
@@ -71,204 +46,5 @@ public class BootUiSampleApplication {
     @EventListener(ApplicationReadyEvent.class)
     void logStartupTime(ApplicationReadyEvent event) {
         log.info("Sample app started up in {} ms", event.getTimeTaken().toMillis());
-    }
-
-    @Bean
-    @ConditionalOnProperty(prefix = "spring.flyway", name = "enabled", matchIfMissing = true)
-    FlywayMigrationStrategy sampleFlywayStartupStrategy() {
-        return flyway -> {
-            // BootUI should demonstrate pending migrations, so the sample applies
-            // its base schema in a runner below.
-        };
-    }
-
-    @Bean
-    ApplicationRunner sampleMigrationDemoInitializer(
-            ObjectProvider<Flyway> flywayProvider,
-            ObjectProvider<SpringLiquibase> liquibaseProvider,
-            DataSource dataSource,
-            ResourceLoader resourceLoader) {
-        return args -> {
-            // The sample migrations are disabled by default in the Docker images for a faster
-            // startup (and can be toggled with SPRING_FLYWAY_ENABLED / SPRING_LIQUIBASE_ENABLED),
-            // so this demo wiring must tolerate either tool being absent rather than fail to start.
-            // Gating on bean presence (rather than reading the property at runtime) keeps the
-            // behaviour consistent for the native image, where the toggle is baked in at build time.
-            Flyway flyway = flywayProvider.getIfAvailable();
-            if (flyway != null) {
-                Flyway.configure()
-                        .configuration(flyway.getConfiguration())
-                        .target(FLYWAY_STARTUP_TARGET)
-                        .load()
-                        .migrate();
-            }
-
-            if (liquibaseProvider.getIfAvailable() != null) {
-                SpringLiquibase baseLiquibase = new SpringLiquibase();
-                baseLiquibase.setDataSource(dataSource);
-                baseLiquibase.setResourceLoader(resourceLoader);
-                baseLiquibase.setChangeLog(LIQUIBASE_BASE_CHANGELOG);
-                baseLiquibase.setShouldRun(true);
-                baseLiquibase.afterPropertiesSet();
-            }
-        };
-    }
-
-    @Bean
-    @ConditionalOnProperty(prefix = "spring.liquibase", name = "enabled", matchIfMissing = true)
-    SpringLiquibase liquibase(DataSource dataSource) {
-        SpringLiquibase liquibase = new SpringLiquibase();
-        liquibase.setDataSource(dataSource);
-        liquibase.setChangeLog(LIQUIBASE_MASTER_CHANGELOG);
-        liquibase.setShouldRun(false);
-        return liquibase;
-    }
-
-    @ConfigurationProperties(prefix = "sample")
-    public static class SampleSettings {
-
-        private String greeting = "Hello";
-
-        private int retries = 3;
-
-        public String getGreeting() {
-            return greeting;
-        }
-
-        public void setGreeting(String greeting) {
-            this.greeting = greeting;
-        }
-
-        public int getRetries() {
-            return retries;
-        }
-
-        public void setRetries(int retries) {
-            this.retries = retries;
-        }
-    }
-
-    @RestController
-    @RequestMapping("/api/sample")
-    public static class SampleController {
-
-        private final SampleSettings settings;
-        private final SampleCatalog catalog;
-
-        public SampleController(SampleSettings settings, SampleCatalog catalog) {
-            this.settings = settings;
-            this.catalog = catalog;
-        }
-
-        @GetMapping("/hello")
-        public String hello() {
-            return catalog.greeting(settings.getGreeting(), settings.getRetries());
-        }
-
-        @GetMapping("/products")
-        public List<ProductSummary> products() {
-            return catalog.activeProducts();
-        }
-
-        @GetMapping("/product-search")
-        public List<ProductSummary> productSearch(@RequestParam(name = "term", defaultValue = "console") String term) {
-            return catalog.searchProducts(term);
-        }
-
-        @GetMapping("/session")
-        public Map<String, Object> session(HttpServletRequest request) {
-            HttpSession session = request.getSession(true);
-            Object previousClickCount = session.getAttribute("sampleClickCount");
-            int sampleClickCount = previousClickCount instanceof Number number ? number.intValue() + 1 : 1;
-            session.setAttribute("sampleMessage", "Hello from the sample session");
-            session.setAttribute("sampleCount", 42);
-            session.setAttribute("sampleClickCount", sampleClickCount);
-            session.setAttribute("sampleGeneratedAt", Instant.now().toString());
-            session.setAttribute("apiToken", "sample-secret-token");
-            return Map.of(
-                    "sessionId",
-                    session.getId(),
-                    "attributeCount",
-                    5,
-                    "sampleClickCount",
-                    sampleClickCount,
-                    "attributes",
-                    List.of("sampleMessage", "sampleCount", "sampleClickCount", "sampleGeneratedAt", "apiToken"));
-        }
-
-        @GetMapping("/boom")
-        public String boom() {
-            try {
-                Integer.parseInt("not-a-number");
-                return "unreachable";
-            } catch (NumberFormatException cause) {
-                throw new IllegalStateException(
-                        "Sample failure for the BootUI Exceptions panel demo (apiToken=sample-secret-token)", cause);
-            }
-        }
-    }
-
-    @Service
-    public static class SampleCatalog {
-
-        private final ProductRepository products;
-
-        public SampleCatalog(ProductRepository products) {
-            this.products = products;
-        }
-
-        @Cacheable(cacheNames = "sample-greetings", key = "#greeting + ':' + #retries")
-        public String greeting(String greeting, int retries) {
-            return greeting + ", BootUI! (retries=" + retries + ")";
-        }
-
-        @Cacheable(cacheNames = "sample-products", key = "'active'", unless = "#result.isEmpty()")
-        public List<ProductSummary> activeProducts() {
-            return products.findByActiveTrueOrderByNameAsc().stream()
-                    .map(ProductSummary::from)
-                    .toList();
-        }
-
-        public List<ProductSummary> searchProducts(String term) {
-            // Intentionally uncached so every call runs a live SQL SELECT for the SQL Trace panel to capture.
-            return products.searchByName(term).stream()
-                    .map(ProductSummary::from)
-                    .toList();
-        }
-
-        @CacheEvict(cacheNames = "sample-products", allEntries = true)
-        public void evictProducts() {}
-    }
-
-    public record ProductSummary(Long id, String name, String category, boolean active) implements Serializable {
-
-        static ProductSummary from(Product product) {
-            return new ProductSummary(product.getId(), product.getName(), product.getCategory(), product.isActive());
-        }
-    }
-
-    @RestController
-    @RequestMapping("/api")
-    public static class HelloController {
-
-        @GetMapping("/hello")
-        public String hello() {
-            return "Hello, world";
-        }
-
-        @GetMapping("/secure")
-        public String secure() {
-            return "Secure Hello, world";
-        }
-    }
-
-    @RestController
-    @RequestMapping("/admin")
-    public static class AdminController {
-
-        @GetMapping
-        public String admin() {
-            return "BootUI sample admin";
-        }
     }
 }

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/architecture/ArchitectureIssuesController.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/architecture/ArchitectureIssuesController.java
@@ -1,5 +1,6 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.architecture;
 
+import io.github.jdubois.bootui.sample.catalog.ProductRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleAppPreferences.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleAppPreferences.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleAuditEntry.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleAuditEntry.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleBillingDocument.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleBillingDocument.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleCustomer.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleCustomer.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleCustomerRepository.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleCustomerRepository.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleDevice.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleDevice.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleDeviceRepository.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleDeviceRepository.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleInvoice.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleInvoice.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleLegacyTicket.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleLegacyTicket.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrder.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrder.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrderDetails.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrderDetails.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrderRepository.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrderRepository.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import java.util.Collection;
 import java.util.List;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrderStatus.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrderStatus.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 public enum SampleOrderStatus {
     NEW,

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleReceipt.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleReceipt.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleTag.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleTag.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleTagRepository.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleTagRepository.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.advisor.hibernate;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/Product.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/Product.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.catalog;
 
 import jakarta.persistence.*;
 

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/ProductRepository.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/ProductRepository.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.catalog;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/ProductSummary.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/ProductSummary.java
@@ -1,0 +1,10 @@
+package io.github.jdubois.bootui.sample.catalog;
+
+import java.io.Serializable;
+
+public record ProductSummary(Long id, String name, String category, boolean active) implements Serializable {
+
+    static ProductSummary from(Product product) {
+        return new ProductSummary(product.getId(), product.getName(), product.getCategory(), product.isActive());
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleCatalog.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleCatalog.java
@@ -1,0 +1,36 @@
+package io.github.jdubois.bootui.sample.catalog;
+
+import java.util.List;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SampleCatalog {
+
+    private final ProductRepository products;
+
+    public SampleCatalog(ProductRepository products) {
+        this.products = products;
+    }
+
+    @Cacheable(cacheNames = "sample-greetings", key = "#greeting + ':' + #retries")
+    public String greeting(String greeting, int retries) {
+        return greeting + ", BootUI! (retries=" + retries + ")";
+    }
+
+    @Cacheable(cacheNames = "sample-products", key = "'active'", unless = "#result.isEmpty()")
+    public List<ProductSummary> activeProducts() {
+        return products.findByActiveTrueOrderByNameAsc().stream()
+                .map(ProductSummary::from)
+                .toList();
+    }
+
+    public List<ProductSummary> searchProducts(String term) {
+        // Intentionally uncached so every call runs a live SQL SELECT for the SQL Trace panel to capture.
+        return products.searchByName(term).stream().map(ProductSummary::from).toList();
+    }
+
+    @CacheEvict(cacheNames = "sample-products", allEntries = true)
+    public void evictProducts() {}
+}

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleController.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleController.java
@@ -1,0 +1,71 @@
+package io.github.jdubois.bootui.sample.catalog;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/sample")
+public class SampleController {
+
+    private final SampleSettings settings;
+    private final SampleCatalog catalog;
+
+    public SampleController(SampleSettings settings, SampleCatalog catalog) {
+        this.settings = settings;
+        this.catalog = catalog;
+    }
+
+    @GetMapping("/hello")
+    public String hello() {
+        return catalog.greeting(settings.getGreeting(), settings.getRetries());
+    }
+
+    @GetMapping("/products")
+    public List<ProductSummary> products() {
+        return catalog.activeProducts();
+    }
+
+    @GetMapping("/product-search")
+    public List<ProductSummary> productSearch(@RequestParam(name = "term", defaultValue = "console") String term) {
+        return catalog.searchProducts(term);
+    }
+
+    @GetMapping("/session")
+    public Map<String, Object> session(HttpServletRequest request) {
+        HttpSession session = request.getSession(true);
+        Object previousClickCount = session.getAttribute("sampleClickCount");
+        int sampleClickCount = previousClickCount instanceof Number number ? number.intValue() + 1 : 1;
+        session.setAttribute("sampleMessage", "Hello from the sample session");
+        session.setAttribute("sampleCount", 42);
+        session.setAttribute("sampleClickCount", sampleClickCount);
+        session.setAttribute("sampleGeneratedAt", Instant.now().toString());
+        session.setAttribute("apiToken", "sample-secret-token");
+        return Map.of(
+                "sessionId",
+                session.getId(),
+                "attributeCount",
+                5,
+                "sampleClickCount",
+                sampleClickCount,
+                "attributes",
+                List.of("sampleMessage", "sampleCount", "sampleClickCount", "sampleGeneratedAt", "apiToken"));
+    }
+
+    @GetMapping("/boom")
+    public String boom() {
+        try {
+            Integer.parseInt("not-a-number");
+            return "unreachable";
+        } catch (NumberFormatException cause) {
+            throw new IllegalStateException(
+                    "Sample failure for the BootUI Exceptions panel demo (apiToken=sample-secret-token)", cause);
+        }
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleSettings.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleSettings.java
@@ -1,0 +1,27 @@
+package io.github.jdubois.bootui.sample.catalog;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "sample")
+public class SampleSettings {
+
+    private String greeting = "Hello";
+
+    private int retries = 3;
+
+    public String getGreeting() {
+        return greeting;
+    }
+
+    public void setGreeting(String greeting) {
+        this.greeting = greeting;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+    public void setRetries(int retries) {
+        this.retries = retries;
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/chat/ChatController.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/chat/ChatController.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.chat;
 
 import java.util.Map;
 import org.springframework.ai.chat.client.ChatClient;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/NativeHintsConfiguration.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/NativeHintsConfiguration.java
@@ -1,5 +1,7 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.config;
 
+import io.github.jdubois.bootui.sample.catalog.ProductSummary;
+import io.github.jdubois.bootui.sample.catalog.SampleCatalog;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -21,10 +23,10 @@ import org.springframework.context.annotation.ImportRuntimeHints;
  *
  * <ul>
  *   <li><b>SpEL reflection</b> — {@code unless = "#result.isEmpty()"} on {@link
- *       BootUiSampleApplication.SampleCatalog#activeProducts()} invokes a method reflectively. SpEL
- *       resolves {@code isEmpty()} against the {@link List} interface while the receiver is the
- *       concrete (JDK-internal) immutable list returned by {@link Stream#toList()} / {@link
- *       List#of}; the public methods of both are registered.
+ *       SampleCatalog#activeProducts()} invokes a method reflectively. SpEL resolves {@code
+ *       isEmpty()} against the {@link List} interface while the receiver is the concrete
+ *       (JDK-internal) immutable list returned by {@link Stream#toList()} / {@link List#of};
+ *       the public methods of both are registered.
  *   <li><b>JDK serialization</b> — the default Redis cache serializer serializes cached values with
  *       {@link java.io.ObjectOutputStream}. The cached {@code List<ProductSummary>} graph (the
  *       record, its element wrappers and the immutable list type) is registered for serialization.
@@ -68,7 +70,7 @@ class NativeHintsConfiguration {
 
             // JDK serialization graph for the cached List<ProductSummary> value.
             Set<Class<?>> serializable = new LinkedHashSet<>();
-            serializable.add(BootUiSampleApplication.ProductSummary.class);
+            serializable.add(ProductSummary.class);
             serializable.add(Long.class);
             serializable.add(Integer.class);
             serializable.add(Boolean.class);

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/SampleMigrationConfiguration.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/SampleMigrationConfiguration.java
@@ -1,0 +1,75 @@
+package io.github.jdubois.bootui.sample.config;
+
+import javax.sql.DataSource;
+import liquibase.integration.spring.SpringLiquibase;
+import org.flywaydb.core.Flyway;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.flyway.autoconfigure.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ResourceLoader;
+
+/**
+ * Wires the database-migration demo so the BootUI Flyway and Liquibase panels have pending work to
+ * show: only the base schema is applied on startup, leaving later migrations and change sets pending.
+ */
+@Configuration(proxyBeanMethods = false)
+class SampleMigrationConfiguration {
+
+    private static final String FLYWAY_STARTUP_TARGET = "2";
+    private static final String LIQUIBASE_BASE_CHANGELOG = "classpath:db/changelog/db.changelog-base.xml";
+    private static final String LIQUIBASE_MASTER_CHANGELOG = "classpath:db/changelog/db.changelog-master.xml";
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.flyway", name = "enabled", matchIfMissing = true)
+    FlywayMigrationStrategy sampleFlywayStartupStrategy() {
+        return flyway -> {
+            // BootUI should demonstrate pending migrations, so the sample applies
+            // its base schema in a runner below.
+        };
+    }
+
+    @Bean
+    ApplicationRunner sampleMigrationDemoInitializer(
+            ObjectProvider<Flyway> flywayProvider,
+            ObjectProvider<SpringLiquibase> liquibaseProvider,
+            DataSource dataSource,
+            ResourceLoader resourceLoader) {
+        return args -> {
+            // The sample migrations are disabled by default in the Docker images for a faster
+            // startup (and can be toggled with SPRING_FLYWAY_ENABLED / SPRING_LIQUIBASE_ENABLED),
+            // so this demo wiring must tolerate either tool being absent rather than fail to start.
+            // Gating on bean presence (rather than reading the property at runtime) keeps the
+            // behaviour consistent for the native image, where the toggle is baked in at build time.
+            Flyway flyway = flywayProvider.getIfAvailable();
+            if (flyway != null) {
+                Flyway.configure()
+                        .configuration(flyway.getConfiguration())
+                        .target(FLYWAY_STARTUP_TARGET)
+                        .load()
+                        .migrate();
+            }
+
+            if (liquibaseProvider.getIfAvailable() != null) {
+                SpringLiquibase baseLiquibase = new SpringLiquibase();
+                baseLiquibase.setDataSource(dataSource);
+                baseLiquibase.setResourceLoader(resourceLoader);
+                baseLiquibase.setChangeLog(LIQUIBASE_BASE_CHANGELOG);
+                baseLiquibase.setShouldRun(true);
+                baseLiquibase.afterPropertiesSet();
+            }
+        };
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.liquibase", name = "enabled", matchIfMissing = true)
+    SpringLiquibase liquibase(DataSource dataSource) {
+        SpringLiquibase liquibase = new SpringLiquibase();
+        liquibase.setDataSource(dataSource);
+        liquibase.setChangeLog(LIQUIBASE_MASTER_CHANGELOG);
+        liquibase.setShouldRun(false);
+        return liquibase;
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/SecurityConfiguration.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/SecurityConfiguration.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.config;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/scheduling/EchoScheduler.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/scheduling/EchoScheduler.java
@@ -1,4 +1,4 @@
-package io.github.jdubois.bootui.sample;
+package io.github.jdubois.bootui.sample.scheduling;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/web/AdminController.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/web/AdminController.java
@@ -1,0 +1,15 @@
+package io.github.jdubois.bootui.sample.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+    @GetMapping
+    public String admin() {
+        return "BootUI sample admin";
+    }
+}

--- a/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/web/HelloController.java
+++ b/bootui-sample-app/src/main/java/io/github/jdubois/bootui/sample/web/HelloController.java
@@ -1,0 +1,20 @@
+package io.github.jdubois.bootui.sample.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "Hello, world";
+    }
+
+    @GetMapping("/secure")
+    public String secure() {
+        return "Secure Hello, world";
+    }
+}

--- a/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -2,6 +2,8 @@ package io.github.jdubois.bootui.sample;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.jdubois.bootui.sample.catalog.Product;
+import io.github.jdubois.bootui.sample.catalog.ProductRepository;
 import java.net.CookieManager;
 import java.net.HttpCookie;
 import java.net.Proxy;


### PR DESCRIPTION
## What does this PR do?

Reorganizes the `bootui-sample-app` Java code from one flat package (with a 274-line `BootUiSampleApplication` god class holding 6 nested types) into clean feature sub-packages, one class per file.

## Why is this change needed?

The sample app had grown into a single flat `io.github.jdubois.bootui.sample` package where the application class doubled as a controller registry, service, DTO, and config-properties holder. That makes the reference app harder to read and to use as an example of clean Spring Boot structure.

Closes # N/A

## How was it tested?

- [x] `bootui-sample-app` test suite passes locally (40 tests, including the full Testcontainers integration suite that boots the whole app)
- [x] Verified the live `/bootui/api/data/repositories` endpoint returns the relocated `ProductRepository` FQN via the integration test
- [x] `spotless:check` passes
- [x] Added or updated tests where applicable (updated the `data.spec.js` FQN assertion and integration-test imports)

The new package layout:

- `catalog` - `Product`, `ProductRepository`, `ProductSummary`, `SampleCatalog`, `SampleController`, `SampleSettings`
- `chat` - `ChatController`
- `web` - `HelloController`, `AdminController`
- `scheduling` - `EchoScheduler`
- `config` - `SecurityConfiguration`, `NativeHintsConfiguration`, and a new `SampleMigrationConfiguration` (the extracted Flyway/Liquibase demo beans)
- `advisor.hibernate` - the intentional Hibernate-advisor demo entities/repositories
- `advisor.architecture` - `ArchitectureIssuesController`

`BootUiSampleApplication` is now just the entry point, compose-file discovery, and startup logging.

## Behavior / compatibility note

This is a pure refactor with no behavior change. Class names, HTTP paths, cache names, the scheduled task, the `sample.*` config prefix, and the `io.github.jdubois.bootui.sample` base package (used for logging) are all preserved, because the e2e suite and the BootUI advisors key off those (the Hibernate advisor reports findings by simple class name, for example). The only externally visible change is `ProductRepository`'s fully-qualified name (now under `...catalog`), so I updated the one `data.spec.js` assertion that pinned it and added imports in the integration test. The Playwright docs screenshot script uses synthetic package names and is not part of CI, so it was left untouched.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no behaviour change; README references the base package and bean names, which are unchanged)
- [x] Public API kept backward compatible, or a migration note added to the PR description (sample app is not published; see note above)
- [x] No secrets, tokens, or local paths committed