### PR TITLE
Report LiveReload client count for honest "Trigger LiveReload" feedback

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DefaultDevToolsBridge.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DefaultDevToolsBridge.java
@@ -7,6 +7,7 @@ import jakarta.annotation.PreDestroy;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -28,6 +29,8 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
 
     private static final String OPTIONAL_LIVE_RELOAD_SERVER_CLASS =
             "org.springframework.boot.devtools.autoconfigure.OptionalLiveReloadServer";
+
+    private static final int DEFAULT_LIVE_RELOAD_PORT = 35729;
 
     private final ApplicationContext applicationContext;
 
@@ -54,6 +57,7 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
                 restartPending.get(),
                 liveReload.available(),
                 liveReload.port(),
+                liveReload.connections(),
                 liveReload.reason());
     }
 
@@ -66,11 +70,25 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
         try {
             Method triggerReload = liveReload.target().getClass().getMethod("triggerReload");
             triggerReload.invoke(liveReload.target());
-            return new DevToolsActionResult(
-                    "livereload", "triggered", "LiveReload notification sent to connected browsers.");
         } catch (ReflectiveOperationException ex) {
             throw new DevToolsException("Could not trigger Spring Boot DevTools LiveReload", unwrap(ex));
         }
+        int connections = liveReload.connections();
+        if (connections <= 0) {
+            int port = liveReload.port() == null ? DEFAULT_LIVE_RELOAD_PORT : liveReload.port();
+            return new DevToolsActionResult(
+                    "livereload",
+                    "no_clients",
+                    "LiveReload command sent, but no browsers are connected on port " + port
+                            + ", so nothing reloaded. Spring Boot does not inject livereload.js: install the LiveReload"
+                            + " browser extension and reload the page you want to refresh so it connects, then trigger"
+                            + " again.");
+        }
+        return new DevToolsActionResult(
+                "livereload",
+                "triggered",
+                "LiveReload command sent to " + connections + " connected client" + (connections == 1 ? "" : "s")
+                        + ".");
     }
 
     @Override
@@ -165,22 +183,40 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
                 return LiveReloadHandle.unavailable(null);
             }
             Object bean = beans.values().iterator().next();
-            return new LiveReloadHandle(bean, liveReloadPort(bean), null);
+            Object server = liveReloadServer(bean);
+            return new LiveReloadHandle(bean, liveReloadPort(server), connectionCount(server), null);
         } catch (ReflectiveOperationException | LinkageError ex) {
             return LiveReloadHandle.unavailable("Spring Boot DevTools LiveReload server is not available.");
         }
     }
 
-    private Integer liveReloadPort(Object bean) {
-        Object target = liveReloadServer(bean);
-        if (target == null) {
+    private Integer liveReloadPort(Object server) {
+        if (server == null) {
             return null;
         }
         try {
-            Method getPort = target.getClass().getMethod("getPort");
-            return (Integer) getPort.invoke(target);
+            Method getPort = server.getClass().getMethod("getPort");
+            return (Integer) getPort.invoke(server);
         } catch (ReflectiveOperationException ex) {
             return null;
+        }
+    }
+
+    private int connectionCount(Object server) {
+        if (server == null) {
+            return 0;
+        }
+        try {
+            Field connections = server.getClass().getDeclaredField("connections");
+            connections.setAccessible(true);
+            if (connections.get(server) instanceof Collection<?> collection) {
+                synchronized (collection) {
+                    return collection.size();
+                }
+            }
+            return 0;
+        } catch (ReflectiveOperationException ex) {
+            return 0;
         }
     }
 
@@ -214,10 +250,10 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
         }
     }
 
-    private record LiveReloadHandle(Object target, Integer port, String reason) {
+    private record LiveReloadHandle(Object target, Integer port, int connections, String reason) {
 
         static LiveReloadHandle unavailable(String reason) {
-            return new LiveReloadHandle(null, null, reason);
+            return new LiveReloadHandle(null, null, 0, reason);
         }
 
         boolean available() {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevToolsControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DevToolsControllerTests.java
@@ -17,7 +17,7 @@ class DevToolsControllerTests {
     @Test
     void reportsDevToolsStatus() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-                        new DevToolsStatus(true, null, false, true, 35729, null),
+                        new DevToolsStatus(true, null, false, true, 35729, 2, null),
                         new DevToolsActionResult("livereload", "triggered", "ok"),
                         new DevToolsActionResult("restart", "scheduled", "ok"))))
                 .build();
@@ -27,14 +27,15 @@ class DevToolsControllerTests {
                 .andExpect(jsonPath("$.restartAvailable").value(true))
                 .andExpect(jsonPath("$.restartPending").value(false))
                 .andExpect(jsonPath("$.liveReloadAvailable").value(true))
-                .andExpect(jsonPath("$.liveReloadPort").value(35729));
+                .andExpect(jsonPath("$.liveReloadPort").value(35729))
+                .andExpect(jsonPath("$.liveReloadConnections").value(2));
     }
 
     @Test
     void triggersLiveReloadWhenAvailable() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-                        new DevToolsStatus(true, null, false, true, 35729, null),
-                        new DevToolsActionResult("livereload", "triggered", "LiveReload notification sent."),
+                        new DevToolsStatus(true, null, false, true, 35729, 1, null),
+                        new DevToolsActionResult("livereload", "triggered", "LiveReload command sent to 1 client."),
                         new DevToolsActionResult("restart", "scheduled", "ok"))))
                 .build();
 
@@ -45,9 +46,23 @@ class DevToolsControllerTests {
     }
 
     @Test
+    void reportsNoClientsWhenNoBrowsersConnected() throws Exception {
+        MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
+                        new DevToolsStatus(true, null, false, true, 35729, 0, null),
+                        new DevToolsActionResult("livereload", "no_clients", "no browsers are connected"),
+                        new DevToolsActionResult("restart", "scheduled", "ok"))))
+                .build();
+
+        mvc.perform(post("/bootui/api/devtools/livereload"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("no_clients"))
+                .andExpect(jsonPath("$.message").value("no browsers are connected"));
+    }
+
+    @Test
     void returnsConflictWhenLiveReloadUnavailable() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-                        new DevToolsStatus(false, "no restart", false, false, null, "no livereload"),
+                        new DevToolsStatus(false, "no restart", false, false, null, 0, "no livereload"),
                         new DevToolsActionResult("livereload", "unavailable", "no livereload"),
                         new DevToolsActionResult("restart", "unavailable", "no restart"))))
                 .build();
@@ -61,7 +76,7 @@ class DevToolsControllerTests {
     @Test
     void restartRequiresConfirmation() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-                        new DevToolsStatus(true, null, false, true, 35729, null),
+                        new DevToolsStatus(true, null, false, true, 35729, 0, null),
                         new DevToolsActionResult("livereload", "triggered", "ok"),
                         new DevToolsActionResult("restart", "scheduled", "ok"))))
                 .build();
@@ -76,7 +91,7 @@ class DevToolsControllerTests {
     @Test
     void schedulesRestartWhenConfirmed() throws Exception {
         MockMvc mvc = standaloneSetup(new DevToolsController(new StubDevToolsBridge(
-                        new DevToolsStatus(true, null, false, true, 35729, null),
+                        new DevToolsStatus(true, null, false, true, 35729, 0, null),
                         new DevToolsActionResult("livereload", "triggered", "ok"),
                         new DevToolsActionResult("restart", "scheduled", "Restart scheduled."))))
                 .build();

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DevToolsStatus.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DevToolsStatus.java
@@ -9,4 +9,5 @@ public record DevToolsStatus(
         boolean restartPending,
         boolean liveReloadAvailable,
         Integer liveReloadPort,
+        int liveReloadConnections,
         String liveReloadUnavailableReason) {}

--- a/bootui-sample-app/e2e/tests/devtools.spec.js
+++ b/bootui-sample-app/e2e/tests/devtools.spec.js
@@ -28,6 +28,7 @@ test.describe('DevTools view', () => {
             restartPending: false,
             liveReloadAvailable: true,
             liveReloadPort: 35729,
+            liveReloadConnections: 2,
             liveReloadUnavailableReason: null
           })
         })
@@ -41,7 +42,7 @@ test.describe('DevTools view', () => {
           body: JSON.stringify({
             action: 'livereload',
             status: 'triggered',
-            message: 'LiveReload notification sent to connected browsers.'
+            message: 'LiveReload command sent to 2 connected clients.'
           })
         })
       }
@@ -50,9 +51,51 @@ test.describe('DevTools view', () => {
     await openView('devtools', /^DevTools/)
 
     await expect(page.getByText('LiveReload port:')).toBeVisible()
+    await expect(page.getByText('Connected clients:')).toBeVisible()
     await expect(page.getByRole('button', {name: /Restart app/})).toBeDisabled()
 
     await page.getByRole('button', {name: /Trigger LiveReload/}).click()
-    await expect(page.locator('.alert-success')).toContainText('LiveReload notification sent')
+    await expect(page.locator('.alert-success')).toContainText('LiveReload command sent')
+  })
+
+  test('warns when LiveReload has no connected clients', async ({openView, page}) => {
+    await page.route(
+      (url) => url.pathname === '/bootui/api/devtools',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            restartAvailable: false,
+            restartUnavailableReason: 'Spring Boot DevTools Restarter is not initialized.',
+            restartPending: false,
+            liveReloadAvailable: true,
+            liveReloadPort: 35729,
+            liveReloadConnections: 0,
+            liveReloadUnavailableReason: null
+          })
+        })
+      }
+    )
+    await page.route(
+      (url) => url.pathname === '/bootui/api/devtools/livereload',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            action: 'livereload',
+            status: 'no_clients',
+            message: 'LiveReload command sent, but no browsers are connected on port 35729, so nothing reloaded.'
+          })
+        })
+      }
+    )
+
+    await openView('devtools', /^DevTools/)
+
+    const liveReloadCard = page.locator('.card', {hasText: 'Trigger LiveReload'})
+    await expect(liveReloadCard).toContainText('No browsers are connected to the LiveReload server')
+
+    await page.getByRole('button', {name: /Trigger LiveReload/}).click()
+    await expect(page.locator('.alert-warning')).toContainText('no browsers are connected')
   })
 })

--- a/bootui-sample-app/e2e/tests/devtools.spec.js
+++ b/bootui-sample-app/e2e/tests/devtools.spec.js
@@ -96,6 +96,8 @@ test.describe('DevTools view', () => {
     await expect(liveReloadCard).toContainText('No browsers are connected to the LiveReload server')
 
     await page.getByRole('button', {name: /Trigger LiveReload/}).click()
-    await expect(page.locator('.alert-warning')).toContainText('no browsers are connected')
+    await expect(page.locator('.alert-warning', {hasText: 'LiveReload command sent'})).toContainText(
+      'no browsers are connected'
+    )
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/DevTools.test.js
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.test.js
@@ -14,6 +14,7 @@ function devToolsStatus() {
     restartUnavailableReason: 'Spring Boot DevTools is not on the classpath.',
     liveReloadAvailable: false,
     liveReloadPort: null,
+    liveReloadConnections: 0,
     liveReloadUnavailableReason: 'Spring Boot DevTools is not on the classpath.'
   }
 }
@@ -78,5 +79,68 @@ describe('DevTools', () => {
     await flushPromises()
 
     expect(wrapper.text()).not.toContain('spring.devtools.livereload.enabled=true')
+  })
+
+  it('warns when LiveReload is available but no browsers are connected', async () => {
+    const status = {
+      ...devToolsStatus(),
+      liveReloadAvailable: true,
+      liveReloadPort: 35729,
+      liveReloadConnections: 0,
+      liveReloadUnavailableReason: null
+    }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(status)))
+
+    wrapper = mount(DevTools)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Connected clients:')
+    expect(wrapper.text()).toContain('No browsers are connected to the LiveReload server')
+  })
+
+  it('does not warn when LiveReload clients are connected', async () => {
+    const status = {
+      ...devToolsStatus(),
+      liveReloadAvailable: true,
+      liveReloadPort: 35729,
+      liveReloadConnections: 2,
+      liveReloadUnavailableReason: null
+    }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(status)))
+
+    wrapper = mount(DevTools)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Connected clients:')
+    expect(wrapper.text()).not.toContain('No browsers are connected to the LiveReload server')
+  })
+
+  it('flashes a warning when triggering LiveReload reaches no connected clients', async () => {
+    const status = {
+      ...devToolsStatus(),
+      liveReloadAvailable: true,
+      liveReloadPort: 35729,
+      liveReloadConnections: 0,
+      liveReloadUnavailableReason: null
+    }
+    const fetchMock = vi.fn().mockImplementation((url) => {
+      if (url === 'api/devtools/livereload') {
+        return Promise.resolve(
+          jsonResponse({action: 'livereload', status: 'no_clients', message: 'no browsers are connected'})
+        )
+      }
+      return Promise.resolve(jsonResponse(status))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    wrapper = mount(DevTools)
+    await flushPromises()
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await flushPromises()
+
+    const banner = wrapper.findAll('.alert').find((alert) => alert.find('.btn-close').exists())
+    expect(banner.classes()).toContain('alert-warning')
+    expect(banner.text()).toContain('no browsers are connected')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -22,6 +22,7 @@ let reconnectTimer = null
 
 const restartReady = computed(() => status.value?.restartAvailable && !status.value?.restartPending)
 const liveReloadReady = computed(() => status.value?.liveReloadAvailable)
+const liveReloadConnections = computed(() => status.value?.liveReloadConnections ?? 0)
 const liveReloadDisabled = computed(
   () =>
     !!status.value &&
@@ -55,7 +56,7 @@ async function triggerLiveReload() {
       await load()
       return
     }
-    flash(result.message || 'LiveReload triggered.', 'success')
+    flash(result.message || 'LiveReload triggered.', result.status === 'triggered' ? 'success' : 'warning')
     await load()
   } catch (e) {
     flash(formatLoadError(e, 'Could not trigger LiveReload'), 'danger')
@@ -182,6 +183,22 @@ onUnmounted(clearReconnectTimer)
                 >LiveReload port: <code>{{ status.liveReloadPort }}</code></span
               >
               <span v-else>{{ status.liveReloadUnavailableReason || 'No LiveReload port reported.' }}</span>
+              <span v-if="liveReloadReady"
+                >&nbsp;&middot; Connected clients: <code>{{ liveReloadConnections }}</code></span
+              >
+            </div>
+
+            <div
+              v-if="liveReloadReady && liveReloadConnections === 0"
+              class="alert alert-warning small d-flex align-items-start gap-2 py-2 px-3 mb-3"
+              role="note"
+            >
+              <i class="bi bi-exclamation-triangle-fill mt-1"></i>
+              <div>
+                No browsers are connected to the LiveReload server, so triggering a reload has no visible effect. Spring
+                Boot does not inject <code>livereload.js</code>: install the LiveReload browser extension and reload the
+                page you want to refresh so it connects, then trigger again.
+              </div>
             </div>
 
             <div

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -819,6 +819,11 @@ are shown only when available and require explicit confirmation before execution
 the LiveReload server is not running, the panel shows a tip to set `spring.devtools.livereload.enabled=true` (Spring
 Boot 4 disables LiveReload by default).
 
+The LiveReload card also reports how many browsers are currently connected to the LiveReload server. Triggering a reload
+only reaches those connected clients — Spring Boot does not inject `livereload.js`, so a browser needs the LiveReload
+extension (or the script) to connect on port 35729. When no clients are connected the panel warns that triggering has no
+visible effect, and the trigger action returns that warning instead of a misleading success.
+
 ![BootUI DevTools panel](./images/bootui-devtools.png)
 
 ### Dev Services


### PR DESCRIPTION
## What does this PR do?

Makes the DevTools "Trigger LiveReload" action report how many browsers are actually connected, and gives honest feedback when none are.

## Why is this change needed?

The button looked broken: setting `spring.devtools.livereload.enabled=true` enabled the action, clicking it reported a green "notification sent to connected browsers" success, but nothing reloaded.

The action itself was working correctly. `LiveReloadServer.triggerReload()` only pushes a reload to browsers with a live WebSocket connection to the LiveReload server (port 35729). Spring Boot does not inject `livereload.js` into your pages, so a browser only connects when the LiveReload extension is installed. With zero connected clients the command is a no-op, but the UI still flashed success, which is what made it feel like "it doesn't work".

The fix surfaces the missing diagnostic instead of hiding it:

- `DevToolsStatus` gains `liveReloadConnections`, reflected from `LiveReloadServer.connections`.
- `triggerLiveReload()` returns status `triggered` with the client count when browsers are connected, or `no_clients` with guidance (install the LiveReload extension and reload the target page) when none are.
- The DevTools panel shows "Connected clients: N", warns on the LiveReload card when the count is 0, and flashes the trigger result as a warning rather than a misleading success.

No linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran `./mvnw -pl bootui-autoconfigure test` (1238 passed, including new `DevToolsControllerTests` coverage for the `no_clients` path and `liveReloadConnections`) and the frontend Vitest suite (248 passed, including new `DevTools.test.js` cases). Applied and verified Spotless plus Prettier (frontend and e2e). Updated the e2e `devtools.spec.js` for the connected-client display and the no-clients warning.

## Screenshots (UI changes)

N/A. The LiveReload card now shows a "Connected clients: N" line plus a warning note when zero clients are connected; no layout changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

Note: `DevToolsStatus` is a JSON DTO consumed by BootUI's own SPA; the new `liveReloadConnections` field is purely additive.