### PR TITLE
Audit REST API advisor rules: fix JAX-RS void-handler status bugs

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiHandlerModelBuilder.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiHandlerModelBuilder.java
@@ -328,6 +328,11 @@ final class RestApiHandlerModelBuilder {
         boolean returnsResponseEntity =
                 Types.JAXRS_RESPONSE.equals(returnTypeName) || Types.QUARKUS_REST_RESPONSE.equals(returnTypeName);
         boolean returnsVoid = "void".equals(returnTypeName) || "java.lang.Void".equals(returnTypeName);
+        // Per the Jakarta REST spec, a void-returning resource method always answers 204 No Content —
+        // unlike Spring MVC, which defaults an unannotated void handler to 200 OK. Modelling that as a
+        // known response status keeps RAPI-RESP-002/RAPI-RESP-005 from flagging a JAX-RS void handler
+        // for a "silently defaults to 200 OK" footgun that cannot actually happen on this framework.
+        boolean hasImplicitNoContentStatus = returnsVoid;
 
         JavaType bodyType = unwrapWrappers(returnType);
         JavaClass bodyErasure = bodyType.toErasure();
@@ -393,6 +398,9 @@ final class RestApiHandlerModelBuilder {
                 || lowerName.startsWith("fetchall")
                 || lowerName.startsWith("readall");
         boolean hidden = classHidden || method.isAnnotatedWith(Types.HIDDEN) || operationHidden(method);
+        // A broad "throws Exception/Throwable" is a plain JVM method-signature fact, not a Spring-specific
+        // one, so it applies to JAX-RS resource methods exactly the same way (RAPI-ERR-002).
+        boolean declaresBroadThrows = declaresBroadThrows(method);
 
         return new HandlerMethodModel(
                 type.getName(),
@@ -427,10 +435,10 @@ final class RestApiHandlerModelBuilder {
                 false,
                 false,
                 hasExplicitPageParam,
+                hasImplicitNoContentStatus,
                 false,
-                false,
-                "",
-                false,
+                hasImplicitNoContentStatus ? "NO_CONTENT" : "",
+                declaresBroadThrows,
                 method.isAnnotatedWith(Types.OPERATION),
                 stateChanging,
                 findAll,

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/JaxRsRestApiModelTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/JaxRsRestApiModelTests.java
@@ -22,6 +22,19 @@ class JaxRsRestApiModelTests {
         return RestApiHandlerModelBuilder.build(classes);
     }
 
+    private RestApiContext context(String pkg) {
+        RestApiHandlerModelBuilder model = build(pkg);
+        return new RestApiContext(
+                java.util.List.of(pkg),
+                model.controllers(),
+                model.handlers(),
+                model.exceptionHandlers(),
+                false,
+                model.hasExceptionHandling(),
+                model.responseStatusExceptionClasses(),
+                model.framework());
+    }
+
     @Test
     void modelsJaxRsResourcesAsControllers() {
         RestApiHandlerModelBuilder model = build(GOOD);
@@ -53,18 +66,58 @@ class JaxRsRestApiModelTests {
 
     @Test
     void stateChangingGetRuleFiresOnJaxRs() {
-        RestApiHandlerModelBuilder model = build(BAD);
-        RestApiContext context = new RestApiContext(
-                java.util.List.of(BAD),
-                model.controllers(),
-                model.handlers(),
-                model.exceptionHandlers(),
-                false,
-                model.hasExceptionHandling(),
-                model.responseStatusExceptionClasses(),
-                model.framework());
         String status =
-                new StateChangingHandlersNotOnGetRule().evaluate(context).status();
+                new StateChangingHandlersNotOnGetRule().evaluate(context(BAD)).status();
+        assertThat(status).isEqualTo(RestApiRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void voidHandlersModelTheImplicitJaxRsNoContentStatus() {
+        // Per the Jakarta REST spec, a void resource method always answers 204 No Content — unlike
+        // Spring MVC, which defaults an unannotated void handler to 200 OK. GoodWidgetResource#delete
+        // has no status-setting annotation at all, yet the model must still resolve NO_CONTENT so
+        // RAPI-RESP-002 does not mistake it for the Spring "silently defaults to 200 OK" footgun.
+        HandlerMethodModel delete = build(GOOD).handlers().stream()
+                .filter(h -> h.methodName().equals("delete"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(delete.returnsVoid()).isTrue();
+        assertThat(delete.hasResponseStatus()).isTrue();
+        assertThat(delete.methodHasResponseStatus()).isFalse();
+        assertThat(delete.responseStatusValue()).isEqualTo("NO_CONTENT");
+    }
+
+    @Test
+    void voidDeleteRuleDoesNotFireOnJaxRs() {
+        String status = new VoidDeleteReturns204Rule().evaluate(context(GOOD)).status();
+        assertThat(status).isEqualTo(RestApiRuleSupport.PASS);
+    }
+
+    @Test
+    void voidReadRuleDoesNotFireOnJaxRs() {
+        HandlerMethodModel probe = build(GOOD).handlers().stream()
+                .filter(h -> h.methodName().equals("probe"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(probe.httpMethods()).contains("GET");
+        assertThat(probe.returnsVoid()).isTrue();
+
+        String status =
+                new VoidReadEndpointsReturnContentRule().evaluate(context(GOOD)).status();
+        assertThat(status).isEqualTo(RestApiRuleSupport.PASS);
+    }
+
+    @Test
+    void broadThrowsRuleFiresOnJaxRs() {
+        // A "throws Exception/Throwable" is a plain JVM method-signature fact, not a Spring-only one,
+        // so RAPI-ERR-002 must fire on a JAX-RS resource method exactly as it does on Spring.
+        HandlerMethodModel read = build(BAD).handlers().stream()
+                .filter(h -> h.methodName().equals("read"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(read.declaresBroadThrows()).isTrue();
+
+        String status = new NoBroadThrowsOnHandlersRule().evaluate(context(BAD)).status();
         assertThat(status).isEqualTo(RestApiRuleSupport.VIOLATION);
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/jaxrs/VoidResponseResource.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/jaxrs/VoidResponseResource.java
@@ -1,0 +1,18 @@
+package io.github.jdubois.bootui.engine.restapi.jaxrs;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+
+/**
+ * A JAX-RS resource with a void GET handler. Per the Jakarta REST spec a void-returning resource
+ * method always answers 204 No Content — unlike Spring MVC, which defaults an unannotated void
+ * handler to 200 OK — so RAPI-RESP-005 must not flag this as "defaults to 200 OK".
+ */
+@Path("/probes")
+public class VoidResponseResource {
+
+    @GET
+    @Path("/{id}")
+    public void probe(@PathParam("id") String id) {}
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/jaxrs/bad/BadThrowsResource.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/jaxrs/bad/BadThrowsResource.java
@@ -1,0 +1,18 @@
+package io.github.jdubois.bootui.engine.restapi.jaxrs.bad;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+/**
+ * A JAX-RS resource declaring a broad {@code throws Exception} on a handler method (RAPI-ERR-002,
+ * LOW). Declaring a broad throws clause is a plain JVM method-signature fact, not a Spring-only
+ * one, so this must be flagged on JAX-RS resources exactly as it is on Spring controllers.
+ */
+@Path("/faulty")
+public class BadThrowsResource {
+
+    @GET
+    public String read() throws Exception {
+        return "ok";
+    }
+}

--- a/docs/REST-API-CHECKS.md
+++ b/docs/REST-API-CHECKS.md
@@ -1,24 +1,26 @@
 # REST API checks
 
-The REST API panel runs a fixed, zero-config ruleset against the host application's own web layer
-(`@RestController` / `@Controller` handler methods). This page lists every rule that ships with BootUI today, what it
-inspects, when it fires, and what to do about it.
+The REST API panel runs a fixed, zero-config ruleset against the host application's own web layer — Spring MVC
+(`@RestController` / `@Controller` handler methods) or, on Quarkus, JAX-RS/RESTEasy Reactive (`@Path` resource methods).
+This page lists every rule that ships with BootUI today, what it inspects, when it fires, and what to do about it.
 
 Each rule is a small class registered in
-[`RestApiRuleRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/restapi/RestApiRuleRegistry.java)
+[`RestApiRuleRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleRegistry.java)
 and implemented in
-[`RestApiRules.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/restapi/RestApiRules.java).
-The list intentionally stays compact and reviewable; adding a new rule means adding one focused class plus a registry
-entry.
+[`RestApiRules.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRules.java),
+both in the framework-neutral `bootui-engine` module so the same 47 rules run identically on Spring Boot and Quarkus. The
+list intentionally stays compact and reviewable; adding a new rule means adding one focused class plus a registry entry.
 
 ## What BootUI does
 
-The scanner detects the host application's base package(s) from the `@SpringBootApplication` configuration via
-`AutoConfigurationPackages`, imports the compiled `.class` files from those packages with ArchUnit's
-`ClassFileImporter`, derives a read-only handler model (HTTP method(s), path(s), parameters and their annotations,
-return type, `produces`/`consumes`, validation flags, declared throws) once, and evaluates every registered rule against
-that model. Importing is bounded to the application's own base package(s) — never the entire classpath — and runs only
-on demand when the scan action is invoked, caching the last report in the controller.
+The scanner detects the host application's base package(s) — from the `@SpringBootApplication` configuration via
+`AutoConfigurationPackages` on Spring, or from a build-time Jandex index on Quarkus — imports the compiled `.class`
+files from those packages with ArchUnit's `ClassFileImporter`, derives a read-only handler model (HTTP method(s),
+path(s), parameters and their annotations, return type, `produces`/`consumes`, validation flags, declared throws) once,
+and evaluates every registered rule against that model. Importing is bounded to the application's own base package(s) —
+never the entire classpath — and runs only on demand when the scan action is invoked, caching the last report in the
+controller. A handful of rules reason about Spring-only types with no JAX-RS equivalent (RFC 9457 `ProblemDetail`); on
+Quarkus those report `SKIPPED` with an explanatory reason instead of misfiring — see RAPI-ERR-003 and RAPI-ERR-006 below.
 
 When BootUI is installed through `bootui-spring-boot-starter`, ArchUnit is included transitively so the panel works
 without an extra application dependency. The panel is available only when:
@@ -175,7 +177,7 @@ reported as `SKIPPED`.
 ### RAPI-RESP-002 - Void DELETE returns 204 No Content
 
 - **Severity**: LOW
-- **Detects**: A DELETE handler returning void but defaulting to 200 OK sends an empty 200 instead of the more precise 204 No Content.
+- **Detects**: A DELETE handler returning void but defaulting to 200 OK sends an empty 200 instead of the more precise 204 No Content. On JAX-RS/Quarkus this never fires: a void resource method already defaults to 204 per the Jakarta REST spec, unlike Spring MVC.
 - **Recommendation**: Annotate void DELETE handlers with @ResponseStatus(HttpStatus.NO_CONTENT) or return ResponseEntity.noContent().
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9110.html>
 
@@ -196,7 +198,7 @@ reported as `SKIPPED`.
 ### RAPI-RESP-005 - GET endpoints return content
 
 - **Severity**: LOW
-- **Detects**: A GET handler that returns void responds with an empty 200 OK and no representation, which is rarely the intent for a read endpoint.
+- **Detects**: A GET handler that returns void responds with an empty 200 OK and no representation, which is rarely the intent for a read endpoint. On JAX-RS/Quarkus this never fires: a void resource method already answers 204 No Content per the Jakarta REST spec, so there is no "silent 200 OK" to flag there.
 - **Recommendation**: Return the resource representation from GET handlers (or use a more precise status when no body is expected).
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9110.html>
 
@@ -360,7 +362,7 @@ reported as `SKIPPED`.
 ### RAPI-ERR-003 - Prefer RFC 9457 ProblemDetail
 
 - **Severity**: INFO
-- **Detects**: @ExceptionHandler methods that model errors as ad-hoc maps/strings instead of ProblemDetail produce non-standard error payloads.
+- **Detects**: @ExceptionHandler methods that model errors as ad-hoc maps/strings instead of ProblemDetail produce non-standard error payloads. Not applicable on JAX-RS/Quarkus: Spring's `ProblemDetail` type has no equivalent there, so the rule reports `SKIPPED`.
 - **Recommendation**: Return ProblemDetail (or ErrorResponse) from @ExceptionHandler methods for RFC 9457 compliant errors.
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9457.html>
 
@@ -381,7 +383,7 @@ reported as `SKIPPED`.
 ### RAPI-ERR-006 - Prefer ErrorResponseException over @ResponseStatus on exceptions
 
 - **Severity**: INFO
-- **Detects**: The project uses ProblemDetail (RFC 9457) for error responses but some application exception classes are annotated with @ResponseStatus instead, mixing error-handling approaches.
+- **Detects**: The project uses ProblemDetail (RFC 9457) for error responses but some application exception classes are annotated with @ResponseStatus instead, mixing error-handling approaches. Not applicable on JAX-RS/Quarkus: Spring's `ProblemDetail` type has no equivalent there, so the rule reports `SKIPPED`.
 - **Recommendation**: Replace @ResponseStatus on exception classes with ErrorResponseException (or a subclass) so all errors consistently produce RFC 9457 ProblemDetail responses.
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9457.html>
 


### PR DESCRIPTION
## Context

Light re-check of the REST API advisor (47 rules, `bootui-engine/.../restapi/*.java`), following two recent hardening passes: `9c43d8e2` "Harden REST API advisor rules (Phase 2)" and `e0e92d48`/#320 "Improve REST API Advisor: 9 new rules, 8 bug fixes". Given how fresh those passes are, this was a spot-check rather than a full re-verification of all 47 rules.

## What I checked

1. **Version-specific claims against primary sources** — verified the Spring Framework 6/7 suffix-pattern-matching removal claim (RAPI-NAME-004), the Spring Framework 7 `@RequestMapping(version=...)` attribute claim (RAPI-VER-006 and the model's `mappingVersion` extraction), and the Jackson/`java.time` claim (RAPI-DTO-005). All held up against current docs — no changes needed.
2. **Dual-framework angle** (the most valuable thing to check, since neither prior pass focused on it): `RestApiRules` is shared engine code serving both Spring MVC and JAX-RS/RESTEasy Reactive on Quarkus. I traced every hardcoded field in `RestApiHandlerModelBuilder.toJaxRsHandler` against the rules that consume them, looking for hidden Spring-MVC-only assumptions.

## Bugs found and fixed

`toJaxRsHandler` hardcoded three handler-model fields (`hasResponseStatus`, `responseStatusValue`, `declaresBroadThrows`) to `false`/`""` for every JAX-RS resource method, even though Spring's `toHandler` computes them properly. This caused real misfires/under-fires on Quarkus:

- **RAPI-RESP-002** (void DELETE returns 204) and **RAPI-RESP-005** (GET endpoints return content) both **false-positived** on JAX-RS: a void resource method always answers 204 No Content per the Jakarta REST spec (3.1, §3.3.2), unlike Spring MVC, which defaults an unannotated void handler to 200 OK. The model never recorded that implicit status, so both rules flagged every well-behaved void JAX-RS handler as "defaults to 200 OK".
- **RAPI-ERR-002** (no broad throws on handlers) could **never fire on JAX-RS at all**: `declaresBroadThrows` was hardcoded `false` even though the underlying check (`method.getExceptionTypes()`) is plain JVM introspection with no Spring dependency — the existing helper was already framework-neutral and reused as-is.

Fix: compute `hasImplicitNoContentStatus` (→ `hasResponseStatus`/`responseStatusValue`) and `declaresBroadThrows` in `toJaxRsHandler` instead of hardcoding them. `methodHasResponseStatus` stays `false` (correctly — no JAX-RS `@ResponseStatus` equivalent exists).

## Tests

Added two new JAX-RS fixtures (`VoidResponseResource` — a void GET handler; `jaxrs.bad/BadThrowsResource` — a `throws Exception` handler) and four new tests in `JaxRsRestApiModelTests`:
- Model-level: void JAX-RS handlers now resolve `hasResponseStatus()=true`, `responseStatusValue()="NO_CONTENT"`, `methodHasResponseStatus()=false`.
- Rule-level: `VoidDeleteReturns204Rule` and `VoidReadEndpointsReturnContentRule` now `PASS` on well-behaved JAX-RS resources (previously would have been `VIOLATION`).
- Model/rule-level: `declaresBroadThrows()` now `true` and `NoBroadThrowsOnHandlersRule` now `VIOLATION` on a JAX-RS resource declaring `throws Exception`.

## Docs

Updated `docs/REST-API-CHECKS.md`:
- Fixed two stale GitHub links pointing at `bootui-spring-autoconfigure` (the rule classes moved to `bootui-engine` during the dual-framework refactor).
- Clarified in the intro that the ruleset runs against Spring MVC controllers **or** JAX-RS/RESTEasy Reactive resources on Quarkus.
- Documented the JAX-RS behavior for RAPI-RESP-002/005 (why they never fire there).
- Documented that RAPI-ERR-003/006 report `SKIPPED` on JAX-RS (this pre-existing skip behavior — via `RestApiScanner.SPRING_ONLY_RULE_IDS` — wasn't previously mentioned in the doc at all).

No new rules added — a genuine spot-check didn't surface anything else clearly high-value and missing, consistent with a light re-check.

## Verification

- `./mvnw -pl bootui-core,bootui-engine,bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-sample-app -am test` → **1756 tests, 0 failures**
- `./mvnw -pl bootui-quarkus,bootui-quarkus-deployment -am install` + the full `bootui-quarkus-integration-tests` reactor (all 10 submodules, incl. `BootUiQuarkusRestApiResourceTest` and `BootUiQuarkusApiConformanceTest`) → **all pass, 0 failures**
- `./mvnw -B -ntp spotless:apply` + `spotless:check` → clean
- `bootui-ui/src/main/frontend/src/views/RestApi.vue` reviewed — no changes needed (generic advisor-panel renderer with no rule-specific or framework-specific logic; the DTO shape didn't change).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>