### PR TITLE
Add MCP Server tip to Overview after running all scanners

### DIFF
--- a/bootui-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-sample-app/e2e/tests/overview.spec.js
@@ -49,6 +49,23 @@ test.describe('Overview view', () => {
     }
   })
 
+  test('reveals an MCP Server tip after running all scanners', async ({openView, page}) => {
+    await openView('overview', 'Overview')
+
+    const overall = page.locator('.overall-card').first()
+    await expect(page.locator('.mcp-tip')).toHaveCount(0)
+
+    await overall.getByRole('button', {name: /Run all scanners/}).click()
+
+    const tip = page.locator('.mcp-tip')
+    await expect(tip).toBeVisible()
+    await expect(tip).toContainText('BootUI MCP Server')
+    await expect(tip.getByRole('link', {name: 'BootUI MCP Server'})).toHaveAttribute('href', /#\/mcp-server$/)
+
+    await tip.getByRole('button', {name: 'Dismiss tip'}).click()
+    await expect(tip).toHaveCount(0)
+  })
+
   test('hero links to the BootUI GitHub project', async ({openView}) => {
     const page = await openView('overview', 'Overview')
 

--- a/bootui-ui/src/main/frontend/src/views/Overview.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Overview.test.js
@@ -164,6 +164,56 @@ describe('Overview', () => {
     expect(wrapper.text()).toContain('9 of 9 scanners scored')
   })
 
+  it('surfaces a dismissible MCP Server tip after running all scanners', async () => {
+    stubFetch({
+      'api/architecture/scan': severityReport([]),
+      'api/hibernate/scan': severityReport([]),
+      'api/vulnerabilities/scan': severityReport([]),
+      'api/pentesting/scan': severityReport([]),
+      'api/github/refresh': githubReport({alerts: 0})
+    })
+    const wrapper = mountOverview({
+      panels: [
+        {id: 'architecture', available: true},
+        {id: 'mcp-server', available: true}
+      ]
+    })
+    await flushPromises()
+
+    // The tip is not shown before the scanners are run.
+    expect(wrapper.find('.mcp-tip').exists()).toBe(false)
+
+    const runAll = wrapper.findAll('button').find((b) => b.text().includes('Run all scanners'))
+    await runAll.trigger('click')
+    await flushPromises()
+
+    const tip = wrapper.find('.mcp-tip')
+    expect(tip.exists()).toBe(true)
+    expect(tip.text()).toContain('BootUI MCP Server')
+
+    await tip.find('.btn-close').trigger('click')
+    expect(wrapper.find('.mcp-tip').exists()).toBe(false)
+  })
+
+  it('hides the MCP Server tip when the panel is unavailable', async () => {
+    stubFetch({
+      'api/architecture/scan': severityReport([])
+    })
+    const wrapper = mountOverview({
+      panels: [
+        {id: 'architecture', available: true},
+        {id: 'mcp-server', available: false}
+      ]
+    })
+    await flushPromises()
+
+    const runAll = wrapper.findAll('button').find((b) => b.text().includes('Run all scanners'))
+    await runAll.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('.mcp-tip').exists()).toBe(false)
+  })
+
   it('shows a connect button for GitHub and excludes it from the score until authenticated', async () => {
     stubFetch({
       'api/github/refresh': githubReport({connected: false, authenticated: false})

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -262,7 +262,14 @@ const overallContributions = computed(() => {
     .sort((a, b) => a.deduction - b.deduction)
 })
 
+// A run-all-scanners nudge toward the MCP Server panel: with the MCP server enabled,
+// an AI agent can read these same scan results and act on them. Only surfaced when the
+// panel is available, and dismissible so it stays a temporary tip.
+const mcpServerVisible = computed(() => panelAvailable('mcp-server'))
+const showMcpTip = ref(false)
+
 async function runAll() {
+  if (mcpServerVisible.value) showMcpTip.value = true
   const tasks = visibleScanners.value
     .filter((def) => scanners[def.id].state !== 'running')
     .map((def) => runScanner(def))
@@ -309,6 +316,22 @@ onActivated(refreshScores)
 
     <div class="row gx-3 gy-4 mb-4">
       <div class="col-12">
+        <div v-if="showMcpTip" class="alert alert-info d-flex align-items-start gap-2 mb-3 mcp-tip" role="alert">
+          <i class="bi bi-lightbulb-fill flex-shrink-0 mt-1" aria-hidden="true"></i>
+          <div class="flex-grow-1">
+            <strong>Tip:</strong>
+            Enable the
+            <router-link to="/mcp-server" class="alert-link">BootUI MCP Server</router-link>
+            to give your AI agent direct access to these scan results — so it can investigate and fix the issues for you
+            automatically.
+          </div>
+          <button
+            type="button"
+            class="btn-close flex-shrink-0"
+            aria-label="Dismiss tip"
+            @click="showMcpTip = false"
+          ></button>
+        </div>
         <div class="card overall-card">
           <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center gap-4">
             <div class="flex-shrink-0 min-w-0">

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -23,7 +23,8 @@ project.
 Below the hero is an on-demand security & health scoring dashboard. An overall score out of 100 summarizes the
 application's posture, with a qualitative band (Good at 80+, Needs attention at 50+, At risk below 50) and a breakdown of
 how much each scanner deducted from a perfect score. A single "Run all scanners" button triggers every available scanner,
-or each scanner card can be run individually.
+or each scanner card can be run individually. After a run-all, a dismissible tip points to the MCP Server panel, since
+enabling the BootUI MCP Server lets an AI agent read these same scan results and fix the findings for you.
 
 Each scanner card shows its own 0–100 score, status, and severity counts. The severity-based scanners are Architecture, Memory,
 REST API, Spring, Hibernate, Security, Pentesting, and Vulnerabilities; scores start at 100


### PR DESCRIPTION
## What does this PR do?

After clicking "Run all scanners" on the Overview panel, a dismissible tip appears above the overall-score card pointing users to the MCP Server panel.

## Why is this change needed?

Once a user runs the scanners, the natural next step is acting on the findings. Enabling the BootUI MCP Server lets an AI agent read these same scan results and fix the issues automatically, so this is a good moment to surface that capability. The tip turns a passive dashboard into a hand-off toward automated remediation.

The tip only renders when the `mcp-server` panel is available (so the dashboard still degrades gracefully when it is not), links to `/mcp-server`, and can be dismissed to keep it transient.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Added Vitest coverage (tip appears after Run-all, dismisses on close, stays hidden when the MCP panel is unavailable) and a Playwright case (reveal, link target, dismissal). Full frontend suite passes (250 tests).

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed