### PR TITLE
Fix VuePress docs anchor links landing on the wrong section

### DIFF
--- a/docs/.vuepress/styles/index.css
+++ b/docs/.vuepress/styles/index.css
@@ -578,6 +578,8 @@ body {
   display: block;
   overflow: hidden;
   width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
   border: 1px solid var(--bootui-border);
   border-radius: 1.1rem;
   box-shadow: var(--bootui-shadow-sm);


### PR DESCRIPTION
## What does this PR do?

Reserves vertical space for the lazy-loaded Features screenshots so deep links like `/features#mcp-server` scroll to the correct heading instead of the section above it.

## Why is this change needed?

After lazy-loading was added to the Features screenshots (#357), the images render with `width: 100%` but no reserved height, so they collapse to ~0px until they load. When the browser jumps to an anchor on initial load, the screenshots above the target are still collapsed, so it scrolls to where the heading currently sits. The lazy images above then load, grow, and push the heading far down, leaving the viewport parked on the previous section.

Concretely, `https://www.julien-dubois.com/boot-ui/features#mcp-server` landed on the CRaC panel. This is a layout-shift problem, not a sidebar/menu problem: the sidebar scroll-sync in `client.js` only scrolls `.vp-sidebar`, never the window.

The fix adds `height: auto; aspect-ratio: 16 / 9;` to the `[vp-content] img[src*='bootui-']` rule. All 45 screenshots are uniformly 1600x900 (16:9), so reserving that ratio gives the page its full height before any image loads. Anchor jumps then land correctly, lazy-loading is preserved, and cumulative layout shift is eliminated (including on the home page overview image).

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

N/A for the above (docs-site-only CSS change). Instead, verified by building the site and driving a headless Chromium probe against the served `dist`:

- Before: `#mcp-server` landed on the `crac` heading, with the real target ~9500px further down.
- After: every probed anchor (`#mcp-server`, `#crac`, `#copilot`, `#health`, `#graalvm`) lands on its own heading.

## Screenshots (UI changes)

N/A (docs site styling only; no Vue UI change).

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (this change is in the docs site itself)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

Note: the docs site (`bootui-site`) has no format tooling and that CSS file already failed the root prettier config before this change, so the edit follows the file's existing 2-space style rather than reformatting the whole file.