### PR TITLE
Fix Quarkus dev mode NPE in DevUI Welcome page

### DIFF
--- a/bootui-quarkus/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/bootui-quarkus/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,15 +1,20 @@
 name: BootUI
 description: Local-only developer console for Quarkus, served at /bootui (the Quarkus adapter over bootui-engine).
-# group-id/artifact-id make this hand-authored template a self-sufficient extension descriptor so the Dev UI's
-# DevUIProcessor.getExtensionNamespace (which needs `artifact` OR `group-id`+`artifact-id`) works even when the
-# quarkus-extension-maven-plugin's extension-descriptor goal did NOT run. A full Maven build runs that goal and
-# overwrites this file in target/classes with the resolved `artifact` GAV — but IntelliJ's native (JPS) builder
-# never runs Maven plugin goals (in any phase); it just copies src/main/resources verbatim into target/classes,
-# so without these keys the copied descriptor is GAV-less and quarkus:dev fails. Kept version-free (group-id +
-# artifact-id only, the published coordinates) so it can never go stale across releases; the build-time goal
-# still injects the full versioned `artifact` for real builds.
+# group-id/artifact-id/artifact make this hand-authored template a self-sufficient extension descriptor so it keeps
+# working even when the quarkus-extension-maven-plugin's extension-descriptor goal did NOT (re)run against this exact
+# file. A full Maven build (process-resources phase) runs that goal and overwrites this file in target/classes with
+# the resolved, correctly-versioned `artifact` GAV — but two other paths only ever copy src/main/resources verbatim
+# into target/classes, never invoking the plugin: IntelliJ's native (JPS) builder (any phase), and, more commonly,
+# Quarkus dev mode's own workspace-module reload for reactor dependencies (`quarkus:dev` recompiles/copies bootui-
+# quarkus's changed sources/resources directly, without re-running the Maven plugin goal, even with `-am`). Without
+# `artifact`, Quarkus DevUI's WelcomeProcessor NPEs on `extension.getArtifact().split(":")` (it has no null-safe
+# fallback to group-id/artifact-id, unlike DevUIProcessor.getExtensionNamespace) — so every `quarkus:dev` session
+# needs this field present, not just IDE builds. `artifact` below is a deliberately fake, version-free placeholder
+# (real Maven builds always regenerate it with the accurate versioned GAV); its only consumer here is the
+# groupId:artifactId key WelcomeProcessor derives from it, so the placeholder version can never go stale or mislead.
 group-id: com.julien-dubois.bootui
 artifact-id: bootui-quarkus
+artifact: "com.julien-dubois.bootui:bootui-quarkus::jar:0"
 metadata:
   keywords:
     - bootui


### PR DESCRIPTION
## What does this PR do?

Fixes a `NullPointerException` in Quarkus DevUI's Welcome page that breaks `quarkus:dev` for `bootui-quarkus-sample-app`.

## Why is this change needed?

`quarkus:dev` never re-invokes the `quarkus-extension-maven-plugin`'s `extension-descriptor` goal against `bootui-quarkus`'s reactor module for live-coding purposes -- it just copies `src/main/resources` -> `target/classes` verbatim, the same fallback path already documented in this file for IntelliJ's JPS builder. Since the checked-in `quarkus-extension.yaml` template only had `group-id`/`artifact-id` (no `artifact` field), Quarkus DevUI's `WelcomeProcessor` NPEs on `extension.getArtifact().split(":")`: unlike `DevUIProcessor`'s namespace lookup, `WelcomeProcessor` has no fallback to `group-id`/`artifact-id`.

This happens on every `quarkus:dev` session regardless of JDK version, IDE vs CLI, or `-am` reactor flags, because the plugin goal simply doesn't re-run for reactor dependencies during dev-mode's incremental reload.

Fix: add a static placeholder `artifact` field to the template so it's never null during dev mode. A real Maven build (`process-resources` phase) still overwrites the whole file with the accurate, correctly-versioned GAV, so this placeholder never goes stale or affects published artifacts.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Started `bootui-quarkus-sample-app` via `quarkus:dev` (JDK 21) and verified `/bootui` loads (HTTP 200) without the previous NPE crashing the build
- [x] Added or updated tests where applicable (N/A - this is a static resource fix, no code paths to unit test)

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - internal comment updated in the fixed file itself)
- [x] Public API kept backward compatible, or a migration note added to the PR description (no API changes)
- [x] No secrets, tokens, or local paths committed