### PR TITLE
Add concern filtering to GraalVM and CRaC panels

### DIFF
--- a/bootui-sample-app/e2e/tests/crac.spec.js
+++ b/bootui-sample-app/e2e/tests/crac.spec.js
@@ -32,6 +32,16 @@ test.describe('CRaC view', () => {
     // The scan-status card surfaces a status badge once the scan completes.
     const scanStatusCard = page.locator('.card', {hasText: 'Scan status'}).first()
     await expect(scanStatusCard.locator('.badge').first()).toBeVisible()
+
+    // After a scan, the concerns list can be filtered. The severity/category/search controls only
+    // appear when the scan surfaced at least one concern, so guard on the sample app having any.
+    const search = page.getByPlaceholder('Search concerns')
+    if (await search.count()) {
+      await search.fill('zzz-no-such-concern')
+      await expect(page.getByText('No concerns match the active filters')).toBeVisible()
+      await page.getByRole('button', {name: 'Clear filters'}).first().click()
+      await expect(page.getByText('No concerns match the active filters')).toHaveCount(0)
+    }
   })
 
   test('offers the generated CRaC container assets', async ({openView, page}) => {

--- a/bootui-sample-app/e2e/tests/graalvm.spec.js
+++ b/bootui-sample-app/e2e/tests/graalvm.spec.js
@@ -35,6 +35,16 @@ test.describe('GraalVM view', () => {
     // The readiness-concerns section renders once the scan completes.
     await expect(page.getByText('Readiness concerns')).toBeVisible()
 
+    // After a scan, the concerns list can be filtered. The severity/category/search controls only
+    // appear when the scan surfaced at least one concern. The sample app may have none, so guard on it.
+    const search = page.getByPlaceholder('Search concerns')
+    if (await search.count()) {
+      await search.fill('zzz-no-such-concern')
+      await expect(page.getByText('No concerns match the active filters')).toBeVisible()
+      await page.getByRole('button', {name: 'Clear filters'}).first().click()
+      await expect(page.getByText('No concerns match the active filters')).toHaveCount(0)
+    }
+
     // The metadata, Dockerfile and combined artifacts live in a three-drawer accordion. The combined
     // "All files" drawer is open by default and offers a single action that writes both artifacts into
     // the source tree. Drawers are located by their header button so the shared "Write into project" label

--- a/bootui-ui/src/main/frontend/src/views/Crac.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Crac.test.js
@@ -71,6 +71,30 @@ function cracReport({installable = true, status = 'NOT_SCANNED', files, runtimeO
   }
 }
 
+function finding(id, name, severity, occurrenceCount = 1, status = 'REVIEW', category = 'Configuration') {
+  return {
+    id,
+    name,
+    category,
+    severity,
+    description: `${name} description.`,
+    status,
+    occurrenceCount,
+    sampleOccurrences: occurrenceCount > 0 ? [`${id} detail`] : [],
+    recommendation: `${name} recommendation.`
+  }
+}
+
+function scannedReport(findings) {
+  const report = cracReport({status: 'SCANNED'})
+  report.checksRun = 6
+  report.classesAnalyzed = 24
+  report.findingsFound = findings.length
+  report.findings = findings
+  report.scan = {...report.scan, status: 'SCANNED', findingsFound: findings.length, checksRun: 6, classesAnalyzed: 24}
+  return report
+}
+
 async function mountWithReport(report) {
   vi.stubGlobal(
     'fetch',
@@ -178,5 +202,78 @@ describe('Crac', () => {
     const writeButton = dockerCard.findAll('button').find((button) => button.text().includes('Write into project'))
     expect(writeButton).toBeUndefined()
     expect(wrapper.text()).toContain('Direct write unavailable')
+  })
+
+  function concernTitles(wrapper) {
+    return wrapper.findAll('.list-group-item h3').map((title) => title.text())
+  }
+
+  function severityFilterButton(wrapper, severity) {
+    return wrapper
+      .findAll('[aria-label="Filter concerns by severity"] button')
+      .find((button) => button.text().startsWith(severity))
+  }
+
+  describe('concern filtering', () => {
+    it('does not render the filter bar until a scan finds concerns', async () => {
+      const wrapper = await mountWithReport(scannedReport([]))
+
+      expect(wrapper.find('input[aria-label="Search concerns"]').exists()).toBe(false)
+      expect(wrapper.find('select[aria-label="Filter by category"]').exists()).toBe(false)
+    })
+
+    it('filters concerns by severity and reflects the visible count', async () => {
+      const wrapper = await mountWithReport(
+        scannedReport([
+          finding('CRAC-HIGH-001', 'High concern', 'HIGH'),
+          finding('CRAC-MED-001', 'Medium concern', 'MEDIUM'),
+          finding('CRAC-LOW-001', 'Low concern', 'LOW')
+        ])
+      )
+
+      const highButton = severityFilterButton(wrapper, 'HIGH')
+      expect(highButton).toBeDefined()
+      await highButton.trigger('click')
+
+      expect(concernTitles(wrapper)).toEqual(['High concern'])
+      expect(wrapper.text()).toContain('Showing 1 of 3 concerns')
+    })
+
+    it('filters concerns by category', async () => {
+      const wrapper = await mountWithReport(
+        scannedReport([
+          finding('CRAC-POOL-001', 'Pool concern', 'HIGH', 1, 'REVIEW', 'Connections'),
+          finding('CRAC-FILE-001', 'File concern', 'LOW', 1, 'REVIEW', 'Files')
+        ])
+      )
+
+      await wrapper.find('select[aria-label="Filter by category"]').setValue('Files')
+
+      expect(concernTitles(wrapper)).toEqual(['File concern'])
+    })
+
+    it('filters concerns by free-text search and clears back to all concerns', async () => {
+      const wrapper = await mountWithReport(
+        scannedReport([
+          finding('CRAC-HIGH-001', 'Open socket concern', 'HIGH'),
+          finding('CRAC-LOW-001', 'Temp file concern', 'LOW')
+        ])
+      )
+
+      await wrapper.find('input[aria-label="Search concerns"]').setValue('socket')
+      expect(concernTitles(wrapper)).toEqual(['Open socket concern'])
+
+      const clear = wrapper.findAll('button').find((button) => button.text() === 'Clear filters')
+      await clear.trigger('click')
+      expect(concernTitles(wrapper)).toEqual(['Open socket concern', 'Temp file concern'])
+    })
+
+    it('shows a no-match empty state when filters exclude every concern', async () => {
+      const wrapper = await mountWithReport(scannedReport([finding('CRAC-MED-001', 'Medium concern', 'MEDIUM')]))
+
+      await wrapper.find('input[aria-label="Search concerns"]').setValue('no-such-concern')
+
+      expect(wrapper.text()).toContain('No concerns match the active filters')
+    })
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Crac.vue
+++ b/bootui-ui/src/main/frontend/src/views/Crac.vue
@@ -68,7 +68,67 @@ const maxSeverityCount = computed(() => {
   return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
 })
 
-const visibleFindings = computed(() => [...(report.value?.findings || [])])
+const severityOrder = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO']
+const severityFilter = ref([])
+const categoryFilter = ref('')
+const searchText = ref('')
+
+const allFindings = computed(() => report.value?.findings || [])
+
+const availableSeverities = computed(() => {
+  const present = new Set(allFindings.value.map((finding) => finding.severity))
+  const known = severityOrder.filter((severity) => present.has(severity))
+  const extra = [...present].filter((severity) => !severityOrder.includes(severity)).sort()
+  return [...known, ...extra]
+})
+
+const availableCategories = computed(() =>
+  [...new Set(allFindings.value.map((finding) => finding.category).filter(Boolean))].sort()
+)
+
+const visibleFindings = computed(() => {
+  const term = searchText.value.trim().toLowerCase()
+  return allFindings.value.filter((finding) => {
+    if (severityFilter.value.length && !severityFilter.value.includes(finding.severity)) return false
+    if (categoryFilter.value && finding.category !== categoryFilter.value) return false
+    if (term) {
+      const haystack = [
+        finding.name,
+        finding.description,
+        finding.id,
+        finding.category,
+        ...(finding.sampleOccurrences || [])
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+      if (!haystack.includes(term)) return false
+    }
+    return true
+  })
+})
+
+const filtersActive = computed(
+  () => severityFilter.value.length > 0 || categoryFilter.value !== '' || searchText.value.trim() !== ''
+)
+
+function toggleSeverity(severity) {
+  if (severityFilter.value.includes(severity)) {
+    severityFilter.value = severityFilter.value.filter((value) => value !== severity)
+  } else {
+    severityFilter.value = [...severityFilter.value, severity]
+  }
+}
+
+function severityChipCount(severity) {
+  return allFindings.value.filter((finding) => finding.severity === severity).length
+}
+
+function clearFilters() {
+  severityFilter.value = []
+  categoryFilter.value = ''
+  searchText.value = ''
+}
 
 const emptyFindingsTitle = computed(() => {
   if (!hasScanData.value) return 'Run readiness checks to see checkpoint/restore concerns'
@@ -586,17 +646,71 @@ onMounted(loadReport)
             <div class="fw-semibold">Readiness concerns</div>
             <div class="text-muted small">
               <template v-if="hasScanData && report.findingsFound > 0">
-                {{ report.findingsFound }} {{ pluralize(report.findingsFound, 'concern') }}, sorted by importance
+                <template v-if="filtersActive"
+                  >Showing {{ visibleFindings.length }} of {{ report.findingsFound }}
+                  {{ pluralize(report.findingsFound, 'concern') }}</template
+                >
+                <template v-else
+                  >{{ report.findingsFound }} {{ pluralize(report.findingsFound, 'concern') }}, sorted by
+                  importance</template
+                >
               </template>
               <template v-else>{{ report.findingsFound }} concern(s) to review</template>
             </div>
           </div>
           <span v-if="hasScanData && report.findingsFound === 0" class="badge text-bg-success">No concerns</span>
         </div>
+        <div
+          v-if="hasScanData && report.findingsFound > 0"
+          class="card-header d-flex flex-wrap align-items-center gap-2 border-top"
+        >
+          <span class="small fw-semibold text-muted me-1">Filter</span>
+          <div class="btn-group btn-group-sm" role="group" aria-label="Filter concerns by severity">
+            <button
+              v-for="sev in availableSeverities"
+              :key="sev"
+              type="button"
+              class="btn"
+              :class="severityFilter.includes(sev) ? severityClass(sev) : 'btn-outline-secondary'"
+              :aria-pressed="severityFilter.includes(sev)"
+              @click="toggleSeverity(sev)"
+            >
+              {{ sev }} <span class="opacity-75">{{ severityChipCount(sev) }}</span>
+            </button>
+          </div>
+          <select v-model="categoryFilter" class="form-select form-select-sm w-auto" aria-label="Filter by category">
+            <option value="">All categories</option>
+            <option v-for="cat in availableCategories" :key="cat" :value="cat">{{ cat }}</option>
+          </select>
+          <input
+            v-model="searchText"
+            type="search"
+            class="form-control form-control-sm w-auto"
+            placeholder="Search concerns"
+            aria-label="Search concerns"
+          />
+          <button
+            v-if="filtersActive"
+            type="button"
+            class="btn btn-sm btn-link text-decoration-none ms-auto"
+            @click="clearFilters"
+          >
+            Clear filters
+          </button>
+        </div>
         <div v-if="visibleFindings.length === 0" class="card-body text-center text-muted py-5">
-          <i class="bi bi-camera fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">{{ emptyFindingsTitle }}</div>
-          <div>An actual checkpoint/restore run on a CRaC-enabled JDK remains the best way to verify readiness.</div>
+          <template v-if="filtersActive">
+            <i class="bi bi-funnel fs-2 d-block mb-2"></i>
+            <div class="fw-semibold text-body">No concerns match the active filters</div>
+            <button type="button" class="btn btn-sm btn-outline-secondary mt-2" @click="clearFilters">
+              Clear filters
+            </button>
+          </template>
+          <template v-else>
+            <i class="bi bi-camera fs-2 d-block mb-2"></i>
+            <div class="fw-semibold text-body">{{ emptyFindingsTitle }}</div>
+            <div>An actual checkpoint/restore run on a CRaC-enabled JDK remains the best way to verify readiness.</div>
+          </template>
         </div>
         <div v-else class="list-group list-group-flush">
           <div v-for="finding in visibleFindings" :key="finding.id" class="list-group-item">

--- a/bootui-ui/src/main/frontend/src/views/GraalVm.test.js
+++ b/bootui-ui/src/main/frontend/src/views/GraalVm.test.js
@@ -7,11 +7,11 @@ vi.mock('../utils/useConfirm.js', () => ({
   useConfirm: () => ({confirm: () => Promise.resolve(true)})
 }))
 
-function finding(id, name, severity, occurrenceCount = 1, status = 'REVIEW') {
+function finding(id, name, severity, occurrenceCount = 1, status = 'REVIEW', category = 'Reflection') {
   return {
     id,
     name,
-    category: 'Reflection',
+    category,
     severity,
     description: `${name} description.`,
     status,
@@ -348,5 +348,78 @@ describe('GraalVm', () => {
     const writeButton = bothCard.findAll('button').find((button) => button.text().includes('Write into project'))
     expect(writeButton).toBeUndefined()
     expect(bothCard.text()).toContain('Direct write unavailable')
+  })
+
+  function concernTitles(wrapper) {
+    return wrapper.findAll('.list-group-item h3').map((title) => title.text())
+  }
+
+  function severityFilterButton(wrapper, severity) {
+    return wrapper
+      .findAll('[aria-label="Filter concerns by severity"] button')
+      .find((button) => button.text().startsWith(severity))
+  }
+
+  describe('concern filtering', () => {
+    it('does not render the filter bar until a scan finds concerns', async () => {
+      const wrapper = await mountWithReport(graalvmReport([]))
+
+      expect(wrapper.find('input[aria-label="Search concerns"]').exists()).toBe(false)
+      expect(wrapper.find('select[aria-label="Filter by category"]').exists()).toBe(false)
+    })
+
+    it('filters concerns by severity and reflects the visible count', async () => {
+      const wrapper = await mountWithReport(
+        graalvmReport([
+          finding('GRAAL-HIGH-001', 'High concern', 'HIGH'),
+          finding('GRAAL-MED-001', 'Medium concern', 'MEDIUM'),
+          finding('GRAAL-LOW-001', 'Low concern', 'LOW')
+        ])
+      )
+
+      const highButton = severityFilterButton(wrapper, 'HIGH')
+      expect(highButton).toBeDefined()
+      await highButton.trigger('click')
+
+      expect(concernTitles(wrapper)).toEqual(['High concern'])
+      expect(wrapper.text()).toContain('Showing 1 of 3 concerns')
+    })
+
+    it('filters concerns by category', async () => {
+      const wrapper = await mountWithReport(
+        graalvmReport([
+          finding('GRAAL-REFLECT-001', 'Reflection concern', 'HIGH', 1, 'REVIEW', 'Reflection'),
+          finding('GRAAL-RES-001', 'Resource concern', 'LOW', 1, 'REVIEW', 'Resources')
+        ])
+      )
+
+      await wrapper.find('select[aria-label="Filter by category"]').setValue('Resources')
+
+      expect(concernTitles(wrapper)).toEqual(['Resource concern'])
+    })
+
+    it('filters concerns by free-text search and clears back to all concerns', async () => {
+      const wrapper = await mountWithReport(
+        graalvmReport([
+          finding('GRAAL-HIGH-001', 'Dynamic proxy concern', 'HIGH'),
+          finding('GRAAL-LOW-001', 'Resource bundle concern', 'LOW')
+        ])
+      )
+
+      await wrapper.find('input[aria-label="Search concerns"]').setValue('proxy')
+      expect(concernTitles(wrapper)).toEqual(['Dynamic proxy concern'])
+
+      const clear = wrapper.findAll('button').find((button) => button.text() === 'Clear filters')
+      await clear.trigger('click')
+      expect(concernTitles(wrapper)).toEqual(['Dynamic proxy concern', 'Resource bundle concern'])
+    })
+
+    it('shows a no-match empty state when filters exclude every concern', async () => {
+      const wrapper = await mountWithReport(graalvmReport([finding('GRAAL-MED-001', 'Medium concern', 'MEDIUM')]))
+
+      await wrapper.find('input[aria-label="Search concerns"]').setValue('no-such-concern')
+
+      expect(wrapper.text()).toContain('No concerns match the active filters')
+    })
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/GraalVm.vue
+++ b/bootui-ui/src/main/frontend/src/views/GraalVm.vue
@@ -44,7 +44,67 @@ const maxSeverityCount = computed(() => {
   return Math.max(1, ...report.value.severityCounts.map((count) => count.count))
 })
 
-const visibleFindings = computed(() => [...(report.value?.findings || [])])
+const severityOrder = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO']
+const severityFilter = ref([])
+const categoryFilter = ref('')
+const searchText = ref('')
+
+const allFindings = computed(() => report.value?.findings || [])
+
+const availableSeverities = computed(() => {
+  const present = new Set(allFindings.value.map((finding) => finding.severity))
+  const known = severityOrder.filter((severity) => present.has(severity))
+  const extra = [...present].filter((severity) => !severityOrder.includes(severity)).sort()
+  return [...known, ...extra]
+})
+
+const availableCategories = computed(() =>
+  [...new Set(allFindings.value.map((finding) => finding.category).filter(Boolean))].sort()
+)
+
+const visibleFindings = computed(() => {
+  const term = searchText.value.trim().toLowerCase()
+  return allFindings.value.filter((finding) => {
+    if (severityFilter.value.length && !severityFilter.value.includes(finding.severity)) return false
+    if (categoryFilter.value && finding.category !== categoryFilter.value) return false
+    if (term) {
+      const haystack = [
+        finding.name,
+        finding.description,
+        finding.id,
+        finding.category,
+        ...(finding.sampleOccurrences || [])
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+      if (!haystack.includes(term)) return false
+    }
+    return true
+  })
+})
+
+const filtersActive = computed(
+  () => severityFilter.value.length > 0 || categoryFilter.value !== '' || searchText.value.trim() !== ''
+)
+
+function toggleSeverity(severity) {
+  if (severityFilter.value.includes(severity)) {
+    severityFilter.value = severityFilter.value.filter((value) => value !== severity)
+  } else {
+    severityFilter.value = [...severityFilter.value, severity]
+  }
+}
+
+function severityChipCount(severity) {
+  return allFindings.value.filter((finding) => finding.severity === severity).length
+}
+
+function clearFilters() {
+  severityFilter.value = []
+  categoryFilter.value = ''
+  searchText.value = ''
+}
 
 const dependenciesWithMetadata = computed(() => {
   const total = report.value?.dependenciesAnalyzed || 0
@@ -671,17 +731,71 @@ onBeforeUnmount(stopProgressPolling)
             <div class="fw-semibold">Readiness concerns</div>
             <div class="text-muted small">
               <template v-if="hasScanData && report.findingsFound > 0">
-                {{ report.findingsFound }} {{ pluralize(report.findingsFound, 'concern') }}, sorted by importance
+                <template v-if="filtersActive"
+                  >Showing {{ visibleFindings.length }} of {{ report.findingsFound }}
+                  {{ pluralize(report.findingsFound, 'concern') }}</template
+                >
+                <template v-else
+                  >{{ report.findingsFound }} {{ pluralize(report.findingsFound, 'concern') }}, sorted by
+                  importance</template
+                >
               </template>
               <template v-else>{{ report.findingsFound }} concern(s) to review</template>
             </div>
           </div>
           <span v-if="hasScanData && report.findingsFound === 0" class="badge text-bg-success">No concerns</span>
         </div>
+        <div
+          v-if="hasScanData && report.findingsFound > 0"
+          class="card-header d-flex flex-wrap align-items-center gap-2 border-top"
+        >
+          <span class="small fw-semibold text-muted me-1">Filter</span>
+          <div class="btn-group btn-group-sm" role="group" aria-label="Filter concerns by severity">
+            <button
+              v-for="sev in availableSeverities"
+              :key="sev"
+              type="button"
+              class="btn"
+              :class="severityFilter.includes(sev) ? severityClass(sev) : 'btn-outline-secondary'"
+              :aria-pressed="severityFilter.includes(sev)"
+              @click="toggleSeverity(sev)"
+            >
+              {{ sev }} <span class="opacity-75">{{ severityChipCount(sev) }}</span>
+            </button>
+          </div>
+          <select v-model="categoryFilter" class="form-select form-select-sm w-auto" aria-label="Filter by category">
+            <option value="">All categories</option>
+            <option v-for="cat in availableCategories" :key="cat" :value="cat">{{ cat }}</option>
+          </select>
+          <input
+            v-model="searchText"
+            type="search"
+            class="form-control form-control-sm w-auto"
+            placeholder="Search concerns"
+            aria-label="Search concerns"
+          />
+          <button
+            v-if="filtersActive"
+            type="button"
+            class="btn btn-sm btn-link text-decoration-none ms-auto"
+            @click="clearFilters"
+          >
+            Clear filters
+          </button>
+        </div>
         <div v-if="visibleFindings.length === 0" class="card-body text-center text-muted py-5">
-          <i class="bi bi-rocket-takeoff fs-2 d-block mb-2"></i>
-          <div class="fw-semibold text-body">{{ emptyFindingsTitle }}</div>
-          <div>The GraalVM tracing agent and an actual native build remain the best way to verify readiness.</div>
+          <template v-if="filtersActive">
+            <i class="bi bi-funnel fs-2 d-block mb-2"></i>
+            <div class="fw-semibold text-body">No concerns match the active filters</div>
+            <button type="button" class="btn btn-sm btn-outline-secondary mt-2" @click="clearFilters">
+              Clear filters
+            </button>
+          </template>
+          <template v-else>
+            <i class="bi bi-rocket-takeoff fs-2 d-block mb-2"></i>
+            <div class="fw-semibold text-body">{{ emptyFindingsTitle }}</div>
+            <div>The GraalVM tracing agent and an actual native build remain the best way to verify readiness.</div>
+          </template>
         </div>
         <div v-else class="list-group list-group-flush">
           <div v-for="finding in visibleFindings" :key="finding.id" class="list-group-item">

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -427,8 +427,9 @@ release when the project has no wrapper). It can be downloaded, or written direc
 same exploded-build constraint and the same fail-closed guard (BootUI never overwrites a `Dockerfile-native` it did not
 generate). The metadata scaffold and the `Dockerfile-native` are presented in a three-drawer accordion whose default,
 top drawer is an **All files** action that generates and writes both artifacts into the project's source tree in a
-single step (under the same exploded-build constraint and fail-closed guards), reporting each file's outcome. The checks
-and generated
+single step (under the same exploded-build constraint and fail-closed guards), reporting each file's outcome. After a
+scan, the concerns list can be filtered in place by severity, category, or free-text search to focus on a subset of
+findings without rerunning the scan. The checks and generated
 metadata are heuristic review aids that complement, but do not replace, the GraalVM tracing agent and an actual native
 build. See [GRAALVM-READINESS-CHECKS.md](GRAALVM-READINESS-CHECKS.md) for the full catalogue of checks and what each one
 inspects.
@@ -451,9 +452,10 @@ application's own classes (bounded to the detected base package(s)) and runs a c
 constructs that complicate checkpoint/restore — open resources and file handles held outside Spring/CRaC lifecycle,
 network listeners, live connection pools and cache managers, unmanaged threads, captured timestamps, captured
 environment/system configuration, static random seeds, eagerly captured secrets, and missing `org.crac.Resource`
-registrations. The checks are heuristic review aids that complement, but do not replace, an actual checkpoint/restore run
-on a CRaC-enabled JDK. See [CRAC-READINESS-CHECKS.md](CRAC-READINESS-CHECKS.md) for the full catalogue of checks and what
-each one inspects.
+registrations. After a scan, the concerns list can be filtered in place by severity, category, or free-text search to
+focus on a subset of findings without rerunning the scan. The checks are heuristic review aids that complement, but do
+not replace, an actual checkpoint/restore run on a CRaC-enabled JDK. See [CRAC-READINESS-CHECKS.md](CRAC-READINESS-CHECKS.md)
+for the full catalogue of checks and what each one inspects.
 
 The panel also generates ready-to-use container assets for the host application: a multi-stage `Dockerfile-crac` that
 builds with a plain JDK and runs on a CRaC-enabled BellSoft Liberica JDK, plus the `checkpoint-and-run.sh` entrypoint it


### PR DESCRIPTION
## What does this PR do?

Adds an in-place filter toolbar to the readiness-concerns list in the GraalVM and CRaC panels, and uniforms the two so they show and filter findings the same way.

## Why is this change needed?

After a scan, both panels just dumped every concern in one long list with no way to focus. Once a project has more than a handful of findings, that is hard to triage. This lets you narrow by severity, category, or text without rerunning the scan.

Closes #

The shared toolbar appears only once a scan finds at least one concern and offers:

- Severity chips (with per-severity counts) that toggle on/off
- A category dropdown, populated from the findings present
- A free-text search across name, description, id, category, and sample details
- A "Clear filters" reset, plus a "no concerns match" empty state

The list, severity/category options, and the header count ("Showing X of Y concerns") all update reactively. CRaC was structurally identical to GraalVM, so it received the same logic and markup verbatim.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable (Vitest filter tests for both panels; Playwright filter check in both specs). Full frontend suite: 281 passing.

## Screenshots (UI changes)

![CRaC readiness concerns with the new filter toolbar](https://github.com/user-attachments/assets/dbc9419f-8df4-417b-89e3-953cbf5989af)

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (`docs/FEATURES.md` GraalVM + CRaC sections)
- [x] Public API kept backward compatible, or a migration note added to the PR description (UI-only; no API/DTO changes)
- [x] No secrets, tokens, or local paths committed