### PR TITLE
docs: add Ecosystem family page to VuePress site

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -48,7 +48,8 @@ export default defineUserConfig({
       {text: 'Setup', link: toDocLink('SETUP.md')},
       {text: 'Features', link: toDocLink('FEATURES.md')},
       {text: 'Properties', link: toDocLink('PROPERTIES.md')},
-      {text: 'AI agents', link: toDocLink('AI-AGENTS.md')}
+      {text: 'AI agents', link: toDocLink('AI-AGENTS.md')},
+      {text: 'Ecosystem', link: toDocLink('WORKS-WITH.md')}
     ],
     sidebar: createDocsSidebar()
   })

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -11,6 +11,7 @@ const coreDocs = [
   'FEATURES.md',
   'PROPERTIES.md',
   'AI-AGENTS.md',
+  'WORKS-WITH.md',
   'REPOSITORY.md',
   'SPECIFICATION.md',
   'PLAN.md'

--- a/docs/WORKS-WITH.md
+++ b/docs/WORKS-WITH.md
@@ -1,0 +1,43 @@
+# The BootUI family
+
+BootUI is one of three projects by [Julien Dubois](https://www.julien-dubois.com) that share a single Java workflow —
+from scaffolding an application, to observing it from the inside, to driving its build and run lifecycle from Copilot.
+Each owns one colour in a shared **circle of color**:
+
+| Colour   | Project                                               | Role                                                                                        |
+| -------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| 🟢 Green | BootUI (this site)                                    | An in-app developer console served by the running Spring Boot app over `/bootui/`.          |
+| 🔵 Blue  | [Coffilot](https://www.julien-dubois.com/coffilot/)   | A Copilot canvas extension that builds, tests, runs and debugs the app from the side panel. |
+| 🟡 Gold  | [Dr JSkill](https://www.julien-dubois.com/dr-jskill/) | Generates a Spring Boot application to start from.                                          |
+
+## How they work together
+
+1. **Generate the app with Dr JSkill.** Start from a freshly scaffolded Spring Boot 4 application instead of a blank
+   directory, so the project layout, build, and dependencies are in place from the first commit.
+2. **Add the BootUI starter.** Drop in the BootUI starter to get a local-only, in-app developer console at `/bootui/`,
+   backed by its REST API at `/bootui/api/**`. It activates automatically in the `dev` / `local` profiles and stays
+   silent and disabled in production.
+3. **Drive build/run/test/debug from the Copilot side panel with Coffilot.** Build, test, run, and debug the same app
+   from the GitHub Copilot App's side panel, and let Coffilot read BootUI's endpoints to surface richer runtime insight
+   without leaving your editor.
+
+## Where BootUI fits
+
+BootUI is the project that observes the app **from the inside**. While it is active, the running Spring Boot application
+serves its own developer console — health, metrics, live memory, threads, startup timeline, configuration, beans,
+mappings, and advisor scans for architecture, Spring, security, Hibernate, REST API, JVM memory, GraalVM and CRaC
+readiness, and more. Every panel reuses the same controllers and immutable DTOs that back the loopback-only REST API at
+`/bootui/api/**`, so the data is already sanitized and secret-masked before it leaves the process.
+
+That REST surface is also what lets [Coffilot](https://www.julien-dubois.com/coffilot/) reach its richest tier. When
+Coffilot detects BootUI on a running app, it sources live JVM metrics from BootUI's sanitized DTOs (and shows a `BootUI`
+badge), and it adds a REST advisor-scan panel that runs BootUI's scans and hands the findings straight back to the agent
+for a fix-and-rescan loop. Both BootUI and Coffilot stay strictly loopback-only, so this richer integration never widens
+your app's exposure.
+
+## Learn more
+
+- [Coffilot](https://www.julien-dubois.com/coffilot/) — build, run, test and debug the app from the Copilot side panel.
+- [Dr JSkill](https://www.julien-dubois.com/dr-jskill/) — generate the Spring Boot application to start from.
+- [AI agents](AI-AGENTS.md) — connect Copilot, Claude Code, or any MCP client to BootUI.
+- [Features](FEATURES.md) — the full list of BootUI panels and what each one shows.

--- a/docs/WORKS-WITH.md
+++ b/docs/WORKS-WITH.md
@@ -4,11 +4,11 @@ BootUI is one of three projects by [Julien Dubois](https://www.julien-dubois.com
 from scaffolding an application, to observing it from the inside, to driving its build and run lifecycle from Copilot.
 Each owns one colour in a shared **circle of color**:
 
-| Colour   | Project                                               | Role                                                                                        |
-| -------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| 🟢 Green | BootUI (this site)                                    | An in-app developer console served by the running Spring Boot app over `/bootui/`.          |
-| 🔵 Blue  | [Coffilot](https://www.julien-dubois.com/coffilot/)   | A Copilot canvas extension that builds, tests, runs and debugs the app from the side panel. |
-| 🟡 Gold  | [Dr JSkill](https://www.julien-dubois.com/dr-jskill/) | Generates a Spring Boot application to start from.                                          |
+| Colour        | Project                                               | Role                                                                                        |
+| ------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| 🟢 Green      | BootUI (this site)                                    | An in-app developer console served by the running Spring Boot app over `/bootui/`.          |
+| 🔵 Blue       | [Coffilot](https://www.julien-dubois.com/coffilot/)   | A Copilot canvas extension that builds, tests, runs and debugs the app from the side panel. |
+| 🟤 Terracotta | [Dr JSkill](https://www.julien-dubois.com/dr-jskill/) | Generates a Spring Boot application to start from.                                          |
 
 ## How they work together
 


### PR DESCRIPTION
## What does this PR do?

Adds an "Ecosystem" page and navbar item to the BootUI documentation site, matching the sibling Coffilot and Dr JSkill sites which each have a family/ecosystem page.

## Why is this change needed?

The three projects by Julien Dubois (BootUI, Coffilot, Dr JSkill) share one Java workflow but the BootUI docs site had no page telling that shared-ecosystem story. This adds the missing "circle of color" page from BootUI's own perspective so readers can discover the sibling tools and understand how they fit together.

Closes # N/A

## How was it tested?

Docs-only change (no Java/UI code touched), so the Maven checklist below does not apply.

- [ ] `./mvnw clean install` passes locally — N/A (docs only)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end — N/A (docs only)
- [ ] Added or updated tests where applicable — N/A (docs only)

Verified instead with the docs toolchain:
- `npm run docs:build` succeeds cleanly (20 pages, up from 19, no dead-link warnings).
- Prettier formatting check passes on all touched files.
- Confirmed the rendered page resolves its internal cross-links as base-prefixed `route-link`s (`/boot-ui/ai-agents`, `/boot-ui/features`) rather than external new-tab anchors.

## Screenshots (UI changes)

N/A - no Vue UI changes.

## Approach / notes

- `docs/WORKS-WITH.md` (new): H1 `# The BootUI family`, written from BootUI's perspective. Intro, a colour/role table (Green BootUI = this site, Blue Coffilot, Terracotta Dr JSkill), a `## How they work together` numbered flow (Dr JSkill generates -> add the BootUI starter at `/bootui/` + `/bootui/api/**` -> drive build/run/test/debug from Coffilot), a `## Where BootUI fits` paragraph, and a `## Learn more` cross-link list.
- `docs/.vuepress/config.js`: appends one navbar entry `{text: 'Ecosystem', link: toDocLink('WORKS-WITH.md')}` after the existing 'AI agents' item, using the same `toDocLink` helper as the other entries.
- `docs/.vuepress/sidebar.js`: adds `'WORKS-WITH.md'` to the `coreDocs` array (after `'AI-AGENTS.md'`) so it appears in the "Project documentation" sidebar group.

One non-obvious choice worth a look: the AI agents / Features cross-links in the page use the repo's `.md` link form (`AI-AGENTS.md`, `FEATURES.md`) rather than literal `/ai-agents` `/features`. The raw absolute paths render as external `target="_blank"` anchors with no `/boot-ui/` base and would 404 on the deployed site; the `.md` form is rewritten by the existing `cleanMarkdownDocLinksPlugin` to correct internal routes.

New navbar order: Try it, Setup, Features, Properties, AI agents, Ecosystem.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed