### PR TITLE
docs: add missing 1.5.0 changelog compare link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -668,6 +668,7 @@ First tagged BootUI alpha. Highlights of the harden-all-visible-panels scope:
   request history, distributed tracing, multi-service orchestration, and live
   Docker Compose lifecycle control are intentionally out of scope for the alpha.
 
+[1.5.0]: https://github.com/jdubois/boot-ui/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/jdubois/boot-ui/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/jdubois/boot-ui/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/jdubois/boot-ui/compare/v1.1.0...v1.2.0


### PR DESCRIPTION
## What does this PR do?

Adds the missing reference-style link definition for the `## [1.5.0]` changelog heading so it renders as a link to the GitHub compare view.

## Why is this change needed?

The 1.5.0 entry was added in commit `6c6ad525` ("docs: add 1.5.0 changelog and sync properties table"), but that commit added only the `## [1.5.0]` heading and forgot the matching link-reference definition at the bottom of `CHANGELOG.md`. Because the heading is a reference-style Markdown link, it rendered as plain text instead of linking to `v1.4.0...v1.5.0`, unlike every other release. This restores the established pattern.

Closes # N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Docs-only change; no build, sample-app, or test runs required. Verified the new `[1.5.0]:` definition follows the exact format of the surrounding release links.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed