### PR TITLE
fix(docs): use scroll-margin-top for heading anchor offset

### DIFF
--- a/docs/.vuepress/styles/index.css
+++ b/docs/.vuepress/styles/index.css
@@ -959,3 +959,14 @@ html[data-theme='dark'] [vp-content] code {
     transition-duration: 0.01ms !important;
   }
 }
+
+[vp-content] h1,
+[vp-content] h2,
+[vp-content] h3,
+[vp-content] h4,
+[vp-content] h5,
+[vp-content] h6 {
+  margin-top: 1.5rem;
+  padding-top: 0;
+  scroll-margin-top: calc(1rem + var(--header-offset));
+}


### PR DESCRIPTION
## What does this PR do?

Go to: https://www.julien-dubois.com/boot-ui/
<img width="591" height="299" alt="image" src="https://github.com/user-attachments/assets/37413fcb-6a81-4812-8e45-f40718b736ef" />
`AI Agents` link is not clickable

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
