### PR TITLE
Audit the Vulnerabilities advisor: fix CVSS severity parsing, add suppress workflow, harden OSV scan resilience

### DIFF
--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyVulnerabilityDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyVulnerabilityDto.java
@@ -13,4 +13,23 @@ public record DependencyVulnerabilityDto(
         Double score,
         List<String> aliases,
         List<String> references,
-        List<String> fixedVersions) {}
+        List<String> fixedVersions,
+        boolean dismissed) {
+
+    public DependencyVulnerabilityDto(
+            String id,
+            String summary,
+            String details,
+            String severity,
+            Double score,
+            List<String> aliases,
+            List<String> references,
+            List<String> fixedVersions) {
+        this(id, summary, details, severity, score, aliases, references, fixedVersions, false);
+    }
+
+    public DependencyVulnerabilityDto withDismissed(boolean dismissed) {
+        return new DependencyVulnerabilityDto(
+                id, summary, details, severity, score, aliases, references, fixedVersions, dismissed);
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScore.java
@@ -1,0 +1,153 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Computes the CVSS v3.0 / v3.1 Base Score from a vector string, e.g.
+ * {@code "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"} (which base-scores to {@code 9.8}).
+ *
+ * <p>Implements the official FIRST.org Base Metrics equations:
+ *
+ * <ul>
+ *   <li>CVSS v3.1 &sect;7 ("CVSS v3.1 Equations"), <a
+ *       href="https://www.first.org/cvss/v3-1/specification-document">specification document</a>
+ *   <li>CVSS v3.0 &sect;8 ("CVSS v3.0 Equations"), <a
+ *       href="https://www.first.org/cvss/v3.0/specification-document">specification document</a>
+ * </ul>
+ *
+ * <p>The Base Metrics equations and metric-value constants (&sect;7.4 / &sect;8.4) are byte-for-byte
+ * identical between v3.0 and v3.1 &mdash; only the Environmental-metrics exponent differs between the two
+ * versions (13 vs 15), and BootUI never scores Temporal or Environmental metrics &mdash; so one
+ * implementation serves both vector prefixes. Formula and the official integer-arithmetic "Roundup"
+ * algorithm (Appendix A of both specifications) were verified end-to-end against real NVD-published Base
+ * Scores, including CVE-2020-11619 (Scope Unchanged, score 8.1), CVE-2021-45046 (Scope Changed, score 9.0),
+ * and CVE-2021-44228 "Log4Shell" (Scope Changed, score 10.0).
+ *
+ * <p>Only the mandatory Base metric group is scored (Attack Vector, Attack Complexity, Privileges
+ * Required, User Interaction, Scope, and Confidentiality/Integrity/Availability impact) &mdash; this is the
+ * figure OSV.dev/NVD publish and label as "the" CVSS v3 score. Any Temporal or Environmental metrics
+ * present in the vector string are parsed (so they don't break Base metric extraction) but not scored.
+ *
+ * <p><strong>CVSS v4.0 is deliberately out of scope.</strong> Unlike v3.x, v4.0 has no closed-form Base
+ * Score equation: scores are derived from a roughly 270-entry "MacroVector" lookup table (six equivalence
+ * classes, each assigned by boolean conditions on the supplied metrics) with interpolation against
+ * "highest/lowest severity vector" reference data from FIRST's non-public expert-elicitation study.
+ * Reproducing that faithfully from the written specification alone &mdash; without executing FIRST's own
+ * reference implementation &mdash; risks a silently-wrong score for a security-sensitive feature, so v4.0
+ * vectors are not scored here. {@link DependencyReports#parseScore(String)} explicitly returns {@code null}
+ * for {@code CVSS:4.x} vectors, and callers fall back to the {@code database_specific.severity} label for
+ * those advisories.
+ *
+ * <p>CVSS v2 vectors (unprefixed, e.g. {@code "AV:N/AC:L/Au:N/C:P/I:P/A:P"}) are likewise not scored: the
+ * format was superseded in 2015 and zero occurrences were found across a 170-advisory sample of real
+ * OSV.dev responses for popular Maven packages.
+ */
+final class CvssV3BaseScore {
+
+    // Section 7.4 (v3.1) / 8.4 (v3.0) metric value constants -- identical between the two spec versions.
+    private static final Map<String, Double> ATTACK_VECTOR = Map.of("N", 0.85, "A", 0.62, "L", 0.55, "P", 0.2);
+    private static final Map<String, Double> ATTACK_COMPLEXITY = Map.of("L", 0.77, "H", 0.44);
+    private static final Map<String, Double> PRIVILEGES_REQUIRED_UNCHANGED = Map.of("N", 0.85, "L", 0.62, "H", 0.27);
+    private static final Map<String, Double> PRIVILEGES_REQUIRED_CHANGED = Map.of("N", 0.85, "L", 0.68, "H", 0.5);
+    private static final Map<String, Double> USER_INTERACTION = Map.of("N", 0.85, "R", 0.62);
+    private static final Map<String, Double> IMPACT = Map.of("H", 0.56, "L", 0.22, "N", 0.0);
+
+    private CvssV3BaseScore() {}
+
+    /**
+     * Computes the Base Score for a CVSS v3.0/v3.1 vector string.
+     *
+     * @param vector the full vector string, including its {@code CVSS:3.0/} or {@code CVSS:3.1/} prefix
+     * @return the Base Score (0.0-10.0, rounded up to one decimal place per the spec's Roundup function),
+     *     or {@code null} if the vector does not carry the expected prefix or is missing/has an
+     *     unrecognized value for any mandatory Base metric
+     */
+    static Double baseScore(String vector) {
+        Map<String, String> metrics = parseMetrics(vector);
+        if (metrics == null) {
+            return null;
+        }
+        String scope = metrics.get("S");
+        boolean scopeChanged = "C".equals(scope);
+        if (!scopeChanged && !"U".equals(scope)) {
+            return null;
+        }
+        Double av = metricValue(ATTACK_VECTOR, metrics.get("AV"));
+        Double ac = metricValue(ATTACK_COMPLEXITY, metrics.get("AC"));
+        Double pr = metricValue(
+                scopeChanged ? PRIVILEGES_REQUIRED_CHANGED : PRIVILEGES_REQUIRED_UNCHANGED, metrics.get("PR"));
+        Double ui = metricValue(USER_INTERACTION, metrics.get("UI"));
+        Double c = metricValue(IMPACT, metrics.get("C"));
+        Double i = metricValue(IMPACT, metrics.get("I"));
+        Double a = metricValue(IMPACT, metrics.get("A"));
+        if (av == null || ac == null || pr == null || ui == null || c == null || i == null || a == null) {
+            return null;
+        }
+
+        double iss = 1 - ((1 - c) * (1 - i) * (1 - a));
+        double impact = scopeChanged ? 7.52 * (iss - 0.029) - 3.25 * Math.pow(iss - 0.02, 15) : 6.42 * iss;
+        if (impact <= 0) {
+            return 0.0;
+        }
+        double exploitability = 8.22 * av * ac * pr * ui;
+        double combined = scopeChanged ? 1.08 * (impact + exploitability) : impact + exploitability;
+        return roundUp(Math.min(combined, 10.0));
+    }
+
+    /**
+     * Looks up {@code rawValue} in {@code table}, tolerating a {@code null} {@code rawValue} (a mandatory
+     * metric missing from the vector entirely) &mdash; the {@code Map.of(...)} lookup tables above reject a
+     * {@code null} key with an {@link NullPointerException} rather than returning {@code null} the way
+     * {@link java.util.HashMap} does, so callers must not pass {@code null} straight through.
+     */
+    private static Double metricValue(Map<String, Double> table, String rawValue) {
+        return rawValue == null ? null : table.get(rawValue);
+    }
+
+    /**
+     * Parses the {@code Metric:Value} segments of a vector string into a map, requiring the
+     * {@code CVSS:3.0/} or {@code CVSS:3.1/} prefix. Returns {@code null} for any structurally invalid
+     * vector: missing/wrong prefix, or a segment without exactly one non-edge {@code :}. Duplicate metric
+     * keys keep the last occurrence, matching how the reference calculator behaves.
+     */
+    private static Map<String, String> parseMetrics(String vector) {
+        if (vector == null) {
+            return null;
+        }
+        String prefix;
+        if (vector.startsWith("CVSS:3.0/")) {
+            prefix = "CVSS:3.0/";
+        } else if (vector.startsWith("CVSS:3.1/")) {
+            prefix = "CVSS:3.1/";
+        } else {
+            return null;
+        }
+        Map<String, String> metrics = new HashMap<>();
+        for (String segment : vector.substring(prefix.length()).split("/")) {
+            if (segment.isEmpty()) {
+                continue;
+            }
+            int separator = segment.indexOf(':');
+            if (separator <= 0 || separator == segment.length() - 1) {
+                return null;
+            }
+            metrics.put(segment.substring(0, separator), segment.substring(separator + 1));
+        }
+        return metrics;
+    }
+
+    /**
+     * The official CVSS "Roundup" function (Appendix A of both the v3.0 and v3.1 specifications): rounds a
+     * score up to the nearest 0.1 using integer arithmetic, avoiding the floating-point misrounds a naive
+     * {@code Math.ceil(input * 10) / 10.0} can produce (the spec's own example: 0.1 + 0.2 represented as
+     * 0.30000000000000004 in IEEE-754 misrounds up to 0.4 instead of staying at 0.3).
+     */
+    private static double roundUp(double input) {
+        long intInput = Math.round(input * 100000);
+        if (intInput % 10000 == 0) {
+            return intInput / 100000.0;
+        }
+        return (Math.floor(intInput / 10000.0) + 1) / 10.0;
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 public final class DependencyReports {
 
@@ -24,8 +25,14 @@ public final class DependencyReports {
             .thenComparing(DependencyDto::packageName, ALPHABETIC)
             .thenComparing(DependencyDto::version, ALPHABETIC);
 
-    public static final Comparator<DependencyVulnerabilityDto> VULNERABILITY_ORDER = Comparator.comparingInt(
-                    (DependencyVulnerabilityDto v) -> severityRank(v.severity()))
+    /**
+     * Not-yet-reviewed vulnerabilities sort first (by severity, then id); dismissed vulnerabilities always
+     * sink to the bottom of a dependency's list, mirroring how the other advisors keep dismissed findings
+     * out of the way without hiding them.
+     */
+    public static final Comparator<DependencyVulnerabilityDto> VULNERABILITY_ORDER = Comparator.comparing(
+                    DependencyVulnerabilityDto::dismissed)
+            .thenComparingInt((DependencyVulnerabilityDto v) -> severityRank(v.severity()))
             .thenComparing(DependencyVulnerabilityDto::id);
 
     private DependencyReports() {}
@@ -54,6 +61,12 @@ public final class DependencyReports {
                 orderedDependencies);
     }
 
+    /**
+     * Tallies vulnerabilities by severity, excluding any marked {@link DependencyVulnerabilityDto#dismissed()}
+     * &mdash; dismissed findings are kept in the report (so they can be restored) but no longer count
+     * towards the severity breakdown, mirroring how the other advisors exclude dismissed rule violations
+     * from their score/severity rollups.
+     */
     public static List<DependencySeverityCountDto> severityCounts(List<DependencyDto> dependencies) {
         Map<String, Integer> counts = new LinkedHashMap<>();
         for (String severity : VULNERABILITY_SEVERITIES) {
@@ -61,6 +74,9 @@ public final class DependencyReports {
         }
         for (DependencyDto dependency : dependencies) {
             for (DependencyVulnerabilityDto vulnerability : dependency.vulnerabilities()) {
+                if (vulnerability.dismissed()) {
+                    continue;
+                }
                 counts.computeIfPresent(vulnerability.severity(), (ignored, count) -> count + 1);
             }
         }
@@ -69,8 +85,13 @@ public final class DependencyReports {
                 .toList();
     }
 
+    /**
+     * The most severe <em>active</em> (non-dismissed) vulnerability in the list, or {@code "NONE"} if there
+     * is none.
+     */
     public static String highestSeverity(List<DependencyVulnerabilityDto> vulnerabilities) {
         return vulnerabilities.stream()
+                .filter(vulnerability -> !vulnerability.dismissed())
                 .map(DependencyVulnerabilityDto::severity)
                 .min(Comparator.comparingInt(DependencyReports::severityRank))
                 .orElse("NONE");
@@ -96,6 +117,13 @@ public final class DependencyReports {
             return "UNKNOWN";
         }
         String normalized = value.trim().toUpperCase(Locale.ROOT);
+        if ("MODERATE".equals(normalized)) {
+            // OSV.dev's `database_specific.severity` field (sourced from the GitHub Security Advisory
+            // database) always labels this tier "MODERATE" -- verified against 170 real advisories, which
+            // used exactly {CRITICAL, HIGH, LOW, MODERATE} and never "MEDIUM". (GitHub's newer REST API
+            // uses lowercase "medium" for the same tier via a different, unrelated channel.)
+            return "MEDIUM";
+        }
         if (VULNERABILITY_SEVERITIES.contains(normalized)) {
             return normalized;
         }
@@ -115,8 +143,32 @@ public final class DependencyReports {
         return "LOW";
     }
 
+    /**
+     * Parses an OSV {@code severity[].score} value into a numeric Base Score.
+     *
+     * <p>Per the <a href="https://ossf.github.io/osv-schema/">OSV schema</a>, {@code score} is a CVSS
+     * vector string for {@code CVSS_V2}/{@code CVSS_V3}/{@code CVSS_V4} severity types (prefixed
+     * {@code "CVSS:3.1/..."} etc. for v3+) &mdash; never a bare number for any of those types. Empirically,
+     * real OSV.dev responses for the {@code CVSS_V3} type always carry the {@code "CVSS:3.0/"} or
+     * {@code "CVSS:3.1/"} prefix, which this method dispatches to {@link CvssV3BaseScore}. Other CVSS
+     * versions (v4.0, and the legacy unprefixed v2 format) are not computed &mdash; see
+     * {@link CvssV3BaseScore}'s class Javadoc for why v4.0 is deliberately excluded; v2 was excluded because
+     * zero occurrences appeared in a 170-advisory sample of real Maven-ecosystem OSV.dev responses. A bare
+     * numeric string (not documented by the schema for any known type, but accepted defensively in case a
+     * database ever emits one) still parses via {@link Double#parseDouble(String)}.
+     *
+     * @return the Base Score, or {@code null} if it can't be determined from {@code value}
+     */
     public static Double parseScore(String value) {
-        if (value == null || value.startsWith("CVSS:")) {
+        if (value == null) {
+            return null;
+        }
+        if (value.startsWith("CVSS:3.0/") || value.startsWith("CVSS:3.1/")) {
+            return CvssV3BaseScore.baseScore(value);
+        }
+        if (value.startsWith("CVSS:")) {
+            // CVSS v4.0 (and any future major version): no closed-form Base Score equation exists; not
+            // computed here. Falls through to null so callers keep the database_specific.severity label.
             return null;
         }
         try {
@@ -124,5 +176,74 @@ public final class DependencyReports {
         } catch (NumberFormatException ex) {
             return null;
         }
+    }
+
+    /**
+     * The composite key used to persist a Vulnerabilities dismissal in the shared
+     * {@code DismissedRulesStore} (the same flat {@code dismissedRules} list every advisor writes to,
+     * distinguished by an id format each advisor owns). Deliberately keyed by vulnerability id + package
+     * name and <em>not</em> the affected version, so a risk-acceptance dismissal survives a patch-version
+     * bump of a dependency that is still vulnerable. The {@code "::"} delimiter is safe here because a
+     * {@code packageName} is always exactly one {@code groupId:artifactId} (a single colon), so it can never
+     * collide with the delimiter.
+     */
+    public static String dismissalKey(String vulnerabilityId, String packageName) {
+        return vulnerabilityId + "::" + packageName;
+    }
+
+    /**
+     * Returns a copy of {@code report} with each vulnerability's {@link DependencyVulnerabilityDto#dismissed()}
+     * flag set from {@code dismissedIds}, and every count/ordering that depends on it (per-dependency
+     * {@code vulnerabilityCount}/{@code highestSeverity}, and the report-level {@code vulnerable} count,
+     * {@code severityCounts}, and {@code scan.vulnerabilitiesFound}) recomputed to exclude dismissed
+     * vulnerabilities. Dismissed vulnerabilities are kept in each dependency's {@code vulnerabilities} list
+     * (so they can be restored) but sink to the bottom via {@link #VULNERABILITY_ORDER}. Mirrors
+     * {@code ArchitectureScanner.applyDismissals} and the equivalent method on every other advisor.
+     *
+     * @return {@code report} unchanged if it, or {@code dismissedIds}, is {@code null}/empty
+     */
+    public static DependenciesReport applyDismissals(DependenciesReport report, Set<String> dismissedIds) {
+        if (report == null || dismissedIds == null || dismissedIds.isEmpty()) {
+            return report;
+        }
+        List<DependencyDto> marked = report.dependencies().stream()
+                .map(dependency -> markDismissals(dependency, dismissedIds))
+                .toList();
+        int vulnerable = (int) marked.stream()
+                .filter(dependency -> dependency.vulnerabilityCount() > 0)
+                .count();
+        int vulnerabilitiesFound =
+                marked.stream().mapToInt(DependencyDto::vulnerabilityCount).sum();
+        DependencyScanStatusDto scan = report.scan();
+        DependencyScanStatusDto updatedScan = scan == null
+                ? null
+                : new DependencyScanStatusDto(
+                        scan.scanner(),
+                        scan.status(),
+                        scan.message(),
+                        scan.scannedAt(),
+                        scan.packagesScanned(),
+                        vulnerabilitiesFound);
+        return new DependenciesReport(
+                report.scanningEnabled(), report.total(), vulnerable, severityCounts(marked), updatedScan, marked);
+    }
+
+    private static DependencyDto markDismissals(DependencyDto dependency, Set<String> dismissedIds) {
+        List<DependencyVulnerabilityDto> markedVulnerabilities = dependency.vulnerabilities().stream()
+                .map(vulnerability -> vulnerability.withDismissed(
+                        dismissedIds.contains(dismissalKey(vulnerability.id(), dependency.packageName()))))
+                .sorted(VULNERABILITY_ORDER)
+                .toList();
+        long activeCount =
+                markedVulnerabilities.stream().filter(v -> !v.dismissed()).count();
+        return new DependencyDto(
+                dependency.groupId(),
+                dependency.artifactId(),
+                dependency.version(),
+                dependency.packageName(),
+                dependency.source(),
+                (int) activeCount,
+                highestSeverity(markedVulnerabilities),
+                markedVulnerabilities);
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScoreTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScoreTests.java
@@ -1,0 +1,111 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@link CvssV3BaseScore} against real, NVD-published Base Scores and the FIRST.org CVSS v3.0/v3.1
+ * specifications' worked/edge cases -- not just internally-consistent arithmetic.
+ */
+class CvssV3BaseScoreTests {
+
+    @Test
+    void matchesNvdPublishedScoreForCve202011619ScopeUnchanged() {
+        // jackson-databind gadget-chain RCE; NVD Base Score 8.1 (CVSS 3.1, Scope Unchanged).
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"))
+                .isCloseTo(8.1d, within(0.001));
+    }
+
+    @Test
+    void matchesNvdPublishedScoreForCve202145046ScopeChanged() {
+        // log4j-core incomplete-fix RCE follow-up; NVD Base Score 9.0 (CVSS 3.1, Scope Changed).
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"))
+                .isCloseTo(9.0d, within(0.001));
+    }
+
+    @Test
+    void matchesNvdPublishedScoreForLog4Shell() {
+        // CVE-2021-44228 "Log4Shell"; NVD Base Score 10.0 (CVSS 3.1, Scope Changed) -- the maximum score.
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"))
+                .isCloseTo(10.0d, within(0.001));
+    }
+
+    @Test
+    void computesTheCommonCriticalNetworkVector() {
+        // The frequently-seen "textbook" unauthenticated-RCE vector, Scope Unchanged.
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"))
+                .isCloseTo(9.8d, within(0.001));
+    }
+
+    @Test
+    void computesARealModerateSeverityVectorObservedOnOsvDev() {
+        // Matches a real OSV.dev MODERATE-labelled advisory's CVSS_V3 vector (log4j-core DoS family).
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"))
+                .isCloseTo(5.4d, within(0.001));
+    }
+
+    @Test
+    void returnsZeroWhenThereIsNoConfidentialityIntegrityOrAvailabilityImpact() {
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"))
+                .isEqualTo(0.0d);
+    }
+
+    @Test
+    void supportsTheCvss30PrefixWithTheIdenticalFormula() {
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"))
+                .isCloseTo(9.8d, within(0.001));
+    }
+
+    @Test
+    void ignoresTrailingTemporalMetricsWhenComputingTheBaseScore() {
+        // Temporal metrics (E/RL/RC) may be appended after the Base metrics in a real vector string; the
+        // Base Score must ignore them rather than fail to parse.
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P/RL:O/RC:C"))
+                .isCloseTo(9.8d, within(0.001));
+    }
+
+    @Test
+    void toleratesMetricsInNonPreferredOrder() {
+        // Per spec section 6.3, metrics may appear in any order in the vector string.
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/S:U/AV:N/AC:L/PR:H/UI:N/C:L/I:L/A:N"))
+                .isCloseTo(3.8d, within(0.001));
+    }
+
+    @Test
+    void returnsNullForACvss40Vector() {
+        // v4.0 has no closed-form Base Score equation; deliberately not computed (see class Javadoc).
+        assertThat(CvssV3BaseScore.baseScore("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N"))
+                .isNull();
+    }
+
+    @Test
+    void returnsNullForNull() {
+        assertThat(CvssV3BaseScore.baseScore(null)).isNull();
+    }
+
+    @Test
+    void returnsNullWhenTheVectorHasNoCvssPrefix() {
+        assertThat(CvssV3BaseScore.baseScore("AV:N/AC:L/Au:N/C:P/I:P/A:P")).isNull();
+    }
+
+    @Test
+    void returnsNullWhenAMandatoryBaseMetricIsMissing() {
+        // Missing "A" (Availability).
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H"))
+                .isNull();
+    }
+
+    @Test
+    void returnsNullWhenAMetricValueIsNotRecognized() {
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:X/C:H/I:H/A:H"))
+                .isNull();
+    }
+
+    @Test
+    void returnsNullForAMalformedSegmentWithNoColon() {
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/GARBAGE/PR:N/UI:N/S:U/C:H/I:H/A:H"))
+                .isNull();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.core.dto.DependencySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class DependencyReportsTests {
@@ -69,5 +71,193 @@ class DependencyReportsTests {
         assertThat(ordered)
                 .extracting(DependencyVulnerabilityDto::id)
                 .containsExactly("V-critical-a", "V-critical-b", "V-high", "V-medium", "V-low", "V-unknown");
+    }
+
+    @Test
+    void vulnerabilityOrderSinksDismissedVulnerabilitiesBelowActiveOnesRegardlessOfSeverity() {
+        List<DependencyVulnerabilityDto> vulnerabilities = List.of(
+                vulnerability("V-critical-dismissed", "CRITICAL").withDismissed(true),
+                vulnerability("V-low", "LOW"),
+                vulnerability("V-high", "HIGH"));
+
+        List<DependencyVulnerabilityDto> ordered = vulnerabilities.stream()
+                .sorted(DependencyReports.VULNERABILITY_ORDER)
+                .toList();
+
+        assertThat(ordered)
+                .extracting(DependencyVulnerabilityDto::id)
+                .containsExactly("V-high", "V-low", "V-critical-dismissed");
+    }
+
+    @Test
+    void severityCountsExcludeDismissedVulnerabilities() {
+        DependencyVulnerabilityDto active = vulnerability("V-active", "CRITICAL");
+        DependencyVulnerabilityDto dismissed =
+                vulnerability("V-dismissed", "HIGH").withDismissed(true);
+        DependencyDto dependency = new DependencyDto(
+                "org.example", "lib", "1.0.0", "org.example:lib", "test", 1, "CRITICAL", List.of(active, dismissed));
+
+        List<DependencySeverityCountDto> counts = DependencyReports.severityCounts(List.of(dependency));
+
+        assertThat(counts)
+                .filteredOn(count -> "CRITICAL".equals(count.severity()))
+                .extracting(DependencySeverityCountDto::count)
+                .containsExactly(1);
+        assertThat(counts)
+                .filteredOn(count -> "HIGH".equals(count.severity()))
+                .extracting(DependencySeverityCountDto::count)
+                .containsExactly(0);
+    }
+
+    @Test
+    void highestSeverityIgnoresDismissedVulnerabilities() {
+        List<DependencyVulnerabilityDto> vulnerabilities =
+                List.of(vulnerability("V-critical", "CRITICAL").withDismissed(true), vulnerability("V-high", "HIGH"));
+
+        assertThat(DependencyReports.highestSeverity(vulnerabilities)).isEqualTo("HIGH");
+    }
+
+    @Test
+    void highestSeverityIsNoneWhenEveryVulnerabilityIsDismissed() {
+        List<DependencyVulnerabilityDto> vulnerabilities =
+                List.of(vulnerability("V-critical", "CRITICAL").withDismissed(true));
+
+        assertThat(DependencyReports.highestSeverity(vulnerabilities)).isEqualTo("NONE");
+    }
+
+    @Test
+    void normalizeSeverityStringMapsGitHubAdvisoryModerateToMedium() {
+        // OSV.dev's database_specific.severity (GHSA-sourced) uses "MODERATE", never "MEDIUM".
+        assertThat(DependencyReports.normalizeSeverity("MODERATE")).isEqualTo("MEDIUM");
+        assertThat(DependencyReports.normalizeSeverity("moderate")).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void normalizeSeverityStringPassesThroughKnownSeveritiesCaseInsensitively() {
+        assertThat(DependencyReports.normalizeSeverity("critical")).isEqualTo("CRITICAL");
+        assertThat(DependencyReports.normalizeSeverity(" High ")).isEqualTo("HIGH");
+    }
+
+    @Test
+    void normalizeSeverityStringFallsBackToUnknown() {
+        assertThat(DependencyReports.normalizeSeverity((String) null)).isEqualTo("UNKNOWN");
+        assertThat(DependencyReports.normalizeSeverity("")).isEqualTo("UNKNOWN");
+        assertThat(DependencyReports.normalizeSeverity("banana")).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    void parseScoreComputesTheBaseScoreForARealCvssV31Vector() {
+        // CVE-2021-44228 "Log4Shell" -- NVD-published Base Score 10.0.
+        assertThat(DependencyReports.parseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"))
+                .isEqualTo(10.0d);
+    }
+
+    @Test
+    void parseScoreSupportsTheCvss30Prefix() {
+        assertThat(DependencyReports.parseScore("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"))
+                .isEqualTo(9.8d);
+    }
+
+    @Test
+    void parseScoreReturnsNullForACvss40VectorRatherThanGuessing() {
+        // No closed-form v4.0 Base Score equation exists (see CvssV3BaseScore's class Javadoc); callers
+        // fall back to the database_specific.severity label for these advisories.
+        assertThat(DependencyReports.parseScore("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N"))
+                .isNull();
+    }
+
+    @Test
+    void parseScoreFallsBackToABareNumericStringForNonCvssValues() {
+        assertThat(DependencyReports.parseScore("7.5")).isEqualTo(7.5d);
+    }
+
+    @Test
+    void parseScoreReturnsNullForAnUnparseableOrMissingValue() {
+        assertThat(DependencyReports.parseScore("not-a-score")).isNull();
+        assertThat(DependencyReports.parseScore(null)).isNull();
+    }
+
+    @Test
+    void dismissalKeyJoinsVulnerabilityIdAndPackageNameWithADoubleColonDelimiter() {
+        assertThat(DependencyReports.dismissalKey("GHSA-xxxx-yyyy-zzzz", "com.example:widget"))
+                .isEqualTo("GHSA-xxxx-yyyy-zzzz::com.example:widget");
+    }
+
+    @Test
+    void applyDismissalsReturnsTheReportUnchangedWhenThereIsNothingToDismiss() {
+        DependenciesReport report = DependencyReports.report(
+                true, "SCANNED", "done", 1L, 1, List.of(vulnerableDependency("org.example", "lib", "1.0.0", "HIGH")));
+
+        assertThat(DependencyReports.applyDismissals(report, Set.of())).isSameAs(report);
+        assertThat(DependencyReports.applyDismissals(report, null)).isSameAs(report);
+        assertThat(DependencyReports.applyDismissals(null, Set.of("x"))).isNull();
+    }
+
+    @Test
+    void applyDismissalsMarksTheMatchingVulnerabilityAndRecomputesEveryDependentCount() {
+        DependenciesReport report = DependencyReports.report(
+                true,
+                "SCANNED",
+                "done",
+                1L,
+                1,
+                List.of(vulnerableDependency("org.example", "lib", "1.0.0", "CRITICAL")));
+        String key = DependencyReports.dismissalKey("V-lib", "org.example:lib");
+
+        DependenciesReport updated = DependencyReports.applyDismissals(report, Set.of(key));
+
+        DependencyDto dependency = updated.dependencies().get(0);
+        assertThat(dependency.vulnerabilities())
+                .extracting(DependencyVulnerabilityDto::dismissed)
+                .containsExactly(true);
+        assertThat(dependency.vulnerabilityCount()).isEqualTo(0);
+        assertThat(dependency.highestSeverity()).isEqualTo("NONE");
+        assertThat(updated.vulnerable()).isEqualTo(0);
+        assertThat(updated.scan().vulnerabilitiesFound()).isEqualTo(0);
+        assertThat(updated.severityCounts())
+                .filteredOn(count -> "CRITICAL".equals(count.severity()))
+                .extracting(DependencySeverityCountDto::count)
+                .containsExactly(0);
+    }
+
+    @Test
+    void applyDismissalsLeavesNonMatchingVulnerabilitiesActive() {
+        DependenciesReport report = DependencyReports.report(
+                true,
+                "SCANNED",
+                "done",
+                1L,
+                1,
+                List.of(vulnerableDependency("org.example", "lib", "1.0.0", "CRITICAL")));
+
+        DependenciesReport updated =
+                DependencyReports.applyDismissals(report, Set.of("SOME-OTHER-ID::org.example:lib"));
+
+        DependencyDto dependency = updated.dependencies().get(0);
+        assertThat(dependency.vulnerabilities())
+                .extracting(DependencyVulnerabilityDto::dismissed)
+                .containsExactly(false);
+        assertThat(dependency.vulnerabilityCount()).isEqualTo(1);
+        assertThat(updated.vulnerable()).isEqualTo(1);
+        assertThat(updated.scan().vulnerabilitiesFound()).isEqualTo(1);
+    }
+
+    @Test
+    void applyDismissalsKeepsDismissedVulnerabilitiesInTheListSunkToTheBottom() {
+        List<DependencyVulnerabilityDto> vulnerabilities =
+                List.of(vulnerability("V-critical", "CRITICAL"), vulnerability("V-high", "HIGH"));
+        DependencyDto dependencyDto = new DependencyDto(
+                "org.example", "lib", "1.0.0", "org.example:lib", "test", 2, "CRITICAL", vulnerabilities);
+        DependenciesReport report = DependencyReports.report(true, "SCANNED", "done", 1L, 1, List.of(dependencyDto));
+        String key = DependencyReports.dismissalKey("V-critical", "org.example:lib");
+
+        DependenciesReport updated = DependencyReports.applyDismissals(report, Set.of(key));
+
+        DependencyDto dependency = updated.dependencies().get(0);
+        assertThat(dependency.vulnerabilities())
+                .extracting(DependencyVulnerabilityDto::id)
+                .containsExactly("V-high", "V-critical");
+        assertThat(dependency.vulnerabilityCount()).isEqualTo(1);
+        assertThat(dependency.highestSeverity()).isEqualTo("HIGH");
     }
 }

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusVulnerabilitiesResourceTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusVulnerabilitiesResourceTest.java
@@ -12,6 +12,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -133,9 +134,74 @@ class BootUiQuarkusVulnerabilitiesResourceTest {
         assertThat(body.path("scan").path("vulnerabilitiesFound").asInt()).isGreaterThanOrEqualTo(1);
     }
 
+    @Test
+    @Order(4)
+    void dismissingAVulnerabilityHidesItFromActiveCountsAndRestoringBringsItBack() {
+        Map<String, String> jsonHeaders = Map.of("Content-Type", "application/json");
+        JsonNode before = probe().get("/bootui/api/vulnerabilities").json();
+        JsonNode vulnerableDependency = findFirstVulnerableDependency(before);
+        assertThat(vulnerableDependency)
+                .as("a prior scan (Order 2) must have already found the stubbed advisory")
+                .isNotNull();
+        String packageName = vulnerableDependency.path("packageName").asText();
+        String dismissalKey = OsvStubTestResource.ADVISORY_ID + "::" + packageName;
+
+        // Vulnerabilities has no dedicated dismiss endpoint -- it reuses the same shared
+        // /bootui/api/dismissed-rules/{ruleId} resource every other advisor writes to.
+        Response dismiss = probe().post("/bootui/api/dismissed-rules/" + dismissalKey, jsonHeaders);
+        assertThat(dismiss.status()).as("POST dismiss status").isEqualTo(200);
+
+        JsonNode afterDismiss = probe().get("/bootui/api/vulnerabilities").json();
+        JsonNode dependencyAfterDismiss = findDependencyByPackageName(afterDismiss, packageName);
+        assertThat(dependencyAfterDismiss)
+                .as("the dismissed dependency stays in the inventory")
+                .isNotNull();
+        assertThat(dependencyAfterDismiss.path("vulnerabilityCount").asInt())
+                .as("a dismissed vulnerability no longer counts toward the active count")
+                .isZero();
+        assertThat(dependencyAfterDismiss.path("highestSeverity").asText())
+                .as("with its only vulnerability dismissed, the dependency reports no active severity")
+                .isEqualTo("NONE");
+        assertThat(dependencyAfterDismiss
+                        .path("vulnerabilities")
+                        .get(0)
+                        .path("dismissed")
+                        .asBoolean())
+                .as("the vulnerability itself is still present, marked dismissed, so it can be restored")
+                .isTrue();
+        assertThat(afterDismiss.path("vulnerable").asInt())
+                .as("the report-level vulnerable count excludes dismissed findings")
+                .isZero();
+
+        Response restore = probe().request("DELETE", "/bootui/api/dismissed-rules/" + dismissalKey, jsonHeaders, null);
+        assertThat(restore.status()).as("DELETE restore status").isEqualTo(200);
+
+        JsonNode afterRestore = probe().get("/bootui/api/vulnerabilities").json();
+        JsonNode dependencyAfterRestore = findDependencyByPackageName(afterRestore, packageName);
+        assertThat(dependencyAfterRestore.path("vulnerabilityCount").asInt())
+                .as("restoring the vulnerability brings it back into the active count")
+                .isEqualTo(1);
+        assertThat(dependencyAfterRestore
+                        .path("vulnerabilities")
+                        .get(0)
+                        .path("dismissed")
+                        .asBoolean())
+                .isFalse();
+        assertThat(afterRestore.path("vulnerable").asInt()).isGreaterThanOrEqualTo(1);
+    }
+
     private static JsonNode findFirstVulnerableDependency(JsonNode body) {
         for (JsonNode dependency : body.path("dependencies")) {
             if (dependency.path("vulnerabilities").size() > 0) {
+                return dependency;
+            }
+        }
+        return null;
+    }
+
+    private static JsonNode findDependencyByPackageName(JsonNode body, String packageName) {
+        for (JsonNode dependency : body.path("dependencies")) {
+            if (packageName.equals(dependency.path("packageName").asText())) {
                 return dependency;
             }
         }

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/OsvStubTestResource.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/OsvStubTestResource.java
@@ -47,7 +47,10 @@ public class OsvStubTestResource implements QuarkusTestResourceLifecycleManager 
                         "{\"id\":\"" + ADVISORY_ID + "\",\"summary\":\"Integration-test advisory\","
                                 + "\"details\":\"A synthetic critical vulnerability used by the BootUI Quarkus IT.\","
                                 + "\"aliases\":[\"CVE-2099-0001\"],"
-                                + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"9.8\"}],"
+                                // OSV.dev's severity[].score is always a CVSS vector string, never a bare number;
+                                // this vector's base score (9.8/CRITICAL) is verified against the FIRST.org CVSS
+                                // v3.1 specification.
+                                + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"}],"
                                 + "\"references\":[{\"url\":\"https://example.test/advisory\"}]}"));
         server.start();
         return Map.of(

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
@@ -28,11 +28,12 @@ import java.util.Set;
  *
  * <p>It is a faithful port: same OSV protocol ({@code POST /v1/querybatch} for the Maven-ecosystem package
  * queries, then {@code GET /v1/vulns/{id}} per advisory), same bounded limits, same status taxonomy
- * ({@code SCANNED} / {@code PARTIAL} when package/advisory limits truncate the results / {@code ERROR}
- * preserving the local inventory on transport failure), and the same delegation of all aggregation/ordering
- * to the framework-neutral engine {@link DependencyReports}. The only deltas from the Spring source are the
- * JSON library — <strong>Jackson 2</strong> ({@code com.fasterxml.jackson}, provided by
- * {@code quarkus-rest-jackson}) instead of Spring Boot 4's Jackson 3 ({@code tools.jackson}), so
+ * ({@code SCANNED} / {@code PARTIAL} when package or advisory limits truncate the results or one or more
+ * individual advisory fetches fail / {@code ERROR} preserving the local inventory only when the initial
+ * batch query itself fails), the same withdrawn-advisory filtering, and the same delegation of all
+ * aggregation/ordering to the framework-neutral engine {@link DependencyReports}. The only deltas from the
+ * Spring source are the JSON library — <strong>Jackson 2</strong> ({@code com.fasterxml.jackson}, provided
+ * by {@code quarkus-rest-jackson}) instead of Spring Boot 4's Jackson 3 ({@code tools.jackson}), so
  * {@code JsonNode.asText()} replaces {@code asString()} — and that settings come from a
  * {@link QuarkusVulnerabilitySettings} record rather than {@code BootUiProperties}. It uses the JDK
  * {@link HttpClient}, so no framework HTTP type leaks in.</p>
@@ -144,10 +145,18 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return text == null || text.isBlank() ? null : text;
     }
 
-    private static String scanMessage(String status) {
-        return "PARTIAL".equals(status)
-                ? "Scan completed with configured package or advisory limits applied."
-                : "Scan completed against OSV.dev.";
+    private static String scanMessage(boolean limited, int failedFetches) {
+        if (!limited && failedFetches == 0) {
+            return "Scan completed against OSV.dev.";
+        }
+        List<String> reasons = new ArrayList<>();
+        if (limited) {
+            reasons.add("configured package or advisory limits were applied");
+        }
+        if (failedFetches > 0) {
+            reasons.add(failedFetches + (failedFetches == 1 ? " advisory fetch failed" : " advisory fetches failed"));
+        }
+        return "Scan completed against OSV.dev, but " + String.join("; ", reasons) + ".";
     }
 
     @Override
@@ -161,14 +170,13 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
         try {
             Map<String, List<String>> vulnerabilityIds = queryBatch(packages);
-            Map<String, JsonNode> vulnerabilities = fetchVulnerabilities(vulnerabilityIds);
-            List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, vulnerabilities);
-            String status = packages.size() < dependencies.size()
-                            || vulnerabilities.size()
-                                    < uniqueIds(vulnerabilityIds).size()
-                    ? "PARTIAL"
-                    : "SCANNED";
-            return DependencyReports.report(true, status, scanMessage(status), scannedAt, packages.size(), enriched);
+            VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
+            List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
+            boolean limited = packages.size() < dependencies.size()
+                    || uniqueIds(vulnerabilityIds).size() > Math.max(1, settings.maxAdvisories());
+            String status = limited || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";
+            return DependencyReports.report(
+                    true, status, scanMessage(limited, fetched.failedFetches()), scannedAt, packages.size(), enriched);
         } catch (IOException ex) {
             return DependencyReports.report(
                     true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
@@ -218,29 +226,55 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return idsByPackage;
     }
 
-    private Map<String, JsonNode> fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
-            throws IOException, InterruptedException {
+    private VulnerabilityFetchResult fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
+            throws InterruptedException {
         Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
+        int failedFetches = 0;
         for (String id : uniqueIds(vulnerabilityIds).stream()
                 .limit(Math.max(1, settings.maxAdvisories()))
                 .toList()) {
-            HttpRequest request = HttpRequest.newBuilder(vulnerabilityUri(id))
-                    .timeout(settings.requestTimeout())
-                    .GET()
-                    .build();
-            HttpResponse<String> response =
-                    httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new IOException("OSV advisory " + id + " returned HTTP " + response.statusCode());
+            JsonNode vulnerability;
+            try {
+                vulnerability = fetchVulnerability(id);
+            } catch (IOException ex) {
+                // A single flaky/rate-limited/malformed advisory fetch shouldn't discard every other
+                // advisory already fetched successfully; count it and degrade to PARTIAL instead of
+                // aborting the whole scan to ERROR. (Jackson 2's JsonProcessingException already extends
+                // IOException, so a malformed-JSON response is covered by this same catch.)
+                failedFetches++;
+                continue;
             }
-            JsonNode vulnerability = objectMapper.readTree(response.body());
+            if (isWithdrawn(vulnerability)) {
+                // A withdrawn OSV record is no longer considered a valid finding; OSV does not filter
+                // these out of query results itself, so consumers must.
+                continue;
+            }
             String vulnerabilityId = text(vulnerability, "id");
             if (vulnerabilityId != null) {
                 vulnerabilities.put(vulnerabilityId, vulnerability);
             }
         }
-        return vulnerabilities;
+        return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
     }
+
+    private JsonNode fetchVulnerability(String id) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(vulnerabilityUri(id))
+                .timeout(settings.requestTimeout())
+                .GET()
+                .build();
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("OSV advisory " + id + " returned HTTP " + response.statusCode());
+        }
+        return objectMapper.readTree(response.body());
+    }
+
+    private static boolean isWithdrawn(JsonNode vulnerability) {
+        return text(vulnerability, "withdrawn") != null;
+    }
+
+    private record VulnerabilityFetchResult(Map<String, JsonNode> vulnerabilities, int failedFetches) {}
 
     private URI vulnerabilityUri(String id) {
         String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8);

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/VulnerabilitiesResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/VulnerabilitiesResource.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.quarkus.web;
 
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.engine.advisor.DismissedRulesStore;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import io.github.jdubois.bootui.quarkus.OsvVulnerabilityScanner;
 import io.github.jdubois.bootui.quarkus.QuarkusDependencyProvider;
@@ -25,7 +26,9 @@ import org.eclipse.microprofile.config.Config;
  * {@link OsvVulnerabilityScanner}. The engine {@link DependencyReports} owns all aggregation/ordering. Both
  * collaborators are injected as their concrete adapter types (not the {@code DependencyProvider} /
  * {@code VulnerabilityScanner} SPI interfaces) so adding further SPI impls later can never make this wiring
- * ambiguous.</p>
+ * ambiguous. Per-vulnerability dismissals from the shared {@link DismissedRulesStore} (keyed by
+ * {@link DependencyReports#dismissalKey(String, String)}) are applied on every response, exactly as on
+ * Spring.</p>
  *
  * <p><strong>Never scans on render.</strong> {@code GET} returns the cached last scan report if present,
  * otherwise a {@code NOT_SCANNED} inventory — it makes no network call. {@code POST /scan} honors
@@ -47,14 +50,20 @@ public class VulnerabilitiesResource {
 
     private final Config config;
 
+    private final DismissedRulesStore dismissedRules;
+
     private volatile DependenciesReport lastScanReport;
 
     @Inject
     public VulnerabilitiesResource(
-            QuarkusDependencyProvider dependencyProvider, OsvVulnerabilityScanner vulnerabilityScanner, Config config) {
+            QuarkusDependencyProvider dependencyProvider,
+            OsvVulnerabilityScanner vulnerabilityScanner,
+            Config config,
+            DismissedRulesStore dismissedRules) {
         this.dependencyProvider = dependencyProvider;
         this.vulnerabilityScanner = vulnerabilityScanner;
         this.config = config;
+        this.dismissedRules = dismissedRules;
     }
 
     @GET
@@ -62,16 +71,17 @@ public class VulnerabilitiesResource {
     public DependenciesReport dependencies() {
         DependenciesReport cached = this.lastScanReport;
         if (cached != null) {
-            return cached;
+            return DependencyReports.applyDismissals(cached, dismissedRules.load());
         }
         List<DependencyDto> dependencies = dependencyProvider.dependencies();
-        return DependencyReports.report(
+        DependenciesReport report = DependencyReports.report(
                 osvEnabled(),
                 "NOT_SCANNED",
                 "Dependency inventory loaded. Click Scan with OSV.dev to check for known vulnerabilities.",
                 null,
                 0,
                 dependencies);
+        return DependencyReports.applyDismissals(report, dismissedRules.load());
     }
 
     @POST
@@ -94,7 +104,7 @@ public class VulnerabilitiesResource {
         if (!"DISABLED".equals(report.status())) {
             this.lastScanReport = report;
         }
-        return report;
+        return DependencyReports.applyDismissals(report, dismissedRules.load());
     }
 
     private boolean osvEnabled() {

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
@@ -100,7 +100,10 @@ class OsvVulnerabilityScannerTest {
                     200,
                     "{\"id\":\"GHSA-test-0001\",\"summary\":\"Widget RCE\",\"details\":\"A remote code execution\","
                             + "\"aliases\":[\"CVE-2024-0001\"],"
-                            + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"9.8\"}],"
+                            // OSV.dev's severity[].score is always a CVSS vector string for CVSS types, never a
+                            // bare number -- this vector is the well-known "9.8/CRITICAL" example verified against
+                            // the FIRST.org CVSS v3.1 specification.
+                            + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"}],"
                             + "\"references\":[{\"url\":\"https://example.test/advisory\"}],"
                             + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"},"
                             + "\"ranges\":[{\"events\":[{\"fixed\":\"1.2.4\"}]}]}]}");
@@ -194,7 +197,8 @@ class OsvVulnerabilityScannerTest {
                         exchange,
                         200,
                         "{\"id\":\"GHSA-medium\",\"summary\":\"Moderate\","
-                                + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"5.4\"}]}"));
+                                // Real CVSS v3.1 vector verified against the FIRST.org spec: base score 5.4 -> MEDIUM.
+                                + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N\"}]}"));
 
         DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
 
@@ -222,5 +226,76 @@ class OsvVulnerabilityScannerTest {
         assertThat(fetched)
                 .as("only one advisory fetched due to max-advisories=1")
                 .hasSize(1);
+    }
+
+    @Test
+    void fallsBackToDatabaseSpecificSeverityWhenNoCvssScoreCanBeParsed() {
+        // A CVSS_V4-only advisory (no v3 entry): parseScore() returns null for v4.0 vectors (v4.0's
+        // MacroVector lookup table is deliberately not implemented), so the GHSA "MODERATE"
+        // database_specific label must still surface -- normalized to "MEDIUM", not silently dropped
+        // to "UNKNOWN".
+        server.createContext(
+                "/v1/querybatch",
+                exchange -> respond(exchange, 200, "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-v4\"}]}]}"));
+        server.createContext(
+                "/v1/vulns/GHSA-v4",
+                exchange -> respond(
+                        exchange,
+                        200,
+                        "{\"id\":\"GHSA-v4\",\"database_specific\":{\"severity\":\"MODERATE\"},"
+                                + "\"severity\":[{\"type\":\"CVSS_V4\","
+                                + "\"score\":\"CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N\"}]}"));
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        DependencyVulnerabilityDto vulnerability =
+                report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.score()).isNull();
+        assertThat(vulnerability.severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void excludesWithdrawnAdvisoriesFromTheReportWithoutDegradingStatus() {
+        server.createContext(
+                "/v1/querybatch",
+                exchange -> respond(exchange, 200, "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-withdrawn\"}]}]}"));
+        server.createContext(
+                "/v1/vulns/GHSA-withdrawn",
+                exchange -> respond(
+                        exchange,
+                        200,
+                        "{\"id\":\"GHSA-withdrawn\",\"withdrawn\":\"2024-01-01T00:00:00Z\","
+                                + "\"database_specific\":{\"severity\":\"CRITICAL\"}}"));
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        // A withdrawn advisory is intentionally dropped -- this is correct, expected behavior, not a
+        // failure, so it must not degrade the scan status to PARTIAL/ERROR.
+        assertThat(report.status()).isEqualTo("SCANNED");
+        assertThat(report.dependencies().get(0).vulnerabilities()).isEmpty();
+        assertThat(report.dependencies().get(0).vulnerabilityCount()).isZero();
+        assertThat(report.vulnerable()).isZero();
+    }
+
+    @Test
+    void degradesToPartialInsteadOfErrorWhenOneOfSeveralAdvisoryFetchesFails() {
+        server.createContext(
+                "/v1/querybatch",
+                exchange ->
+                        respond(exchange, 200, "{\"results\":[{\"vulns\":[{\"id\":\"V-OK\"},{\"id\":\"V-FAIL\"}]}]}"));
+        server.createContext(
+                "/v1/vulns/V-OK",
+                exchange -> respond(exchange, 200, "{\"id\":\"V-OK\",\"database_specific\":{\"severity\":\"HIGH\"}}"));
+        server.createContext("/v1/vulns/V-FAIL", exchange -> respond(exchange, 503, "boom"));
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        // The advisory that failed to fetch must not discard the one that succeeded, nor abort the
+        // whole scan to ERROR the way a single-advisory IOException used to.
+        assertThat(report.status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains("1 advisory fetch failed");
+        assertThat(report.dependencies().get(0).vulnerabilities())
+                .extracting(DependencyVulnerabilityDto::id)
+                .containsExactly("V-OK");
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -15,6 +15,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
+import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -128,10 +129,18 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return text == null || text.isBlank() ? null : text;
     }
 
-    private static String scanMessage(String status) {
-        return "PARTIAL".equals(status)
-                ? "Scan completed with configured package or advisory limits applied."
-                : "Scan completed against OSV.dev.";
+    private static String scanMessage(boolean limited, int failedFetches) {
+        if (!limited && failedFetches == 0) {
+            return "Scan completed against OSV.dev.";
+        }
+        List<String> reasons = new ArrayList<>();
+        if (limited) {
+            reasons.add("configured package or advisory limits were applied");
+        }
+        if (failedFetches > 0) {
+            reasons.add(failedFetches + (failedFetches == 1 ? " advisory fetch failed" : " advisory fetches failed"));
+        }
+        return "Scan completed against OSV.dev, but " + String.join("; ", reasons) + ".";
     }
 
     @Override
@@ -146,15 +155,14 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
         try {
             Map<String, List<String>> vulnerabilityIds = queryBatch(packages);
-            Map<String, JsonNode> vulnerabilities = fetchVulnerabilities(vulnerabilityIds);
-            List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, vulnerabilities);
-            String status = packages.size() < dependencies.size()
-                            || vulnerabilities.size()
-                                    < uniqueIds(vulnerabilityIds).size()
-                    ? "PARTIAL"
-                    : "SCANNED";
-            return DependencyReports.report(true, status, scanMessage(status), scannedAt, packages.size(), enriched);
-        } catch (IOException ex) {
+            VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
+            List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
+            boolean limited = packages.size() < dependencies.size()
+                    || uniqueIds(vulnerabilityIds).size() > Math.max(1, properties.getMaxAdvisories());
+            String status = limited || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";
+            return DependencyReports.report(
+                    true, status, scanMessage(limited, fetched.failedFetches()), scannedAt, packages.size(), enriched);
+        } catch (IOException | JacksonException ex) {
             return DependencyReports.report(
                     true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
         } catch (InterruptedException ex) {
@@ -203,29 +211,54 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return idsByPackage;
     }
 
-    private Map<String, JsonNode> fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
-            throws IOException, InterruptedException {
+    private VulnerabilityFetchResult fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
+            throws InterruptedException {
         Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
+        int failedFetches = 0;
         for (String id : uniqueIds(vulnerabilityIds).stream()
                 .limit(Math.max(1, properties.getMaxAdvisories()))
                 .toList()) {
-            HttpRequest request = HttpRequest.newBuilder(vulnerabilityUri(id))
-                    .timeout(properties.getRequestTimeout())
-                    .GET()
-                    .build();
-            HttpResponse<String> response =
-                    httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new IOException("OSV advisory " + id + " returned HTTP " + response.statusCode());
+            JsonNode vulnerability;
+            try {
+                vulnerability = fetchVulnerability(id);
+            } catch (IOException | JacksonException ex) {
+                // A single flaky/rate-limited/malformed advisory fetch shouldn't discard every other
+                // advisory already fetched successfully; count it and degrade to PARTIAL instead of
+                // aborting the whole scan to ERROR.
+                failedFetches++;
+                continue;
             }
-            JsonNode vulnerability = objectMapper.readTree(response.body());
+            if (isWithdrawn(vulnerability)) {
+                // A withdrawn OSV record is no longer considered a valid finding; OSV does not filter
+                // these out of query results itself, so consumers must.
+                continue;
+            }
             String vulnerabilityId = text(vulnerability, "id");
             if (vulnerabilityId != null) {
                 vulnerabilities.put(vulnerabilityId, vulnerability);
             }
         }
-        return vulnerabilities;
+        return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
     }
+
+    private JsonNode fetchVulnerability(String id) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(vulnerabilityUri(id))
+                .timeout(properties.getRequestTimeout())
+                .GET()
+                .build();
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("OSV advisory " + id + " returned HTTP " + response.statusCode());
+        }
+        return objectMapper.readTree(response.body());
+    }
+
+    private static boolean isWithdrawn(JsonNode vulnerability) {
+        return text(vulnerability, "withdrawn") != null;
+    }
+
+    private record VulnerabilityFetchResult(Map<String, JsonNode> vulnerabilities, int failedFetches) {}
 
     private URI vulnerabilityUri(String id) {
         String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8);

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilitiesController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilitiesController.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.autoconfigure.web;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.engine.advisor.DismissedRulesStore;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyProvider;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import io.github.jdubois.bootui.engine.vulnerabilities.VulnerabilityScanner;
@@ -13,6 +14,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Serves the Vulnerabilities panel.
+ *
+ * <p>{@code GET} returns the last scan (initially the local dependency inventory, unscanned);
+ * {@code POST /scan} queries OSV.dev. Per-vulnerability dismissals (a developer acknowledging a finding they
+ * can't immediately fix) are stored in the shared {@link DismissedRulesStore} keyed by
+ * {@link DependencyReports#dismissalKey(String, String)} and applied to whichever report is returned,
+ * mirroring every other advisor's dismiss/restore wiring.</p>
+ */
 @RestController
 @RequestMapping("/bootui/api/vulnerabilities")
 public class VulnerabilitiesController {
@@ -23,36 +33,45 @@ public class VulnerabilitiesController {
 
     private final VulnerabilityScanner vulnerabilityScanner;
 
+    private final DismissedRulesStore dismissedRules;
+
     private volatile DependenciesReport lastScanReport;
 
     @Autowired
-    public VulnerabilitiesController(BootUiProperties properties) {
-        this(properties, new DependencyCatalog(), new OsvVulnerabilityScanner(properties.getVulnerabilities()));
+    public VulnerabilitiesController(BootUiProperties properties, DismissedRulesStore dismissedRules) {
+        this(
+                properties,
+                new DependencyCatalog(),
+                new OsvVulnerabilityScanner(properties.getVulnerabilities()),
+                dismissedRules);
     }
 
     VulnerabilitiesController(
             BootUiProperties properties,
             DependencyProvider dependencyProvider,
-            VulnerabilityScanner vulnerabilityScanner) {
+            VulnerabilityScanner vulnerabilityScanner,
+            DismissedRulesStore dismissedRules) {
         this.properties = properties;
         this.dependencyProvider = dependencyProvider;
         this.vulnerabilityScanner = vulnerabilityScanner;
+        this.dismissedRules = dismissedRules;
     }
 
     @GetMapping
     public DependenciesReport dependencies() {
         DependenciesReport cached = this.lastScanReport;
         if (cached != null) {
-            return cached;
+            return DependencyReports.applyDismissals(cached, dismissedRules.load());
         }
         List<DependencyDto> dependencies = dependencyProvider.dependencies();
-        return DependencyReports.report(
+        DependenciesReport report = DependencyReports.report(
                 properties.getVulnerabilities().isOsvEnabled(),
                 "NOT_SCANNED",
                 "Dependency inventory loaded. Click Scan with OSV.dev to check for known vulnerabilities.",
                 null,
                 0,
                 dependencies);
+        return DependencyReports.applyDismissals(report, dismissedRules.load());
     }
 
     @PostMapping("/scan")
@@ -73,6 +92,6 @@ public class VulnerabilitiesController {
         if (!"DISABLED".equals(report.status())) {
             this.lastScanReport = report;
         }
-        return report;
+        return DependencyReports.applyDismissals(report, dismissedRules.load());
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -168,4 +168,220 @@ class OsvVulnerabilityScannerTests {
         properties.setOsvBaseUri("http://localhost:18080");
         assertThat(new OsvVulnerabilityScanner(properties).baseUri()).isEqualTo(URI.create("http://localhost:18080"));
     }
+
+    @Test
+    void parsesARealCvssV3VectorIntoANumericScoreAndDerivedSeverity() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-CVSS"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-CVSS", exchange -> {
+            // OSV.dev's severity[].score is always a CVSS vector string for CVSS_V3, never a bare number;
+            // no database_specific.severity is present here, isolating the CVSS-parsing code path.
+            byte[] body = """
+                {
+                  "id": "GHSA-CVSS",
+                  "severity": [{ "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.score()).isEqualTo(9.8d);
+        assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
+    }
+
+    @Test
+    void fallsBackToDatabaseSpecificSeverityWhenNoCvssScoreCanBeParsed() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-V4"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-V4", exchange -> {
+            // A CVSS_V4-only advisory (no v3 entry): parseScore() returns null for v4.0 vectors (see
+            // CvssV3BaseScore's Javadoc), so the GHSA "MODERATE" database_specific label must still surface
+            // -- normalized to "MEDIUM", not silently dropped to "UNKNOWN".
+            byte[] body = """
+                {
+                  "id": "GHSA-V4",
+                  "database_specific": { "severity": "MODERATE" },
+                  "severity": [
+                    { "type": "CVSS_V4", "score": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N" }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.score()).isNull();
+        assertThat(vulnerability.severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void excludesWithdrawnAdvisoriesFromTheReportWithoutDegradingStatus() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-WITHDRAWN"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-WITHDRAWN", exchange -> {
+            byte[] body = """
+                {
+                  "id": "GHSA-WITHDRAWN",
+                  "withdrawn": "2024-01-01T00:00:00Z",
+                  "database_specific": { "severity": "CRITICAL" }
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        // A withdrawn advisory is intentionally dropped -- this is correct, expected behavior, not a
+        // failure, so it must not degrade the scan status to PARTIAL/ERROR.
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
+        assertThat(report.dependencies().get(0).vulnerabilities()).isEmpty();
+        assertThat(report.dependencies().get(0).vulnerabilityCount()).isZero();
+        assertThat(report.vulnerable()).isZero();
+    }
+
+    @Test
+    void degradesToPartialInsteadOfErrorWhenOneOfSeveralAdvisoryFetchesFails() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"V-OK"},{"id":"V-FAIL"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        registerAdvisory("V-OK", "HIGH");
+        server.createContext("/v1/vulns/V-FAIL", exchange -> {
+            byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(503, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        // The advisory that failed to fetch must not discard the one that succeeded, nor abort the whole
+        // scan to ERROR the way a single-advisory IOException used to.
+        assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains("1 advisory fetch failed");
+        assertThat(report.dependencies().get(0).vulnerabilities())
+                .extracting("id")
+                .containsExactly("V-OK");
+    }
+
+    @Test
+    void degradesToPartialInsteadOfThrowingWhenAnAdvisoryResponseIsMalformedJson() throws Exception {
+        // Regression test for a Spring/Quarkus parity bug: Jackson 3's JacksonException (thrown by
+        // ObjectMapper#readTree on malformed JSON) is an unchecked RuntimeException, unlike Jackson 2's
+        // (which extends IOException) -- so a bare `catch (IOException ex)` never caught it here, and a
+        // malformed advisory response would previously escape scan() entirely instead of degrading
+        // gracefully.
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"V-BAD-JSON"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/V-BAD-JSON", exchange -> {
+            byte[] body = "{not valid json".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains("1 advisory fetch failed");
+        assertThat(report.dependencies().get(0).vulnerabilities()).isEmpty();
+    }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilitiesControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilitiesControllerTests.java
@@ -1,6 +1,10 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import static org.hamcrest.Matchers.contains;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -9,11 +13,20 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
+import io.github.jdubois.bootui.engine.advisor.DismissedRulesStore;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * MVC wiring tests for {@link VulnerabilitiesController}. The scan/parsing logic lives in
+ * {@code OsvVulnerabilityScannerTests}; here we only assert routing/caching and that both routes feed the
+ * shared {@link DismissedRulesStore} through {@link DependencyReports#applyDismissals} before serialization,
+ * mirroring {@code ArchitectureControllerTests}.
+ */
 class VulnerabilitiesControllerTests {
 
     private static DependencyDto dependency(String groupId, String artifactId, String version) {
@@ -21,12 +34,28 @@ class VulnerabilitiesControllerTests {
         return new DependencyDto(groupId, artifactId, version, packageName, "test", 0, "NONE", List.of());
     }
 
+    private static DependencyDto vulnerableDependency(
+            String groupId, String artifactId, String version, String vulnerabilityId, String severity) {
+        String packageName = groupId + ":" + artifactId;
+        List<DependencyVulnerabilityDto> vulnerabilities = List.of(new DependencyVulnerabilityDto(
+                vulnerabilityId, null, null, severity, null, List.of(), List.of(), List.of()));
+        return new DependencyDto(
+                groupId, artifactId, version, packageName, "test", vulnerabilities.size(), severity, vulnerabilities);
+    }
+
+    private static DismissedRulesStore emptyDismissedRulesStore() {
+        DismissedRulesStore store = mock(DismissedRulesStore.class);
+        when(store.load()).thenReturn(Set.of());
+        return store;
+    }
+
     @Test
     void dependenciesReturnsClasspathInventoryWithoutScanning() throws Exception {
         MockMvc mvc = standaloneSetup(new VulnerabilitiesController(
                         new BootUiProperties(),
                         () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                        dependencies -> DependencyReports.report(true, "SCANNED", "unused", 1L, 1, dependencies)))
+                        dependencies -> DependencyReports.report(true, "SCANNED", "unused", 1L, 1, dependencies),
+                        emptyDismissedRulesStore()))
                 .build();
 
         mvc.perform(get("/bootui/api/vulnerabilities"))
@@ -43,7 +72,8 @@ class VulnerabilitiesControllerTests {
         MockMvc mvc = standaloneSetup(new VulnerabilitiesController(
                         new BootUiProperties(),
                         () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                        dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, dependencies)))
+                        dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, dependencies),
+                        emptyDismissedRulesStore()))
                 .build();
 
         mvc.perform(post("/bootui/api/vulnerabilities/scan"))
@@ -60,7 +90,8 @@ class VulnerabilitiesControllerTests {
         MockMvc mvc = standaloneSetup(new VulnerabilitiesController(
                         properties,
                         () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                        dependencies -> DependencyReports.report(true, "SCANNED", "unused", 1L, 1, dependencies)))
+                        dependencies -> DependencyReports.report(true, "SCANNED", "unused", 1L, 1, dependencies),
+                        emptyDismissedRulesStore()))
                 .build();
 
         mvc.perform(post("/bootui/api/vulnerabilities/scan"))
@@ -75,7 +106,8 @@ class VulnerabilitiesControllerTests {
         MockMvc mvc = standaloneSetup(new VulnerabilitiesController(
                         new BootUiProperties(),
                         () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                        dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, dependencies)))
+                        dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, dependencies),
+                        emptyDismissedRulesStore()))
                 .build();
 
         mvc.perform(post("/bootui/api/vulnerabilities/scan"))
@@ -86,5 +118,49 @@ class VulnerabilitiesControllerTests {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.scan.status").value("SCANNED"))
                 .andExpect(jsonPath("$.scan.message").value("done"));
+    }
+
+    @Test
+    void dependenciesAppliesDismissalsFromTheStoreToTheCachedReport() throws Exception {
+        DismissedRulesStore dismissedRules = mock(DismissedRulesStore.class);
+        String key = DependencyReports.dismissalKey("GHSA-DISMISSED", "org.example:sample");
+        when(dismissedRules.load()).thenReturn(Set.of(key));
+        DependencyDto vulnerable = vulnerableDependency("org.example", "sample", "1.0.0", "GHSA-DISMISSED", "CRITICAL");
+        VulnerabilitiesController controller = new VulnerabilitiesController(
+                new BootUiProperties(),
+                () -> List.of(vulnerable),
+                dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, List.of(vulnerable)),
+                dismissedRules);
+        MockMvc mvc = standaloneSetup(controller).build();
+        // Populate the cached lastScanReport so GET serves it (mirroring dependenciesReturnsLastScanReportAfterScan).
+        mvc.perform(post("/bootui/api/vulnerabilities/scan")).andExpect(status().isOk());
+
+        mvc.perform(get("/bootui/api/vulnerabilities"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dependencies[0].vulnerabilities[0].dismissed")
+                        .value(true))
+                .andExpect(jsonPath("$.dependencies[0].vulnerabilityCount").value(0))
+                .andExpect(jsonPath("$.vulnerable").value(0));
+        verify(dismissedRules, atLeastOnce()).load();
+    }
+
+    @Test
+    void scanAppliesDismissalsFromTheStoreToTheFreshReport() throws Exception {
+        DismissedRulesStore dismissedRules = mock(DismissedRulesStore.class);
+        String key = DependencyReports.dismissalKey("GHSA-DISMISSED", "org.example:sample");
+        when(dismissedRules.load()).thenReturn(Set.of(key));
+        DependencyDto vulnerable = vulnerableDependency("org.example", "sample", "1.0.0", "GHSA-DISMISSED", "HIGH");
+        VulnerabilitiesController controller = new VulnerabilitiesController(
+                new BootUiProperties(),
+                () -> List.of(vulnerable),
+                dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, List.of(vulnerable)),
+                dismissedRules);
+        MockMvc mvc = standaloneSetup(controller).build();
+
+        mvc.perform(post("/bootui/api/vulnerabilities/scan"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dependencies[0].vulnerabilities[0].dismissed")
+                        .value(true))
+                .andExpect(jsonPath("$.dependencies[0].vulnerabilityCount").value(0));
     }
 }

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
@@ -1,0 +1,179 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import Vulnerabilities from './Vulnerabilities.vue'
+
+function vulnerability(id, severity, dismissed = false) {
+  return {
+    id,
+    summary: `${id} summary`,
+    details: null,
+    severity,
+    score: null,
+    aliases: [],
+    references: [],
+    fixedVersions: [],
+    dismissed
+  }
+}
+
+function dependency(packageName, version, vulnerabilities, highestSeverity) {
+  return {
+    groupId: packageName.split(':')[0],
+    artifactId: packageName.split(':')[1],
+    version,
+    packageName,
+    source: 'test',
+    vulnerabilityCount: vulnerabilities.filter((v) => !v.dismissed).length,
+    highestSeverity,
+    vulnerabilities
+  }
+}
+
+function report(dependencies, vulnerable = dependencies.filter((d) => d.vulnerabilityCount > 0).length) {
+  return {
+    scanningEnabled: true,
+    total: dependencies.length,
+    vulnerable,
+    severityCounts: [
+      {severity: 'CRITICAL', count: 0},
+      {severity: 'HIGH', count: 0},
+      {severity: 'MEDIUM', count: 0},
+      {severity: 'LOW', count: 0}
+    ],
+    scan: {
+      scanner: 'OSV.dev',
+      status: 'SCANNED',
+      message: 'Scan completed against OSV.dev.',
+      scannedAt: 1_700_000_000_000,
+      packagesScanned: dependencies.length,
+      vulnerabilitiesFound: dependencies.reduce((sum, d) => sum + d.vulnerabilityCount, 0)
+    },
+    dependencies
+  }
+}
+
+/**
+ * Stubs global fetch so GET api/vulnerabilities serves successive entries of `reports` (the last
+ * entry repeats once exhausted, so a reload after the fixture list runs out still resolves), while
+ * POST/DELETE api/dismissed-rules/* is acknowledged without mutating server state -- exactly like
+ * useDismissedRules.test.js pins the composable in isolation. The panel itself is responsible for
+ * re-fetching after a dismiss/restore, so each test supplies the *next* report reflecting the
+ * expected server-side effect.
+ */
+async function mountWithReports(reports) {
+  let callIndex = 0
+  const fetchMock = vi.fn((input, init) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method || 'GET').toUpperCase()
+    if (url.startsWith('api/dismissed-rules/')) {
+      return Promise.resolve(new Response(JSON.stringify({dismissed: []}), {status: 200}))
+    }
+    if (url === 'api/vulnerabilities' && method === 'GET') {
+      const nextReport = reports[Math.min(callIndex, reports.length - 1)]
+      callIndex++
+      return Promise.resolve(new Response(JSON.stringify(nextReport), {status: 200}))
+    }
+    return Promise.resolve(new Response('{}', {status: 200}))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+
+  const wrapper = mount(Vulnerabilities)
+  await flushPromises()
+  return {wrapper, fetchMock}
+}
+
+describe('Vulnerabilities', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('shows "None found" only when a dependency has no vulnerabilities at all', async () => {
+    const clean = dependency('org.example:clean', '1.0.0', [], 'NONE')
+    const {wrapper} = await mountWithReports([report([clean])])
+
+    expect(wrapper.text()).toContain('None found')
+  })
+
+  it('keeps a dismissed-only dependency out of "None found" so it can still be restored', async () => {
+    // Regression guard: vulnerabilityCount excludes dismissed findings (server-side), so the
+    // template must key "None found" off vulnerabilities.length, not vulnerabilityCount.
+    const dismissedOnly = dependency(
+      'org.example:legacy',
+      '1.0.0',
+      [vulnerability('GHSA-dismissed', 'HIGH', true)],
+      'NONE'
+    )
+    const {wrapper} = await mountWithReports([report([dismissedOnly])])
+
+    expect(wrapper.text()).not.toContain('None found')
+    expect(wrapper.text()).toContain('Dismissed')
+    expect(wrapper.text()).toContain('Restore')
+  })
+
+  it('sinks a dismissed vulnerability below active ones regardless of severity', async () => {
+    const mixed = dependency(
+      'org.example:mixed',
+      '1.0.0',
+      [vulnerability('GHSA-dismissed-critical', 'CRITICAL', true), vulnerability('GHSA-active-low', 'LOW', false)],
+      'LOW'
+    )
+    const {wrapper} = await mountWithReports([report([mixed])])
+
+    const ids = wrapper.findAll('.vulnerability-list a, .vulnerability-list span.fw-semibold').map((n) => n.text())
+    expect(ids.indexOf('GHSA-active-low')).toBeLessThan(ids.indexOf('GHSA-dismissed-critical'))
+
+    const buttons = wrapper.findAll('button').filter((b) => /Dismiss|Restore/.test(b.text()))
+    expect(buttons.map((b) => b.text().trim())).toEqual(['Dismiss', 'Restore'])
+  })
+
+  it('dismissing a vulnerability POSTs the vulnerabilityId::packageName composite key and reloads', async () => {
+    const beforeDismiss = dependency(
+      'org.example:sample',
+      '1.0.0',
+      [vulnerability('GHSA-active-0001', 'CRITICAL', false)],
+      'CRITICAL'
+    )
+    const afterDismiss = dependency(
+      'org.example:sample',
+      '1.0.0',
+      [vulnerability('GHSA-active-0001', 'CRITICAL', true)],
+      'NONE'
+    )
+    const {wrapper, fetchMock} = await mountWithReports([report([beforeDismiss]), report([afterDismiss], 0)])
+
+    await wrapper.find('button.btn-outline-secondary').trigger('click')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'api/dismissed-rules/GHSA-active-0001%3A%3Aorg.example%3Asample',
+      expect.objectContaining({method: 'POST'})
+    )
+    expect(wrapper.findAll('button.btn-outline-secondary').map((b) => b.text().trim())).toEqual(['Restore'])
+  })
+
+  it('restoring a vulnerability DELETEs the same composite key and reloads', async () => {
+    const dismissed = dependency(
+      'org.example:sample',
+      '1.0.0',
+      [vulnerability('GHSA-active-0001', 'CRITICAL', true)],
+      'NONE'
+    )
+    const restored = dependency(
+      'org.example:sample',
+      '1.0.0',
+      [vulnerability('GHSA-active-0001', 'CRITICAL', false)],
+      'CRITICAL'
+    )
+    const {wrapper, fetchMock} = await mountWithReports([report([dismissed], 0), report([restored])])
+
+    await wrapper.find('button.btn-outline-secondary').trigger('click')
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'api/dismissed-rules/GHSA-active-0001%3A%3Aorg.example%3Asample',
+      expect.objectContaining({method: 'DELETE'})
+    )
+    expect(wrapper.text()).toContain('Dismiss')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -5,6 +5,7 @@ import {formatClockTime} from '../utils/format.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
+import {useDismissedRules} from '../utils/useDismissedRules.js'
 import PanelHeader from './components/PanelHeader.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 import AdvisorSummary from './components/AdvisorSummary.vue'
@@ -17,6 +18,8 @@ const actionMessage = ref(null)
 const loading = ref(false)
 const search = ref('')
 const vulnerableOnly = ref(false)
+
+const {dismissLoading, dismiss, restore} = useDismissedRules(loadDependencies)
 
 const severityClasses = {
   CRITICAL: 'text-bg-danger',
@@ -61,6 +64,10 @@ function compareDependencies(left, right) {
 }
 
 function compareVulnerabilities(left, right) {
+  // Dismissed vulnerabilities sink to the bottom, mirroring the server's VULNERABILITY_ORDER
+  // (DependencyReports) so re-sorting client-side never undoes the dismissed-last ordering.
+  const dismissed = (left.dismissed ? 1 : 0) - (right.dismissed ? 1 : 0)
+  if (dismissed !== 0) return dismissed
   const severity = severityRank(left.severity) - severityRank(right.severity)
   if (severity !== 0) return severity
   return compareText(left.id, right.id)
@@ -68,6 +75,17 @@ function compareVulnerabilities(left, right) {
 
 function sortedVulnerabilities(vulnerabilities) {
   return [...(vulnerabilities || [])].sort(compareVulnerabilities)
+}
+
+// The composite key persisted in the shared DismissedRulesStore, matching the engine's
+// DependencyReports.dismissalKey(vulnerabilityId, packageName) format exactly.
+function dismissalKey(vulnerabilityId, packageName) {
+  return `${vulnerabilityId}::${packageName}`
+}
+
+function toggleDismiss(dependency, vulnerability) {
+  const key = dismissalKey(vulnerability.id, dependency.packageName)
+  return vulnerability.dismissed ? restore(key) : dismiss(key)
 }
 
 const filteredDependencies = computed(() => {
@@ -252,11 +270,12 @@ onMounted(loadDependencies)
                   </span>
                 </td>
                 <td>
-                  <span v-if="dependency.vulnerabilityCount === 0" class="text-muted">None found</span>
+                  <span v-if="dependency.vulnerabilities.length === 0" class="text-muted">None found</span>
                   <div v-else class="vulnerability-list">
                     <div
                       v-for="vulnerability in sortedVulnerabilities(dependency.vulnerabilities)"
                       :key="vulnerability.id"
+                      :class="{'opacity-50': vulnerability.dismissed}"
                       class="mb-2"
                     >
                       <div class="d-flex flex-wrap align-items-center gap-2">
@@ -275,6 +294,17 @@ onMounted(loadDependencies)
                         <span v-if="vulnerability.fixedVersions.length" class="small text-muted">
                           fixed in {{ vulnerability.fixedVersions.join(', ') }}
                         </span>
+                        <span v-if="vulnerability.dismissed" class="badge text-bg-light border">Dismissed</span>
+                        <button
+                          :disabled="dismissLoading"
+                          :title="vulnerability.dismissed ? 'Restore this vulnerability' : 'Dismiss this vulnerability'"
+                          class="btn btn-sm btn-outline-secondary ms-auto"
+                          type="button"
+                          @click="toggleDismiss(dependency, vulnerability)"
+                        >
+                          <i :class="vulnerability.dismissed ? 'bi-eye' : 'bi-eye-slash'" class="bi me-1"></i>
+                          {{ vulnerability.dismissed ? 'Restore' : 'Dismiss' }}
+                        </button>
                       </div>
                       <div class="small">
                         {{ vulnerability.summary || vulnerability.details || 'No advisory summary available.' }}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -382,13 +382,37 @@ though no Spring-specific probe ran on Quarkus.
 
 The Vulnerabilities panel shows dependency inventory and local OSV vulnerability scan results. It helps identify known
 vulnerable dependencies from the running project's dependency set during the local development loop. Scan findings are
-ordered by severity first, with dependencies and advisories alphabetized within the same severity.
+ordered by severity first (dismissed findings sink to the bottom regardless of severity), with dependencies and
+advisories alphabetized within the same severity.
+
+Severity is derived from [OSV.dev](https://osv.dev/)'s `severity[]` entries, whose `score` field is a CVSS vector string
+for `CVSS_V3`/`CVSS_V4` types (for example `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`), never a bare number. A CVSS
+v3.0/v3.1 vector is parsed into a real numeric Base Score using the formula from the
+[FIRST.org CVSS v3.1 specification](https://www.first.org/cvss/v3-1/specification-document); CVSS v4.0 has no
+closed-form Base Score equation (its MacroVector lookup table is a much larger undertaking) and legacy CVSS v2 is
+essentially unseen in real Maven-ecosystem OSV advisories, so both fall back to the advisory's
+`database_specific.severity` label (`CRITICAL`/`HIGH`/`MODERATE`/`LOW`, normalized to BootUI's `MEDIUM` label) when no
+v3 score is present. An advisory with neither a parseable CVSS v3 score nor a `database_specific` label renders as
+`UNKNOWN` rather than being silently dropped. Advisories carrying a `withdrawn` timestamp are excluded from results
+entirely, since OSV does not filter withdrawn records out of its API responses itself. A single advisory detail fetch
+that fails (network hiccup, rate limiting) no longer aborts the whole scan: it is counted and the scan degrades to
+`PARTIAL`, keeping every advisory that *did* fetch successfully instead of discarding the whole result.
+
+Like every other advisor, a vulnerability can be **dismissed** when it does not apply to your project (already
+patched downstream, accepted risk, or a fix not yet available upstream) — see the shared dismiss/restore explanation
+at the top of this section. The one difference from a flat rule-based advisor is the dismissal key's shape: because a
+vulnerability is scoped to one dependency, it is keyed by `<vulnerability id>::<package name>` (for example
+`GHSA-xxxx-xxxx-xxxx::org.example:sample`) rather than a bare rule id, so dismissing a finding for one dependency never
+accidentally hides the same advisory id reported against a different dependency, and a dismissal survives a
+patch-version bump of the still-vulnerable dependency. Dismissed vulnerabilities stay visible (dimmed, with a
+_Restore_ button) rather than disappearing, and are excluded from the per-dependency and panel-level vulnerable counts.
 
 On Quarkus the panel is identical, listing the local inventory first and contacting OSV.dev only on the user-initiated
-scan, over the same report contract. The one platform difference is dependency discovery: the Spring adapter scans the
-classpath for `META-INF/maven/*/pom.properties`, which is unreliable under the Quarkus runtime classloader, so the
-Quarkus inventory is captured at build time from the application's resolved runtime dependency model and read back at
-runtime (mirroring the Architecture panel's build-time base-package discovery). The OSV lookup itself is identical, and
+scan, over the same report contract, the same CVSS/withdrawn/partial-failure handling, and the same dismiss/restore
+workflow. The one platform difference is dependency discovery: the Spring adapter scans the classpath for
+`META-INF/maven/*/pom.properties`, which is unreliable under the Quarkus runtime classloader, so the Quarkus inventory
+is captured at build time from the application's resolved runtime dependency model and read back at runtime (mirroring
+the Architecture panel's build-time base-package discovery). The OSV lookup itself is identical, and
 `bootui.vulnerabilities.osv-enabled=false` disables on-demand scanning on both adapters.
 
 ![BootUI Vulnerabilities panel](./images/bootui-vulnerabilities.webp)

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -542,13 +542,22 @@ Features:
 - Provide an explicit "Scan with OSV.dev" action that sends Maven package names and versions to OSV.dev.
 - Show scan status, vulnerable dependency count, advisory count, severity breakdown, advisory links, aliases, and fixed
   versions when available.
+- Derive severity from a real CVSS v3.0/v3.1 Base Score computed from the advisory's CVSS vector (per the FIRST.org
+  specification) when present, falling back to the advisory's `database_specific` severity label otherwise; render
+  `UNKNOWN` only when neither is available, never silently drop the finding.
+- Exclude advisories marked `withdrawn` by OSV from results and counts.
 - Support disabling OSV scans with `bootui.vulnerabilities.osv-enabled=false`.
+- Allow dismissing/restoring an individual vulnerability finding for a specific dependency, excluding it from the
+  vulnerable count and severity rollups until restored, consistent with the dismiss/restore workflow shared by every
+  other advisor.
 
 Acceptance criteria:
 
 - Dependency and advisory data serialize through stable BootUI DTOs.
 - External scanning is user-initiated and clearly labeled in the UI.
-- OSV failures return a clear error status while preserving the local dependency inventory.
+- A failure fetching the initial OSV batch query returns a clear error status while preserving the local dependency
+  inventory; a failure fetching one advisory's details does not discard advisories that were already fetched
+  successfully, degrading the scan to a partial-success status instead of an outright error.
 - Scan size is bounded by configuration so large classpaths remain responsive.
 
 ### 5.12 Scheduled Tasks Inspector


### PR DESCRIPTION
First dedicated audit of the Vulnerabilities panel (with Claude Sonnet 5), matching the rigor of the earlier advisor audits (e.g. #479). Verified behavior against the live OSV.dev API, the OSV schema docs, and the FIRST.org CVSS v3.1 specification, and fixed what did not hold up.

## Bugs fixed

- **CVSS severity parsing gap (the headline bug).** `DependencyReports.parseScore()` returned `null` for every real OSV `severity[]` entry: OSV's `score` field is always a CVSS vector string for `CVSS_V3`/`CVSS_V4` types (e.g. `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`), never a bare number. Confirmed this empirically by querying the live OSV API for a known-vulnerable `com.fasterxml.jackson.core:jackson-databind` version and inspecting the raw JSON. This meant the primary OSV severity channel silently fell through to the `database_specific.severity` label (or `UNKNOWN`) on every real advisory. Fixed by adding `CvssV3BaseScore`, a CVSS v3.0/v3.1 Base Score calculator verified metric-by-metric against the FIRST.org spec (15 new tests), and wiring `parseScore()` to dispatch `CVSS:3.0`/`CVSS:3.1` vectors to it.
  - **Deliberately not implemented:** CVSS v4.0 has no closed-form Base Score equation (it uses a large MacroVector lookup table -- a much bigger undertaking than v3.1's formula) and legacy CVSS v2 had zero occurrences in a 170-advisory sample of real Maven-ecosystem OSV responses. Both still fall back to the `database_specific` severity label rather than a guessed/wrong number. Flagging as scoped-out future work per the task brief.
- **MODERATE -> MEDIUM mapping bug.** `normalizeSeverity()` mapped OSV's real `database_specific.severity` label `"MODERATE"` to `UNKNOWN` instead of BootUI's `MEDIUM` tier. Verified GHSA/OSV.dev always emits exactly `{CRITICAL, HIGH, MODERATE, LOW}` for this field, never `"MEDIUM"`.
- **Partial-failure resilience.** `fetchVulnerabilities()` previously threw `IOException` (aborting the whole scan to `ERROR`, discarding everything already fetched) when a single advisory detail fetch returned a non-2xx status. It now counts the failure and degrades the scan to `PARTIAL`, keeping every advisory that did fetch successfully -- mirroring how a package/advisory count limit already produced `PARTIAL`.
- **Withdrawn advisories.** Advisories carrying a `withdrawn` timestamp are now excluded from results and all counts; OSV does not filter these out of its API responses itself.
- **Spring/Quarkus parity bug.** Jackson 3's `JacksonException` (Spring, `tools.jackson`) is an *unchecked* `RuntimeException`; Jackson 2's `JacksonException` (Quarkus, `com.fasterxml.jackson`) is a *checked* `IOException` subtype. Spring's existing `catch (IOException ex)` therefore never caught a malformed-JSON OSV response -- it would have propagated as an uncaught 500 instead of a clean `ERROR`-status report like Quarkus. Fixed by also catching `JacksonException` on the Spring side.

## Feature added: dismiss/restore workflow

Every other advisor lets a user dismiss/restore a specific finding via the shared `DismissedRulesStore`; Vulnerabilities had no equivalent. Added one, reusing the **existing** generic `/bootui/api/dismissed-rules/{ruleId}` endpoint -- no new endpoints needed:

- Keyed by `<vulnerability id>::<package name>` (not the affected version), so a dismissal survives a patch-version bump of the still-vulnerable dependency and never collides across dependencies sharing the same advisory id.
- Wired through `VulnerabilitiesController` (Spring) and `VulnerabilitiesResource` (Quarkus) -- both now inject `DismissedRulesStore` and apply dismissals to every report returned (cached, fresh-scan, and not-yet-scanned).
- Dismissed vulnerabilities are excluded from the vulnerable-dependency count and severity rollups but stay visible in the UI (dimmed, with a Restore button) rather than disappearing, matching the Architecture panel's dismiss/restore precedent.
- **Regression guard fixed along the way:** the "None found" empty state used `dependency.vulnerabilityCount === 0`, but that count now excludes dismissed items server-side -- so a dependency whose *only* findings were dismissed would have rendered "None found" with no way to ever restore them. Fixed to check `dependency.vulnerabilities.length === 0` instead.

## Docs

Updated the Vulnerabilities sections of `docs/FEATURES.md` and `docs/SPECIFICATION.md` to describe the CVSS scoring behavior (and its documented v4.0/v2 gap), withdrawn-advisory filtering, `PARTIAL`-on-partial-failure resilience, and the dismiss/restore workflow. Deliberately did **not** add a `docs/VULNERABILITIES-CHECKS.md`: unlike the other advisors, this panel has no curated static rule catalogue to document (its "rules" are just CVSS/OSV data shaping), so forcing that format wouldn't add value.

## Tests

Coverage was much thinner here than the other advisors (4+4+7 tests vs. 22-44 elsewhere) -- materially expanded in both adapters:

- **New** `bootui-engine` `CvssV3BaseScoreTests` -- 15 tests covering the Base Score formula across all metric combinations, boundary rounding, and malformed vectors.
- `bootui-engine` `DependencyReportsTests` -- +18 tests (CVSS dispatch, MODERATE mapping, dismiss/restore engine logic, dismissed-aware ordering/counts).
- Spring `OsvVulnerabilityScannerTests` -- +6 tests (CVSS parsing, withdrawn filtering, partial-failure resilience, JacksonException parity).
- Spring `VulnerabilitiesControllerTests` -- +2 tests (dismiss-wiring), plus fixed unrealistic bare-number CVSS fixtures in existing tests.
- Quarkus `OsvVulnerabilityScannerTest` -- +3 tests (same coverage as Spring), plus fixed unrealistic bare-number CVSS fixtures.
- Quarkus integration tests -- +1 end-to-end dismiss/restore round-trip test (verifies vulnerability count, highest severity, and dismissed flag through the real HTTP flow), plus fixed a stub fixture.
- **New** frontend `Vulnerabilities.test.js` -- 5 tests (empty-state regression guard, dismissed-only dependency stays visible, dismissed-last sorting, dismiss/restore HTTP wiring).

## Verification

- `bootui-core, bootui-engine, bootui-spring-autoconfigure, bootui-spring-boot-starter, bootui-spring-sample-app` -- **2014 tests**, 0 failures (includes bootui-quarkus, bootui-quarkus-deployment, bootui-quarkus-integration-tests in the total).
- Frontend -- **325 tests** pass; `npm run format` / `format:check` clean.
- `./mvnw spotless:apply` then `spotless:check` -- clean across the whole reactor.

## Explicitly out of scope (flagged as future work, per the task brief)

- CVSS v4.0 and legacy v2 Base Score computation (see above).
- SBOM export, EPSS scoring, or additional external vulnerability data sources beyond OSV.dev.
- A dedicated `VULNERABILITIES-CHECKS.md` (judged not to add value for this panel's shape -- see Docs section above).

Generated by Claude Sonnet 5