### PR TITLE
Make Docker Hub untagged-manifest prune opt-in (Pro/Team only)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -493,7 +493,7 @@ jobs:
         run: docker buildx imagetools inspect "${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}"
 
   prune:
-    name: Prune tags and untagged manifests older than one week
+    name: Prune Docker Hub tags (and untagged manifests when enabled)
     runs-on: ubuntu-latest
     # Prune only after a successful merge, so old daily images are removed only once
     # fresh ones have replaced them - never pruning a repository down to a stale
@@ -550,19 +550,22 @@ jobs:
         # phase stitches those digests into the tagged multi-arch manifest list. Deleting a
         # tag above only removes the tag pointer - Docker Hub never garbage-collects the
         # untagged per-platform child manifests, and the tags API does not even list them,
-        # so they would otherwise accumulate forever. Sweep them here via the images API
-        # (currently_tagged=false returns only untagged manifests) and the bulk delete-images
-        # endpoint. active_from is the same cutoff and is passed to delete-images as a
-        # server-side safety net, so nothing pushed or pulled within the window can be removed
-        # even by mistake. Runs after the tag deletion above, so a manifest list freshly
-        # orphaned by that step is itself untagged and swept here too.
+        # so they accumulate. This step sweeps them via the images API (currently_tagged=false
+        # returns only untagged manifests) and the bulk delete-images endpoint. active_from is
+        # the same cutoff and is passed to delete-images as a server-side safety net, so nothing
+        # pushed or pulled within the window can be removed even by mistake.
         #
-        # The namespaces images / delete-images API is only available to Docker Pro and Team
-        # plans and is authenticated with a Bearer token (not the JWT scheme the older
-        # /v2/repositories tags API accepts). On a Free plan Docker Hub returns 403/404 for it,
-        # so this step degrades gracefully: it logs a warning and skips rather than failing the
-        # whole publish pipeline. Untagged manifests then have to be removed manually from the
-        # Docker Hub UI (or by upgrading the plan).
+        # IMPORTANT - this is OPT-IN and disabled by default. The images / delete-images API it
+        # uses is only available to Docker Pro and Team plans (it returns 403/404 on Free) and
+        # uses Bearer auth, not the JWT scheme the older /v2/repositories tags API accepts. On
+        # the Free plan there is no safe automated way to reclaim untagged-manifest storage:
+        # deleting a tag does not free the underlying manifest, and the only Free operation that
+        # does - deleting the whole repository - would also reset these public images' stars and
+        # pull counts and make them unavailable during each rebuild. So the step runs only when
+        # the repository variable DOCKERHUB_UNTAGGED_PRUNE is set to 'true' (do that after
+        # upgrading to a Pro/Team plan). If it is enabled on a plan that lacks the API it still
+        # degrades gracefully - it warns and skips rather than failing the publish pipeline.
+        if: vars.DOCKERHUB_UNTAGGED_PRUNE == 'true'
         env:
           DRY_RUN: ${{ github.event.inputs.prune_dry_run || 'false' }}
         run: |


### PR DESCRIPTION
## What does this PR do?

Makes the untagged-manifest prune step **opt-in and disabled by default**, gated behind a new repository variable `DOCKERHUB_UNTAGGED_PRUNE`, and documents why automated untagged cleanup is not achievable on Docker Hub's Free plan.

## Why is this change needed?

Follow-up to #439. That PR stopped the daily publish workflow from failing, but on a Free plan the step still logs in and 404-skips on every scheduled run, leaving a daily warning annotation for a no-op.

I looked into doing the cleanup another way on Free, and confirmed against Docker's own storage docs that there is no safe automated option for these repos:

- Docker Hub's `images` / `delete-images` API (the only per-manifest cleanup) is **Pro/Team only** - it returns 403/404 on Free.
- **Deleting a tag does not reclaim** the underlying manifest's storage; the per-platform children stay as untagged manifests regardless.
- The only Free operation that truly reclaims untagged storage is **deleting the entire repository** - but `jdubois/bootui-sample-app*` are all **public**, **starred**, and **actively pulled** (450-870 pulls each). Deleting/recreating them would reset stars and pull counts and make the images unavailable during each rebuild. That's worse than the storage cost, so it's intentionally not done.

## What this PR does about it

- Gates the untagged-prune step on `vars.DOCKERHUB_UNTAGGED_PRUNE == 'true'`, so by default it doesn't run at all (clean, green scheduled runs - no daily no-op API calls or warning annotation).
- Keeps the real, Bearer-authenticated sweep ready: set the repo variable to `true` after upgrading to a Pro/Team plan and it runs for real. The graceful 403/404 skip is retained as a safety net if it's ever enabled on a plan that lacks the API.
- Renames the prune job and rewrites the step comment to document the Free-plan limitation and the rationale.

## Recommendation for later

If you do want old per-platform manifests cleaned up automatically without paying for Pro, the realistic path is publishing these images to **GitHub Container Registry (ghcr.io)**, which prunes untagged image versions for free via `GITHUB_TOKEN` (e.g. a retention action). That's a registry change affecting where users pull from, so I left it as a recommendation rather than doing it here - happy to implement it if you want.

## How was it tested?

Workflow-only change. Validated the YAML parses and `bash -n` syntax-checks the step script (the script body is unchanged from #439, which was mock-tested across the 200 / 403-404 / 500 paths).

- [ ] `./mvnw clean install` passes locally (N/A - workflow-only change)
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end (N/A)
- [ ] Added or updated tests where applicable (N/A - GitHub Actions workflow)

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (rationale documented inline in the workflow)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed