### PR TITLE
docs: add 1.5.1 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-06-15
+
+Patch release that fixes a graceful-shutdown regression introduced by 1.5.0's move to Server-Sent Events: BootUI's live
+panels no longer hold the JVM open until the configured shutdown timeout.
+
 ### Fixed
 
 - **BootUI's live panels no longer delay graceful shutdown.** The Server-Sent Events panels (Live Activity, Exceptions,
@@ -678,6 +683,7 @@ First tagged BootUI alpha. Highlights of the harden-all-visible-panels scope:
   request history, distributed tracing, multi-service orchestration, and live
   Docker Compose lifecycle control are intentionally out of scope for the alpha.
 
+[1.5.1]: https://github.com/jdubois/boot-ui/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/jdubois/boot-ui/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/jdubois/boot-ui/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/jdubois/boot-ui/compare/v1.2.0...v1.3.0


### PR DESCRIPTION
Prepares the 1.5.1 release by finalizing the changelog. Following the established prep pattern, this PR only edits `CHANGELOG.md`; the actual version-number bumps (pom.xml, package.json/lock, docs/SETUP.md) are done by the `Release` workflow when it runs `versions:set` and tags `v1.5.1`.

### Changes

- Promote the `[Unreleased]` section to `## [1.5.1] - 2026-06-15` with a short patch-release summary.
- Add the `[1.5.1]` compare link to the footer.

### About 1.5.1

Patch release covering the single change merged since v1.5.0:

- **Fixed** — BootUI's live SSE panels no longer delay graceful shutdown. They now complete their streams on `ContextClosedEvent` (before the web server's graceful-shutdown lifecycle) instead of from a `@PreDestroy` hook, so the JVM stops promptly again (#404).

### Next step

Run the **Release** workflow with version `1.5.1` to bump versions, commit, tag `v1.5.1`, and publish to Maven Central.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>