### PR TITLE
fix: update Claude icon

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -27,7 +27,7 @@ const panelConfigs = {
   'claude-code': {
     apiBase: 'api/claude-code',
     title: 'Claude Code',
-    icon: 'bi-stars',
+    icon: 'bi-claude',
     description: 'Sanitized Claude Code tool use, failures, project activity, and recent sessions.',
     propertyPrefix: 'bootui.claude-code',
     emptyTitle: 'No Claude Code project logs found',


### PR DESCRIPTION
## What does this PR do?

<img width="517" height="77" alt="image" src="https://github.com/user-attachments/assets/105de61c-a950-48d8-bf85-b2be6b26b2d3" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
