### PR TITLE
fix: accept YAML boolean for bootui.enabled so ON/OFF activate (#447)

### DIFF
--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,0 +1,1 @@
+{"version":1,"sessions":{}}

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationCondition.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationCondition.java
@@ -12,13 +12,14 @@ import org.springframework.util.ClassUtils;
  *
  * <p>BootUI activates only when at least one of these is true:
  * <ul>
- *     <li>{@code bootui.enabled=ON}</li>
+ *     <li>{@code bootui.enabled=ON} (also {@code true}/{@code yes}; in YAML {@code ON} is parsed as
+ *         a boolean, so it arrives as {@code true})</li>
  *     <li>An active profile is present in {@code bootui.enabled-profiles}</li>
  *     <li>{@code spring-boot-devtools} is on the classpath</li>
  * </ul>
  * and none of these is true:
  * <ul>
- *     <li>{@code bootui.enabled=OFF}</li>
+ *     <li>{@code bootui.enabled=OFF} (also {@code false}/{@code no})</li>
  *     <li>An active profile is present in {@code bootui.disabled-profiles}</li>
  * </ul>
  */
@@ -27,7 +28,8 @@ public class BootUiActivationCondition implements Condition {
     public static final String DEVTOOLS_CLASS = "org.springframework.boot.devtools.restart.RestartScope";
 
     public static BootUiActivation resolve(Environment environment, ClassLoader classLoader) {
-        String mode = environment.getProperty("bootui.enabled", "AUTO").trim().toUpperCase(Locale.ROOT);
+        String rawMode = environment.getProperty("bootui.enabled", "AUTO").trim();
+        String mode = normalizeMode(rawMode);
         List<String> warnings = new ArrayList<>();
         Collection<String> activeProfiles = Arrays.asList(environment.getActiveProfiles());
 
@@ -37,7 +39,7 @@ public class BootUiActivationCondition implements Condition {
                 listProperty(environment, "bootui.enabled-profiles", BootUiDefaults.ENABLED_PROFILES);
 
         if (!List.of("AUTO", "ON", "OFF").contains(mode)) {
-            return new BootUiActivation(false, "Disabled: invalid bootui.enabled value '" + mode + "'", warnings);
+            return new BootUiActivation(false, "Disabled: invalid bootui.enabled value '" + rawMode + "'", warnings);
         }
 
         for (String profile : disabledProfiles) {
@@ -76,6 +78,26 @@ public class BootUiActivationCondition implements Condition {
 
         return new BootUiActivation(
                 false, "Disabled: no enabled profile and devtools is not on the classpath", warnings);
+    }
+
+    /**
+     * Normalizes a configured {@code bootui.enabled} value to a canonical {@code AUTO}/{@code ON}/
+     * {@code OFF} token.
+     *
+     * <p>YAML treats {@code on}/{@code off}/{@code yes}/{@code no}/{@code true}/{@code false} as
+     * booleans, so {@code bootui.enabled: ON} is delivered to the {@link Environment} as the string
+     * {@code "true"}. To keep the documented {@code ON}/{@code OFF} switch working in YAML (and to
+     * stay consistent with Spring's relaxed binding of the {@code Mode} enum used everywhere else),
+     * boolean-ish values are mapped onto {@code ON}/{@code OFF}. Genuinely unknown values are passed
+     * through unchanged so they still fail closed.</p>
+     */
+    private static String normalizeMode(String rawMode) {
+        String mode = rawMode.toUpperCase(Locale.ROOT);
+        return switch (mode) {
+            case "ON", "TRUE", "YES" -> "ON";
+            case "OFF", "FALSE", "NO" -> "OFF";
+            default -> mode;
+        };
     }
 
     private static List<String> listProperty(Environment env, String key, List<String> defaults) {

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationConditionAdditionalTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiActivationConditionAdditionalTests.java
@@ -8,6 +8,9 @@ import java.nio.file.Path;
 import javax.tools.ToolProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
@@ -186,26 +189,41 @@ class BootUiActivationConditionAdditionalTests {
     }
 
     @Test
-    void invalidEnabledValueFailsClosedWithNoActiveProfile() {
+    void yesValueActivatesAsYamlBooleanTrue() {
         MockEnvironment env = new MockEnvironment();
+        // YAML parses `bootui.enabled: yes` as the boolean true; either form must enable BootUI.
         env.setProperty("bootui.enabled", "YES");
 
         BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
 
-        assertThat(activation.enabled()).isFalse();
-        assertThat(activation.reason()).contains("invalid bootui.enabled");
+        assertThat(activation.enabled()).isTrue();
+        assertThat(activation.reason()).contains("ON");
     }
 
     @Test
-    void invalidEnabledValueFailsClosedEvenWithDevProfile() {
+    void trueValueActivatesAsYamlBooleanTrue() {
         MockEnvironment env = new MockEnvironment();
         env.setActiveProfiles("dev");
+        // YAML parses `bootui.enabled: ON` as the boolean true, delivered to the environment as "true".
         env.setProperty("bootui.enabled", "TRUE");
 
         BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
 
+        assertThat(activation.enabled()).isTrue();
+        assertThat(activation.reason()).contains("ON");
+    }
+
+    @Test
+    void falseValueDisablesAsYamlBooleanFalse() {
+        MockEnvironment env = new MockEnvironment();
+        env.setActiveProfiles("dev");
+        // YAML parses `bootui.enabled: OFF`/`no` as the boolean false, delivered as "false".
+        env.setProperty("bootui.enabled", "FALSE");
+
+        BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
+
         assertThat(activation.enabled()).isFalse();
-        assertThat(activation.reason()).contains("TRUE");
+        assertThat(activation.reason()).contains("OFF");
     }
 
     @Test
@@ -225,7 +243,7 @@ class BootUiActivationConditionAdditionalTests {
 
         BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
 
-        // The condition uppercases the raw value, so the reason contains the uppercased form.
+        // The condition reports the raw supplied value verbatim in the reason.
         assertThat(activation.reason()).containsIgnoringCase("bogus");
     }
 
@@ -252,5 +270,40 @@ class BootUiActivationConditionAdditionalTests {
         BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
 
         assertThat(activation.enabled()).isTrue();
+    }
+
+    /**
+     * Regression test for #447: YAML parses {@code bootui.enabled: ON} as the boolean {@code true},
+     * which previously reached the condition as the string {@code "true"} and was rejected as an
+     * invalid value, silently disabling BootUI. Drive the value through the real
+     * {@link YamlPropertySourceLoader} to prove the documented YAML switch activates BootUI.
+     */
+    @Test
+    void yamlEnabledOnActivates() throws Exception {
+        StandardEnvironment env = environmentFromYaml("bootui:\n  enabled: ON\n");
+
+        BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
+
+        assertThat(activation.enabled()).isTrue();
+        assertThat(activation.reason()).contains("ON");
+    }
+
+    @Test
+    void yamlEnabledOffDisables() throws Exception {
+        StandardEnvironment env = environmentFromYaml("bootui:\n  enabled: OFF\n");
+        env.setActiveProfiles("dev");
+
+        BootUiActivation activation = BootUiActivationCondition.resolve(env, classLoader);
+
+        assertThat(activation.enabled()).isFalse();
+        assertThat(activation.reason()).contains("OFF");
+    }
+
+    private static StandardEnvironment environmentFromYaml(String yaml) throws java.io.IOException {
+        StandardEnvironment env = new StandardEnvironment();
+        new YamlPropertySourceLoader()
+                .load("test-yaml", new ByteArrayResource(yaml.getBytes(java.nio.charset.StandardCharsets.UTF_8)))
+                .forEach(source -> env.getPropertySources().addFirst(source));
+        return env;
     }
 }

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -17,7 +17,7 @@ Panel settings are consistent across the UI and API:
 
 | Property                         | Default                                 | Description                                                                                                                     |
 | -------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `bootui.enabled`                 | `AUTO`                                  | Activation mode. `AUTO` activates only for configured local profiles or DevTools; `ON` forces BootUI on; `OFF` forces it off.   |
+| `bootui.enabled`                 | `AUTO`                                  | Activation mode. `AUTO` activates only for configured local profiles or DevTools; `ON` forces BootUI on; `OFF` forces it off. In YAML, `ON`/`OFF` are parsed as booleans, so `true`/`yes` and `false`/`no` are accepted as `ON`/`OFF`. |
 | `bootui.enabled-profiles`        | `dev,local`                             | Profiles that activate BootUI when `bootui.enabled=AUTO`.                                                                       |
 | `bootui.disabled-profiles`       | `prod,production`                       | Profiles that force BootUI off unless `bootui.enabled=ON`.                                                                      |
 | `bootui.force-web`               | `true`                                  | While BootUI is active, force a non-web (command-line) application into a servlet web application so the console can be served. No effect on apps that are already servlet web apps or explicitly reactive. Set to `false` to leave the host's web-application type untouched. |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -72,6 +72,12 @@ bootui.enabled=OFF
 `prod` and `production` profiles disable BootUI unless `bootui.enabled=ON` is set. Invalid `bootui.enabled` values fail
 closed and keep BootUI disabled.
 
+::: tip YAML users
+In `application.yml`, YAML parses `ON`/`OFF` (and `yes`/`no`/`true`/`false`) as booleans, so
+`bootui.enabled: ON` arrives as `true`. BootUI accepts these: `ON`/`true`/`yes` enable it and
+`OFF`/`false`/`no` disable it, so the documented `bootui.enabled: ON` works unquoted in YAML.
+:::
+
 ## 4) Open BootUI
 
 Nice job! BootUI is now configured 🚀
@@ -297,7 +303,7 @@ subnet over the broad `172.16.0.0/12`, and keep it limited to trusted local/dev 
 
 | Symptom                      | Check                                                                                                                                   |
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `/bootui` returns 404        | Use the `dev` or `local` profile, add DevTools, or set `bootui.enabled=ON`.                                                             |
+| `/bootui` returns 404        | Use the `dev` or `local` profile, add DevTools, or set `bootui.enabled=ON`. In `application.yml`, `bootui.enabled: ON` is valid — YAML parses it as a boolean, which BootUI accepts as `ON`. |
 | BootUI is disabled in `prod` | This is intentional; only `bootui.enabled=ON` can force activation with a disabled profile.                                             |
 | Command-line app now stays up | Expected: BootUI starts a servlet server so the console is reachable. Set `bootui.force-web=false` to keep the app non-web.              |
 | Browser is rejected          | BootUI accepts loopback callers and fails closed for everything else. Inside a container, set `bootui.trust-container-gateway=AUTO` to auto-detect and trust the default gateway `/32` (the SNAT source of published-port traffic) — no subnet needed on any Docker flavor, and the Host + CSRF protections stay on. For a custom proxy/bridge or LAN access, add that source range to `bootui.trusted-proxies` instead — `172.16.0.0/12` on Linux Docker Engine, `192.168.65.0/24` on Docker Desktop (macOS/Windows) — plus the hostname you browse with to `bootui.allowed-hosts`. Use `bootui.allow-non-localhost=true` only as a blunt last resort on a trusted local network. |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1226,7 +1226,7 @@ Initial properties:
 
 | Property                                     | Default                                 | Description                                                                                       |
 | -------------------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `bootui.enabled`                             | `AUTO`                                  | Enables BootUI. Values: `AUTO`, `ON`, `OFF`.                                                      |
+| `bootui.enabled`                             | `AUTO`                                  | Enables BootUI. Values: `AUTO`, `ON`, `OFF` (YAML parses `ON`/`OFF` as booleans, so `true`/`yes` and `false`/`no` are accepted too). |
 | `bootui.path`                                | `/bootui`                               | UI base path used by the banner and safety filter; `/bootui` is the supported route.              |
 | `bootui.api-path`                            | `/bootui/api`                           | Internal API base path used by the safety filter; controllers currently serve `/bootui/api/**`.   |
 | `bootui.allow-non-localhost`                 | `false`                                 | Explicitly allow non-loopback requests.                                                           |


### PR DESCRIPTION
## What does this PR do?

Makes `bootui.enabled: ON` in `application.yml` actually enable BootUI instead of silently disabling it and returning a 404 for `/bootui`.

## Why is this change needed?

On Spring Boot 4.1, YAML parses `ON`/`OFF` (and `yes`/`no`/`true`/`false`) as **booleans**. So `bootui.enabled: ON` reaches the environment as the string `"true"`. `BootUiActivationCondition` read that raw value, uppercased it to `"TRUE"`, found it was not in `{AUTO, ON, OFF}`, and disabled BootUI as an "invalid value". The `/bootui` request then fell through to the default static-resource handler and failed with `NoResourceFoundException: No static resource bootui for request '/bootui'`.

I confirmed this by running the real `YamlPropertySourceLoader` against `bootui.enabled: ON` (it yields Boolean `true`). Notably, Spring's relaxed enum binding already maps `true/on/yes -> ON` and `false/off/no -> OFF` for every other `Mode` property (`bootui.mcp.enabled`, `bootui.copilot.enabled`, `bootui.claude-code.enabled`); only the hand-rolled string match in the activation condition was out of step.

Fixes: #447

Closes #447

## How was it tested?

- [x] Added tests: revised the cases that previously asserted `TRUE`/`YES` were invalid (they encoded the bug), added coverage for `true/false/yes/no`, and added a real `YamlPropertySourceLoader` round-trip proving `bootui.enabled: ON` activates and `OFF` disables.
- [x] `bootui-autoconfigure` suite passes: 1244 tests, 0 failures.
- [x] `spotless:apply` / `spotless:check` clean.

The fix normalizes boolean-ish values in `BootUiActivationCondition` (`TRUE/YES -> ON`, `FALSE/NO -> OFF`) before validation, matching Spring's own enum binding. Genuinely unknown values (e.g. `1`, `bogus`) still fail closed.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` updated when behaviour changes (`SETUP.md`, `PROPERTIES.md`, `SPECIFICATION.md` now note YAML accepts `ON`/`OFF`/`true`/`false`/`yes`/`no`)
- [x] Public API kept backward compatible. This widens accepted values for `bootui.enabled` (now also `true/false/yes/no`); no existing valid configuration changes behavior.
- [x] No secrets, tokens, or local paths committed

### Note for reviewers

This is a deliberate, small behavior change: `bootui.enabled` now also accepts `true/false/yes/no` in addition to `AUTO/ON/OFF`, consistent with Spring's relaxed enum binding. Fail-closed behavior is preserved for ambiguous/unknown values.