### PR TITLE
Fix SQL tracing failing under Spring Boot DevTools class-loader split

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTracingProxies.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTracingProxies.java
@@ -62,7 +62,26 @@ final class SqlTracingProxies {
             return dataSource;
         }
         return (DataSource) Proxy.newProxyInstance(
-                classLoader(dataSource), DATA_SOURCE_INTERFACES, new DataSourceHandler(dataSource, recorder));
+                dataSourceProxyClassLoader(dataSource),
+                DATA_SOURCE_INTERFACES,
+                new DataSourceHandler(dataSource, recorder));
+    }
+
+    /**
+     * Picks a class loader able to see every interface in {@link #DATA_SOURCE_INTERFACES}, including
+     * BootUI's own {@link SqlTracedDataSource} marker. Under Spring Boot DevTools the data source is
+     * loaded by the base class loader (its driver/pool lives in a jar) while BootUI's classes live in the
+     * child {@code RestartClassLoader}, so the data source's own loader cannot see
+     * {@code SqlTracedDataSource} and {@link Proxy#newProxyInstance} fails. BootUI's loader is always a
+     * descendant of (or equal to) the data source's loader and can still see the standard JDBC interfaces
+     * (they come from the JDK), so it is a valid loader for all three proxy interfaces.
+     */
+    private static ClassLoader dataSourceProxyClassLoader(DataSource dataSource) {
+        ClassLoader bootUiLoader = SqlTracingProxies.class.getClassLoader();
+        if (bootUiLoader != null) {
+            return bootUiLoader;
+        }
+        return classLoader(dataSource);
     }
 
     private static ClassLoader classLoader(Object target) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/sqltrace/IsolatedTestDataSource.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/sqltrace/IsolatedTestDataSource.java
@@ -1,0 +1,56 @@
+package io.github.jdubois.bootui.autoconfigure.sqltrace;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+/**
+ * Minimal {@link DataSource} used only by {@code SqlTracingProxiesTests} to reproduce the Spring Boot
+ * DevTools class-loader split. It is a standalone top-level class (no reference to any BootUI type) so a
+ * test class loader can define it in isolation, mimicking a driver/pool data source whose loader cannot
+ * see BootUI's {@code SqlTracedDataSource} marker.
+ */
+public class IsolatedTestDataSource implements DataSource {
+
+    @Override
+    public Connection getConnection() {
+        return null;
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) {
+        return null;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+        return null;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {}
+
+    @Override
+    public void setLoginTimeout(int seconds) {}
+
+    @Override
+    public int getLoginTimeout() {
+        return 0;
+    }
+
+    @Override
+    public Logger getParentLogger() {
+        return Logger.getGlobal();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) {
+        return iface.cast(this);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+        return iface.isInstance(this);
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTracingProxiesTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTracingProxiesTests.java
@@ -216,6 +216,39 @@ class SqlTracingProxiesTests {
         verify(ds).close();
     }
 
+    @Test
+    void wrapsDataSourceWhoseClassLoaderCannotSeeBootUiMarker() throws Exception {
+        SqlTraceRecorder recorder = recorder();
+        // Reproduces Spring Boot DevTools: the data source class is loaded by a parent loader (its
+        // driver/pool jar) that cannot see SqlTracedDataSource, which lives in the child RestartClassLoader
+        // alongside BootUI's classes. Building the proxy with the data source's own loader used to fail with
+        // "SqlTracedDataSource ... is not visible from class loader" because that interface was invisible.
+        DataSource isolated = newDataSourceWithoutBootUiVisibility();
+        assertThat(loaderSees(isolated.getClass().getClassLoader(), SqlTracedDataSource.class.getName()))
+                .isFalse();
+
+        DataSource traced = SqlTracingProxies.wrap(isolated, recorder);
+
+        assertThat(traced).isInstanceOf(SqlTracedDataSource.class);
+        assertThat(traced.getConnection()).isNull();
+    }
+
+    private static DataSource newDataSourceWithoutBootUiVisibility() throws Exception {
+        ClassLoader isolated = new BootUiBlindClassLoader();
+        Class<?> type = Class.forName(IsolatedTestDataSource.class.getName(), true, isolated);
+        assertThat(type.getClassLoader()).isSameAs(isolated);
+        return (DataSource) type.getDeclaredConstructor().newInstance();
+    }
+
+    private static boolean loaderSees(ClassLoader loader, String className) {
+        try {
+            Class.forName(className, false, loader);
+            return true;
+        } catch (ClassNotFoundException ex) {
+            return false;
+        }
+    }
+
     private static void assertThatNoCloseFailure(AutoCloseable closeable) {
         try {
             closeable.close();
@@ -226,4 +259,49 @@ class SqlTracingProxiesTests {
 
     /** A {@link DataSource} that is also {@link Closeable}, like Hikari's pool, for the delegation test. */
     private interface CloseableDataSource extends DataSource, Closeable {}
+
+    /**
+     * Loads {@link IsolatedTestDataSource} itself (defining it from the test classpath bytes) while
+     * delegating only to the JDK platform loader, so the resulting data source class cannot see any BootUI
+     * type. This mirrors how DevTools keeps third-party jars in the base loader, separate from BootUI's
+     * classes in the child {@code RestartClassLoader}.
+     */
+    private static final class BootUiBlindClassLoader extends ClassLoader {
+
+        private final ClassLoader source = SqlTracingProxiesTests.class.getClassLoader();
+
+        BootUiBlindClassLoader() {
+            super(ClassLoader.getPlatformClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.equals(IsolatedTestDataSource.class.getName())) {
+                synchronized (getClassLoadingLock(name)) {
+                    Class<?> loaded = findLoadedClass(name);
+                    if (loaded == null) {
+                        loaded = defineFromSource(name);
+                    }
+                    if (resolve) {
+                        resolveClass(loaded);
+                    }
+                    return loaded;
+                }
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private Class<?> defineFromSource(String name) throws ClassNotFoundException {
+            String resource = name.replace('.', '/') + ".class";
+            try (java.io.InputStream in = source.getResourceAsStream(resource)) {
+                if (in == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                byte[] bytes = in.readAllBytes();
+                return defineClass(name, bytes, 0, bytes.length);
+            } catch (java.io.IOException ex) {
+                throw new ClassNotFoundException(name, ex);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Builds BootUI's traced `DataSource` proxy with a class loader that can actually see the `SqlTracedDataSource` marker interface, so SQL tracing works under Spring Boot DevTools instead of silently disabling itself.

## Why is this change needed?

When the sample app runs with DevTools active (for example via Docker Compose), startup logged a warning and SQL tracing never engaged:

```
BootUI could not enable SQL tracing for DataSource bean 'dataSource'; leaving it unwrapped
java.lang.IllegalArgumentException: ...SqlTracedDataSource referenced from a method is not visible from class loader: 'app'
```

The traced `DataSource` proxy advertises three interfaces: the JDK `DataSource`, `AutoCloseable`, and BootUI's own `SqlTracedDataSource` marker. The proxy was created with the data source's own class loader. That works in a normal run, but DevTools splits classes across two loaders: third-party jars (the HikariCP `DataSource`) load in the base `app` loader, while BootUI's classes (including `SqlTracedDataSource`) load in the child `RestartClassLoader`. The base loader cannot see the child's marker interface, so `Proxy.newProxyInstance` threw, the post-processor failed open, and tracing stayed off.

The fix selects BootUI's own class loader for the `DataSource` proxy. It is always a descendant of (or equal to) the data source's loader, so it can see all three interfaces (the JDBC ones come from the JDK). Connection and statement proxies are unaffected since they only use `java.sql.*` interfaces, which are visible everywhere.

Closes # N/A (no tracked issue)

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end <!-- reproduced originally via Docker Compose + DevTools; this PR removes the warning -->
- [x] Added or updated tests where applicable

Added a regression test that defines a `DataSource` in a class loader deliberately blind to BootUI classes, reproducing the exact `IllegalArgumentException` before the fix and passing after. Ran `SqlTracingProxiesTests` (10 tests) and `SqlTraceRuntimeHintsTests` (3 tests); both green.

GraalVM native build is unaffected: the native proxy hints key on the interface set (unchanged), and DevTools is excluded from the native image, so there is no class-loader split at native runtime.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes <!-- internal fix, no behaviour/docs change -->
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed