### PR TITLE
Fix broken javadoc @link references causing CI warnings

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/agent/AgentSessionStore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/agent/AgentSessionStore.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * configurable debounce, then notifies subscribers. When the directory does not
  * exist on startup the thread polls every five seconds until it appears.</p>
  *
- * <p>Subclasses ({@link CopilotSessionStore}, {@link ClaudeCodeSessionStore}) supply
+ * <p>Subclasses ({@code CopilotSessionStore}, {@code ClaudeCodeSessionStore} in the Spring adapter) supply
  * agent-specific {@link AgentSessionProperties} configuration; all parsing and
  * dashboard logic is shared.</p>
  */

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/package-info.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/package-info.java
@@ -8,6 +8,6 @@
  * Each adapter constructs and wires them explicitly (Spring through an {@code @Bean} factory, Quarkus
  * through {@code @Produces}), injecting already-resolved optional handles so the engine never
  * statically references an optional dependency. The boundary is enforced by
- * {@link io.github.jdubois.bootui.engine.EngineBoundaryArchitectureTests}.
+ * {@code io.github.jdubois.bootui.engine.EngineBoundaryArchitectureTests}.
  */
 package io.github.jdubois.bootui.engine;

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/sqltrace/SqlTracedDataSource.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/sqltrace/SqlTracedDataSource.java
@@ -4,6 +4,6 @@ import javax.sql.DataSource;
 
 /**
  * Marker interface mixed into BootUI's traced {@link DataSource} proxies so the
- * {@link SqlTraceDataSourceBeanPostProcessor} never double-wraps a data source.
+ * {@code SqlTraceDataSourceBeanPostProcessor} (Spring adapter) never double-wraps a data source.
  */
 public interface SqlTracedDataSource {}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/sqltrace/SqlTracingProxies.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/sqltrace/SqlTracingProxies.java
@@ -35,7 +35,7 @@ import javax.sql.DataSource;
  * <p><b>GraalVM:</b> each proxy is created over a fixed set of standard JDBC API
  * interfaces (rather than every interface of the concrete driver/pool class) so
  * the proxy classes are known at build time and can be registered as native-image
- * proxy metadata by {@link SqlTraceRuntimeHints}. The trade-off is that callers who
+ * proxy metadata by {@code SqlTraceRuntimeHints} (Spring adapter). The trade-off is that callers who
  * cast a connection/statement directly to a driver-specific type must instead go
  * through {@code unwrap(...)}, which the proxy delegates to the real object.</p>
  */

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/package-info.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/package-info.java
@@ -7,6 +7,6 @@
  * must never reference a host-framework or transport API. Their method signatures may use only BootUI
  * core DTOs, neutral {@code jakarta.*} contracts that every framework shares (e.g.
  * {@code jakarta.persistence}, {@code jakarta.sql}) and Micrometer. The boundary is enforced by
- * {@link io.github.jdubois.bootui.spi.SpiBoundaryArchitectureTests}.
+ * {@code io.github.jdubois.bootui.spi.SpiBoundaryArchitectureTests}.
  */
 package io.github.jdubois.bootui.spi;

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiEngineProducer.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiEngineProducer.java
@@ -651,7 +651,8 @@ public class BootUiEngineProducer {
 
     /**
      * The Dev Services panel report assembler. The engine {@link DevServicesReportService} owns only the
-     * framework-neutral sort + count + wrap; {@link QuarkusDevServicesProvider} supplies the build-time-captured
+     * framework-neutral sort + count + wrap; {@link io.github.jdubois.bootui.quarkus.devservices.QuarkusDevServicesProvider}
+     * supplies the build-time-captured
      * services (masked) and presence flags. The concrete provider is injected (not the SPI) so resolution can
      * never become ambiguous, mirroring the other producers.
      */


### PR DESCRIPTION
## Why

The release build (https://github.com/jdubois/boot-ui/actions/runs/28515246386) reported 20 warnings, all `Tag @link: reference not found` javadoc issues.

## What

Each broken `@link` pointed at a class that isn't visible on the javadoc classpath being built:

- `bootui-engine` linking to Spring-adapter-only classes (`SqlTraceDataSourceBeanPostProcessor`, `SqlTraceRuntimeHints`, `CopilotSessionStore`, `ClaudeCodeSessionStore`) - the engine module correctly does not depend on the Spring adapter, so these can never resolve from there.
- `package-info.java` files linking to test-scope ArchUnit classes (`SpiBoundaryArchitectureTests`, `EngineBoundaryArchitectureTests`), which aren't included in the main javadoc.
- `bootui-quarkus`'s `BootUiEngineProducer` referencing `QuarkusDevServicesProvider` by simple name without an import, which javadoc can't resolve.

Replaced the unresolvable `{@link}` tags with `{@code}` (or a fully-qualified `{@link}` for the same-reactor Quarkus case) so the prose still reads clearly, without javadoc failing to link it.

## Verification

Ran `./mvnw -pl bootui-engine,bootui-quarkus -am -Dmaven.test.skip=true javadoc:javadoc` before and after - confirmed the 20 `Tag @link` warnings are gone (only unrelated, pre-existing JVM/native-access noise remains). Also ran `spotless:apply`, which made no additional changes.