### PR TITLE
Fix stale JDK-version gates in Memory advisor's JVM-tuning calculator

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCalculator.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCalculator.java
@@ -354,15 +354,27 @@ final class MemoryCalculator {
     }
 
     private void appendCommonOptions(StringBuilder sb, long heapBytes) {
-        if (heapBytes >= GC_FLIP_HEAP_BYTES) {
+        boolean usesZgc = heapBytes >= GC_FLIP_HEAP_BYTES;
+        if (usesZgc) {
             sb.append(" -XX:+UseZGC");
-            if (jdkVersion.feature() >= 21 && jdkVersion.feature() < 24) {
+            // JEP 439 (JDK 21) added generational ZGC as an experimental opt-in; JEP 474 (JDK 23)
+            // made it the default and deprecated the flag (a warning is printed if it is set
+            // explicitly); JEP 490 (JDK 24) obsoletes it further, and later releases stop
+            // recognizing it altogether, causing the JVM to refuse to start. So the flag is only
+            // useful on 21/22.
+            if (jdkVersion.feature() >= 21 && jdkVersion.feature() < 23) {
                 sb.append(" -XX:+ZGenerational");
             }
         } else {
             sb.append(" -XX:+UseG1GC");
         }
-        sb.append(" -XX:+UseStringDeduplication");
+        // G1 has supported string deduplication since JDK 8u20 (JEP 192); ZGC only gained support
+        // in JDK 18. Setting it with ZGC on an older JDK is not fatal, but the JVM disables it with
+        // a startup warning ("String Deduplication disabled: not supported by selected GC"), so skip
+        // it there rather than emit a flag that silently does nothing.
+        if (!usesZgc || jdkVersion.feature() >= 18) {
+            sb.append(" -XX:+UseStringDeduplication");
+        }
         if (jdkVersion.feature() >= 25) {
             sb.append(" -XX:+UseCompactObjectHeaders");
         }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCalculatorTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCalculatorTests.java
@@ -9,8 +9,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests for the Paketo {@code libjvm}-style {@link MemoryCalculator}.
  *
- * <p>Verifies the partition formula, libjvm-equivalent constants, and the JDK
- * version gating that controls {@code -XX:+UseCompactObjectHeaders}.
+ * <p>Verifies the partition formula, libjvm-equivalent constants, and the JDK version gating that
+ * controls {@code -XX:+UseCompactObjectHeaders}, {@code -XX:+ZGenerational}, and
+ * {@code -XX:+UseStringDeduplication}.
  */
 class MemoryCalculatorTests {
 
@@ -18,6 +19,11 @@ class MemoryCalculatorTests {
 
     private static final JdkVersion JDK_25 = () -> 25;
     private static final JdkVersion JDK_24 = () -> 24;
+    private static final JdkVersion JDK_23 = () -> 23;
+    private static final JdkVersion JDK_22 = () -> 22;
+    private static final JdkVersion JDK_21 = () -> 21;
+    private static final JdkVersion JDK_18 = () -> 18;
+    private static final JdkVersion JDK_17 = () -> 17;
 
     @Test
     void heapIsTotalMinusFixedRegionsAndHeadroom() {
@@ -134,6 +140,54 @@ class MemoryCalculatorTests {
 
         assertThat(result25.jvmOptions()).contains("-XX:+UseCompactObjectHeaders");
         assertThat(result24.jvmOptions()).doesNotContain("-XX:+UseCompactObjectHeaders");
+    }
+
+    @Test
+    void zGenerationalFlagOnlyAppliedOnJdk21And22() {
+        long largeHeap = 8L * 1024 * MB; // flips GC selection to ZGC
+
+        MemoryCalculationDto on21 = new MemoryCalculator(JDK_21).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+        MemoryCalculationDto on22 = new MemoryCalculator(JDK_22).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+        MemoryCalculationDto on23 = new MemoryCalculator(JDK_23).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+        MemoryCalculationDto on24 = new MemoryCalculator(JDK_24).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+        MemoryCalculationDto on25 = new MemoryCalculator(JDK_25).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+
+        // JEP 439 (JDK 21) shipped generational ZGC as an experimental opt-in flag.
+        assertThat(on21.jvmOptions()).contains("-XX:+ZGenerational");
+        assertThat(on22.jvmOptions()).contains("-XX:+ZGenerational");
+        // JEP 474 (JDK 23) makes generational ZGC the default and deprecates the explicit flag
+        // (printing a warning if set); JEP 490 (JDK 24) obsoletes it further, and later releases
+        // stop recognizing it altogether, causing the JVM to refuse to start. It must never be
+        // emitted from JDK 23 onward.
+        assertThat(on23.jvmOptions()).doesNotContain("-XX:+ZGenerational");
+        assertThat(on24.jvmOptions()).doesNotContain("-XX:+ZGenerational");
+        assertThat(on25.jvmOptions()).doesNotContain("-XX:+ZGenerational");
+    }
+
+    @Test
+    void stringDeduplicationSkippedForZgcBeforeJdk18() {
+        long largeHeap = 8L * 1024 * MB; // flips GC selection to ZGC
+
+        MemoryCalculationDto on17 = new MemoryCalculator(JDK_17).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+        MemoryCalculationDto on18 = new MemoryCalculator(JDK_18).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+        MemoryCalculationDto on21 = new MemoryCalculator(JDK_21).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+
+        // ZGC did not support string deduplication until JDK 18. On JDK 17 the JVM would print a
+        // startup warning ("String Deduplication disabled: not supported by selected GC") and
+        // silently disable it anyway, so the flag must be omitted rather than emitted uselessly.
+        assertThat(on17.jvmOptions()).contains("-XX:+UseZGC").doesNotContain("-XX:+UseStringDeduplication");
+        assertThat(on18.jvmOptions()).contains("-XX:+UseZGC").contains("-XX:+UseStringDeduplication");
+        assertThat(on21.jvmOptions()).contains("-XX:+UseZGC").contains("-XX:+UseStringDeduplication");
+    }
+
+    @Test
+    void stringDeduplicationAlwaysPresentForG1RegardlessOfJdkVersion() {
+        long smallHeap = 1024 * MB; // stays under the ZGC flip threshold, selects G1
+
+        MemoryCalculationDto on17 = new MemoryCalculator(JDK_17).calculate(smallHeap, 250, 1_000, 0, 1, 1_000);
+
+        // G1 has supported string deduplication since JDK 8u20 (JEP 192), so it is always present.
+        assertThat(on17.jvmOptions()).contains("-XX:+UseG1GC").contains("-XX:+UseStringDeduplication");
     }
 
     @Test


### PR DESCRIPTION
## Context

Light re-check of the Memory advisor panel (previously hardened in `961d9c47` "Harden Memory advisor rules (Phase 5)" and `569acc73` "Improve Memory Advisor: 7 new rules, 8 fixes incl. concurrent-GC inflation bug", ~22 days ago). Per the audit scope, this is a spot-check for drift, not a full re-verification — I confirmed the 32 rules, the concurrent-GC inflation fix, and the container/K8s sizing logic all still hold up, and found two flag-currency bugs in the JVM-tuning calculator.

## What I checked (spot-check, no changes needed)

- Container/cgroup detection (ContainerMemoryLimitDetector, MemoryKubernetesSizer): cgroup v1/v2 limit detection, headroom/burstable/QoS logic - all correct and current.
- Concurrent-GC inflation fix from 569acc73: isConcurrentCycleBean() exclusion, cross-scan GcTrend/GcSample plumbing - intact, not regressed. GC bean names (ZGC/G1/Serial) still match current JDK behavior.
- All 32 rules in MemoryRules.java: reviewed in full, no bugs found.
- docs/MEMORY-CHECKS.md: documents the 32 rules only, doesn't reference the flags below - no update needed.

## What I fixed

Both bugs live in MemoryCalculator.appendCommonOptions() (the JVM-flag generator behind the Kubernetes sizing panel) and were verified empirically against real JDK 17/21/25/26 binaries (not just docs), since this repo's advisor logic must stay correct across whatever JDK a user's own app runs on, not just the build's JDK 17 baseline:

1. **-XX:+ZGenerational emitted on JDK 23 (too late a cutoff)**: JEP 439 (JDK 21) shipped it as an opt-in experimental flag; JEP 474 (JDK 23) makes generational ZGC the default and deprecates the explicit flag (prints a warning); JEP 490 (JDK 24) obsoletes it further. Empirically confirmed on this machine: JDK 25 prints "Ignoring option ZGenerational; support was removed in 24.0", and JDK 26 refuses to start entirely (Unrecognized VM option 'ZGenerational'). The code's boundary was `< 24` (already correctly excluding 24+) but incorrectly still emitted it on JDK 23. Narrowed to `< 23`.

2. **-XX:+UseStringDeduplication emitted unconditionally with ZGC, even on JDK 17**: ZGC didn't gain string-dedup support until JDK 18 (confirmed via Per Liden's - ZGC's lead engineer - blog on JDK 18, plus empirically: JDK 17 + `-XX:+UseZGC -XX:+UseStringDeduplication` starts but prints "String Deduplication disabled: not supported by selected GC" and silently does nothing; JDK 21 runs it correctly). G1 has supported it since JDK 8u20 (JEP 192) and is unaffected. Now the flag is only emitted for ZGC on JDK >= 18; G1 keeps it unconditionally.

## Tests

Added 3 focused tests to MemoryCalculatorTests (98 Memory-related tests total, all passing):
- `zGenerationalFlagOnlyAppliedOnJdk21And22` - asserts presence on 21/22, absence on 23/24/25.
- `stringDeduplicationSkippedForZgcBeforeJdk18` - asserts absence on JDK 17 (with ZGC), presence on 18/21.
- `stringDeduplicationAlwaysPresentForG1RegardlessOfJdkVersion` - asserts G1 always has it, even on JDK 17.

## Verification

- `./mvnw -pl bootui-core,bootui-engine,bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-sample-app -am test` -> BUILD SUCCESS (all modules; bootui-engine Memory package: 98 tests, 0 failures)
- `./mvnw -pl bootui-quarkus,bootui-quarkus-deployment,bootui-quarkus-integration-tests -am install` -> BUILD SUCCESS
- `./mvnw -B -ntp spotless:apply` + `spotless:check` -> clean, no changes needed

No .vue files touched, so frontend tests/formatting weren't run (out of scope for this change).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>