### PR TITLE
Fix startup crash when app provides its own HttpExchangeRepository

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.aot.AotDetector;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
 import org.springframework.boot.actuate.autoconfigure.web.exchanges.HttpExchangesProperties;
@@ -230,6 +231,8 @@ public class BootUiAutoConfiguration {
 
         private static final int HTTP_EXCHANGES_FILTER_ORDER = OrderedFilter.REQUEST_WRAPPER_FILTER_MAX_ORDER - 101;
 
+        private static final String BOOTUI_HTTP_EXCHANGE_REPOSITORY_BEAN = "bootUiHttpExchangeRepository";
+
         @Bean
         @ConditionalOnMissingBean(HttpExchangeRepository.class)
         HttpExchangeRepository bootUiHttpExchangeRepository(BootUiProperties properties) {
@@ -237,6 +240,35 @@ public class BootUiAutoConfiguration {
             repository.setCapacity(Math.max(1, properties.getHttpExchanges().getMaxExchanges()));
             repository.setReverse(true);
             return repository;
+        }
+
+        /**
+         * Drops BootUI's fallback repository when the application also contributes its own
+         * {@link HttpExchangeRepository}.
+         *
+         * <p>BootUI runs {@code @AutoConfigureBefore} the standard HTTP exchange auto-configurations,
+         * so the {@link ConditionalOnMissingBean} guard on {@link #bootUiHttpExchangeRepository} cannot
+         * detect a repository contributed by a configuration ordered after BootUI (such as the
+         * application's own auto-configuration). That would otherwise leave two repositories in the
+         * context and break single-bean injection &mdash; both BootUI's recording filter and Spring
+         * Boot's own {@code httpExchangesEndpoint}. Reconciling as a {@link BeanFactoryPostProcessor}
+         * runs after every bean definition has been registered, regardless of ordering, and before any
+         * bean is instantiated, so the application's repository always wins.</p>
+         */
+        @Bean
+        static BeanFactoryPostProcessor bootUiHttpExchangeRepositoryDeduplicator() {
+            return beanFactory -> {
+                if (!(beanFactory instanceof BeanDefinitionRegistry registry)
+                        || !registry.containsBeanDefinition(BOOTUI_HTTP_EXCHANGE_REPOSITORY_BEAN)) {
+                    return;
+                }
+                for (String name : beanFactory.getBeanNamesForType(HttpExchangeRepository.class, true, false)) {
+                    if (!BOOTUI_HTTP_EXCHANGE_REPOSITORY_BEAN.equals(name)) {
+                        registry.removeBeanDefinition(BOOTUI_HTTP_EXCHANGE_REPOSITORY_BEAN);
+                        return;
+                    }
+                }
+            };
         }
 
         @Bean

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -40,6 +40,8 @@ import org.springframework.boot.actuate.security.AuthenticationAuditListener;
 import org.springframework.boot.actuate.security.AuthorizationAuditListener;
 import org.springframework.boot.actuate.web.exchanges.HttpExchange;
 import org.springframework.boot.actuate.web.exchanges.HttpExchangeRepository;
+import org.springframework.boot.actuate.web.exchanges.InMemoryHttpExchangeRepository;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.servlet.actuate.web.exchanges.HttpExchangesFilter;
 import org.springframework.boot.servlet.filter.OrderedFilter;
@@ -47,6 +49,7 @@ import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.core.SpringProperties;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.web.servlet.MockMvc;
@@ -495,6 +498,22 @@ class BootUiAutoConfigurationTests {
     }
 
     @Test
+    void backsOffWhenApplicationContributesItsOwnHttpExchangeRepositoryFromLaterAutoConfiguration() {
+        runner.withConfiguration(AutoConfigurations.of(ApplicationHttpExchangeRepositoryAutoConfiguration.class))
+                .withPropertyValues("bootui.enabled=ON")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(HttpExchangeRepository.class);
+                    assertThat(context.getBeanNamesForType(HttpExchangeRepository.class))
+                            .containsExactly("applicationHttpExchangeRepository");
+                    assertThat(context).hasSingleBean(HttpExchangesFilter.class);
+                    assertThat(context.getBean(HttpExchangesFilter.class))
+                            .extracting("repository")
+                            .isSameAs(context.getBean(HttpExchangeRepository.class));
+                });
+    }
+
+    @Test
     void optionalClasspathPanelsAreRegisteredWhenDependenciesArePresent() {
         runner.withPropertyValues("bootui.enabled=ON")
                 .run(context -> assertThat(context)
@@ -600,5 +619,14 @@ class BootUiAutoConfigurationTests {
                 null,
                 null,
                 Duration.ofMillis(1));
+    }
+
+    @AutoConfiguration(after = BootUiAutoConfiguration.class)
+    static class ApplicationHttpExchangeRepositoryAutoConfiguration {
+
+        @Bean
+        HttpExchangeRepository applicationHttpExchangeRepository() {
+            return new InMemoryHttpExchangeRepository();
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Stops BootUI from registering a duplicate `HttpExchangeRepository` when the host application already provides its own, which was crashing the application on startup.

## Why is this change needed?

BootUI registers a fallback `bootUiHttpExchangeRepository` guarded by `@ConditionalOnMissingBean`, but it runs `@AutoConfigureBefore` the standard HTTP exchange auto-configurations. When the application contributes its own `HttpExchangeRepository` from a configuration ordered *after* BootUI (for example its own auto-configuration, as in the issue's `@ConditionalOnAvailableEndpoint` example), `@ConditionalOnMissingBean` cannot see it yet, so BootUI still creates the fallback. The two repositories then break single-bean injection in `bootUiHttpExchangesFilter` (and would also break Spring Boot's own `httpExchangesEndpoint`), so the context fails to start with:

```
No qualifying bean of type 'HttpExchangeRepository' available:
expected single matching bean but found 2: bootUiHttpExchangeRepository,exchangeRepository
```

The fix adds a `BeanFactoryPostProcessor` that drops BootUI's fallback repository whenever another `HttpExchangeRepository` bean is present. A BFPP runs after every bean definition has been registered (regardless of auto-config ordering) and before any bean is instantiated, so exactly one repository remains, the application's own, and BootUI's recording filter and panel transparently use it. `@ConditionalOnMissingBean` is kept so the common case never even creates the fallback; the BFPP only reconciles the late-ordered race.

Closes #422

Fixes: #422

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Verified by reproducing the exact failure in a `WebApplicationContextRunner` test (an application repository contributed by an auto-config ordered after BootUI), then confirming the fix. Ran the full `bootui-autoconfigure` test suite (1242 tests, all green) and `spotless:check` (clean). The new regression test asserts the context starts, a single repository remains (the application's), and BootUI's `HttpExchangesFilter` is created and wired to it.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no behaviour/doc change; bug fix only)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed