### PR TITLE
Audit Architecture panel rules: fix bugs, verify Quarkus/CDI neutrality

### DIFF
--- a/bootui-engine/pom.xml
+++ b/bootui-engine/pom.xml
@@ -81,9 +81,11 @@
 
         <!--
           Test-scope only: the architecture rule-detection tests need real framework-annotated bytecode
-          (e.g. @Service, @Transactional, @RestController, BeanPostProcessor) to verify the curated rules
-          fire correctly. These never reach the production classpath, and the engine boundary tripwire
-          excludes test classes (DoNotIncludeTests), so the engine stays framework-neutral in production.
+          (e.g. @Service, @Transactional, @RestController, BeanPostProcessor, and plain jakarta.inject /
+          jakarta.transaction annotations for the CDI/Quarkus-neutrality fixtures) to verify the curated
+          rules fire correctly. These never reach the production classpath, and the engine boundary
+          tripwire excludes test classes (DoNotIncludeTests), so the engine stays framework-neutral in
+          production.
         -->
         <dependency>
             <groupId>org.springframework</groupId>
@@ -128,6 +130,16 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistry.java
@@ -20,6 +20,7 @@ final class ArchitectureRuleRegistry {
             new NoLegacyDateTimeRule(),
             new NoDeprecatedApiRule(),
             new NoFieldInjectionRule(),
+            new FieldsShouldNotUseStandardInjectionAnnotationsRule(),
             new ControllersShouldNotDependOnRepositoriesRule(),
             new RepositoriesShouldNotDependOnControllersRule(),
             new RepositoriesShouldNotDependOnServicesRule(),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.architecture;
 
 import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
+import static com.tngtech.archunit.lang.conditions.ArchConditions.beAnnotatedWith;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
@@ -24,6 +25,7 @@ import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.EvaluationResult;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.library.GeneralCodingRules;
 import com.tngtech.archunit.library.ProxyRules;
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition;
@@ -86,6 +88,8 @@ final class SpringStereotypes {
     static final String COMPONENT = "org.springframework.stereotype.Component";
     static final String SERVICE = "org.springframework.stereotype.Service";
     static final String CONFIGURATION = "org.springframework.context.annotation.Configuration";
+    static final String AUTOWIRED = "org.springframework.beans.factory.annotation.Autowired";
+    static final String VALUE = "org.springframework.beans.factory.annotation.Value";
 
     static final String TRANSACTIONAL = "org.springframework.transaction.annotation.Transactional";
     static final String JAKARTA_TRANSACTIONAL = "jakarta.transaction.Transactional";
@@ -447,10 +451,23 @@ final class NoDeprecatedApiRule extends AbstractArchitectureRule {
 }
 
 /**
- * Flags field injection ({@code @Autowired} / {@code @Inject} / {@code @Value} / {@code @Resource}
- * on fields), which hampers testability and hides required dependencies.
+ * Flags Spring field injection ({@code @Autowired} / {@code @Value} on fields), which hampers
+ * testability and hides required dependencies.
+ *
+ * <p>Deliberately scoped to Spring's own annotations only. ArchUnit's built-in {@code
+ * NO_CLASSES_SHOULD_USE_FIELD_INJECTION} also matches the standard {@code jakarta.inject.Inject} /
+ * {@code javax.inject.Inject} / {@code jakarta.annotation.Resource} annotations, which are the
+ * idiomatic way to do field injection in a CDI/Quarkus application — reusing it here would make a
+ * rule filed under "Spring stereotypes" fire on ordinary CDI code with no Spring on the classpath at
+ * all. {@link FieldsShouldNotUseStandardInjectionAnnotationsRule} covers those standard annotations
+ * as a separate, framework-neutral coding-practice rule instead.</p>
  */
 final class NoFieldInjectionRule extends AbstractArchitectureRule {
+
+    private static final ArchCondition<JavaField> BE_ANNOTATED_WITH_SPRING_INJECTION_ANNOTATION =
+            ArchConditions.<JavaField>beAnnotatedWith(SpringStereotypes.AUTOWIRED)
+                    .or(beAnnotatedWith(SpringStereotypes.VALUE))
+                    .as("be annotated with @Autowired or @Value");
 
     NoFieldInjectionRule() {
         super(new ArchitectureRuleDefinition(
@@ -458,14 +475,55 @@ final class NoFieldInjectionRule extends AbstractArchitectureRule {
                 "Classes should not use field injection",
                 ArchitectureCategory.SPRING_STEREOTYPES,
                 "MEDIUM",
-                "Detects @Autowired, @Inject, @Value, or @Resource on fields instead of constructor injection.",
+                "Detects @Autowired or @Value on fields instead of constructor injection.",
                 "Prefer constructor injection so dependencies are explicit, final, and easy to test.",
                 "https://docs.spring.io/spring-boot/reference/using/spring-beans-and-dependency-injection.html"));
     }
 
     @Override
     ArchRule rule(ArchitectureContext context) {
-        return GeneralCodingRules.NO_CLASSES_SHOULD_USE_FIELD_INJECTION;
+        return noFields()
+                .should(BE_ANNOTATED_WITH_SPRING_INJECTION_ANNOTATION)
+                .as("no classes should use Spring field injection");
+    }
+}
+
+/**
+ * Flags field injection through the standard JSR-330 / Jakarta / Guice injection annotations ({@code
+ * @Inject}, {@code @Resource}) that CDI containers such as Quarkus' Arc use, alongside plain Guice.
+ * Framework-neutral counterpart to {@link NoFieldInjectionRule}, which only covers Spring's own
+ * {@code @Autowired} / {@code @Value}.
+ */
+final class FieldsShouldNotUseStandardInjectionAnnotationsRule extends AbstractArchitectureRule {
+
+    private static final ArchCondition<JavaField> BE_ANNOTATED_WITH_STANDARD_INJECTION_ANNOTATION =
+            ArchConditions.<JavaField>beAnnotatedWith("jakarta.inject.Inject")
+                    .or(beAnnotatedWith("javax.inject.Inject"))
+                    .or(beAnnotatedWith("jakarta.annotation.Resource"))
+                    .or(beAnnotatedWith("javax.annotation.Resource"))
+                    .or(beAnnotatedWith("com.google.inject.Inject"))
+                    .as("be annotated with a standard injection annotation");
+
+    FieldsShouldNotUseStandardInjectionAnnotationsRule() {
+        super(new ArchitectureRuleDefinition(
+                "ARCH-CODE-016",
+                "Classes should not use standard-annotation field injection",
+                ArchitectureCategory.CODING_PRACTICES,
+                "MEDIUM",
+                "Detects jakarta.inject.Inject, javax.inject.Inject, jakarta.annotation.Resource, "
+                        + "javax.annotation.Resource, or com.google.inject.Inject on fields instead of constructor "
+                        + "injection. This is the CDI/Quarkus and Guice equivalent of Spring's @Autowired field "
+                        + "injection.",
+                "Prefer constructor injection so dependencies are explicit, final, and easy to test; CDI containers "
+                        + "such as Quarkus' Arc inject constructor parameters just as readily as fields.",
+                "https://quarkus.io/guides/cdi"));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return noFields()
+                .should(BE_ANNOTATED_WITH_STANDARD_INJECTION_ANNOTATION)
+                .as("no classes should use standard-annotation field injection");
     }
 }
 
@@ -825,65 +883,111 @@ final class TransactionalAnnotationsShouldNotBeDeclaredOnInterfacesRule extends 
 }
 
 /**
- * Flags non-public or static methods annotated with proxy-driven Spring annotations. Interface-based
- * proxies and the default transaction advisor only apply to public instance methods, so the proxy
- * behaviour can be silently skipped and the annotation is therefore misleading.
+ * Flags methods annotated with proxy-driven annotations that the runtime's proxy mechanism cannot
+ * actually intercept.
+ *
+ * <p>Spring's own proxy-driven annotations ({@code @Async}, {@code @Cacheable}, and Spring's own
+ * {@code @Transactional}) require a public, non-static, non-final method: interface-based JDK
+ * proxies and the default CGLIB subclass proxy only ever intercept public instance methods (Spring's
+ * transaction-management reference documents this restriction explicitly, and {@code CglibAopProxy}
+ * logs a warning and silently calls the original, un-intercepted method for a {@code final} method).
+ *
+ * <p>The portable {@code jakarta.transaction.Transactional} annotation is held to a different,
+ * CDI-accurate bar instead of Spring's stricter one: the Jakarta CDI specification's "Unproxyable
+ * bean types" section lists only classes "which have non-static, final methods with public,
+ * protected or default visibility" as breaking proxyability, and a private no-arg constructor
+ * separately &mdash; i.e. a CDI client proxy can intercept public, protected, <em>and</em>
+ * package-private methods alike; only {@code private}, {@code static}, or {@code final} methods are
+ * excluded. Applying Spring's stricter "must be public" bar to the shared annotation would false
+ * positive on a protected or package-private {@code jakarta.transaction.Transactional} method in a
+ * Quarkus/CDI application, where the container's own client-proxy mechanism intercepts it correctly.
+ * A {@code final} class-level self-invocation combined with a proxy annotation on a CDI-managed bean
+ * would instead fail Arc's bean deployment outright, so the final-class case never applies to a class
+ * that could exist in a running Quarkus application in the first place.</p>
  */
 final class ProxiedMethodsShouldNotBePrivateOrStaticRule extends AbstractArchitectureRule {
 
     ProxiedMethodsShouldNotBePrivateOrStaticRule() {
         super(new ArchitectureRuleDefinition(
                 "ARCH-SPRING-010",
-                "Proxy-driven methods should be public and non-static",
+                "Proxy-driven methods should be publicly overridable",
                 ArchitectureCategory.SPRING_STEREOTYPES,
                 "MEDIUM",
-                "Detects non-public or static methods annotated with @Transactional, @Async, or @Cacheable. Interface-based proxies and the default transaction advisor only apply to public instance methods, so the proxy behaviour can be silently skipped.",
-                "Make the annotated method public and non-static so it can be invoked through a Spring proxy, or move the annotation to a method that can be.",
+                "Detects @Async, @Cacheable, or Spring's own @Transactional on a non-public, static, or final method, and jakarta.transaction.Transactional on a private, static, or final method. Interface-based and CGLIB proxies can only intercept public, overridable instance methods, while a CDI client proxy can also intercept protected and package-private ones, so the proxy behaviour can be silently skipped.",
+                "Make the annotated method public, non-static, and non-final so it can be intercepted by a Spring proxy (or at least package-visible, non-static, and non-final for the portable jakarta.transaction.Transactional annotation, which a CDI client proxy can also intercept), or move the annotation to a method that can be.",
                 "https://docs.spring.io/spring-framework/reference/core/aop/proxying.html"));
     }
 
     @Override
     ArchRule rule(ArchitectureContext context) {
         return classes()
-                .should(new ArchCondition<JavaClass>("not declare non-public or static proxy-driven methods") {
+                .should(new ArchCondition<JavaClass>("not declare unproxyable proxy-driven methods") {
                     @Override
                     public void check(JavaClass javaClass, ConditionEvents events) {
                         for (JavaMethod method : javaClass.getMethods()) {
-                            if (SpringStereotypes.PROXIED_METHOD_ANNOTATED.test(method)
-                                    && isNonPublicOrStatic(method)) {
-                                events.add(SimpleConditionEvent.violated(
-                                        method,
-                                        "Method " + method.getFullName()
-                                                + " is annotated with a proxy-driven Spring annotation but is "
-                                                + visibilityProblem(method)));
-                            }
+                            proxyabilityProblem(method)
+                                    .ifPresent(reason -> events.add(SimpleConditionEvent.violated(
+                                            method,
+                                            "Method " + method.getFullName()
+                                                    + " is annotated with a proxy-driven annotation but is "
+                                                    + reason)));
                         }
                     }
                 })
-                .as("Proxy-driven methods should be public and non-static");
+                .as("Proxy-driven methods should be publicly overridable");
     }
 
-    private static boolean isNonPublicOrStatic(JavaMethod method) {
-        Set<JavaModifier> modifiers = method.getModifiers();
-        return modifiers.contains(JavaModifier.STATIC) || !modifiers.contains(JavaModifier.PUBLIC);
+    /**
+     * Returns the visibility/modifier problem preventing this method's proxy annotation from being
+     * honoured, if any. Spring's own annotations are held to Spring's stricter "public only" bar;
+     * a method annotated only with the portable {@code jakarta.transaction.Transactional} is held to
+     * the more permissive bar a CDI client proxy actually supports.
+     */
+    private static Optional<String> proxyabilityProblem(JavaMethod method) {
+        boolean springAnnotated = method.isAnnotatedWith(SpringStereotypes.TRANSACTIONAL)
+                || method.isAnnotatedWith(SpringStereotypes.ASYNC)
+                || method.isAnnotatedWith(SpringStereotypes.CACHEABLE);
+        if (springAnnotated) {
+            return visibilityProblem(method, JavaModifier.PUBLIC);
+        }
+        if (method.isAnnotatedWith(SpringStereotypes.JAKARTA_TRANSACTIONAL)) {
+            return visibilityProblem(method, null);
+        }
+        return Optional.empty();
     }
 
-    private static String visibilityProblem(JavaMethod method) {
+    /**
+     * @param requiredVisibility the minimum {@link JavaModifier} visibility the proxy mechanism
+     *     requires, or {@code null} to only exclude {@code private} (the CDI-permissive bar, which
+     *     also accepts protected and package-private methods).
+     */
+    private static Optional<String> visibilityProblem(JavaMethod method, JavaModifier requiredVisibility) {
         Set<JavaModifier> modifiers = method.getModifiers();
         List<String> problems = new ArrayList<>();
-        if (!modifiers.contains(JavaModifier.PUBLIC)) {
-            if (modifiers.contains(JavaModifier.PRIVATE)) {
-                problems.add("private");
-            } else if (modifiers.contains(JavaModifier.PROTECTED)) {
-                problems.add("protected");
-            } else {
-                problems.add("package-private");
+        if (requiredVisibility == JavaModifier.PUBLIC) {
+            if (!modifiers.contains(JavaModifier.PUBLIC)) {
+                problems.add(visibilityLabel(modifiers));
             }
+        } else if (modifiers.contains(JavaModifier.PRIVATE)) {
+            problems.add("private");
         }
         if (modifiers.contains(JavaModifier.STATIC)) {
             problems.add("static");
         }
-        return String.join(" and ", problems);
+        if (modifiers.contains(JavaModifier.FINAL)) {
+            problems.add("final");
+        }
+        return problems.isEmpty() ? Optional.empty() : Optional.of(String.join(" and ", problems));
+    }
+
+    private static String visibilityLabel(Set<JavaModifier> modifiers) {
+        if (modifiers.contains(JavaModifier.PRIVATE)) {
+            return "private";
+        }
+        if (modifiers.contains(JavaModifier.PROTECTED)) {
+            return "protected";
+        }
+        return "package-private";
     }
 }
 
@@ -935,6 +1039,15 @@ final class AsyncMethodsShouldHaveSupportedSignaturesRule extends AbstractArchit
 
 /**
  * Flags scheduled methods with parameters or unsupported return types.
+ *
+ * <p>Spring's {@code ScheduledAnnotationReactiveSupport} recognizes a fixed, evolving set of
+ * deferred reactive return types via {@code ReactiveAdapterRegistry}: any {@code
+ * org.reactivestreams.Publisher} (Reactor's {@code Mono}/{@code Flux} included), the JDK's own
+ * {@code java.util.concurrent.Flow.Publisher}, Kotlin's {@code Flow}/{@code Deferred}, RxJava
+ * <strong>3</strong> types, and SmallRye Mutiny's {@code Uni}/{@code Multi} when on the classpath —
+ * but never RxJava 2 ({@code io.reactivex.*}, without the {@code rxjava3} segment) or {@code
+ * CompletionStage}/{@code CompletableFuture}, both of which Spring registers as non-deferred and so
+ * discards exactly like any other synchronous return value.</p>
  */
 final class ScheduledMethodsShouldHaveSupportedSignaturesRule extends AbstractArchitectureRule {
 
@@ -945,7 +1058,7 @@ final class ScheduledMethodsShouldHaveSupportedSignaturesRule extends AbstractAr
                 ArchitectureCategory.SPRING_STEREOTYPES,
                 "MEDIUM",
                 "Detects @Scheduled methods that accept parameters or return non-void, non-reactive values that Spring ignores.",
-                "Declare scheduled methods without parameters and return void unless using a supported deferred reactive Publisher type.",
+                "Declare scheduled methods without parameters and return void unless using a supported deferred reactive type (a Reactor/Reactive Streams Publisher, java.util.concurrent.Flow.Publisher, RxJava 3, or SmallRye Mutiny Uni/Multi).",
                 "https://docs.spring.io/spring-framework/reference/integration/scheduling.html"));
     }
 
@@ -990,11 +1103,13 @@ final class ScheduledMethodsShouldHaveSupportedSignaturesRule extends AbstractAr
     private static boolean isKnownReactiveReturnType(JavaClass returnType) {
         String name = returnType.getName();
         return returnType.isAssignableTo("org.reactivestreams.Publisher")
+                || returnType.isAssignableTo(java.util.concurrent.Flow.Publisher.class)
                 || name.startsWith("reactor.core.publisher.")
                 || name.equals("kotlinx.coroutines.flow.Flow")
                 || name.equals("kotlinx.coroutines.Deferred")
-                || name.startsWith("io.reactivex.")
-                || name.startsWith("io.reactivex.rxjava3.");
+                || name.startsWith("io.reactivex.rxjava3.")
+                || name.equals("io.smallrye.mutiny.Uni")
+                || name.equals("io.smallrye.mutiny.Multi");
     }
 }
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureCdiNeutralityTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureCdiNeutralityTests.java
@@ -1,0 +1,191 @@
+package io.github.jdubois.bootui.engine.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import io.github.jdubois.bootui.core.dto.ArchitectureRuleResultDto;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architecture is unusual among BootUI's advisors: it runs the exact same ArchUnit ruleset,
+ * unmodified, on both Spring and Quarkus applications (see {@code docs/QUARKUS-SUPPORT.md}). These
+ * tests pin the single most important correctness property that follows from that design: every
+ * {@code SPRING_STEREOTYPES} ({@code ARCH-SPRING-*}) rule must degrade gracefully — {@code PASS} or
+ * {@code SKIPPED}, never a {@code VIOLATION} or {@code ERROR} — when scanning a pure-CDI/Quarkus
+ * application that has no Spring classes or annotations anywhere on its classpath or in its code.
+ *
+ * <p>A small number of {@code ARCH-SPRING-*} rules are intentionally dual-framework: they also match
+ * the shared {@code jakarta.transaction.Transactional} / {@code jakarta.annotation.PostConstruct} /
+ * {@code PreDestroy} annotations, because CDI containers such as Quarkus' Arc have the exact same
+ * proxy self-invocation and lifecycle-callback pitfalls as Spring. The fixtures below are written the
+ * idiomatic, correct way (constructor injection, no self-invocation across the proxy boundary, no
+ * lifecycle callback combined with a proxy-driven annotation) so that even those dual-framework rules
+ * correctly report no violation — proving the rule set is safe to run unmodified on Quarkus.
+ */
+class ArchitectureCdiNeutralityTests {
+
+    @Test
+    void everySpringStereotypeRulePassesOrSkipsOnAnIdiomaticCdiApplication() {
+        ArchitectureContext context = importCdiFixtures();
+
+        for (ArchitectureRule rule : ArchitectureRuleRegistry.activeRules()) {
+            ArchitectureRuleResultDto result = rule.evaluate(context);
+            if (rule.definition().category() == ArchitectureCategory.SPRING_STEREOTYPES) {
+                assertThat(result.status())
+                        .as(
+                                "Spring-stereotype rule %s (%s) must never VIOLATION/ERROR on a pure-CDI application",
+                                result.id(), result.name())
+                        .isIn(ArchitectureRuleSupport.PASS, ArchitectureRuleSupport.SKIPPED);
+            } else {
+                // Framework-neutral rules may legitimately fire (the field-injected bean below is a
+                // deliberate ARCH-CODE-016 positive), but must never blow up while evaluating CDI code.
+                assertThat(result.status())
+                        .as(
+                                "Rule %s (%s) must not ERROR while scanning a pure-CDI application",
+                                result.id(), result.name())
+                        .isNotEqualTo(ArchitectureRuleSupport.ERROR);
+            }
+        }
+    }
+
+    @Test
+    void fieldInjectedCdiBeanTriggersTheStandardAnnotationRuleNotTheSpringOnlyOne() {
+        ArchitectureRuleResultDto standardRuleResult =
+                evaluate(new FieldsShouldNotUseStandardInjectionAnnotationsRule(), CdiFieldInjectedBean.class);
+        assertThat(standardRuleResult.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(standardRuleResult.id()).isEqualTo("ARCH-CODE-016");
+        assertThat(standardRuleResult.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("CdiFieldInjectedBean"));
+
+        ArchitectureRuleResultDto springOnlyRuleResult =
+                evaluate(new NoFieldInjectionRule(), CdiFieldInjectedBean.class);
+        assertThat(springOnlyRuleResult.status())
+                .as("plain @Inject must never trigger the Spring-only field injection rule")
+                .isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void transactionalSelfInvocationStillFiresOnPlainJakartaTransactional() {
+        // Documents that ARCH-SPRING-004 is an intentional dual-framework true positive: CDI/JTA
+        // self-invocation bypasses the container-managed transaction interceptor exactly like a Spring
+        // proxy, so this is not a false positive to guard against, unlike the field-injection case above.
+        ArchitectureRuleResultDto result =
+                evaluate(new NoSelfInvocationOfProxiedMethodsRule(), CdiSelfInvokingTransactionalBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-004");
+    }
+
+    @Test
+    void lifecycleCallbackRuleStillFiresOnPlainJakartaTransactionalPostConstruct() {
+        // Per the jakarta.transaction.Transactional Javadoc ("Jakarta Transactions" spec): "The
+        // Transactional interceptor interposes on business method invocations only and not on
+        // lifecycle events. Lifecycle methods are invoked in an unspecified transaction context." So a
+        // @PostConstruct method also annotated @Transactional silently runs without a transaction on
+        // Quarkus/CDI exactly as it does on Spring — another intentional dual-framework true positive.
+        ArchitectureRuleResultDto result =
+                evaluate(new LifecycleCallbacksShouldNotBeProxyDrivenRule(), CdiTransactionalPostConstructBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-018");
+    }
+
+    private static ArchitectureContext importCdiFixtures() {
+        JavaClasses importedClasses = new ClassFileImporter()
+                .importClasses(CdiResource.class, CdiService.class, CdiRepository.class, CdiFieldInjectedBean.class);
+        return new ArchitectureContext(importedClasses, List.of(ArchitectureCdiNeutralityTests.class.getPackageName()));
+    }
+
+    private static ArchitectureRuleResultDto evaluate(ArchitectureRule rule, Class<?>... classes) {
+        JavaClasses importedClasses = new ClassFileImporter().importClasses(classes);
+        return rule.evaluate(new ArchitectureContext(
+                importedClasses, List.of(ArchitectureCdiNeutralityTests.class.getPackageName())));
+    }
+
+    /** A JAX-RS resource, constructor-injected — the idiomatic CDI/Quarkus entry point. */
+    @Path("/cdi")
+    private static class CdiResource {
+
+        private final CdiService service;
+
+        @Inject
+        CdiResource(CdiService service) {
+            this.service = service;
+        }
+
+        @GET
+        String get() {
+            return service.read();
+        }
+    }
+
+    /** A CDI service bean using constructor injection, a shared Jakarta lifecycle callback, and a
+     * shared Jakarta transaction annotation — all used correctly (no self-invocation). */
+    private static class CdiService {
+
+        private final CdiRepository repository;
+
+        @Inject
+        CdiService(CdiRepository repository) {
+            this.repository = repository;
+        }
+
+        @Transactional
+        String read() {
+            return repository.find();
+        }
+
+        @PostConstruct
+        void init() {}
+
+        @PreDestroy
+        void destroy() {}
+    }
+
+    /** A CDI-managed persistence-style bean with no Spring stereotype anywhere. */
+    private static class CdiRepository {
+
+        String find() {
+            return "ok";
+        }
+    }
+
+    /** The one deliberate anti-pattern: standard-annotation field injection, mirroring the exact
+     * shape of the repo's own {@code bootui-quarkus-sample-app} fixture. Must trigger ARCH-CODE-016
+     * only, never the Spring-only ARCH-SPRING-001. */
+    private static class CdiFieldInjectedBean {
+
+        @Inject
+        CdiRepository repository;
+    }
+
+    /** A CDI bean that self-invokes its own {@code @Transactional} method — a genuine, intentional
+     * dual-framework true positive for ARCH-SPRING-004. */
+    private static class CdiSelfInvokingTransactionalBean {
+
+        void outer() {
+            inner();
+        }
+
+        @Transactional
+        void inner() {}
+    }
+
+    /** A CDI bean whose {@code @PostConstruct} callback is also annotated {@code @Transactional} — a
+     * genuine, intentional dual-framework true positive for ARCH-SPRING-018 (the JTA interceptor does
+     * not apply to lifecycle callbacks, same as Spring's AOP proxy). */
+    private static class CdiTransactionalPostConstructBean {
+
+        @PostConstruct
+        @Transactional
+        void init() {}
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistryTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistryTests.java
@@ -37,6 +37,7 @@ class ArchitectureRuleRegistryTests {
                         "ARCH-CODE-011",
                         "ARCH-CODE-012",
                         "ARCH-CODE-013",
+                        "ARCH-CODE-016",
                         "ARCH-SPRING-006",
                         "ARCH-SPRING-007",
                         "ARCH-SPRING-008",

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
@@ -6,6 +6,8 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import io.github.jdubois.bootui.core.dto.ArchitectureRuleResultDto;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Resource;
+import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -14,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.AopContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -502,6 +506,152 @@ class ArchitectureRulesTests {
                 .noneSatisfy(sample -> assertThat(sample).contains("ModuleOnePublic"));
     }
 
+    @Test
+    void noFieldInjectionRuleFlagsAutowiredAndValueFields() {
+        ArchitectureRuleResultDto result = evaluate(new NoFieldInjectionRule(), AutowiredFieldBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-001");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("service"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("name"));
+    }
+
+    @Test
+    void noFieldInjectionRulePassesForConstructorInjection() {
+        ArchitectureRuleResultDto result = evaluate(new NoFieldInjectionRule(), ConstructorInjectedBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void noFieldInjectionRuleDoesNotFlagStandardJakartaInjectionAnnotations() {
+        // Regression guard for the ARCH-SPRING-001 narrowing: plain jakarta.inject.Inject / @Resource
+        // field injection (the idiomatic CDI/Quarkus style) must never trip Spring's own field-injection
+        // rule. See FieldsShouldNotUseStandardInjectionAnnotationsRule (ARCH-CODE-016) for the
+        // framework-neutral counterpart, and ArchitectureCdiNeutralityTests for the exhaustive
+        // cross-rule check against a full pure-CDI fixture set.
+        ArchitectureRuleResultDto result = evaluate(new NoFieldInjectionRule(), JakartaInjectFieldBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void fieldsShouldNotUseStandardInjectionAnnotationsFlagsJakartaInjectAndResourceFields() {
+        ArchitectureRuleResultDto result =
+                evaluate(new FieldsShouldNotUseStandardInjectionAnnotationsRule(), JakartaInjectFieldBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-016");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("service"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("name"));
+    }
+
+    @Test
+    void fieldsShouldNotUseStandardInjectionAnnotationsPassesForConstructorInjection() {
+        ArchitectureRuleResultDto result =
+                evaluate(new FieldsShouldNotUseStandardInjectionAnnotationsRule(), ConstructorInjectedBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void fieldsShouldNotUseStandardInjectionAnnotationsDoesNotFlagSpringFieldInjection() {
+        // The two field-injection rules are deliberately disjoint: Spring's own @Autowired/@Value must
+        // never also trip the standard-annotation rule.
+        ArchitectureRuleResultDto result =
+                evaluate(new FieldsShouldNotUseStandardInjectionAnnotationsRule(), AutowiredFieldBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void proxiedMethodsShouldNotBePrivateOrStaticFlagsFinalSpringTransactionalMethod() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ProxiedMethodsShouldNotBePrivateOrStaticRule(), FinalProxyAnnotationComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-010");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("final"));
+    }
+
+    @Test
+    void proxiedMethodsShouldNotBePrivateOrStaticPassesForProtectedOrPackagePrivateJakartaTransactional() {
+        // The key CDI-neutrality finding: a CDI client proxy can intercept public, protected, AND
+        // package-private methods alike (Jakarta CDI spec, "Unproxyable bean types"); only private,
+        // static, or final methods are excluded. Spring's stricter "public only" bar must not apply to
+        // the portable jakarta.transaction.Transactional annotation, or this rule would false-positive
+        // on a perfectly valid Quarkus/CDI transactional service method.
+        ArchitectureRuleResultDto result = evaluate(
+                new ProxiedMethodsShouldNotBePrivateOrStaticRule(), GoodJakartaTransactionalVisibilityComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void proxiedMethodsShouldNotBePrivateOrStaticFlagsPrivateOrFinalJakartaTransactional() {
+        // Even under the CDI-permissive bar, private and final methods are still unproxyable (Jakarta
+        // CDI's "Unproxyable bean types" excludes both), so these remain genuine violations.
+        ArchitectureRuleResultDto result = evaluate(
+                new ProxiedMethodsShouldNotBePrivateOrStaticRule(), BadJakartaTransactionalVisibilityComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-010");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("private"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("final"));
+        assertThat(result.sampleViolations())
+                .noneSatisfy(sample -> assertThat(sample).contains("protected"));
+        assertThat(result.sampleViolations())
+                .noneSatisfy(sample -> assertThat(sample).contains("package-private"));
+    }
+
+    @Test
+    void scheduledMethodsShouldHaveSupportedSignaturesFlagsRxJava2ReturnType() {
+        // The false-negative fix: Spring's ScheduledAnnotationReactiveSupport only recognizes RxJava
+        // 3's io.reactivex.rxjava3.* namespace, never the older io.reactivex.* (RxJava 2) one, so a
+        // scheduled method returning a bare RxJava 2 type has its return value silently discarded.
+        ArchitectureRuleResultDto result =
+                evaluate(new ScheduledMethodsShouldHaveSupportedSignaturesRule(), RxJava2ScheduledComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-012");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("io.reactivex.Flowable"));
+    }
+
+    @Test
+    void scheduledMethodsShouldHaveSupportedSignaturesPassesForRxJava3ReturnType() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ScheduledMethodsShouldHaveSupportedSignaturesRule(), RxJava3ScheduledComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void scheduledMethodsShouldHaveSupportedSignaturesPassesForJdkFlowPublisherReturnType() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ScheduledMethodsShouldHaveSupportedSignaturesRule(), JdkFlowScheduledComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void scheduledMethodsShouldHaveSupportedSignaturesPassesForMutinyUniAndMultiReturnTypes() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ScheduledMethodsShouldHaveSupportedSignaturesRule(), MutinyScheduledComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
     private static ArchitectureRuleResultDto evaluate(ArchitectureRule rule, Class<?>... classes) {
         JavaClasses importedClasses = new ClassFileImporter().importClasses(classes);
         return rule.evaluate(
@@ -778,6 +928,12 @@ class ArchitectureRulesTests {
         protected void protectedTransactional() {}
     }
 
+    private static class FinalProxyAnnotationComponent {
+
+        @Transactional
+        final void finalTransactional() {}
+    }
+
     @Async
     private static class ClassLevelAsyncBean {
 
@@ -881,4 +1037,86 @@ class ArchitectureRulesTests {
     }
 
     private static class SampleBeanPostProcessor implements BeanPostProcessor {}
+
+    private static class AutowiredFieldBean {
+
+        @Autowired
+        private ExampleService service;
+
+        @Value("${some.name}")
+        private String name;
+    }
+
+    private static class JakartaInjectFieldBean {
+
+        @Inject
+        private ExampleService service;
+
+        @Resource
+        private String name;
+    }
+
+    private static class ConstructorInjectedBean {
+
+        private final ExampleService service;
+
+        ConstructorInjectedBean(ExampleService service) {
+            this.service = service;
+        }
+    }
+
+    private static class GoodJakartaTransactionalVisibilityComponent {
+
+        @jakarta.transaction.Transactional
+        protected void protectedTransactional() {}
+
+        @jakarta.transaction.Transactional
+        void packagePrivateTransactional() {}
+    }
+
+    private static class BadJakartaTransactionalVisibilityComponent {
+
+        @jakarta.transaction.Transactional
+        private void privateTransactional() {}
+
+        @jakarta.transaction.Transactional
+        final void finalTransactional() {}
+    }
+
+    private static class RxJava2ScheduledComponent {
+
+        @Scheduled(fixedDelay = 1000)
+        io.reactivex.Flowable<String> run() {
+            return null;
+        }
+    }
+
+    private static class RxJava3ScheduledComponent {
+
+        @Scheduled(fixedDelay = 1000)
+        io.reactivex.rxjava3.core.Single<String> run() {
+            return null;
+        }
+    }
+
+    private static class JdkFlowScheduledComponent {
+
+        @Scheduled(fixedDelay = 1000)
+        java.util.concurrent.Flow.Publisher<String> run() {
+            return null;
+        }
+    }
+
+    private static class MutinyScheduledComponent {
+
+        @Scheduled(fixedDelay = 1000)
+        io.smallrye.mutiny.Uni<String> uni() {
+            return null;
+        }
+
+        @Scheduled(fixedDelay = 1000)
+        io.smallrye.mutiny.Multi<String> multi() {
+            return null;
+        }
+    }
 }

--- a/bootui-engine/src/test/java/io/reactivex/Flowable.java
+++ b/bootui-engine/src/test/java/io/reactivex/Flowable.java
@@ -1,0 +1,9 @@
+package io.reactivex;
+
+/**
+ * Minimal test stub standing in for the absent RxJava 2 library, so ARCH-SPRING-012 fixtures can
+ * compile and exercise the "old io.reactivex.* namespace is not a Spring-recognized deferred
+ * return type" detection (Spring's {@code ScheduledAnnotationReactiveSupport} only recognizes
+ * RxJava 3's {@code io.reactivex.rxjava3.*} namespace). Not the real library.
+ */
+public class Flowable<T> {}

--- a/bootui-engine/src/test/java/io/reactivex/rxjava3/core/Single.java
+++ b/bootui-engine/src/test/java/io/reactivex/rxjava3/core/Single.java
@@ -1,0 +1,8 @@
+package io.reactivex.rxjava3.core;
+
+/**
+ * Minimal test stub standing in for the absent RxJava 3 library, so ARCH-SPRING-012 fixtures can
+ * compile and exercise the "io.reactivex.rxjava3.* is a Spring-recognized deferred return type"
+ * detection. Not the real library.
+ */
+public class Single<T> {}

--- a/bootui-engine/src/test/java/io/smallrye/mutiny/Multi.java
+++ b/bootui-engine/src/test/java/io/smallrye/mutiny/Multi.java
@@ -1,0 +1,9 @@
+package io.smallrye.mutiny;
+
+/**
+ * Minimal test stub standing in for the absent SmallRye Mutiny library (Quarkus' reactive type,
+ * registered with Spring's {@code ReactiveAdapterRegistry} when on the classpath), so
+ * ARCH-SPRING-012 fixtures can compile and exercise the "Multi is a Spring-recognized deferred
+ * return type" detection. Not the real library.
+ */
+public class Multi<T> {}

--- a/bootui-engine/src/test/java/io/smallrye/mutiny/Uni.java
+++ b/bootui-engine/src/test/java/io/smallrye/mutiny/Uni.java
@@ -1,0 +1,9 @@
+package io.smallrye.mutiny;
+
+/**
+ * Minimal test stub standing in for the absent SmallRye Mutiny library (Quarkus' reactive type,
+ * registered with Spring's {@code ReactiveAdapterRegistry} when on the classpath), so
+ * ARCH-SPRING-012 fixtures can compile and exercise the "Uni is a Spring-recognized deferred
+ * return type" detection. Not the real library.
+ */
+public class Uni<T> {}

--- a/bootui-quarkus-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/architecture/ArchitectureIssuesResource.java
+++ b/bootui-quarkus-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/architecture/ArchitectureIssuesResource.java
@@ -8,14 +8,16 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
 /**
- * Intentionally contains issues the Architecture advisor (framework-agnostic, e.g. ARCH-CODE-001) and the
- * forthcoming Quarkus advisor flag. Mirrors the Spring sample's {@code ArchitectureIssuesController}.
+ * Intentionally contains issues the Architecture advisor (framework-agnostic, e.g. ARCH-CODE-001 and
+ * ARCH-CODE-016) and the forthcoming Quarkus advisor flag. Mirrors the Spring sample's {@code
+ * ArchitectureIssuesController}.
  */
 @Path("/api/architecture")
 @Produces(MediaType.TEXT_PLAIN)
 public class ArchitectureIssuesResource {
 
-    // Placeholder for a Quarkus-advisor "prefer constructor injection" rule.
+    // This should trigger ARCH-CODE-016 (standard-annotation field injection); the Spring-only
+    // ARCH-SPRING-001 does not fire here since @Inject is CDI's own idiomatic injection annotation.
     @Inject
     ProductRepository repository;
 

--- a/bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -1599,7 +1599,7 @@ const architecture = {
     'These checks complement, but do not replace, a project-specific ArchUnit test suite or an architecture review.',
   basePackages: ['io.github.jdubois.bootui.sample'],
   classesAnalyzed: 42,
-  rulesEvaluated: 32,
+  rulesEvaluated: 37,
   violationsFound: 4,
   severityCounts: [
     {severity: 'HIGH', count: 1},
@@ -1612,7 +1612,7 @@ const architecture = {
     status: 'SCANNED',
     message: 'Architecture rules completed against 42 application class(es) under the detected base package(s).',
     scannedAt: nowMillis - 35_000,
-    rulesEvaluated: 32,
+    rulesEvaluated: 37,
     classesAnalyzed: 42,
     violationsFound: 4
   },
@@ -1633,7 +1633,7 @@ const architecture = {
       'Classes should not use field injection',
       'Spring stereotypes',
       'MEDIUM',
-      'Detects @Autowired, @Inject, @Value, or @Resource on fields instead of constructor injection.',
+      'Detects @Autowired or @Value on fields instead of constructor injection.',
       'VIOLATION',
       3,
       [

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -5,32 +5,44 @@ application's own classes. This page lists every rule that ships with BootUI tod
 what to do about it.
 
 Each rule is a small class registered in
-[`ArchitectureRuleRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRuleRegistry.java)
+[`ArchitectureRuleRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistry.java)
 and implemented in
-[`ArchitectureRules.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/architecture/ArchitectureRules.java).
+[`ArchitectureRules.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java).
 The list intentionally stays compact and reviewable; adding a new rule means adding one focused class plus a registry
-entry.
+entry. The rules, the scanner, and the base-package-discovery seam all live in the framework-neutral `bootui-engine`
+module, so the exact same ruleset runs unmodified on both the Spring and Quarkus adapters — see
+[`docs/QUARKUS-SUPPORT.md`](QUARKUS-SUPPORT.md) for how base-package discovery differs per adapter.
 
 ## What BootUI does
 
-The scanner detects the host application's base package(s) from the `@SpringBootApplication` configuration via
-`AutoConfigurationPackages`, imports the compiled `.class` files from those packages with ArchUnit's
-`ClassFileImporter`, and evaluates every registered rule against the imported classes. Importing is bounded to the
-application's own base package(s) — never the entire classpath — and runs only on demand when the scan action is
-invoked, caching the last report in the controller. When several base packages are detected, all of them are imported
-and analyzed together. ArchUnit still resolves the external types those classes reference (super-classes, interfaces)
-from the classpath so hierarchy-aware checks work; BootUI keeps that resolution enabled but quietly skips any referenced
-class whose resource location uses a URL scheme the JVM cannot open — such as the Quarkus runtime classloader's
-`quarkus:` scheme — so a scan never floods the console with per-class resolution warnings.
+The scanner detects the host application's base package(s) — via the Spring adapter's `@SpringBootApplication`
+configuration (`AutoConfigurationPackages`) or, on Quarkus, via a build-time `BasePackageProvider` seam that reduces the
+Jandex application index to a package root antichain (see [`docs/QUARKUS-SUPPORT.md`](QUARKUS-SUPPORT.md)) — imports the
+compiled `.class` files from those packages with ArchUnit's `ClassFileImporter`, and evaluates every registered rule
+against the imported classes. Importing is bounded to the application's own base package(s) — never the entire classpath
+— and runs only on demand when the scan action is invoked, caching the last report in the controller. When several base
+packages are detected, all of them are imported and analyzed together. ArchUnit still resolves the external types those
+classes reference (super-classes, interfaces) from the classpath so hierarchy-aware checks work; BootUI keeps that
+resolution enabled but quietly skips any referenced class whose resource location uses a URL scheme the JVM cannot open —
+such as the Quarkus runtime classloader's `quarkus:` scheme — so a scan never floods the console with per-class resolution
+warnings.
 
 When BootUI is installed through `bootui-spring-boot-starter`, ArchUnit is included transitively so the panel works
-without an extra application dependency. The panel is available only when:
+without an extra application dependency; the Quarkus adapter bundles ArchUnit itself. The panel is available only when:
 
 - ArchUnit is on the classpath, and
 - a base package is resolvable from the running application.
 
 If no classes can be imported (for example in some fat-jar or DevTools restart-classloader situations), the panel
 degrades to a stable, empty report with an explanatory reason rather than failing.
+
+The exact same rules, including the `SPRING_STEREOTYPES` category below, run unmodified against Quarkus/CDI
+applications: rules keyed on Spring-only annotations (`@Autowired`, `@Component`, `@Service`, …) simply match zero
+classes and degrade to a no-op pass — never a false positive — while a handful of rules are deliberately dual-framework
+because they also key on the shared `jakarta.*` annotations (`jakarta.transaction.Transactional`,
+`jakarta.annotation.PostConstruct`/`PreDestroy`) that both Spring and CDI containers recognize. See each rule's entry
+below for which category it falls into, and `ArchitectureCdiNeutralityTests` for the automated check that pins this
+property across every `SPRING_STEREOTYPES` rule against a pure-CDI fixture set.
 
 ## What BootUI does not do
 
@@ -212,16 +224,34 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Recommendation**: make utility classes `final` and give them a single private constructor so they cannot be
   instantiated or subclassed.
 
+### ARCH-CODE-016 — Classes should not use standard-annotation field injection
+
+- **Severity**: MEDIUM
+- **Inspects**: `jakarta.inject.Inject`, `javax.inject.Inject`, `jakarta.annotation.Resource`,
+  `javax.annotation.Resource`, or `com.google.inject.Inject` annotations on fields — the standard JSR-330 / Jakarta /
+  Guice injection annotations a CDI container such as Quarkus' Arc (or plain Guice) uses.
+- **Fires when**: a dependency is injected directly into a field via one of these standard annotations instead of
+  through a constructor.
+- **Why it matters**: field injection hides required dependencies, prevents `final` fields, and makes classes harder to
+  instantiate in tests — the same rationale as ARCH-SPRING-001, just for the framework-neutral annotation set. Kept as a
+  separate rule (rather than folded into ARCH-SPRING-001) so it fires correctly on a Quarkus/CDI application that has no
+  Spring annotations anywhere on its classpath.
+- **Recommendation**: prefer constructor injection so dependencies are explicit, final, and easy to test; CDI containers
+  such as Quarkus' Arc inject constructor parameters just as readily as fields.
+
 ## Spring stereotypes
 
 ### ARCH-SPRING-001 — Classes should not use field injection
 
 - **Severity**: MEDIUM
-- **Inspects**: `@Autowired`, `@Inject`, `@Value`, or `@Resource` annotations on fields.
+- **Inspects**: `@Autowired` or `@Value` (Spring's own field-injection annotations) on fields.
 - **Fires when**: a dependency is injected directly into a field instead of through a constructor.
 - **Why it matters**: field injection hides required dependencies, prevents `final` fields, and makes classes harder to
   instantiate in tests.
 - **Recommendation**: prefer constructor injection so dependencies are explicit, final, and easy to test.
+- **Quarkus/CDI note**: deliberately scoped to Spring's own annotations only, so it never fires on plain
+  `jakarta.inject.Inject` / `@Resource` field injection — the idiomatic style on a CDI/Quarkus application. See
+  ARCH-CODE-016 for the framework-neutral equivalent that covers those standard annotations instead.
 
 ### ARCH-SPRING-002 — Controllers should not depend on repositories
 
@@ -259,13 +289,18 @@ include up to a handful of sample detail lines from ArchUnit.
 ### ARCH-SPRING-004 — Beans should not self-invoke their own proxied methods
 
 - **Severity**: HIGH
-- **Inspects**: direct self-invocation (`this.method()`) of methods proxied through `@Transactional`, `@Async`, or
-  `@Cacheable` on the method, or `@Async` / `@Cacheable` on the declaring class.
+- **Inspects**: direct self-invocation (`this.method()`) of methods proxied through `@Transactional` (Spring's own or the
+  portable `jakarta.transaction.Transactional`), `@Async`, or `@Cacheable` on the method, or `@Async` / `@Cacheable` on
+  the declaring class.
 - **Fires when**: a bean calls one of its own proxied methods directly, bypassing the Spring proxy.
 - **Why it matters**: the transaction, async execution, or caching behaviour is silently lost because the call never
   passes through the proxy — a real correctness bug, not just a style issue.
 - **Recommendation**: refactor so the call goes through the Spring proxy: move the proxied method to a separate bean, or,
   only if necessary, inject a `@Lazy` self-reference and call through it.
+- **Quarkus/CDI note**: this is a deliberate dual-framework true positive, not a false-positive risk to guard against —
+  self-invocation bypasses a CDI client proxy exactly the same way it bypasses a Spring proxy (Jakarta CDI specification,
+  "Client proxy invocation"), so a CDI bean that self-invokes its own `jakarta.transaction.Transactional` method has the
+  identical bug and should be flagged. See `ArchitectureCdiNeutralityTests` for the pinned true-positive case.
 
 ### ARCH-SPRING-005 — Spring stereotypes should not reside in the default package
 
@@ -297,16 +332,25 @@ include up to a handful of sample detail lines from ArchUnit.
   behave differently across proxy modes and may be silently ignored with AspectJ weaving.
 - **Recommendation**: move transaction annotations to concrete implementation classes or methods.
 
-### ARCH-SPRING-010 — Proxy-driven methods should be public and non-static
+### ARCH-SPRING-010 — Proxy-driven methods should be publicly overridable
 
 - **Severity**: MEDIUM
-- **Inspects**: non-public or static methods annotated with `@Transactional`, `@Async`, or `@Cacheable`.
-- **Fires when**: a proxy-driven Spring annotation is applied to a method that is private, protected, package-private, or
-  static.
-- **Why it matters**: interface-based proxies and the default transaction advisor only apply to public instance methods,
-  so the proxy behaviour can be silently skipped.
-- **Recommendation**: make the annotated method public and non-static so it can be invoked through a Spring proxy, or
-  move the annotation to a method that can be invoked through one.
+- **Inspects**: methods annotated with `@Transactional` (Spring's own or the portable
+  `jakarta.transaction.Transactional`), `@Async`, or `@Cacheable`.
+- **Fires when**: `@Async`, `@Cacheable`, or Spring's own `@Transactional` is applied to a method that is private,
+  protected, package-private, static, or final; or the portable `jakarta.transaction.Transactional` is applied to a
+  method that is private, static, or final.
+- **Why it matters**: interface-based JDK proxies and the default CGLIB subclass proxy only intercept public, overridable
+  instance methods — CGLIB additionally warns and silently calls the original, un-intercepted method when a `final`
+  method carries the annotation — so the proxy behaviour can be silently skipped.
+- **Recommendation**: make the annotated method public, non-static, and non-final so it can be invoked through a Spring
+  proxy, or move the annotation to a method that can be invoked through one.
+- **Quarkus/CDI note**: the portable `jakarta.transaction.Transactional` annotation is held to a different, more
+  permissive bar than Spring's own annotations. Per the Jakarta CDI specification's "Unproxyable bean types" section, a
+  CDI client proxy can intercept public, protected, **and** package-private methods alike — only `private`, `static`, or
+  `final` methods are excluded. Applying Spring's stricter "public only" bar to the shared annotation would false-positive
+  on a protected or package-private `jakarta.transaction.Transactional` method in a Quarkus/CDI application, where the
+  container's own client-proxy mechanism intercepts it correctly.
 
 ### ARCH-SPRING-011 — Async methods should return void or Future
 
@@ -326,9 +370,16 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Fires when**: a scheduled method declares parameters, or returns a non-`void`, non-reactive value type whose result
   Spring will ignore.
 - **Why it matters**: Spring invokes scheduled methods without arguments; synchronous return values are discarded, which
-  often indicates a misunderstood job contract.
+  often indicates a misunderstood job contract. Spring's `ScheduledAnnotationReactiveSupport` recognizes a fixed,
+  evolving set of deferred reactive return types via `ReactiveAdapterRegistry`: any `org.reactivestreams.Publisher`
+  (Reactor's `Mono`/`Flux` included), the JDK's own `java.util.concurrent.Flow.Publisher`, Kotlin's
+  `Flow`/`Deferred`, RxJava **3** types (`io.reactivex.rxjava3.*`), and SmallRye Mutiny's `Uni`/`Multi` when on the
+  classpath — but never RxJava 2 (`io.reactivex.*`, without the `rxjava3` segment) or `CompletionStage`/
+  `CompletableFuture`, both of which Spring registers as non-deferred and so discards exactly like any other synchronous
+  return value.
 - **Recommendation**: declare scheduled methods without parameters and return `void` unless using a supported deferred
-  reactive `Publisher` type.
+  reactive type (a Reactor/Reactive Streams `Publisher`, `java.util.concurrent.Flow.Publisher`, RxJava 3, or SmallRye
+  Mutiny `Uni`/`Multi`).
 
 ### ARCH-SPRING-013 — Async should not be used in configuration classes
 
@@ -388,13 +439,18 @@ include up to a handful of sample detail lines from ArchUnit.
 ### ARCH-SPRING-018 — Lifecycle callbacks should not be proxy-driven
 
 - **Severity**: HIGH
-- **Inspects**: `@PostConstruct` or `@PreDestroy` methods that are also annotated with `@Transactional`, `@Async`, or
-  `@Cacheable`.
+- **Inspects**: `@PostConstruct` or `@PreDestroy` methods that are also annotated with `@Transactional` (Spring's own or
+  the portable `jakarta.transaction.Transactional`), `@Async`, or `@Cacheable`.
 - **Fires when**: a lifecycle callback is annotated with a proxy-driven annotation.
 - **Why it matters**: Spring invokes lifecycle callbacks before the bean is wrapped in its proxy, and after it is unwrapped
   at destruction, so the proxy behaviour never applies.
 - **Recommendation**: move the transactional, asynchronous, or cached work to a separate proxied bean method and invoke it
   after initialization rather than annotating the lifecycle callback itself.
+- **Quarkus/CDI note**: also a deliberate dual-framework true positive. Per the `jakarta.transaction.Transactional`
+  Javadoc (Jakarta Transactions specification): "The Transactional interceptor interposes on business method invocations
+  only and not on lifecycle events. Lifecycle methods are invoked in an unspecified transaction context." So a
+  `@PostConstruct`/`@PreDestroy` method combined with the portable `@Transactional` silently runs without a transaction on
+  Quarkus/CDI exactly as it does on Spring. See `ArchitectureCdiNeutralityTests` for the pinned true-positive case.
 
 ### ARCH-SPRING-019 — Async and transactional semantics on one method should be reviewed
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -198,7 +198,8 @@ configuration, imports the compiled classes from that package, and evaluates a f
 architecture hygiene rules: package cycles between slices, general coding practices (no standard streams, generic
 exceptions, `java.util.logging`, JodaTime, `printStackTrace`, `System.exit`, JDK-internal APIs, legacy date/time, or
 deprecated APIs, poorly named exceptions/interfaces, mutable/visible loggers, production dependencies on test
-frameworks, public mutable static fields, or non-final utility classes), and Spring stereotype/proxy heuristics (no field
+frameworks, public mutable static fields, non-final utility classes, or standard-annotation (`jakarta.inject.Inject` /
+`@Resource`) field injection), and Spring stereotype/proxy heuristics (no `@Autowired`/`@Value` field
 injection, controllers should not depend on repositories, repositories should not depend on controllers or services,
 services should not depend on controllers, services and repositories should stay servlet-agnostic, no self-invocation or
 unproxyable proxy annotations, async/scheduled method signatures should be supported, async should stay out of
@@ -220,7 +221,13 @@ violating rules, sorted by severity and violation count. See
 
 On Quarkus the panel is identical, running the same shared ArchUnit ruleset and on-demand scan over the same report
 contract — the framework-agnostic hygiene rules apply unchanged, while the Spring-stereotype rules simply find no
-matching classes on a Quarkus application. The one platform difference is base-package discovery: Quarkus has no
+matching classes on a Quarkus application. A handful of these rules are deliberately dual-framework instead of
+Spring-only, because they also key on the portable `jakarta.*` annotations a CDI container recognizes: self-invocation
+and proxy-visibility checks also fire on `jakarta.transaction.Transactional`, held to the CDI-accurate, more permissive
+visibility bar (a CDI client proxy can intercept protected and package-private methods, unlike Spring's stricter
+public-only proxies) so they degrade gracefully rather than false-positive — see
+[ARCHITECTURE-CHECKS.md](ARCHITECTURE-CHECKS.md) for the per-rule detail. The one platform
+difference is base-package discovery: Quarkus has no
 `@SpringBootApplication` to read and no reliable runtime package scan under its classloader, so the application's base
 packages are discovered at **build time** from the Jandex application index and supplied to the scanner. Discovery is
 single-module today (sibling modules in a multi-module build are not auto-discovered; the `bootui.internal.base-packages`

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -188,8 +188,9 @@ Diff` (**Implemented** — → SmallRye Config; groups active `%profile.`-prefix
 read, BootUI's own routes filtered out at build time) · `Flyway` (→ `quarkus-flyway`) · `Liquibase` (**Implemented** — → `quarkus-liquibase`;
 discovered via `LiquibaseFactoryUtil.getActiveLiquibaseFactories()`, the shared `RanChangeSet` history read + `update`
 action behind the same DTO contract) · `Scheduled Tasks`
-(→ `quarkus-scheduler`) · `Architecture` advisor (ArchUnit engine shared; Spring-stereotype rules get CDI/JAX-RS
-variants) · `Overview` (panel available; the scoring dashboard aggregates the advisor endpoints client-side, and
+(→ `quarkus-scheduler`) · `Architecture` advisor (ArchUnit engine + rules run unmodified; Spring-stereotype rules
+simply match no classes and degrade to a no-op pass, while a few rules are already dual-framework via the shared
+`jakarta.*` annotations) · `Overview` (panel available; the scoring dashboard aggregates the advisor endpoints client-side, and
 `GET /bootui/api/overview` reports the Quarkus version + shell chrome).
 
 ### 5.3 Kept, with a rebuilt capture layer or reduced fidelity (8)
@@ -376,7 +377,7 @@ Pentesting, HTTP Probe, MCP Server) need no special ingredients — they work ag
 | Flyway              | equiv       | Adapt   | Flyway mapper                    | `MigrationProvider` → quarkus-flyway        |
 | Liquibase           | equiv       | Adapt   | Liquibase mapper                 | `MigrationProvider` → quarkus-liquibase     |
 | Scheduled Tasks     | equiv       | Adapt   | Scheduled mapper                 | `ScheduledTaskProvider` → quarkus-scheduler |
-| Architecture        | equiv       | Adapt   | ArchUnit engine                  | `BasePackageProvider` + CDI/JAX-RS rules    |
+| Architecture        | equiv       | Adapt   | ArchUnit engine                  | `BasePackageProvider` (rules run unmodified) |
 | REST API            | partial     | Rebuild | REST conventions engine          | JAX-RS handler-model builder                |
 | DB Connection Pools | partial     | Rebuild | Pool model                       | `DataSourcePoolProvider` → Agroal           |
 | SQL Trace           | partial     | Rebuild | SQL trace model                  | `SqlTraceSource` → Agroal/JDBC              |


### PR DESCRIPTION
Second-round deep audit of the Architecture advisor (following up on `e60ddf8c` "Harden Architecture advisor rules (Phase 1)" from 2026-06-08), matching the rigor of the most recent precedent audit, `b3162c0b` (Pentesting). Verified all 36 pre-existing rules against primary sources — Spring Framework 7 / Spring Boot 4.1.0 reference docs, the Jakarta CDI 4.1 and Jakarta Transactions 2.0 specifications, and the pinned ArchUnit 1.4.2 API/behavior — rather than taking existing rule descriptions at face value.

## Bugs found and fixed

- **ARCH-SPRING-001** (no field injection): narrowed to Spring's own `@Autowired`/`@Value` only. It previously reused ArchUnit's built-in `NO_CLASSES_SHOULD_USE_FIELD_INJECTION`, which also matches `jakarta.inject.Inject`/`javax.inject.Inject`/`jakarta.annotation.Resource` — the idiomatic way to do field injection in a CDI/Quarkus application — so a rule filed under "Spring stereotypes" was a **false positive on ordinary CDI code with no Spring on the classpath at all**. Added **ARCH-CODE-016** as the new framework-neutral coding-practice counterpart covering those standard injection annotations (plus `com.google.inject.Inject`).
- **ARCH-SPRING-010** (proxy-driven methods should be public/non-static): added a missing **`final`-method check** (CGLIB's default proxy cannot intercept final methods either — logs a warning and silently calls the un-intercepted method), and split the visibility bar in two: Spring's own `@Transactional`/`@Async`/`@Cacheable` keep the strict "public only" bar Spring's own proxies actually require, but the portable `jakarta.transaction.Transactional` is now held to the **CDI-accurate bar** instead. Per the Jakarta CDI 4.1 spec's "Unproxyable bean types" section, a CDI client proxy can intercept public, protected, *and* package-private methods; only `private`/`static`/`final` methods break it. The old rule **false-positived on a protected or package-private `jakarta.transaction.Transactional` method in a Quarkus/CDI app** — a correct, idiomatic pattern there.
- **ARCH-SPRING-012** (scheduled methods should have supported return types): fixed the reactive-type predicate, which had both a false negative and false positives. Spring's `ScheduledAnnotationReactiveSupport` only recognizes RxJava **3**'s `io.reactivex.rxjava3.*` namespace, never the older `io.reactivex.*` (RxJava 2) one the rule previously matched — a false positive, since RxJava 2 `@Scheduled` return values are silently discarded by Spring exactly like any other synchronous type. It was also **missing** `java.util.concurrent.Flow.Publisher` and SmallRye Mutiny's `Uni`/`Multi`, both genuinely deferred/reactive return types Spring recognizes via `ReactiveAdapterRegistry` — a false negative.

## Verified as correct (no bug, but added missing coverage)

Went deeper on the two rules most likely to hide a dual-framework gap and confirmed both are genuine, verified true positives on Quarkus/CDI too, with primary-source citations now in the docs:

- **ARCH-SPRING-004** (self-invocation bypasses the proxy): CDI self-invocation bypasses the client proxy identically to Spring's CGLIB self-invocation (Jakarta CDI spec, client proxy invocation semantics) — the existing `TRANSACTIONAL_ANNOTATED` predicate already matches both Spring's and `jakarta.transaction.Transactional`.
- **ARCH-SPRING-018** (proxy annotation on a lifecycle callback): fetched the official `jakarta.transaction.Transactional` Javadoc directly — "The Transactional interceptor interposes on business method invocations only and not on lifecycle events. Lifecycle methods are invoked in an unspecified transaction context." Definitive confirmation this is a correct dual-framework true positive.

## New test coverage

Added `ArchitectureCdiNeutralityTests`, a new suite that scans an idiomatic pure-CDI fixture app (no Spring classes, only `jakarta.inject`/`jakarta.transaction`/`jakarta.annotation` annotations) and asserts **every `ARCH-SPRING-*` rule is inert** (`PASSED` or `SKIPPED`, never a false positive or `ERROR`) — the single most important correctness property for a panel that runs the same ruleset unmodified on both Spring Boot and Quarkus applications, per the task brief. Also added focused fixtures/tests for the field-injection split, the final-method check, the CDI-permissive visibility bar, the fixed reactive-type predicate, and the self-invocation/lifecycle true positives.

## Docs

- `docs/ARCHITECTURE-CHECKS.md`: new ARCH-CODE-016 entry, rewritten ARCH-SPRING-001/010/012 entries, "Quarkus/CDI note" bullets on ARCH-SPRING-004/010/018 citing the CDI spec and Jakarta Transactions Javadoc.
- `docs/FEATURES.md`: Architecture section updated for the field-injection split and the dual-framework self-invocation/proxy-visibility rules.
- `docs/QUARKUS-SUPPORT.md`: fixed two stale "CDI/JAX-RS variants" claims that predated the dual-framework rule work (rules run **unmodified**, not variant-adjusted).
- Corrected a stale rule count and a stale ARCH-SPRING-001 description string in the sample app's docs-screenshot mock data (`capture-docs-screenshots.mjs`).

## Verification

- 71 architecture tests pass: 57 `ArchitectureRulesTests` + 4 `ArchitectureCdiNeutralityTests` + 2 `ArchitectureRuleRegistryTests` + 8 `ArchitectureScannerTests`.
- `EngineBoundaryArchitectureTests` + `SpiBoundaryArchitectureTests` pass — `bootui-engine` confirmed framework-free (no Spring/Quarkus/Jakarta leaks).
- Full `bootui-engine`/`bootui-spring-autoconfigure`/`bootui-spring-boot-starter`/`bootui-spring-sample-app` reactor test: BUILD SUCCESS, 55 tests.
- Quarkus extension + deployment + integration-tests reactor (incl. `BootUiQuarkusArchitectureResourceTest`, `BootUiQuarkusApiConformanceTest`): BUILD SUCCESS, 125 tests.
- Quarkus sample app compiles cleanly.
- `spotless:apply` / `spotless:check`: clean across the whole reactor.
- e2e `npm run format` / `format:check` on the touched `.mjs` file: clean.

No other advisors' files were touched; rule IDs are stable (no renames).