### PR TITLE
Traces: show HTTP request path and fully exclude BootUI self-traces

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/BootUiSpanExporter.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/BootUiSpanExporter.java
@@ -36,12 +36,11 @@ public final class BootUiSpanExporter implements SpanExporter {
             return CompletableResultCode.ofSuccess();
         }
         String apiPath = properties.getApiPath();
+        boolean excludeSelf = telemetry.isExcludeSelfSpans();
         for (SpanData span : spans) {
             NormalizedSpan normalized = toNormalized(span);
-            if (telemetry.isExcludeSelfSpans() && TelemetrySpanFilter.isSelfSpan(normalized, apiPath)) {
-                continue;
-            }
-            store.add(normalized);
+            boolean selfSpan = excludeSelf && TelemetrySpanFilter.isSelfSpan(normalized, apiPath);
+            store.add(normalized, selfSpan);
         }
         return CompletableResultCode.ofSuccess();
     }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryStore.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetryStore.java
@@ -20,13 +20,38 @@ public class TelemetryStore {
     static final int HARD_MAX_TRACES = 10_000;
 
     static final int HARD_MAX_SPANS_PER_TRACE = 1_000;
+
+    /**
+     * Upper bound on the number of trace ids remembered as BootUI's own traffic. Spans of a single
+     * trace are exported within a short window, so a generous bound keeps a self trace identifiable
+     * across export batches without growing without limit.
+     */
+    static final int SELF_TRACE_MEMORY = 4_096;
+
     private final BootUiProperties.Telemetry config;
     private final LinkedHashMap<String, TraceBucket> tracesById;
+
+    /**
+     * Trace ids known to belong to BootUI's own API traffic. A trace is remembered here the first
+     * time any of its spans is classified as a self span (for example the path-bearing HTTP server
+     * span for {@code /bootui/api/**}). Sibling spans of the same trace that carry no path
+     * attribute &mdash; such as Spring Security {@code security filterchain before/after}
+     * observations &mdash; are then dropped as well, even when they are exported in an earlier batch
+     * than the root span that identifies the trace.
+     */
+    private final LinkedHashMap<String, Boolean> selfTraceIds;
+
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     public TelemetryStore(BootUiProperties.Telemetry config) {
         this.config = config;
         this.tracesById = new LinkedHashMap<>(256, 0.75f, false);
+        this.selfTraceIds = new LinkedHashMap<>(256, 0.75f, false) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, Boolean> eldest) {
+                return size() > SELF_TRACE_MEMORY;
+            }
+        };
     }
 
     static int effectiveMaxTraces(BootUiProperties.Telemetry config) {
@@ -45,14 +70,37 @@ public class TelemetryStore {
      * Append a span to its trace, evicting the eldest trace when capacity is reached.
      */
     public void add(NormalizedSpan span) {
+        add(span, false);
+    }
+
+    /**
+     * Append a span to its trace unless the span (or any sibling already seen) marks the trace as
+     * BootUI's own traffic.
+     *
+     * @param span the normalized span to store
+     * @param selfSpan {@code true} when the caller has classified this span as BootUI's own (for
+     *     example because it carries a {@code /bootui/**} path); the whole trace is then dropped and
+     *     remembered so its remaining spans are dropped too
+     * @return {@code true} when the span was stored, {@code false} when it was dropped
+     */
+    public boolean add(NormalizedSpan span, boolean selfSpan) {
         if (span == null || span.traceId() == null || span.traceId().isEmpty()) {
-            return;
+            return false;
         }
         lock.writeLock().lock();
         try {
-            TraceBucket bucket = tracesById.remove(span.traceId());
+            String traceId = span.traceId();
+            if (selfSpan) {
+                selfTraceIds.put(traceId, Boolean.TRUE);
+                tracesById.remove(traceId);
+                return false;
+            }
+            if (selfTraceIds.containsKey(traceId)) {
+                return false;
+            }
+            TraceBucket bucket = tracesById.remove(traceId);
             if (bucket == null) {
-                bucket = new TraceBucket(span.traceId());
+                bucket = new TraceBucket(traceId);
                 while (tracesById.size() >= effectiveMaxTraces(config)) {
                     Iterator<Map.Entry<String, TraceBucket>> it =
                             tracesById.entrySet().iterator();
@@ -67,7 +115,8 @@ public class TelemetryStore {
                 bucket.spans.add(span);
             }
             bucket.lastUpdateEpochNanos = Math.max(bucket.lastUpdateEpochNanos, span.endEpochNanos());
-            tracesById.put(span.traceId(), bucket);
+            tracesById.put(traceId, bucket);
+            return true;
         } finally {
             lock.writeLock().unlock();
         }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
@@ -78,13 +78,13 @@ public class OtlpReceiverController {
         try {
             List<NormalizedSpan> spans = decoder.decode(body);
             String apiPath = properties.getApiPath();
+            boolean excludeSelf = telemetry.isExcludeSelfSpans();
             int kept = 0;
             for (NormalizedSpan span : spans) {
-                if (telemetry.isExcludeSelfSpans() && TelemetrySpanFilter.isSelfSpan(span, apiPath)) {
-                    continue;
+                boolean selfSpan = excludeSelf && TelemetrySpanFilter.isSelfSpan(span, apiPath);
+                if (store.add(span, selfSpan)) {
+                    kept++;
                 }
-                store.add(span);
-                kept++;
             }
             if (log.isTraceEnabled()) {
                 log.trace("OTLP receiver stored {} spans (of {} received)", kept, spans.size());

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/TracesController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/TracesController.java
@@ -12,6 +12,7 @@ import io.github.jdubois.bootui.core.dto.SpanEventDto;
 import io.github.jdubois.bootui.core.dto.TraceDetailDto;
 import io.github.jdubois.bootui.core.dto.TraceSummaryDto;
 import io.github.jdubois.bootui.core.dto.TracesReport;
+import java.net.URI;
 import java.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -26,6 +27,15 @@ import org.springframework.web.server.ResponseStatusException;
 public class TracesController {
 
     private static final int MAX_SUMMARY_SERVICES = 20;
+
+    /**
+     * Span attribute keys that can carry an HTTP request path, ordered from the most literal
+     * request path to the most templated/abstract, so the Traces list can label a trace with the
+     * URL path it served instead of a generic root span name such as {@code security filterchain
+     * before}.
+     */
+    private static final List<String> HTTP_PATH_ATTRIBUTE_KEYS =
+            List.of("url.path", "http.target", "http.path", "path", "uri", "http.route", "url.full", "http.url");
 
     private final TelemetryStore store;
 
@@ -89,6 +99,7 @@ public class TracesController {
         return new TraceSummaryDto(
                 bucket.traceId(),
                 rootSpanName,
+                resolveHttpPath(bucket.spans(), earliest),
                 firstServices(services),
                 minStart,
                 maxEnd,
@@ -96,6 +107,96 @@ public class TracesController {
                 bucket.spans().size(),
                 hasError,
                 hasAi);
+    }
+
+    /**
+     * Resolves the HTTP request path a trace served, when one is available, so the Traces list can
+     * show something more useful than the raw root span name. The root span is preferred; otherwise
+     * the earliest server span carrying a path wins, falling back to the earliest span of any kind.
+     */
+    static String resolveHttpPath(Collection<NormalizedSpan> spans, NormalizedSpan root) {
+        String rootPath = httpPath(root);
+        if (rootPath != null) {
+            return rootPath;
+        }
+        if (spans == null) {
+            return null;
+        }
+        NormalizedSpan bestServer = null;
+        String bestServerPath = null;
+        NormalizedSpan bestAny = null;
+        String bestAnyPath = null;
+        for (NormalizedSpan span : spans) {
+            String path = httpPath(span);
+            if (path == null) {
+                continue;
+            }
+            if (bestAny == null || span.startEpochNanos() < bestAny.startEpochNanos()) {
+                bestAny = span;
+                bestAnyPath = path;
+            }
+            if (isServer(span) && (bestServer == null || span.startEpochNanos() < bestServer.startEpochNanos())) {
+                bestServer = span;
+                bestServerPath = path;
+            }
+        }
+        return bestServerPath != null ? bestServerPath : bestAnyPath;
+    }
+
+    static String httpPath(NormalizedSpan span) {
+        if (span == null) {
+            return null;
+        }
+        Map<String, AttributeValue> attributes = span.attributes();
+        if (attributes == null || attributes.isEmpty()) {
+            return null;
+        }
+        for (String key : HTTP_PATH_ATTRIBUTE_KEYS) {
+            AttributeValue value = attributes.get(key);
+            if (value == null) {
+                continue;
+            }
+            String path = normalizePath(value.asString());
+            if (path != null) {
+                return path;
+            }
+        }
+        return null;
+    }
+
+    private static String normalizePath(String raw) {
+        if (raw == null) {
+            return null;
+        }
+        String path = raw.trim();
+        if (path.isEmpty()) {
+            return null;
+        }
+        if (path.contains("://")) {
+            try {
+                String uriPath = URI.create(path).getRawPath();
+                if (uriPath != null && !uriPath.isEmpty()) {
+                    path = uriPath;
+                }
+            } catch (IllegalArgumentException ignored) {
+                // Keep the raw value if it cannot be parsed as a URI.
+            }
+        }
+        int cut = path.length();
+        int query = path.indexOf('?');
+        if (query >= 0) {
+            cut = query;
+        }
+        int fragment = path.indexOf('#');
+        if (fragment >= 0 && fragment < cut) {
+            cut = fragment;
+        }
+        path = path.substring(0, cut).trim();
+        return path.isEmpty() ? null : path;
+    }
+
+    private static boolean isServer(NormalizedSpan span) {
+        return span.kind() != null && span.kind().contains("SERVER");
     }
 
     static SpanDto toSpanDto(NormalizedSpan span) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/otlp/BootUiSpanExporterTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/otlp/BootUiSpanExporterTests.java
@@ -99,6 +99,33 @@ class BootUiSpanExporterTests {
         }
     }
 
+    @Test
+    void dropsChildSpansOfBootUiSelfTraces() {
+        BootUiProperties properties = new BootUiProperties();
+        TelemetryStore store = new TelemetryStore(properties.getTelemetry());
+        SdkTracerProvider provider = tracerProvider(new BootUiSpanExporter(store, properties));
+        try {
+            Tracer tracer = provider.get("bootui-test-scope");
+            // The HTTP server span carries the /bootui path; the nested Spring Security filter-chain
+            // span does not. With SimpleSpanProcessor the child is exported when it ends (before the
+            // parent), mirroring how OpenTelemetry batches spans in production.
+            Span root = tracer.spanBuilder("http get /bootui/api/traces")
+                    .setSpanKind(SpanKind.SERVER)
+                    .setAttribute("http.route", "/bootui/api/traces")
+                    .startSpan();
+            Span child = tracer.spanBuilder("security filterchain before")
+                    .setParent(io.opentelemetry.context.Context.current().with(root))
+                    .startSpan();
+            child.end();
+            root.end();
+            provider.forceFlush().join(1, TimeUnit.SECONDS);
+
+            assertThat(store.retainedTraceCount()).isZero();
+        } finally {
+            provider.shutdown().join(1, TimeUnit.SECONDS);
+        }
+    }
+
     private SdkTracerProvider tracerProvider(BootUiSpanExporter exporter) {
         return SdkTracerProvider.builder()
                 .setResource(Resource.create(Attributes.of(SERVICE_NAME, "sample-service")))

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetrySelfTraceTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/otlp/TelemetrySelfTraceTests.java
@@ -1,0 +1,83 @@
+package io.github.jdubois.bootui.autoconfigure.otlp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TelemetrySelfTraceTests {
+
+    private static final String TRACE = "0123456789abcdef0123456789abcdef";
+
+    @Test
+    void dropsChildSpanWhenRootSelfSpanArrivesFirst() {
+        TelemetryStore store = new TelemetryStore(new BootUiProperties().getTelemetry());
+
+        assertThat(store.add(httpRoot(), true)).isFalse();
+        assertThat(store.add(securityFilterChain(), false)).isFalse();
+
+        assertThat(store.retainedTraceCount()).isZero();
+        assertThat(store.findTrace(TRACE)).isNull();
+    }
+
+    @Test
+    void purgesAlreadyStoredChildSpansWhenRootSelfSpanArrivesLater() {
+        TelemetryStore store = new TelemetryStore(new BootUiProperties().getTelemetry());
+
+        // Spring Security "security filterchain before" ends (and is exported) before the
+        // path-bearing HTTP server span that identifies the trace as BootUI's own traffic.
+        assertThat(store.add(securityFilterChain(), false)).isTrue();
+        assertThat(store.retainedTraceCount()).isEqualTo(1);
+
+        assertThat(store.add(httpRoot(), true)).isFalse();
+
+        assertThat(store.retainedTraceCount()).isZero();
+        assertThat(store.findTrace(TRACE)).isNull();
+    }
+
+    @Test
+    void keepsTracesThatAreNotBootUiTraffic() {
+        TelemetryStore store = new TelemetryStore(new BootUiProperties().getTelemetry());
+
+        assertThat(store.add(span("app-trace", "root", null, "GET /api/orders", Map.of()), false))
+                .isTrue();
+        assertThat(store.add(span("app-trace", "child", "root", "security filterchain before", Map.of()), false))
+                .isTrue();
+
+        assertThat(store.retainedTraceCount()).isEqualTo(1);
+        assertThat(store.findTrace("app-trace").spans()).hasSize(2);
+    }
+
+    private static NormalizedSpan httpRoot() {
+        return span(TRACE, "1111111111111111", null, "http get /bootui/api/traces", Map.of());
+    }
+
+    private static NormalizedSpan securityFilterChain() {
+        return span(
+                TRACE,
+                "2222222222222222",
+                "1111111111111111",
+                "security filterchain before",
+                Map.of("spring.security.filterchain.position", AttributeValue.ofString("0/14")));
+    }
+
+    private static NormalizedSpan span(
+            String traceId, String spanId, String parentSpanId, String name, Map<String, AttributeValue> attributes) {
+        return new NormalizedSpan(
+                traceId,
+                spanId,
+                parentSpanId,
+                name,
+                "SERVER",
+                "sample",
+                "test",
+                1L,
+                2L,
+                "OK",
+                null,
+                attributes,
+                List.of());
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverControllerTests.java
@@ -37,9 +37,13 @@ class OtlpReceiverControllerTests {
 
     private static final String TRACE_ID = "0123456789abcdef0123456789abcdef";
 
+    private static final String HOST_TRACE_ID = "fedcba9876543210fedcba9876543210";
+
     private static final String HOST_SPAN_ID = "1111111111111111";
 
     private static final String SELF_SPAN_ID = "2222222222222222";
+
+    private static final String SELF_CHILD_SPAN_ID = "3333333333333333";
 
     private BootUiProperties properties;
 
@@ -83,7 +87,7 @@ class OtlpReceiverControllerTests {
     private static Span hostSpan() {
         long now = System.currentTimeMillis() * 1_000_000L;
         return Span.newBuilder()
-                .setTraceId(bytes(TRACE_ID))
+                .setTraceId(bytes(HOST_TRACE_ID))
                 .setSpanId(bytes(HOST_SPAN_ID))
                 .setName("chat qwen3")
                 .setKind(Span.SpanKind.SPAN_KIND_CLIENT)
@@ -110,6 +114,27 @@ class OtlpReceiverControllerTests {
                         .setCode(Status.StatusCode.STATUS_CODE_OK)
                         .build())
                 .addAttributes(stringAttr("http.route", "/bootui/api/overview"))
+                .build();
+    }
+
+    /**
+     * A nested Spring Security observation span that belongs to the same BootUI request as
+     * {@link #selfSpan()} but carries no path attribute, so it can only be recognized as BootUI's
+     * own through its trace association.
+     */
+    private static Span selfFilterChainSpan() {
+        long now = System.currentTimeMillis() * 1_000_000L;
+        return Span.newBuilder()
+                .setTraceId(bytes(TRACE_ID))
+                .setSpanId(bytes(SELF_CHILD_SPAN_ID))
+                .setParentSpanId(bytes(SELF_SPAN_ID))
+                .setName("security filterchain before")
+                .setKind(Span.SpanKind.SPAN_KIND_INTERNAL)
+                .setStartTimeUnixNano(now)
+                .setEndTimeUnixNano(now + 1_000_000L)
+                .setStatus(Status.newBuilder()
+                        .setCode(Status.StatusCode.STATUS_CODE_OK)
+                        .build())
                 .build();
     }
 
@@ -194,12 +219,16 @@ class OtlpReceiverControllerTests {
     }
 
     @Test
-    void dropsOnlySelfSpansFromMixedPayload() throws Exception {
+    void dropsWholeSelfTraceButKeepsUnrelatedHostTrace() throws Exception {
+        // The self request contributes both its path-bearing root and a nested filter-chain span
+        // that carries no path; both must be dropped, while the unrelated host trace is kept.
         mvc.perform(post("/bootui/api/otlp/v1/traces")
                         .contentType("application/x-protobuf")
-                        .content(request(selfSpan(), hostSpan()).toByteArray()))
+                        .content(request(selfFilterChainSpan(), hostSpan(), selfSpan())
+                                .toByteArray()))
                 .andExpect(status().isOk());
 
+        assertThat(store.findTrace(TRACE_ID)).isNull();
         assertThat(store.allSpansSnapshot()).hasSize(1);
         assertThat(store.allSpansSnapshot().get(0).spanId()).isEqualTo(HOST_SPAN_ID);
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/TracesControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/TracesControllerTests.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,6 +10,7 @@ import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.otlp.AttributeValue;
 import io.github.jdubois.bootui.autoconfigure.otlp.NormalizedSpan;
 import io.github.jdubois.bootui.autoconfigure.otlp.TelemetryStore;
+import io.github.jdubois.bootui.core.dto.TraceSummaryDto;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -29,10 +31,91 @@ class TracesControllerTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.retained").value(1))
                 .andExpect(jsonPath("$.traces.length()").value(1))
-                .andExpect(jsonPath("$.traces[0].traceId").value("host-trace"));
+                .andExpect(jsonPath("$.traces[0].traceId").value("host-trace"))
+                .andExpect(jsonPath("$.traces[0].httpPath").value("/api/orders"));
 
         mvc.perform(get("/bootui/api/traces/bootui-trace")).andExpect(status().isNotFound());
         mvc.perform(get("/bootui/api/traces/host-trace")).andExpect(status().isOk());
+    }
+
+    @Test
+    void summaryExposesHttpPathFromRootServerSpan() {
+        NormalizedSpan root = new NormalizedSpan(
+                "trace",
+                "root",
+                null,
+                "security filterchain before",
+                "INTERNAL",
+                "sample",
+                "test",
+                1L,
+                5L,
+                "OK",
+                null,
+                Map.of("url.path", AttributeValue.ofString("/api/products/42?page=1")),
+                List.of());
+
+        TraceSummaryDto summary = TracesController.toSummary(bucketOf(root));
+
+        assertThat(summary.rootSpanName()).isEqualTo("security filterchain before");
+        assertThat(summary.httpPath()).isEqualTo("/api/products/42");
+    }
+
+    @Test
+    void summaryFallsBackToServerSpanWhenRootHasNoPath() {
+        NormalizedSpan root = new NormalizedSpan(
+                "trace", "root", null, "GET", "INTERNAL", "sample", "test", 1L, 9L, "OK", null, Map.of(), List.of());
+        NormalizedSpan server = new NormalizedSpan(
+                "trace",
+                "child",
+                "root",
+                "GET /api/orders",
+                "SERVER",
+                "sample",
+                "test",
+                2L,
+                8L,
+                "OK",
+                null,
+                Map.of("http.route", AttributeValue.ofString("/api/orders/{id}")),
+                List.of());
+
+        TraceSummaryDto summary = TracesController.toSummary(bucketOf(root, server));
+
+        assertThat(summary.httpPath()).isEqualTo("/api/orders/{id}");
+    }
+
+    @Test
+    void summaryLeavesHttpPathNullWhenNoPathAttributeIsPresent() {
+        NormalizedSpan root = new NormalizedSpan(
+                "trace",
+                "root",
+                null,
+                "scheduled task",
+                "INTERNAL",
+                "sample",
+                "test",
+                1L,
+                2L,
+                "OK",
+                null,
+                Map.of("code.function", AttributeValue.ofString("run")),
+                List.of());
+
+        TraceSummaryDto summary = TracesController.toSummary(bucketOf(root));
+
+        assertThat(summary.rootSpanName()).isEqualTo("scheduled task");
+        assertThat(summary.httpPath()).isNull();
+    }
+
+    private static TelemetryStore.TraceBucket bucketOf(NormalizedSpan... spans) {
+        TelemetryStore store = new TelemetryStore(new BootUiProperties().getTelemetry());
+        String traceId = null;
+        for (NormalizedSpan span : spans) {
+            store.add(span);
+            traceId = span.traceId();
+        }
+        return store.findTrace(traceId);
     }
 
     private static NormalizedSpan span(String traceId, String spanId, String parentSpanId, String name, String route) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TraceSummaryDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TraceSummaryDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 public record TraceSummaryDto(
         String traceId,
         String rootSpanName,
+        String httpPath,
         List<String> services,
         long startEpochNanos,
         long endEpochNanos,

--- a/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -672,6 +672,7 @@ const traceReport = {
     {
       traceId,
       rootSpanName: 'POST /api/chat',
+      httpPath: '/api/chat',
       services: ['bootui-sample', 'ollama', 'redis'],
       startEpochNanos: nowNanos - 45_000_000_000,
       endEpochNanos: nowNanos - 43_780_000_000,
@@ -683,6 +684,7 @@ const traceReport = {
     {
       traceId: 'fedcba9876543210fedcba9876543210',
       rootSpanName: 'GET /api/sample/products',
+      httpPath: '/api/sample/products',
       services: ['bootui-sample', 'postgres'],
       startEpochNanos: nowNanos - 23_000_000_000,
       endEpochNanos: nowNanos - 22_870_000_000,

--- a/bootui-sample-app/e2e/tests/traces.spec.js
+++ b/bootui-sample-app/e2e/tests/traces.spec.js
@@ -10,7 +10,8 @@ const traceReport = {
   traces: [
     {
       traceId,
-      rootSpanName: 'GET /api/sample/hello',
+      rootSpanName: 'security filterchain before',
+      httpPath: '/api/sample/hello',
       services: ['sample-app', 'inventory'],
       startEpochNanos: Date.now() * 1_000_000,
       endEpochNanos: Date.now() * 1_000_000 + 125_000_000,
@@ -78,7 +79,7 @@ test.describe('Traces view', () => {
 
     await openView('traces', /^Traces/)
     await expect(page.getByText('1 / 500 retained trace')).toBeVisible()
-    const traceRow = page.locator('tbody tr', {hasText: 'GET /api/sample/hello'})
+    const traceRow = page.locator('tbody tr', {hasText: '/api/sample/hello'})
     await expect(traceRow).toBeVisible()
     await expect(page.getByText('sample-app')).toBeVisible()
     await expect(traceRow.getByText('AI', {exact: true})).toBeVisible()

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -95,6 +95,7 @@ const filteredTraces = computed(() => {
   return report.value.traces.filter(
     (t) =>
       (t.traceId || '').toLowerCase().includes(v) ||
+      (t.httpPath || '').toLowerCase().includes(v) ||
       (t.rootSpanName || '').toLowerCase().includes(v) ||
       (t.services || []).join(' ').toLowerCase().includes(v)
   )
@@ -182,7 +183,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
           <input
             v-model="filter"
             class="form-control form-control-sm"
-            placeholder="Filter by trace id, root span, or service…"
+            placeholder="Filter by trace id, path, root span, or service…"
           />
         </div>
 
@@ -191,7 +192,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
             <thead>
               <tr>
                 <th>Started</th>
-                <th>Root span</th>
+                <th>Request</th>
                 <th>Services</th>
                 <th>Spans</th>
                 <th>Duration</th>
@@ -205,7 +206,11 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
                   <td class="text-muted small">{{ formatTime(t.startEpochNanos) }}</td>
                   <td>
                     <code class="me-2">{{ shortId(t.traceId) }}</code>
-                    <span class="fw-semibold">{{ t.rootSpanName || '—' }}</span>
+                    <span
+                      class="fw-semibold"
+                      :title="t.httpPath && t.rootSpanName && t.httpPath !== t.rootSpanName ? t.rootSpanName : null"
+                      >{{ t.httpPath || t.rootSpanName || '—' }}</span
+                    >
                     <span v-if="t.hasAi" class="badge text-bg-info ms-1"><i class="bi bi-stars"></i> AI</span>
                   </td>
                   <td>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -601,10 +601,14 @@ The Traces panel shows distributed tracing spans captured locally by the BootUI 
 panel are enabled. The starter contributes the tracing dependencies and sampling default needed for local development, so
 the host application does not need manual `management.*` tracing properties. BootUI also keeps an embedded OTLP/HTTP
 receiver at `/bootui/api/otlp/v1/traces` so cooperating local services can export spans into the same in-memory store.
-The list shows the most recent traces with service name, root span name, status, duration, and span count; opening a trace
+The list shows the most recent traces with service name, the HTTP request path each trace served (falling back to the
+root span name when no path attribute is present), status, duration, and span count; opening a trace
 renders a waterfall view of its spans so you can see latency contributions, errors, and parent/child relationships across
-services. Spans emitted by BootUI's own API are filtered out on ingestion by default, and retained self-only traces are
-hidden from the panel, to keep the view focused on application traffic. Span ingestion can be tuned with
+services. Traces emitted by BootUI's own API are filtered out on ingestion by default: as soon as any span in a trace is
+recognized as BootUI traffic (for example the path-bearing HTTP server span for `/bootui/api/**`), the whole trace is
+dropped, including nested spans that carry no path of their own such as Spring Security `security filterchain
+before`/`after` observations. Retained self-only traces are also hidden from the panel, to keep the view focused on
+application traffic. Span ingestion can be tuned with
 `bootui.telemetry.exclude-self-spans=false`; read-time panel filtering follows `bootui.monitoring.exclude-self`. When
 `bootui.telemetry.enabled=false`, the sidebar dims the panel and the view shows a disabled state instead of implying that
 tracing is merely empty. The in-memory trace buffer is bounded by `bootui.telemetry.max-traces`,


### PR DESCRIPTION
## What does this PR do?

Labels traces in the Traces panel with the HTTP request path they served, and stops BootUI's own API traffic from leaking into the panel as orphaned `security filterchain before/after` traces.

## Why is this change needed?

Two related issues with the Traces panel:

1. The list labelled each trace with its root span name, which is often a generic Spring Security observation like `security filterchain before` rather than the request that was served.
2. Those `security filterchain before/after` entries showed up constantly, even with no sample-app traffic. They were actually BootUI's own UI polling of `/bootui/api/*`. Self-span filtering ran per span: the path-bearing `/bootui` HTTP server span was dropped, but its nested spans carry no path of their own, so they survived as orphaned traces that the read-time filter could no longer recognize as BootUI's.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Test scope run locally for this change:

- `bootui-autoconfigure` test suite (full module) green, including new/updated coverage:
  - `TelemetrySelfTraceTests` (new) for both span orderings (root-first and child-first).
  - `BootUiSpanExporterTests` end-to-end case reproducing the child-exported-before-root scenario.
  - `OtlpReceiverControllerTests` tightened so the leaking sibling span is dropped while an unrelated host trace survives.
  - `TracesControllerTests` for HTTP-path resolution (root server span, server-span fallback, and null-when-no-path).
- Frontend Vitest suite (210 tests) green.
- `spotless:check` (Java) and Prettier checks clean for the touched files.

## Screenshots (UI changes)

The Traces list "Root span" column is renamed to "Request" and now renders the HTTP path (for example `/api/sample/products`) instead of `security filterchain before`. When a path is shown, the underlying root span name is available as a hover tooltip, and the filter box matches on the path too.

## Approach notes

- The HTTP path is resolved in `TracesController` from a prioritized set of span attributes (`url.path`, `http.target`, `http.path`, `path`, `uri`, `http.route`, `url.full`, `http.url`), preferring the root span, then the earliest server span, then any span. Full URLs are reduced to their path and query/fragment are stripped. `TraceSummaryDto` gains a nullable `httpPath`; `rootSpanName` is kept as the fallback and tooltip.
- Self-span filtering is now trace-level. `TelemetryStore` remembers trace ids identified as BootUI traffic (bounded LRU). The moment any span marks a trace as self, the whole trace is dropped and remembered, so sibling spans arriving in earlier or later OTLP export batches are dropped too. This is wired through both ingestion paths (the in-process `BootUiSpanExporter` and the `/bootui/api/otlp` receiver); the read-time filter remains as a backstop for externally received self-only traces.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

Backward-compatibility note: `TelemetryStore.add(NormalizedSpan)` is preserved and delegates to the new `add(NormalizedSpan, boolean)` overload; `TraceSummaryDto` only adds a nullable field, so the serialized JSON shape stays additive.