### PR TITLE
Complete SSE streams on ContextClosedEvent to fix slow shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **BootUI's live panels no longer delay graceful shutdown.** The Server-Sent Events panels (Live Activity, Exceptions,
+  SQL Trace, Security Logs, Log Tail, Copilot, Claude Code) open an `SseEmitter` with no timeout, which counts as an
+  active request. Their emitter cleanup ran from a bean-destruction (`@PreDestroy`) hook — too late, because Spring Boot
+  4's default graceful shutdown waits for in-flight requests *before* beans are destroyed, so every JVM stop blocked
+  until the `spring.lifecycle.timeout-per-shutdown-phase` timeout (30s by default). BootUI now completes these streams on
+  `ContextClosedEvent`, which fires before the web server's graceful-shutdown lifecycle, so the application stops
+  promptly again.
+
 ## [1.5.0] - 2026-06-15
 
 Feature release headlined by a new **Live Activity** panel — a diagnostics "home base" that merges BootUI's already

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityController.java
@@ -12,12 +12,12 @@ import io.github.jdubois.bootui.autoconfigure.web.SecurityLogsController;
 import io.github.jdubois.bootui.autoconfigure.web.TracesController;
 import io.github.jdubois.bootui.core.dto.LiveActivityReport;
 import io.github.jdubois.bootui.core.dto.RequestProfileDto;
-import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -95,12 +95,17 @@ public class LiveActivityController {
     }
 
     /**
-     * Releases the change stream's scheduler thread and SSE emitters, and detaches the source listeners,
-     * when the context shuts down. This keeps a Spring Boot DevTools restart from leaking a
-     * {@code bootui-activity-stream} daemon thread (and, through it, the discarded application context and
-     * its class loader) on every live reload.
+     * Completes any open SSE streams and detaches the merged source listeners when the context starts
+     * closing.
+     *
+     * <p>Runs on {@link ContextClosedEvent} rather than {@code @PreDestroy}: the event is published
+     * before the web server's graceful-shutdown lifecycle waits for in-flight requests, whereas
+     * {@code @PreDestroy} runs during later bean destruction. An {@code SseEmitter(0L)} never completes
+     * on its own, so cleaning up at destroy time would let graceful shutdown block until its timeout on
+     * every stop. Doing it here also keeps a Spring Boot DevTools restart from leaking the
+     * {@code bootui-activity-stream} daemon thread (and the discarded context's class loader behind it).
      */
-    @PreDestroy
+    @EventListener(ContextClosedEvent.class)
     void shutdown() {
         unsubscribers.forEach(Runnable::run);
         unsubscribers.clear();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/ExceptionsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/ExceptionsController.java
@@ -10,11 +10,12 @@ import io.github.jdubois.bootui.core.dto.ExceptionFrameDto;
 import io.github.jdubois.bootui.core.dto.ExceptionGroupDto;
 import io.github.jdubois.bootui.core.dto.ExceptionOccurrenceDto;
 import io.github.jdubois.bootui.core.dto.ExceptionsReport;
-import jakarta.annotation.PreDestroy;
 import java.util.List;
 import java.util.regex.Pattern;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -66,11 +67,16 @@ public class ExceptionsController {
     }
 
     /**
-     * Releases the change stream's scheduler thread and SSE emitters, and detaches the store listener,
-     * when the context shuts down so a Spring Boot DevTools restart does not leak the
+     * Completes any open SSE streams and detaches the store listener when the context starts closing.
+     *
+     * <p>Runs on {@link ContextClosedEvent} rather than {@code @PreDestroy}: the event is published
+     * before the web server's graceful-shutdown lifecycle waits for in-flight requests, whereas
+     * {@code @PreDestroy} runs during later bean destruction. An {@code SseEmitter(0L)} never completes
+     * on its own, so cleaning up at destroy time would let graceful shutdown block until its timeout on
+     * every stop. Doing it here also keeps a Spring Boot DevTools restart from leaking the
      * {@code bootui-exceptions-stream} daemon thread (and the discarded context behind it).
      */
-    @PreDestroy
+    @EventListener(ContextClosedEvent.class)
     void shutdown() {
         if (storeUnsubscribe != null) {
             storeUnsubscribe.run();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceController.java
@@ -7,11 +7,12 @@ import io.github.jdubois.bootui.autoconfigure.stream.BootUiChangeStream;
 import io.github.jdubois.bootui.core.dto.SqlTraceEntryDto;
 import io.github.jdubois.bootui.core.dto.SqlTraceRecordingRequest;
 import io.github.jdubois.bootui.core.dto.SqlTraceReport;
-import jakarta.annotation.PreDestroy;
 import java.util.ArrayList;
 import java.util.List;
 import javax.sql.DataSource;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -56,11 +57,16 @@ public class SqlTraceController {
     }
 
     /**
-     * Releases the change stream's scheduler thread and SSE emitters, and detaches the recorder listener,
-     * when the context shuts down so a Spring Boot DevTools restart does not leak the
+     * Completes any open SSE streams and detaches the recorder listener when the context starts closing.
+     *
+     * <p>Runs on {@link ContextClosedEvent} rather than {@code @PreDestroy}: the event is published
+     * before the web server's graceful-shutdown lifecycle waits for in-flight requests, whereas
+     * {@code @PreDestroy} runs during later bean destruction. An {@code SseEmitter(0L)} never completes
+     * on its own, so cleaning up at destroy time would let graceful shutdown block until its timeout on
+     * every stop. Doing it here also keeps a Spring Boot DevTools restart from leaking the
      * {@code bootui-sql-trace-stream} daemon thread (and the discarded context behind it).
      */
-    @PreDestroy
+    @EventListener(ContextClosedEvent.class)
     void shutdown() {
         if (recorderUnsubscribe != null) {
             recorderUnsubscribe.run();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AgentSessionController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AgentSessionController.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -145,6 +147,23 @@ public abstract class AgentSessionController {
         if (unsubscribe != null) {
             unsubscribe.run();
         }
+    }
+
+    /**
+     * Completes any open activity streams when the context starts closing.
+     *
+     * <p>Runs on {@link ContextClosedEvent}, which is published before the web server's
+     * graceful-shutdown lifecycle waits for in-flight requests. An {@code SseEmitter(0L)} never
+     * completes on its own, so without this the server would block until the graceful-shutdown timeout
+     * on every stop (and a Spring Boot DevTools restart would leave the discarded context pinned behind
+     * the dangling stream).
+     */
+    @EventListener(ContextClosedEvent.class)
+    void shutdown() {
+        for (SseEmitter emitter : emitters) {
+            emitter.complete();
+        }
+        emitters.clear();
     }
 
     // exposed only for testing

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
@@ -1,12 +1,13 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.dto.LogLineDto;
-import jakarta.annotation.PreDestroy;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -81,10 +82,17 @@ public class LogTailController {
 
     /**
      * Completes any open log-tail streams and detaches the shared Logback appender when the context
-     * shuts down, so a Spring Boot DevTools restart does not leave dead SSE subscribers attached to the
-     * surviving {@code LoggerContext} (and the old context pinned behind them) on every live reload.
+     * starts closing.
+     *
+     * <p>Runs on {@link ContextClosedEvent} rather than {@code @PreDestroy}: the event is published
+     * before the web server's graceful-shutdown lifecycle waits for in-flight requests, whereas
+     * {@code @PreDestroy} runs during later bean destruction. An {@code SseEmitter(0L)} never completes
+     * on its own, so cleaning up at destroy time would let graceful shutdown block until its timeout on
+     * every stop. Doing it here also keeps a Spring Boot DevTools restart from leaving dead SSE
+     * subscribers attached to the surviving {@code LoggerContext} (and the old context pinned behind
+     * them) on every live reload.
      */
-    @PreDestroy
+    @EventListener(ContextClosedEvent.class)
     void shutdown() {
         for (SseEmitter emitter : emitters) {
             emitter.complete();

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityLogsController.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityLogsController.java
@@ -9,7 +9,6 @@ import io.github.jdubois.bootui.core.dto.SecurityLogDataDto;
 import io.github.jdubois.bootui.core.dto.SecurityLogEventDto;
 import io.github.jdubois.bootui.core.dto.SecurityLogTypeSummaryDto;
 import io.github.jdubois.bootui.core.dto.SecurityLogsReport;
-import jakarta.annotation.PreDestroy;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -25,6 +24,8 @@ import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -113,11 +114,16 @@ public class SecurityLogsController implements ApplicationListener<AuditApplicat
     }
 
     /**
-     * Releases the change stream's scheduler thread and SSE emitters when the context shuts down so a
-     * Spring Boot DevTools restart does not leak the {@code bootui-security-logs-stream} daemon thread
-     * (and the discarded context behind it) on every live reload.
+     * Completes any open SSE streams when the context starts closing.
+     *
+     * <p>Runs on {@link ContextClosedEvent} rather than {@code @PreDestroy}: the event is published
+     * before the web server's graceful-shutdown lifecycle waits for in-flight requests, whereas
+     * {@code @PreDestroy} runs during later bean destruction. An {@code SseEmitter(0L)} never completes
+     * on its own, so cleaning up at destroy time would let graceful shutdown block until its timeout on
+     * every stop. Doing it here also keeps a Spring Boot DevTools restart from leaking the
+     * {@code bootui-security-logs-stream} daemon thread (and the discarded context behind it).
      */
-    @PreDestroy
+    @EventListener(ContextClosedEvent.class)
     void shutdown() {
         changeStream.close();
     }

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/CopilotControllerTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/CopilotControllerTests.java
@@ -63,6 +63,21 @@ class CopilotControllerTests {
     }
 
     @Test
+    void contextCloseCompletesOpenStreams(@TempDir Path tempDir) {
+        BootUiProperties props = propertiesFor(tempDir);
+        CopilotController controller = new CopilotController(storeFor(props), props);
+
+        controller.stream();
+        controller.stream();
+        assertThat(controller.emittersForTesting()).hasSize(2);
+
+        // Completing emitters on ContextClosedEvent (before the web server's graceful-shutdown
+        // lifecycle waits) is what stops an SseEmitter(0L) from blocking shutdown until its timeout.
+        controller.shutdown();
+        assertThat(controller.emittersForTesting()).isEmpty();
+    }
+
+    @Test
     void sessionsReturnsUnavailableWhenDirectoryMissing(@TempDir Path tempDir) throws Exception {
         Path missing = tempDir.resolve("does-not-exist");
         BootUiProperties props = propertiesFor(missing);


### PR DESCRIPTION
## What does this PR do?

Stops BootUI's Server-Sent Events panels from blocking application shutdown for ~30 seconds.

## Why is this change needed?

Spring Boot 4 defaults to graceful shutdown, which waits for in-flight requests to finish before stopping. BootUI's live panels open an `SseEmitter(0L)` (no timeout), so each open stream counts as an active request that never completes on its own. Their emitter cleanup ran from a bean-destruction hook (`@PreDestroy`), or not at all for the Copilot/Claude Code controllers.

The ordering in `AbstractApplicationContext.doClose()` (verified from the bytecode) is:

1. publish `ContextClosedEvent`
2. `lifecycleProcessor.onClose()` -> the web server's graceful-shutdown lifecycle (phase `2147482623`) waits here for active requests, up to `spring.lifecycle.timeout-per-shutdown-phase` (30s by default)
3. `destroyBeans()` -> `@PreDestroy` runs here, too late

So the open streams were only torn down after the 30s timeout had already elapsed, which is exactly the "Graceful shutdown aborted with one or more requests still active" hang users were seeing.

The fix moves emitter completion to `ContextClosedEvent` (step 1), which fires before graceful shutdown begins waiting, so the requests finish first and the app stops promptly. This event also fires on DevTools restart, so the existing restart-hygiene the `@PreDestroy` hooks were written for is preserved.

Applied to every SSE owner:
- `ExceptionsController`, `SqlTraceController`, `LiveActivityController`, `SecurityLogsController`, `LogTailController`: `@PreDestroy` -> `@EventListener(ContextClosedEvent.class)`
- `AgentSessionController` (Copilot + Claude Code): added an `@EventListener(ContextClosedEvent.class)` handler that completes and clears emitters (it previously had none)

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran the affected module tests (`bootui-autoconfigure`) covering the change-stream controllers, log tail, Copilot/Claude Code, and architecture rules: all green. Added `CopilotControllerTests#contextCloseCompletesOpenStreams` as a regression test (opens streams, fires the context-closed handler, asserts the emitter list is drained). Spotless apply/check clean.

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (CHANGELOG `Unreleased` -> Fixed)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed