### PR TITLE
fix: remove unused dependency @vue/server-renderer

### DIFF
--- a/bootui-ui/src/main/frontend/package-lock.json
+++ b/bootui-ui/src/main/frontend/package-lock.json
@@ -15,7 +15,6 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "6.0.7",
-        "@vue/server-renderer": "3.5.38",
         "@vue/test-utils": "2.4.11",
         "fonteditor-core": "2.6.3",
         "jsdom": "29.1.1",

--- a/bootui-ui/src/main/frontend/package.json
+++ b/bootui-ui/src/main/frontend/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "6.0.7",
-    "@vue/server-renderer": "3.5.38",
     "@vue/test-utils": "2.4.11",
     "fonteditor-core": "2.6.3",
     "jsdom": "29.1.1",


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
