### PR TITLE
Show Dependabot alert details in the GitHub panel drawer

### DIFF
--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -747,6 +747,13 @@ public class BootUiProperties {
         private int maxIssues = 25;
 
         /**
+         * Maximum Dependabot alert details listed in one dashboard refresh. The alert count is still
+         * exact; only the inlined detail list is capped. Code scanning and secret scanning remain
+         * count-only and never inline alert details.
+         */
+        private int maxSecurityAlerts = 50;
+
+        /**
          * Maximum workflow runs returned in one dashboard refresh.
          */
         private int maxWorkflowRuns = 20;
@@ -796,6 +803,14 @@ public class BootUiProperties {
 
         public void setMaxIssues(int maxIssues) {
             this.maxIssues = maxIssues;
+        }
+
+        public int getMaxSecurityAlerts() {
+            return maxSecurityAlerts;
+        }
+
+        public void setMaxSecurityAlerts(int maxSecurityAlerts) {
+            this.maxSecurityAlerts = maxSecurityAlerts;
         }
 
         public int getMaxWorkflowRuns() {

--- a/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubApiClient.java
+++ b/bootui-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/GitHubApiClient.java
@@ -192,7 +192,8 @@ final class GitHubApiClient implements GitHubClient {
                     "Dependabot alerts",
                     "dependabot/alerts?state=open&per_page=100",
                     token,
-                    budget);
+                    budget,
+                    true);
             addSecuritySignal(
                     securitySignals,
                     repository,
@@ -200,7 +201,8 @@ final class GitHubApiClient implements GitHubClient {
                     "Code scanning alerts",
                     "code-scanning/alerts?state=open&per_page=100",
                     token,
-                    budget);
+                    budget,
+                    false);
             addSecuritySignal(
                     securitySignals,
                     repository,
@@ -208,7 +210,8 @@ final class GitHubApiClient implements GitHubClient {
                     "Secret scanning alerts",
                     "secret-scanning/alerts?state=open&per_page=100",
                     token,
-                    budget);
+                    budget,
+                    false);
             addRepositoryQuota(
                     quotas,
                     repository,
@@ -528,20 +531,52 @@ final class GitHubApiClient implements GitHubClient {
             String label,
             String relativePath,
             GitHubTokenProvider.Token token,
-            RequestBudget budget)
+            RequestBudget budget,
+            boolean includeAlerts)
             throws IOException, InterruptedException {
         ApiResponse response = get(repository, repoPath + "/" + relativePath, token, budget, label);
         if (response.success()) {
+            boolean array = response.json().isArray();
             signals.add(new GitHubSecuritySignalDto(
                     label,
                     "AVAILABLE",
-                    response.json().isArray()
-                            ? paginatedAlertCount(repository, relativePath, label, response, token, budget)
-                            : 0,
-                    null));
+                    array ? paginatedAlertCount(repository, relativePath, label, response, token, budget) : 0,
+                    null,
+                    includeAlerts && array ? dependabotAlerts(response.json()) : List.of()));
         } else {
             signals.add(new GitHubSecuritySignalDto(label, "UNAVAILABLE", null, response.safeMessage()));
         }
+    }
+
+    private List<GitHubDependabotAlertDto> dependabotAlerts(JsonNode root) {
+        int max = positive(properties.getMaxSecurityAlerts(), 50);
+        List<GitHubDependabotAlertDto> alerts = new ArrayList<>();
+        for (JsonNode item : root) {
+            if (alerts.size() >= max) {
+                break;
+            }
+            JsonNode dependency = item.path("dependency");
+            JsonNode pkg = dependency.path("package");
+            JsonNode advisory = item.path("security_advisory");
+            JsonNode vulnerability = item.path("security_vulnerability");
+            String severity = textOrDefault(vulnerability, "severity", text(advisory, "severity"));
+            alerts.add(new GitHubDependabotAlertDto(
+                    item.path("number").asInt(),
+                    text(item, "state"),
+                    text(pkg, "name"),
+                    text(pkg, "ecosystem"),
+                    text(dependency, "manifest_path"),
+                    severity,
+                    text(advisory, "ghsa_id"),
+                    text(advisory, "cve_id"),
+                    text(advisory, "summary"),
+                    text(vulnerability, "vulnerable_version_range"),
+                    text(vulnerability.path("first_patched_version"), "identifier"),
+                    text(item, "html_url"),
+                    instantMillis(text(item, "created_at")),
+                    instantMillis(text(item, "updated_at"))));
+        }
+        return alerts;
     }
 
     private int paginatedAlertCount(

--- a/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubApiClientTests.java
+++ b/bootui-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/GitHubApiClientTests.java
@@ -181,6 +181,54 @@ class GitHubApiClientTests {
         assertThat(report.warnings()).singleElement().asString().contains("safety threshold");
     }
 
+    @Test
+    void dependabotSignalIncludesSafeAlertDetails() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        json("/rate_limit", """
+                {"resources":{"core":{"limit":5000,"used":50,"remaining":4950,"reset":1893456000}}}
+                """);
+        json("/repos/jdubois/boot-ui", """
+                {"full_name":"jdubois/boot-ui","html_url":"https://github.com/jdubois/boot-ui","default_branch":"main","owner":{"type":"User"}}
+                """);
+        json("/repos/jdubois/boot-ui/dependabot/alerts", """
+                [{"number":7,"state":"open","dependency":{"package":{"ecosystem":"maven","name":"org.example:lib"},"manifest_path":"pom.xml"},"security_advisory":{"ghsa_id":"GHSA-aaaa-bbbb-cccc","cve_id":"CVE-2026-1234","summary":"Remote code execution","severity":"high"},"security_vulnerability":{"severity":"critical","vulnerable_version_range":"< 1.2.3","first_patched_version":{"identifier":"1.2.3"}},"html_url":"https://github.com/jdubois/boot-ui/security/dependabot/7","created_at":"2026-05-01T08:00:00Z","updated_at":"2026-05-02T08:00:00Z"}]
+                """);
+        json("/repos/jdubois/boot-ui/code-scanning/alerts", "[]");
+        json("/repos/jdubois/boot-ui/secret-scanning/alerts", "[]");
+        json("/repos/jdubois/boot-ui/pulls", "[]");
+        json("/repos/jdubois/boot-ui/issues", "[]");
+        json("/repos/jdubois/boot-ui/actions/runs", "{\"workflow_runs\":[]}");
+        json("/repos/jdubois/boot-ui/actions/workflows", "{\"workflows\":[]}");
+        json("/repos/jdubois/boot-ui/actions/cache/usage", "{\"active_caches_size_in_bytes\":0}");
+        json("/repos/jdubois/boot-ui/actions/artifacts", "{\"total_count\":0}");
+        json("/users/jdubois/settings/billing/actions", "{\"included_minutes\":0,\"total_minutes_used\":0}");
+        server.start();
+
+        GitHubApiClient client = client("local-token");
+
+        GitHubDashboardReport report = client.refresh(repository());
+
+        assertThat(report.securitySignals())
+                .filteredOn(signal -> signal.label().equals("Dependabot alerts"))
+                .singleElement()
+                .satisfies(signal -> {
+                    assertThat(signal.count()).isEqualTo(1);
+                    assertThat(signal.alerts()).singleElement().satisfies(alert -> {
+                        assertThat(alert.packageName()).isEqualTo("org.example:lib");
+                        assertThat(alert.ecosystem()).isEqualTo("maven");
+                        assertThat(alert.severity()).isEqualTo("critical");
+                        assertThat(alert.ghsaId()).isEqualTo("GHSA-aaaa-bbbb-cccc");
+                        assertThat(alert.cveId()).isEqualTo("CVE-2026-1234");
+                        assertThat(alert.firstPatchedVersion()).isEqualTo("1.2.3");
+                        assertThat(alert.htmlUrl())
+                                .isEqualTo("https://github.com/jdubois/boot-ui/security/dependabot/7");
+                    });
+                });
+        assertThat(report.securitySignals())
+                .filteredOn(signal -> !signal.label().equals("Dependabot alerts"))
+                .allSatisfy(signal -> assertThat(signal.alerts()).isEmpty());
+    }
+
     private GitHubApiClient client(String token) {
         BootUiProperties.GitHub properties = new BootUiProperties.GitHub();
         properties.setRequestTimeout(Duration.ofSeconds(2));

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubDependabotAlertDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubDependabotAlertDto.java
@@ -1,0 +1,21 @@
+package io.github.jdubois.bootui.core.dto;
+
+/**
+ * Bounded, non-secret summary of a single open Dependabot alert. Only public security-advisory
+ * metadata is exposed: no secret values or vulnerable code snippets.
+ */
+public record GitHubDependabotAlertDto(
+        int number,
+        String state,
+        String packageName,
+        String ecosystem,
+        String manifestPath,
+        String severity,
+        String ghsaId,
+        String cveId,
+        String summary,
+        String vulnerableVersionRange,
+        String firstPatchedVersion,
+        String htmlUrl,
+        Long createdAt,
+        Long updatedAt) {}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubSecuritySignalDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubSecuritySignalDto.java
@@ -1,6 +1,15 @@
 package io.github.jdubois.bootui.core.dto;
 
+import java.util.List;
+
 /**
- * Permission-aware security signal summary from GitHub.
+ * Permission-aware security signal summary from GitHub. Code scanning and secret scanning expose
+ * counts only; Dependabot may additionally carry a bounded list of non-secret alert details.
  */
-public record GitHubSecuritySignalDto(String label, String status, Integer count, String unavailableReason) {}
+public record GitHubSecuritySignalDto(
+        String label, String status, Integer count, String unavailableReason, List<GitHubDependabotAlertDto> alerts) {
+
+    public GitHubSecuritySignalDto(String label, String status, Integer count, String unavailableReason) {
+        this(label, status, count, unavailableReason, List.of());
+    }
+}

--- a/bootui-sample-app/e2e/tests/github.spec.js
+++ b/bootui-sample-app/e2e/tests/github.spec.js
@@ -95,9 +95,48 @@ function connectedDashboard() {
       }
     ],
     securitySignals: [
-      {label: 'Dependabot alerts', status: 'AVAILABLE', count: 0, unavailableReason: null},
-      {label: 'Code scanning alerts', status: 'AVAILABLE', count: 1, unavailableReason: null},
-      {label: 'Secret scanning alerts', status: 'AVAILABLE', count: 0, unavailableReason: null}
+      {
+        label: 'Dependabot alerts',
+        status: 'AVAILABLE',
+        count: 2,
+        unavailableReason: null,
+        alerts: [
+          {
+            number: 7,
+            state: 'open',
+            packageName: 'org.example:lib',
+            ecosystem: 'maven',
+            manifestPath: 'pom.xml',
+            severity: 'critical',
+            ghsaId: 'GHSA-aaaa-bbbb-cccc',
+            cveId: 'CVE-2026-1234',
+            summary: 'Remote code execution in org.example:lib',
+            vulnerableVersionRange: '< 1.2.3',
+            firstPatchedVersion: '1.2.3',
+            htmlUrl: 'https://github.com/jdubois/boot-ui/security/dependabot/7',
+            createdAt: now - 3 * 24 * 60 * 60 * 1000,
+            updatedAt: now - 12 * 60 * 60 * 1000
+          },
+          {
+            number: 6,
+            state: 'open',
+            packageName: 'com.sample:utils',
+            ecosystem: 'maven',
+            manifestPath: 'bootui-core/pom.xml',
+            severity: 'medium',
+            ghsaId: 'GHSA-dddd-eeee-ffff',
+            cveId: null,
+            summary: 'Denial of service in com.sample:utils',
+            vulnerableVersionRange: '>= 2.0.0, < 2.4.1',
+            firstPatchedVersion: '2.4.1',
+            htmlUrl: 'https://github.com/jdubois/boot-ui/security/dependabot/6',
+            createdAt: now - 6 * 24 * 60 * 60 * 1000,
+            updatedAt: now - 2 * 24 * 60 * 60 * 1000
+          }
+        ]
+      },
+      {label: 'Code scanning alerts', status: 'AVAILABLE', count: 1, unavailableReason: null, alerts: []},
+      {label: 'Secret scanning alerts', status: 'AVAILABLE', count: 0, unavailableReason: null, alerts: []}
     ],
     copilotUsage: null,
     warnings: []
@@ -160,6 +199,18 @@ test.describe('GitHub view', () => {
     await expect(drawer).toContainText('Open issues')
     await expect(drawer).toContainText('#188 Flaky Playwright run on slow CI agents')
     await expect(drawer).toContainText('#184 Document the GitHub issues drawer')
+
+    // Dependabot card opens a drawer that lists the non-secret alert details.
+    await page.getByRole('button', {name: /Dependabot alerts/}).click()
+    await expect(drawer).toContainText('org.example:lib')
+    await expect(drawer).toContainText('Remote code execution in org.example:lib')
+    await expect(drawer).toContainText('GHSA-aaaa-bbbb-cccc')
+    await expect(drawer).toContainText('Fixed in: 1.2.3')
+    await expect(drawer).toContainText('com.sample:utils')
+
+    // Secret scanning stays count-only with no inline alert details.
+    await page.getByRole('button', {name: /Secret scanning alerts/}).click()
+    await expect(drawer).toContainText('does not expose secret values')
 
     // The trusted panel reached the live data through the POST refresh endpoint.
     expect(refreshMethod).toBe('POST')

--- a/bootui-ui/src/main/frontend/src/views/GitHub.test.js
+++ b/bootui-ui/src/main/frontend/src/views/GitHub.test.js
@@ -236,7 +236,28 @@ function connectedReport() {
       }
     ],
     securitySignals: [
-      {label: 'Dependabot alerts', status: 'AVAILABLE', count: 0, unavailableReason: null},
+      {
+        label: 'Dependabot alerts',
+        status: 'AVAILABLE',
+        count: 1,
+        unavailableReason: null,
+        alerts: [
+          {
+            number: 7,
+            state: 'open',
+            packageName: 'org.example:lib',
+            ecosystem: 'maven',
+            manifestPath: 'pom.xml',
+            severity: 'critical',
+            ghsaId: 'GHSA-aaaa-bbbb-cccc',
+            cveId: 'CVE-2026-1234',
+            summary: 'Remote code execution in org.example:lib',
+            vulnerableVersionRange: '< 1.2.3',
+            firstPatchedVersion: '1.2.3',
+            htmlUrl: 'https://github.com/jdubois/boot-ui/security/dependabot/7'
+          }
+        ]
+      },
       {label: 'Code scanning alerts', status: 'AVAILABLE', count: 1, unavailableReason: null},
       {label: 'Secret scanning alerts', status: 'UNAVAILABLE', count: null, unavailableReason: 'Requires admin access'}
     ],
@@ -397,6 +418,7 @@ describe('GitHub', () => {
 
     expect(wrapper.find('.details-drawer').text()).toContain('Code scanning alerts')
     expect(wrapper.find('.details-drawer').text()).toContain('At least one alert returned')
+    expect(wrapper.find('.details-drawer').text()).toContain('does not expose secret values')
     expect(wrapper.find('.details-drawer a.github-link-chip').attributes('href')).toBe(
       'https://github.com/jdubois/boot-ui/security/code-scanning'
     )
@@ -406,6 +428,11 @@ describe('GitHub', () => {
     expect(wrapper.find('.details-drawer a.github-link-chip').attributes('href')).toBe(
       'https://github.com/jdubois/boot-ui/security/dependabot'
     )
+    const dependabotDrawer = wrapper.find('.details-drawer').text()
+    expect(dependabotDrawer).toContain('org.example:lib')
+    expect(dependabotDrawer).toContain('Remote code execution in org.example:lib')
+    expect(dependabotDrawer).toContain('GHSA-aaaa-bbbb-cccc')
+    expect(dependabotDrawer).toContain('Fixed in: 1.2.3')
 
     await metricButton(wrapper, 'Secret scanning alerts').trigger('click')
     await flushPromises()

--- a/bootui-ui/src/main/frontend/src/views/GitHub.vue
+++ b/bootui-ui/src/main/frontend/src/views/GitHub.vue
@@ -229,6 +229,19 @@ function securitySignalDetail(signal) {
   return signal.count > 0 ? 'At least one alert returned' : 'No alerts returned'
 }
 
+const securityAlerts = computed(() => activeSecuritySignal.value?.alerts ?? [])
+
+function dependabotSeverityClass(severity) {
+  return (
+    {
+      critical: 'text-bg-danger',
+      high: 'text-bg-danger',
+      medium: 'text-bg-warning',
+      low: 'text-bg-info'
+    }[(severity || '').toLowerCase()] || 'text-bg-secondary'
+  )
+}
+
 const displayMetrics = computed(() =>
   metrics.value.map((metric) => {
     if (drawerForMetric(metric) !== 'quotas') return metric
@@ -836,11 +849,39 @@ function securitySignalUrl(signal) {
               <div v-if="activeSecuritySignal.unavailableReason" class="alert alert-light border mb-0 flex-grow-1">
                 {{ activeSecuritySignal.unavailableReason }}
               </div>
-              <div v-else class="alert alert-light border mb-0 flex-grow-1">
-                BootUI only shows the alert count from GitHub. It does not expose alert payloads, secret values, or
-                vulnerable code snippets.
+              <div v-else-if="!securityAlerts.length" class="alert alert-light border mb-0 flex-grow-1">
+                BootUI lists Dependabot advisory metadata only. It does not expose secret values or vulnerable code
+                snippets from code or secret scanning.
               </div>
             </div>
+            <ul v-if="securityAlerts.length" class="list-group list-group-flush mt-3">
+              <li v-for="alert in securityAlerts" :key="alert.number" class="list-group-item px-0">
+                <div class="d-flex flex-wrap align-items-center gap-2">
+                  <span :class="dependabotSeverityClass(alert.severity)" class="badge text-uppercase">
+                    {{ alert.severity || 'unknown' }}
+                  </span>
+                  <code class="fw-semibold">{{ alert.packageName || 'unknown package' }}</code>
+                  <span v-if="alert.ecosystem" class="badge text-bg-light border">{{ alert.ecosystem }}</span>
+                  <a
+                    v-if="alert.htmlUrl"
+                    :href="alert.htmlUrl"
+                    class="github-link-chip ms-auto"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {{ alert.ghsaId || alert.cveId || `#${alert.number}` }}
+                    <i class="bi bi-box-arrow-up-right"></i>
+                  </a>
+                </div>
+                <div v-if="alert.summary" class="small mt-1">{{ alert.summary }}</div>
+                <div class="text-muted small mt-1 d-flex flex-wrap gap-3">
+                  <span v-if="alert.manifestPath"><i class="bi bi-folder2-open me-1"></i>{{ alert.manifestPath }}</span>
+                  <span v-if="alert.vulnerableVersionRange">Affected: {{ alert.vulnerableVersionRange }}</span>
+                  <span v-if="alert.firstPatchedVersion">Fixed in: {{ alert.firstPatchedVersion }}</span>
+                  <span v-if="alert.cveId && alert.ghsaId">{{ alert.cveId }}</span>
+                </div>
+              </li>
+            </ul>
           </div>
         </template>
       </div>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -126,7 +126,10 @@ time (pull requests returned by the issues endpoint are excluded). GitHub Action
 run, show the workflow, branch, event, status, and
 duration, and mirror the recent-run list from the GitHub Actions page. The workflow failure count only considers the
 latest execution for each workflow and branch, so older failures drop out once a later run fixes that workflow on that
-branch; security signal drawers link to the matching GitHub alert pages.
+branch; security signal drawers link to the matching GitHub alert pages. The Dependabot drawer additionally lists the
+bounded set of open alerts with their package, ecosystem, severity, advisory ID, summary, affected range, and fixed
+version (capped by `bootui.github.max-security-alerts`); code scanning and secret scanning stay count-only and never
+inline secret values or vulnerable code snippets.
 The quota card shows the lowest remaining quota percentage with a red-to-green threshold palette. The quota drawer is
 hidden by default, renders every resource returned by GitHub's `/rate_limit` response dynamically,
 highlights resources with 10% or less remaining or at quota, then adds best-effort cards for repository or owner quotas

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -118,6 +118,7 @@ Panel settings are consistent across the UI and API:
 | `bootui.github.request-timeout`        | `5s`             | Timeout for each GitHub API request and local `gh auth token` lookup.                |
 | `bootui.github.max-pull-requests`      | `10`             | Maximum open pull requests returned in one refresh.                                  |
 | `bootui.github.max-issues`             | `25`             | Maximum open issues fetched for the issue buckets and open issue list in one refresh. |
+| `bootui.github.max-security-alerts`    | `50`             | Maximum Dependabot alert details listed per refresh (count stays exact; metadata only). |
 | `bootui.github.max-workflow-runs`      | `20`             | Maximum recent workflow runs returned in one refresh.                                |
 | `bootui.github.quota-safety-threshold` | `10`             | Skip optional API calls when remaining core quota is at or below this value.         |
 | `bootui.github.max-api-calls`          | `17`             | Maximum GitHub API requests issued by one refresh.                                   |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1252,6 +1252,7 @@ Initial properties:
 | `bootui.github.request-timeout`              | `5s`                                    | Timeout for each GitHub API request and local `gh auth token` lookup.                             |
 | `bootui.github.max-pull-requests`            | `10`                                    | Maximum open pull requests returned in one GitHub refresh.                                        |
 | `bootui.github.max-issues`                   | `25`                                    | Maximum open issues fetched for the issue buckets and open issue list.                            |
+| `bootui.github.max-security-alerts`          | `50`                                    | Maximum Dependabot alert details listed per refresh; count stays exact, metadata only.            |
 | `bootui.github.max-workflow-runs`            | `20`                                    | Maximum recent workflow runs returned in one GitHub refresh.                                      |
 | `bootui.github.quota-safety-threshold`       | `10`                                    | Skip optional GitHub calls when remaining core quota is at or below this value.                   |
 | `bootui.github.max-api-calls`                | `17`                                    | Maximum GitHub API calls issued by one refresh.                                                   |


### PR DESCRIPTION
## What does this PR do?

Replaces the count-only Dependabot drawer in the GitHub panel with a bounded list of individual open alerts.

## Why is this change needed?

Clicking the Dependabot alerts card only showed a count plus a generic "BootUI only shows the alert count" message, so there was no way to see which packages were affected. Dependabot alert metadata is public security-advisory data (package, severity, GHSA/CVE, summary, fixed version), so listing it is safe and far more useful. Code scanning and secret scanning stay count-only since their payloads include vulnerable code snippets and secret values.

The drawer now lists each open alert with package, ecosystem, severity, advisory ID/summary, affected range, fixed version, and a link. A new `bootui.github.max-security-alerts` (default 50) caps the inlined detail list; the count remains exact.

## How was it tested?

- [x] `./mvnw clean install` passes locally (1261 backend tests; frontend Vitest)
- [x] Started `bootui-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable (GitHubApiClientTests, GitHub.test.js, github.spec.js)

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (FEATURES, PROPERTIES, SPECIFICATION)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed