### PR TITLE
Pentesting sanity pass: fix residual evidence-truncation bug in ReconActuatorEndpointsCheck

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingCheckSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingCheckSupport.java
@@ -7,7 +7,10 @@ import java.util.Map;
 
 final class PentestingCheckSupport {
 
-    private static final int MAX_EVIDENCE_CHARS = 240;
+    // Package-visible (not private): AbstractActuatorEndpointCheck reads this to size its own
+    // "Detected mapping(s)" list so it can never push fixed context past this same cap (see its
+    // boundedMappingList) instead of relying on this class's blind tail-truncation below.
+    static final int MAX_EVIDENCE_CHARS = 240;
 
     private PentestingCheckSupport() {}
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingChecks.java
@@ -1878,9 +1878,34 @@ abstract class AbstractActuatorEndpointCheck extends AbstractPentestingCheck {
         if (matched.isEmpty()) {
             return List.of();
         }
-        String evidence =
-                riskContext() + " Detected mapping(s): " + String.join(", ", matched) + "." + extraEvidence(context);
+        String prefix = riskContext() + " Detected mapping(s): ";
+        String trailer = "." + extraEvidence(context);
+        String evidence = prefix + boundedMappingList(matched, prefix.length() + trailer.length()) + trailer;
         return List.of(finding(definition(), severity(context), definition().target(), evidence));
+    }
+
+    /**
+     * Bounds the rendered mapping list so a check with several matched endpoints (only {@code
+     * ReconActuatorEndpointsCheck} lists more than one) can never silently push the fixed risk-context/
+     * security-posture text past the shared {@code PentestingCheckSupport#MAX_EVIDENCE_CHARS}-char evidence
+     * cap. Rather than relying on that cap's blind tail-truncation — which previously dropped later-matched
+     * endpoint names and even the trailing security-posture note without any indication — this shows as many
+     * matches as fit and collapses the rest into an explicit "(+N more)" count.
+     */
+    private static String boundedMappingList(List<String> matched, int fixedTextLength) {
+        int budget = PentestingCheckSupport.MAX_EVIDENCE_CHARS - fixedTextLength;
+        String full = String.join(", ", matched);
+        if (full.length() <= budget) {
+            return full;
+        }
+        for (int shown = matched.size() - 1; shown > 0; shown--) {
+            String candidate =
+                    String.join(", ", matched.subList(0, shown)) + " (+" + (matched.size() - shown) + " more)";
+            if (candidate.length() <= budget) {
+                return candidate;
+            }
+        }
+        return matched.size() + " endpoint(s) matched";
     }
 
     protected abstract String riskContext();
@@ -2257,7 +2282,10 @@ final class ReconActuatorEndpointsCheck extends AbstractActuatorEndpointCheck {
 
     @Override
     protected String riskContext() {
-        return "These endpoints reveal the bean graph, schedules, dependency versions, and migration history for reconnaissance.";
+        // Kept short deliberately: with up to nine possible matches, a verbose risk context leaves too
+        // little budget for boundedMappingList to show any matches before the security-posture note
+        // (see the recommendation above for the full list of what each endpoint reveals).
+        return "These endpoints reveal internals useful for reconnaissance.";
     }
 
     @Override

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/pentesting/PentestingScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/pentesting/PentestingScannerTests.java
@@ -350,6 +350,47 @@ class PentestingScannerTests {
     }
 
     @Test
+    void reconActuatorEndpointsBoundsItsMappingListInsteadOfLettingEvidenceTruncationDropSecurityContext() {
+        // All 9 recon suffixes at once (e.g. management.endpoints.web.exposure.include=*) is the realistic
+        // worst case: before AbstractActuatorEndpointCheck bounded its own mapping list, the shared 240-char
+        // evidence cap silently truncated the tail of this evidence, dropping later endpoint names and even
+        // the trailing "no Spring Security filter chain" note that explains the MEDIUM severity below.
+        PentestingEndpointInventory endpoints = new PentestingEndpointInventory(
+                0,
+                List.of(
+                        "/actuator/beans",
+                        "/actuator/conditions",
+                        "/actuator/scheduledtasks",
+                        "/actuator/startup",
+                        "/actuator/metrics",
+                        "/actuator/auditevents",
+                        "/actuator/sbom",
+                        "/actuator/flyway",
+                        "/actuator/liquibase"),
+                java.util.Set.of(),
+                "/actuator");
+        // No Spring Security filter chain present: securityConfigured(context) is false.
+        PentestingSecurityStatus noSecurity = new PentestingSecurityStatus(false, 0, 0, 0, null, false);
+        PentestingObservation observation = observation(endpoints, noSecurity, defaultConfig(), "8123", "");
+
+        PentestingReport report =
+                scanner(new CapturingLocalHttpClient(), observation).scan();
+
+        assertThat(report.findings())
+                .filteredOn(finding -> "PT-A05-055".equals(finding.id()))
+                .singleElement()
+                .satisfies(finding -> {
+                    assertThat(finding.severity()).isEqualTo("MEDIUM");
+                    assertThat(finding.evidence())
+                            .hasSizeLessThanOrEqualTo(240)
+                            .contains("/actuator/beans")
+                            .contains("more)")
+                            .contains(
+                                    "No Spring Security filter chain was detected, so the mapping is likely reachable unauthenticated.");
+                });
+    }
+
+    @Test
     void everyActiveCheckExposesAnHttpsLearnMoreUrl() {
         assertThat(PentestingCheckRegistry.activeChecks())
                 .allSatisfy(check -> assertThat(check.definition().learnMoreUrl())

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/pentesting/SpringPentestingObservationCollectorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/pentesting/SpringPentestingObservationCollectorTests.java
@@ -314,15 +314,51 @@ class SpringPentestingObservationCollectorTests {
         assertThat(report.findings())
                 .extracting(PentestingFindingDto::id)
                 .contains("PT-A05-052", "PT-A05-053", "PT-A05-054", "PT-A05-055", "PT-A05-056");
+        // 5 of the 9 recon suffixes match here; boundedMappingList shows as many as fit within the
+        // shared evidence cap and collapses the rest into a "(+N more)" count (see the dedicated
+        // reconActuatorEndpointsEvidenceStaysWithinCapAndKeepsSecurityPostureNote test below for why).
         assertThat(report.findings())
                 .filteredOn(finding -> "PT-A05-055".equals(finding.id()))
                 .singleElement()
                 .satisfies(finding -> assertThat(finding.evidence())
                         .contains("/actuator/beans")
-                        .contains("/actuator/scheduledtasks")
-                        .contains("/actuator/sbom")
-                        .contains("/actuator/flyway")
-                        .contains("/actuator/liquibase"));
+                        .contains("(+3 more)")
+                        .contains("No Spring Security filter chain was detected")
+                        .hasSizeLessThanOrEqualTo(240));
+    }
+
+    @Test
+    void reconActuatorEndpointsEvidenceStaysWithinCapAndKeepsSecurityPostureNote() {
+        // All 9 recon suffixes mapped at once (e.g. management.endpoints.web.exposure.include=*) is the
+        // realistic worst case this check exists to flag. Before boundedMappingList, the shared 240-char
+        // evidence cap silently truncated the tail of the evidence string here, dropping both the last few
+        // endpoint names and the entire security-posture note (the part that explains the MEDIUM severity).
+        CapturingLocalHttpClient client = new CapturingLocalHttpClient();
+        RequestMappingInfoHandlerMapping mapping = handlerMapping(
+                "/actuator/beans",
+                "/actuator/conditions",
+                "/actuator/scheduledtasks",
+                "/actuator/startup",
+                "/actuator/metrics",
+                "/actuator/auditevents",
+                "/actuator/sbom",
+                "/actuator/flyway",
+                "/actuator/liquibase");
+
+        PentestingReport report = scanner(client, environment(), mapping).scan();
+
+        assertThat(report.findings())
+                .filteredOn(finding -> "PT-A05-055".equals(finding.id()))
+                .singleElement()
+                .satisfies(finding -> {
+                    assertThat(finding.severity()).isEqualTo("MEDIUM");
+                    assertThat(finding.evidence())
+                            .hasSizeLessThanOrEqualTo(240)
+                            .contains("/actuator/beans")
+                            .contains("more)")
+                            .contains(
+                                    "No Spring Security filter chain was detected, so the mapping is likely reachable unauthenticated.");
+                });
     }
 
     @Test

--- a/docs/PENTEST-CHECKS.md
+++ b/docs/PENTEST-CHECKS.md
@@ -409,7 +409,9 @@ disclosure.
   and database migration history — all useful for reconnaissance (the SBOM in particular hands an attacker exact
   dependency versions to cross-reference against known CVEs). `/info` is intentionally **not** included: Spring's own
   guidance treats `/health` and `/info` as the two endpoints commonly exposed publicly, so flagging it here would be
-  noisy rather than actionable.
+  noisy rather than actionable. With several endpoints mapped at once, the evidence lists as many as fit within the
+  shared evidence-length limit and collapses the rest into a trailing `(+N more)` count, so the Spring Security posture
+  note at the end is never silently dropped.
 - **Recommendation**: restrict or disable these low-risk-but-revealing actuator endpoints outside development.
 
 ### PT-A05-056 — Actuator /shutdown endpoint is web-mapped


### PR DESCRIPTION
## Context

This is a light sanity/completeness follow-up to today's Pentesting audit (`b3162c0b` / #479), which verified all 70 checks against primary sources. Per the audit-round instructions, this pass does **not** re-verify all checks — it only (1) confirms that audit's own claims hold up, (2) checks doc/code consistency, and (3) looks for at most 1-2 high-value quick wins the same-day audit might have left on the table.

## What I verified from #479 (no changes needed)

1. **"Wired through both Spring and Quarkus observation collectors" claim for `PT-A05-062`** — confirmed. Spring's `SpringPentestingObservationCollector` genuinely reads `spring.devtools.remote.secret` from `Environment`. Quarkus's `QuarkusPentestingObservationCollector` hardcodes the field to `false` — this is the documented, intentional convention for Spring-only config fields on Quarkus (an inert neutral default so the check never misfires), not a gap.
2. **Doc/code check-count consistency** — confirmed. 70 unique `PT-*` IDs in `PentestingChecks.java` match `docs/PENTEST-CHECKS.md`'s stated total and its per-OWASP-category breakdown (A01=1, A02=55, A04=4, A07=5, A10=5).

## The one quick win found and fixed

`ReconActuatorEndpointsCheck` is the only check with more than one matchable endpoint (up to 9: `/beans`, `/conditions`, `/scheduledtasks`, `/startup`, `/metrics`, `/auditevents`, `/sbom`, `/flyway`, `/liquibase`). Today's audit shortened its `riskContext()` specifically to fix an evidence-truncation issue — but the fix wasn't quite sufficient.

The evidence string is built as `riskContext() + " Detected mapping(s): " + <matched endpoints> + "." + extraEvidence(context)`, where `extraEvidence()` is the trailing Spring-Security-posture note (the text explaining *why* severity is MEDIUM vs LOW). This whole string is capped at 240 chars by a shared blind tail-truncation. I reproduced (with a real test, not just arithmetic) that even after today's shortening, mapping **all 9** recon endpoints at once (a realistic "wide-open dev actuator" scenario — exactly what this check exists to flag) still overflows 240 chars, so the tail-truncation silently:
- dropped the last few endpoint names (including the `/sbom`, `/flyway`, `/liquibase` this same audit just added), **and**
- dropped the entire trailing security-posture note.

Even a **single** matched endpoint could truncate mid-word, because `riskContext()` + boilerplate already consumed most of the 240-char budget before `extraEvidence()` was appended.

### Fix

- `AbstractActuatorEndpointCheck` now builds its "Detected mapping(s)" list through a new `boundedMappingList()` helper that dynamically sizes the list to fit the remaining evidence budget (after reserving space for the fixed risk-context/security-posture text), collapsing overflow into an explicit `"(+N more)"` marker instead of relying on the shared truncation to (silently, unpredictably) cut whatever happens to be at the end.
- Made `PentestingCheckSupport.MAX_EVIDENCE_CHARS` package-visible so both classes share one source of truth for the cap.
- Shortened `ReconActuatorEndpointsCheck.riskContext()` further to leave more headroom.
- Confirmed via reproduction test that the security-posture note is now always preserved and evidence never needs the fallback truncation.

**Scope check:** only `ReconActuatorEndpointsCheck` is affected — the other 13 `AbstractActuatorEndpointCheck` subclasses always match at most one endpoint, so their behavior is provably unchanged (verified by the full test suite passing with no regressions). Quarkus is unaffected by design (its endpoint inventory is always empty, so this check never fires there).

### Tests

- New engine-level test in `PentestingScannerTests` covering the all-9-endpoints worst case.
- New Spring-adapter test `reconActuatorEndpointsEvidenceStaysWithinCapAndKeepsSecurityPostureNote`, plus updated assertions in the existing `infoAndReconActuatorEndpointChecksFireForMappedEndpoints` test to match the new bounded-list behavior.
- Updated `docs/PENTEST-CHECKS.md`'s `PT-A05-055` entry to document the bounded-list behavior.

## Verification

- `./mvnw -B -ntp -pl bootui-core,bootui-engine,bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-sample-app -am test` → BUILD SUCCESS
- `./mvnw -B -ntp -pl bootui-quarkus,bootui-quarkus-deployment,bootui-quarkus-integration-tests,bootui-quarkus-integration-tests/base -am install` → BUILD SUCCESS, 125 tests incl. `BootUiQuarkusPentestingResourceTest` (needed to explicitly add the `base` child module to `-pl`, since the aggregator POM alone doesn't pull it in)
- `./mvnw -B -ntp spotless:apply` / `spotless:check` → clean, no changes needed

No `.vue` files touched, so no frontend test/format run needed.