### PR TITLE
Cache Maven and npm downloads in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+#
 # Multi-stage Dockerfile for a JVM image of the BootUI sample app.
 #
 # BootUI is a multi-module Maven project, so the whole reactor is copied into
@@ -64,8 +66,16 @@ RUN apt-get update && \
 COPY . .
 RUN chmod +x mvnw
 
-# Build the sample app and its reactor dependencies.
-RUN ./mvnw -DskipTests -pl bootui-sample-app -am clean package
+# Build the sample app and its reactor dependencies. The Maven local repository
+# (~/.m2) and the npm package cache (~/.npm) are kept in BuildKit cache mounts so
+# they survive across rebuilds instead of being re-downloaded on every build. The
+# ~/.m2 mount also covers the frontend-maven-plugin's Node.js and npm archive
+# downloads, which it caches under ~/.m2/repository/com/github/eirslett. These
+# caches live in the builder, not in the image, so they add nothing to the final
+# image size. (Requires BuildKit, the default in modern Docker.)
+RUN --mount=type=cache,target=/root/.m2 \
+    --mount=type=cache,target=/root/.npm \
+    ./mvnw -DskipTests -pl bootui-sample-app -am clean package
 
 # Explode the repackaged Spring Boot jar into its layers (dependencies,
 # spring-boot-loader, snapshot-dependencies, application). These are copied

--- a/Dockerfile-aot
+++ b/Dockerfile-aot
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+#
 # Multi-stage Dockerfile for a JVM + AOT image of the BootUI sample app.
 #
 # This image adds two complementary Ahead-of-Time (AOT) optimizations on top of
@@ -76,7 +78,15 @@ RUN chmod +x mvnw
 # before spring-boot:repackage bundles it into the executable jar. Tests are
 # skipped to keep the build fast; the generated Spring AOT sources are compiled
 # and included in the final jar automatically by the plugin.
-RUN ./mvnw -Paot -DskipTests -pl bootui-sample-app -am clean package
+#
+# The Maven local repository (~/.m2, which also caches the frontend-maven-plugin's
+# Node.js/npm archive downloads under com/github/eirslett) and the npm package
+# cache (~/.npm) are kept in BuildKit cache mounts so they are reused across
+# rebuilds rather than re-downloaded every time. These caches live in the builder,
+# not in the image. (Requires BuildKit, the default in modern Docker.)
+RUN --mount=type=cache,target=/root/.m2 \
+    --mount=type=cache,target=/root/.npm \
+    ./mvnw -Paot -DskipTests -pl bootui-sample-app -am clean package
 
 # Explode the repackaged Spring Boot jar into its layers (dependencies,
 # spring-boot-loader, snapshot-dependencies, application). These are copied

--- a/Dockerfile-crac
+++ b/Dockerfile-crac
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+#
 # Multi-stage Dockerfile for a CRaC (Coordinated Restore at Checkpoint) image of
 # the BootUI sample app.
 #
@@ -52,7 +54,15 @@ RUN chmod +x mvnw
 # Build the sample app and its reactor dependencies. The sample app binds the
 # spring-boot-maven-plugin "repackage" goal, so this produces a runnable Spring
 # Boot jar (with BOOT-INF and a Main-Class) alongside the thin *.jar.original.
-RUN ./mvnw -Pcrac -DskipTests -pl bootui-sample-app -am clean package
+#
+# The Maven local repository (~/.m2, which also caches the frontend-maven-plugin's
+# Node.js/npm archive downloads under com/github/eirslett) and the npm package
+# cache (~/.npm) are kept in BuildKit cache mounts so they are reused across
+# rebuilds rather than re-downloaded every time. These caches live in the builder,
+# not in the image. (Requires BuildKit, the default in modern Docker.)
+RUN --mount=type=cache,target=/root/.m2 \
+    --mount=type=cache,target=/root/.npm \
+    ./mvnw -Pcrac -DskipTests -pl bootui-sample-app -am clean package
 
 # Runtime stage with a CRaC-enabled JDK (BellSoft Liberica with CRaC support).
 FROM bellsoft/liberica-runtime-container:jdk-21-crac-slim-glibc

--- a/Dockerfile-native
+++ b/Dockerfile-native
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+#
 # Multi-stage Dockerfile for a GraalVM native image of the BootUI sample app.
 #
 # BootUI is a multi-module Maven project, so the whole reactor is copied into
@@ -44,7 +46,17 @@ ENV NATIVE_IMAGE_OPTIONS="-H:+StaticExecutableWithDynamicLibC"
 # The `native` profile (declared in bootui-sample-app/pom.xml) runs Spring
 # Boot's process-aot goal, downloads GraalVM reachability metadata and then
 # compiles the native image during the `package` phase (build-native).
-RUN ./mvnw -Pnative -DskipTests -pl bootui-sample-app -am clean package
+#
+# The Maven local repository (~/.m2, which also caches the frontend-maven-plugin's
+# Node.js/npm archive downloads under com/github/eirslett) and the npm package
+# cache (~/.npm) are kept in BuildKit cache mounts so they are reused across
+# rebuilds rather than re-downloaded every time. (The native-image compilation
+# itself is not cached.) These caches live in the builder, not in the image, and
+# require BuildKit, the default in modern Docker. The GraalVM build image runs as
+# root, so the Maven/npm home is /root.
+RUN --mount=type=cache,target=/root/.m2 \
+    --mount=type=cache,target=/root/.npm \
+    ./mvnw -Pnative -DskipTests -pl bootui-sample-app -am clean package
 
 # Move the native executable to a known path (the native-maven-plugin names it
 # after the module artifactId, i.e. bootui-sample-app).


### PR DESCRIPTION
## What does this PR do?

Adds BuildKit cache mounts for `~/.m2` and `~/.npm` to the Maven build step in all four Dockerfiles (JVM, AOT, CRaC, native), so dependencies and the Node/npm toolchain are reused across rebuilds instead of being re-downloaded every time.

## Why is this change needed?

Every `docker build` did `COPY . .` then `./mvnw ... clean package` with nothing persisting between builds, so each rebuild re-downloaded the entire Maven local repository plus the frontend-maven-plugin's Node.js/npm toolchain. Any source change forced a full cold dependency fetch.

The `--mount=type=cache,target=/root/.m2` mount covers all Java dependencies and the Node/npm archives (the plugin caches those under `~/.m2/repository/com/github/eirslett`), and `--mount=type=cache,target=/root/.npm` covers the npm packages `npm ci` pulls. Each file also gets a `# syntax=docker/dockerfile:1` directive so the cache-mount syntax is explicit and portable.

The caches live in the builder, not in the image, so final image size is unchanged.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Verified the build behavior directly with Docker (29.5, BuildKit):

- All four Dockerfiles pass `docker build --check` with no warnings.
- Built the JVM image `build` stage end-to-end (full reactor + Vue UI): success.
- Cold cache: Maven step ~29s, ~900 downloads from Maven Central.
- Warm cache (edited the context to bust `COPY . .`, no `--no-cache`): Maven step ~14s with **0** downloads from Central; Node/npm not re-fetched.

Note: passing `--no-cache` / `--no-cache-filter` also resets cache mounts, so those flags still force a full re-download (expected). No application code changed; AOT/CRaC/native use the identical mount pattern as the verified JVM image.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (build commands are unchanged; no doc update needed)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed