### PR TITLE
refactor: finish template literals in Config.vue

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -241,7 +241,8 @@ async function removeOverride(name) {
     const res = await apiFetch(`api/config/overrides/${encodeURIComponent(name)}`, {method: 'DELETE'})
     const result = await res.json().catch(() => ({}))
     if (!res.ok) {
-      flash('Could not remove override: ' + (result.message || `HTTP ${res.status}`), 'danger')
+      const msg = result.message || `HTTP ${res.status}`
+      flash(`Could not remove override: ${msg}`, 'danger')
       return
     }
     flash(`Override removed for ${name}.`, 'success')
@@ -388,7 +389,7 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
                   :disabled="readOnly"
                   :placeholder="
                     hasDefaultValue(selectedNewSuggestion)
-                      ? 'default: ' + formatDefaultValue(selectedNewSuggestion.defaultValue)
+                      ? `default: ${formatDefaultValue(selectedNewSuggestion.defaultValue)}`
                       : 'new value'
                   "
                   class="form-control font-monospace"


### PR DESCRIPTION
Follow-up to #454. That PR converted string concatenation to template literals across the frontend, but two interpolation concatenations remained in `Config.vue`:

- **`removeOverride` error message** — was mixed style (`'Could not remove override: ' + (result.message || \`HTTP \${res.status}\`)`). Now extracts a `msg` variable and uses a single template literal, mirroring `saveOverride`.
- **`default:` placeholder binding** — `'default: ' + formatDefaultValue(...)` → `\`default: \${formatDefaultValue(...)}\``, matching the identical pattern already converted in `useAdvisorPanel.js`.

No behavior change. `npm run format:check` and the full Vitest suite (252 tests) pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>