### PR TITLE
fix: warning plugin @vuepress/plugin-markdown-tab has been used multiple times

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,7 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import {viteBundler} from '@vuepress/bundler-vite'
-import {markdownTabPlugin} from '@vuepress/plugin-markdown-tab'
 import {defaultTheme} from '@vuepress/theme-default'
 import {defineUserConfig} from 'vuepress'
 import {inferRoutePath} from 'vuepress/shared'
@@ -27,8 +26,7 @@ export default defineUserConfig({
   plugins: [
     cleanDocsPermalinksPlugin(),
     cleanMarkdownDocLinksPlugin(),
-    lazyLoadMarkdownImagesPlugin(),
-    markdownTabPlugin({tabs: true, codeTabs: true})
+    lazyLoadMarkdownImagesPlugin()
   ],
   theme: defaultTheme({
     hostname: 'https://www.julien-dubois.com',


### PR DESCRIPTION
## What does this PR do?

Before
<img width="787" height="104" alt="image" src="https://github.com/user-attachments/assets/04225dc9-9f5f-492a-b828-fb933e2a0124" />

After
<img width="585" height="89" alt="image" src="https://github.com/user-attachments/assets/117004fe-e98c-406e-b3af-c02eaef0bc18" />

`@vuepress/theme-default` already defined `markdownTabPlugin` with same options

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
