### PR TITLE
Audit Spring advisor rules: fix 2 gaps, add 2 rules

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringContext.java
@@ -2,8 +2,11 @@ package io.github.jdubois.bootui.autoconfigure.spring;
 
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.BeanRef;
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.CacheManagerRef;
+import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.Environment;
 
 /**
@@ -31,7 +34,8 @@ record SpringContext(
         boolean schedulingEnabled,
         boolean entityManagerFactoryPresent,
         boolean dispatcherServletPresent,
-        List<String> defaultPackageBeans) {
+        List<String> defaultPackageBeans,
+        List<String> mutableSingletonFields) {
 
     SpringContext {
         objectMappers = List.copyOf(objectMappers);
@@ -41,6 +45,7 @@ record SpringContext(
         restTemplates = List.copyOf(restTemplates);
         cacheManagers = List.copyOf(cacheManagers);
         defaultPackageBeans = List.copyOf(defaultPackageBeans);
+        mutableSingletonFields = List.copyOf(mutableSingletonFields);
     }
 
     String firstProperty(String... keys) {
@@ -70,6 +75,28 @@ record SpringContext(
     boolean isPropertyTrue(String... keys) {
         String value = firstProperty(keys);
         return value != null && "true".equalsIgnoreCase(value);
+    }
+
+    /**
+     * Returns the millisecond value of a {@link Duration} property, or {@code null} if unset or
+     * unparsable. Uses the relaxed {@link Binder} (rather than {@code Environment.getProperty}) because
+     * a plain {@code Environment} has no {@code String -> Duration} converter registered; only Boot's
+     * configuration property binding infrastructure does.
+     */
+    Long firstDurationMillisProperty(String... keys) {
+        for (String key : keys) {
+            try {
+                Duration value = Binder.get(environment)
+                        .bind(key, Bindable.of(Duration.class))
+                        .orElse(null);
+                if (value != null) {
+                    return value.toMillis();
+                }
+            } catch (RuntimeException ex) {
+                // Ignore unparsable values and try the next key.
+            }
+        }
+        return null;
     }
 
     boolean hasProperty(String key) {
@@ -165,6 +192,7 @@ record SpringContext(
         private boolean entityManagerFactoryPresent;
         private boolean dispatcherServletPresent;
         private List<String> defaultPackageBeans = List.of();
+        private List<String> mutableSingletonFields = List.of();
 
         private Builder(Environment environment) {
             this.environment = environment;
@@ -270,6 +298,11 @@ record SpringContext(
             return this;
         }
 
+        Builder mutableSingletonFields(List<String> value) {
+            this.mutableSingletonFields = value;
+            return this;
+        }
+
         SpringContext build() {
             return new SpringContext(
                     environment,
@@ -292,7 +325,8 @@ record SpringContext(
                     schedulingEnabled,
                     entityManagerFactoryPresent,
                     dispatcherServletPresent,
-                    defaultPackageBeans);
+                    defaultPackageBeans,
+                    mutableSingletonFields);
         }
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRuleRegistry.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRuleRegistry.java
@@ -18,6 +18,7 @@ final class SpringRuleRegistry {
             new AmbiguousTransactionManagerRule(),
             new RestTemplateInUseRule(),
             new DefaultPackageComponentsRule(),
+            new MutableSingletonFieldRule(),
             // Configuration
             new LazyInitializationDisabledRule(),
             new DebugOrTraceLoggingRule(),
@@ -46,6 +47,7 @@ final class SpringRuleRegistry {
             new RedundantTomcatThreadsRule(),
             // Data and persistence
             new OpenSessionInViewEnabledRule(),
+            new InMemoryDatasourceInProductionRule(),
             // Actuator and management
             new ActuatorExposeAllRule(),
             new SensitiveActuatorEndpointsExposedRule(),

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
@@ -4,6 +4,7 @@ import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.BeanRef;
 import io.github.jdubois.bootui.core.dto.SpringRuleResultDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 abstract class AbstractSpringRule implements SpringRule {
 
@@ -328,7 +329,9 @@ final class DebugOrTraceLoggingRule extends AbstractSpringRule {
                 SpringCategory.CONFIGURATION,
                 "LOW",
                 "Detects debug=true or trace=true, which switch on verbose auto-configuration logging"
-                        + " and can leak internal details or slow down the application.",
+                        + " and can leak internal details or slow down the application. Raised to MEDIUM when a"
+                        + " production-like profile is active, since the performance and data-leak cost of"
+                        + " verbose logging is highest there.",
                 "Remove the debug/trace flags and configure logging levels per package instead.",
                 "https://docs.spring.io/spring-boot/reference/features/logging.html"));
     }
@@ -349,7 +352,8 @@ final class DebugOrTraceLoggingRule extends AbstractSpringRule {
                         + " emits verbose framework logging that can leak internals and slow the application.");
             }
         }
-        return violation(findings);
+        String severity = context.isProductionProfileActive() ? SpringRuleSupport.MEDIUM : null;
+        return violation(severity, findings);
     }
 }
 
@@ -803,11 +807,12 @@ final class GracefulShutdownDisabledRule extends AbstractSpringRule {
                 "Keep graceful shutdown enabled",
                 SpringCategory.WEB,
                 "MEDIUM",
-                "Detects server.shutdown=immediate, which overrides the Spring Boot 4 default of graceful"
-                        + " shutdown, so in-flight requests can be dropped when the application stops.",
-                "Remove server.shutdown=immediate (Spring Boot 4 defaults to graceful) and tune"
-                        + " spring.lifecycle.timeout-per-shutdown-phase so active requests can complete during"
-                        + " rollouts.",
+                "Detects server.shutdown=immediate, or spring.lifecycle.timeout-per-shutdown-phase set to zero,"
+                        + " either of which overrides the Spring Boot 4 default of graceful shutdown so in-flight"
+                        + " requests can be dropped when the application stops.",
+                "Remove server.shutdown=immediate (Spring Boot 4 defaults to graceful) and keep"
+                        + " spring.lifecycle.timeout-per-shutdown-phase at a positive value (30s by default) so"
+                        + " active requests can complete during rollouts.",
                 "https://docs.spring.io/spring-boot/reference/web/graceful-shutdown.html"));
     }
 
@@ -817,6 +822,12 @@ final class GracefulShutdownDisabledRule extends AbstractSpringRule {
         if (shutdown != null && "immediate".equalsIgnoreCase(shutdown)) {
             return violation("server.shutdown=immediate overrides Spring Boot 4 graceful shutdown, so in-flight"
                     + " requests may be dropped on stop.");
+        }
+        Long timeoutMillis = context.firstDurationMillisProperty("spring.lifecycle.timeout-per-shutdown-phase");
+        if (timeoutMillis != null && timeoutMillis == 0) {
+            return violation("spring.lifecycle.timeout-per-shutdown-phase is set to zero, so graceful shutdown has"
+                    + " no grace period and in-flight requests are dropped immediately, the same as"
+                    + " server.shutdown=immediate.");
         }
         return pass();
     }
@@ -1180,5 +1191,81 @@ final class OpenSessionInViewEnabledRule extends AbstractSpringRule {
                     "spring.jpa.open-in-view=true keeps a persistence context open for the entire web request.");
         }
         return pass();
+    }
+}
+
+final class InMemoryDatasourceInProductionRule extends AbstractSpringRule {
+
+    /**
+     * JDBC URL substrings that identify an in-memory/embedded database. Each engine's in-memory
+     * subsubprotocol is distinct from its on-disk/file form (for example {@code jdbc:h2:file:...} or a
+     * plain path is durable, only {@code jdbc:h2:mem:...} is not), so matching these specific markers
+     * avoids flagging a perfectly normal file- or server-backed connection.
+     */
+    private static final List<String> IN_MEMORY_URL_MARKERS =
+            List.of("jdbc:h2:mem:", "jdbc:hsqldb:mem:", "jdbc:derby:memory:");
+
+    InMemoryDatasourceInProductionRule() {
+        super(new SpringRuleDefinition(
+                "SPRING-DATA-001",
+                "Avoid an in-memory database in production",
+                SpringCategory.PERSISTENCE,
+                "MEDIUM",
+                "spring.datasource.url targets an in-memory/embedded database (H2, HSQLDB, or Derby) while a"
+                        + " production-like profile is active, so data is lost on every restart and can never be"
+                        + " shared across replicas.",
+                "Point spring.datasource.url at a real managed database (PostgreSQL, MySQL, ...) for"
+                        + " production-like profiles; keep the in-memory database for tests and local development.",
+                "https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.datasource.embedded"));
+    }
+
+    @Override
+    SpringRuleResultDto evaluateRule(SpringContext context) {
+        if (!context.isProductionProfileActive()) {
+            return skipped("No production-like profile is active, so an in-memory datasource is expected in"
+                    + " tests and local development.");
+        }
+        String url = context.firstProperty("spring.datasource.url");
+        if (url == null) {
+            return pass();
+        }
+        String normalized = url.toLowerCase(Locale.ROOT);
+        for (String marker : IN_MEMORY_URL_MARKERS) {
+            if (normalized.contains(marker)) {
+                return violation("spring.datasource.url=" + url + " targets an in-memory database while a"
+                        + " production-like profile is active.");
+            }
+        }
+        return pass();
+    }
+}
+
+final class MutableSingletonFieldRule extends AbstractSpringRule {
+
+    MutableSingletonFieldRule() {
+        super(
+                new SpringRuleDefinition(
+                        "SPRING-WIRING-009",
+                        "Avoid public mutable fields on singleton beans",
+                        SpringCategory.BEAN_WIRING,
+                        "MEDIUM",
+                        "A singleton-scoped bean (the Spring default) declares a public, non-final instance field that"
+                                + " is not an injection point. Singleton beans are a single instance shared across every"
+                                + " concurrent request and thread, so a public mutable field is unsynchronised shared"
+                                + " state that any caller can read or overwrite outside the bean's own control.",
+                        "Make the field private (and final if it is only ever assigned once), encapsulate mutation"
+                                + " behind a synchronized or atomic accessor, or move genuinely per-request state to a"
+                                + " prototype- or request-scoped bean.",
+                        "https://docs.spring.io/spring-framework/reference/core/beans/factory-scopes.html#beans-factory-scopes-singleton"));
+    }
+
+    @Override
+    SpringRuleResultDto evaluateRule(SpringContext context) {
+        List<String> fields = context.mutableSingletonFields();
+        if (fields.isEmpty()) {
+            return pass();
+        }
+        return violation("Found " + fields.size() + " public mutable field(s) on singleton bean(s): "
+                + String.join(", ", fields) + ".");
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScanner.java
@@ -6,6 +6,9 @@ import io.github.jdubois.bootui.core.dto.SpringReport;
 import io.github.jdubois.bootui.core.dto.SpringRuleResultDto;
 import io.github.jdubois.bootui.core.dto.SpringScanStatusDto;
 import io.github.jdubois.bootui.core.dto.SpringSeverityCountDto;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -60,6 +63,25 @@ final class SpringScanner {
 
     /** Hard cap on the number of default-package bean names collected, to keep the scan bounded. */
     private static final int MAX_DEFAULT_PACKAGE_BEANS = 50;
+
+    /** Hard cap on the number of mutable-singleton-field findings collected, to keep the scan bounded. */
+    private static final int MAX_MUTABLE_SINGLETON_FIELDS = 50;
+
+    /**
+     * Field-level annotations that mark a legitimate injection point rather than loose shared state.
+     * Matched by annotation type name (not the annotation {@code Class} literal) so this works even
+     * when {@code jakarta.inject}/{@code jakarta.persistence} are not on the advisor's own classpath;
+     * the annotated field's own class can only carry these annotations if its classloader already
+     * resolves them.
+     */
+    private static final Set<String> INJECTION_ANNOTATIONS = Set.of(
+            "org.springframework.beans.factory.annotation.Autowired",
+            "org.springframework.beans.factory.annotation.Value",
+            "org.springframework.beans.factory.annotation.Qualifier",
+            "jakarta.inject.Inject",
+            "jakarta.annotation.Resource",
+            "jakarta.persistence.PersistenceContext",
+            "jakarta.persistence.PersistenceUnit");
 
     private static final Comparator<SpringRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(
                     (SpringRuleResultDto result) -> severityRank(result.severity()))
@@ -269,6 +291,7 @@ final class SpringScanner {
         boolean dispatcherServletPresent =
                 !beansOfType(beanFactory, DISPATCHER_SERVLET_TYPE, classLoader).isEmpty();
         List<String> defaultPackageBeans = defaultPackageBeans(beanFactory);
+        List<String> mutableSingletonFields = mutableSingletonFields(beanFactory);
 
         return SpringContext.builder(environment)
                 .virtualThreadsSupported(virtualThreadsSupported())
@@ -291,6 +314,7 @@ final class SpringScanner {
                 .entityManagerFactoryPresent(entityManagerFactoryPresent)
                 .dispatcherServletPresent(dispatcherServletPresent)
                 .defaultPackageBeans(defaultPackageBeans)
+                .mutableSingletonFields(mutableSingletonFields)
                 .build();
     }
 
@@ -369,6 +393,75 @@ final class SpringScanner {
             }
         }
         return List.copyOf(defaultPackage);
+    }
+
+    /**
+     * Collects public, non-final, non-static fields declared on singleton-scoped application beans.
+     * A singleton is a single instance shared across every concurrent request and thread, so a public
+     * mutable field is unsynchronised shared state that any caller can read or overwrite outside the
+     * bean's own control. Injection-point fields (recognised by annotation) are excluded: intentional
+     * field injection is a separate, narrower concern than accidental shared mutable state.
+     */
+    private static List<String> mutableSingletonFields(ConfigurableListableBeanFactory beanFactory) {
+        if (beanFactory == null) {
+            return List.of();
+        }
+        String[] names;
+        try {
+            names = beanFactory.getBeanDefinitionNames();
+        } catch (RuntimeException | LinkageError ex) {
+            return List.of();
+        }
+        List<String> findings = new ArrayList<>();
+        for (String name : names) {
+            if (findings.size() >= MAX_MUTABLE_SINGLETON_FIELDS) {
+                break;
+            }
+            try {
+                BeanDefinition definition = beanFactory.getBeanDefinition(name);
+                if (definition.getRole() != BeanDefinition.ROLE_APPLICATION || !definition.isSingleton()) {
+                    continue;
+                }
+                Class<?> type = beanFactory.getType(name, false);
+                if (type == null || type.isInterface()) {
+                    continue;
+                }
+                collectMutableFields(type, findings);
+            } catch (RuntimeException | LinkageError ex) {
+                // Ignore beans whose type/fields cannot be inspected.
+            }
+        }
+        return List.copyOf(findings);
+    }
+
+    private static void collectMutableFields(Class<?> type, List<String> findings) {
+        for (Field field : type.getDeclaredFields()) {
+            if (findings.size() >= MAX_MUTABLE_SINGLETON_FIELDS) {
+                return;
+            }
+            int modifiers = field.getModifiers();
+            if (!Modifier.isPublic(modifiers) || Modifier.isFinal(modifiers) || Modifier.isStatic(modifiers)) {
+                continue;
+            }
+            if (isInjectionPoint(field)) {
+                continue;
+            }
+            findings.add(type.getName() + "#" + field.getName());
+        }
+    }
+
+    private static boolean isInjectionPoint(Field field) {
+        try {
+            for (Annotation annotation : field.getAnnotations()) {
+                if (INJECTION_ANNOTATIONS.contains(annotation.annotationType().getName())) {
+                    return true;
+                }
+            }
+        } catch (RuntimeException | LinkageError ex) {
+            // If the field's annotations cannot be inspected, fail safe and don't flag it.
+            return true;
+        }
+        return false;
     }
 
     private static List<BeanRef> beansOfType(

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
@@ -37,6 +37,27 @@ class SpringRulesTests {
         assertThat(rule.evaluate(context(env()).build()).status()).isEqualTo("PASS");
     }
 
+    @Test
+    void gracefulShutdownFlagsZeroedGracePeriod() {
+        GracefulShutdownDisabledRule rule = new GracefulShutdownDisabledRule();
+
+        // Zero grace period defeats graceful shutdown just like server.shutdown=immediate.
+        assertThat(rule.evaluate(context(env().withProperty("spring.lifecycle.timeout-per-shutdown-phase", "0"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.lifecycle.timeout-per-shutdown-phase", "0s"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        // A positive grace period (the 30s default or an explicit override) is fine.
+        assertThat(rule.evaluate(context(env().withProperty("spring.lifecycle.timeout-per-shutdown-phase", "20s"))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(rule.evaluate(context(env()).build()).status()).isEqualTo("PASS");
+    }
+
     // ── SPRING-WIRING-003: union of Jackson 2 + Jackson 3 mapper beans ────────────
 
     @Test
@@ -123,6 +144,20 @@ class SpringRulesTests {
 
         assertThat(rule.evaluate(context(env())
                                 .defaultPackageBeans(List.of("rootBean"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env()).build()).status()).isEqualTo("PASS");
+    }
+
+    // ── SPRING-WIRING-009: public mutable fields on singleton beans ──────────────
+
+    @Test
+    void mutableSingletonFieldsFlagged() {
+        MutableSingletonFieldRule rule = new MutableSingletonFieldRule();
+
+        assertThat(rule.evaluate(context(env())
+                                .mutableSingletonFields(List.of("com.example.Counter#hits"))
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
@@ -296,6 +331,24 @@ class SpringRulesTests {
                         .status())
                 .isEqualTo("PASS");
         assertThat(rule.evaluate(context(env()).build()).status()).isEqualTo("PASS");
+    }
+
+    @Test
+    void verboseLoggingIsMediumInProduction() {
+        DebugOrTraceLoggingRule rule = new DebugOrTraceLoggingRule();
+
+        MockEnvironment prod = env();
+        prod.setActiveProfiles("prod");
+        prod.setProperty("debug", "true");
+        SpringRuleResultDto result = rule.evaluate(context(prod).build());
+
+        assertThat(result.status()).isEqualTo("VIOLATION");
+        assertThat(result.severity()).isEqualTo("MEDIUM");
+
+        // Outside a production-like profile the declared LOW severity is unchanged.
+        assertThat(rule.evaluate(context(env().withProperty("debug", "true")).build())
+                        .severity())
+                .isEqualTo("LOW");
     }
 
     // ── SPRING-WEB-005 ───────────────────────────────────────────────────────────
@@ -565,5 +618,57 @@ class SpringRulesTests {
                 .build());
         assertThat(result.status()).isEqualTo("VIOLATION");
         assertThat(result.severity()).isEqualTo("HIGH");
+    }
+
+    // ── SPRING-DATA-001: in-memory datasource in production ──────────────────────
+
+    @Test
+    void inMemoryDatasourceSkippedOutsideProduction() {
+        InMemoryDatasourceInProductionRule rule = new InMemoryDatasourceInProductionRule();
+
+        assertThat(rule.evaluate(context(env().withProperty("spring.datasource.url", "jdbc:h2:mem:testdb"))
+                                .build())
+                        .status())
+                .isEqualTo("SKIPPED");
+    }
+
+    @Test
+    void inMemoryDatasourceFlaggedInProductionForEachEngine() {
+        InMemoryDatasourceInProductionRule rule = new InMemoryDatasourceInProductionRule();
+
+        MockEnvironment h2 = env();
+        h2.setActiveProfiles("prod");
+        h2.setProperty("spring.datasource.url", "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1");
+        assertThat(rule.evaluate(context(h2).build()).status()).isEqualTo("VIOLATION");
+
+        MockEnvironment hsqldb = env();
+        hsqldb.setActiveProfiles("production");
+        hsqldb.setProperty("spring.datasource.url", "jdbc:hsqldb:mem:testdb");
+        assertThat(rule.evaluate(context(hsqldb).build()).status()).isEqualTo("VIOLATION");
+
+        MockEnvironment derby = env();
+        derby.setActiveProfiles("prod");
+        derby.setProperty("spring.datasource.url", "jdbc:derby:memory:testdb;create=true");
+        assertThat(rule.evaluate(context(derby).build()).status()).isEqualTo("VIOLATION");
+    }
+
+    @Test
+    void inMemoryDatasourcePassesInProductionForARealDatabase() {
+        InMemoryDatasourceInProductionRule rule = new InMemoryDatasourceInProductionRule();
+
+        MockEnvironment prod = env();
+        prod.setActiveProfiles("prod");
+        prod.setProperty("spring.datasource.url", "jdbc:postgresql://db.internal:5432/app");
+        assertThat(rule.evaluate(context(prod).build()).status()).isEqualTo("PASS");
+
+        // File-backed H2 (not jdbc:h2:mem:) is a legitimate durable embedded deployment.
+        MockEnvironment fileH2 = env();
+        fileH2.setActiveProfiles("prod");
+        fileH2.setProperty("spring.datasource.url", "jdbc:h2:file:/var/data/app");
+        assertThat(rule.evaluate(context(fileH2).build()).status()).isEqualTo("PASS");
+
+        MockEnvironment noUrl = env();
+        noUrl.setActiveProfiles("prod");
+        assertThat(rule.evaluate(context(noUrl).build()).status()).isEqualTo("PASS");
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScannerTests.java
@@ -16,7 +16,7 @@ import org.springframework.mock.env.MockEnvironment;
 
 class SpringScannerTests {
 
-    private static final int RULE_COUNT = 35;
+    private static final int RULE_COUNT = 37;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-06T10:00:00Z"), ZoneOffset.UTC);
 
     @Test

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -259,7 +259,8 @@ each one inspects.
 The Spring panel runs an explicit, read-only scan of the host application's running Spring application context and
 `Environment`. It takes a bounded snapshot of selected bean groups (Jackson `ObjectMapper`s, `TaskExecutor`s,
 `DataSource`s) and feature flags, then evaluates a curated ruleset across bean wiring, configuration hygiene, profiles and
-environment, performance and concurrency (including virtual threads), web/HTTP settings, and Actuator/management exposure.
+environment, performance and concurrency (including virtual threads), web/HTTP settings, data and persistence, and
+Actuator/management exposure.
 Because it runs inside the
 already-started application, it focuses on "started but suboptimal" states rather than fatal startup conditions. It
 complements the Architecture panel, which statically analyzes compiled bytecode with ArchUnit, by inspecting the live,

--- a/docs/SPRING-CHECKS.md
+++ b/docs/SPRING-CHECKS.md
@@ -78,6 +78,13 @@ The panel is always available (a Spring application context always exists). Bean
 - **Recommendation**: Move these classes into a named package (for example com.example.app) so component scanning is bounded to your application's packages.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/using/structuring-your-code.html>
 
+### SPRING-WIRING-009 - Avoid mutable public fields on singleton beans
+
+- **Severity**: MEDIUM
+- **Detects**: Detects a public, non-final, non-static field on a singleton-scoped application bean that is not an injection point (not annotated @Autowired, @Value, @Qualifier, @Inject, @Resource, @PersistenceContext, or @PersistenceUnit). Because the default bean scope is a shared singleton, such a field is effectively unsynchronized mutable global state: any caller can reassign it, and concurrent requests reading and writing it race without a memory barrier.
+- **Recommendation**: Make the field private and expose an accessor if needed, mark it final and set it only from the constructor, or move truly per-request/per-call state out of the singleton (a method-local variable, a request-scoped bean, or immutable value types).
+- **Learn more**: <https://docs.spring.io/spring-framework/reference/core/beans/factory-scopes.html#beans-factory-scopes-singleton>
+
 ## Configuration
 
 ### SPRING-CONFIG-001 - Consider lazy initialization for large contexts
@@ -89,7 +96,7 @@ The panel is always available (a Spring application context always exists). Bean
 
 ### SPRING-CONFIG-002 - Disable global debug or trace logging
 
-- **Severity**: LOW
+- **Severity**: LOW (MEDIUM when a production-like profile is active)
 - **Detects**: Detects debug=true or trace=true, or broad root/web/sql/org.springframework/org.hibernate loggers set to DEBUG or TRACE, which enable verbose framework logging that can leak internal details or slow down the application.
 - **Recommendation**: Remove the debug/trace flags and configure logging levels only for narrow packages that need them.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/logging.html>
@@ -201,8 +208,8 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-WEB-002 - Keep graceful shutdown enabled
 
 - **Severity**: MEDIUM
-- **Detects**: Detects server.shutdown=immediate, which overrides the Spring Boot 4 default of graceful shutdown, so in-flight requests can be dropped when the application stops.
-- **Recommendation**: Remove server.shutdown=immediate (Spring Boot 4 defaults to graceful) and tune spring.lifecycle.timeout-per-shutdown-phase so active requests can complete during rollouts.
+- **Detects**: Detects server.shutdown=immediate, which overrides the Spring Boot 4 default of graceful shutdown, so in-flight requests can be dropped when the application stops. Also detects graceful shutdown left nominally enabled but with spring.lifecycle.timeout-per-shutdown-phase set to a zero duration (0, 0s, 0ms, PT0S, ...), which grants no grace period and so drops in-flight requests just like the immediate mode.
+- **Recommendation**: Remove server.shutdown=immediate (Spring Boot 4 defaults to graceful) and set spring.lifecycle.timeout-per-shutdown-phase to a positive duration (the default is 30s) so active requests can complete during rollouts.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/graceful-shutdown.html>
 
 ### SPRING-WEB-003 - Consider enabling HTTP/2
@@ -249,6 +256,13 @@ The panel is always available (a Spring application context always exists). Bean
 - **Recommendation**: Set spring.jpa.open-in-view=false and load the associations each request needs explicitly (fetch joins, entity graphs, or DTO projections).
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.jpa-and-spring-data.open-entity-manager-in-view>
 
+### SPRING-DATA-001 - Do not run production on an in-memory database
+
+- **Severity**: MEDIUM
+- **Detects**: A production-like profile is active while spring.datasource.url points at an in-process, in-memory database (an H2 jdbc:h2:mem: or HSQLDB jdbc:hsqldb:mem: URL, or a Derby jdbc:derby:memory: URL). These engines keep their data only in the JVM heap of a single instance: a restart, redeploy, or crash silently discards everything, and the data is invisible to any other instance in a multi-instance deployment. A file-backed embedded URL (for example jdbc:h2:file:) is not flagged.
+- **Recommendation**: Point spring.datasource.url at a durable, shared database server (PostgreSQL, MySQL, SQL Server, ...) for any production-like profile. Reserve the in-memory engines for tests and local development.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.datasource.embedded>
+
 ## Actuator and management
 
 ### SPRING-MGMT-001 - Avoid exposing all Actuator endpoints
@@ -283,14 +297,14 @@ The panel is always available (a Spring application context always exists). Bean
 
 ## Rule summary
 
-The Spring Advisor ships **35 curated rules** across seven categories. By declared default severity: **0 CRITICAL**, **1 HIGH**, **17 MEDIUM**, **9 LOW**, **8 INFO**. Context-aware rules can raise SPRING-JPA-001, SPRING-MGMT-001, and SPRING-MGMT-002 to HIGH, and SPRING-MGMT-004 to CRITICAL.
+The Spring Advisor ships **37 curated rules** across seven categories. By declared default severity: **0 CRITICAL**, **1 HIGH**, **19 MEDIUM**, **9 LOW**, **8 INFO**. Context-aware rules can raise SPRING-JPA-001, SPRING-MGMT-001, and SPRING-MGMT-002 to HIGH, and SPRING-MGMT-004 to CRITICAL; SPRING-CONFIG-002 can raise from LOW to MEDIUM.
 
 | Category | Rules |
 | --- | --- |
-| Bean wiring | SPRING-WIRING-001 ... SPRING-WIRING-008 |
+| Bean wiring | SPRING-WIRING-001 ... SPRING-WIRING-009 |
 | Configuration | SPRING-CONFIG-001 ... SPRING-CONFIG-005 |
 | Profiles and environment | SPRING-PROFILE-001 ... SPRING-PROFILE-003 |
 | Performance and concurrency | SPRING-PERF-001 ... SPRING-PERF-006, SPRING-CACHE-001 |
 | Web and HTTP | SPRING-WEB-001 ... SPRING-WEB-007 |
-| Data and persistence | SPRING-JPA-001 |
+| Data and persistence | SPRING-JPA-001, SPRING-DATA-001 |
 | Actuator and management | SPRING-MGMT-001 ... SPRING-MGMT-004 |


### PR DESCRIPTION
## Summary

Second-round audit of the Spring application advisor (panel `spring`, route `/spring`), following the Phase 3 hardening pass (`e7cfc964`) and matching the rigor of the Pentesting audit (`b3162c0b`). Verified all 35 existing rules against the pinned **Spring Boot 4.1.0 / Spring Framework 7.0.7** source and reference docs, and cross-checked the just-expanded Quarkus application advisor (`QuarkusAppChecks.java`, #472) for parity gaps worth porting back.

## Existing-rule fixes

- **SPRING-WEB-002** (graceful shutdown): also flags `spring.lifecycle.timeout-per-shutdown-phase=0` (`0s`/`0ms`/`PT0S`/...), which defeats graceful shutdown just as completely as `server.shutdown=immediate` but previously went undetected. Reads the `Duration` via `Binder.get(environment).bind(key, Bindable.of(Duration.class))` rather than `Environment.getProperty(key, Duration.class)` — I verified against the actual pinned jars that the latter throws `ConverterNotFoundException` on a plain `Environment`, since only Boot's `ApplicationConversionService`/`Binder` infrastructure registers a `String -> Duration` converter (this matches the existing `ActuatorExposure` precedent). Mirrors Quarkus `QA-WEB-002`.
- **SPRING-CONFIG-002** (debug/trace logging): now escalates LOW → MEDIUM when a production-like profile is active, reusing the severity-override mechanism already wired for SPRING-JPA-001/SPRING-MGMT-001/002, and matching Quarkus `QA-CFG-003`'s MEDIUM severity for the same signal.

## New rules

- **SPRING-DATA-001** (MEDIUM): flags `spring.datasource.url` pointing at an in-process, in-memory database (`jdbc:h2:mem:`/`jdbc:hsqldb:mem:`/`jdbc:derby:memory:`) while a production-like profile is active — previously uncovered by any advisor (confirmed the Hibernate advisor only covers `ddl-auto`/`show-sql`). File-backed embedded URLs (`jdbc:h2:file:`) are correctly not flagged.
- **SPRING-WIRING-009** (MEDIUM): flags public, non-final, non-static fields on singleton-scoped application beans that aren't injection points (`@Autowired`/`@Value`/`@Qualifier`/`@Inject`/`@Resource`/`@PersistenceContext`/`@PersistenceUnit`) — unsynchronized shared mutable state on Spring's default bean scope. Ported from Quarkus's CDI mutable-field checks (`QA-CDI-001`/`QA-CDI-002`), deliberately reusing only the **narrower** `QA-CDI-002` heuristic (public fields only) since Spring's single bean model merges what Quarkus splits into an `@ApplicationScoped` rule and a JAX-RS-resource-specific rule — the broader `QA-CDI-001` heuristic (which also flags private mutable fields) would be too noisy for ordinary Spring beans.

## Considered and declined (from the Quarkus cross-check)

- `QA-SCH-001` (ShedLock/clustered scheduling): too 3rd-party-coupled and false-positive-prone to port as-is.
- `QA-CFG-001` (type-safe config) and `QA-RX-001` (reactive + blocking JDBC): lower value on Spring, where `@ConfigurationProperties` is already idiomatic and the WebFlux+blocking-JDBC combination is a narrower audience than Quarkus's Mutiny+Agroal.

## Docs & verification

- All 20 pre-existing `learnMoreUrl` links plus the 2 new anchor-fragment links (`data.sql.datasource.embedded`, `beans-factory-scopes-singleton`) confirmed reachable (HTTP 200) with the anchor id present in the page HTML — no stale links found this round.
- Updated `docs/SPRING-CHECKS.md` (rule count 35 → 37, severity tally, new/changed entries — every `learnMoreUrl` cross-checked byte-for-byte against the Java source via script) and `docs/FEATURES.md` (added the previously-missing "data and persistence" category to the panel summary sentence).
- Added 6 tests to `SpringRulesTests.java` (24 → 30) covering both new rules and both changed rules; bumped `SpringScannerTests.RULE_COUNT` to 37.

**Verified**: 986 tests pass (53 `bootui-core` + 878 `bootui-spring-autoconfigure` + 55 `bootui-spring-sample-app`), 0 failures/errors; `spotless:apply` / `spotless:check` clean.

## Guardrails honored

- Did not touch `QuarkusAppChecks.java` or any Quarkus-side file (read-only cross-check reference).
- Did not touch other advisors (Hibernate, Pentesting, Architecture, Security, etc.).
- No unrelated pre-existing issues fixed outside this panel's scope.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>