### PR TITLE
feat: add keyboard shortcuts and number-key navigation to command palette

### DIFF
--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -62,277 +62,277 @@ export const routes = [
     path: '/overview',
     name: 'overview',
     component: Overview,
-    meta: {group: groups.overview, icon: 'bi-speedometer2', title: 'Overview'}
+    meta: {group: groups.overview, icon: 'bi-speedometer2', title: 'Overview', shortcut: 'ov'}
   },
   {
     path: '/github',
     name: 'github',
     component: GitHub,
-    meta: {group: groups.overview, icon: 'bi-github', title: 'GitHub'}
+    meta: {group: groups.overview, icon: 'bi-github', title: 'GitHub', shortcut: 'gh'}
   },
   {
     path: '/architecture',
     name: 'architecture',
     component: Architecture,
-    meta: {group: groups.advisors, icon: 'bi-diagram-2', title: 'Architecture'}
+    meta: {group: groups.advisors, icon: 'bi-diagram-2', title: 'Architecture', shortcut: 'ar'}
   },
   {
     path: '/rest-api',
     name: 'rest-api',
     component: RestApi,
-    meta: {group: groups.advisors, icon: 'bi-signpost-split', title: 'REST API'}
+    meta: {group: groups.advisors, icon: 'bi-signpost-split', title: 'REST API', shortcut: 'ra'}
   },
   {
     path: '/spring',
     name: 'spring',
     component: Spring,
-    meta: {group: groups.advisors, icon: 'bi-leaf', title: 'Spring'}
+    meta: {group: groups.advisors, icon: 'bi-leaf', title: 'Spring', shortcut: 'sr'}
   },
   {
     path: '/hibernate',
     name: 'hibernate',
     component: Hibernate,
-    meta: {group: groups.advisors, icon: 'bi-database-gear', title: 'Hibernate'}
+    meta: {group: groups.advisors, icon: 'bi-database-gear', title: 'Hibernate', shortcut: 'hb'}
   },
   {
     path: '/memory',
     name: 'memory',
     component: Memory,
-    meta: {group: groups.advisors, icon: 'bi-clipboard2-pulse', title: 'Memory'}
+    meta: {group: groups.advisors, icon: 'bi-clipboard2-pulse', title: 'Memory', shortcut: 'mm'}
   },
   {
     path: '/security',
     name: 'security',
     component: Security,
-    meta: {group: groups.advisors, icon: 'bi-shield-check', title: 'Security'}
+    meta: {group: groups.advisors, icon: 'bi-shield-check', title: 'Security', shortcut: 'sc'}
   },
   {
     path: '/pentesting',
     name: 'pentesting',
     component: Pentesting,
-    meta: {group: groups.advisors, icon: 'bi-shield-exclamation', title: 'Pentesting'}
+    meta: {group: groups.advisors, icon: 'bi-shield-exclamation', title: 'Pentesting', shortcut: 'pt'}
   },
   {
     path: '/vulnerabilities',
     name: 'vulnerabilities',
     component: Vulnerabilities,
-    meta: {group: groups.advisors, icon: 'bi-bug', title: 'Vulnerabilities'}
+    meta: {group: groups.advisors, icon: 'bi-bug', title: 'Vulnerabilities', shortcut: 'vu'}
   },
   {
     path: '/health',
     name: 'health',
     component: Health,
-    meta: {group: groups.runtime, icon: 'bi-heart-pulse', title: 'Health'}
+    meta: {group: groups.runtime, icon: 'bi-heart-pulse', title: 'Health', shortcut: 'hl'}
   },
   {
     path: '/http-sessions',
     name: 'http-sessions',
     component: HttpSessions,
-    meta: {group: groups.runtime, icon: 'bi-cookie', title: 'HTTP Sessions'}
+    meta: {group: groups.runtime, icon: 'bi-cookie', title: 'HTTP Sessions', shortcut: 'hs'}
   },
   {
     path: '/metrics',
     name: 'metrics',
     component: Metrics,
-    meta: {group: groups.runtime, icon: 'bi-activity', title: 'Metrics'}
+    meta: {group: groups.runtime, icon: 'bi-activity', title: 'Metrics', shortcut: 'mt'}
   },
   {
     path: '/live-memory',
     name: 'live-memory',
     component: LiveMemory,
-    meta: {group: groups.runtime, icon: 'bi-memory', title: 'Live Memory'}
+    meta: {group: groups.runtime, icon: 'bi-memory', title: 'Live Memory', shortcut: 'lm'}
   },
   {
     path: '/jvm-tuning',
     name: 'jvm-tuning',
     component: JvmTuning,
-    meta: {group: groups.runtime, icon: 'bi-sliders2-vertical', title: 'JVM Tuning'}
+    meta: {group: groups.runtime, icon: 'bi-sliders2-vertical', title: 'JVM Tuning', shortcut: 'jv'}
   },
   {
     path: '/heap-dump',
     name: 'heap-dump',
     component: HeapDump,
-    meta: {group: groups.runtime, icon: 'bi-file-earmark-binary', title: 'Heap Dump'}
+    meta: {group: groups.runtime, icon: 'bi-file-earmark-binary', title: 'Heap Dump', shortcut: 'hd'}
   },
   {
     path: '/threads',
     name: 'threads',
     component: Threads,
-    meta: {group: groups.runtime, icon: 'bi-list-task', title: 'Threads'}
+    meta: {group: groups.runtime, icon: 'bi-list-task', title: 'Threads', shortcut: 'th'}
   },
   {
     path: '/startup',
     name: 'startup',
     component: Startup,
-    meta: {group: groups.runtime, icon: 'bi-bar-chart-steps', title: 'Startup Timeline'}
+    meta: {group: groups.runtime, icon: 'bi-bar-chart-steps', title: 'Startup Timeline', shortcut: 'su'}
   },
   {
     path: '/graalvm',
     name: 'graalvm',
     component: GraalVm,
-    meta: {group: groups.runtime, icon: 'bi-rocket-takeoff', title: 'GraalVM'}
+    meta: {group: groups.runtime, icon: 'bi-rocket-takeoff', title: 'GraalVM', shortcut: 'gv'}
   },
   {
     path: '/crac',
     name: 'crac',
     component: Crac,
-    meta: {group: groups.runtime, icon: 'bi-camera', title: 'CRaC'}
+    meta: {group: groups.runtime, icon: 'bi-camera', title: 'CRaC', shortcut: 'cr'}
   },
   {
     path: '/config',
     name: 'config',
     component: Config,
-    meta: {group: groups.configuration, icon: 'bi-sliders', title: 'Configuration'}
+    meta: {group: groups.configuration, icon: 'bi-sliders', title: 'Configuration', shortcut: 'cf'}
   },
   {
     path: '/profile-diff',
     name: 'profile-diff',
     component: ProfileDiff,
-    meta: {group: groups.configuration, icon: 'bi-layers', title: 'Profile Diff'}
+    meta: {group: groups.configuration, icon: 'bi-layers', title: 'Profile Diff', shortcut: 'pd'}
   },
   {
     path: '/loggers',
     name: 'loggers',
     component: Loggers,
-    meta: {group: groups.configuration, icon: 'bi-journal-text', title: 'Loggers'}
+    meta: {group: groups.configuration, icon: 'bi-journal-text', title: 'Loggers', shortcut: 'lg'}
   },
   {
     path: '/beans',
     name: 'beans',
     component: Beans,
-    meta: {group: groups.configuration, icon: 'bi-diagram-3', title: 'Beans'}
+    meta: {group: groups.configuration, icon: 'bi-diagram-3', title: 'Beans', shortcut: 'bn'}
   },
   {
     path: '/conditions',
     name: 'conditions',
     component: Conditions,
-    meta: {group: groups.configuration, icon: 'bi-check2-circle', title: 'Conditions'}
+    meta: {group: groups.configuration, icon: 'bi-check2-circle', title: 'Conditions', shortcut: 'cd'}
   },
   {
     path: '/mappings',
     name: 'mappings',
     component: Mappings,
-    meta: {group: groups.configuration, icon: 'bi-signpost-2', title: 'Mappings'}
+    meta: {group: groups.configuration, icon: 'bi-signpost-2', title: 'Mappings', shortcut: 'mp'}
   },
   {
     path: '/database-connection-pools',
     name: 'database-connection-pools',
     component: DatabaseConnectionPools,
-    meta: {group: groups.database, icon: 'bi-hdd-network', title: 'Database Connection Pools'}
+    meta: {group: groups.database, icon: 'bi-hdd-network', title: 'Database Connection Pools', shortcut: 'dc'}
   },
   {
     path: '/sql-trace',
     name: 'sql-trace',
     component: SqlTrace,
-    meta: {group: groups.database, icon: 'bi-stopwatch', title: 'SQL Trace'}
+    meta: {group: groups.database, icon: 'bi-stopwatch', title: 'SQL Trace', shortcut: 'sq'}
   },
   {
     path: '/data',
     name: 'data',
     component: Data,
-    meta: {group: groups.database, icon: 'bi-database', title: 'Spring Data'}
+    meta: {group: groups.database, icon: 'bi-database', title: 'Spring Data', shortcut: 'sd'}
   },
   {
     path: '/flyway',
     name: 'flyway',
     component: Flyway,
-    meta: {group: groups.database, icon: 'bi-arrow-up-right-circle', title: 'Flyway'}
+    meta: {group: groups.database, icon: 'bi-arrow-up-right-circle', title: 'Flyway', shortcut: 'fw'}
   },
   {
     path: '/liquibase',
     name: 'liquibase',
     component: Liquibase,
-    meta: {group: groups.database, icon: 'bi-droplet', title: 'Liquibase'}
+    meta: {group: groups.database, icon: 'bi-droplet', title: 'Liquibase', shortcut: 'lb'}
   },
   {
     path: '/spring-security',
     name: 'spring-security',
     component: SpringSecurity,
-    meta: {group: groups.security, icon: 'bi-person-lock', title: 'Spring Security'}
+    meta: {group: groups.security, icon: 'bi-person-lock', title: 'Spring Security', shortcut: 'ss'}
   },
   {
     path: '/security-logs',
     name: 'security-logs',
     component: SecurityLogs,
-    meta: {group: groups.security, icon: 'bi-shield-lock', title: 'Security Logs'}
+    meta: {group: groups.security, icon: 'bi-shield-lock', title: 'Security Logs', shortcut: 'sl'}
   },
   {
     path: '/scheduled',
     name: 'scheduled',
     component: Scheduled,
-    meta: {group: groups.services, icon: 'bi-clock-history', title: 'Scheduled Tasks'}
+    meta: {group: groups.services, icon: 'bi-clock-history', title: 'Scheduled Tasks', shortcut: 'sk'}
   },
   {
     path: '/spring-cache',
     name: 'spring-cache',
     component: SpringCache,
-    meta: {group: groups.services, icon: 'bi-hdd-stack', title: 'Spring Cache'}
+    meta: {group: groups.services, icon: 'bi-hdd-stack', title: 'Spring Cache', shortcut: 'ca'}
   },
   {
     path: '/ai',
     name: 'ai',
     component: Ai,
-    meta: {group: groups.services, icon: 'bi-cpu', title: 'AI Usage'}
+    meta: {group: groups.services, icon: 'bi-cpu', title: 'AI Usage', shortcut: 'ai'}
   },
   {
     path: '/traces',
     name: 'traces',
     component: Traces,
-    meta: {group: groups.diagnostics, icon: 'bi-bezier2', title: 'Traces'}
+    meta: {group: groups.diagnostics, icon: 'bi-bezier2', title: 'Traces', shortcut: 'tr'}
   },
   {
     path: '/log-tail',
     name: 'log-tail',
     component: LogTail,
-    meta: {group: groups.diagnostics, icon: 'bi-terminal', title: 'Log Tail'}
+    meta: {group: groups.diagnostics, icon: 'bi-terminal', title: 'Log Tail', shortcut: 'lt'}
   },
   {
     path: '/exceptions',
     name: 'exceptions',
     component: Exceptions,
-    meta: {group: groups.diagnostics, icon: 'bi-exclamation-octagon', title: 'Exceptions'}
+    meta: {group: groups.diagnostics, icon: 'bi-exclamation-octagon', title: 'Exceptions', shortcut: 'ex'}
   },
   {
     path: '/http-exchanges',
     name: 'http-exchanges',
     component: HttpExchanges,
-    meta: {group: groups.diagnostics, icon: 'bi-arrow-left-right', title: 'HTTP Exchanges'}
+    meta: {group: groups.diagnostics, icon: 'bi-arrow-left-right', title: 'HTTP Exchanges', shortcut: 'hx'}
   },
   {
     path: '/http-probe',
     name: 'http-probe',
     component: HttpProbe,
-    meta: {group: groups.diagnostics, icon: 'bi-send', title: 'HTTP Probe'}
+    meta: {group: groups.diagnostics, icon: 'bi-send', title: 'HTTP Probe', shortcut: 'hp'}
   },
   {
     path: '/mcp-server',
     name: 'mcp-server',
     component: McpServer,
-    meta: {group: groups.developerTools, icon: 'bi-plug', title: 'MCP Server'}
+    meta: {group: groups.developerTools, icon: 'bi-plug', title: 'MCP Server', shortcut: 'mc'}
   },
   {
     path: '/devtools',
     name: 'devtools',
     component: DevTools,
-    meta: {group: groups.developerTools, icon: 'bi-lightning-charge', title: 'DevTools'}
+    meta: {group: groups.developerTools, icon: 'bi-lightning-charge', title: 'DevTools', shortcut: 'dt'}
   },
   {
     path: '/dev-services',
     name: 'dev-services',
     component: DevServices,
-    meta: {group: groups.developerTools, icon: 'bi-box-seam', title: 'Dev Services'}
+    meta: {group: groups.developerTools, icon: 'bi-box-seam', title: 'Dev Services', shortcut: 'ds'}
   },
   {
     path: '/copilot',
     name: 'copilot',
     component: Copilot,
-    meta: {group: groups.developerTools, icon: 'bi-robot', title: 'Copilot'}
+    meta: {group: groups.developerTools, icon: 'bi-robot', title: 'Copilot', shortcut: 'cp'}
   },
   {
     path: '/claude-code',
     name: 'claude-code',
     component: Copilot,
-    meta: {group: groups.developerTools, icon: 'bi-claude', title: 'Claude Code'}
+    meta: {group: groups.developerTools, icon: 'bi-claude', title: 'Claude Code', shortcut: 'cc'}
   },
   {path: '/tuning-advisor', redirect: '/jvm-tuning'},
   {path: '/pentest', redirect: '/pentesting'},

--- a/bootui-ui/src/main/frontend/src/routes.test.js
+++ b/bootui-ui/src/main/frontend/src/routes.test.js
@@ -59,6 +59,7 @@ describe('routes', () => {
     expect(new Set(namedRoutes.map((route) => route.name)).size).toBe(namedRoutes.length)
     expect(new Set(namedRoutes.map((route) => route.path)).size).toBe(namedRoutes.length)
     expect(new Set(namedRoutes.map((route) => route.meta.icon)).size).toBe(namedRoutes.length)
+    expect(new Set(namedRoutes.map((route) => route.meta.shortcut)).size).toBe(namedRoutes.length)
 
     for (const route of namedRoutes) {
       expect(route.path).toMatch(/^\/[a-z0-9-]+$/)
@@ -68,7 +69,8 @@ describe('routes', () => {
         icon: expect.stringMatching(/^bi-/),
         group: expect.stringMatching(
           /^(overview|advisors|runtime|configuration|database|security|services|diagnostics|developer-tools)$/
-        )
+        ),
+        shortcut: expect.stringMatching(/^[a-z]{2,3}$/)
       })
     }
   })

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.test.js
@@ -1,6 +1,6 @@
-import {mount} from '@vue/test-utils'
+import {flushPromises, mount} from '@vue/test-utils'
 import {createMemoryHistory, createRouter} from 'vue-router'
-import {describe, expect, it} from 'vitest'
+import {describe, expect, it, vi} from 'vitest'
 
 import {routes} from '../../routes.js'
 import CommandPalette from './CommandPalette.vue'
@@ -15,21 +15,70 @@ async function mountPalette() {
   await router.push('/overview')
   await router.isReady()
 
-  return mount(CommandPalette, {
+  const wrapper = mount(CommandPalette, {
     global: {
       plugins: [router]
     }
   })
+
+  return {wrapper, router}
+}
+
+async function setQuery(wrapper, value) {
+  const input = wrapper.find('.cp-input')
+  await input.setValue(value)
+  return input
 }
 
 describe('CommandPalette', () => {
   it('lists every navigable panel before filtering', async () => {
-    const wrapper = await mountPalette()
+    const {wrapper} = await mountPalette()
     const items = wrapper.findAll('.cp-item')
 
     expect(items).toHaveLength(namedRoutes.length)
     expect(items.map((item) => item.find('.cp-item-title').text())).toEqual(
       namedRoutes.map((route) => route.meta.title)
     )
+  })
+
+  it('shows number badges only while browsing the unfiltered list', async () => {
+    const {wrapper} = await mountPalette()
+    expect(wrapper.findAll('.cp-item-num').length).toBeGreaterThan(0)
+
+    await setQuery(wrapper, 'security')
+    expect(wrapper.findAll('.cp-item-num')).toHaveLength(0)
+  })
+
+  it('ranks a panel by its shortcut even when the title does not match', async () => {
+    const {wrapper} = await mountPalette()
+    await setQuery(wrapper, 'ai')
+
+    const titles = wrapper.findAll('.cp-item-title').map((item) => item.text())
+    expect(titles[0]).toBe('AI Usage')
+  })
+
+  it('navigates with a number key while browsing the unfiltered list', async () => {
+    const {wrapper, router} = await mountPalette()
+    const push = vi.spyOn(router, 'push')
+    const second = wrapper.findAll('.cp-item').at(1)
+
+    await wrapper.find('.cp-input').trigger('keydown', {key: '2'})
+    await flushPromises()
+
+    expect(second.find('.cp-item-num').text()).toBe('2')
+    expect(push).toHaveBeenCalledWith(namedRoutes[1].path)
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('does not hijack number keys while a query is active', async () => {
+    const {wrapper, router} = await mountPalette()
+    await setQuery(wrapper, 'security')
+    const push = vi.spyOn(router, 'push')
+
+    await wrapper.find('.cp-input').trigger('keydown', {key: '1'})
+    await flushPromises()
+
+    expect(push).not.toHaveBeenCalled()
+    expect(wrapper.emitted('close')).toBeUndefined()
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
@@ -19,9 +19,12 @@ const recentNames = new Set(recentRouteList.map((r) => r.name))
 function score(route, q) {
   const title = (route.meta.title || '').toLowerCase()
   const group = (route.meta.group || '').toLowerCase()
+  const shortcut = (route.meta.shortcut || '').toLowerCase()
   const needle = q.toLowerCase()
   if (title.startsWith(needle)) return 3
+  if (shortcut.startsWith(needle)) return 3
   if (title.includes(needle)) return 2
+  if (shortcut.includes(needle)) return 2
   if (group.includes(needle)) return 1
   return 0
 }
@@ -55,6 +58,8 @@ function navigate(route) {
   emit('close')
 }
 
+const numberedNavKeys = ['1', '2', '3', '4', '5', '6', '7', '8', '9']
+
 function onKeydown(e) {
   if (e.key === 'ArrowDown') {
     e.preventDefault()
@@ -68,6 +73,12 @@ function onKeydown(e) {
     if (selected) navigate(selected)
   } else if (e.key === 'Escape') {
     emit('close')
+  } else if (numberedNavKeys.includes(e.key) && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    const idx = numberedNavKeys.indexOf(e.key)
+    if (idx < results.value.length) {
+      e.preventDefault()
+      navigate(results.value[idx])
+    }
   }
 }
 
@@ -106,6 +117,7 @@ defineExpose({focusInput})
           @click="navigate(r)"
           @mouseover="activeIndex = i"
         >
+          <span v-if="i < 9 && !query.trim()" class="cp-item-num">{{ i + 1 }}</span>
           <i :class="['bi', r.meta.icon, 'cp-item-icon']"></i>
           <span class="cp-item-title">{{ r.meta.title }}</span>
           <i
@@ -114,6 +126,7 @@ defineExpose({focusInput})
             title="Recently viewed"
             aria-hidden="true"
           ></i>
+          <span v-if="r.meta.shortcut" class="cp-item-shortcut">{{ r.meta.shortcut }}</span>
           <span class="cp-item-group">{{ r.meta.group }}</span>
         </li>
       </ul>
@@ -226,6 +239,30 @@ defineExpose({focusInput})
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+}
+
+.cp-item-num {
+  align-items: center;
+  background: var(--bootui-nav-group-bg, rgba(100, 116, 139, 0.08));
+  border-radius: 0.35rem;
+  color: var(--bootui-text-muted, #94a3b8);
+  display: inline-flex;
+  font-size: 0.65rem;
+  font-weight: 700;
+  height: 1.25rem;
+  justify-content: center;
+  line-height: 1;
+  min-width: 1.25rem;
+}
+
+.cp-item-shortcut {
+  background: var(--bootui-nav-group-bg, rgba(100, 116, 139, 0.08));
+  border-radius: 0.25rem;
+  color: var(--bootui-text-muted, #94a3b8);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.15rem 0.35rem;
 }
 
 .cp-item-recent {

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
@@ -73,7 +73,7 @@ function onKeydown(e) {
     if (selected) navigate(selected)
   } else if (e.key === 'Escape') {
     emit('close')
-  } else if (numberedNavKeys.includes(e.key) && !e.metaKey && !e.ctrlKey && !e.altKey) {
+  } else if (!query.value.trim() && numberedNavKeys.includes(e.key) && !e.metaKey && !e.ctrlKey && !e.altKey) {
     const idx = numberedNavKeys.indexOf(e.key)
     if (idx < results.value.length) {
       e.preventDefault()


### PR DESCRIPTION
## Summary

Adds two keyboard productivity features to the command palette (`⌘K`):

- **Shortcut badges & search**: Each panel now has a 2-letter shortcut (e.g., `hl` for Health). Typing it in the palette jumps directly to that panel. Shortcut matches rank equally with title prefix matches.
- **Number-key navigation**: When the palette opens (no query typed), pressing `1`-`9` immediately navigates to the Nth result. Number hints are shown inline for the top 9 panels.

### Files changed

- `bootui-ui/src/main/frontend/src/routes.js` — added `shortcut` metadata to all 46 panel routes
- `bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue` — shortcut score, shortcut display, number-key handler, CSS for new elements
- `bootui-ui/src/main/frontend/src/routes.test.js` — validates every route has a unique `shortcut`

All 215 existing tests pass.