### PR TITLE
fix: enable collapse accordion in SpringSecurity view

### DIFF
--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -1,6 +1,7 @@
 import {createApp} from 'vue'
 import {createRouter, createWebHashHistory} from 'vue-router'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import 'bootstrap/js/dist/collapse'
 import './generated/bootstrap-icons.css'
 import App from './App.vue'
 import {routes} from './routes.js'


### PR DESCRIPTION
## What does this PR do?

Go to http://localhost:5173/bootui/#/spring-security
Click on the accordion, it doesn't work
<img width="1581" height="219" alt="image" src="https://github.com/user-attachments/assets/579e368b-43bb-4d3c-b07e-8789ff199fc0" />


## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
