### PR TITLE
chore: gitignore .impeccable hook cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ dist/
 # BootUI runtime persistence (local developer overrides)
 .bootui/
 
+# Impeccable hook local cache
+.impeccable/
+
 # Local env
 .env
 *.env.local

--- a/.impeccable/hook.cache.json
+++ b/.impeccable/hook.cache.json
@@ -1,1 +1,0 @@
-{"version":1,"sessions":{}}


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [ ] No secrets, tokens, or local paths committed
