### PR TITLE
fix: colors do not have a sufficient contrast ratio

### DIFF
--- a/docs/.vuepress/styles/index.css
+++ b/docs/.vuepress/styles/index.css
@@ -768,6 +768,10 @@ html[data-theme='dark'] [vp-content] code {
   color: var(--bootui-green);
 }
 
+[vp-content] div[class*='language-'] .token.number {
+  color: #c9a3c9;
+}
+
 .vp-tabs {
   overflow: hidden;
   border-color: var(--bootui-border);


### PR DESCRIPTION
## What does this PR do?

Lighthouse shows
<img width="660" height="536" alt="image" src="https://github.com/user-attachments/assets/125c3208-ccb6-4e33-80c8-4e2517a0a76e" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
