### PR TITLE
Use https scheme in startup banner when SSL is enabled

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -538,10 +538,15 @@ public class BootUiAutoConfiguration {
             if (!properties.isShowBanner()) {
                 return;
             }
-            String port = environment.getProperty("local.server.port", environment.getProperty("server.port", "8080"));
-            String contextPath = environment.getProperty("server.servlet.context-path", "");
-            String url = "http://localhost:" + port + contextPath + properties.getPath();
-            log.info("BootUI is available at {}", url);
+            log.info("BootUI is available at {}", buildStartupUrl(environment, properties));
         };
+    }
+
+    static String buildStartupUrl(Environment environment, BootUiProperties properties) {
+        boolean sslEnabled = environment.getProperty("server.ssl.enabled", Boolean.class, false);
+        String scheme = sslEnabled ? "https" : "http";
+        String port = environment.getProperty("local.server.port", environment.getProperty("server.port", "8080"));
+        String contextPath = environment.getProperty("server.servlet.context-path", "");
+        return scheme + "://localhost:" + port + contextPath + properties.getPath();
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiStartupBannerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiStartupBannerTests.java
@@ -1,0 +1,76 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class BootUiStartupBannerTests {
+
+    private final BootUiProperties properties = new BootUiProperties();
+
+    @Test
+    void usesHttpSchemeByDefault() {
+        MockEnvironment environment = new MockEnvironment();
+
+        assertThat(BootUiAutoConfiguration.buildStartupUrl(environment, properties))
+                .isEqualTo("http://localhost:8080/bootui");
+    }
+
+    @Test
+    void usesHttpsSchemeWhenSslEnabled() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("server.ssl.enabled", "true");
+
+        assertThat(BootUiAutoConfiguration.buildStartupUrl(environment, properties))
+                .isEqualTo("https://localhost:8080/bootui");
+    }
+
+    @Test
+    void usesHttpSchemeWhenSslExplicitlyDisabled() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("server.ssl.enabled", "false");
+
+        assertThat(BootUiAutoConfiguration.buildStartupUrl(environment, properties))
+                .isEqualTo("http://localhost:8080/bootui");
+    }
+
+    @Test
+    void usesConfiguredServerPort() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("server.port", "9443");
+        environment.setProperty("server.ssl.enabled", "true");
+
+        assertThat(BootUiAutoConfiguration.buildStartupUrl(environment, properties))
+                .isEqualTo("https://localhost:9443/bootui");
+    }
+
+    @Test
+    void prefersLocalServerPortOverServerPort() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("server.port", "0");
+        environment.setProperty("local.server.port", "54321");
+
+        assertThat(BootUiAutoConfiguration.buildStartupUrl(environment, properties))
+                .isEqualTo("http://localhost:54321/bootui");
+    }
+
+    @Test
+    void includesServletContextPath() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("server.servlet.context-path", "/app");
+        environment.setProperty("server.ssl.enabled", "true");
+
+        assertThat(BootUiAutoConfiguration.buildStartupUrl(environment, properties))
+                .isEqualTo("https://localhost:8080/app/bootui");
+    }
+
+    @Test
+    void honorsCustomBootUiPath() {
+        MockEnvironment environment = new MockEnvironment();
+        properties.setPath("/console");
+
+        assertThat(BootUiAutoConfiguration.buildStartupUrl(environment, properties))
+                .isEqualTo("http://localhost:8080/console");
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -119,6 +119,10 @@ When BootUI is enabled, the application startup output should include:
 BootUI is available at http://localhost:8080/bootui
 ```
 
+The scheme follows `server.ssl.enabled`: when TLS is enabled the banner uses `https://`
+instead of `http://`. The port and context path are resolved from `local.server.port`
+(falling back to `server.port`, then `8080`) and `server.servlet.context-path`.
+
 This should integrate with the project's startup banner convention.
 
 ### 4.4 First-run experience


### PR DESCRIPTION
## What does this PR do?

Makes the BootUI startup banner log an `https://` URL when the host app serves over TLS, instead of always printing `http://`.

## Why is this change needed?

When the application enables TLS via `server.ssl.enabled=true`, BootUI still logged `BootUI is available at http://localhost:8080/bootui`. That `http` URL is not reachable on an HTTPS-only server, so the link in the logs was broken.

The banner now reads `server.ssl.enabled` (Boolean, default `false`) and selects the `https`/`http` scheme accordingly. The URL building was extracted into a small package-private `buildStartupUrl(Environment, BootUiProperties)` helper so it is unit-testable without booting a full web context. Existing precedence is preserved: `local.server.port` then `server.port` then `8080`, plus `server.servlet.context-path`. Behavior is unchanged when SSL is off.

Closes #373
Fixes: #373

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Added `BootUiStartupBannerTests` (7 cases via `MockEnvironment`): default http, https when SSL enabled, explicit SSL disabled, custom `server.port`, `local.server.port` precedence, `server.servlet.context-path`, and a custom BootUI path. Ran `spotless:apply`/`spotless:check` (clean) and the `bootui-core` + `bootui-autoconfigure` reactor build, all green.

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed