### PR TITLE
Remove unnecessary casts from Java code

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesPropertySource.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiOverridesPropertySource.java
@@ -23,9 +23,8 @@ public class BootUiOverridesPropertySource extends MapPropertySource {
         super(NAME, new LinkedHashMap<>());
     }
 
-    @SuppressWarnings("unchecked")
     public Map<String, Object> mutableSource() {
-        return (Map<String, Object>) getSource();
+        return getSource();
     }
 
     public void put(String name, Object value) {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -309,12 +309,11 @@ final class SecurityScanner {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static AuthorizationManager<HttpServletRequest> authorizationManager(List<Filter> filters) {
         for (Filter filter : filters) {
             if (filter instanceof AuthorizationFilter authorizationFilter) {
                 try {
-                    return (AuthorizationManager<HttpServletRequest>) authorizationFilter.getAuthorizationManager();
+                    return authorizationFilter.getAuthorizationManager();
                 } catch (RuntimeException | LinkageError ex) {
                     return null;
                 }

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SpringSecurityService.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SpringSecurityService.java
@@ -301,7 +301,6 @@ class SpringSecurityService {
      * its {@link Object#toString() toString()} when it is a well-known type, so role
      * and authority names can be reported.
      */
-    @SuppressWarnings("unchecked")
     private SpringSecurityEndpointDto classifyRule(
             String method,
             String pattern,
@@ -310,8 +309,7 @@ class SpringSecurityService {
             SecurityFilterChain chain,
             AuthorizationFilter authFilter,
             ExplainRequest request) {
-        AuthorizationManager<HttpServletRequest> manager =
-                (AuthorizationManager<HttpServletRequest>) authFilter.getAuthorizationManager();
+        AuthorizationManager<HttpServletRequest> manager = authFilter.getAuthorizationManager();
 
         boolean anonymousGranted = simulate(manager, anonymousAuth(), request);
         if (anonymousGranted) {

--- a/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerCustomPatternsTests.java
+++ b/bootui-core/src/test/java/io/github/jdubois/bootui/core/SecretMaskerCustomPatternsTests.java
@@ -26,7 +26,7 @@ class SecretMaskerCustomPatternsTests {
 
     @Test
     void customPatternsReplaceDefaults() {
-        SecretMasker masker = new SecretMasker((Set<String>) Set.of("custom-pattern"));
+        SecretMasker masker = new SecretMasker(Set.of("custom-pattern"));
         assertThat(masker.isSecret("app.custom-pattern")).isTrue();
         // default patterns are no longer in effect
         assertThat(masker.isSecret("spring.datasource.password")).isFalse();


### PR DESCRIPTION
## What does this PR do?

Removes four redundant casts (and the three `@SuppressWarnings("unchecked")` annotations that existed only to silence them) from the Java sources.

## Why is this change needed?

These casts were no-ops: the expressions already had the cast target type, so the casts added noise and forced unnecessary `unchecked` suppressions. They were found by compiling all main and test modules with `javac -Xlint:cast`.

The redundant casts:

- `BootUiOverridesPropertySource.mutableSource()` cast `getSource()` to `Map<String, Object>`, which `MapPropertySource.getSource()` already returns.
- `SecurityScanner` and `SpringSecurityService` cast `getAuthorizationManager()` to `AuthorizationManager<HttpServletRequest>`, which is already its return type.
- `SecretMaskerCustomPatternsTests` cast `Set.of(...)` to `Set<String>`, which it already returns.

The genuinely necessary `(Set<String>) null` cast in the same test (it disambiguates an overloaded constructor) was correctly not flagged and is left untouched. No behavior changes.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Verified a clean recompile reports zero `[cast]` warnings, `spotless:check` passes on the touched modules, and the affected test classes (SecretMasker, BootUiOverrides, SecurityScanner, SpringSecurity) all pass.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed