### PR TITLE
Publish to Maven Central before bumping the documented version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Prepare release commit and tag
+      - name: Prepare release version
         if: github.event_name == 'workflow_dispatch' && inputs.version != ''
         env:
           RELEASE_VERSION: ${{ inputs.version }}
@@ -131,19 +131,7 @@ jobs:
             ./mvnw -B -ntp -Prelease clean verify -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
           fi
 
-          if [[ -n "$(git status --porcelain)" ]]; then
-            git add pom.xml */pom.xml README.md docs/SETUP.md \
-              package.json package-lock.json \
-              bootui-ui/src/main/frontend/package.json bootui-ui/src/main/frontend/package-lock.json \
-              bootui-sample-app/e2e/package.json bootui-sample-app/e2e/package-lock.json
-            git commit -m "Release $TAG"
-          else
-            echo "Project files already declare version $VERSION; tagging current HEAD."
-          fi
-
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "HEAD:$GITHUB_REF_NAME"
-          git push origin "$TAG"
+          echo "Prepared release $TAG (version $VERSION) in the working tree; deferring the commit, tag, and push until the artifacts are verified on Maven Central."
 
           echo "PREPARED_TAG=$TAG" >> "$GITHUB_ENV"
 
@@ -205,11 +193,150 @@ jobs:
             -Dcentral.autoPublish="${CENTRAL_AUTO_PUBLISH}" \
             -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
 
+      - name: Wait for Maven Central availability
+        if: env.CENTRAL_AUTO_PUBLISH == 'true'
+        run: |
+          set -euo pipefail
+
+          VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
+          BASE="https://repo1.maven.org/maven2/com/julien-dubois/bootui"
+
+          # The artifacts a consumer needs to resolve the starter: the parent POM and every
+          # published module JAR (the bootui-ui JAR carries the bundled Vue UI resources).
+          ARTIFACTS=(
+            "bootui-parent/${VERSION}/bootui-parent-${VERSION}.pom"
+            "bootui-core/${VERSION}/bootui-core-${VERSION}.jar"
+            "bootui-autoconfigure/${VERSION}/bootui-autoconfigure-${VERSION}.jar"
+            "bootui-ui/${VERSION}/bootui-ui-${VERSION}.jar"
+            "bootui-spring-boot-starter/${VERSION}/bootui-spring-boot-starter-${VERSION}.jar"
+          )
+
+          # Sonatype Central -> Maven Central propagation can lag behind a successful
+          # autoPublish, so poll until every file is downloadable (or time out).
+          DEADLINE=$(( SECONDS + 45 * 60 ))
+          for artifact in "${ARTIFACTS[@]}"; do
+            url="${BASE}/${artifact}"
+            echo "Waiting for ${url}"
+            until curl -fsI "$url" >/dev/null 2>&1; do
+              if (( SECONDS > DEADLINE )); then
+                echo "::error::Timed out waiting for ${url} to become available on Maven Central"
+                exit 1
+              fi
+              sleep 20
+            done
+            echo "Available: ${artifact}"
+          done
+
+          echo "All BootUI ${VERSION} artifacts are available on Maven Central."
+
+      - name: Smoke test published artifacts
+        if: env.CENTRAL_AUTO_PUBLISH == 'true'
+        run: |
+          set -euo pipefail
+
+          VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
+          echo "Smoke-testing BootUI ${VERSION} by running the sample app against the published artifacts."
+
+          # Drop the locally built/installed BootUI artifacts so the sample app is forced to
+          # resolve them from Maven Central, exercising exactly what consumers download.
+          rm -rf "$HOME/.m2/repository/com/julien-dubois/bootui"
+
+          LOG="$(mktemp)"
+          # No -am (do not rebuild the reactor modules) and no -o (must download from Central).
+          # fork=false keeps the app in the Maven JVM so killing this PID stops it cleanly.
+          ./mvnw -ntp -pl bootui-sample-app -Dmaven.test.skip=true \
+            -Dspring-boot.run.fork=false \
+            spring-boot:run -Dspring-boot.run.profiles=dev > "$LOG" 2>&1 &
+          APP_PID=$!
+          cleanup() { kill "$APP_PID" 2>/dev/null || true; wait "$APP_PID" 2>/dev/null || true; }
+          trap cleanup EXIT
+
+          BASE_URL="http://localhost:8080/bootui/"
+          body=""
+          ready=""
+          DEADLINE=$(( SECONDS + 300 ))
+          while (( SECONDS <= DEADLINE )); do
+            if ! kill -0 "$APP_PID" 2>/dev/null; then
+              echo "::error::The sample app exited before BootUI became available."
+              cat "$LOG"
+              exit 1
+            fi
+            body="$(curl -fsSL -H 'X-Forwarded-For: 127.0.0.1' "$BASE_URL" 2>/dev/null || true)"
+            if printf '%s' "$body" | grep -q 'id="app"'; then
+              ready=1
+              break
+            fi
+            sleep 5
+          done
+
+          if [[ -z "$ready" ]]; then
+            echo "::error::BootUI did not serve its UI at ${BASE_URL} within the timeout."
+            cat "$LOG"
+            exit 1
+          fi
+
+          if ! printf '%s' "$body" | grep -q '<title>BootUI</title>'; then
+            echo "::error::BootUI index.html did not contain the expected <title>BootUI</title> marker."
+            printf '%s\n' "$body"
+            exit 1
+          fi
+
+          asset="$(printf '%s' "$body" | grep -oE 'assets/[A-Za-z0-9._-]+\.js' | head -n 1)"
+          if [[ -z "$asset" ]]; then
+            echo "::error::Could not find a bundled UI asset reference in BootUI index.html."
+            printf '%s\n' "$body"
+            exit 1
+          fi
+
+          echo "Verifying the bundled UI asset ${asset} is served."
+          curl -fsSL -o /dev/null -H 'X-Forwarded-For: 127.0.0.1' "http://localhost:8080/bootui/${asset}"
+
+          echo "BootUI ${VERSION} served its UI from the Maven Central artifacts successfully."
+
+      - name: Commit, tag, and push release
+        if: github.event_name == 'workflow_dispatch' && inputs.version != ''
+        run: |
+          set -euo pipefail
+
+          TAG="${PREPARED_TAG:?PREPARED_TAG was not set by the prepare step}"
+
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add pom.xml */pom.xml README.md docs/SETUP.md \
+              package.json package-lock.json \
+              bootui-ui/src/main/frontend/package.json bootui-ui/src/main/frontend/package-lock.json \
+              bootui-sample-app/e2e/package.json bootui-sample-app/e2e/package-lock.json
+            git commit -m "Release $TAG"
+          else
+            echo "Project files already declare the released version; tagging current HEAD."
+          fi
+
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "HEAD:$GITHUB_REF_NAME"
+          git push origin "$TAG"
+
       - name: Redeploy documentation site
+        if: env.CENTRAL_AUTO_PUBLISH == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           # The release commit is pushed to main with GITHUB_TOKEN, which does not
           # trigger the Pages workflow. Dispatch it explicitly so the docs site
-          # rebuilds with the released version's setup instructions.
+          # rebuilds with the released version's setup instructions - only now that the
+          # artifacts are live on Maven Central and the smoke test has passed.
           gh workflow run pages.yml --ref main
+
+      - name: Manual publish reminder
+        if: env.CENTRAL_AUTO_PUBLISH != 'true'
+        run: |
+          cat <<'EOF'
+          Auto-publish was disabled, so the deployment was uploaded to the Sonatype Central
+          Portal but the artifacts are NOT yet public on Maven Central.
+
+          To keep the documented version in lockstep with what is downloadable, this run skipped
+          the Maven Central availability wait, the published-artifact smoke test, and the
+          documentation-site redeploy.
+
+          Finish the release by publishing the deployment in the Central Portal, then run the
+          "pages.yml" workflow (from the Actions tab) so the documentation site advertises the
+          new version.
+          EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,11 +140,16 @@ to stage for manual publishing instead.
 To prepare and publish a release, run the **Release** GitHub Actions workflow
 from the branch you want to release, usually `main`, and enter the target version
 without the leading `v`, for example `1.0.0`. The workflow updates all Maven
-module versions, refreshes the documentation dependency examples, optionally verifies
-with the `release` Maven profile, commits the release, creates an annotated
-`v1.0.0` tag, pushes the branch plus tag, and publishes to Maven Central in the
-same run. The selected branch must allow `github-actions[bot]` to push the
-release commit and tag.
+module versions and refreshes the documentation dependency examples in the working
+tree, optionally verifies with the `release` Maven profile, and publishes to Maven
+Central. It then waits until every published artifact is downloadable from Maven
+Central, smoke-tests the release by running the sample app against the published
+starter and confirming the BootUI console is served, and **only then** commits the
+release, creates an annotated `v1.0.0` tag, pushes the branch plus tag, and
+redeploys the documentation site. Deferring the version bump and the docs rebuild
+until after the JARs are live keeps the documented install version in lockstep with
+what consumers can actually download. The selected branch must allow
+`github-actions[bot]` to push the release commit and tag.
 
 The same workflow (`.github/workflows/release.yml`) also runs on manually pushed
 `v*` tags, or manually with an empty version when the selected ref is already
@@ -159,7 +164,11 @@ secrets before running it:
 | `MAVEN_GPG_PASSPHRASE`   | Passphrase for the GPG private key               |
 
 Manual runs publish automatically by default; disable `auto_publish` when you
-want to review and publish the deployment in the Central Portal.
+want to review and publish the deployment in the Central Portal. With
+`auto_publish` disabled the workflow cannot confirm the artifacts are live, so it
+skips the Maven Central availability wait, the published-artifact smoke test, and
+the documentation-site redeploy — finish the release by publishing the deployment
+in the Portal and then running the `pages.yml` workflow.
 
 ## Submitting a change
 


### PR DESCRIPTION
## What does this PR do?

Reorders the `release.yml` workflow so it publishes to Maven Central, confirms the JARs are downloadable, and smoke-tests them before committing the version bump or rebuilding the docs site.

## Why is this change needed?

The release workflow committed/pushed the version bump (the `docs/SETUP.md` "try the sample app" install snippet, the npm `package.json` files, and the poms) and dispatched the documentation-site rebuild *before* the artifacts were available on Maven Central. The published website therefore advertised a version that consumers could not yet download. This is the current live state: the repo is at `1.5.1` but Maven Central only has `1.5.0`.

The fix inverts the order so the documented version stays in lockstep with what is actually downloadable:

1. **Prepare release version** now only edits the working tree (`versions:set`, docs/npm bumps, optional verify build). It no longer commits/tags/pushes.
2. **Publish to Maven Central** (unchanged deploy).
3. **Wait for Maven Central availability** (new) polls `repo1.maven.org` for the parent POM plus all four module JARs until each is downloadable, with a 45 minute cap.
4. **Smoke test published artifacts** (new) purges the local `com/julien-dubois/bootui` artifacts so the sample app must resolve them from Central, runs it on the `dev` profile, and verifies `/bootui/` serves the real UI (`id="app"` / `<title>BootUI</title>` markers plus fetching a bundled `assets/*.js` file).
5. **Commit, tag, and push release** (new) runs only after the JARs are live and tested.
6. **Redeploy documentation site** is now gated and runs last.

When `auto_publish` is disabled the wait, smoke test, and docs redeploy are skipped, with a reminder to finish publishing in the Central Portal and then run `pages.yml`.

`CONTRIBUTING.md`'s Publishing section is updated to describe the new ordering.

No linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

The change is workflow + docs only and the release flow can only fully execute on GitHub Actions (it needs Maven Central credentials and live propagation). What was verifiable locally was checked:

- YAML parses; every embedded `run` script passes `bash -n`; `spotless:check` is clean.
- Confirmed the Maven Central URL pattern and the UI-detection logic (markers + `assets/*.js` extraction) against the actually-published `bootui-ui-1.5.0.jar`.

## Screenshots (UI changes)

N/A - no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed