### PR TITLE
fix: remove unused dependency @vuepress/plugin-markdown-tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.5.2",
       "devDependencies": {
         "@vuepress/bundler-vite": "2.0.0-rc.30",
-        "@vuepress/plugin-markdown-tab": "2.0.0-rc.130",
         "@vuepress/theme-default": "2.0.0-rc.130",
         "sass-embedded": "1.100.0",
         "serve": "14.2.6",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "@vuepress/bundler-vite": "2.0.0-rc.30",
-    "@vuepress/plugin-markdown-tab": "2.0.0-rc.130",
     "@vuepress/theme-default": "2.0.0-rc.130",
     "sass-embedded": "1.100.0",
     "serve": "14.2.6",


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
