### PR TITLE
docs: mark PLAN 3.1 correlation done as Live Activity panel

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -30,6 +30,15 @@ The priorities for every item below remain unchanged:
 - Fixed Spring Modulith Flyway reporting and proxied Hikari datasource discovery so the existing Database panels better
   match real applications.
 
+### Completed in this workstream
+
+- Shipped §3.1 (Trace ↔ Log ↔ Request correlation) as the **Live Activity** panel: a single reverse-chronological stream
+  that merges requests, SQL, exceptions, and security events from BootUI's existing in-memory buffers, nests correlated
+  signals under the request that produced them, and adds a per-request profiler that joins each request's signals by
+  trace id, serving thread, and time window. It refreshes over a `/bootui/api/activity/stream` Server-Sent Events feed,
+  carries a KPI strip, and deep-links into the HTTP Exchanges, SQL Trace, Exceptions, Health, and Heap Dump panels. The
+  panel is read-only and reuses the existing masking, value-exposure, and panel-toggle model.
+
 Each new panel must:
 
 - be **read-only or read-mostly**, with any mutating control explicitly confirmation-gated like the existing Spring Cache
@@ -42,23 +51,30 @@ Each new panel must:
 
 ## 2. Scope of this workstream
 
-Three open features, grouped by priority. Items are intended to land roughly in the order listed: the existing correlation
-and graph items remain in scope; the capture-heavy e-mail viewer lands after the read-only items because it needs stricter
+Two open features remain, grouped by priority. The §3.1 correlation item has shipped as the **Live Activity** panel; the
+graph item remains in scope, and the capture-heavy e-mail viewer lands after the read-only items because it needs stricter
 masking, bounding, sandboxing, and opt-in behaviour.
 
 | Priority | Feature                               | Group         | Primary data source                                | Mutation?         | Origin           |
 | -------- | ------------------------------------- | ------------- | -------------------------------------------------- | ----------------- | ---------------- |
-| 1        | Trace ↔ Log ↔ Request correlation     | Diagnostics   | Existing Traces, Log Tail, and HTTP Exchanges data | No                | Existing roadmap |
-| 2        | Bean / dependency graph visualization | Configuration | Existing Beans and Conditions data                 | No                | Existing roadmap |
-| 3        | E-mail Viewer                         | Diagnostics   | Intercepted `JavaMailSender`                       | No (capture only) | New addition     |
+| Done     | Trace ↔ Log ↔ Request correlation     | Diagnostics   | Existing Traces, Log Tail, and HTTP Exchanges data | No                | Existing roadmap |
+| 1        | Bean / dependency graph visualization | Configuration | Existing Beans and Conditions data                 | No                | Existing roadmap |
+| 2        | E-mail Viewer                         | Diagnostics   | Intercepted `JavaMailSender`                       | No (capture only) | New addition     |
 
-The Trace ↔ Log ↔ Request correlation work in §3.1 builds on the already-shipped HTTP Exchanges panel and the existing
-Traces and Log Tail panels. The E-mail Viewer is the only remaining capture-oriented feature in this workstream, so it
-must keep pass-through application behaviour by default and make any dev-trap mode explicitly opt-in.
+The Trace ↔ Log ↔ Request correlation work in §3.1 has shipped as the **Live Activity** panel, building on the
+already-shipped HTTP Exchanges panel and the existing Traces and Log Tail panels. The E-mail Viewer is the only remaining
+capture-oriented feature in this workstream, so it must keep pass-through application behaviour by default and make any
+dev-trap mode explicitly opt-in.
 
 ## 3. Feature specifications
 
-### 3.1 Trace ↔ Log ↔ Request correlation — Diagnostics
+### 3.1 Trace ↔ Log ↔ Request correlation — Diagnostics ✅ Completed
+
+**Status: completed.** Shipped as the **Live Activity** panel (see `docs/FEATURES.md` → *Live Activity*), which merges
+requests, SQL, exceptions, and security events into one reverse-chronological stream with request-scoped nesting, a
+per-request profiler that correlates each request's signals by trace id / serving thread / time window, an SSE feed at
+`/bootui/api/activity/stream`, and deep links back into the HTTP Exchanges, SQL Trace, and Exceptions panels. The original
+scope and design constraints below are retained for reference.
 
 This is where Aspire and Symfony differentiate. BootUI already owns a trace pipeline (the in-app OTLP sink and Traces
 panel) plus Log Tail, and the HTTP Exchanges panel; the three can be cross-linked by trace and span id.


### PR DESCRIPTION
## What does this PR do?

Updates `docs/PLAN.md` to record that roadmap item §3.1 (Trace ↔ Log ↔ Request correlation) has shipped as the **Live Activity** panel.

## Why is this change needed?

The implementation plan still listed the correlation feature as open work, but it has landed as the Live Activity panel. This keeps the plan an accurate reflection of what's done versus what remains.

Closes #

The change is documentation-only:

- Adds a "Completed in this workstream" subsection summarizing the Live Activity panel (merged request/SQL/exception/security stream, request-scoped nesting, per-request profiler, `/bootui/api/activity/stream` SSE feed, KPI strip, and deep links).
- Updates the scope intro from "Three open features" to "Two open features remain" and marks the correlation row in the scope table as Done, renumbering the remaining priorities (graph -> 1, e-mail -> 2).
- Tags the §3.1 heading as Completed with a short status note pointing at `docs/FEATURES.md`, while retaining the original scope and design constraints for reference.

Section numbers (3.1/3.2/3.3) are intentionally left stable so existing cross-references still resolve.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

N/A - documentation-only change with no code or behaviour impact.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed