### PR TITLE
build: remove ineffective esbuild.drop option ignored by Vite 8 (oxc)

### DIFF
--- a/bootui-ui/src/main/frontend/vite.config.js
+++ b/bootui-ui/src/main/frontend/vite.config.js
@@ -53,9 +53,6 @@ export default defineConfig(({command}) => ({
     assetsDir: 'assets',
     sourcemap: false
   },
-  esbuild: {
-    drop: process.env.NODE_ENV === 'production' ? ['console', 'debugger'] : []
-  },
   test: {
     environment: 'jsdom',
     include: ['src/**/*.test.js', 'scripts/**/*.test.js'],


### PR DESCRIPTION
## What does this PR do?

Go to bootui-ui/src/main/frontend
Start: npm t
Warning
<img width="722" height="140" alt="image" src="https://github.com/user-attachments/assets/01e7b988-2637-4604-8c39-e85106d59ca2" />

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
