### PR TITLE
fix: add spacing between statistic label and value in metrics samples

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Metrics.vue
+++ b/bootui-ui/src/main/frontend/src/views/Metrics.vue
@@ -335,7 +335,7 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
                     </td>
                     <td>
                       <span v-for="measurement in sample.measurements" :key="measurement.statistic" class="me-3">
-                        <span class="text-muted">{{ measurement.statistic }}</span>
+                        <span class="text-muted me-1">{{ measurement.statistic }}</span>
                         <code>{{ formatNumber(measurement.value) }}</code>
                       </span>
                     </td>


### PR DESCRIPTION
## What does this PR do?

On http://localhost:5173/bootui/#/metrics

Before
<img width="175" height="265" alt="image" src="https://github.com/user-attachments/assets/4afe8ef3-8047-4124-96d5-62b8302de22a" />

After
<img width="214" height="269" alt="image" src="https://github.com/user-attachments/assets/2ad52bc9-9ba1-442b-a21a-19e67fd28e0c" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
