### PR TITLE
Make Live Activity dashboard safe across DevTools restarts

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -300,7 +300,7 @@ public class BootUiAutoConfiguration {
         @ConditionalOnClass(name = "ch.qos.logback.classic.LoggerContext")
         static class LogbackExceptionCaptureConfiguration {
 
-            @Bean
+            @Bean(destroyMethod = "uninstall")
             BootUiExceptionLogAppender bootUiExceptionLogAppender(ExceptionStore store) {
                 return BootUiExceptionLogAppender.install(store);
             }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityController.java
@@ -12,6 +12,9 @@ import io.github.jdubois.bootui.autoconfigure.web.SecurityLogsController;
 import io.github.jdubois.bootui.autoconfigure.web.TracesController;
 import io.github.jdubois.bootui.core.dto.LiveActivityReport;
 import io.github.jdubois.bootui.core.dto.RequestProfileDto;
+import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.List;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
@@ -45,6 +48,7 @@ public class LiveActivityController {
     private final LiveActivityCorrelator correlator;
     private final SecurityEventCorrelationRegistry securityCorrelations;
     private final BootUiChangeStream changeStream;
+    private final List<Runnable> unsubscribers = new ArrayList<>();
     private final String selfPath;
 
     public LiveActivityController(
@@ -82,12 +86,25 @@ public class LiveActivityController {
         this.selfPath = properties.getPath();
         SqlTraceRecorder recorder = sqlTraceRecorder.getIfAvailable();
         if (recorder != null) {
-            recorder.subscribe(changeStream::signal);
+            unsubscribers.add(recorder.subscribe(changeStream::signal));
         }
         ExceptionStore store = exceptionStore.getIfAvailable();
         if (store != null) {
-            store.subscribe(changeStream::signal);
+            unsubscribers.add(store.subscribe(changeStream::signal));
         }
+    }
+
+    /**
+     * Releases the change stream's scheduler thread and SSE emitters, and detaches the source listeners,
+     * when the context shuts down. This keeps a Spring Boot DevTools restart from leaking a
+     * {@code bootui-activity-stream} daemon thread (and, through it, the discarded application context and
+     * its class loader) on every live reload.
+     */
+    @PreDestroy
+    void shutdown() {
+        unsubscribers.forEach(Runnable::run);
+        unsubscribers.clear();
+        changeStream.close();
     }
 
     @GetMapping

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/BootUiExceptionLogAppender.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/BootUiExceptionLogAppender.java
@@ -60,6 +60,20 @@ public class BootUiExceptionLogAppender extends AppenderBase<ILoggingEvent> {
         return null;
     }
 
+    /**
+     * Detaches this appender from the (JVM-global) Logback {@link LoggerContext} and stops it. Invoked
+     * as the bean's destroy method so a Spring Boot DevTools restart does not leave the appender — and,
+     * through it, the discarded {@link ExceptionStore} and its class loader — pinned by the surviving
+     * {@code LoggerContext}, and so the new context's store is wired in cleanly on the next start.
+     */
+    public void uninstall() {
+        ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+        if (factory instanceof LoggerContext context) {
+            context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).detachAppender(this);
+        }
+        stop();
+    }
+
     @Override
     protected void append(ILoggingEvent event) {
         IThrowableProxy proxy = event.getThrowableProxy();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/ExceptionsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/ExceptionsController.java
@@ -10,6 +10,7 @@ import io.github.jdubois.bootui.core.dto.ExceptionFrameDto;
 import io.github.jdubois.bootui.core.dto.ExceptionGroupDto;
 import io.github.jdubois.bootui.core.dto.ExceptionOccurrenceDto;
 import io.github.jdubois.bootui.core.dto.ExceptionsReport;
+import jakarta.annotation.PreDestroy;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.ObjectProvider;
@@ -49,6 +50,8 @@ public class ExceptionsController {
 
     private final BootUiChangeStream changeStream;
 
+    private Runnable storeUnsubscribe;
+
     @Autowired
     public ExceptionsController(
             ObjectProvider<ExceptionStore> storeProvider, BootUiProperties properties, BootUiExposure exposure) {
@@ -58,8 +61,22 @@ public class ExceptionsController {
         this.changeStream = new BootUiChangeStream("exceptions");
         ExceptionStore store = storeProvider.getIfAvailable();
         if (store != null) {
-            store.subscribe(changeStream::signal);
+            this.storeUnsubscribe = store.subscribe(changeStream::signal);
         }
+    }
+
+    /**
+     * Releases the change stream's scheduler thread and SSE emitters, and detaches the store listener,
+     * when the context shuts down so a Spring Boot DevTools restart does not leak the
+     * {@code bootui-exceptions-stream} daemon thread (and the discarded context behind it).
+     */
+    @PreDestroy
+    void shutdown() {
+        if (storeUnsubscribe != null) {
+            storeUnsubscribe.run();
+            storeUnsubscribe = null;
+        }
+        changeStream.close();
     }
 
     ExceptionsController(ObjectProvider<ExceptionStore> storeProvider, BootUiProperties properties) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceController.java
@@ -7,6 +7,7 @@ import io.github.jdubois.bootui.autoconfigure.stream.BootUiChangeStream;
 import io.github.jdubois.bootui.core.dto.SqlTraceEntryDto;
 import io.github.jdubois.bootui.core.dto.SqlTraceRecordingRequest;
 import io.github.jdubois.bootui.core.dto.SqlTraceReport;
+import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.List;
 import javax.sql.DataSource;
@@ -38,6 +39,7 @@ public class SqlTraceController {
     private final ObjectProvider<DataSource> dataSourceProvider;
     private final BootUiExposure exposure;
     private final BootUiChangeStream changeStream;
+    private Runnable recorderUnsubscribe;
 
     public SqlTraceController(
             ObjectProvider<SqlTraceRecorder> recorderProvider,
@@ -49,8 +51,22 @@ public class SqlTraceController {
         this.changeStream = new BootUiChangeStream("sql-trace");
         SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
         if (recorder != null) {
-            recorder.subscribe(changeStream::signal);
+            this.recorderUnsubscribe = recorder.subscribe(changeStream::signal);
         }
+    }
+
+    /**
+     * Releases the change stream's scheduler thread and SSE emitters, and detaches the recorder listener,
+     * when the context shuts down so a Spring Boot DevTools restart does not leak the
+     * {@code bootui-sql-trace-stream} daemon thread (and the discarded context behind it).
+     */
+    @PreDestroy
+    void shutdown() {
+        if (recorderUnsubscribe != null) {
+            recorderUnsubscribe.run();
+            recorderUnsubscribe = null;
+        }
+        changeStream.close();
     }
 
     @GetMapping

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTracingProxies.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTracingProxies.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Proxy;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
@@ -61,10 +62,47 @@ final class SqlTracingProxies {
         if (dataSource instanceof SqlTracedDataSource) {
             return dataSource;
         }
+        DataSource target = unwrapForeignTracedProxy(dataSource);
         return (DataSource) Proxy.newProxyInstance(
-                dataSourceProxyClassLoader(dataSource),
-                DATA_SOURCE_INTERFACES,
-                new DataSourceHandler(dataSource, recorder));
+                dataSourceProxyClassLoader(target), DATA_SOURCE_INTERFACES, new DataSourceHandler(target, recorder));
+    }
+
+    /**
+     * Returns the real pool behind a BootUI tracing proxy that was built by a <em>different</em> class
+     * loader, or the argument unchanged when it is not such a proxy.
+     *
+     * <p>Under Spring Boot DevTools a data source preserved across a restart (for example a
+     * {@code @RestartScope} pool kept so an in-memory database keeps its rows) can still be a tracing
+     * proxy created by the previous {@code RestartClassLoader}. Its {@link SqlTracedDataSource} marker is
+     * a different {@link Class} than this loader's, so the {@code instanceof} guard in {@link #wrap} misses
+     * it. Wrapping it again would nest a second proxy over the stale one — double-counting every statement
+     * and pinning the old class loader in memory — so we unwrap back to the genuine pool and re-wrap that
+     * with the current recorder instead. Detection is by interface <em>name</em> so it is class-loader
+     * agnostic; unwrapping uses the JDBC {@code unwrap} contract the proxy already delegates to its target,
+     * and falls back to the proxy unchanged if that throws.</p>
+     */
+    private static DataSource unwrapForeignTracedProxy(DataSource dataSource) {
+        if (!isForeignTracedProxy(dataSource)) {
+            return dataSource;
+        }
+        try {
+            DataSource unwrapped = dataSource.unwrap(DataSource.class);
+            return unwrapped != null ? unwrapped : dataSource;
+        } catch (SQLException | RuntimeException ex) {
+            return dataSource;
+        }
+    }
+
+    private static boolean isForeignTracedProxy(DataSource dataSource) {
+        if (dataSource instanceof SqlTracedDataSource || !Proxy.isProxyClass(dataSource.getClass())) {
+            return false;
+        }
+        for (Class<?> iface : dataSource.getClass().getInterfaces()) {
+            if (SqlTracedDataSource.class.getName().equals(iface.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiLogAppender.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiLogAppender.java
@@ -52,6 +52,20 @@ public class BootUiLogAppender extends AppenderBase<ILoggingEvent> {
         return null;
     }
 
+    /**
+     * Detaches this appender from the (JVM-global) Logback {@link LoggerContext} and stops it, so a
+     * Spring Boot DevTools restart does not leave the appender — and the discarded context's stream
+     * subscribers behind it — pinned by the surviving {@code LoggerContext} on every live reload.
+     */
+    public void uninstall() {
+        ILoggerFactory factory = LoggerFactory.getILoggerFactory();
+        if (factory instanceof LoggerContext context) {
+            context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).detachAppender(this);
+        }
+        subscribers.clear();
+        stop();
+    }
+
     @Override
     protected void append(ILoggingEvent event) {
         LogLineDto line = new LogLineDto(

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.dto.LogLineDto;
+import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -76,6 +77,20 @@ public class LogTailController {
     private void cleanup(SseEmitter emitter, Runnable unsubscribe) {
         emitters.remove(emitter);
         unsubscribe.run();
+    }
+
+    /**
+     * Completes any open log-tail streams and detaches the shared Logback appender when the context
+     * shuts down, so a Spring Boot DevTools restart does not leave dead SSE subscribers attached to the
+     * surviving {@code LoggerContext} (and the old context pinned behind them) on every live reload.
+     */
+    @PreDestroy
+    void shutdown() {
+        for (SseEmitter emitter : emitters) {
+            emitter.complete();
+        }
+        emitters.clear();
+        appender.uninstall();
     }
 
     private void sendLog(SseEmitter emitter, LogLineDto line) throws IOException {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityLogsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityLogsController.java
@@ -9,6 +9,7 @@ import io.github.jdubois.bootui.core.dto.SecurityLogDataDto;
 import io.github.jdubois.bootui.core.dto.SecurityLogEventDto;
 import io.github.jdubois.bootui.core.dto.SecurityLogTypeSummaryDto;
 import io.github.jdubois.bootui.core.dto.SecurityLogsReport;
+import jakarta.annotation.PreDestroy;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -109,6 +110,16 @@ public class SecurityLogsController implements ApplicationListener<AuditApplicat
     @Override
     public void onApplicationEvent(AuditApplicationEvent event) {
         changeStream.signal();
+    }
+
+    /**
+     * Releases the change stream's scheduler thread and SSE emitters when the context shuts down so a
+     * Spring Boot DevTools restart does not leak the {@code bootui-security-logs-stream} daemon thread
+     * (and the discarded context behind it) on every live reload.
+     */
+    @PreDestroy
+    void shutdown() {
+        changeStream.close();
     }
 
     @ExceptionHandler({DateTimeParseException.class, IllegalArgumentException.class})

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityControllerTests.java
@@ -24,6 +24,54 @@ class LiveActivityControllerTests {
     }
 
     @Test
+    void shutdownClosesChangeStreamAndTerminatesSchedulerThread() throws Exception {
+        SqlTraceRecorder recorder = new SqlTraceRecorder(true, true, true, 100, 100, 2000, 200, 5);
+        LiveActivityController controller = controllerWith(provider(recorder), empty(ExceptionStore.class));
+
+        controller.stream(); // open an SSE emitter so a signal schedules a flush
+        java.util.Set<Thread> before = streamThreads();
+        recorder.clear(); // notifies the subscribed change stream → schedules a flush → starts its thread
+
+        Thread scheduler = awaitNewStreamThread(before);
+        assertThat(scheduler).as("scheduler thread should have started").isNotNull();
+
+        controller.shutdown();
+
+        // close() shuts the scheduler down so a DevTools restart does not leak one daemon thread
+        // (and, through it, the discarded context's class loader) per live reload.
+        assertThat(awaitNotAlive(scheduler)).isTrue();
+    }
+
+    private static java.util.Set<Thread> streamThreads() {
+        java.util.Set<Thread> threads = new java.util.HashSet<>();
+        for (Thread thread : Thread.getAllStackTraces().keySet()) {
+            if ("bootui-activity-stream".equals(thread.getName())) {
+                threads.add(thread);
+            }
+        }
+        return threads;
+    }
+
+    private static Thread awaitNewStreamThread(java.util.Set<Thread> before) throws InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            java.util.Set<Thread> now = streamThreads();
+            now.removeAll(before);
+            if (!now.isEmpty()) {
+                return now.iterator().next();
+            }
+            Thread.sleep(10);
+        }
+        return null;
+    }
+
+    private static boolean awaitNotAlive(Thread thread) throws InterruptedException {
+        for (int i = 0; i < 100 && thread.isAlive(); i++) {
+            Thread.sleep(10);
+        }
+        return !thread.isAlive();
+    }
+
+    @Test
     void hostRequestExcludesBootUiOwnTrafficToAvoidRefreshLoop() {
         // BootUI's own re-fetches and SSE connection must not re-trigger the feed.
         assertThat(LiveActivityController.isHostRequest("/bootui/api/activity", "/bootui"))
@@ -43,6 +91,18 @@ class LiveActivityControllerTests {
     }
 
     private static LiveActivityController controller(BootUiProperties properties) {
+        return controllerWith(empty(SqlTraceRecorder.class), empty(ExceptionStore.class), properties);
+    }
+
+    private static LiveActivityController controllerWith(
+            ObjectProvider<SqlTraceRecorder> recorder, ObjectProvider<ExceptionStore> exceptionStore) {
+        return controllerWith(recorder, exceptionStore, new BootUiProperties());
+    }
+
+    private static LiveActivityController controllerWith(
+            ObjectProvider<SqlTraceRecorder> recorder,
+            ObjectProvider<ExceptionStore> exceptionStore,
+            BootUiProperties properties) {
         return new LiveActivityController(
                 empty(HttpExchangesController.class),
                 empty(SqlTraceController.class),
@@ -50,8 +110,8 @@ class LiveActivityControllerTests {
                 empty(SecurityLogsController.class),
                 empty(TracesController.class),
                 empty(HealthController.class),
-                empty(SqlTraceRecorder.class),
-                empty(ExceptionStore.class),
+                recorder,
+                exceptionStore,
                 empty(RequestCorrelationRegistry.class),
                 empty(SecurityEventCorrelationRegistry.class),
                 properties);
@@ -61,6 +121,13 @@ class LiveActivityControllerTests {
     private static <T> ObjectProvider<T> empty(Class<T> type) {
         ObjectProvider<T> provider = mock(ObjectProvider.class);
         when(provider.getIfAvailable()).thenReturn(null);
+        return provider;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ObjectProvider<T> provider(T value) {
+        ObjectProvider<T> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(value);
         return provider;
     }
 }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/exceptions/BootUiExceptionLogAppenderTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/exceptions/BootUiExceptionLogAppenderTests.java
@@ -1,0 +1,56 @@
+package io.github.jdubois.bootui.autoconfigure.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.ThrowableProxy;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link BootUiExceptionLogAppender}, including its DevTools-restart cleanup. */
+class BootUiExceptionLogAppenderTests {
+
+    @AfterEach
+    void detachAppender() {
+        BootUiExceptionLogAppender installed = BootUiExceptionLogAppender.find();
+        if (installed != null) {
+            installed.uninstall();
+        }
+    }
+
+    @Test
+    void appendRecordsLoggedThrowableInStore() {
+        ExceptionStore store = new ExceptionStore(100, 25, 50);
+        BootUiExceptionLogAppender appender = new BootUiExceptionLogAppender(store);
+        appender.start();
+
+        appender.doAppend(eventWithThrowable(new IllegalStateException("boom")));
+
+        assertThat(store.groups()).hasSize(1);
+    }
+
+    @Test
+    void uninstallDetachesAppenderFromLoggerContext() {
+        ExceptionStore store = new ExceptionStore(100, 25, 50);
+        BootUiExceptionLogAppender appender = BootUiExceptionLogAppender.install(store);
+        assertThat(BootUiExceptionLogAppender.find()).isSameAs(appender);
+
+        appender.uninstall();
+
+        // Detached from the JVM-global LoggerContext so a DevTools restart does not leave the old
+        // appender — and its discarded ExceptionStore — pinned; install() re-wires a fresh store next start.
+        assertThat(BootUiExceptionLogAppender.find()).isNull();
+        assertThat(appender.isStarted()).isFalse();
+    }
+
+    private static ILoggingEvent eventWithThrowable(Throwable throwable) {
+        ILoggingEvent event = mock(ILoggingEvent.class);
+        when(event.getLevel()).thenReturn(Level.ERROR);
+        when(event.getThreadName()).thenReturn("test-thread");
+        when(event.getThrowableProxy()).thenReturn(new ThrowableProxy(throwable));
+        return event;
+    }
+}

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTracingProxiesTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTracingProxiesTests.java
@@ -10,6 +10,7 @@ import io.github.jdubois.bootui.autoconfigure.sqltrace.SqlTraceRecorder.Captured
 import io.github.jdubois.bootui.autoconfigure.sqltrace.SqlTraceRecorder.Category;
 import io.github.jdubois.bootui.autoconfigure.sqltrace.SqlTraceRecorder.StatementType;
 import java.io.Closeable;
+import java.lang.reflect.Proxy;
 import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -240,6 +241,69 @@ class SqlTracingProxiesTests {
         return (DataSource) type.getDeclaredConstructor().newInstance();
     }
 
+    @Test
+    void unwrapsAndRewrapsAForeignClassLoaderTracedProxy() throws Exception {
+        SqlTraceRecorder recorder = recorder();
+        // Reproduces a DataSource preserved across a Spring Boot DevTools restart (e.g. via @RestartScope):
+        // it is already a BootUI tracing proxy, but built by the *previous* RestartClassLoader, so its
+        // SqlTracedDataSource marker is a different Class than this loader's and instanceof misses it.
+        DataSource realPool = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        Statement st = mock(Statement.class);
+        when(realPool.getConnection()).thenReturn(conn);
+        when(realPool.unwrap(DataSource.class)).thenReturn(realPool);
+        when(conn.createStatement()).thenReturn(st);
+        when(st.execute("select 1")).thenReturn(true);
+
+        DataSource foreign = newForeignTracedProxy(realPool);
+        assertThat(foreign).isNotInstanceOf(SqlTracedDataSource.class);
+
+        DataSource traced = SqlTracingProxies.wrap(foreign, recorder);
+
+        // Re-wrapped with THIS loader's marker (so it is recognised next time), over the real pool rather
+        // than nested over the stale foreign proxy — which would double-count and pin the old class loader.
+        assertThat(traced).isInstanceOf(SqlTracedDataSource.class);
+        assertThat(proxyTarget(traced)).isSameAs(realPool);
+
+        // And it still traces: a statement executed through it is recorded exactly once.
+        try (Connection c = traced.getConnection()) {
+            c.createStatement().execute("select 1");
+        }
+        assertThat(recorder.recent()).hasSize(1);
+    }
+
+    private static DataSource newForeignTracedProxy(DataSource realTarget) throws Exception {
+        ForeignMarkerClassLoader loader = new ForeignMarkerClassLoader();
+        Class<?> foreignMarker = Class.forName(SqlTracedDataSource.class.getName(), true, loader);
+        assertThat(foreignMarker).isNotSameAs(SqlTracedDataSource.class);
+        Class<?>[] interfaces = {DataSource.class, foreignMarker};
+        return (DataSource) Proxy.newProxyInstance(loader, interfaces, (proxy, method, args) -> {
+            if (method.getDeclaringClass() == Object.class) {
+                return switch (method.getName()) {
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "equals" -> proxy == (args == null ? null : args[0]);
+                    case "toString" -> "ForeignTracedProxy";
+                    default -> null;
+                };
+            }
+            return method.invoke(realTarget, args);
+        });
+    }
+
+    private static Object proxyTarget(Object proxy) throws Exception {
+        Object handler = Proxy.getInvocationHandler(proxy);
+        for (Class<?> type = handler.getClass(); type != null; type = type.getSuperclass()) {
+            try {
+                java.lang.reflect.Field field = type.getDeclaredField("target");
+                field.setAccessible(true);
+                return field.get(handler);
+            } catch (NoSuchFieldException ignored) {
+                // Walk up to the DelegatingHandler superclass that declares the field.
+            }
+        }
+        throw new NoSuchFieldException("target");
+    }
+
     private static boolean loaderSees(ClassLoader loader, String className) {
         try {
             Class.forName(className, false, loader);
@@ -277,6 +341,51 @@ class SqlTracingProxiesTests {
         @Override
         protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
             if (name.equals(IsolatedTestDataSource.class.getName())) {
+                synchronized (getClassLoadingLock(name)) {
+                    Class<?> loaded = findLoadedClass(name);
+                    if (loaded == null) {
+                        loaded = defineFromSource(name);
+                    }
+                    if (resolve) {
+                        resolveClass(loaded);
+                    }
+                    return loaded;
+                }
+            }
+            return super.loadClass(name, resolve);
+        }
+
+        private Class<?> defineFromSource(String name) throws ClassNotFoundException {
+            String resource = name.replace('.', '/') + ".class";
+            try (java.io.InputStream in = source.getResourceAsStream(resource)) {
+                if (in == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                byte[] bytes = in.readAllBytes();
+                return defineClass(name, bytes, 0, bytes.length);
+            } catch (java.io.IOException ex) {
+                throw new ClassNotFoundException(name, ex);
+            }
+        }
+    }
+
+    /**
+     * Defines its own copy of {@link SqlTracedDataSource} from the test classpath bytes while delegating
+     * everything else (including {@link DataSource}) to the test class loader. The locally-defined marker is
+     * a distinct {@link Class} with the same name, so a proxy built against it mimics a tracing proxy left
+     * behind by a previous DevTools {@code RestartClassLoader}.
+     */
+    private static final class ForeignMarkerClassLoader extends ClassLoader {
+
+        private final ClassLoader source = SqlTracingProxiesTests.class.getClassLoader();
+
+        ForeignMarkerClassLoader() {
+            super(SqlTracingProxiesTests.class.getClassLoader());
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.equals(SqlTracedDataSource.class.getName())) {
                 synchronized (getClassLoadingLock(name)) {
                     Class<?> loaded = findLoadedClass(name);
                     if (loaded == null) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LogTailControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LogTailControllerTests.java
@@ -209,4 +209,19 @@ class LogTailControllerTests {
                 .andExpect(jsonPath("$[?(@.message == '" + uniqueMsg + "')].thread")
                         .value("shape-thread"));
     }
+
+    // ── DevTools restart lifecycle ────────────────────────────────────────────
+
+    @Test
+    void uninstallDetachesAppenderFromLoggerContext() {
+        BootUiLogAppender appender = BootUiLogAppender.install();
+        assertThat(BootUiLogAppender.find()).isSameAs(appender);
+
+        appender.uninstall();
+
+        // Detached from the JVM-global LoggerContext so a DevTools restart does not leak the old
+        // context's subscribers; install() re-creates it on the next start.
+        assertThat(BootUiLogAppender.find()).isNull();
+        assertThat(appender.isStarted()).isFalse();
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Releases the long-lived resources behind the Live Activity dashboard on context shutdown, and hardens the SQL trace DataSource proxy, so a Spring DevTools live reload no longer leaks threads/class loaders or mis-wires tracing.

## Why is this change needed?

The Live Activity stack (and the SQL Trace, Exceptions, Security Logs panels it aggregates) sets up several JVM-global / long-lived resources that were never torn down. Under DevTools live reload a new `ApplicationContext` and `RestartClassLoader` are created on every restart, so each reload leaked the previous ones:

- **SQL trace proxy.** `SqlTracingProxies.wrap()` guards against re-wrapping with `instanceof SqlTracedDataSource`. That guard is class-loader fragile: a DataSource preserved across a restart (e.g. via `@RestartScope`) is already a tracing proxy built by the *previous* `RestartClassLoader`, whose marker is a different `Class` with the same name, so `instanceof` misses it and the pool gets wrapped again, double counting SQL and pinning the old class loader.
- **`BootUiChangeStream`.** Four controllers `new` a change stream (a daemon scheduler thread) and subscribe to the recorder/store, but never closed it or released the subscriptions, leaking one thread plus the discarded context per reload.
- **Logback appenders.** `BOOTUI_EXCEPTIONS` and `BOOTUI_LOG_TAIL` attach to the JVM-global `LoggerContext` and were never detached, so a stale survivor could feed the previous context's store.

## Approach

- Detect a foreign tracing proxy by interface **name** (class-loader agnostic) and `unwrap()` it before re-wrapping over the real pool, instead of nesting.
- Add `@PreDestroy shutdown()` to `LiveActivityController`, `SqlTraceController`, `ExceptionsController` and `SecurityLogsController` that runs the stored unsubscribers and calls `changeStream.close()`.
- Add `uninstall()` to both appenders (detach from the root logger + `stop()`); wired via `LogTailController` `@PreDestroy` and the exception appender's `@Bean(destroyMethod = "uninstall")`.

This is defensive cleanup: it changes no panel behavior or API shapes. In a GraalVM native image the live-reload scenario does not occur, and the change adds no new reachability metadata (Fix #1 reuses the already-registered `DATA_SOURCE_INTERFACES` JDK proxy; `@PreDestroy` is handled by Spring AOT).

## How was it tested?

- [x] `./mvnw clean install` passes locally (full `bootui-autoconfigure` suite: 1237 tests green)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

New tests cover: a foreign-class-loader tracing proxy being unwrapped-and-rewrapped (not nested), `LiveActivityController.shutdown()` terminating the `bootui-activity-stream` scheduler thread, and `uninstall()` detaching both appenders from the `LoggerContext`.

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - internal lifecycle only, no visible behavior change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed