### PR TITLE
refactor: move Health sub-components into views/components

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -1,7 +1,7 @@
 <script setup>
 import {getJson} from '../api.js'
 import {computed, ref} from 'vue'
-import HealthNode from './HealthNode.vue'
+import HealthNode from './components/HealthNode.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
 import {describeLoadError} from '../utils/loadError.js'

--- a/bootui-ui/src/main/frontend/src/views/components/HealthDetails.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/HealthDetails.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {formatBytes, isPlainObject} from '../utils/format.js'
+import {formatBytes, isPlainObject} from '../../utils/format.js'
 
 defineProps({
   value: {required: false, default: null}

--- a/bootui-ui/src/main/frontend/src/views/components/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/HealthNode.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {isPlainObject} from '../utils/format.js'
+import {isPlainObject} from '../../utils/format.js'
 import HealthDetails from './HealthDetails.vue'
 
 defineProps({


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
