### PR TITLE
Quiet OTel/Micrometer tracing DEBUG noise at full sampling

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
@@ -32,6 +32,22 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
 
     public static final String TRACING_SAMPLING_PROBABILITY = "1.0";
 
+    /**
+     * Log level BootUI applies (as an overridable default) to the tracing libraries it drives at full
+     * sampling. Raising {@link #TRACING_SAMPLING_PROBABILITY} to {@code 1.0} runs the OpenTelemetry SDK
+     * and Micrometer Tracing span/propagation machinery on every request, so when the host has the root
+     * logger at {@code DEBUG} those libraries flood the console with low-value lines (for example
+     * {@code Invalid TraceId in B3 header: null}, {@code Will propagate new baggage context}, and
+     * {@code Ignoring setStatus() description since status is not ERROR}). Pinning these specific
+     * loggers to {@code INFO} silences that DEBUG chatter while leaving the host's other loggers
+     * untouched; the host can still opt back in by setting the matching {@code logging.level.*} key.
+     */
+    public static final String TRACING_LOG_LEVEL = "INFO";
+
+    public static final Map<String, String> TRACING_LOG_LEVEL_DEFAULTS = Map.of(
+            "logging.level.io.opentelemetry", TRACING_LOG_LEVEL,
+            "logging.level.io.micrometer.tracing", TRACING_LOG_LEVEL);
+
     private static final Map<String, Object> ACTUATOR_DEFAULTS = Map.of(
             "management.endpoints.web.exposure.include",
             REQUIRED_ENDPOINTS,
@@ -53,6 +69,7 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
         Map<String, Object> defaults = new LinkedHashMap<>(ACTUATOR_DEFAULTS);
         if (telemetryEnabled(environment) && tracesPanelEnabled(environment)) {
             defaults.put(TRACING_SAMPLING_PROBABILITY_PROPERTY, TRACING_SAMPLING_PROBABILITY);
+            defaults.putAll(TRACING_LOG_LEVEL_DEFAULTS);
         }
 
         // Only contribute defaults the host has not already configured through any property source,
@@ -86,6 +103,8 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
             case "management.endpoints.web.exposure.include" -> REQUIRED_ENDPOINTS.equals(normalized);
             case "management.endpoint.health.show-details" -> "always".equalsIgnoreCase(normalized);
             case TRACING_SAMPLING_PROBABILITY_PROPERTY -> TRACING_SAMPLING_PROBABILITY.equals(normalized);
+            case "logging.level.io.opentelemetry", "logging.level.io.micrometer.tracing" ->
+                TRACING_LOG_LEVEL.equalsIgnoreCase(normalized);
             default -> false;
         };
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
@@ -28,8 +28,26 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         assertThat(env.getProperty(
                         BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
                 .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY);
+        assertThat(env.getProperty("logging.level.io.opentelemetry"))
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_LOG_LEVEL);
+        assertThat(env.getProperty("logging.level.io.micrometer.tracing"))
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_LOG_LEVEL);
         assertThat(env.getPropertySources().contains(DefaultPropertiesPropertySource.NAME))
                 .isTrue();
+    }
+
+    @Test
+    void keepsHostConfiguredTracingLogLevels() {
+        MockEnvironment env = new MockEnvironment()
+                .withProperty("bootui.enabled", "ON")
+                .withProperty("logging.level.io.opentelemetry", "DEBUG");
+
+        processor.postProcessEnvironment(env, new SpringApplication());
+
+        assertThat(env.getProperty("logging.level.io.opentelemetry")).isEqualTo("DEBUG");
+        // The other tracing logger the host did not set still gets BootUI's quiet default.
+        assertThat(env.getProperty("logging.level.io.micrometer.tracing"))
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_LOG_LEVEL);
     }
 
     @Test
@@ -63,6 +81,8 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         assertThat(env.getProperty(
                         BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
                 .isNull();
+        assertThat(env.getProperty("logging.level.io.opentelemetry")).isNull();
+        assertThat(env.getProperty("logging.level.io.micrometer.tracing")).isNull();
     }
 
     @Test
@@ -78,6 +98,8 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         assertThat(env.getProperty(
                         BootUiActuatorDefaultsEnvironmentPostProcessor.TRACING_SAMPLING_PROBABILITY_PROPERTY))
                 .isNull();
+        assertThat(env.getProperty("logging.level.io.opentelemetry")).isNull();
+        assertThat(env.getProperty("logging.level.io.micrometer.tracing")).isNull();
     }
 
     @Test

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -676,7 +676,11 @@ capture, is in-memory only, and is cleared on restart.
 
 The Traces panel shows distributed tracing spans captured locally by the BootUI starter when telemetry and the Traces
 panel are enabled. The starter contributes the tracing dependencies and sampling default needed for local development, so
-the host application does not need manual `management.*` tracing properties. BootUI also keeps an embedded OTLP/HTTP
+the host application does not need manual `management.*` tracing properties. Because that default raises sampling to
+100% (`management.tracing.sampling.probability=1.0`), the OpenTelemetry SDK and Micrometer Tracing span/propagation code
+runs on every request; to keep that from flooding the console when the host's root logger is at `DEBUG`, BootUI also
+pins `logging.level.io.opentelemetry` and `logging.level.io.micrometer.tracing` to `INFO` as overridable defaults (set
+either key yourself to opt back in). BootUI also keeps an embedded OTLP/HTTP
 receiver at `/bootui/api/otlp/v1/traces` so cooperating local services can export spans into the same in-memory store.
 The list shows the most recent traces with service name, the HTTP request path each trace served (falling back to the
 root span name when no path attribute is present), status, duration, and span count; opening a trace


### PR DESCRIPTION
## What does this PR do?

Contributes overridable `INFO` log-level defaults for `io.opentelemetry` and `io.micrometer.tracing` when BootUI enables full-sampling tracing, so those libraries stop flooding the console with DEBUG chatter.

## Why is this change needed?

BootUI sets `management.tracing.sampling.probability=1.0` so the Traces panel captures every request. That runs the OpenTelemetry SDK and Micrometer Tracing span/propagation machinery on every request. When a host app sets its root logger to DEBUG (for example JHipster's `dev` profile, which sets `logging.level.ROOT: DEBUG` and does not quiet the tracing packages), the console floods with low-value lines on every request:

```
... B3PropagatorExtractorMultipleHeaders : Invalid TraceId in B3 header: null'. Returning INVALID span context.
... BaggageTextMapPropagator : Will propagate new baggage context for entries {}
... io.opentelemetry.sdk.trace.SdkSpan : Ignoring setStatus() description since status is not ERROR.
```

BootUI raised the sampling that amplifies this noise, so it should also tame it.

Closes # N/A

### Approach

Alongside the existing sampling default in `BootUiActuatorDefaultsEnvironmentPostProcessor`, BootUI now also contributes `logging.level.io.opentelemetry=INFO` and `logging.level.io.micrometer.tracing=INFO`. Key points:

- Contributed only when telemetry and the Traces panel are enabled, matching the gate on the sampling default.
- Contributed as lowest-priority `defaultProperties`, and only for keys the host has not set. These specific package loggers win over a host `ROOT=DEBUG`, yet stay fully overridable: a host that wants the DEBUG output back just sets either `logging.level.*` key.
- `isBootUiActuatorDefault(...)` now recognizes the two new keys so the security/pentesting scanners attribute them as BootUI defaults rather than host config.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran the affected unit tests (`BootUiActuatorDefaultsEnvironmentPostProcessorTests`, `SecurityScannerTests`, `PentestingScannerTests`) plus `spotless:check` on `bootui-autoconfigure`; all green. New tests assert the INFO defaults are contributed at full sampling, withheld when telemetry/Traces are disabled, and that a host-configured tracing log level wins.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed