### PR TITLE
Audit the Security advisor: fix 2 bugs, add 4 rules, cross-check Quarkus findings

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
@@ -4,13 +4,20 @@ import io.github.jdubois.bootui.autoconfigure.config.BootUiActuatorDefaultsEnvir
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.CorsConfigModel;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.FilterChainModel;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.PasswordEncoderModel;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.env.ConfigTreePropertySource;
 import org.springframework.boot.env.DefaultPropertiesPropertySource;
+import org.springframework.boot.env.RandomValuePropertySource;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
 
 /**
  * Read-only inputs handed to every Spring Security Advisor rule: the introspected filter chains and
@@ -55,6 +62,27 @@ record SecurityContext(
                                 "spring.security.oauth2.resourceserver.jwt.public-key-location")
                         != null
                 || !jwtDecoderTypes.isEmpty();
+    }
+
+    /**
+     * {@code true} when the application configures (or is expected to run behind) TLS: server-side
+     * SSL is configured, a forwarded-headers strategy indicates TLS is terminated upstream, or a
+     * chain installs an HTTPS-redirect filter.
+     */
+    boolean isTlsConfigured() {
+        if (isPropertyTrue("server.ssl.enabled")
+                || firstProperty("server.ssl.key-store") != null
+                || firstProperty("server.ssl.bundle") != null
+                || firstProperty("server.ssl.certificate") != null) {
+            return true;
+        }
+        String forwarded = firstProperty("server.forward-headers-strategy");
+        if (forwarded != null && ("framework".equalsIgnoreCase(forwarded) || "native".equalsIgnoreCase(forwarded))) {
+            return true;
+        }
+        return chains.stream()
+                .anyMatch(
+                        chain -> chain.hasFilter("ChannelProcessingFilter") || chain.hasFilter("HttpsRedirectFilter"));
     }
 
     String firstProperty(String... keys) {
@@ -140,5 +168,62 @@ record SecurityContext(
             }
         }
         return false;
+    }
+
+    private static final Pattern SUSPECTED_SECRET_KEY = Pattern.compile(
+            ".*(password|passwd|secret|token|api-?key|client-secret|private-key).*", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Configuration property names (never values) that look like they hold a credential -- matching
+     * {@link #SUSPECTED_SECRET_KEY} -- and whose raw, per-source value is a non-blank literal rather
+     * than an unresolved {@code ${...}} placeholder reference. Only ordinary, file-like configuration
+     * sources are scanned: system properties, the OS environment, the random-value source, BootUI's
+     * own defaults, and mounted config-tree secrets are excluded because they are already legitimate
+     * externalization mechanisms, not hardcoded literals. The literal value itself is never returned
+     * or retained here, so it cannot leak into a violation message or the browser.
+     */
+    Set<String> suspectedHardcodedSecretKeys() {
+        if (!(environment instanceof ConfigurableEnvironment configurableEnvironment)) {
+            return Set.of();
+        }
+        Set<String> found = new LinkedHashSet<>();
+        for (PropertySource<?> propertySource : configurableEnvironment.getPropertySources()) {
+            if (!isScannableConfigSource(propertySource)) {
+                continue;
+            }
+            if (!(propertySource instanceof EnumerablePropertySource<?> enumerable)) {
+                continue;
+            }
+            for (String name : enumerable.getPropertyNames()) {
+                if (name == null
+                        || name.isBlank()
+                        || name.toLowerCase(Locale.ROOT).startsWith("bootui.")) {
+                    continue;
+                }
+                if (!SUSPECTED_SECRET_KEY.matcher(name).matches()) {
+                    continue;
+                }
+                Object rawValue = propertySource.getProperty(name);
+                if (!(rawValue instanceof String text) || text.isBlank() || text.contains("${")) {
+                    continue;
+                }
+                found.add(name);
+            }
+        }
+        return found;
+    }
+
+    private static boolean isScannableConfigSource(PropertySource<?> propertySource) {
+        if (ConfigurationPropertySources.isAttachedConfigurationPropertySource(propertySource)) {
+            return false;
+        }
+        String name = propertySource.getName();
+        if (StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME.equals(name)
+                || StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME.equals(name)
+                || RandomValuePropertySource.RANDOM_PROPERTY_SOURCE_NAME.equals(name)
+                || DefaultPropertiesPropertySource.NAME.equals(name)) {
+            return false;
+        }
+        return !(propertySource instanceof ConfigTreePropertySource);
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.security;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Bounded, read-only snapshot of the host application's Spring Security configuration. Built by the
@@ -22,6 +23,14 @@ final class SecurityModel {
      *     to skip session-fixation protection, {@code null} when it could not be determined
      * @param headerWriterNames simple class names of the {@code HeaderWriter}s installed by the
      *     chain's {@code HeaderWriterFilter}, when one is present
+     * @param hstsMaxAgeSeconds the {@code HstsHeaderWriter}'s configured {@code maxAgeInSeconds},
+     *     when an HSTS writer is present and the field could be read, {@code null} otherwise
+     * @param hstsIncludeSubdomains the {@code HstsHeaderWriter}'s configured
+     *     {@code includeSubDomains}, when an HSTS writer is present and the field could be read,
+     *     {@code null} otherwise
+     * @param cspPolicyDirectives the {@code ContentSecurityPolicyHeaderWriter}'s configured
+     *     {@code policyDirectives}, when a CSP writer is present and the field could be read,
+     *     {@code null} otherwise
      */
     record FilterChainModel(
             int index,
@@ -29,11 +38,41 @@ final class SecurityModel {
             List<String> filterNames,
             Boolean permitsAllAnonymous,
             Boolean sessionFixationDisabled,
-            List<String> headerWriterNames) {
+            List<String> headerWriterNames,
+            Long hstsMaxAgeSeconds,
+            Boolean hstsIncludeSubdomains,
+            String cspPolicyDirectives) {
+
+        private static final long HSTS_MIN_MAX_AGE_SECONDS = 31536000L; // HstsHeaderWriter's own 1-year default
+
+        private static final Pattern CSP_WILDCARD_SOURCE = Pattern.compile(".*(default-src|script-src)\\s+[^;]*\\*.*");
 
         FilterChainModel {
             filterNames = List.copyOf(filterNames);
             headerWriterNames = headerWriterNames == null ? List.of() : List.copyOf(headerWriterNames);
+        }
+
+        /**
+         * Convenience constructor for callers that do not need the HSTS/CSP policy details (e.g.
+         * chains with no HSTS or CSP writer, or existing tests built before those fields existed).
+         */
+        FilterChainModel(
+                int index,
+                String matcher,
+                List<String> filterNames,
+                Boolean permitsAllAnonymous,
+                Boolean sessionFixationDisabled,
+                List<String> headerWriterNames) {
+            this(
+                    index,
+                    matcher,
+                    filterNames,
+                    permitsAllAnonymous,
+                    sessionFixationDisabled,
+                    headerWriterNames,
+                    null,
+                    null,
+                    null);
         }
 
         boolean hasFilter(String simpleClassName) {
@@ -50,6 +89,36 @@ final class SecurityModel {
 
         boolean hasHeaderWriterContaining(String fragment) {
             return headerWriterNames.stream().anyMatch(name -> name.contains(fragment));
+        }
+
+        /**
+         * {@code true} when an {@code HstsHeaderWriter} is present but configured with a max-age
+         * under one year or without {@code includeSubDomains}, weakening the protocol-downgrade and
+         * cookie-hijacking protection HSTS is meant to provide. {@code false} when no HSTS writer was
+         * detected or its fields could not be read.
+         */
+        boolean hasWeakHsts() {
+            if (hstsMaxAgeSeconds == null) {
+                return false;
+            }
+            return hstsMaxAgeSeconds < HSTS_MIN_MAX_AGE_SECONDS || Boolean.FALSE.equals(hstsIncludeSubdomains);
+        }
+
+        /**
+         * {@code true} when a {@code ContentSecurityPolicyHeaderWriter} policy allows
+         * {@code 'unsafe-inline'} / {@code 'unsafe-eval'} or a wildcard {@code default-src}/
+         * {@code script-src}, which largely defeats the XSS mitigation a CSP is meant to provide.
+         * {@code false} when no CSP writer was detected or its policy could not be read.
+         */
+        boolean hasWeakCsp() {
+            if (cspPolicyDirectives == null) {
+                return false;
+            }
+            String normalized = cspPolicyDirectives.toLowerCase(Locale.ROOT);
+            if (normalized.contains("'unsafe-inline'") || normalized.contains("'unsafe-eval'")) {
+                return true;
+            }
+            return CSP_WILDCARD_SOURCE.matcher(normalized).matches();
         }
 
         /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuleRegistry.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuleRegistry.java
@@ -12,6 +12,7 @@ final class SecurityRuleRegistry {
             new WeakBcryptStrengthRule(),
             new DefaultInMemoryUserRule(),
             new DefaultLoginPageProductionRule(),
+            new BasicAuthWithoutTlsRule(),
             // Authorization
             new MissingAuthorizationFilterRule(),
             new PermitAllCatchAllRule(),
@@ -36,6 +37,8 @@ final class SecurityRuleRegistry {
             new ReferrerPolicyHeaderRule(),
             new PermissionsPolicyHeaderRule(),
             new HeaderWritersDisabledRule(),
+            new WeakHstsPolicyRule(),
+            new WeakContentSecurityPolicyRule(),
             // CORS
             new CorsWildcardOriginRule(),
             new CorsWildcardWithCredentialsRule(),
@@ -62,7 +65,8 @@ final class SecurityRuleRegistry {
             new H2ConsoleFrameOptionsRule(),
             new WebSecurityConfigurerAdapterRule(),
             new ErrorResponseDisclosureRule(),
-            new HttpsEnforcementRule());
+            new HttpsEnforcementRule(),
+            new HardcodedSecretPropertyRule());
 
     private SecurityRuleRegistry() {}
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
@@ -7,6 +7,7 @@ import io.github.jdubois.bootui.core.dto.SecurityRuleResultDto;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 abstract class AbstractSecurityRule implements SecurityRule {
 
@@ -220,6 +221,34 @@ final class WeakBcryptStrengthRule extends AbstractSecurityRule {
             if (strength != null && strength >= 0 && strength < RECOMMENDED_MINIMUM_STRENGTH) {
                 details.add("PasswordEncoder bean " + encoder.type() + " uses BCrypt strength " + strength
                         + ", below the recommended minimum of " + RECOMMENDED_MINIMUM_STRENGTH + ".");
+            }
+        }
+        return violation(details);
+    }
+}
+
+final class BasicAuthWithoutTlsRule extends AbstractSecurityRule {
+
+    BasicAuthWithoutTlsRule() {
+        super(new SecurityRuleDefinition(
+                "SEC-AUTH-007",
+                "HTTP Basic authentication should run only over HTTPS",
+                SecurityCategory.AUTHENTICATION,
+                "HIGH",
+                "Detects an HTTP Basic authentication chain (BasicAuthenticationFilter) while a production profile is active and no server-side TLS, HTTPS redirect, or forwarded-header strategy is configured. Basic sends the username/password Base64-encoded, not encrypted, on every request.",
+                "Enforce HTTPS via server.ssl.* (or a forwarded-headers strategy when TLS terminates upstream) for any chain using httpBasic(), or switch to a mechanism that does not repeat credentials on every request.",
+                "https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/basic.html"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        if (!context.isProductionProfileActive() || context.isTlsConfigured()) {
+            return pass();
+        }
+        List<String> details = new ArrayList<>();
+        for (FilterChainModel chain : context.chains()) {
+            if (chain.hasFilter("BasicAuthenticationFilter")) {
+                details.add(chain.describe() + " authenticates with HTTP Basic while no TLS is configured.");
             }
         }
         return violation(details);
@@ -762,7 +791,7 @@ final class PermissionsPolicyHeaderRule extends AbstractSecurityRule {
 }
 
 // ---------------------------------------------------------------------------
-// CORS
+// Transport & security headers (continued)
 // ---------------------------------------------------------------------------
 
 final class HeaderWritersDisabledRule extends AbstractSecurityRule {
@@ -790,6 +819,63 @@ final class HeaderWritersDisabledRule extends AbstractSecurityRule {
         return violation(details);
     }
 }
+
+final class WeakHstsPolicyRule extends AbstractSecurityRule {
+
+    WeakHstsPolicyRule() {
+        super(new SecurityRuleDefinition(
+                "SEC-HEAD-008",
+                "HSTS should use a strong max-age and includeSubDomains",
+                SecurityCategory.HEADERS,
+                "LOW",
+                "Detects an HstsHeaderWriter configured with a max-age under one year or without includeSubDomains, which weakens the protocol-downgrade and cookie-hijacking protection HSTS is meant to provide.",
+                "Keep the default HstsHeaderWriter settings (max-age=31536000, includeSubDomains=true), or configure headers().httpStrictTransportSecurity() explicitly with those values.",
+                "https://docs.spring.io/spring-security/reference/servlet/exploits/headers.html#servlet-headers-hsts"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        List<String> details = new ArrayList<>();
+        for (FilterChainModel chain : context.chains()) {
+            if (chain.hasWeakHsts()) {
+                details.add(
+                        chain.describe() + " emits an HSTS header with a weak max-age or without includeSubDomains.");
+            }
+        }
+        return violation(details);
+    }
+}
+
+final class WeakContentSecurityPolicyRule extends AbstractSecurityRule {
+
+    WeakContentSecurityPolicyRule() {
+        super(new SecurityRuleDefinition(
+                "SEC-HEAD-009",
+                "Content-Security-Policy should not allow unsafe-inline/unsafe-eval or wildcard sources",
+                SecurityCategory.HEADERS,
+                "MEDIUM",
+                "Detects a ContentSecurityPolicyHeaderWriter policy that includes 'unsafe-inline' or 'unsafe-eval', or a wildcard (*) default-src/script-src, which largely defeats the XSS mitigation a CSP is meant to provide.",
+                "Remove 'unsafe-inline'/'unsafe-eval' and wildcard sources; use nonces or hashes for the scripts/styles the application actually serves.",
+                "https://docs.spring.io/spring-security/reference/servlet/exploits/headers.html#servlet-headers-csp"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        List<String> details = new ArrayList<>();
+        for (FilterChainModel chain : context.chains()) {
+            if (chain.hasWeakCsp()) {
+                details.add(
+                        chain.describe()
+                                + " defines a Content-Security-Policy that allows unsafe-inline/unsafe-eval or a wildcard source.");
+            }
+        }
+        return violation(details);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CORS
+// ---------------------------------------------------------------------------
 
 final class CorsWildcardOriginRule extends AbstractSecurityRule {
 
@@ -1172,7 +1258,7 @@ final class ManagementPortIsolationRule extends AbstractSecurityRule {
 }
 
 // ---------------------------------------------------------------------------
-// OAuth2 / JWT resource server
+// Actuator exposure (continued)
 // ---------------------------------------------------------------------------
 
 final class ActuatorShowValuesRule extends AbstractSecurityRule {
@@ -1203,7 +1289,7 @@ final class ActuatorShowValuesRule extends AbstractSecurityRule {
 }
 
 // ---------------------------------------------------------------------------
-// OAuth2 / JWT resource server (continued)
+// OAuth2 / JWT resource server
 // ---------------------------------------------------------------------------
 
 final class ResourceServerValidationRule extends AbstractSecurityRule {
@@ -1430,27 +1516,39 @@ final class HttpsEnforcementRule extends AbstractSecurityRule {
 
     @Override
     SecurityRuleResultDto evaluateRule(SecurityContext context) {
-        if (!context.isProductionProfileActive() || isTlsHandled(context)) {
+        if (!context.isProductionProfileActive() || context.isTlsConfigured()) {
             return pass();
         }
         return violation(
                 List.of(
                         "No server-side TLS, HTTPS redirect, or forwarded-header strategy is configured while a production profile is active."));
     }
+}
 
-    private boolean isTlsHandled(SecurityContext context) {
-        if (context.isPropertyTrue("server.ssl.enabled")
-                || context.firstProperty("server.ssl.key-store") != null
-                || context.firstProperty("server.ssl.bundle") != null
-                || context.firstProperty("server.ssl.certificate") != null) {
-            return true;
+final class HardcodedSecretPropertyRule extends AbstractSecurityRule {
+
+    HardcodedSecretPropertyRule() {
+        super(new SecurityRuleDefinition(
+                "SEC-CONFIG-007",
+                "Configuration should not hold literal secret values",
+                SecurityCategory.CONFIGURATION,
+                "CRITICAL",
+                "Detects configuration property names that look like they hold a credential (password, secret, token, api-key, client-secret, private-key) whose value is a literal, unresolved string rather than an externalized reference. System properties, the OS environment, the random-value source, and mounted config-tree secrets are not scanned because they are already externalized. Property values are never read into the finding; only the offending property name is reported.",
+                "Move the literal value out of the configuration file into an environment variable, a secrets manager, or a mounted config-tree secret, and reference it with ${ENV_VAR_NAME} instead of a hardcoded literal.",
+                "https://docs.spring.io/spring-boot/reference/features/external-config.html"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        Set<String> keys = context.suspectedHardcodedSecretKeys();
+        if (keys.isEmpty()) {
+            return pass();
         }
-        String forwarded = context.firstProperty("server.forward-headers-strategy");
-        if (forwarded != null && ("framework".equalsIgnoreCase(forwarded) || "native".equalsIgnoreCase(forwarded))) {
-            return true;
-        }
-        return context.chains().stream()
-                .anyMatch(
-                        chain -> chain.hasFilter("ChannelProcessingFilter") || chain.hasFilter("HttpsRedirectFilter"));
+        List<String> details = keys.stream()
+                .sorted()
+                .map(key -> "Property '" + key
+                        + "' appears to hold a hardcoded secret value in the application configuration.")
+                .toList();
+        return violation(details);
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -277,9 +277,17 @@ final class SecurityScanner {
         String matcher = matcherDescription(chain);
         Boolean permitsAllAnonymous = simulateAnonymous(filters);
         Boolean sessionFixationDisabled = detectSessionFixationDisabled(filters);
-        List<String> headerWriters = detectHeaderWriters(filters);
+        HeaderWriterInfo headerWriters = detectHeaderWriters(filters);
         return new FilterChainModel(
-                index, matcher, filterNames, permitsAllAnonymous, sessionFixationDisabled, headerWriters);
+                index,
+                matcher,
+                filterNames,
+                permitsAllAnonymous,
+                sessionFixationDisabled,
+                headerWriters.names(),
+                headerWriters.hstsMaxAgeSeconds(),
+                headerWriters.hstsIncludeSubdomains(),
+                headerWriters.cspPolicyDirectives());
     }
 
     private static String matcherDescription(SecurityFilterChain chain) {
@@ -362,23 +370,49 @@ final class SecurityScanner {
         }
     }
 
-    private static List<String> detectHeaderWriters(List<Filter> filters) {
+    /**
+     * Simple class names of the installed {@code HeaderWriter}s, plus the HSTS max-age/
+     * includeSubDomains and CSP policyDirectives fields when those specific writers are present (read
+     * via the same reflection helper used for {@link #bcryptStrength(Object)}).
+     */
+    private record HeaderWriterInfo(
+            List<String> names, Long hstsMaxAgeSeconds, Boolean hstsIncludeSubdomains, String cspPolicyDirectives) {}
+
+    private static final HeaderWriterInfo NO_HEADER_WRITERS = new HeaderWriterInfo(List.of(), null, null, null);
+
+    private static HeaderWriterInfo detectHeaderWriters(List<Filter> filters) {
         for (Filter filter : filters) {
             if (!"HeaderWriterFilter".equals(filter.getClass().getSimpleName())) {
                 continue;
             }
             Object writers = readField(filter, "headerWriters");
             List<String> names = new ArrayList<>();
+            Long hstsMaxAgeSeconds = null;
+            Boolean hstsIncludeSubdomains = null;
+            String cspPolicyDirectives = null;
             if (writers instanceof Iterable<?> iterable) {
                 for (Object writer : iterable) {
-                    if (writer != null) {
-                        names.add(writer.getClass().getSimpleName());
+                    if (writer == null) {
+                        continue;
+                    }
+                    String simpleName = writer.getClass().getSimpleName();
+                    names.add(simpleName);
+                    if (simpleName.contains("Hsts")) {
+                        if (readField(writer, "maxAgeInSeconds") instanceof Long maxAge) {
+                            hstsMaxAgeSeconds = maxAge;
+                        }
+                        if (readField(writer, "includeSubDomains") instanceof Boolean includeSubDomains) {
+                            hstsIncludeSubdomains = includeSubDomains;
+                        }
+                    } else if (simpleName.contains("ContentSecurityPolicy")
+                            && readField(writer, "policyDirectives") instanceof String directives) {
+                        cspPolicyDirectives = directives;
                     }
                 }
             }
-            return names;
+            return new HeaderWriterInfo(names, hstsMaxAgeSeconds, hstsIncludeSubdomains, cspPolicyDirectives);
         }
-        return List.of();
+        return NO_HEADER_WRITERS;
     }
 
     private static boolean discoverCors(

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
@@ -7,11 +7,17 @@ import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.FilterChain
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.PasswordEncoderModel;
 import io.github.jdubois.bootui.core.dto.SecurityRuleResultDto;
 import java.util.List;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertiesPropertySource;
+import org.springframework.core.env.StandardEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
-/** Focused per-rule coverage for the Phase 6 Security advisor hardening. */
+/**
+ * Focused per-rule coverage for the Phase 6 Security advisor hardening, plus the follow-up audit
+ * that added SEC-AUTH-007, SEC-HEAD-008/009, and SEC-CONFIG-007.
+ */
 class SecurityRulesTests {
 
     // --- SEC-AUTH-001: plaintext encoder is CRITICAL ----------------------------------------
@@ -290,6 +296,236 @@ class SecurityRulesTests {
                         "AuthorizationFilter"));
 
         SecurityRuleResultDto result = new CsrfDisabledStatefulRule().evaluate(singleChain(tokenLogin));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-AUTH-007: HTTP Basic requires TLS in production -------------------------------
+
+    @Test
+    void basicAuthWithoutTlsFiresInProduction() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+        FilterChainModel chain = chain("any request", List.of("BasicAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new BasicAuthWithoutTlsRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void basicAuthWithoutTlsIsIgnoredOutsideProduction() {
+        FilterChainModel chain = chain("any request", List.of("BasicAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new BasicAuthWithoutTlsRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void basicAuthWithTlsConfiguredPasses() {
+        MockEnvironment environment = new MockEnvironment().withProperty("server.ssl.enabled", "true");
+        environment.setActiveProfiles("prod");
+        FilterChainModel chain = chain("any request", List.of("BasicAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new BasicAuthWithoutTlsRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-HEAD-008: weak HSTS policy ------------------------------------------------------
+
+    @Test
+    void weakHstsMaxAgeFiresViolation() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("HstsHeaderWriter"),
+                3600L,
+                Boolean.TRUE,
+                null);
+
+        SecurityRuleResultDto result = new WeakHstsPolicyRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("LOW");
+    }
+
+    @Test
+    void hstsWithoutIncludeSubdomainsFiresViolation() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("HstsHeaderWriter"),
+                31536000L,
+                Boolean.FALSE,
+                null);
+
+        SecurityRuleResultDto result = new WeakHstsPolicyRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void strongHstsPolicyPasses() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("HstsHeaderWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null);
+
+        SecurityRuleResultDto result = new WeakHstsPolicyRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void weakHstsPolicyPassesWhenHstsWriterNotDetected() {
+        FilterChainModel chain = chain("any request", List.of("HeaderWriterFilter"));
+
+        SecurityRuleResultDto result = new WeakHstsPolicyRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-HEAD-009: weak Content-Security-Policy -----------------------------------------
+
+    @Test
+    void weakCspWithUnsafeInlineFiresViolation() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("ContentSecurityPolicyHeaderWriter"),
+                null,
+                null,
+                "default-src 'self'; script-src 'unsafe-inline'");
+
+        SecurityRuleResultDto result = new WeakContentSecurityPolicyRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void weakCspWithWildcardScriptSrcFiresViolation() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("ContentSecurityPolicyHeaderWriter"),
+                null,
+                null,
+                "default-src 'self'; script-src *");
+
+        SecurityRuleResultDto result = new WeakContentSecurityPolicyRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void strictCspPasses() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("ContentSecurityPolicyHeaderWriter"),
+                null,
+                null,
+                "default-src 'self'; script-src 'self'");
+
+        SecurityRuleResultDto result = new WeakContentSecurityPolicyRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-CONFIG-007: hardcoded secret in configuration ----------------------------------
+
+    @Test
+    void hardcodedSecretPropertyFiresCriticalViolationWithoutLeakingTheValue() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("spring.datasource.password", "supersecret123");
+
+        SecurityRuleResultDto result = new HardcodedSecretPropertyRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("CRITICAL");
+        assertThat(result.sampleViolations()).anyMatch(detail -> detail.contains("spring.datasource.password"));
+        assertThat(result.sampleViolations()).noneMatch(detail -> detail.contains("supersecret123"));
+    }
+
+    @Test
+    void hardcodedSecretPropertyIgnoresPlaceholderReferences() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("spring.datasource.password", "${DB_PASSWORD}");
+
+        SecurityRuleResultDto result = new HardcodedSecretPropertyRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void hardcodedSecretPropertyIgnoresSystemPropertiesSource() {
+        Properties systemProps = new Properties();
+        systemProps.setProperty("some.api-key", "abc123");
+        MockEnvironment environment = new MockEnvironment();
+        environment
+                .getPropertySources()
+                .addLast(new PropertiesPropertySource(
+                        StandardEnvironment.SYSTEM_PROPERTIES_PROPERTY_SOURCE_NAME, systemProps));
+
+        SecurityRuleResultDto result = new HardcodedSecretPropertyRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void hardcodedSecretPropertyIgnoresSystemEnvironmentSource() {
+        Properties systemEnv = new Properties();
+        systemEnv.setProperty("GITHUB_TOKEN", "ghp_abc123");
+        MockEnvironment environment = new MockEnvironment();
+        environment
+                .getPropertySources()
+                .addLast(new PropertiesPropertySource(
+                        StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, systemEnv));
+
+        SecurityRuleResultDto result = new HardcodedSecretPropertyRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void hardcodedSecretPropertyIgnoresBootUiOwnProperties() {
+        MockEnvironment environment = new MockEnvironment().withProperty("bootui.github.token", "internal-value");
+
+        SecurityRuleResultDto result = new HardcodedSecretPropertyRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void hardcodedSecretPropertyPassesWhenNoSecretLikeKeysPresent() {
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.application.name", "bootui-sample");
+
+        SecurityRuleResultDto result = new HardcodedSecretPropertyRule().evaluate(context(environment));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -23,7 +23,7 @@ import org.springframework.security.web.FilterChainProxy;
 
 class SecurityScannerTests {
 
-    private static final int RULE_COUNT = 48;
+    private static final int RULE_COUNT = 52;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 
     @Test
@@ -79,9 +79,11 @@ class SecurityScannerTests {
                         "SEC-CORS-002",
                         "SEC-CORS-003",
                         "SEC-ACT-001",
-                        "SEC-CONFIG-001");
-        // Results are ordered by severity; the first finding must be HIGH.
-        assertThat(report.results().get(0).severity()).isEqualTo("HIGH");
+                        "SEC-CONFIG-001",
+                        "SEC-CONFIG-007");
+        // Results are ordered by severity; the first finding must be CRITICAL (spring.security.user.password is a
+        // literal, matching SEC-CONFIG-007).
+        assertThat(report.results().get(0).severity()).isEqualTo("CRITICAL");
         // The severity histogram leads with CRITICAL so promoted rules sort and count correctly.
         assertThat(report.severityCounts())
                 .extracting("severity")

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -78,6 +78,13 @@ includes up to a handful of sample details plus a remediation link.
 - **Recommendation**: Provide a custom login page via formLogin().loginPage(...) for production so the unstyled default page (which advertises the Spring Security stack) is not served.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/form.html>
 
+### SEC-AUTH-007 - HTTP Basic authentication should run only over HTTPS
+
+- **Severity**: HIGH
+- **Detects**: Detects an HTTP Basic authentication chain (BasicAuthenticationFilter) while a production profile is active and no server-side TLS, HTTPS redirect, or forwarded-header strategy is configured. Basic sends the username/password Base64-encoded, not encrypted, on every request.
+- **Recommendation**: Enforce HTTPS via server.ssl.* (or a forwarded-headers strategy when TLS terminates upstream) for any chain using httpBasic(), or switch to a mechanism that does not repeat credentials on every request.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/basic.html>
+
 ## Authorization
 
 ### SEC-AUTHZ-001 - Every filter chain should enforce authorization
@@ -225,6 +232,20 @@ includes up to a handful of sample details plus a remediation link.
 - **Detects**: Detects a browser-facing (authenticated or session) chain that installs no HeaderWriterFilter, which means headers().disable() removed every security header (HSTS, X-Frame-Options, X-Content-Type-Options, ...).
 - **Recommendation**: Remove headers().disable(); keep the default HeaderWriterFilter so security headers are emitted, and only tune individual writers you do not need.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/exploits/headers.html>
+
+### SEC-HEAD-008 - HSTS should use a strong max-age and includeSubDomains
+
+- **Severity**: LOW
+- **Detects**: Detects an HstsHeaderWriter configured with a max-age under one year or without includeSubDomains, which weakens the protocol-downgrade and cookie-hijacking protection HSTS is meant to provide.
+- **Recommendation**: Keep the default HstsHeaderWriter settings (max-age=31536000, includeSubDomains=true), or configure headers().httpStrictTransportSecurity() explicitly with those values.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/exploits/headers.html#servlet-headers-hsts>
+
+### SEC-HEAD-009 - Content-Security-Policy should not allow unsafe-inline/unsafe-eval or wildcard sources
+
+- **Severity**: MEDIUM
+- **Detects**: Detects a ContentSecurityPolicyHeaderWriter policy that includes 'unsafe-inline' or 'unsafe-eval', or a wildcard (*) default-src/script-src, which largely defeats the XSS mitigation a CSP is meant to provide.
+- **Recommendation**: Remove 'unsafe-inline'/'unsafe-eval' and wildcard sources; use nonces or hashes for the scripts/styles the application actually serves.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/exploits/headers.html#servlet-headers-csp>
 
 ## CORS
 
@@ -389,3 +410,10 @@ includes up to a handful of sample details plus a remediation link.
 - **Detects**: Notes that, while a production profile is active, the application configures no server-side TLS, HTTPS redirect (requiresChannel/ChannelProcessingFilter), or forwarded-header strategy indicating TLS is terminated upstream.
 - **Recommendation**: Enforce HTTPS via server.ssl.* (or requiresChannel().requiresSecure()), or set server.forward-headers-strategy=framework when TLS is terminated by a proxy so secure cookies and redirects behave correctly.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/servlet.html#web.servlet.embedded-container.configure-ssl>
+
+### SEC-CONFIG-007 - Configuration should not hold literal secret values
+
+- **Severity**: CRITICAL
+- **Detects**: Detects configuration property names that look like they hold a credential (password, secret, token, api-key, client-secret, private-key) whose value is a literal, unresolved string rather than an externalized reference. System properties, the OS environment, the random-value source, and mounted config-tree secrets are not scanned because they are already externalized. Property values are never read into the finding; only the offending property name is reported.
+- **Recommendation**: Move the literal value out of the configuration file into an environment variable, a secrets manager, or a mounted config-tree secret, and reference it with ${ENV_VAR_NAME} instead of a hardcoded literal.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/features/external-config.html>


### PR DESCRIPTION
Second-round deep audit of the Spring Security advisor's 48 rules (Phase 6 was `634963f9`, 23 days ago), matching the rigor of the recent Pentesting audit (`b3162c0b`).

## Verified

- Confirmed **Spring Security 7.1.0** is the actually-pinned version (via Spring Boot 4.1.0's managed dependencies), not 6.x as some code comments assumed.
- Verified the `matchesAnyRequest()`/`isStateful()` heuristics and "no `SessionManagementFilter` by default" claim still hold in 7.1.0, via a throwaway JUnit probe against the real jars (not just reading docs).
- Checked the Spring Security 7.0 migration guide's breaking changes (`authorizeRequests()`/`.and()`/`AntPathRequestMatcher` removals, `AccessDecisionManager#check`) against the ruleset — none of the 48 existing rules reference the removed APIs. The two "Spring Security 6" mentions in rule prose describe *when* a change happened (still historically true under 7.1.0), so no further version drift beyond what Phase 6 already fixed.
- Read the Quarkus Security advisor's very recent critique/expansion (`944c8e9d`/`99ac5556`, `00d627cd`/`cf067dde`) for portable ideas.

## Fixed

- Two pre-existing cosmetic bugs — behavior was always correct (the real `SecurityCategory` enum field was right), only the section-banner **comments** were misplaced by one rule: `SEC-HEAD-007` sat under a `// CORS` banner instead of "Transport & security headers", and `SEC-ACT-007` sat under `// OAuth2 / JWT resource server` instead of "Actuator exposure".

## Added (48 → 52 rules)

Cross-checking the Quarkus critique surfaced 4 missing Spring Security analogs:

| Rule | Severity | Detects |
|---|---|---|
| `SEC-AUTH-007` | HIGH | HTTP Basic auth without TLS in production — Basic sends credentials Base64-encoded (not encrypted) on every request. Extracted `HttpsEnforcementRule`'s private TLS-detection logic into a shared `SecurityContext.isTlsConfigured()` reused by both rules. |
| `SEC-HEAD-008` | LOW | Weak HSTS (`max-age` < 1 year or missing `includeSubDomains`) — reflectively reads `HstsHeaderWriter`'s fields (verified present via `javap` against the real jar). |
| `SEC-HEAD-009` | MEDIUM | Weak CSP (`'unsafe-inline'`/`'unsafe-eval'` or wildcard `default-src`/`script-src`) — reflectively reads `ContentSecurityPolicyHeaderWriter`'s `policyDirectives`. |
| `SEC-CONFIG-007` | CRITICAL | Configuration property names that look like a credential (password/secret/token/api-key/client-secret/private-key) holding a literal, unresolved value. |

`SEC-CONFIG-007` deliberately diverges from its Quarkus analog (`QS-CFG-001`): it does **not** exclude the whole `spring.*` namespace, since that's exactly where real hardcoded secrets live (`spring.datasource.password`, OAuth2 `client-secret`, ...) and Spring's structural config keys don't collide with the narrow keyword regex the way Quarkus's do. System properties, the OS environment, the random-value source, BootUI's own defaults, and mounted config-tree secrets are excluded as already-legitimate externalization mechanisms — **only the offending property name is ever reported, never the value.**

Deliberately **not** ported: management host-binding (`QS-MGMT-001`) is already covered by the sibling Pentesting advisor's `PT-A05-043` (porting it here would duplicate a finding across panels); CORS regex-anchoring (`QS-CORS-004`) doesn't transfer since Spring CORS uses glob patterns, not regex.

## Tests & docs

- `FilterChainModel` grew 3 new fields (`hstsMaxAgeSeconds`, `hstsIncludeSubdomains`, `cspPolicyDirectives`) via a backward-compatible auxiliary constructor, so all 15 pre-existing call sites compile unchanged.
- Added 16 tests to `SecurityRulesTests.java`: true-positive + true-negative pairs for each new rule, plus dedicated coverage of the secret-scanner's source-exclusion logic (system properties, system environment, BootUI's own `bootui.*` properties, `${...}` placeholder references).
- Bumped `RULE_COUNT` 48 → 52 in `SecurityScannerTests.java`, which surfaced one genuine true-positive: its existing `MockEnvironment` fixture already contained `spring.security.user.password=admin`, so the scan's top severity now correctly escalates from HIGH to CRITICAL.
- Updated `docs/SECURITY-CHECKS.md` with the 4 new rule entries. `docs/FEATURES.md`/`docs/QUARKUS-SUPPORT.md` needed no changes — their Security-panel prose describes categories/architecture, not per-rule counts, and remained accurate.

## Verification

- `./mvnw -pl bootui-core,bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-sample-app -am clean test` — **996 tests pass**, 0 failures/errors.
- `./mvnw spotless:apply` / `spotless:check` — clean (no changes needed; new code already matched the palantir-java-format style).
- No `.vue` files touched, so frontend tests were not required.

## Guardrails honored

- Did not touch `QuarkusSecurityChecks.java` or `engine/security/*` (out of scope).
- No existing rule severities were lowered.
- No other advisors' files were touched.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>