### PR TITLE
Expand Quarkus and Quarkus Security advisors toward Spring parity

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppChecks.java
@@ -15,7 +15,7 @@ import java.util.List;
 final class QuarkusAppChecks {
 
     private static final String VIOLATION = "VIOLATION";
-    private static final int RULE_COUNT = 10;
+    private static final int RULE_COUNT = 16;
     private static final String GUIDE = "https://quarkus.io/guides/cdi-reference";
     private static final String CONFIG_GUIDE = "https://quarkus.io/guides/config-reference";
     private static final String REACTIVE_GUIDE = "https://quarkus.io/guides/getting-started-reactive";
@@ -23,6 +23,10 @@ final class QuarkusAppChecks {
     private static final String HIBERNATE_GUIDE = "https://quarkus.io/guides/hibernate-orm";
     private static final String DATASOURCE_GUIDE = "https://quarkus.io/guides/datasource";
     private static final String SCHEDULER_GUIDE = "https://quarkus.io/guides/scheduler-reference";
+    private static final String LOGGING_GUIDE = "https://quarkus.io/guides/logging";
+    private static final String HTTP_GUIDE = "https://quarkus.io/guides/http-reference";
+    private static final String REST_CLIENT_GUIDE = "https://quarkus.io/guides/rest-client";
+    private static final String VIRTUAL_THREADS_GUIDE = "https://quarkus.io/guides/virtual-threads";
 
     private QuarkusAppChecks() {}
 
@@ -72,16 +76,18 @@ final class QuarkusAppChecks {
                     "Inject configuration with @ConfigProperty or a @ConfigMapping interface.",
                     CONFIG_GUIDE));
         }
-        if (s.reactiveEndpointCount() > 0 && s.blockingAnnotationCount() == 0 && s.jdbcDatasourcePresent()) {
+        if (s.reactiveEndpointsWithoutBlockingCount() > 0 && s.jdbcDatasourcePresent()) {
             v.add(rule(
                     "QA-RX-001",
                     "Reactive endpoints with a blocking JDBC datasource",
                     "Reactive",
                     "INFO",
-                    "Endpoints return Uni/Multi (run on the I/O event loop) and a blocking JDBC datasource is"
-                            + " configured, yet no @Blocking guard was found; a JDBC call on the event loop stalls it.",
-                    s.reactiveEndpointCount(),
-                    List.of(s.reactiveEndpointCount() + " reactive endpoint(s), 0 @Blocking, JDBC datasource present"),
+                    "Endpoint(s) return Uni/Multi (run on the I/O event loop), lack a @Blocking guard on the"
+                            + " method or resource class, and a blocking JDBC datasource is configured; a JDBC call"
+                            + " on the event loop stalls it.",
+                    s.reactiveEndpointsWithoutBlockingCount(),
+                    List.of(s.reactiveEndpointsWithoutBlockingCount()
+                            + " reactive endpoint(s) without @Blocking, JDBC datasource present"),
                     "Annotate blocking work with @Blocking, or use a reactive datasource client.",
                     REACTIVE_GUIDE));
         }
@@ -137,6 +143,19 @@ final class QuarkusAppChecks {
                     "Disable SQL logging in %prod; enable it only in %dev when debugging.",
                     HIBERNATE_GUIDE));
         }
+        if (s.prodLogLevelVerbose()) {
+            v.add(rule(
+                    "QA-CFG-003",
+                    "Verbose log level in the prod profile",
+                    "Config",
+                    "MEDIUM",
+                    "%prod.quarkus.log.level resolves to DEBUG/TRACE/ALL, far more verbose than production"
+                            + " needs; it hurts performance and risks leaking sensitive data into logs.",
+                    1,
+                    List.of("%prod quarkus.log.level=DEBUG/TRACE/ALL"),
+                    "Set %prod.quarkus.log.level to INFO or WARN; use DEBUG/TRACE only in %dev.",
+                    LOGGING_GUIDE));
+        }
         if (s.scheduledCount() > 0 && !s.clusteredScheduler()) {
             v.add(rule(
                     "QA-SCH-001",
@@ -163,6 +182,80 @@ final class QuarkusAppChecks {
                     List.of("no %prod./%dev. keys, no active profile"),
                     "Add %prod. overrides (or externalise config) so production differs from dev defaults.",
                     PROFILE_GUIDE));
+        }
+        if (!s.compressionEnabled()) {
+            v.add(rule(
+                    "QA-WEB-001",
+                    "HTTP response compression disabled",
+                    "Web",
+                    "INFO",
+                    "quarkus.http.enable-compression is not set (Quarkus's own default), so responses are not"
+                            + " gzip/brotli-compressed, increasing bandwidth and latency for text-heavy payloads.",
+                    1,
+                    List.of("quarkus.http.enable-compression not set"),
+                    "Set quarkus.http.enable-compression=true (tune quarkus.http.compress-media-types if needed).",
+                    HTTP_GUIDE));
+        }
+        if (s.shutdownTimeoutZeroed()) {
+            v.add(rule(
+                    "QA-WEB-002",
+                    "Graceful shutdown grace period zeroed",
+                    "Web",
+                    "MEDIUM",
+                    "quarkus.shutdown.timeout or quarkus.http.shutdown.timeout is explicitly set to 0, disabling"
+                            + " the graceful-shutdown grace period; in-flight requests are dropped instead of"
+                            + " being allowed to complete on SIGTERM.",
+                    1,
+                    List.of("shutdown timeout=0"),
+                    "Remove the override (or set a positive duration) so in-flight requests can drain before"
+                            + " shutdown.",
+                    HTTP_GUIDE));
+        }
+        if (s.restClientsRegistered() && !s.restClientTimeoutConfigured()) {
+            v.add(rule(
+                    "QA-WEB-003",
+                    "REST client without a connect/read timeout",
+                    "Web",
+                    "MEDIUM",
+                    "A @RegisterRestClient interface is declared, but no connect-timeout/read-timeout is"
+                            + " configured anywhere. Quarkus REST clients have no default timeout, so a"
+                            + " slow/hanging remote service can block a caller indefinitely.",
+                    1,
+                    List.of("@RegisterRestClient present, no connect-timeout/read-timeout configured"),
+                    "Set quarkus.rest-client.\"<client-key>\".connect-timeout / read-timeout, or the global"
+                            + " quarkus.rest-client.connect-timeout / read-timeout.",
+                    REST_CLIENT_GUIDE));
+        }
+        if (s.endpointCount() > 0 && s.virtualThreadEndpointCount() == 0 && s.jdkMajorVersion() >= 21) {
+            v.add(rule(
+                    "QA-PERF-001",
+                    "No virtual-thread adoption",
+                    "Performance",
+                    "INFO",
+                    "The app declares " + s.endpointCount() + " JAX-RS endpoint(s) but none use"
+                            + " @RunOnVirtualThread. If any perform blocking I/O (JDBC, file access, blocking"
+                            + " REST calls), running them on virtual threads can improve throughput without"
+                            + " sizing a worker thread pool.",
+                    s.endpointCount(),
+                    List.of(s.endpointCount() + " JAX-RS endpoint(s), 0 @RunOnVirtualThread"),
+                    "Annotate blocking I/O-bound endpoint methods (or the resource class) with @RunOnVirtualThread.",
+                    VIRTUAL_THREADS_GUIDE));
+        }
+        if (s.virtualThreadSynchronizedCount() > 0 && s.jdkMajorVersion() >= 21 && s.jdkMajorVersion() < 24) {
+            v.add(rule(
+                    "QA-PERF-002",
+                    "Virtual-thread pinning via synchronized (JEP 491)",
+                    "Performance",
+                    "HIGH",
+                    s.virtualThreadSynchronizedCount() + " @RunOnVirtualThread method(s) are also declared"
+                            + " synchronized. On JDK " + s.jdkMajorVersion() + " (21-23), entering a synchronized"
+                            + " method pins the carrier thread instead of yielding it, defeating the scalability"
+                            + " benefit of virtual threads; JEP 491 removes this pinning starting in JDK 24.",
+                    s.virtualThreadSynchronizedCount(),
+                    List.of(s.virtualThreadSynchronizedCount() + " @RunOnVirtualThread synchronized method(s), JDK "
+                            + s.jdkMajorVersion()),
+                    "Replace synchronized with a java.util.concurrent.locks.ReentrantLock, or upgrade to JDK 24+.",
+                    VIRTUAL_THREADS_GUIDE));
         }
         return v;
     }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityChecks.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 final class QuarkusSecurityChecks {
 
     private static final String VIOLATION = "VIOLATION";
-    private static final int RULE_COUNT = 25;
+    private static final int RULE_COUNT = 43;
     private static final String GUIDE = "https://quarkus.io/guides/security-overview";
     private static final Pattern MAX_AGE = Pattern.compile("max-age\\s*=\\s*(\\d+)");
     private static final long HSTS_MIN_MAX_AGE = 31536000L;
@@ -59,11 +59,11 @@ final class QuarkusSecurityChecks {
                     "Form authentication without CSRF protection",
                     "Authentication",
                     "HIGH",
-                    "Cookie-based form authentication is enabled but the CSRF reactive filter is absent, leaving"
+                    "Cookie-based form authentication is enabled but the CSRF filter is absent, leaving"
                             + " state-changing requests open to cross-site request forgery.",
                     1,
-                    List.of("quarkus.http.auth.form.enabled=true, quarkus-csrf-reactive absent"),
-                    "Add the quarkus-csrf-reactive extension and embed the CSRF token in forms."));
+                    List.of("quarkus.http.auth.form.enabled=true, quarkus-rest-csrf absent"),
+                    "Add the io.quarkus:quarkus-rest-csrf extension and embed the CSRF token in forms."));
         }
         if (s.jwtConfigured() && !s.jwtIssuerConfigured()) {
             v.add(rule(
@@ -89,6 +89,80 @@ final class QuarkusSecurityChecks {
                     1,
                     List.of("quarkus.http.auth.proactive=false"),
                     "Confirm this is intentional; enable quarkus.security.jaxrs.deny-unannotated-endpoints."));
+        }
+        if (s.jwtAllowUnsignedTokens()) {
+            v.add(rule(
+                    "QS-AUTH-006",
+                    "JWT unsigned tokens allowed",
+                    "Authentication",
+                    "CRITICAL",
+                    "quarkus.smallrye-jwt.allow-unsigned-tokens=true accepts JWTs with alg=none, meaning anyone"
+                            + " can forge a token with an arbitrary payload and no signature at all.",
+                    1,
+                    List.of("quarkus.smallrye-jwt.allow-unsigned-tokens=true"),
+                    "Remove the override; only allow unsigned tokens in a throwaway local dev profile, never"
+                            + " in any deployed environment."));
+        }
+        if (s.embeddedUsersEnabled()) {
+            v.add(rule(
+                    "QS-AUTH-007",
+                    "Embedded properties-file users enabled",
+                    "Authentication",
+                    "MEDIUM",
+                    "quarkus.security.users.embedded.enabled=true authenticates against a static in-memory/"
+                            + "properties-file user list — a convenience meant for demos/tests, not a real"
+                            + " identity store.",
+                    1,
+                    List.of("quarkus.security.users.embedded.enabled=true"),
+                    "Use quarkus-elytron-security-jdbc/oidc for real deployments; keep embedded users to %dev/%test."));
+        }
+        if (s.jwtConfigured() && !s.jwtAudiencesConfigured()) {
+            v.add(rule(
+                    "QS-AUTH-008",
+                    "JWT verification without audience validation",
+                    "Authentication",
+                    "MEDIUM",
+                    "SmallRye JWT verification is configured without mp.jwt.verify.audiences, so a token minted"
+                            + " for a different client/service by the same trusted issuer is still accepted.",
+                    1,
+                    List.of("mp.jwt.verify.publickey* set, mp.jwt.verify.audiences absent"),
+                    "Set mp.jwt.verify.audiences to this service's expected audience(s)."));
+        }
+        if (s.jwtConfigured() && s.jwtInlinePublicKey()) {
+            v.add(rule(
+                    "QS-AUTH-009",
+                    "JWT public key configured inline",
+                    "Authentication",
+                    "LOW",
+                    "mp.jwt.verify.publickey holds a static inline key. Unlike a JWKS location, an inline key"
+                            + " cannot be rotated without a redeploy.",
+                    1,
+                    List.of("mp.jwt.verify.publickey set"),
+                    "Prefer mp.jwt.verify.publickey.location pointing at a JWKS endpoint that supports rotation."));
+        }
+        if (s.jdbcClearPasswordMapperEnabled()) {
+            v.add(rule(
+                    "QS-AUTH-010",
+                    "JDBC identity store using clear-text password mapper",
+                    "Authentication",
+                    "HIGH",
+                    "A quarkus-elytron-security-jdbc principal-query uses the clear-password mapper, meaning"
+                            + " passwords are compared/stored in plain text rather than hashed.",
+                    1,
+                    List.of("principal-query *.clear-password-mapper.enabled=true"),
+                    "Switch to bcrypt-password-mapper (or another hashing mapper) and re-hash stored passwords."));
+        }
+        if (s.jdbcBcryptWorkFactorLow()) {
+            v.add(rule(
+                    "QS-AUTH-011",
+                    "JDBC identity store bcrypt work-factor too low",
+                    "Authentication",
+                    "MEDIUM",
+                    "A quarkus-elytron-security-jdbc principal-query's bcrypt-password-mapper work-factor is set"
+                            + " below the default (10), weakening resistance to offline brute-force attacks.",
+                    1,
+                    List.of("principal-query *.bcrypt-password-mapper.work-factor < 10"),
+                    "Remove the override, or raise it to at least the default of 10."));
         }
         if (s.permissions().isEmpty() && s.annotationCount() == 0 && s.anyAuthMechanism()) {
             v.add(rule(
@@ -223,20 +297,23 @@ final class QuarkusSecurityChecks {
                     List.of("cors.access-control-allow-credentials=true with cors.methods/headers=*"),
                     "List the exact methods and headers the client needs instead of *."));
         }
-        if (!s.hstsHeader() && !s.cspHeader()) {
+        List<String> unanchoredCorsRegexes = unanchoredCorsRegexOrigins(s);
+        if (!unanchoredCorsRegexes.isEmpty()) {
             v.add(rule(
-                    "QS-HDR-001",
-                    "No security headers configured",
-                    "Headers",
-                    "LOW",
-                    "No Strict-Transport-Security or Content-Security-Policy response headers are configured.",
-                    1,
-                    List.of("quarkus.http.header.* absent"),
-                    "Add HSTS and CSP headers via quarkus.http.header.\"...\"."));
+                    "QS-CORS-004",
+                    "CORS regex origin pattern not anchored",
+                    "CORS",
+                    "MEDIUM",
+                    "A quarkus.http.cors.origins entry uses the /regex/ syntax without ^/$ anchors. Quarkus"
+                            + " matches the pattern anywhere in the origin string, so e.g. /example\\.com/ also"
+                            + " matches \"evil-example.com.attacker.net\" (quarkusio/quarkus#34718).",
+                    unanchoredCorsRegexes.size(),
+                    unanchoredCorsRegexes,
+                    "Anchor the pattern with ^ and $, e.g. /^https:\\/\\/(?:[a-z0-9-]+\\.)*example\\.com$/."));
         }
         if (s.hstsHeader() && isWeakHsts(s.hstsHeaderValue())) {
             v.add(rule(
-                    "QS-HDR-002",
+                    "QS-HDR-001",
                     "Weak Strict-Transport-Security policy",
                     "Headers",
                     "LOW",
@@ -246,21 +323,9 @@ final class QuarkusSecurityChecks {
                     List.of("Strict-Transport-Security: " + nullToEmpty(s.hstsHeaderValue())),
                     "Use max-age=31536000 (1 year) and add includeSubDomains."));
         }
-        if (missingFramingHeaders(s)) {
-            v.add(rule(
-                    "QS-HDR-003",
-                    "Missing clickjacking/MIME-sniffing headers",
-                    "Headers",
-                    "LOW",
-                    "No X-Frame-Options/CSP frame-ancestors (clickjacking) or X-Content-Type-Options=nosniff"
-                            + " (MIME sniffing) protection is configured.",
-                    1,
-                    List.of("X-Frame-Options/frame-ancestors and/or X-Content-Type-Options absent"),
-                    "Add X-Frame-Options=DENY (or CSP frame-ancestors 'none') and X-Content-Type-Options=nosniff."));
-        }
         if (s.cspHeader() && isWeakCsp(s.cspHeaderValue())) {
             v.add(rule(
-                    "QS-HDR-004",
+                    "QS-HDR-002",
                     "Weak Content-Security-Policy",
                     "Headers",
                     "MEDIUM",
@@ -269,6 +334,85 @@ final class QuarkusSecurityChecks {
                     1,
                     List.of("Content-Security-Policy: " + nullToEmpty(s.cspHeaderValue())),
                     "Remove unsafe-inline/unsafe-eval and wildcard sources; use nonces/hashes for scripts."));
+        }
+        if (!s.hstsHeader()) {
+            v.add(
+                    rule(
+                            "QS-HDR-003",
+                            "Missing Strict-Transport-Security header",
+                            "Headers",
+                            "LOW",
+                            "No Strict-Transport-Security response header is configured, so browsers fall back to"
+                                    + " trusting whatever scheme a link/redirect uses instead of enforcing HTTPS.",
+                            1,
+                            List.of("quarkus.http.header.\"Strict-Transport-Security\".value absent"),
+                            "Add quarkus.http.header.\"Strict-Transport-Security\".value=max-age=31536000; includeSubDomains."));
+        }
+        if (!s.cspHeader()) {
+            v.add(rule(
+                    "QS-HDR-004",
+                    "Missing Content-Security-Policy header",
+                    "Headers",
+                    "LOW",
+                    "No Content-Security-Policy response header is configured, losing a defense-in-depth"
+                            + " control against XSS and data-injection attacks.",
+                    1,
+                    List.of("quarkus.http.header.\"Content-Security-Policy\".value absent"),
+                    "Add a Content-Security-Policy tailored to the app's script/style/asset origins."));
+        }
+        boolean cspFrameAncestors =
+                s.cspHeaderValue() != null && s.cspHeaderValue().toLowerCase().contains("frame-ancestors");
+        if (!s.xFrameOptionsHeader() && !cspFrameAncestors) {
+            v.add(rule(
+                    "QS-HDR-005",
+                    "Missing clickjacking protection",
+                    "Headers",
+                    "LOW",
+                    "Neither X-Frame-Options nor a CSP frame-ancestors directive is configured, so the app can"
+                            + " be embedded in a hidden/opaque iframe on an attacker's page (clickjacking).",
+                    1,
+                    List.of("X-Frame-Options and CSP frame-ancestors both absent"),
+                    "Add quarkus.http.header.\"X-Frame-Options\".value=DENY (or a CSP frame-ancestors 'none')."));
+        }
+        if (!s.xContentTypeOptionsHeader()) {
+            v.add(rule(
+                    "QS-HDR-006",
+                    "Missing X-Content-Type-Options header",
+                    "Headers",
+                    "LOW",
+                    "No X-Content-Type-Options=nosniff response header is configured, allowing browsers to"
+                            + " MIME-sniff responses and potentially execute content served with the wrong"
+                            + " Content-Type.",
+                    1,
+                    List.of("quarkus.http.header.\"X-Content-Type-Options\".value absent"),
+                    "Add quarkus.http.header.\"X-Content-Type-Options\".value=nosniff."));
+        }
+        if (!s.referrerPolicyHeader()) {
+            v.add(
+                    rule(
+                            "QS-HDR-007",
+                            "Missing Referrer-Policy header",
+                            "Headers",
+                            "INFO",
+                            "No Referrer-Policy response header is configured, so browsers may forward the full"
+                                    + " request URL (including any sensitive query parameters) to third-party sites"
+                                    + " linked from the app.",
+                            1,
+                            List.of("quarkus.http.header.\"Referrer-Policy\".value absent"),
+                            "Add quarkus.http.header.\"Referrer-Policy\".value=strict-origin-when-cross-origin (or stricter)."));
+        }
+        if (!s.permissionsPolicyHeader()) {
+            v.add(rule(
+                    "QS-HDR-008",
+                    "Missing Permissions-Policy header",
+                    "Headers",
+                    "INFO",
+                    "No Permissions-Policy response header is configured, leaving browser features (camera,"
+                            + " microphone, geolocation, …) at their default availability instead of explicitly"
+                            + " disabled where unused.",
+                    1,
+                    List.of("quarkus.http.header.\"Permissions-Policy\".value absent"),
+                    "Add quarkus.http.header.\"Permissions-Policy\".value listing only the features the app uses."));
         }
         if (s.oidcTlsVerificationNone()) {
             v.add(rule(
@@ -282,15 +426,25 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.oidc.tls.verification=none"),
                     "Remove the override outside local dev; never ship with verification disabled."));
         }
-        if (s.swaggerUiAlwaysInclude() || s.openApiAlwaysInclude()) {
+        if (s.swaggerUiAlwaysInclude() || s.openApiAlwaysInclude() || s.graphqlUiAlwaysInclude()) {
+            List<String> alwaysIncluded = new ArrayList<>();
+            if (s.swaggerUiAlwaysInclude()) {
+                alwaysIncluded.add("swagger-ui.always-include=true");
+            }
+            if (s.openApiAlwaysInclude()) {
+                alwaysIncluded.add("smallrye-openapi.always-include=true");
+            }
+            if (s.graphqlUiAlwaysInclude()) {
+                alwaysIncluded.add("smallrye-graphql.ui.always-include=true");
+            }
             v.add(rule(
                     "QS-DEV-002",
-                    "OpenAPI/Swagger UI always included",
+                    "OpenAPI/Swagger/GraphQL UI always included",
                     "Dev exposure",
                     "MEDIUM",
-                    "API documentation is exposed in all profiles, including production.",
-                    1,
-                    List.of("swagger-ui/smallrye-openapi always-include=true"),
+                    "API documentation and/or the GraphQL UI is exposed in all profiles, including production.",
+                    alwaysIncluded.size(),
+                    alwaysIncluded,
                     "Restrict to dev, or remove always-include."));
         }
         if (s.oidcConfigured() && !s.oidcAudienceConfigured()) {
@@ -331,6 +485,22 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.management.enabled=true on a non-loopback host"),
                     "Bind quarkus.management.host to 127.0.0.1, or protect the management endpoints."));
         }
+        if ("/".equals(s.nonApplicationRootPath())) {
+            v.add(rule(
+                    "QS-MGMT-002",
+                    "Non-application endpoints merged into the main application path",
+                    "Management",
+                    "MEDIUM",
+                    "quarkus.http.non-application-root-path=/ collapses health/metrics/OpenAPI endpoints into the"
+                            + " main application namespace instead of keeping them on the separate /q root,"
+                            + " widening the app's exposed surface and risking accidental path collisions"
+                            + " (quarkusio/quarkus#14800). Quarkus-specific: there is no Spring equivalent of this"
+                            + " particular footgun.",
+                    1,
+                    List.of("quarkus.http.non-application-root-path=/"),
+                    "Leave non-application-root-path at its default (/q), or use the separate management"
+                            + " interface (quarkus.management.enabled=true) instead."));
+        }
         if (!s.suspectedSecretKeys().isEmpty()) {
             v.add(rule(
                     "QS-CFG-001",
@@ -341,6 +511,85 @@ final class QuarkusSecurityChecks {
                     s.suspectedSecretKeys().size(),
                     s.suspectedSecretKeys(),
                     "Move secrets to a vault or environment variables; never commit literals."));
+        }
+        if (s.formAuth() && !s.formCookieHttpOnly()) {
+            v.add(rule(
+                    "QS-SESSION-001",
+                    "Form-auth session cookie not HttpOnly",
+                    "Session",
+                    "HIGH",
+                    "quarkus.http.auth.form.http-only-cookie defaults to false, so the form-auth session cookie"
+                            + " is readable from JavaScript — a single XSS bug is enough to steal the session.",
+                    1,
+                    List.of("quarkus.http.auth.form.http-only-cookie=false (the Quarkus default)"),
+                    "Set quarkus.http.auth.form.http-only-cookie=true."));
+        }
+        if (s.formAuth() && s.formCookieSameSiteNone()) {
+            v.add(rule(
+                    "QS-SESSION-002",
+                    "Form-auth session cookie SameSite=None",
+                    "Session",
+                    "MEDIUM",
+                    "quarkus.http.auth.form.cookie-same-site was weakened from the secure default (strict) to"
+                            + " none, letting the session cookie be sent on cross-site requests (CSRF exposure).",
+                    1,
+                    List.of("quarkus.http.auth.form.cookie-same-site=none"),
+                    "Remove the override (default strict), or use lax only if cross-site GET flows require it."));
+        }
+        if (s.formAuth() && s.formSessionTimeoutExcessive()) {
+            v.add(rule(
+                    "QS-SESSION-003",
+                    "Excessive form-auth session timeout",
+                    "Session",
+                    "LOW",
+                    "quarkus.http.auth.form.timeout is set above 8 hours, keeping an authenticated session alive"
+                            + " long after a user has stepped away.",
+                    1,
+                    List.of("quarkus.http.auth.form.timeout > 8h"),
+                    "Lower the timeout (the Quarkus default is 30 minutes) and pair it with new-cookie-interval."));
+        }
+        if (s.grpcReflectionEnabledInProd()) {
+            v.add(rule(
+                    "QS-GRPC-001",
+                    "gRPC server reflection enabled in the prod profile",
+                    "gRPC",
+                    "MEDIUM",
+                    "quarkus.grpc.server.enable-reflection-service is enabled for the prod profile. Quarkus"
+                            + " disables reflection in prod by default specifically so the full service/method/"
+                            + " message schema isn't discoverable; an explicit override re-exposes it. No Spring"
+                            + " equivalent — Spring has no first-party gRPC server support.",
+                    1,
+                    List.of("%prod quarkus.grpc.server.enable-reflection-service=true"),
+                    "Remove the %prod override; keep reflection enabled only in %dev/%test."));
+        }
+        if (s.graphqlPresent() && s.graphqlIntrospectionEnabled()) {
+            v.add(rule(
+                    "QS-GRAPHQL-001",
+                    "GraphQL schema introspection enabled",
+                    "GraphQL",
+                    "LOW",
+                    "quarkus.smallrye-graphql.introspection-enabled defaults to true in every profile, including"
+                            + " production, letting any client enumerate the full schema (types, fields,"
+                            + " mutations). Often intentional for public APIs, but worth a deliberate decision."
+                            + " No Spring equivalent — Spring has no first-party GraphQL server support.",
+                    1,
+                    List.of("quarkus.smallrye-graphql.introspection-enabled=true (the Quarkus default)"),
+                    "Set quarkus.smallrye-graphql.introspection-enabled=false in %prod unless the schema is"
+                            + " meant to be publicly discoverable."));
+        }
+        if (s.messagingCredentialsWithoutTls()) {
+            v.add(rule(
+                    "QS-MSG-001",
+                    "Messaging credentials configured without an encrypted protocol",
+                    "Messaging",
+                    "HIGH",
+                    "A Kafka/SmallRye Reactive Messaging channel configures SASL credentials (username/password"
+                            + " or JAAS config) without a corresponding SASL_SSL/SSL security.protocol, sending"
+                            + " broker credentials in clear text over the wire. No Spring equivalent in the same"
+                            + " idiomatic reactive-messaging form.",
+                    1,
+                    List.of("*.sasl.password/*.sasl.jaas.config set, *.security.protocol not SASL_SSL/SSL"),
+                    "Set security.protocol=SASL_SSL (or SSL) alongside the SASL credentials."));
         }
         return v;
     }
@@ -371,6 +620,29 @@ final class QuarkusSecurityChecks {
         return csv != null && csv.contains("*");
     }
 
+    /**
+     * Finds {@code /regex/}-syntax CORS origin entries that are not anchored with {@code ^}/{@code $}. Quarkus
+     * matches such a pattern anywhere in the origin string rather than against the whole string, so e.g.
+     * {@code /example\.com/} also matches {@code https://evil-example.com.attacker.net}
+     * (quarkusio/quarkus#34718).
+     */
+    private static List<String> unanchoredCorsRegexOrigins(QuarkusSecuritySnapshot s) {
+        List<String> found = new ArrayList<>();
+        if (!s.corsEnabled() || s.corsOrigins() == null) {
+            return found;
+        }
+        for (String origin : s.corsOrigins().split(",")) {
+            String o = origin.trim();
+            if (o.length() > 2 && o.startsWith("/") && o.endsWith("/")) {
+                String pattern = o.substring(1, o.length() - 1);
+                if (!pattern.startsWith("^") || !pattern.endsWith("$")) {
+                    found.add(o);
+                }
+            }
+        }
+        return found;
+    }
+
     private static boolean isWeakHsts(String value) {
         if (value == null || value.isBlank()) {
             return false;
@@ -397,13 +669,6 @@ final class QuarkusSecurityChecks {
             return true;
         }
         return v.matches(".*(default-src|script-src)\\s+[^;]*\\*.*");
-    }
-
-    private static boolean missingFramingHeaders(QuarkusSecuritySnapshot s) {
-        boolean cspFrameAncestors =
-                s.cspHeaderValue() != null && s.cspHeaderValue().toLowerCase().contains("frame-ancestors");
-        boolean clickjackingProtected = s.xFrameOptionsHeader() || cspFrameAncestors;
-        return !clickjackingProtected || !s.xContentTypeOptionsHeader();
     }
 
     private static String nullToEmpty(String s) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusAppSnapshot.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusAppSnapshot.java
@@ -21,6 +21,9 @@ import java.util.List;
  * @param endpointCount discovered JAX-RS endpoint methods
  * @param defaultScopeResourceCount JAX-RS resources with no explicit CDI scope
  * @param reactiveEndpointCount endpoints returning {@code Uni}/{@code Multi}
+ * @param reactiveEndpointsWithoutBlockingCount reactive ({@code Uni}/{@code Multi}) endpoints whose method and
+ *     declaring class both lack {@code @Blocking} — the exact endpoints QA-RX-001 should flag, correlated
+ *     per-endpoint rather than against the app's total {@code @Blocking} count
  * @param blockingAnnotationCount {@code @Blocking} sites
  * @param scheduledCount {@code @Scheduled} methods
  * @param activeProfiles the SmallRye active profiles
@@ -35,6 +38,14 @@ import java.util.List;
  * @param prodSqlLoggingEnabled whether {@code %prod.quarkus.hibernate-orm.log.sql=true}
  * @param clusteredScheduler whether a clustered (Quartz) scheduler is configured
  * @param publicResourceFields public, non-final instance fields on JAX-RS resource classes (shared mutable state)
+ * @param prodLogLevelVerbose whether {@code %prod.quarkus.log.level} resolves to DEBUG/TRACE/ALL
+ * @param compressionEnabled whether {@code quarkus.http.enable-compression} is on
+ * @param shutdownTimeoutZeroed whether the graceful shutdown grace period was explicitly zeroed
+ * @param restClientsRegistered whether any {@code @RegisterRestClient} interface is declared
+ * @param restClientTimeoutConfigured whether a global or per-client REST client connect/read timeout is set
+ * @param virtualThreadEndpointCount {@code @RunOnVirtualThread} sites (methods or classes)
+ * @param virtualThreadSynchronizedCount {@code @RunOnVirtualThread} sites that are also {@code synchronized}
+ * @param jdkMajorVersion the build JDK's major version (0 if undetermined)
  */
 public record QuarkusAppSnapshot(
         int applicationScopedCount,
@@ -46,6 +57,7 @@ public record QuarkusAppSnapshot(
         int endpointCount,
         int defaultScopeResourceCount,
         int reactiveEndpointCount,
+        int reactiveEndpointsWithoutBlockingCount,
         int blockingAnnotationCount,
         int scheduledCount,
         List<String> activeProfiles,
@@ -59,7 +71,15 @@ public record QuarkusAppSnapshot(
         boolean prodJdbcUrlInMemory,
         boolean prodSqlLoggingEnabled,
         boolean clusteredScheduler,
-        List<String> publicResourceFields) {
+        List<String> publicResourceFields,
+        boolean prodLogLevelVerbose,
+        boolean compressionEnabled,
+        boolean shutdownTimeoutZeroed,
+        boolean restClientsRegistered,
+        boolean restClientTimeoutConfigured,
+        int virtualThreadEndpointCount,
+        int virtualThreadSynchronizedCount,
+        int jdkMajorVersion) {
 
     public QuarkusAppSnapshot {
         mutableAppScopedFields = mutableAppScopedFields == null ? List.of() : List.copyOf(mutableAppScopedFields);

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusSecuritySnapshot.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusSecuritySnapshot.java
@@ -51,6 +51,30 @@ import java.util.List;
  * @param denyUnannotatedEndpoints whether {@code quarkus.security.jaxrs.deny-unannotated-endpoints=true}
  * @param managementEnabled whether the separate management interface is enabled
  * @param managementHostNonLoopback whether the management interface binds a non-loopback host
+ * @param jwtAllowUnsignedTokens whether {@code quarkus.smallrye-jwt.allow-unsigned-tokens=true}
+ * @param jdbcClearPasswordMapperEnabled whether a JDBC principal-query uses the clear-password mapper
+ * @param jdbcBcryptWorkFactorLow whether a JDBC principal-query's bcrypt work-factor is set below the default (10)
+ * @param embeddedUsersEnabled whether {@code quarkus.security.users.embedded.enabled=true}
+ * @param jwtAudiencesConfigured whether {@code mp.jwt.verify.audiences} is configured
+ * @param jwtInlinePublicKey whether {@code mp.jwt.verify.publickey} holds a static inline key (never rotates)
+ * @param referrerPolicyHeader whether a Referrer-Policy response header is configured
+ * @param permissionsPolicyHeader whether a Permissions-Policy response header is configured
+ * @param nonApplicationRootPath the effective {@code quarkus.http.non-application-root-path} (health/metrics/
+ *     openapi endpoints), default {@code /q}; used both to check permission coverage and to detect the
+ *     Quarkus-specific footgun of collapsing it into the main application path (no Spring equivalent)
+ * @param grpcReflectionEnabledInProd whether the gRPC server reflection service is enabled for the prod profile
+ *     (Quarkus-specific; Spring has no first-party gRPC equivalent)
+ * @param graphqlPresent whether the SmallRye GraphQL capability is present
+ * @param graphqlIntrospectionEnabled whether GraphQL schema introspection is enabled (Quarkus-specific;
+ *     Spring has no first-party GraphQL equivalent)
+ * @param graphqlUiAlwaysInclude whether the GraphQL UI is always included, even outside dev/test
+ * @param messagingCredentialsWithoutTls whether a Kafka/Reactive-Messaging channel configures SASL
+ *     credentials without an encrypted (SASL_SSL/SSL) security protocol (Quarkus-specific; Spring has no
+ *     first-party reactive-messaging equivalent)
+ * @param formCookieHttpOnly whether the form-auth cookie has {@code http-only-cookie} set (Quarkus defaults
+ *     this to {@code false}, unlike most frameworks)
+ * @param formCookieSameSiteNone whether the form-auth cookie's {@code cookie-same-site} was weakened to {@code none}
+ * @param formSessionTimeoutExcessive whether the form-auth session {@code timeout} exceeds a sane bound (8h)
  */
 public record QuarkusSecuritySnapshot(
         boolean oidcConfigured,
@@ -92,12 +116,31 @@ public record QuarkusSecuritySnapshot(
         boolean xContentTypeOptionsHeader,
         boolean denyUnannotatedEndpoints,
         boolean managementEnabled,
-        boolean managementHostNonLoopback) {
+        boolean managementHostNonLoopback,
+        boolean jwtAllowUnsignedTokens,
+        boolean jdbcClearPasswordMapperEnabled,
+        boolean jdbcBcryptWorkFactorLow,
+        boolean embeddedUsersEnabled,
+        boolean jwtAudiencesConfigured,
+        boolean jwtInlinePublicKey,
+        boolean referrerPolicyHeader,
+        boolean permissionsPolicyHeader,
+        String nonApplicationRootPath,
+        boolean grpcReflectionEnabledInProd,
+        boolean graphqlPresent,
+        boolean graphqlIntrospectionEnabled,
+        boolean graphqlUiAlwaysInclude,
+        boolean messagingCredentialsWithoutTls,
+        boolean formCookieHttpOnly,
+        boolean formCookieSameSiteNone,
+        boolean formSessionTimeoutExcessive) {
 
     public QuarkusSecuritySnapshot {
         permissions = permissions == null ? List.of() : List.copyOf(permissions);
         suspectedSecretKeys = suspectedSecretKeys == null ? List.of() : List.copyOf(suspectedSecretKeys);
         oidcApplicationType = oidcApplicationType == null ? "" : oidcApplicationType;
+        nonApplicationRootPath =
+                nonApplicationRootPath == null || nonApplicationRootPath.isBlank() ? "/q" : nonApplicationRootPath;
     }
 
     public boolean anyAuthMechanism() {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
@@ -16,386 +16,343 @@ class QuarkusAppScannerTest {
 
     private static final Clock CLOCK = Clock.fixed(Instant.ofEpochMilli(1000), ZoneOffset.UTC);
 
-    /** Full-control builder; every field that could fire a rule is explicit. beanCount = appScoped+singleton = 4. */
-    private static QuarkusAppSnapshot app(
-            List<String> mutable,
-            int configProps,
-            int configMapping,
-            int reactive,
-            int blocking,
-            boolean jdbc,
-            int scheduled,
-            boolean clustered,
-            List<String> activeProfiles,
-            List<String> prodKeys,
-            boolean prodDevServices,
-            String prodSchema,
-            String prodDbKind,
-            boolean prodInMem,
-            boolean prodSqlLog,
-            List<String> publicFields) {
-        return new QuarkusAppSnapshot(
-                3,
-                1,
-                0,
-                0,
-                mutable,
-                configProps,
-                4,
-                0,
-                reactive,
-                blocking,
-                scheduled,
-                activeProfiles,
-                prodKeys,
-                prodDevServices,
-                false,
-                configMapping,
-                jdbc,
-                prodSchema,
-                prodDbKind,
-                prodInMem,
-                prodSqlLog,
-                clustered,
-                publicFields);
-    }
+    /**
+     * Mutable builder whose defaults describe a clean Quarkus app that fires zero rules, so each test can flip
+     * exactly the fields under test. Mirrors the 32-field {@link QuarkusAppSnapshot} positional record.
+     */
+    private static final class Snap {
+        // CDI / beans (beanCount = applicationScoped + singleton + requestScoped + dependentScoped = 4)
+        int applicationScoped = 3;
+        int singleton = 1;
+        int requestScoped = 0;
+        int dependentScoped = 0;
+        List<String> mutableAppScopedFields = List.of();
+        List<String> publicResourceFields = List.of();
+        // Config
+        int configProperties = 2;
+        int configMappings = 0;
+        // Endpoints / reactive
+        int endpoints = 4;
+        int defaultScopeResources = 0;
+        int reactiveEndpoints = 0;
+        int reactiveEndpointsWithoutBlocking = 0;
+        int blockingAnnotations = 0;
+        // Scheduling
+        int scheduled = 0;
+        boolean clusteredScheduler = false;
+        // Profiles
+        List<String> activeProfiles = List.of("prod");
+        List<String> prodProfileKeys = List.of("%prod.x");
+        boolean prodDevServices = false;
+        boolean nativeBuild = false;
+        // Datasource
+        boolean jdbcDatasource = false;
+        String prodSchemaGeneration = "";
+        String prodDbKind = "";
+        boolean prodJdbcUrlInMemory = false;
+        boolean prodSqlLogging = false;
+        // Logging
+        boolean prodLogLevelVerbose = false;
+        // Web
+        boolean compressionEnabled = true;
+        boolean shutdownTimeoutZeroed = false;
+        boolean restClientsRegistered = false;
+        boolean restClientTimeoutConfigured = false;
+        // Performance / virtual threads (jdkMajorVersion=21 + 1 adopting endpoint is a clean modern baseline)
+        int virtualThreadEndpoints = 1;
+        int virtualThreadSynchronized = 0;
+        int jdkMajorVersion = 21;
 
-    /** A snapshot that fires no rules: type-safe config present, an active profile, nothing destructive. */
-    private static QuarkusAppSnapshot clean() {
-        return app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of());
+        QuarkusAppSnapshot build() {
+            return new QuarkusAppSnapshot(
+                    applicationScoped,
+                    singleton,
+                    requestScoped,
+                    dependentScoped,
+                    mutableAppScopedFields,
+                    configProperties,
+                    endpoints,
+                    defaultScopeResources,
+                    reactiveEndpoints,
+                    reactiveEndpointsWithoutBlocking,
+                    blockingAnnotations,
+                    scheduled,
+                    activeProfiles,
+                    prodProfileKeys,
+                    prodDevServices,
+                    nativeBuild,
+                    configMappings,
+                    jdbcDatasource,
+                    prodSchemaGeneration,
+                    prodDbKind,
+                    prodJdbcUrlInMemory,
+                    prodSqlLogging,
+                    clusteredScheduler,
+                    publicResourceFields,
+                    prodLogLevelVerbose,
+                    compressionEnabled,
+                    shutdownTimeoutZeroed,
+                    restClientsRegistered,
+                    restClientTimeoutConfigured,
+                    virtualThreadEndpoints,
+                    virtualThreadSynchronized,
+                    jdkMajorVersion);
+        }
     }
 
     private static SpringRuleResultDto find(SpringReport r, String id) {
         return r.results().stream().filter(x -> x.id().equals(id)).findFirst().orElse(null);
     }
 
-    private static SpringReport scan(QuarkusAppSnapshot s) {
-        return QuarkusAppScanner.usingSnapshot(() -> s, CLOCK).scan();
+    private static SpringReport scan(Snap s) {
+        return QuarkusAppScanner.usingSnapshot(s::build, CLOCK).scan();
     }
 
     @Test
-    void mutableAppScopedStateIsFlagged() {
-        SpringReport r = scan(app(
-                List.of("Foo.count"),
-                2,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of()));
-        assertThat(find(r, "QA-CDI-001").severity()).isEqualTo("MEDIUM");
+    void cleanAppHasNoFindings() {
+        SpringReport r = scan(new Snap());
+        assertThat(r.violationsFound()).isZero();
+        assertThat(r.componentsAnalyzed()).isEqualTo(4);
         assertThat(r.scan().status()).isEqualTo("SCANNED");
     }
 
     @Test
+    void mutableAppScopedStateIsFlagged() {
+        Snap s = new Snap();
+        s.mutableAppScopedFields = List.of("Foo.count");
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-CDI-001").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
     void publicResourceFieldIsFlagged() {
-        SpringReport r = scan(app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of("WidgetResource.cache")));
+        Snap s = new Snap();
+        s.publicResourceFields = List.of("WidgetResource.cache");
+        SpringReport r = scan(s);
         assertThat(find(r, "QA-CDI-002").severity()).isEqualTo("MEDIUM");
     }
 
     @Test
     void noTypeSafeConfigIsFlagged() {
-        SpringReport r = scan(app(
-                List.of(),
-                0,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of()));
+        Snap s = new Snap();
+        s.configProperties = 0;
+        s.configMappings = 0;
+        SpringReport r = scan(s);
         assertThat(find(r, "QA-CFG-001")).isNotNull();
     }
 
     @Test
     void configMappingSuppressesConfigPropertyFinding() {
-        SpringReport r = scan(app(
-                List.of(),
-                0,
-                1,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of()));
+        Snap s = new Snap();
+        s.configProperties = 0;
+        s.configMappings = 1;
+        SpringReport r = scan(s);
         assertThat(find(r, "QA-CFG-001")).isNull();
     }
 
     @Test
     void reactiveWithJdbcDatasourceIsFlagged() {
-        SpringReport firing = scan(app(
-                List.of(),
-                2,
-                0,
-                2,
-                0,
-                true,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of()));
-        assertThat(find(firing, "QA-RX-001")).isNotNull();
+        Snap firing = new Snap();
+        firing.reactiveEndpoints = 2;
+        firing.reactiveEndpointsWithoutBlocking = 2;
+        firing.jdbcDatasource = true;
+        assertThat(find(scan(firing), "QA-RX-001")).isNotNull();
 
-        SpringReport noJdbc = scan(app(
-                List.of(),
-                2,
-                0,
-                2,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of()));
-        assertThat(find(noJdbc, "QA-RX-001")).isNull();
+        Snap noJdbc = new Snap();
+        noJdbc.reactiveEndpoints = 2;
+        noJdbc.reactiveEndpointsWithoutBlocking = 2;
+        noJdbc.jdbcDatasource = false;
+        assertThat(find(scan(noJdbc), "QA-RX-001")).isNull();
+    }
+
+    @Test
+    void blockingGuardedReactiveEndpointsDoNotFlagRx001() {
+        // Regression: the old app-wide blockingAnnotationCount==0 check false-negatived whenever ANY unrelated
+        // @Blocking existed anywhere in the app; the fix correlates per-endpoint via the
+        // reactiveEndpointsWithoutBlockingCount field, computed per reactive JAX-RS method.
+        Snap s = new Snap();
+        s.reactiveEndpoints = 2;
+        s.reactiveEndpointsWithoutBlocking = 0; // both reactive endpoints carry @Blocking themselves
+        s.blockingAnnotations = 1;
+        s.jdbcDatasource = true;
+        assertThat(find(scan(s), "QA-RX-001")).isNull();
     }
 
     @Test
     void prodDevServicesIsHigh() {
-        SpringReport r = scan(app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x.devservices.enabled"),
-                true,
-                "",
-                "",
-                false,
-                false,
-                List.of()));
+        Snap s = new Snap();
+        s.prodDevServices = true;
+        s.prodProfileKeys = List.of("%prod.x.devservices.enabled");
+        SpringReport r = scan(s);
         assertThat(find(r, "QA-PROD-001").severity()).isEqualTo("HIGH");
     }
 
     @Test
     void prodDestructiveSchemaIsHigh() {
-        SpringReport r = scan(app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "drop-and-create",
-                "postgresql",
-                false,
-                false,
-                List.of()));
+        Snap s = new Snap();
+        s.prodSchemaGeneration = "drop-and-create";
+        s.prodDbKind = "postgresql";
+        SpringReport r = scan(s);
         assertThat(find(r, "QA-PROD-002").severity()).isEqualTo("HIGH");
     }
 
     @Test
     void prodInMemoryDatasourceIsFlagged() {
-        SpringReport byKind = scan(app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "h2",
-                false,
-                false,
-                List.of()));
-        assertThat(find(byKind, "QA-PROD-003").severity()).isEqualTo("MEDIUM");
+        Snap byKind = new Snap();
+        byKind.prodDbKind = "h2";
+        assertThat(find(scan(byKind), "QA-PROD-003").severity()).isEqualTo("MEDIUM");
 
-        SpringReport byUrl = scan(app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                true,
-                false,
-                List.of()));
-        assertThat(find(byUrl, "QA-PROD-003")).isNotNull();
+        Snap byUrl = new Snap();
+        byUrl.prodJdbcUrlInMemory = true;
+        assertThat(find(scan(byUrl), "QA-PROD-003")).isNotNull();
     }
 
     @Test
     void prodSqlLoggingIsFlagged() {
-        SpringReport r = scan(app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                0,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                true,
-                List.of()));
+        Snap s = new Snap();
+        s.prodSqlLogging = true;
+        SpringReport r = scan(s);
         assertThat(find(r, "QA-CFG-002").severity()).isEqualTo("MEDIUM");
     }
 
     @Test
-    void scheduledWithoutClusteringIsFlagged() {
-        SpringReport firing = scan(app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                1,
-                false,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of()));
-        assertThat(find(firing, "QA-SCH-001").severity()).isEqualTo("LOW");
+    void prodVerboseLogLevelIsFlagged() {
+        Snap s = new Snap();
+        s.prodLogLevelVerbose = true;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-CFG-003").severity()).isEqualTo("MEDIUM");
+    }
 
-        SpringReport clustered = scan(app(
-                List.of(),
-                2,
-                0,
-                0,
-                0,
-                false,
-                1,
-                true,
-                List.of("prod"),
-                List.of("%prod.x"),
-                false,
-                "",
-                "",
-                false,
-                false,
-                List.of()));
-        assertThat(find(clustered, "QA-SCH-001")).isNull();
+    @Test
+    void scheduledWithoutClusteringIsFlagged() {
+        Snap firing = new Snap();
+        firing.scheduled = 1;
+        assertThat(find(scan(firing), "QA-SCH-001").severity()).isEqualTo("LOW");
+
+        Snap clustered = new Snap();
+        clustered.scheduled = 1;
+        clustered.clusteredScheduler = true;
+        assertThat(find(scan(clustered), "QA-SCH-001")).isNull();
     }
 
     @Test
     void noProfileConfigurationIsInfo() {
-        SpringReport r = scan(app(
-                List.of(), 2, 0, 0, 0, false, 0, false, List.of(), List.of(), false, "", "", false, false, List.of()));
+        Snap s = new Snap();
+        s.activeProfiles = List.of();
+        s.prodProfileKeys = List.of();
+        SpringReport r = scan(s);
         assertThat(find(r, "QA-PROF-001").severity()).isEqualTo("INFO");
     }
 
     @Test
-    void retiredEndpointRuleIsNeverEmitted() {
-        SpringReport r = scan(app(
-                List.of(), 0, 0, 0, 0, false, 0, false, List.of(), List.of(), false, "", "", false, false, List.of()));
-        assertThat(find(r, "QA-EP-001")).isNull();
-        assertThat(r.scan().rulesEvaluated()).isEqualTo(10);
+    void compressionDisabledIsFlagged() {
+        Snap s = new Snap();
+        s.compressionEnabled = false;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-WEB-001").severity()).isEqualTo("INFO");
     }
 
     @Test
-    void cleanAppHasNoFindings() {
-        SpringReport r = scan(clean());
-        assertThat(r.violationsFound()).isZero();
-        assertThat(r.componentsAnalyzed()).isEqualTo(4);
+    void gracefulShutdownZeroedIsFlagged() {
+        Snap s = new Snap();
+        s.shutdownTimeoutZeroed = true;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-WEB-002").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void restClientWithoutTimeoutIsFlagged() {
+        Snap s = new Snap();
+        s.restClientsRegistered = true;
+        s.restClientTimeoutConfigured = false;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-WEB-003").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void restClientWithTimeoutDoesNotFlagWeb003() {
+        Snap s = new Snap();
+        s.restClientsRegistered = true;
+        s.restClientTimeoutConfigured = true;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-WEB-003")).isNull();
+    }
+
+    @Test
+    void noRestClientsDoesNotFlagWeb003() {
+        Snap s = new Snap();
+        s.restClientsRegistered = false;
+        s.restClientTimeoutConfigured = false;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-WEB-003")).isNull();
+    }
+
+    @Test
+    void noVirtualThreadAdoptionIsFlagged() {
+        Snap s = new Snap();
+        s.virtualThreadEndpoints = 0;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-PERF-001").severity()).isEqualTo("INFO");
+    }
+
+    @Test
+    void virtualThreadAdoptionSuppressesPerf001() {
+        Snap s = new Snap();
+        s.virtualThreadEndpoints = 1;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-PERF-001")).isNull();
+    }
+
+    @Test
+    void oldJdkDoesNotFlagPerf001() {
+        // Virtual threads are not a mainstream concern before JDK 21; the rule intentionally does not fire.
+        Snap s = new Snap();
+        s.virtualThreadEndpoints = 0;
+        s.jdkMajorVersion = 17;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-PERF-001")).isNull();
+    }
+
+    @Test
+    void virtualThreadSynchronizedPinningIsFlagged() {
+        Snap s = new Snap();
+        s.virtualThreadSynchronized = 1;
+        s.jdkMajorVersion = 21;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-PERF-002").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void jdk24FixesVirtualThreadPinningPerf002() {
+        // JEP 491 removes synchronized-block/method pinning of the carrier thread starting in JDK 24.
+        Snap s = new Snap();
+        s.virtualThreadSynchronized = 1;
+        s.jdkMajorVersion = 24;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-PERF-002")).isNull();
+    }
+
+    @Test
+    void noSynchronizedVirtualThreadMethodsDoesNotFlagPerf002() {
+        Snap s = new Snap();
+        s.virtualThreadSynchronized = 0;
+        s.jdkMajorVersion = 21;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-PERF-002")).isNull();
+    }
+
+    @Test
+    void rulesEvaluatedMatchesTotalRuleCount() {
+        SpringReport r = scan(new Snap());
+        assertThat(r.scan().rulesEvaluated()).isEqualTo(16);
     }
 
     @Test
     void dismissalsHideMatchingFindings() {
-        QuarkusAppScanner scanner = QuarkusAppScanner.usingSnapshot(
-                () -> app(
-                        List.of(), 0, 0, 0, 0, false, 0, false, List.of(), List.of(), false, "", "", false, false,
-                        List.of()),
-                CLOCK);
+        Snap s = new Snap();
+        s.configProperties = 0;
+        s.configMappings = 0;
+        QuarkusAppScanner scanner = QuarkusAppScanner.usingSnapshot(s::build, CLOCK);
         SpringReport scanned = scanner.scan();
         int before = scanned.violationsFound();
         SpringReport after = scanner.applyDismissals(scanned, Set.of("QA-CFG-001"));
@@ -404,7 +361,8 @@ class QuarkusAppScannerTest {
 
     @Test
     void initialReportIsNotScanned() {
-        SpringReport r = QuarkusAppScanner.usingSnapshot(() -> clean(), CLOCK).initialReport();
+        SpringReport r =
+                QuarkusAppScanner.usingSnapshot(() -> new Snap().build(), CLOCK).initialReport();
         assertThat(r.scan().status()).isEqualTo("NOT_SCANNED");
         assertThat(r.violationsFound()).isZero();
     }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScannerTest.java
@@ -19,7 +19,7 @@ class QuarkusSecurityScannerTest {
 
     /**
      * Mutable builder whose defaults describe a hardened Quarkus app that fires zero rules, so each test can
-     * flip exactly the fields under test. Mirrors the 40-field {@link QuarkusSecuritySnapshot} positional record.
+     * flip exactly the fields under test. Mirrors the 58-field {@link QuarkusSecuritySnapshot} positional record.
      */
     private static final class Snap {
         // Auth mechanisms — basic auth on, over redirected HTTP, is a clean baseline.
@@ -71,6 +71,27 @@ class QuarkusSecurityScannerTest {
         boolean mgmtNonLoopback = false;
         // Config hygiene
         List<String> secrets = List.of();
+        // Auth hardening
+        boolean jwtAllowUnsigned = false;
+        boolean jdbcClearPasswordMapper = false;
+        boolean jdbcBcryptWorkFactorLow = false;
+        boolean embeddedUsers = false;
+        boolean jwtAudiences = true;
+        boolean jwtInlineKey = false;
+        // Headers (nice-to-have)
+        boolean referrerPolicy = true;
+        boolean permissionsPolicy = true;
+        // Quarkus-specific
+        String nonAppRootPath = "/q";
+        boolean grpcReflectionProd = false;
+        boolean graphqlPresent = false;
+        boolean graphqlIntrospection = true;
+        boolean graphqlUi = false;
+        boolean messagingCredsNoTls = false;
+        // Session (form-auth cookies)
+        boolean formHttpOnly = true;
+        boolean formSameSiteNone = false;
+        boolean formTimeoutExcessive = false;
 
         QuarkusSecuritySnapshot build() {
             return new QuarkusSecuritySnapshot(
@@ -113,7 +134,24 @@ class QuarkusSecurityScannerTest {
                     xContentType,
                     denyUnannotated,
                     mgmtEnabled,
-                    mgmtNonLoopback);
+                    mgmtNonLoopback,
+                    jwtAllowUnsigned,
+                    jdbcClearPasswordMapper,
+                    jdbcBcryptWorkFactorLow,
+                    embeddedUsers,
+                    jwtAudiences,
+                    jwtInlineKey,
+                    referrerPolicy,
+                    permissionsPolicy,
+                    nonAppRootPath,
+                    grpcReflectionProd,
+                    graphqlPresent,
+                    graphqlIntrospection,
+                    graphqlUi,
+                    messagingCredsNoTls,
+                    formHttpOnly,
+                    formSameSiteNone,
+                    formTimeoutExcessive);
         }
     }
 
@@ -352,66 +390,67 @@ class QuarkusSecurityScannerTest {
     }
 
     @Test
-    void noSecurityHeadersFlagsHdr001() {
+    void noSecurityHeadersFlagsHdr003AndHdr004() {
         Snap s = new Snap();
         s.hsts = false;
         s.csp = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-HDR-003").severity()).isEqualTo("LOW");
+        assertThat(find(r, "QS-HDR-004").severity()).isEqualTo("LOW");
+    }
+
+    @Test
+    void weakHstsFlagsHdr001() {
+        Snap s = new Snap();
+        s.hsts = true;
+        s.hstsValue = "max-age=3600";
         SecurityReport r = scan(s);
         assertThat(find(r, "QS-HDR-001").severity()).isEqualTo("LOW");
     }
 
     @Test
-    void weakHstsFlagsHdr002() {
-        Snap s = new Snap();
-        s.hsts = true;
-        s.hstsValue = "max-age=3600";
-        SecurityReport r = scan(s);
-        assertThat(find(r, "QS-HDR-002").severity()).isEqualTo("LOW");
-    }
-
-    @Test
-    void strongHstsDoesNotFlagHdr002() {
+    void strongHstsDoesNotFlagHdr001() {
         Snap s = new Snap();
         s.hsts = true;
         s.hstsValue = "max-age=31536000; includeSubDomains";
         SecurityReport r = scan(s);
-        assertThat(find(r, "QS-HDR-002")).isNull();
+        assertThat(find(r, "QS-HDR-001")).isNull();
     }
 
     @Test
-    void missingFramingHeadersFlagsHdr003() {
+    void missingFramingHeadersFlagsHdr005() {
         Snap s = new Snap();
         s.xFrame = false;
         SecurityReport r = scan(s);
-        assertThat(find(r, "QS-HDR-003").severity()).isEqualTo("LOW");
+        assertThat(find(r, "QS-HDR-005").severity()).isEqualTo("LOW");
     }
 
     @Test
-    void cspFrameAncestorsSatisfiesHdr003() {
+    void cspFrameAncestorsSatisfiesHdr005() {
         Snap s = new Snap();
         s.xFrame = false;
         s.cspValue = "default-src 'self'; frame-ancestors 'none'";
         s.xContentType = true;
         SecurityReport r = scan(s);
-        assertThat(find(r, "QS-HDR-003")).isNull();
+        assertThat(find(r, "QS-HDR-005")).isNull();
     }
 
     @Test
-    void weakCspFlagsHdr004() {
+    void weakCspFlagsHdr002() {
         Snap s = new Snap();
         s.csp = true;
         s.cspValue = "default-src 'self'; script-src 'unsafe-inline'";
         SecurityReport r = scan(s);
-        assertThat(find(r, "QS-HDR-004").severity()).isEqualTo("MEDIUM");
+        assertThat(find(r, "QS-HDR-002").severity()).isEqualTo("MEDIUM");
     }
 
     @Test
-    void wildcardScriptCspFlagsHdr004() {
+    void wildcardScriptCspFlagsHdr002() {
         Snap s = new Snap();
         s.csp = true;
         s.cspValue = "default-src *";
         SecurityReport r = scan(s);
-        assertThat(find(r, "QS-HDR-004")).isNotNull();
+        assertThat(find(r, "QS-HDR-002")).isNotNull();
     }
 
     @Test
@@ -482,6 +521,228 @@ class QuarkusSecurityScannerTest {
     }
 
     @Test
+    void unsignedJwtTokensAllowedFlagsAuth006() {
+        Snap s = new Snap();
+        s.jwtAllowUnsigned = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-006").severity()).isEqualTo("CRITICAL");
+    }
+
+    @Test
+    void embeddedUsersEnabledFlagsAuth007() {
+        Snap s = new Snap();
+        s.embeddedUsers = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-007").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void jwtWithoutAudienceFlagsAuth008() {
+        Snap s = new Snap();
+        s.jwt = true;
+        s.jwtAudiences = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-008").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void jwtWithAudienceDoesNotFlagAuth008() {
+        Snap s = new Snap();
+        s.jwt = true;
+        s.jwtAudiences = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-008")).isNull();
+    }
+
+    @Test
+    void jwtInlinePublicKeyFlagsAuth009() {
+        Snap s = new Snap();
+        s.jwt = true;
+        s.jwtInlineKey = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-009").severity()).isEqualTo("LOW");
+    }
+
+    @Test
+    void jwtJwksLocationDoesNotFlagAuth009() {
+        Snap s = new Snap();
+        s.jwt = true;
+        s.jwtInlineKey = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-009")).isNull();
+    }
+
+    @Test
+    void jdbcClearPasswordMapperFlagsAuth010() {
+        Snap s = new Snap();
+        s.jdbcClearPasswordMapper = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-010").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void jdbcLowBcryptWorkFactorFlagsAuth011() {
+        Snap s = new Snap();
+        s.jdbcBcryptWorkFactorLow = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-011").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void unanchoredCorsRegexOriginFlagsCors004() {
+        Snap s = new Snap();
+        s.cors = true;
+        s.corsOrigins = "/example\\.com/";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-CORS-004").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void anchoredCorsRegexOriginDoesNotFlagCors004() {
+        Snap s = new Snap();
+        s.cors = true;
+        s.corsOrigins = "/^https:\\/\\/example\\.com$/";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-CORS-004")).isNull();
+    }
+
+    @Test
+    void plainStringCorsOriginDoesNotFlagCors004() {
+        Snap s = new Snap();
+        s.cors = true;
+        s.corsOrigins = "https://app.example";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-CORS-004")).isNull();
+    }
+
+    @Test
+    void missingReferrerPolicyFlagsHdr007() {
+        Snap s = new Snap();
+        s.referrerPolicy = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-HDR-007").severity()).isEqualTo("INFO");
+    }
+
+    @Test
+    void missingPermissionsPolicyFlagsHdr008() {
+        Snap s = new Snap();
+        s.permissionsPolicy = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-HDR-008").severity()).isEqualTo("INFO");
+    }
+
+    @Test
+    void graphqlUiAlwaysIncludeFlagsDev002() {
+        Snap s = new Snap();
+        s.graphqlUi = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-DEV-002").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void nonApplicationRootPathCollapsedFlagsMgmt002() {
+        Snap s = new Snap();
+        s.nonAppRootPath = "/";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-MGMT-002").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void defaultNonApplicationRootPathDoesNotFlagMgmt002() {
+        Snap s = new Snap();
+        s.nonAppRootPath = "/q";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-MGMT-002")).isNull();
+    }
+
+    @Test
+    void formAuthCookieNotHttpOnlyFlagsSession001() {
+        Snap s = new Snap();
+        s.form = true;
+        s.csrf = true; // isolate from QS-AUTH-003
+        s.formHttpOnly = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-SESSION-001").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void formAuthCookieHttpOnlyDoesNotFlagSession001() {
+        Snap s = new Snap();
+        s.form = true;
+        s.csrf = true;
+        s.formHttpOnly = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-SESSION-001")).isNull();
+    }
+
+    @Test
+    void formAuthCookieSameSiteNoneFlagsSession002() {
+        Snap s = new Snap();
+        s.form = true;
+        s.csrf = true;
+        s.formSameSiteNone = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-SESSION-002").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void formAuthExcessiveSessionTimeoutFlagsSession003() {
+        Snap s = new Snap();
+        s.form = true;
+        s.csrf = true;
+        s.formTimeoutExcessive = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-SESSION-003").severity()).isEqualTo("LOW");
+    }
+
+    @Test
+    void noFormAuthDoesNotFlagSessionRules() {
+        Snap s = new Snap();
+        s.form = false;
+        s.formHttpOnly = false;
+        s.formSameSiteNone = true;
+        s.formTimeoutExcessive = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-SESSION-001")).isNull();
+        assertThat(find(r, "QS-SESSION-002")).isNull();
+        assertThat(find(r, "QS-SESSION-003")).isNull();
+    }
+
+    @Test
+    void grpcReflectionEnabledInProdFlagsGrpc001() {
+        Snap s = new Snap();
+        s.grpcReflectionProd = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-GRPC-001").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void graphqlIntrospectionEnabledFlagsGraphql001() {
+        Snap s = new Snap();
+        s.graphqlPresent = true;
+        s.graphqlIntrospection = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-GRAPHQL-001").severity()).isEqualTo("LOW");
+    }
+
+    @Test
+    void graphqlAbsentDoesNotFlagGraphql001() {
+        Snap s = new Snap();
+        s.graphqlPresent = false;
+        s.graphqlIntrospection = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-GRAPHQL-001")).isNull();
+    }
+
+    @Test
+    void messagingCredentialsWithoutTlsFlagsMsg001() {
+        Snap s = new Snap();
+        s.messagingCredsNoTls = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-MSG-001").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
     void dismissalsHideMatchingFindings() {
         Snap s = new Snap();
         s.basic = false;
@@ -514,6 +775,6 @@ class QuarkusSecurityScannerTest {
         s.secured = 0;
         SecurityReport r = scan(s);
         assertThat(r.results()).allSatisfy(x -> assertThat(x.id()).startsWith("QS-"));
-        assertThat(r.scan().rulesEvaluated()).isEqualTo(25);
+        assertThat(r.scan().rulesEvaluated()).isEqualTo(43);
     }
 }

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -356,10 +356,52 @@ class BootUiQuarkusProcessor {
         emit(runtimeDefaults, "bootui.internal.sec.secured-endpoints", secured);
     }
 
+    /**
+     * Detects whether the {@code io.quarkus:quarkus-rest-csrf} extension is active by checking the build's
+     * registered {@link FeatureBuildItem}s for its feature name ({@code "rest-csrf"}) — fixing a previously dead
+     * {@code bootui.internal.sec.csrf-present} key that no build step ever populated (QS-CSRF-001 bug fix). The
+     * provider additionally reads the live {@code quarkus.rest-csrf.enabled} config flag (default {@code true}),
+     * since the extension can be present but explicitly disabled.
+     */
+    @BuildStep
+    void registerCsrfDetection(
+            LaunchModeBuildItem launchMode,
+            List<FeatureBuildItem> features,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
+        if (launchMode.getLaunchMode() == LaunchMode.NORMAL) {
+            return;
+        }
+        boolean present = features.stream().anyMatch(f -> "rest-csrf".equals(f.getName()));
+        runtimeDefaults.produce(
+                new RunTimeConfigurationDefaultBuildItem("bootui.internal.sec.csrf-present", "" + present));
+    }
+
+    /**
+     * Emits build-time presence flags for two Quarkus-specific optional capabilities the Security advisor
+     * checks: gRPC server reflection (QS-GRPC-001) and SmallRye GraphQL introspection (QS-GRAPHQL-001). Both
+     * are pure presence checks — no optional {@code io.quarkus.grpc.*}/{@code io.smallrye.graphql.*} type is
+     * imported at runtime — so unlike the Cache/Flyway/Liquibase/Hibernate ports, no {@link ExcludedTypeBuildItem}
+     * gate is needed.
+     */
+    @BuildStep
+    void registerQuarkusSpecificCapabilityFlags(
+            LaunchModeBuildItem launchMode,
+            Capabilities capabilities,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
+        if (launchMode.getLaunchMode() == LaunchMode.NORMAL) {
+            return;
+        }
+        runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                "bootui.internal.sec.grpc-present", "" + capabilities.isPresent(Capability.GRPC)));
+        runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                "bootui.internal.sec.graphql-present", "" + capabilities.isPresent(Capability.SMALLRYE_GRAPHQL)));
+    }
+
     private static boolean isSecuredEndpoint(MethodInfo method) {
         for (String sec : List.of(
                 "jakarta.annotation.security.RolesAllowed",
                 "jakarta.annotation.security.PermitAll",
+                "jakarta.annotation.security.DenyAll",
                 "io.quarkus.security.Authenticated")) {
             DotName name = DotName.createSimple(sec);
             if (method.hasAnnotation(name) || method.declaringClass().hasAnnotation(name)) {
@@ -387,6 +429,13 @@ class BootUiQuarkusProcessor {
     private static final DotName INJECT = DotName.createSimple("jakarta.inject.Inject");
     private static final DotName REST_CLIENT =
             DotName.createSimple("org.eclipse.microprofile.rest.client.inject.RestClient");
+    private static final DotName REGISTER_REST_CLIENT =
+            DotName.createSimple("org.eclipse.microprofile.rest.client.inject.RegisterRestClient");
+    private static final DotName RUN_ON_VIRTUAL_THREAD =
+            DotName.createSimple("io.smallrye.common.annotation.RunOnVirtualThread");
+
+    /** Bytecode access-flag bit for the {@code synchronized} method modifier ({@code ACC_SYNCHRONIZED}). */
+    private static final int ACC_SYNCHRONIZED = 0x0020;
 
     /** The seven JAX-RS HTTP-method annotations ({@code @GET}, {@code @POST}, …) by fully-qualified name. */
     private static final List<String> JAXRS_HTTP_METHODS = List.of(
@@ -405,7 +454,12 @@ class BootUiQuarkusProcessor {
      * Captures build-time idiom counts for the Quarkus-native application advisor: CDI scope annotation counts,
      * {@code @ConfigProperty} sites, {@code @ConfigMapping} interfaces, JAX-RS resources without an explicit scope,
      * reactive ({@code Uni}/{@code Multi}) endpoints, {@code @Blocking} sites, shared mutable fields on
-     * {@code @ApplicationScoped} beans (excluding injected fields), and public mutable fields on JAX-RS resources.
+     * {@code @ApplicationScoped} beans (excluding injected fields), public mutable fields on JAX-RS resources,
+     * {@code @RegisterRestClient} interfaces (QA-WEB-003), and the JEP-491 virtual-thread-pinning correlation
+     * (QA-PERF-002): {@code @RunOnVirtualThread} sites total vs. the subset that are also declared {@code
+     * synchronized}, plus the build JDK's major version (the pinning-on-{@code synchronized} bug is fixed in
+     * JDK 24). Note the {@code synchronized}-count only sees the method-level modifier — Jandex does not index
+     * {@code synchronized(lock) { … }} blocks inside a method body, so this is a real but incomplete signal.
      * Emitted as runtime config defaults the advisor reads. Dev/test only — skipped in {@link LaunchMode#NORMAL}.
      */
     @BuildStep
@@ -435,18 +489,26 @@ class BootUiQuarkusProcessor {
 
         int endpoints = 0;
         int reactive = 0;
+        int reactiveWithoutBlocking = 0;
         for (String http : JAXRS_HTTP_METHODS) {
             for (AnnotationInstance ann : app.getAnnotations(DotName.createSimple(http))) {
                 if (ann.target() != null && ann.target().kind() == AnnotationTarget.Kind.METHOD) {
                     endpoints++;
-                    if (isReactive(ann.target().asMethod().returnType())) {
+                    MethodInfo method = ann.target().asMethod();
+                    if (isReactive(method.returnType())) {
                         reactive++;
+                        boolean guarded = method.hasAnnotation(BLOCKING)
+                                || method.declaringClass().hasAnnotation(BLOCKING);
+                        if (!guarded) {
+                            reactiveWithoutBlocking++;
+                        }
                     }
                 }
             }
         }
         emit(runtimeDefaults, "bootui.internal.app.endpoints", endpoints);
         emit(runtimeDefaults, "bootui.internal.app.reactive-endpoints", reactive);
+        emit(runtimeDefaults, "bootui.internal.app.reactive-endpoints-without-blocking", reactiveWithoutBlocking);
 
         int defaultScopeResources = 0;
         List<String> publicResourceFields = new ArrayList<>();
@@ -496,6 +558,27 @@ class BootUiQuarkusProcessor {
             runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
                     "bootui.internal.app.public-resource-fields", String.join(",", publicResourceFields)));
         }
+
+        emit(runtimeDefaults, "bootui.internal.app.rest-clients", classAnnotations(app, REGISTER_REST_CLIENT));
+
+        int virtualThreadSites = 0;
+        int virtualThreadSynchronizedSites = 0;
+        for (AnnotationInstance ann : app.getAnnotations(RUN_ON_VIRTUAL_THREAD)) {
+            if (ann.target() == null || ann.target().kind() != AnnotationTarget.Kind.METHOD) {
+                continue;
+            }
+            virtualThreadSites++;
+            MethodInfo method = ann.target().asMethod();
+            if ((method.flags() & ACC_SYNCHRONIZED) != 0) {
+                virtualThreadSynchronizedSites++;
+            }
+        }
+        emit(runtimeDefaults, "bootui.internal.app.virtual-thread-endpoints", virtualThreadSites);
+        emit(runtimeDefaults, "bootui.internal.app.virtual-thread-synchronized", virtualThreadSynchronizedSites);
+        emit(
+                runtimeDefaults,
+                "bootui.internal.app.jdk-major-version",
+                Runtime.version().feature());
     }
 
     private static int classAnnotations(IndexView index, DotName annotation) {

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/quarkusapp/QuarkusAppSnapshotProviderImpl.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/quarkusapp/QuarkusAppSnapshotProviderImpl.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.quarkus.quarkusapp;
 import io.github.jdubois.bootui.spi.QuarkusAppSnapshot;
 import io.github.jdubois.bootui.spi.QuarkusAppSnapshotProvider;
 import io.smallrye.config.SmallRyeConfig;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.microprofile.config.Config;
@@ -25,10 +26,16 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
     static final String ENDPOINTS_KEY = "bootui.internal.app.endpoints";
     static final String DEFAULT_SCOPE_RESOURCES_KEY = "bootui.internal.app.default-scope-resources";
     static final String REACTIVE_ENDPOINTS_KEY = "bootui.internal.app.reactive-endpoints";
+    static final String REACTIVE_ENDPOINTS_WITHOUT_BLOCKING_KEY =
+            "bootui.internal.app.reactive-endpoints-without-blocking";
     static final String BLOCKING_KEY = "bootui.internal.app.blocking";
     static final String SCHEDULED_KEY = "bootui.internal.app.scheduled";
     static final String CONFIG_MAPPING_KEY = "bootui.internal.app.config-mapping";
     static final String PUBLIC_RESOURCE_FIELDS_KEY = "bootui.internal.app.public-resource-fields";
+    static final String REST_CLIENTS_KEY = "bootui.internal.app.rest-clients";
+    static final String VIRTUAL_THREAD_ENDPOINTS_KEY = "bootui.internal.app.virtual-thread-endpoints";
+    static final String VIRTUAL_THREAD_SYNCHRONIZED_KEY = "bootui.internal.app.virtual-thread-synchronized";
+    static final String JDK_MAJOR_VERSION_KEY = "bootui.internal.app.jdk-major-version";
 
     private final Config config;
 
@@ -58,6 +65,7 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
                 count(ENDPOINTS_KEY),
                 count(DEFAULT_SCOPE_RESOURCES_KEY),
                 count(REACTIVE_ENDPOINTS_KEY),
+                count(REACTIVE_ENDPOINTS_WITHOUT_BLOCKING_KEY),
                 count(BLOCKING_KEY),
                 count(SCHEDULED_KEY),
                 activeProfiles(),
@@ -71,7 +79,38 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
                 prodJdbcUrlInMemory(),
                 bool("%prod.quarkus.hibernate-orm.log.sql"),
                 bool("quarkus.quartz.clustered"),
-                strList(PUBLIC_RESOURCE_FIELDS_KEY));
+                strList(PUBLIC_RESOURCE_FIELDS_KEY),
+                prodLogLevelVerbose(),
+                bool("quarkus.http.enable-compression"),
+                shutdownTimeoutZeroed(),
+                count(REST_CLIENTS_KEY) > 0,
+                restClientTimeoutConfigured(),
+                count(VIRTUAL_THREAD_ENDPOINTS_KEY),
+                count(VIRTUAL_THREAD_SYNCHRONIZED_KEY),
+                count(JDK_MAJOR_VERSION_KEY));
+    }
+
+    private boolean prodLogLevelVerbose() {
+        String level = str("%prod.quarkus.log.level", "").trim().toUpperCase();
+        return level.equals("DEBUG") || level.equals("TRACE") || level.equals("ALL");
+    }
+
+    private boolean shutdownTimeoutZeroed() {
+        return isZero("quarkus.shutdown.timeout") || isZero("quarkus.http.shutdown.timeout");
+    }
+
+    private boolean isZero(String key) {
+        return config.getOptionalValue(key, Duration.class).map(d -> d.isZero()).orElse(false);
+    }
+
+    private boolean restClientTimeoutConfigured() {
+        for (String name : config.getPropertyNames()) {
+            if (name.startsWith("quarkus.rest-client")
+                    && (name.endsWith("connect-timeout") || name.endsWith("read-timeout"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean jdbcDatasourcePresent() {

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/security/QuarkusSecuritySnapshotProviderImpl.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/security/QuarkusSecuritySnapshotProviderImpl.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.quarkus.security;
 import io.github.jdubois.bootui.spi.QuarkusSecurityPermission;
 import io.github.jdubois.bootui.spi.QuarkusSecuritySnapshot;
 import io.github.jdubois.bootui.spi.QuarkusSecuritySnapshotProvider;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,6 +26,8 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
     static final String ENDPOINTS_KEY = "bootui.internal.sec.endpoints";
     static final String SECURED_KEY = "bootui.internal.sec.secured-endpoints";
     static final String CSRF_KEY = "bootui.internal.sec.csrf-present";
+    static final String GRPC_PRESENT_KEY = "bootui.internal.sec.grpc-present";
+    static final String GRAPHQL_PRESENT_KEY = "bootui.internal.sec.graphql-present";
 
     private static final Pattern PERMISSION =
             Pattern.compile("^quarkus\\.http\\.auth\\.permission\\.([^.]+)\\.policy$");
@@ -60,7 +63,8 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
         boolean oidcVerifyNone = "none".equalsIgnoreCase(str("quarkus.oidc.tls.verification", ""));
         boolean swagger = bool("quarkus.swagger-ui.always-include", false);
         boolean openapi = bool("quarkus.smallrye-openapi.always-include", false);
-        boolean csrf = bool(CSRF_KEY, false);
+        boolean csrfExtensionPresent = bool(CSRF_KEY, false);
+        boolean csrf = csrfExtensionPresent && bool("quarkus.rest-csrf.enabled", true);
 
         boolean behindProxy = bool("quarkus.http.proxy.proxy-address-forwarding", false)
                 || bool("quarkus.http.proxy.allow-forwarded", false)
@@ -81,6 +85,26 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
         boolean managementEnabled = bool("quarkus.management.enabled", false);
         boolean managementHostNonLoopback =
                 managementEnabled && !isLoopbackHost(str("quarkus.management.host", "0.0.0.0"));
+
+        boolean jwtAllowUnsigned = bool("quarkus.smallrye-jwt.allow-unsigned-tokens", false);
+        boolean jdbcClearPasswordMapper = jdbcClearPasswordMapperEnabled();
+        boolean jdbcBcryptWorkFactorLow = jdbcBcryptWorkFactorLow();
+        boolean embeddedUsers = bool("quarkus.security.users.embedded.enabled", false);
+        boolean jwtAudiences = has("mp.jwt.verify.audiences");
+        boolean jwtInlineKey = has("mp.jwt.verify.publickey");
+        boolean referrerPolicy = has("quarkus.http.header.\"Referrer-Policy\".value");
+        boolean permissionsPolicy = has("quarkus.http.header.\"Permissions-Policy\".value");
+        String nonApplicationRootPath = str("quarkus.http.non-application-root-path", "/q");
+        boolean grpcPresent = bool(GRPC_PRESENT_KEY, false);
+        boolean grpcReflectionProd = grpcPresent && grpcReflectionEnabledInProdProfile();
+        boolean graphqlPresent = bool(GRAPHQL_PRESENT_KEY, false);
+        boolean graphqlIntrospection = bool("quarkus.smallrye-graphql.introspection-enabled", true);
+        boolean graphqlUiAlwaysInclude = bool("quarkus.smallrye-graphql.ui.always-include", false);
+        boolean messagingCredsWithoutTls = messagingCredentialsWithoutTls();
+        boolean formCookieHttpOnly = bool("quarkus.http.auth.form.http-only-cookie", false);
+        boolean formCookieSameSiteNone =
+                "none".equalsIgnoreCase(str("quarkus.http.auth.form.cookie-same-site", "strict"));
+        boolean formSessionTimeoutExcessive = formSessionTimeoutExcessive();
 
         return new QuarkusSecuritySnapshot(
                 oidc,
@@ -122,7 +146,24 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 xContentType,
                 denyUnannotated,
                 managementEnabled,
-                managementHostNonLoopback);
+                managementHostNonLoopback,
+                jwtAllowUnsigned,
+                jdbcClearPasswordMapper,
+                jdbcBcryptWorkFactorLow,
+                embeddedUsers,
+                jwtAudiences,
+                jwtInlineKey,
+                referrerPolicy,
+                permissionsPolicy,
+                nonApplicationRootPath,
+                grpcReflectionProd,
+                graphqlPresent,
+                graphqlIntrospection,
+                graphqlUiAlwaysInclude,
+                messagingCredsWithoutTls,
+                formCookieHttpOnly,
+                formCookieSameSiteNone,
+                formSessionTimeoutExcessive);
     }
 
     private static boolean isLoopbackHost(String host) {
@@ -135,6 +176,70 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 || h.startsWith("127.")
                 || h.equals("::1")
                 || h.equals("0:0:0:0:0:0:0:1");
+    }
+
+    private boolean jdbcClearPasswordMapperEnabled() {
+        for (String name : config.getPropertyNames()) {
+            if (name.contains("principal-query")
+                    && name.endsWith("clear-password-mapper.enabled")
+                    && bool(name, false)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean jdbcBcryptWorkFactorLow() {
+        for (String name : config.getPropertyNames()) {
+            if (name.contains("principal-query") && name.endsWith("bcrypt-password-mapper.work-factor")) {
+                Integer workFactor =
+                        config.getOptionalValue(name, Integer.class).orElse(null);
+                if (workFactor != null && workFactor < 10) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks only the literal {@code quarkus.grpc.server.enable-reflection-service} or
+     * {@code %prod.quarkus.grpc.server.enable-reflection-service} keys (not the profile-resolved value), so a
+     * dev/test-scoped override doesn't trigger a false positive while the advisor itself runs in dev/test mode.
+     */
+    private boolean grpcReflectionEnabledInProdProfile() {
+        for (String name : config.getPropertyNames()) {
+            if ((name.equals("quarkus.grpc.server.enable-reflection-service")
+                            || name.equals("%prod.quarkus.grpc.server.enable-reflection-service"))
+                    && bool(name, false)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean messagingCredentialsWithoutTls() {
+        boolean saslCredentialsConfigured = false;
+        boolean encryptedProtocolConfigured = false;
+        for (String name : config.getPropertyNames()) {
+            String lower = name.toLowerCase();
+            if ((lower.endsWith(".sasl.password") || lower.endsWith(".sasl.jaas.config"))
+                    && !str(name, "").isBlank()) {
+                saslCredentialsConfigured = true;
+            } else if (lower.endsWith(".security.protocol")) {
+                String protocol = str(name, "").toUpperCase();
+                if (protocol.equals("SASL_SSL") || protocol.equals("SSL")) {
+                    encryptedProtocolConfigured = true;
+                }
+            }
+        }
+        return saslCredentialsConfigured && !encryptedProtocolConfigured;
+    }
+
+    private boolean formSessionTimeoutExcessive() {
+        return config.getOptionalValue("quarkus.http.auth.form.timeout", Duration.class)
+                .map(timeout -> timeout.toHours() >= 8)
+                .orElse(false);
     }
 
     private List<QuarkusSecurityPermission> permissions() {

--- a/docs/QUARKUS-ADVISOR-CHECKS.md
+++ b/docs/QUARKUS-ADVISOR-CHECKS.md
@@ -3,11 +3,13 @@
 The Spring advisor panel, on Quarkus, runs a fixed, on-demand ruleset against the host application's
 **Quarkus idioms** — not the Spring application context. It reads build-time counts of CDI scope
 annotations, `@ConfigProperty` injection sites, `@ConfigMapping` interfaces, JAX-RS endpoints, reactive
-(`Uni`/`Multi`) signatures, `@Blocking` sites, `@Scheduled` methods, public mutable fields on JAX-RS
+(`Uni`/`Multi`) signatures, `@Blocking` sites, `@Scheduled` methods, `@RegisterRestClient` interfaces,
+`@RunOnVirtualThread`/`synchronized` combinations, the build JDK version, public mutable fields on JAX-RS
 resources, and shared mutable fields on `@ApplicationScoped` beans, plus active/`%prod.` profile keys
-(Hibernate schema strategy, datasource kind/URL, SQL logging, Dev Services, clustered scheduler) from
-MicroProfile config. It never intercepts live traffic, exposes config values, or modifies the
-application. Findings are heuristic review prompts; the right remediation depends on the application.
+(Hibernate schema strategy, datasource kind/URL, SQL logging, log level, Dev Services, clustered scheduler)
+and HTTP settings (response compression, graceful-shutdown timeout, REST client timeouts) from MicroProfile
+config. It never intercepts live traffic, exposes config values, or modifies the application. Findings are
+heuristic review prompts; the right remediation depends on the application.
 
 This is the Quarkus replacement for the Spring ruleset in [SPRING-CHECKS.md](SPRING-CHECKS.md): the panel
 and DTO are shared, but the rules are framework-specific (CDI/Arc, MicroProfile Config vs Spring beans), so
@@ -52,13 +54,20 @@ configuration is read ad hoc rather than through type-safe MicroProfile Config. 
 `%prod.quarkus.hibernate-orm.log.sql=true` logs every statement in production, hurting performance and
 risking sensitive data in logs. Disable SQL logging in `%prod`; enable it only in `%dev` when debugging.
 
+### QA-CFG-003 - Verbose log level in the prod profile (MEDIUM)
+`%prod.quarkus.log.level` resolves to `DEBUG`/`TRACE`/`ALL`, far more verbose than production needs; it
+hurts performance and risks leaking sensitive data into logs. Set `%prod.quarkus.log.level` to `INFO` or
+`WARN`; use `DEBUG`/`TRACE` only in `%dev`.
+
 ## Reactive
 
 ### QA-RX-001 - Reactive endpoints with a blocking JDBC datasource (INFO)
-Endpoints return `Uni`/`Multi` (run on the I/O event loop) and a blocking JDBC datasource is configured,
-yet no `@Blocking` guard was found; a JDBC call on the event loop stalls it. Annotate blocking work with
-`@Blocking`, or use a reactive datasource client. (Only raised when a JDBC datasource is present, so
-fully-reactive apps are not flagged.)
+One or more endpoints return `Uni`/`Multi` (run on the I/O event loop), and neither the method nor its
+declaring resource class carries a `@Blocking` guard, while a blocking JDBC datasource is configured; a
+JDBC call on the event loop stalls it. Annotate blocking work with `@Blocking`, or use a reactive datasource
+client. (Only raised when a JDBC datasource is present, so fully-reactive apps are not flagged. The check is
+correlated per endpoint — an unrelated `@Blocking` method elsewhere in the app does not suppress a finding on
+a genuinely unguarded reactive endpoint.)
 
 ## Scheduling
 
@@ -87,3 +96,38 @@ Point `%prod` at a real managed database (PostgreSQL, MySQL, …).
 No active profile and no `%prod.` overrides were found. This is fine when production config is externalised
 (env vars, Secrets/ConfigMaps); otherwise prod shares dev defaults. Add `%prod.` overrides (or externalise
 config) so production differs from dev defaults.
+
+## Web
+
+### QA-WEB-001 - HTTP response compression disabled (INFO)
+`quarkus.http.enable-compression` is not set (Quarkus's own default), so responses are not gzip/brotli
+-compressed, increasing bandwidth and latency for text-heavy payloads. Set
+`quarkus.http.enable-compression=true` (tune `quarkus.http.compress-media-types` if needed).
+
+### QA-WEB-002 - Graceful shutdown grace period zeroed (MEDIUM)
+`quarkus.shutdown.timeout` or `quarkus.http.shutdown.timeout` is explicitly set to `0`, disabling the
+graceful-shutdown grace period; in-flight requests are dropped instead of being allowed to complete on
+`SIGTERM`. Remove the override (or set a positive duration) so in-flight requests can drain before shutdown.
+
+### QA-WEB-003 - REST client without a connect/read timeout (MEDIUM)
+A `@RegisterRestClient` interface is declared, but no connect-timeout/read-timeout is configured anywhere.
+Unlike many HTTP client libraries, Quarkus REST clients have no default timeout, so a slow/hanging remote
+service can block a caller indefinitely. Set `quarkus.rest-client."<client-key>".connect-timeout` /
+`read-timeout`, or the global `quarkus.rest-client.connect-timeout` / `read-timeout`.
+
+## Performance
+
+### QA-PERF-001 - No virtual-thread adoption (INFO)
+The app declares JAX-RS endpoint(s) but none use `@RunOnVirtualThread` (checked only from JDK 21, when
+virtual threads became stable/mainstream). If any endpoint performs blocking I/O (JDBC, file access,
+blocking REST calls), running it on a virtual thread can improve throughput without sizing a worker thread
+pool. Annotate blocking I/O-bound endpoint methods (or the resource class) with `@RunOnVirtualThread`.
+
+### QA-PERF-002 - Virtual-thread pinning via synchronized (HIGH)
+**Quarkus/JDK-specific — no Spring equivalent.** One or more `@RunOnVirtualThread` methods are also declared
+`synchronized`. On JDK 21-23, entering a `synchronized` method or block pins the carrier thread instead of
+yielding it, defeating the scalability benefit of virtual threads under load; [JEP
+491](https://openjdk.org/jeps/491) removes this pinning starting in JDK 24. Replace `synchronized` with a
+`java.util.concurrent.locks.ReentrantLock`, or upgrade to JDK 24+. (Detected via the method's `synchronized`
+modifier; a `synchronized(lock) { }` block inside an otherwise-unsynchronized method is not visible to this
+build-time check.)

--- a/docs/QUARKUS-CHECKS.md
+++ b/docs/QUARKUS-CHECKS.md
@@ -2,12 +2,14 @@
 
 The Security panel, on Quarkus, runs a fixed, on-demand ruleset against the host application's
 **Quarkus security configuration** — not Spring Security. It reads the effective `quarkus.http.*`,
-`quarkus.oidc.*`, `quarkus.smallrye-jwt.*`, `quarkus.tls.*`, `quarkus.management.*` and related
-MicroProfile config, plus build-time counts of the standard authorization annotations (`@RolesAllowed`,
-`@PermitAll`, `@DenyAll`, `@Authenticated`) discovered in the application's own classes. It never
-intercepts live traffic, exposes credentials or secrets, or modifies the configuration. Findings are
-heuristic review prompts; the right remediation depends on the application's threat model and deployment
-topology.
+`quarkus.oidc.*`, `quarkus.smallrye-jwt.*`, `quarkus.tls.*`, `quarkus.management.*`,
+`quarkus.security.users.embedded.*`, `quarkus.rest-csrf.*` (the CSRF extension), `quarkus.grpc.server.*`,
+`quarkus.smallrye-graphql.*`, `quarkus-elytron-security-jdbc` principal-query settings, and Kafka/SmallRye
+Reactive Messaging channel security settings, plus build-time counts of the standard authorization
+annotations (`@RolesAllowed`, `@PermitAll`, `@DenyAll`, `@Authenticated`) discovered in the application's
+own classes. It never intercepts live traffic, exposes credentials or secrets, or modifies the
+configuration. Findings are heuristic review prompts; the right remediation depends on the application's
+threat model and deployment topology.
 
 This is the Quarkus replacement for the Spring ruleset in [SECURITY-CHECKS.md](SECURITY-CHECKS.md):
 the panel and DTO are shared, but the rules are framework-specific (Elytron/OIDC vs Spring Security),
@@ -21,6 +23,10 @@ counts are captured at build time; when an app has zero secured endpoints and no
 is itself a finding, not an unavailable panel. Missing/invalid values fail safe (counted as absent).
 Several rules are suppressed when the app is configured behind a TLS-terminating reverse proxy
 (`quarkus.http.proxy.proxy-address-forwarding=true`), since transport hardening then lives at the proxy.
+A handful of rules — marked **Quarkus-specific** below — have no Spring Security equivalent at all: they
+cover Quarkus-only capabilities (gRPC, GraphQL, SmallRye Reactive Messaging) or Quarkus-only footguns (the
+non-application root path). The rest are Quarkus ports of the same risk the Spring Security advisor
+already checks, adapted to Quarkus's own config keys and extensions.
 
 ## Severity scale
 
@@ -47,9 +53,10 @@ exposes JAX-RS endpoints. Add an auth mechanism (`quarkus-oidc`, `quarkus-smallr
 clear text. Set `insecure-requests=redirect` (or `disabled`) and configure SSL.
 
 ### QS-AUTH-003 - Form authentication without CSRF protection (HIGH)
-`quarkus.http.auth.form.enabled=true` (cookie-based login) without the `quarkus-csrf-reactive` extension
-leaves state-changing requests open to cross-site request forgery. Add `quarkus-csrf-reactive` and embed
-the CSRF token in forms.
+`quarkus.http.auth.form.enabled=true` (cookie-based login) without the `io.quarkus:quarkus-rest-csrf`
+extension (feature name `rest-csrf`) leaves state-changing requests open to cross-site request forgery. Add
+`quarkus-rest-csrf` and embed the CSRF token in forms. (Also fires when the extension is present but
+explicitly disabled via `quarkus.rest-csrf.enabled=false`.)
 
 ### QS-AUTH-004 - JWT verification without an expected issuer (MEDIUM)
 SmallRye JWT verification is configured without `mp.jwt.verify.issuer`, so tokens from any issuer signed
@@ -59,6 +66,36 @@ with a trusted key are accepted. Set `mp.jwt.verify.issuer` to the expected toke
 `quarkus.http.auth.proactive=false` defers authentication until a secured resource is hit. This is a valid
 pattern, but unannotated endpoints then run anonymously unless explicitly secured — pair it with
 deny-by-default (`quarkus.security.jaxrs.deny-unannotated-endpoints=true`).
+
+### QS-AUTH-006 - JWT unsigned tokens allowed (CRITICAL)
+`quarkus.smallrye-jwt.allow-unsigned-tokens=true` accepts JWTs with `alg=none`, meaning anyone can forge a
+token with an arbitrary payload and no signature at all. Remove the override; only allow unsigned tokens in
+a throwaway local dev profile, never in any deployed environment.
+
+### QS-AUTH-007 - Embedded properties-file users enabled (MEDIUM)
+`quarkus.security.users.embedded.enabled=true` authenticates against a static in-memory/properties-file
+user list — a convenience meant for demos/tests, not a real identity store. Use
+`quarkus-elytron-security-jdbc`/`quarkus-oidc` for real deployments; keep embedded users to `%dev`/`%test`.
+
+### QS-AUTH-008 - JWT verification without audience validation (MEDIUM)
+SmallRye JWT verification is configured without `mp.jwt.verify.audiences`, so a token minted for a different
+client/service by the same trusted issuer is still accepted. Set `mp.jwt.verify.audiences` to this
+service's expected audience(s).
+
+### QS-AUTH-009 - JWT public key configured inline (LOW)
+`mp.jwt.verify.publickey` holds a static inline key. Unlike a JWKS location, an inline key cannot be
+rotated without a redeploy. Prefer `mp.jwt.verify.publickey.location` pointing at a JWKS endpoint that
+supports rotation.
+
+### QS-AUTH-010 - JDBC identity store using clear-text password mapper (HIGH)
+A `quarkus-elytron-security-jdbc` `principal-query` uses the `clear-password-mapper`, meaning passwords are
+compared/stored in plain text rather than hashed. Switch to `bcrypt-password-mapper` (or another hashing
+mapper) and re-hash stored passwords.
+
+### QS-AUTH-011 - JDBC identity store bcrypt work-factor too low (MEDIUM)
+A `quarkus-elytron-security-jdbc` `principal-query`'s `bcrypt-password-mapper` work-factor is set below the
+default (10), weakening resistance to offline brute-force attacks. Remove the override, or raise it to at
+least the default of 10.
 
 ## Authorization
 
@@ -113,24 +150,51 @@ credentials.
 CORS allows credentials with a pinned origin but a wildcard `quarkus.http.cors.methods`/`headers` list,
 widening the cross-origin surface. List the exact methods and headers the client needs instead of `*`.
 
+### QS-CORS-004 - CORS regex origin pattern not anchored (MEDIUM)
+A `quarkus.http.cors.origins` entry uses the `/regex/` syntax without `^`/`$` anchors. Quarkus matches the
+pattern anywhere in the origin string rather than against the whole string, so e.g. `/example\.com/` also
+matches `https://evil-example.com.attacker.net`
+([quarkusio/quarkus#34718](https://github.com/quarkusio/quarkus/issues/34718)). Anchor the pattern with `^`
+and `$`, e.g. `/^https:\/\/(?:[a-z0-9-]+\.)*example\.com$/`.
+
 ## Headers
 
-### QS-HDR-001 - No security headers configured (LOW)
-No `Strict-Transport-Security` or `Content-Security-Policy` response headers are configured
-(`quarkus.http.header.*` absent). Add HSTS and CSP headers.
-
-### QS-HDR-002 - Weak Strict-Transport-Security policy (LOW)
+### QS-HDR-001 - Weak Strict-Transport-Security policy (LOW)
 The HSTS header has a `max-age` under one year or omits `includeSubDomains`, weakening HTTPS enforcement.
 Use `max-age=31536000` (1 year) and add `includeSubDomains`.
 
-### QS-HDR-003 - Missing clickjacking/MIME-sniffing headers (LOW)
-No `X-Frame-Options`/CSP `frame-ancestors` (clickjacking) or `X-Content-Type-Options=nosniff` (MIME
-sniffing) protection is configured. Add `X-Frame-Options=DENY` (or CSP `frame-ancestors 'none'`) and
-`X-Content-Type-Options=nosniff`.
-
-### QS-HDR-004 - Weak Content-Security-Policy (MEDIUM)
+### QS-HDR-002 - Weak Content-Security-Policy (MEDIUM)
 The CSP allows `'unsafe-inline'`/`'unsafe-eval'` or a wildcard `default-src`/`script-src`, undermining its
 XSS protection. Remove unsafe-inline/unsafe-eval and wildcard sources; use nonces/hashes for scripts.
+
+### QS-HDR-003 - Missing Strict-Transport-Security header (LOW)
+No `Strict-Transport-Security` response header is configured, so browsers fall back to trusting whatever
+scheme a link/redirect uses instead of enforcing HTTPS. Add
+`quarkus.http.header."Strict-Transport-Security".value=max-age=31536000; includeSubDomains`.
+
+### QS-HDR-004 - Missing Content-Security-Policy header (LOW)
+No `Content-Security-Policy` response header is configured, losing a defense-in-depth control against XSS
+and data-injection attacks. Add a CSP tailored to the app's script/style/asset origins.
+
+### QS-HDR-005 - Missing clickjacking protection (LOW)
+Neither `X-Frame-Options` nor a CSP `frame-ancestors` directive is configured, so the app can be embedded in
+a hidden/opaque iframe on an attacker's page (clickjacking). Add
+`quarkus.http.header."X-Frame-Options".value=DENY` (or a CSP `frame-ancestors 'none'`).
+
+### QS-HDR-006 - Missing X-Content-Type-Options header (LOW)
+No `X-Content-Type-Options=nosniff` response header is configured, allowing browsers to MIME-sniff
+responses and potentially execute content served with the wrong `Content-Type`. Add
+`quarkus.http.header."X-Content-Type-Options".value=nosniff`.
+
+### QS-HDR-007 - Missing Referrer-Policy header (INFO)
+No `Referrer-Policy` response header is configured, so browsers may forward the full request URL (including
+any sensitive query parameters) to third-party sites linked from the app. Add
+`quarkus.http.header."Referrer-Policy".value=strict-origin-when-cross-origin` (or stricter).
+
+### QS-HDR-008 - Missing Permissions-Policy header (INFO)
+No `Permissions-Policy` response header is configured, leaving browser features (camera, microphone,
+geolocation, …) at their default availability instead of explicitly disabled where unused. Add
+`quarkus.http.header."Permissions-Policy".value` listing only the features the app uses.
 
 ## Dev exposure
 
@@ -138,9 +202,10 @@ XSS protection. Remove unsafe-inline/unsafe-eval and wildcard sources; use nonce
 `quarkus.oidc.tls.verification=none` disables provider certificate validation. Sometimes used against a
 local dev provider, but must never reach production.
 
-### QS-DEV-002 - OpenAPI/Swagger UI always included (MEDIUM)
-`quarkus.swagger-ui.always-include=true` or `quarkus.smallrye-openapi.always-include=true` exposes API
-docs in all profiles, including production. Restrict to dev, or remove `always-include`.
+### QS-DEV-002 - OpenAPI/Swagger/GraphQL UI always included (MEDIUM)
+`quarkus.swagger-ui.always-include=true`, `quarkus.smallrye-openapi.always-include=true`, or
+`quarkus.smallrye-graphql.ui.always-include=true` exposes API docs and/or the GraphQL UI in all profiles,
+including production. Restrict to dev, or remove `always-include`.
 
 ## OIDC
 
@@ -160,8 +225,58 @@ The separate management interface (`quarkus.management.enabled=true`, health/met
 host, exposing it beyond the local machine. Bind `quarkus.management.host` to `127.0.0.1`, or protect the
 management endpoints.
 
+### QS-MGMT-002 - Non-application endpoints merged into the main application path (MEDIUM)
+**Quarkus-specific — no Spring equivalent.** `quarkus.http.non-application-root-path=/` collapses
+health/metrics/OpenAPI endpoints into the main application namespace instead of keeping them on the
+separate `/q` root, widening the app's exposed surface and risking accidental path collisions
+([quarkusio/quarkus#14800](https://github.com/quarkusio/quarkus/issues/14800)). Leave
+`non-application-root-path` at its default (`/q`), or use the separate management interface
+(`quarkus.management.enabled=true`) instead.
+
 ## Config hygiene
 
 ### QS-CFG-001 - Possible secret in configuration (CRITICAL)
 A config key looks like a password/secret/token set to a literal. Move to a vault/env var; never commit
 literals.
+
+## Session
+
+### QS-SESSION-001 - Form-auth session cookie not HttpOnly (HIGH)
+`quarkus.http.auth.form.http-only-cookie` defaults to `false` in Quarkus — unlike most frameworks — so the
+form-auth session cookie is readable from JavaScript; a single XSS bug is enough to steal the session. Set
+`quarkus.http.auth.form.http-only-cookie=true`.
+
+### QS-SESSION-002 - Form-auth session cookie SameSite=None (MEDIUM)
+`quarkus.http.auth.form.cookie-same-site` was weakened from the secure default (`strict`) to `none`, letting
+the session cookie be sent on cross-site requests (CSRF exposure). Remove the override (default `strict`),
+or use `lax` only if cross-site GET flows require it.
+
+### QS-SESSION-003 - Excessive form-auth session timeout (LOW)
+`quarkus.http.auth.form.timeout` is set above 8 hours, keeping an authenticated session alive long after a
+user has stepped away. Lower the timeout (the Quarkus default is 30 minutes) and pair it with
+`new-cookie-interval`.
+
+## gRPC
+
+### QS-GRPC-001 - gRPC server reflection enabled in the prod profile (MEDIUM)
+**Quarkus-specific — no Spring equivalent** (Spring has no first-party gRPC server support).
+`quarkus.grpc.server.enable-reflection-service` is enabled for the prod profile. Quarkus disables reflection
+in prod by default specifically so the full service/method/message schema isn't discoverable; an explicit
+override re-exposes it. Remove the `%prod` override; keep reflection enabled only in `%dev`/`%test`.
+
+## GraphQL
+
+### QS-GRAPHQL-001 - GraphQL schema introspection enabled (LOW)
+**Quarkus-specific — no Spring equivalent** (Spring has no first-party GraphQL server support).
+`quarkus.smallrye-graphql.introspection-enabled` defaults to `true` in every profile, including production,
+letting any client enumerate the full schema (types, fields, mutations). Often intentional for public APIs,
+but worth a deliberate decision. Set `quarkus.smallrye-graphql.introspection-enabled=false` in `%prod`
+unless the schema is meant to be publicly discoverable.
+
+## Messaging
+
+### QS-MSG-001 - Messaging credentials configured without an encrypted protocol (HIGH)
+**Quarkus-specific** (no Spring equivalent in the same idiomatic reactive-messaging form). A Kafka/SmallRye
+Reactive Messaging channel configures SASL credentials (username/password or JAAS config) without a
+corresponding `SASL_SSL`/`SSL` `security.protocol`, sending broker credentials in clear text over the wire.
+Set `security.protocol=SASL_SSL` (or `SSL`) alongside the SASL credentials.


### PR DESCRIPTION
## What does this PR do?

Audits and expands the two Quarkus advisors (QA-* app advisor, QS-* security advisor), fixes 3 bugs, and adds rules that are genuinely Quarkus-specific rather than straight Spring ports.

## Why is this change needed?

This is the first advisor audit run with Claude Sonnet 5. The goal was to validate the existing Quarkus advisor rules, bring them toward parity with the Spring and Spring Security advisors, and specifically find checks that reflect something Quarkus does differently (not just re-labelled Spring rules).

**Bug fixes:**
- QS-AUTH-003: CSRF detection was dead code and never fired
- QS-AUTHZ-003/004: `@DenyAll` sites weren't counted as secured endpoints
- QA-RX-001: blocking-JDBC check compared against the global endpoint count instead of the per-endpoint reactive/blocking split

**New rules:**
- Quarkus advisor (QA-*): 10 -> 16 rules (verbose log level in prod, compression/graceful-shutdown/REST-client-timeout hygiene, virtual-thread adoption/pinning)
- Quarkus Security advisor (QS-*): 25 -> 43 rules (JWT hardening, JDBC identity-store checks, CORS regex anchoring, fine-grained security headers, form-auth session hardening, management-endpoint merge risk)

Five of the new rules have no Spring equivalent at all: virtual-thread pinning (JEP 491), `quarkus.http.non-application-root-path` merging health/metrics into the app namespace, gRPC server reflection left on in prod, GraphQL schema introspection, and messaging SASL credentials configured without TLS.

**Note on rule IDs:** the whole Quarkus advisor surface is still unreleased (added in an unpublished commit, never tagged), so this PR keeps rule IDs dense instead of leaving permanent gaps -- the `QS-HDR-*` header rules and a leftover `QA-EP-001` placeholder were renumbered/removed rather than reserved, since nothing has ever shipped referencing them. This is not a breaking change for any consumer.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally (ran targeted reactor builds for `bootui-core`, `bootui-engine`, `bootui-quarkus`, `bootui-quarkus-deployment`, plus the `bootui-quarkus-integration-tests` `base` and `security` submodules)
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end -- not applicable, this PR only touches Quarkus-side advisor code; verified instead via the `@QuarkusTest` conformance/integration suites
- [x] Added or updated tests where applicable (full coverage for both scanners: 772 `bootui-engine` tests green)

## Screenshots (UI changes)

N/A - backend advisor rules and docs only, no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (`docs/QUARKUS-ADVISOR-CHECKS.md`, `docs/QUARKUS-CHECKS.md`)
- [x] Public API kept backward compatible, or a migration note added to the PR description (see rule-ID note above)
- [x] No secrets, tokens, or local paths committed