### PR TITLE
fix: title tag on home page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,5 @@
 ---
 home: true
-title: BootUI
 heroText: BootUI
 tagline: A local-only developer console for Spring Boot 4 applications.
 actions:


### PR DESCRIPTION
## What does this PR do?

Before
<img width="899" height="636" alt="image" src="https://github.com/user-attachments/assets/774f6805-5c87-49f0-8f27-5a80768be1e6" />

After
<img width="907" height="629" alt="image" src="https://github.com/user-attachments/assets/7affe3ef-81a2-47d8-8e80-3b3acb27b18c" />

Redundant title, I think...

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
