### PR TITLE
Stop publishing demo/test modules to Maven Central

### DIFF
--- a/bootui-quarkus-integration-tests/pom.xml
+++ b/bootui-quarkus-integration-tests/pom.xml
@@ -19,6 +19,10 @@
         (otel, health, micrometer, scheduler, cache, flyway, liquibase, datasource). The Hibernate module also
         lives here but is wired into the reactor only on a Hibernate-capable JDK (see the root pom profile).</description>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <modules>
         <module>base</module>
         <module>otel</module>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,14 @@
         <native-build-tools-plugin.version>1.1.3</native-build-tools-plugin.version>
         <archunit.version>1.4.2</archunit.version>
         <central.autoPublish>true</central.autoPublish>
+        <!--
+            central-publishing-maven-plugin does NOT honor maven.deploy.skip (it implements its own
+            skip mechanism). Default it here so every module inherits it, then tie the plugin's own
+            <skip> to it below - modules that already set <maven.deploy.skip>true</maven.deploy.skip>
+            (sample apps, integration tests, conformance) now also skip Central publishing instead of
+            silently uploading multi-hundred-MB fat jars on every release.
+        -->
+        <maven.deploy.skip>false</maven.deploy.skip>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
@@ -228,6 +236,7 @@
                     <configuration>
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>${central.autoPublish}</autoPublish>
+                        <skip>${maven.deploy.skip}</skip>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## What does this PR do?

Fixes Maven Central publishing so demo/test-support modules (sample apps, Quarkus integration tests, the conformance test-support module) are no longer uploaded on every release.

## Why is this change needed?

An audit of the ~855 MB / 1890 files / 15 releases warning found that `central-publishing-maven-plugin` does **not** honor `maven.deploy.skip` (it implements its own skip mechanism). As a result `bootui-sample-app`, `bootui-quarkus-sample-app`, `bootui-quarkus-integration-tests`, and `bootui-conformance` were silently published on every release despite already setting `maven.deploy.skip=true`.

Since 1.3.0, the sample app's published artifact is a ~112 MB Spring Boot fat jar (full `BOOT-INF/lib/` dependency tree bundled in), and it alone accounts for ~750 MB (92%) of BootUI's current Central footprint across 7 releases.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Verified via `help:evaluate -Dexpression=maven.deploy.skip -Prelease` that publishable modules (e.g. `bootui-core`) resolve `false` and demo/test modules resolve `true`
- [x] Verified via `help:effective-pom -Prelease` that `central-publishing-maven-plugin` now gets `<skip>true</skip>` for demo/test modules and `<skip>false</skip>` for publishable ones
- [x] `spotless:check` passes
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (not applicable - build/release plumbing only, no runtime behavior change)

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (not needed - internal release plumbing only)
- [x] Public API kept backward compatible, or a migration note added to the PR description (no API changes)
- [x] No secrets, tokens, or local paths committed

## Implementation

- Root `pom.xml`: default `maven.deploy.skip=false`, and wire `central-publishing-maven-plugin`'s own `<skip>` to that same property so any module already opting out of `maven-deploy-plugin` also opts out of Central publishing.
- `bootui-quarkus-integration-tests/pom.xml`: added the missing `maven.deploy.skip=true` (it had none before) for consistency with the other test/demo modules.

Note: this stops the bleeding for future releases but does not retroactively shrink what is already published (Central artifacts are immutable). A follow-up may be to file a takedown request with Sonatype Central Support for the already-published oversized sample-app versions (1.3.0-1.7.0, ~750 MB).