### PR TITLE
Serve BootUI at /bootui without a trailing slash on Quarkus

### DIFF
--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -94,7 +94,11 @@ import org.jboss.jandex.Type;
  *
  * <p>The shared Vue bundle under {@code META-INF/resources/bootui/} is served by Quarkus' static-resource
  * handler regardless of launch mode; suppressing even the static shell in production is a follow-up to
- * this tracer bullet (the data-bearing {@code /bootui/api/**} endpoints are already prod-gated here).</p>
+ * this tracer bullet (the data-bearing {@code /bootui/api/**} endpoints are already prod-gated here). The
+ * static handler only answers the directory index {@code /bootui/} (trailing slash); {@code /bootui}
+ * without the trailing slash previously 404'd, so {@code QuarkusIndexResource} — a {@code @Path("/bootui")}
+ * JAX-RS resource discovered from the same indexed jar and therefore gated identically to the rest of the
+ * console — answers it directly instead of redirecting (see its Javadoc).</p>
  */
 class BootUiQuarkusProcessor {
 

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusTracerBulletSmokeTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusTracerBulletSmokeTest.java
@@ -38,6 +38,22 @@ class BootUiQuarkusTracerBulletSmokeTest {
     }
 
     @Test
+    void sharedUiBundleIsAlsoServedWithoutTrailingSlash() {
+        // Quarkus' static-resource handler only answers /bootui/ (the directory index); without
+        // QuarkusIndexResource, GET /bootui (no trailing slash) 404'd. See the class Javadoc.
+        Response response = probe().get("/bootui");
+        assertThat(response.status())
+                .as("GET /bootui (no trailing slash) should serve the shared Vue bundle's index.html")
+                .isEqualTo(200);
+        assertThat(response.contentType().toLowerCase())
+                .as("GET /bootui content-type (%s)", response.contentType())
+                .contains("text/html");
+        assertThat(response.body())
+                .as("GET /bootui body should carry a <base href> so relative assets/API resolve")
+                .contains("<base href=\"/bootui/\" />");
+    }
+
+    @Test
     void heapDumpPanelAnswersItsPrimaryGet() {
         Response response = probe().get("/bootui/api/heap-dump");
         assertThat(response.status()).as("GET /bootui/api/heap-dump status").isEqualTo(200);

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusIndexResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusIndexResource.java
@@ -1,0 +1,97 @@
+package io.github.jdubois.bootui.quarkus.web;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Serves the BootUI single-page application shell at {@code /bootui} (no trailing slash).
+ *
+ * <p>Quarkus' static-resource handler already serves the compiled Vue assets shipped inside
+ * {@code bootui-ui} at {@code META-INF/resources/bootui/} — including {@code index.html} at
+ * {@code /bootui/} (with the trailing slash) — but it does not redirect or otherwise resolve a request
+ * for the bare directory path {@code /bootui}, which previously 404'd. The generated {@code index.html}
+ * references its assets relatively (e.g. {@code ./assets/index-*.js}) and the SPA calls its API relatively
+ * (e.g. {@code fetch('api/overview')}), so those relative URLs only resolve correctly once the document's
+ * base URL ends in {@code /bootui/}.</p>
+ *
+ * <p>Rather than {@code 302}-redirect {@code /bootui -> /bootui/} (which a proxy that strips trailing
+ * slashes could turn into an infinite loop, see the Spring adapter's {@code BootUiIndexController} and
+ * #456), this JAX-RS resource answers {@code GET /bootui} directly with the same SPA shell and injects a
+ * {@code <base href="{requestPath}/">} tag, mirroring the Spring adapter exactly. The
+ * {@code quarkus.http.root-path} prefix (if any) is already part of {@code UriInfo#getRequestUri()}, so the
+ * injected base href is correct under a non-default root-path without reading config directly.</p>
+ */
+@Path("/bootui")
+public class QuarkusIndexResource {
+
+    static final String INDEX_LOCATION = "META-INF/resources/bootui/index.html";
+
+    private static final Pattern HEAD_OPEN = Pattern.compile("(?i)<head[^>]*>");
+
+    private static final Pattern EXISTING_BASE = Pattern.compile("(?i)<base\\b");
+
+    private volatile String cachedTemplate;
+
+    @GET
+    public Response index(@Context UriInfo uriInfo) {
+        String path = uriInfo.getRequestUri().getRawPath();
+        String baseHref = path.endsWith("/") ? path : path + "/";
+        String html = injectBaseHref(template(), baseHref);
+        return Response.ok(html, MediaType.TEXT_HTML_TYPE).build();
+    }
+
+    private String template() {
+        String html = cachedTemplate;
+        if (html == null) {
+            html = readTemplate();
+            cachedTemplate = html;
+        }
+        return html;
+    }
+
+    private static String readTemplate() {
+        try (InputStream in = QuarkusIndexResource.class.getClassLoader().getResourceAsStream(INDEX_LOCATION)) {
+            if (in == null) {
+                throw new UncheckedIOException(new IOException("BootUI index.html not found at " + INDEX_LOCATION));
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            throw new UncheckedIOException("Unable to read BootUI index.html from " + INDEX_LOCATION, ex);
+        }
+    }
+
+    /**
+     * Inserts a {@code <base href>} as the first child of {@code <head>} so it precedes every relative
+     * asset/API URL in the document. Returns the markup unchanged when it already declares a
+     * {@code <base>} tag or has no {@code <head>}.
+     */
+    static String injectBaseHref(String html, String baseHref) {
+        if (EXISTING_BASE.matcher(html).find()) {
+            return html;
+        }
+        Matcher matcher = HEAD_OPEN.matcher(html);
+        if (!matcher.find()) {
+            return html;
+        }
+        int insertAt = matcher.end();
+        String baseTag = "\n    <base href=\"" + escapeAttribute(baseHref) + "\" />";
+        return html.substring(0, insertAt) + baseTag + html.substring(insertAt);
+    }
+
+    private static String escapeAttribute(String value) {
+        return value.replace("&", "&amp;")
+                .replace("\"", "&quot;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
+    }
+}

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/QuarkusIndexResourceTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/QuarkusIndexResourceTest.java
@@ -1,0 +1,44 @@
+package io.github.jdubois.bootui.quarkus.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link QuarkusIndexResource#injectBaseHref}, mirroring the Spring adapter's
+ * {@code BootUiIndexControllerTests} base-href-injection coverage.
+ */
+class QuarkusIndexResourceTest {
+
+    @Test
+    void injectsBaseTagAfterHeadAndBeforeRelativeUrls() {
+        String html = "<html><head>\n<link href=\"./favicon.svg\" /></head><body></body></html>";
+
+        String result = QuarkusIndexResource.injectBaseHref(html, "/bootui/");
+
+        assertThat(result).contains("<base href=\"/bootui/\" />");
+        assertThat(result.indexOf("<base")).isGreaterThan(result.indexOf("<head"));
+        assertThat(result.indexOf("<base")).isLessThan(result.indexOf("./favicon.svg"));
+    }
+
+    @Test
+    void leavesMarkupUnchangedWhenBaseTagAlreadyPresent() {
+        String html = "<html><head><base href=\"/existing/\" /></head><body></body></html>";
+
+        assertThat(QuarkusIndexResource.injectBaseHref(html, "/bootui/")).isEqualTo(html);
+    }
+
+    @Test
+    void leavesMarkupUnchangedWhenNoHeadElement() {
+        String html = "<html><body>no head here</body></html>";
+
+        assertThat(QuarkusIndexResource.injectBaseHref(html, "/bootui/")).isEqualTo(html);
+    }
+
+    @Test
+    void escapesBaseHrefAttributeValue() {
+        String result = QuarkusIndexResource.injectBaseHref("<head></head>", "/a\"b/");
+
+        assertThat(result).contains("/a&quot;b/");
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes `GET /bootui` (no trailing slash) returning an error on the Quarkus adapter; only `/bootui/` worked before.

## Why is this change needed?

Quarkus' static-resource handler (which serves the shared Vue bundle shipped in `bootui-ui`) only answers the directory index `/bootui/`; it does not resolve the bare `/bootui` path the way a typical static file server would, so users had to remember to type the trailing slash.

Closes #

## How it was fixed

Added `QuarkusIndexResource`, a thin `@Path("/bootui")` JAX-RS resource that answers the bare path directly with the SPA shell and injects a `<base href="/bootui/">` tag so the shell's relative asset/API URLs still resolve. This mirrors the Spring adapter's existing `BootUiIndexController`, which deliberately serves the shell for both `/bootui` and `/bootui/` instead of issuing a `302` redirect (a redirect can turn into an infinite loop behind a proxy that strips trailing slashes -- see #456 on the Spring side).

The resource is discovered from the same indexed extension jar as the rest of the console, so it stays gated to dev/test launch modes exactly like every other BootUI Quarkus endpoint (prod-dark by default).

## How was it tested?

- [x] `./mvnw clean install` passes locally for the affected modules (`bootui-core`, `bootui-engine`, `bootui-conformance`, `bootui-quarkus`, `bootui-quarkus-deployment`, `bootui-quarkus-integration-tests`)
- [x] Added a `@QuarkusTest` smoke test asserting `GET /bootui` (no slash) now returns 200 with the injected `<base href>`, alongside the existing `/bootui/` coverage
- [x] Added unit tests for the `<base href>` injection helper, mirroring the Spring adapter's tests
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (Spring side is unaffected by this change; not re-verified)

## Screenshots (UI changes)

N/A - no visible UI change, just a routing/serving fix.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (existing docs already reference `/bootui` without a trailing slash; this fix makes the behavior match)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed