### PR TITLE
fix: update Flyway icon

### DIFF
--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -243,7 +243,7 @@ export const routes = [
     path: '/flyway',
     name: 'flyway',
     component: Flyway,
-    meta: {group: groups.database, icon: 'bi-arrow-up-right-circle', title: 'Flyway', shortcut: 'fw'}
+    meta: {group: groups.database, icon: 'bi-database-up', title: 'Flyway', shortcut: 'fw'}
   },
   {
     path: '/liquibase',

--- a/bootui-ui/src/main/frontend/src/views/Flyway.vue
+++ b/bootui-ui/src/main/frontend/src/views/Flyway.vue
@@ -102,7 +102,7 @@ onMounted(load)
 
 <template>
   <div>
-    <PanelHeader icon="bi-arrow-up-right-circle" title="Flyway migrations" :error="error" />
+    <PanelHeader icon="bi-database-up" title="Flyway migrations" :error="error" />
 
     <FlashBanner :message="banner" @dismiss="clear" />
 


### PR DESCRIPTION
## What does this PR do?

Before
<img width="305" height="51" alt="image" src="https://github.com/user-attachments/assets/a12e710f-d025-448f-a78a-4fdc17284566" />

After
<img width="310" height="47" alt="image" src="https://github.com/user-attachments/assets/66b40546-acb3-4a5f-821d-f307ca198a30" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
