### PR TITLE
test: stub vue-router in view tests to silence route injection warning

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Exceptions.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Exceptions.test.js
@@ -3,6 +3,8 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 
 import Exceptions from './Exceptions.vue'
 
+vi.mock('vue-router', () => ({useRoute: () => ({query: {}})}))
+
 function jsonResponse(body, ok = true, status = 200) {
   return {ok, status, json: () => Promise.resolve(body)}
 }

--- a/bootui-ui/src/main/frontend/src/views/HttpExchanges.test.js
+++ b/bootui-ui/src/main/frontend/src/views/HttpExchanges.test.js
@@ -4,6 +4,8 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 import HttpExchanges from './HttpExchanges.vue'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 
+vi.mock('vue-router', () => ({useRoute: () => ({query: {}})}))
+
 function jsonResponse(body, ok = true, status = 200) {
   return {ok, status, json: () => Promise.resolve(body)}
 }

--- a/bootui-ui/src/main/frontend/src/views/SqlTrace.test.js
+++ b/bootui-ui/src/main/frontend/src/views/SqlTrace.test.js
@@ -3,6 +3,8 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 
 import SqlTrace from './SqlTrace.vue'
 
+vi.mock('vue-router', () => ({useRoute: () => ({query: {}})}))
+
 function jsonResponse(body, ok = true, status = 200) {
   return {ok, status, json: () => Promise.resolve(body)}
 }


### PR DESCRIPTION
## What does this PR do?

Go to bootui-ui/src/main/frontend
Start: npm t
There are some warnings
<img width="794" height="349" alt="image" src="https://github.com/user-attachments/assets/592766b4-0274-45bf-a7fb-f314c089a888" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
