### PR TITLE
Fix stale Quarkus version in docs; guard release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,8 @@ jobs:
           export VERSION
           perl -0pi -e 's{(<artifactId>bootui-spring-boot-starter</artifactId>\s*<version>)[^<]*(</version>)}{$1$ENV{VERSION}$2}g' README.md docs/SETUP.md
           perl -0pi -e 's{(com\.julien-dubois\.bootui:bootui-spring-boot-starter:)[0-9][0-9A-Za-z.\-]*}{$1$ENV{VERSION}}g' docs/SETUP.md
+          perl -0pi -e 's{(<artifactId>bootui-quarkus</artifactId>\s*<version>)[^<]*(</version>)}{$1$ENV{VERSION}$2}g' README.md docs/SETUP.md
+          perl -0pi -e 's{(com\.julien-dubois\.bootui:bootui-quarkus:)[0-9][0-9A-Za-z.\-]*}{$1$ENV{VERSION}}g' docs/SETUP.md
 
           if ! grep -q "<version>$VERSION</version>" docs/SETUP.md; then
             echo "::error::Failed to update the bootui-spring-boot-starter version in docs/SETUP.md to $VERSION"
@@ -116,6 +118,19 @@ jobs:
 
           if ! grep -q "com.julien-dubois.bootui:bootui-spring-boot-starter:$VERSION" docs/SETUP.md; then
             echo "::error::Failed to update the Gradle bootui-spring-boot-starter version in docs/SETUP.md to $VERSION"
+            exit 1
+          fi
+
+          if ! grep -q "com.julien-dubois.bootui:bootui-quarkus:$VERSION" docs/SETUP.md; then
+            echo "::error::Failed to update the Gradle bootui-quarkus version in docs/SETUP.md to $VERSION"
+            exit 1
+          fi
+
+          # Belt-and-braces: fail the release if any other declared dependency/plugin
+          # version string still points at the previous release version anywhere in the
+          # docs site or README, so a missed replacement can't silently ship stale docs.
+          if grep -RnE "com\.julien-dubois\.bootui:[A-Za-z0-9_-]+:$CURRENT_VERSION" README.md docs/; then
+            echo "::error::Found leftover references to the previous version ($CURRENT_VERSION) in docs/README after bumping to $VERSION"
             exit 1
           fi
 
@@ -299,13 +314,24 @@ jobs:
           set -euo pipefail
 
           TAG="${PREPARED_TAG:?PREPARED_TAG was not set by the prepare step}"
+          VERSION="${TAG#v}"
+
+          # Fail fast if versions:set (run with -DprocessAllModules=true, so it walks every
+          # pom.xml in the tree regardless of nesting depth) missed a module: a stale nested
+          # pom (e.g. under bootui-quarkus-integration-tests/*/pom.xml) would otherwise slip
+          # through a shallow */pom.xml glob undetected.
+          stale_poms="$(git ls-files '*pom.xml' | xargs -I{} sh -c "grep -q '<version>$VERSION</version>' '{}' || echo '{}'")"
+          if [[ -n "$stale_poms" ]]; then
+            echo "::error::The following poms were not bumped to $VERSION:"
+            echo "$stale_poms"
+            exit 1
+          fi
 
           if [[ -n "$(git status --porcelain)" ]]; then
-            git add pom.xml */pom.xml README.md docs/SETUP.md \
-              package.json package-lock.json \
-              bootui-ui/src/main/frontend/package.json bootui-ui/src/main/frontend/package-lock.json \
-              bootui-spring-sample-app/e2e/package.json bootui-spring-sample-app/e2e/package-lock.json \
-              bootui-quarkus-sample-app/e2e/package.json bootui-quarkus-sample-app/e2e/package-lock.json
+            # Stage every tracked file the version bump touched, at any depth, instead of an
+            # explicit path list: an explicit shallow glob (e.g. */pom.xml) silently misses
+            # nested poms that versions:set still updates in the working tree.
+            git add -u
             git commit -m "Release $TAG"
           else
             echo "Project files already declare the released version; tagging current HEAD."

--- a/bootui-quarkus-integration-tests/base/pom.xml
+++ b/bootui-quarkus-integration-tests/base/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/cache/pom.xml
+++ b/bootui-quarkus-integration-tests/cache/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/datasource/pom.xml
+++ b/bootui-quarkus-integration-tests/datasource/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/flyway/pom.xml
+++ b/bootui-quarkus-integration-tests/flyway/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/health/pom.xml
+++ b/bootui-quarkus-integration-tests/health/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/hibernate/pom.xml
+++ b/bootui-quarkus-integration-tests/hibernate/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/liquibase/pom.xml
+++ b/bootui-quarkus-integration-tests/liquibase/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/micrometer/pom.xml
+++ b/bootui-quarkus-integration-tests/micrometer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/otel/pom.xml
+++ b/bootui-quarkus-integration-tests/otel/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/scheduler/pom.xml
+++ b/bootui-quarkus-integration-tests/scheduler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/bootui-quarkus-integration-tests/security/pom.xml
+++ b/bootui-quarkus-integration-tests/security/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
         <artifactId>bootui-parent</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -205,7 +205,7 @@ Add the BootUI Quarkus extension to your build — nothing else is required. Boo
 <dependency>
   <groupId>com.julien-dubois.bootui</groupId>
   <artifactId>bootui-quarkus</artifactId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
 </dependency>
 ```
 
@@ -213,12 +213,12 @@ Add the BootUI Quarkus extension to your build — nothing else is required. Boo
 
 ```groovy
 // Groovy DSL (build.gradle)
-implementation 'com.julien-dubois.bootui:bootui-quarkus:1.7.0'
+implementation 'com.julien-dubois.bootui:bootui-quarkus:1.8.0'
 ```
 
 ```kotlin
 // Kotlin DSL (build.gradle.kts)
-implementation("com.julien-dubois.bootui:bootui-quarkus:1.7.0")
+implementation("com.julien-dubois.bootui:bootui-quarkus:1.8.0")
 ```
 
 :::


### PR DESCRIPTION
## What does this PR do?

Fixes the stale `bootui-quarkus:1.7.0` reference left in `docs/SETUP.md` after the 1.8.0 release, bumps 11 stale `bootui-quarkus-integration-tests/*/pom.xml` parent versions, and hardens the release workflow so these gaps can't recur.

## Why is this change needed?

Two bugs in `.github/workflows/release.yml` caused version drift on the 1.8.0 release:

1. The version-bump `perl` script only replaced `bootui-spring-boot-starter` coordinates, so the Quarkus Maven/Gradle snippets in `docs/SETUP.md` were never updated and kept advertising 1.7.0.
2. `versions:set -DprocessAllModules=true` correctly bumps every `pom.xml` in the tree, but the commit step only staged `pom.xml */pom.xml` (one level deep), so nested poms under `bootui-quarkus-integration-tests/*/pom.xml` were bumped in the working tree but never committed, leaving them at 1.7.0.

Closes #

## How was it tested?

- [x] `./mvnw -B -ntp spotless:check` passes locally
- [x] Simulated the new stale-pom detection logic in a scratch git repo to confirm it catches a missed nested pom and passes when all poms are bumped
- [x] Validated `release.yml` YAML with `ruby -ryaml`
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (docs/workflow-only change, not applicable)

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

### Details

- `docs/SETUP.md`: bump Quarkus Maven/Gradle snippets to 1.8.0.
- `bootui-quarkus-integration-tests/*/pom.xml` (11 modules): bump stale `bootui-parent` version to 1.8.0.
- `release.yml`:
  - Also replace `bootui-quarkus` coordinates in `README.md`/`docs/SETUP.md` during version prep, with a hard failure if the Gradle Quarkus coordinate isn't bumped.
  - Fail the release if any `com.julien-dubois.bootui:*:<old-version>` reference remains anywhere in `docs/` or `README.md` after bumping (belt-and-braces safety net).
  - Fail the release if any tracked `pom.xml` (found via `git ls-files`, any depth) wasn't bumped to the target version.
  - Replace the explicit shallow `git add` path list with `git add -u` so every modified tracked file is staged for the release commit regardless of nesting depth.