### PR TITLE
Fix daily Docker publish failure from untagged-manifest prune

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -556,6 +556,13 @@ jobs:
         # server-side safety net, so nothing pushed or pulled within the window can be removed
         # even by mistake. Runs after the tag deletion above, so a manifest list freshly
         # orphaned by that step is itself untagged and swept here too.
+        #
+        # The namespaces images / delete-images API is only available to Docker Pro and Team
+        # plans and is authenticated with a Bearer token (not the JWT scheme the older
+        # /v2/repositories tags API accepts). On a Free plan Docker Hub returns 403/404 for it,
+        # so this step degrades gracefully: it logs a warning and skips rather than failing the
+        # whole publish pipeline. Untagged manifests then have to be removed manually from the
+        # Docker Hub UI (or by upgrading the plan).
         env:
           DRY_RUN: ${{ github.event.inputs.prune_dry_run || 'false' }}
         run: |
@@ -582,7 +589,22 @@ jobs:
             digests=()
             url="https://hub.docker.com/v2/namespaces/${DOCKERHUB_USERNAME}/repositories/${repo}/images?status=inactive&currently_tagged=false&active_from=${active_from}&ordering=last_activity&page_size=100"
             while [ -n "$url" ] && [ "$url" != 'null' ]; do
-              resp=$(curl -fsS -H "Authorization: JWT ${token}" "$url")
+              # Capture the HTTP status (no -f) so a plan-gated 403/404 can be skipped gracefully.
+              body=$(mktemp)
+              status=$(curl -sS -o "$body" -w '%{http_code}' -H "Authorization: Bearer ${token}" "$url")
+              resp=$(cat "$body")
+              rm -f "$body"
+              if [ "$status" = '403' ] || [ "$status" = '404' ]; then
+                echo "::warning::Docker Hub returned HTTP ${status} for the image-management API. Untagged-manifest pruning requires a Docker Pro or Team plan; skipping. Untagged per-platform manifests must be removed manually from the Docker Hub UI."
+                echo "::endgroup::"
+                # Plan entitlement is account-wide, so the remaining repositories would fail too.
+                exit 0
+              fi
+              if [ "$status" != '200' ]; then
+                echo "Unexpected HTTP ${status} from the Docker Hub images API:" >&2
+                echo "$resp" >&2
+                exit 1
+              fi
               while read -r digest; do
                 [ -n "$digest" ] && digests+=("$digest")
               done < <(echo "$resp" | jq -r '
@@ -613,7 +635,7 @@ jobs:
                 --argjson manifests "$manifests" \
                 '{dry_run: $dry_run, active_from: $active_from, manifests: $manifests}')
               echo "Deleting batch of ${#batch[@]} manifest(s)..."
-              curl -fsS -X POST -H "Authorization: JWT ${token}" -H 'Content-Type: application/json' \
+              curl -fsS -X POST -H "Authorization: Bearer ${token}" -H 'Content-Type: application/json' \
                 -d "$payload" \
                 "https://hub.docker.com/v2/namespaces/${DOCKERHUB_USERNAME}/delete-images" \
                 | jq '.'


### PR DESCRIPTION
## What does this PR do?

Stops the scheduled "Publish Docker images" workflow from failing on its untagged-manifest cleanup step by switching that step to the documented `Bearer` auth scheme and making it degrade gracefully when Docker Hub's image-management API is not available on the account's plan.

## Why is this change needed?

The untagged-manifest sweep added in #438 fails the daily workflow with `curl: (22) ... 404` ([run](https://github.com/jdubois/boot-ui/actions/runs/27899055731)). The build/merge/publish all succeed; only the new prune step errors.

Root cause: that step calls Docker Hub's `GET /v2/namespaces/.../images` and `POST /v2/namespaces/.../delete-images` endpoints. Per Docker Hub's official API spec these are **only available to Pro and Team plans** and are authenticated with a **Bearer** token, not the `JWT` scheme the older `/v2/repositories/.../tags/` API accepts. On a Free plan Docker Hub returns 404 (it hides the endpoint rather than returning 403), so the step's first `curl --fail` aborted the job.

## How was it tested?

This change only touches `docker-publish.yml` (no app code), so the Maven build is unaffected.

- Validated the workflow YAML parses and `bash -n` syntax-checks the step script.
- Mock-ran the step's shell logic against three Docker Hub responses using PATH shims for `curl`/`date`:
  - **200 (entitled):** lists untagged digests and batches the delete call as before.
  - **403/404 (not entitled):** logs a `::warning::` and exits 0, so the publish pipeline stays green.
  - **other non-200 (e.g. 500):** still fails loudly with the response body.

- [ ] `./mvnw clean install` passes locally (N/A - workflow-only change)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (N/A)
- [ ] Added or updated tests where applicable (N/A - GitHub Actions workflow)

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (the rationale and plan limitation are documented inline in the workflow step)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

## Note for maintainers

If the `jdubois` Docker Hub account is on the **Free** plan, this step will now always warn-and-skip - untagged per-platform manifests can only be removed manually from the Docker Hub UI (or by upgrading to Pro/Team). If the account is on **Pro/Team**, the switch to `Bearer` should let the cleanup run for real. The step is written to work correctly either way.