### PR TITLE
Fix NoSuchMethodError on older Jackson 3 in config metadata catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to BootUI are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`NoSuchMethodError` opening the Configuration or MCP Server panel on older Jackson 3** — `ConfigMetadataCatalog` now
+  binds to the stable `ObjectMapper.treeToValue(TreeNode, Class)` overload instead of `treeToValue(JsonNode, Class)`,
+  which was only added in jackson-databind 3.1. Host applications whose classpath resolves an earlier Jackson 3 (for
+  example 3.0.x dragged in by a transitive dependency) no longer crash `ConfigController` start-up with
+  `java.lang.NoSuchMethodError: 'java.lang.Object tools.jackson.databind.ObjectMapper.treeToValue(...)'` (#384).
+
 ## [1.4.0] - 2026-06-12
 
 Feature release headlined by three new panels — a **SQL Trace** panel that records executed SQL through a hand-written

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigMetadataCatalog.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigMetadataCatalog.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.*;
+import tools.jackson.core.TreeNode;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -104,7 +105,11 @@ final class ConfigMetadataCatalog {
         if (node == null || node.isNull()) {
             return null;
         }
-        return objectMapper.treeToValue(node, Object.class);
+        // Bind to the stable treeToValue(TreeNode, Class) overload (present in every Jackson 3
+        // release). The treeToValue(JsonNode, Class) overload was only added in jackson-databind
+        // 3.1, so calling it directly throws NoSuchMethodError when a transitive dependency pulls
+        // an older Jackson 3 (e.g. 3.0.x from Spring Boot 4.0) onto the classpath.
+        return objectMapper.treeToValue((TreeNode) node, Object.class);
     }
 
     ConfigPropertySuggestionDto get(String name) {


### PR DESCRIPTION
## What does this PR do?

Binds `ConfigMetadataCatalog` to the stable `ObjectMapper.treeToValue(TreeNode, Class)` overload so BootUI starts on any Jackson 3 version, not just 3.1+.

## Why is this change needed?

Opening the Configuration or MCP Server panel constructs `ConfigController`, which builds `ConfigMetadataCatalog`. That class called `objectMapper.treeToValue(node, Object.class)` where `node` is a `JsonNode`. The compiler (against the managed jackson-databind 3.1.4) binds that to the `treeToValue(JsonNode, Class)` overload, which was only added in jackson-databind 3.1.

When a host app's classpath resolves an earlier Jackson 3 (for example 3.0.x dragged in transitively, as reported), that overload does not exist and startup fails with:

```
java.lang.NoSuchMethodError: 'java.lang.Object tools.jackson.databind.ObjectMapper.treeToValue(tools.jackson.databind.JsonNode, java.lang.Class)'
```

I confirmed with `javap` across the actual jars that 3.0.x only ships `treeToValue(TreeNode, Class)`, while 3.1.x adds the `JsonNode` overload. Casting the argument to `TreeNode` forces the bytecode to reference the base overload, which is present in every Jackson 3 release. Behavior is unchanged (`JsonNode implements TreeNode`).

Closes #384

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Verified `ConfigMetadataCatalogTests` still passes (default-value conversion unchanged) and used `javap` to confirm the compiled call now resolves to `treeToValue(TreeNode, Class)`. The existing test already exercises the `defaultValue` conversion path; the failure is a compile-time binding issue that cannot be reproduced in a unit test compiled against a single Jackson version, so no new test was added.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

Added a CHANGELOG entry under `## [Unreleased]`.