### PR TITLE
Don't force servlet web type on Spring Cloud bootstrap context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **BootUI no longer breaks Spring Cloud bootstrap startup.** When a host application used Spring Cloud Config / the
+  legacy bootstrap context (`spring-cloud-starter-bootstrap`) with BootUI active (for example under the `dev` profile),
+  the application crashed at startup with
+  `MissingWebServerFactoryBeanException: No qualifying bean of type 'ServletWebServerFactory' available`. BootUI's
+  command-line support forces a servlet web type so the console can be served, but it was also applying that to Spring
+  Cloud's transient, non-web **bootstrap** application context, which has no `ServletWebServerFactory`. BootUI now
+  detects the bootstrap context (via Spring Cloud's `"bootstrap"` marker property source) and leaves it untouched, while
+  still forcing the servlet web type on the main application.
+
 ## [1.5.1] - 2026-06-15
 
 Patch release that fixes a graceful-shutdown regression introduced by 1.5.0's move to Server-Sent Events: BootUI's live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-
-- **BootUI no longer breaks Spring Cloud bootstrap startup.** When a host application used Spring Cloud Config / the
-  legacy bootstrap context (`spring-cloud-starter-bootstrap`) with BootUI active (for example under the `dev` profile),
-  the application crashed at startup with
-  `MissingWebServerFactoryBeanException: No qualifying bean of type 'ServletWebServerFactory' available`. BootUI's
-  command-line support forces a servlet web type so the console can be served, but it was also applying that to Spring
-  Cloud's transient, non-web **bootstrap** application context, which has no `ServletWebServerFactory`. BootUI now
-  detects the bootstrap context (via Spring Cloud's `"bootstrap"` marker property source) and leaves it untouched, while
-  still forcing the servlet web type on the main application.
-
 ## [1.5.1] - 2026-06-15
 
-Patch release that fixes a graceful-shutdown regression introduced by 1.5.0's move to Server-Sent Events: BootUI's live
-panels no longer hold the JVM open until the configured shutdown timeout.
+Patch release with two fixes: BootUI's live panels no longer hold the JVM open until the configured shutdown timeout
+(a graceful-shutdown regression introduced by 1.5.0's move to Server-Sent Events), and BootUI no longer crashes
+Spring Cloud Config applications during the bootstrap phase.
 
 ### Fixed
 
@@ -32,6 +22,14 @@ panels no longer hold the JVM open until the configured shutdown timeout.
   until the `spring.lifecycle.timeout-per-shutdown-phase` timeout (30s by default). BootUI now completes these streams on
   `ContextClosedEvent`, which fires before the web server's graceful-shutdown lifecycle, so the application stops
   promptly again.
+- **BootUI no longer breaks Spring Cloud bootstrap startup.** When a host application used Spring Cloud Config / the
+  legacy bootstrap context (`spring-cloud-starter-bootstrap`) with BootUI active (for example under the `dev` profile),
+  the application crashed at startup with
+  `MissingWebServerFactoryBeanException: No qualifying bean of type 'ServletWebServerFactory' available`. BootUI's
+  command-line support forces a servlet web type so the console can be served, but it was also applying that to Spring
+  Cloud's transient, non-web **bootstrap** application context, which has no `ServletWebServerFactory`. BootUI now
+  detects the bootstrap context (via Spring Cloud's `"bootstrap"` marker property source) and leaves it untouched, while
+  still forcing the servlet web type on the main application.
 
 ## [1.5.0] - 2026-06-15
 

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiWebApplicationTypeEnvironmentPostProcessor.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiWebApplicationTypeEnvironmentPostProcessor.java
@@ -36,6 +36,16 @@ import org.springframework.util.ClassUtils;
  * explicitly configured as reactive, or that have no embedded servlet container
  * on the classpath. The behaviour can be disabled with
  * {@code bootui.force-web=false}.</p>
+ *
+ * <p>It also skips the transient, non-web Spring Cloud <em>bootstrap</em>
+ * application context. Spring Cloud's {@code BootstrapApplicationListener} builds
+ * that context with {@code WebApplicationType.NONE} and marks its environment with
+ * a property source named {@code "bootstrap"}. Forcing a servlet web type there
+ * would make the bootstrap context try to start a web server it has no
+ * {@code ServletWebServerFactory} for, failing with
+ * {@code MissingWebServerFactoryBeanException}. Detecting that marker property
+ * source mirrors Spring Cloud's own re-entrancy check and needs no Spring Cloud
+ * dependency.</p>
  */
 public class BootUiWebApplicationTypeEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
 
@@ -47,6 +57,13 @@ public class BootUiWebApplicationTypeEnvironmentPostProcessor implements Environ
     static final String WEB_APPLICATION_TYPE_PROPERTY = "spring.main.web-application-type";
 
     static final String PROPERTY_SOURCE_NAME = "bootui-web-application-type";
+
+    /**
+     * Spring Cloud marks its transient, non-web bootstrap context with a property source of this name
+     * (mirrors {@code BootstrapApplicationListener.BOOTSTRAP_PROPERTY_SOURCE_NAME}). Referenced by string
+     * so BootUI needs no Spring Cloud dependency.
+     */
+    static final String BOOTSTRAP_PROPERTY_SOURCE_NAME = "bootstrap";
 
     private static final String DISPATCHER_SERVLET_CLASS = "org.springframework.web.servlet.DispatcherServlet";
 
@@ -68,6 +85,12 @@ public class BootUiWebApplicationTypeEnvironmentPostProcessor implements Environ
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
         if (!environment.getProperty(FORCE_WEB_PROPERTY, Boolean.class, true)) {
+            return;
+        }
+        if (isSpringCloudBootstrapContext(environment)) {
+            // Spring Cloud's bootstrap context is a transient, non-web context with no
+            // ServletWebServerFactory; forcing servlet there fails the whole application
+            // with MissingWebServerFactoryBeanException. Leave it alone.
             return;
         }
         ClassLoader classLoader = application.getClassLoader();
@@ -95,6 +118,10 @@ public class BootUiWebApplicationTypeEnvironmentPostProcessor implements Environ
         log.info("BootUI is active in a non-web application; forcing servlet web mode (" + WEB_APPLICATION_TYPE_PROPERTY
                 + "=servlet) so the BootUI console can be served. Set " + FORCE_WEB_PROPERTY
                 + "=false to disable this.");
+    }
+
+    private boolean isSpringCloudBootstrapContext(ConfigurableEnvironment environment) {
+        return environment.getPropertySources().contains(BOOTSTRAP_PROPERTY_SOURCE_NAME);
     }
 
     private boolean isReactive(WebApplicationType current, String configuredType) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiWebApplicationTypeEnvironmentPostProcessorTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiWebApplicationTypeEnvironmentPostProcessorTests.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.WebApplicationType;
@@ -11,6 +12,7 @@ import org.springframework.boot.logging.DeferredLog;
 import org.springframework.boot.logging.DeferredLogFactory;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.web.context.WebApplicationContext;
@@ -21,6 +23,9 @@ class BootUiWebApplicationTypeEnvironmentPostProcessorTests {
             BootUiWebApplicationTypeEnvironmentPostProcessor.WEB_APPLICATION_TYPE_PROPERTY;
 
     private static final String SOURCE_NAME = BootUiWebApplicationTypeEnvironmentPostProcessor.PROPERTY_SOURCE_NAME;
+
+    private static final String BOOTSTRAP_SOURCE_NAME =
+            BootUiWebApplicationTypeEnvironmentPostProcessor.BOOTSTRAP_PROPERTY_SOURCE_NAME;
 
     private final BootUiWebApplicationTypeEnvironmentPostProcessor processor =
             new BootUiWebApplicationTypeEnvironmentPostProcessor(noOpLogFactory());
@@ -87,6 +92,22 @@ class BootUiWebApplicationTypeEnvironmentPostProcessorTests {
     void doesNotForceWhenDisabledByForceWebProperty() {
         MockEnvironment environment =
                 new MockEnvironment().withProperty("bootui.enabled", "ON").withProperty("bootui.force-web", "false");
+
+        processor.postProcessEnvironment(environment, applicationWithWebType(WebApplicationType.NONE));
+
+        assertThat(environment.getPropertySources().contains(SOURCE_NAME)).isFalse();
+    }
+
+    @Test
+    void doesNotForceInSpringCloudBootstrapContext() {
+        // Spring Cloud's BootstrapApplicationListener marks the transient bootstrap environment with a
+        // "bootstrap" property source and builds it as a non-web context; forcing servlet there crashes
+        // the application with MissingWebServerFactoryBeanException (see issue #405).
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("bootui.enabled", "ON").withProperty(TYPE_PROPERTY, "none");
+        environment
+                .getPropertySources()
+                .addFirst(new MapPropertySource(BOOTSTRAP_SOURCE_NAME, Map.of(TYPE_PROPERTY, "none")));
 
         processor.postProcessEnvironment(environment, applicationWithWebType(WebApplicationType.NONE));
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -207,6 +207,11 @@ Because BootUI only activates in development contexts by default, this never aff
 already servlet web apps, or that are explicitly configured as reactive, are left untouched. To opt out and keep your
 application's web-application type exactly as declared, set `bootui.force-web=false`.
 
+BootUI never forces the web type on Spring Cloud's transient **bootstrap** application context (the early, non-web
+context created by `spring-cloud-starter-bootstrap` for Spring Cloud Config). That context has no embedded web server,
+so forcing it would crash startup with `MissingWebServerFactoryBeanException`; BootUI detects it and leaves it alone,
+then forces the servlet web type on your main application as usual.
+
 ## Running inside a Docker container
 
 BootUI works when your application runs inside a container, but its loopback-only safety filter needs a small opt-in

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -92,8 +92,9 @@ BootUI's panels are served by Spring MVC and require a servlet web application. 
 an embedded servlet container, BootUI also supports non-web (command-line) applications: when BootUI is active and the
 host is configured as non-web (`spring.main.web-application-type=none`), the starter forces a servlet web application so
 the console can be served. This only happens while BootUI is active (development contexts by default), never overrides an
-explicitly reactive application, and never runs without an embedded servlet container on the classpath. It can be
-disabled with `bootui.force-web=false`.
+explicitly reactive application, never runs without an embedded servlet container on the classpath, and never touches
+Spring Cloud's transient non-web bootstrap context (detected via its `"bootstrap"` marker property source) so Spring
+Cloud Config apps still start. It can be disabled with `bootui.force-web=false`.
 
 ### 4.2 URL
 


### PR DESCRIPTION
## What does this PR do?

Stops BootUI from crashing Spring Cloud apps at startup by no longer forcing a servlet web type onto Spring Cloud's transient, non-web bootstrap application context.

## Why is this change needed?

With the BootUI starter on the classpath and BootUI active (for example under the `dev` profile), apps using Spring Cloud Config / the legacy bootstrap context (`spring-cloud-starter-bootstrap`) crashed immediately at startup with:

```
MissingWebServerFactoryBeanException: No qualifying bean of type
'ServletWebServerFactory' available
  ... at BootstrapApplicationListener.bootstrapServiceContext(...)
```

`BootUiWebApplicationTypeEnvironmentPostProcessor` forces `spring.main.web-application-type=servlet` when BootUI is active so the console can be served from non-web apps. The problem is it ran for *every* `SpringApplication`, including Spring Cloud's bootstrap context, which is intentionally non-web and has no `ServletWebServerFactory`. Forcing servlet there blew up the whole application before the real context ever started.

The fix detects the bootstrap context via Spring Cloud's own `"bootstrap"` marker property source (the same idiom Spring Cloud uses for its internal re-entrancy check) and skips it. No Spring Cloud dependency is added; it is a property-source-name check. The main application is still forced to servlet exactly as before.

The other three BootUI `EnvironmentPostProcessor`s also run in the bootstrap context but are harmless there (they only contribute lowest-priority defaults / property sources / a startup buffer and never start a web server), so they are left unchanged to keep the fix surgical.

Fixes: #405

## How was it tested?

- [x] `./mvnw clean install` passes locally (ran the full `bootui-autoconfigure` suite: 1240 tests, 0 failures/errors; `spotless:check` clean)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Added a unit test (`doesNotForceInSpringCloudBootstrapContext`) that simulates a bootstrap environment (a `"bootstrap"` marker property source + `bootui.enabled=ON` + web type `none`) and asserts BootUI does not force servlet, while the existing non-web force tests still pass.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (`CHANGELOG.md`, `docs/SETUP.md`, `docs/SPECIFICATION.md`)
- [x] Public API kept backward compatible, or a migration note added to the PR description (no public API change; `bootui.force-web` semantics preserved)
- [x] No secrets, tokens, or local paths committed