### PR TITLE
Correlate security events into Quarkus Live Activity

### DIFF
--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ActivityEntryDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ActivityEntryDto.java
@@ -24,9 +24,10 @@ package io.github.jdubois.bootui.core.dto;
  * @param profileable whether a per-request profile can be requested for this entry
  * @param parentId id of the {@code REQUEST} entry this entry is correlated to (so the UI can nest it
  *     under that request), or {@code null} when the entry has no precise request correlation
- * @param securedPrincipal for a {@code REQUEST} entry that had a correlated Spring Security audit
- *     event naming a principal, the principal it ran as; {@code null} when the request was not
- *     secured (no correlated audit event, or none with a known principal) or for non-request entries
+ * @param securedPrincipal for a {@code REQUEST} entry that ran as an authenticated principal — either
+ *     from the request's own security context, or via a correlated audit/security event naming one —
+ *     the principal it ran as; {@code null} when the request was not secured (no correlated event, or
+ *     none with a known principal) or for non-request entries
  */
 public record ActivityEntryDto(
         String id,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityLogEventDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityLogEventDto.java
@@ -3,6 +3,11 @@ package io.github.jdubois.bootui.core.dto;
 import java.util.List;
 
 /**
- * One Spring Boot audit event formatted for the Security Logs panel.
+ * One security/audit event formatted for the Security Logs panel.
+ *
+ * @param traceId the distributed-trace id active when the event was captured, or {@code null} when
+ *     unknown (Spring's audit repository carries no trace id) or no trace context was active. Used by
+ *     the Quarkus adapter's Live Activity panel to correlate this event to the request that produced it.
  */
-public record SecurityLogEventDto(String timestamp, String principal, String type, List<SecurityLogDataDto> data) {}
+public record SecurityLogEventDto(
+        String timestamp, String principal, String type, List<SecurityLogDataDto> data, String traceId) {}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/security/CapturedSecurityEvent.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/security/CapturedSecurityEvent.java
@@ -12,8 +12,15 @@ import java.util.Map;
  * {@link SecurityLogsService}; the engine owns type summary, masking, bounding, cap and paging so the
  * wire is identical across frameworks. The {@code data} map is raw key/values — the service sorts,
  * bounds, masks and truncates it.
+ *
+ * <p>{@code traceId} correlates this event to the request that produced it for the Live Activity panel
+ * (see {@code LiveActivityAssembler}), the same trace-id mechanism already used for SQL trace and
+ * exceptions. Spring has no source for it here (its Live Activity correlation is thread-based, not
+ * trace-id-based, and lives entirely in its own {@code LiveActivityService}), so its call site always
+ * passes {@code null}; only the Quarkus adapter stamps a real value.
  */
-public record CapturedSecurityEvent(Instant timestamp, String principal, String type, Map<String, Object> data) {
+public record CapturedSecurityEvent(
+        Instant timestamp, String principal, String type, Map<String, Object> data, String traceId) {
 
     public CapturedSecurityEvent {
         data = data == null ? Map.of() : new LinkedHashMap<>(data);

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/security/SecurityLogsService.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/security/SecurityLogsService.java
@@ -104,7 +104,8 @@ public final class SecurityLogsService {
                 displayText("principal", event.principal(), maskSecrets, exposure)
                         .value(),
                 event.type(),
-                dataEntries(event.data(), maskSecrets, exposure));
+                dataEntries(event.data(), maskSecrets, exposure),
+                event.traceId());
     }
 
     private List<SecurityLogDataDto> dataEntries(

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/LiveActivityAssembler.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/LiveActivityAssembler.java
@@ -6,23 +6,27 @@ import io.github.jdubois.bootui.core.dto.ExceptionGroupDto;
 import io.github.jdubois.bootui.core.dto.HttpExchangeDto;
 import io.github.jdubois.bootui.core.dto.HttpExchangesReport;
 import io.github.jdubois.bootui.core.dto.LiveActivityReport;
+import io.github.jdubois.bootui.core.dto.SecurityLogEventDto;
 import io.github.jdubois.bootui.core.dto.SqlTraceEntryDto;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
 /**
  * Framework-neutral assembly of the Live Activity merged stream + KPI summary from already-masked source
  * reports. The Spring adapter has its own richer, controller-fed service (with per-request signal
- * correlation and thread attribution); the Quarkus adapter feeds this assembler the three signal sources it
- * captures — HTTP requests, SQL trace, and exceptions — which are merged into one reverse-chronological feed
- * with JVM heap and per-type KPIs.
+ * correlation and thread attribution); the Quarkus adapter feeds this assembler the four signal sources it
+ * captures — HTTP requests, SQL trace, exceptions, and security/audit events — which are merged into one
+ * reverse-chronological feed with JVM heap and per-type KPIs.
  *
  * <p>Inputs are already masked and self-filtered by their owning engine services before they reach this
  * shape, so the assembler only normalizes, severities, merges, correlates and caps.</p>
@@ -31,13 +35,15 @@ import java.util.Set;
  * lets it attribute signals by serving thread, but on the Vert.x event loop a thread does not map to a
  * single request, so that strategy is unportable. Instead, when the adapter stamps a distributed-trace id on
  * each signal (the Quarkus adapter reads {@code Span.current()} when OpenTelemetry is present, whose context
- * propagates across the event-loop→worker hops), this assembler nests each SQL/exception entry under the
- * REQUEST entry sharing the same trace id by setting its {@code parentId}. A child is only nested when
- * <em>exactly one</em> request carries that trace id (a uniqueness guard against a reused inbound
+ * propagates across the event-loop→worker hops), this assembler nests each SQL/exception/security entry
+ * under the REQUEST entry sharing the same trace id by setting its {@code parentId}. A child is only nested
+ * when <em>exactly one</em> request carries that trace id (a uniqueness guard against a reused inbound
  * {@code traceparent}). When no trace id is stamped — OpenTelemetry absent — every {@code correlationId} is
- * {@code null}, no {@code parentId} is set, and the feed renders flat (the honest status quo). {@code
- * profileable} stays {@code false} regardless: the per-request profile drill-down is a Spring-only endpoint,
- * and nesting needs only {@code parentId}.</p>
+ * {@code null}, no {@code parentId} is set, and the feed renders flat (the honest status quo). A correlated
+ * security event also stamps {@code securedPrincipal} on its parent REQUEST entry (falling back from the
+ * request's own principal, when Quarkus's security layer directly authenticated it) — see {@link #report}.
+ * {@code profileable} stays {@code false} regardless: the per-request profile drill-down is a Spring-only
+ * endpoint, and nesting needs only {@code parentId}.</p>
  */
 public final class LiveActivityAssembler {
 
@@ -49,6 +55,7 @@ public final class LiveActivityAssembler {
     private static final String TYPE_REQUEST = "REQUEST";
     private static final String TYPE_SQL = "SQL";
     private static final String TYPE_EXCEPTION = "EXCEPTION";
+    private static final String TYPE_SECURITY = "SECURITY";
 
     private static final String SEVERITY_OK = "OK";
     private static final String SEVERITY_SLOW = "SLOW";
@@ -65,6 +72,10 @@ public final class LiveActivityAssembler {
      * @param sqlUnavailableWarning adapter-supplied explanation surfaced when {@code !sqlAvailable} (e.g. no
      *     datasource configured vs tracing intentionally disabled), or {@code null}/blank to surface none
      * @param exceptionGroups captured exception groups (newest-first), or {@code null}
+     * @param securityEvents already-masked security/audit events (newest-first), or {@code null}; ignored
+     *     unless {@code securityAvailable}
+     * @param securityAvailable whether the security-event source is present and feeding (Quarkus's security
+     *     capability is present and {@code quarkus.security.events.enabled=true})
      * @param healthStatus current health status, or {@code null}
      * @param limit maximum merged entries to return, or {@code 0}/negative for no cap
      */
@@ -74,12 +85,15 @@ public final class LiveActivityAssembler {
             boolean sqlAvailable,
             String sqlUnavailableWarning,
             List<ExceptionGroupDto> exceptionGroups,
+            List<SecurityLogEventDto> securityEvents,
+            boolean securityAvailable,
             String healthStatus,
             int limit) {
 
         List<HttpExchangeDto> exchanges = requests == null ? List.of() : requests.exchanges();
         List<SqlTraceEntryDto> sql = !sqlAvailable || sqlEntries == null ? List.of() : sqlEntries;
         List<ExceptionGroupDto> exceptions = exceptionGroups == null ? List.of() : exceptionGroups;
+        List<SecurityLogEventDto> security = !securityAvailable || securityEvents == null ? List.of() : securityEvents;
 
         List<ActivityEntryDto> entries = new ArrayList<>();
 
@@ -92,6 +106,27 @@ public final class LiveActivityAssembler {
         // than one request so an ambiguous (reused) trace never nests a child under the wrong request.
         Map<String, String> requestIdByTrace = new HashMap<>();
         Set<String> ambiguousTraces = new HashSet<>();
+        for (HttpExchangeDto e : exchanges) {
+            String trace = blankToNull(e.traceId());
+            if (trace != null && requestIdByTrace.putIfAbsent(trace, e.id()) != null) {
+                ambiguousTraces.add(trace);
+            }
+        }
+
+        // Correlate security events to their owning request BEFORE building REQUEST entries (an immutable
+        // record can't be patched after construction), so a uniquely-matched event's principal can be
+        // stamped onto the request as `securedPrincipal`. Newest-first iteration + putIfAbsent means the
+        // most recent correlated event's principal wins when more than one shares a request's trace id; a
+        // blank/anonymous principal is never recorded so it can't paint a misleading "secured" badge on an
+        // unauthenticated request.
+        Map<String, String> securedPrincipalByRequestId = new HashMap<>();
+        for (SecurityLogEventDto event : security) {
+            String requestId = parentFor(event.traceId(), requestIdByTrace, ambiguousTraces);
+            String principal = blankToNull(event.principal());
+            if (requestId != null && principal != null) {
+                securedPrincipalByRequestId.putIfAbsent(requestId, principal);
+            }
+        }
 
         for (HttpExchangeDto e : exchanges) {
             long ts = e.timestamp() == null ? 0L : e.timestamp().toEpochMilli();
@@ -105,10 +140,10 @@ public final class LiveActivityAssembler {
                     slowestPath = e.path();
                 }
             }
-            String trace = blankToNull(e.traceId());
-            if (trace != null && requestIdByTrace.putIfAbsent(trace, e.id()) != null) {
-                ambiguousTraces.add(trace);
-            }
+            // The request's own principal (Quarkus's security layer authenticated it directly, e.g. via
+            // rc.user()) takes precedence as the more direct signal; fall back to a correlated security
+            // event's principal only when the request itself carried none.
+            String securedPrincipal = e.principal() != null ? e.principal() : securedPrincipalByRequestId.get(e.id());
             entries.add(new ActivityEntryDto(
                     e.id(),
                     TYPE_REQUEST,
@@ -124,7 +159,7 @@ public final class LiveActivityAssembler {
                     null,
                     false,
                     null,
-                    e.principal()));
+                    securedPrincipal));
         }
 
         Long slowestQuery = null;
@@ -137,6 +172,12 @@ public final class LiveActivityAssembler {
 
         for (ExceptionGroupDto g : exceptions) {
             entries.add(toExceptionEntry(g, parentFor(g.lastTraceId(), requestIdByTrace, ambiguousTraces)));
+        }
+
+        int securityIndex = 0;
+        for (SecurityLogEventDto event : security) {
+            entries.add(toSecurityEntry(
+                    event, securityIndex++, parentFor(event.traceId(), requestIdByTrace, ambiguousTraces)));
         }
 
         entries.sort((a, b) -> Long.compare(b.timestamp(), a.timestamp()));
@@ -154,6 +195,9 @@ public final class LiveActivityAssembler {
         sources.add("exceptions");
         if (sqlAvailable) {
             sources.add("sql");
+        }
+        if (securityAvailable) {
+            sources.add("security");
         }
 
         List<String> warnings = new ArrayList<>();
@@ -232,6 +276,35 @@ public final class LiveActivityAssembler {
     }
 
     /**
+     * Build a SECURITY entry for an already-masked audit/security event. Severity mirrors Spring's
+     * {@code LiveActivityService.toSecurityEntry} mapping: an event type naming a failure or a denial is a
+     * {@code WARN} (worth a glance), anything else (e.g. an authentication success) is {@code OK}.
+     */
+    private ActivityEntryDto toSecurityEntry(SecurityLogEventDto event, int index, String parentId) {
+        String type = event.type() == null ? "" : event.type();
+        String upperType = type.toUpperCase(Locale.ROOT);
+        String severity = upperType.contains("FAILURE") || upperType.contains("DENIED") ? SEVERITY_WARN : SEVERITY_OK;
+        String principal = blankToNull(event.principal());
+        String summary = (type + (principal == null ? "" : " · " + principal)).trim();
+        return new ActivityEntryDto(
+                "sec-" + index,
+                TYPE_SECURITY,
+                parseEpochMillis(event.timestamp()),
+                severity,
+                summary,
+                null,
+                null,
+                event.traceId(),
+                null,
+                null,
+                null,
+                null,
+                false,
+                parentId,
+                null);
+    }
+
+    /**
      * The id of the REQUEST entry a child signal (SQL/exception) should nest under, or {@code null} when
      * the child carries no trace id, no request shares it, or — the uniqueness guard — more than one
      * request carries it (an ambiguous, likely reused, inbound {@code traceparent}).
@@ -246,6 +319,18 @@ public final class LiveActivityAssembler {
 
     private static String blankToNull(String value) {
         return value == null || value.isBlank() ? null : value;
+    }
+
+    /** Parse an ISO-8601 instant to epoch millis, returning {@code 0} for null/blank/unparseable input. */
+    private static long parseEpochMillis(String timestamp) {
+        if (timestamp == null || timestamp.isBlank()) {
+            return 0L;
+        }
+        try {
+            return Instant.parse(timestamp).toEpochMilli();
+        } catch (DateTimeParseException ex) {
+            return 0L;
+        }
     }
 
     private String requestSeverity(int status, Long durationMs) {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/security/SecurityEventBufferTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/security/SecurityEventBufferTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 class SecurityEventBufferTest {
 
     private static CapturedSecurityEvent event() {
-        return new CapturedSecurityEvent(Instant.now(), "alice", "AUTHENTICATION_SUCCESS", Map.of());
+        return new CapturedSecurityEvent(Instant.now(), "alice", "AUTHENTICATION_SUCCESS", Map.of(), null);
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/security/SecurityLogsServiceTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/security/SecurityLogsServiceTests.java
@@ -15,7 +15,7 @@ class SecurityLogsServiceTests {
     private final SecurityLogsService service = new SecurityLogsService();
 
     private static CapturedSecurityEvent event(String principal, String type, String iso) {
-        return new CapturedSecurityEvent(Instant.parse(iso), principal, type, Map.of());
+        return new CapturedSecurityEvent(Instant.parse(iso), principal, type, Map.of(), null);
     }
 
     @Test
@@ -50,7 +50,8 @@ class SecurityLogsServiceTests {
                 Instant.parse("2026-06-03T08:00:00Z"),
                 "alice",
                 "LOGIN",
-                Map.of("password", "hunter2", "user", "alice"));
+                Map.of("password", "hunter2", "user", "alice"),
+                null);
 
         SecurityLogsReport report =
                 service.report(List.of(secret), 500, true, ValueExposure.MASKED, null, null, null, null, null);
@@ -60,6 +61,19 @@ class SecurityLogsServiceTests {
             assertThat(d.masked()).isTrue();
             assertThat(d.value()).isEqualTo("******");
         });
+    }
+
+    @Test
+    void passesTraceIdThroughToTheDto() {
+        CapturedSecurityEvent withTrace =
+                new CapturedSecurityEvent(Instant.parse("2026-06-03T08:00:00Z"), "alice", "LOGIN", Map.of(), "trace-1");
+        CapturedSecurityEvent withoutTrace =
+                new CapturedSecurityEvent(Instant.parse("2026-06-03T08:01:00Z"), "bob", "LOGIN", Map.of(), null);
+
+        SecurityLogsReport report = service.report(
+                List.of(withTrace, withoutTrace), 500, true, ValueExposure.MASKED, null, null, null, null, null);
+
+        assertThat(report.events()).extracting(SecurityLogEventDto::traceId).containsExactly(null, "trace-1");
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/LiveActivityAssemblerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/LiveActivityAssemblerTests.java
@@ -8,6 +8,7 @@ import io.github.jdubois.bootui.core.dto.HttpExchangeDto;
 import io.github.jdubois.bootui.core.dto.HttpExchangesReport;
 import io.github.jdubois.bootui.core.dto.LiveActivityReport;
 import io.github.jdubois.bootui.core.dto.PageMetadata;
+import io.github.jdubois.bootui.core.dto.SecurityLogEventDto;
 import io.github.jdubois.bootui.core.dto.SqlTraceEntryDto;
 import java.time.Instant;
 import java.util.List;
@@ -15,9 +16,11 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies the trace-id correlation the Quarkus adapter relies on: when the captured signals share a
- * distributed-trace id, the assembler nests the SQL/exception entries under the owning REQUEST entry by
- * setting their {@code parentId}; when no shared trace id is present (OpenTelemetry absent) the feed stays
- * flat; and an ambiguous trace id shared by more than one request never nests a child under the wrong one.
+ * distributed-trace id, the assembler nests the SQL/exception/security entries under the owning REQUEST
+ * entry by setting their {@code parentId} (a uniquely-matched security event additionally stamps
+ * {@code securedPrincipal} on that request); when no shared trace id is present (OpenTelemetry absent) the
+ * feed stays flat; and an ambiguous trace id shared by more than one request never nests a child under the
+ * wrong one nor stamps a principal.
  */
 class LiveActivityAssemblerTests {
 
@@ -29,7 +32,7 @@ class LiveActivityAssemblerTests {
         List<SqlTraceEntryDto> sql = List.of(sql(10, "select 1", "trace-a", 1_010L));
         List<ExceptionGroupDto> exceptions = List.of(exception("g-1", "trace-a", 1_020L));
 
-        LiveActivityReport report = assembler.report(requests, sql, true, null, exceptions, "UP", 0);
+        LiveActivityReport report = assembler.report(requests, sql, true, null, exceptions, List.of(), false, "UP", 0);
 
         ActivityEntryDto request = entry(report, "req-1");
         ActivityEntryDto sqlEntry = entry(report, "sql-10");
@@ -49,7 +52,7 @@ class LiveActivityAssemblerTests {
         List<SqlTraceEntryDto> sql = List.of(sql(10, "select 1", null, 1_010L));
         List<ExceptionGroupDto> exceptions = List.of(exception("g-1", null, 1_020L));
 
-        LiveActivityReport report = assembler.report(requests, sql, true, null, exceptions, "UP", 0);
+        LiveActivityReport report = assembler.report(requests, sql, true, null, exceptions, List.of(), false, "UP", 0);
 
         assertThat(entry(report, "sql-10").parentId()).isNull();
         assertThat(entry(report, "exc-g-1").parentId()).isNull();
@@ -61,7 +64,7 @@ class LiveActivityAssemblerTests {
         List<SqlTraceEntryDto> sql = List.of(sql(10, "select 1", "trace-orphan", 1_010L));
         List<ExceptionGroupDto> exceptions = List.of(exception("g-1", "trace-orphan", 1_020L));
 
-        LiveActivityReport report = assembler.report(requests, sql, true, null, exceptions, "UP", 0);
+        LiveActivityReport report = assembler.report(requests, sql, true, null, exceptions, List.of(), false, "UP", 0);
 
         assertThat(entry(report, "sql-10").parentId()).isNull();
         assertThat(entry(report, "exc-g-1").parentId()).isNull();
@@ -73,7 +76,8 @@ class LiveActivityAssemblerTests {
                 request("req-1", "/orders", "trace-a", 1_000L), request("req-2", "/orders", "trace-a", 2_000L));
         List<SqlTraceEntryDto> sql = List.of(sql(10, "select 1", "trace-a", 1_010L));
 
-        LiveActivityReport report = assembler.report(requests, sql, true, null, exceptions(), "UP", 0);
+        LiveActivityReport report =
+                assembler.report(requests, sql, true, null, exceptions(), List.of(), false, "UP", 0);
 
         assertThat(entry(report, "sql-10").parentId()).isNull();
     }
@@ -85,10 +89,89 @@ class LiveActivityAssemblerTests {
         List<SqlTraceEntryDto> sql =
                 List.of(sql(10, "select 1", "trace-a", 1_010L), sql(11, "select 2", "trace-b", 2_010L));
 
-        LiveActivityReport report = assembler.report(requests, sql, true, null, exceptions(), "UP", 0);
+        LiveActivityReport report =
+                assembler.report(requests, sql, true, null, exceptions(), List.of(), false, "UP", 0);
 
         assertThat(entry(report, "sql-10").parentId()).isEqualTo("req-1");
         assertThat(entry(report, "sql-11").parentId()).isEqualTo("req-2");
+    }
+
+    @Test
+    void nestsSecurityEntryUnderRequestSharingTraceIdAndSetsSecuredPrincipal() {
+        HttpExchangesReport requests = requests(request("req-1", "/orders", "trace-a", 1_000L));
+        List<SecurityLogEventDto> security = List.of(security("alice", "AUTHENTICATION_SUCCESS", "trace-a", 1_010L));
+
+        LiveActivityReport report =
+                assembler.report(requests, List.of(), false, null, exceptions(), security, true, "UP", 0);
+
+        ActivityEntryDto securityEntry = entry(report, "sec-0");
+        assertThat(securityEntry.type()).isEqualTo("SECURITY");
+        assertThat(securityEntry.severity()).isEqualTo("OK");
+        assertThat(securityEntry.summary()).isEqualTo("AUTHENTICATION_SUCCESS · alice");
+        assertThat(securityEntry.correlationId()).isEqualTo("trace-a");
+        assertThat(securityEntry.parentId()).isEqualTo("req-1");
+        assertThat(entry(report, "req-1").securedPrincipal()).isEqualTo("alice");
+        assertThat(report.sources()).contains("security");
+    }
+
+    @Test
+    void mapsFailureSecurityEventTypeToWarnSeverity() {
+        HttpExchangesReport requests = requests(request("req-1", "/login", "trace-a", 1_000L));
+        List<SecurityLogEventDto> security = List.of(security("bob", "AUTHENTICATION_FAILURE", "trace-a", 1_010L));
+
+        LiveActivityReport report =
+                assembler.report(requests, List.of(), false, null, exceptions(), security, true, "UP", 0);
+
+        assertThat(entry(report, "sec-0").severity()).isEqualTo("WARN");
+    }
+
+    @Test
+    void doesNotNestAmbiguousSecurityEventAndDoesNotStampSecuredPrincipal() {
+        HttpExchangesReport requests =
+                requests(request("req-1", "/orders", "trace-a", 1_000L), request("req-2", "/items", "trace-a", 2_000L));
+        List<SecurityLogEventDto> security = List.of(security("alice", "AUTHENTICATION_SUCCESS", "trace-a", 1_010L));
+
+        LiveActivityReport report =
+                assembler.report(requests, List.of(), false, null, exceptions(), security, true, "UP", 0);
+
+        assertThat(entry(report, "sec-0").parentId()).isNull();
+        assertThat(entry(report, "req-1").securedPrincipal()).isNull();
+        assertThat(entry(report, "req-2").securedPrincipal()).isNull();
+    }
+
+    @Test
+    void leavesSecurityEntryFlatWhenNoTraceIdIsStamped() {
+        HttpExchangesReport requests = requests(request("req-1", "/orders", null, 1_000L));
+        List<SecurityLogEventDto> security = List.of(security("alice", "AUTHENTICATION_SUCCESS", null, 1_010L));
+
+        LiveActivityReport report =
+                assembler.report(requests, List.of(), false, null, exceptions(), security, true, "UP", 0);
+
+        ActivityEntryDto securityEntry = entry(report, "sec-0");
+        assertThat(securityEntry.parentId()).isNull();
+        assertThat(securityEntry.correlationId()).isNull();
+        assertThat(entry(report, "req-1").securedPrincipal()).isNull();
+    }
+
+    @Test
+    void prefersTheRequestsOwnPrincipalOverACorrelatedSecurityEvent() {
+        HttpExchangesReport requests = requests(request("req-1", "/orders", "trace-a", "bob", 1_000L));
+        List<SecurityLogEventDto> security = List.of(security("alice", "AUTHENTICATION_SUCCESS", "trace-a", 1_010L));
+
+        LiveActivityReport report =
+                assembler.report(requests, List.of(), false, null, exceptions(), security, true, "UP", 0);
+
+        assertThat(entry(report, "req-1").securedPrincipal()).isEqualTo("bob");
+    }
+
+    @Test
+    void omitsSecuritySourceWhenUnavailable() {
+        HttpExchangesReport requests = requests(request("req-1", "/orders", "trace-a", 1_000L));
+
+        LiveActivityReport report =
+                assembler.report(requests, List.of(), false, null, exceptions(), List.of(), false, "UP", 0);
+
+        assertThat(report.sources()).doesNotContain("security");
     }
 
     private static ActivityEntryDto entry(LiveActivityReport report, String id) {
@@ -105,6 +188,10 @@ class LiveActivityAssemblerTests {
     }
 
     private static HttpExchangeDto request(String id, String path, String traceId, long epochMillis) {
+        return request(id, path, traceId, null, epochMillis);
+    }
+
+    private static HttpExchangeDto request(String id, String path, String traceId, String principal, long epochMillis) {
         return new HttpExchangeDto(
                 id,
                 Instant.ofEpochMilli(epochMillis),
@@ -117,11 +204,16 @@ class LiveActivityAssemblerTests {
                 12L,
                 34L,
                 "127.0.0.1",
-                null,
+                principal,
                 null,
                 traceId,
                 List.of(),
                 List.of());
+    }
+
+    private static SecurityLogEventDto security(String principal, String type, String traceId, long epochMillis) {
+        return new SecurityLogEventDto(
+                Instant.ofEpochMilli(epochMillis).toString(), principal, type, List.of(), traceId);
     }
 
     private static SqlTraceEntryDto sql(long id, String sql, String traceId, long epochMillis) {

--- a/bootui-quarkus-integration-tests/security/pom.xml
+++ b/bootui-quarkus-integration-tests/security/pom.xml
@@ -19,7 +19,10 @@
         into the shared SecurityEventBuffer, assembled by the neutral SecurityLogsService and surfaced on
         GET /bootui/api/security-logs, with the panel reported available in the manifest. Kept separate from
         bootui-quarkus-integration-tests (which has NO security extension) so the security-absent unavailable path
-        and the security-present capture path are each proven in isolation.</description>
+        and the security-present capture path are each proven in isolation. Also adds quarkus-opentelemetry (like
+        the sibling otel module) so a real server-span trace id is available at capture time, proving the Live
+        Activity feed's security correlation: a captured security event nests under the REQUEST entry sharing its
+        trace id and stamps that request's securedPrincipal.</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -54,6 +57,16 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-elytron-security-properties-file</artifactId>
+        </dependency>
+
+        <!-- Adds the OpenTelemetry SDK + tracer, exactly like the sibling otel module. Its presence flips the
+             OPENTELEMETRY_TRACER capability gate on, so QuarkusSecurityEventCapture can stamp the active server
+             span's trace id on each captured security event, letting the Live Activity feed nest it under the
+             owning REQUEST entry. Not a test of OTLP export — the test resources set
+             quarkus.otel.traces.exporter=none, so no network is touched. -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
 
         <dependency>

--- a/bootui-quarkus-integration-tests/security/src/main/resources/application.properties
+++ b/bootui-quarkus-integration-tests/security/src/main/resources/application.properties
@@ -9,3 +9,10 @@ quarkus.security.users.embedded.roles.admin=admin
 
 # Fire CDI security events so QuarkusSecurityEventCapture feeds the Security Logs panel.
 quarkus.security.events.enabled=true
+
+# Keep the OpenTelemetry SDK active (so QuarkusOtelTraceIdProvider resolves a real trace id at capture
+# time) but export nowhere: this is an in-process correlation test, not an OTLP-export test, so no
+# collector/network is needed.
+quarkus.otel.traces.exporter=none
+# Sample every span so the request's trace id is always available for the Live Activity correlation test.
+quarkus.otel.traces.sampler=always_on

--- a/bootui-quarkus-integration-tests/security/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusLiveActivitySecurityCorrelationTest.java
+++ b/bootui-quarkus-integration-tests/security/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusLiveActivitySecurityCorrelationTest.java
@@ -1,0 +1,156 @@
+package io.github.jdubois.bootui.quarkus.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real-boot proof of both fixes this module adds on top of {@link BootUiQuarkusSecurityLogsCaptureTest}:
+ *
+ * <ul>
+ *   <li><strong>Part A</strong> ({@code QuarkusHttpExchangeCaptureFilter}): an authenticated call to
+ *       {@code /secure} must capture the real principal on the HTTP exchange instead of a hardcoded
+ *       {@code null}; an unauthenticated call must capture {@code null}.
+ *   <li><strong>Part B</strong> ({@code LiveActivityAssembler} + {@code QuarkusSecurityEventCapture}): with
+ *       real OpenTelemetry context propagation, the authentication event fired by {@code /secure} must
+ *       surface as a standalone {@code SECURITY} entry in the Live Activity feed, nested under the
+ *       {@code REQUEST} entry that shares its trace id, which must in turn carry the correlated
+ *       {@code securedPrincipal}.
+ * </ul>
+ *
+ * <p>The pure nesting/ambiguity algorithm is already pinned by the engine's
+ * {@code LiveActivityAssemblerTests}; this test is the end-to-end proof that the trace id actually
+ * survives capture on a real Quarkus request and that the two adapters (capture filter + CDI event
+ * observer) agree on it.
+ */
+@QuarkusTest
+class BootUiQuarkusLiveActivitySecurityCorrelationTest {
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    private BootUiHttpProbe probe() {
+        return new BootUiHttpProbe(baseUrl.toExternalForm());
+    }
+
+    private static String basicAuth(String user, String password) {
+        return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void authenticatedRequestCapturesPrincipalAndCorrelatesSecurityEntry() {
+        Response secure = probe().get("/secure", Map.of("Authorization", basicAuth("admin", "admin")));
+        assertThat(secure.status()).as("/secure with valid credentials").isEqualTo(200);
+
+        // Part A: the captured HTTP exchange itself must carry the resolved principal.
+        Response exchanges = probe().get("/bootui/api/http-exchanges");
+        assertThat(exchanges.status())
+                .as("GET /bootui/api/http-exchanges status")
+                .isEqualTo(200);
+        JsonNode secureExchange = firstByPath(exchanges.json().path("exchanges"), "/secure");
+        assertThat(secureExchange).as("captured /secure exchange").isNotNull();
+        assertThat(secureExchange.path("principal").asText(null))
+                .as("Part A: an authenticated request's captured exchange must carry the real principal")
+                .isEqualTo("admin");
+
+        // Part B: the Live Activity feed must produce a standalone SECURITY entry, nested by trace id
+        // under the REQUEST entry, which must also carry the correlated securedPrincipal.
+        Response activity = probe().get("/bootui/api/activity");
+        assertThat(activity.status()).as("GET /bootui/api/activity status").isEqualTo(200);
+        JsonNode entries = activity.json().path("entries");
+
+        JsonNode request = firstByTypeAndPath(entries, "REQUEST", "/secure");
+        assertThat(request)
+                .as("the /secure call must surface as a REQUEST entry")
+                .isNotNull();
+        String requestId = request.path("id").asText(null);
+        String requestTrace = request.path("correlationId").asText(null);
+        assertThat(requestTrace)
+                .as("with OpenTelemetry present the request entry must carry the server span's trace id")
+                .isNotBlank();
+        assertThat(request.path("securedPrincipal").asText(null))
+                .as("the REQUEST entry must carry the authenticated principal")
+                .isEqualTo("admin");
+
+        JsonNode security = firstOfType(entries, "SECURITY");
+        assertThat(security)
+                .as("an authentication event must surface as a SECURITY entry")
+                .isNotNull();
+        assertThat(security.path("summary").asText())
+                .as("the security entry summary should name the authentication event")
+                .startsWith("Authentication");
+        assertThat(security.path("correlationId").asText(null))
+                .as("the SECURITY entry must carry the same trace id as its request")
+                .isEqualTo(requestTrace);
+        assertThat(security.path("parentId").asText(null))
+                .as("the SECURITY entry must nest under its owning request")
+                .isEqualTo(requestId);
+
+        boolean securitySourceListed = false;
+        for (JsonNode source : activity.json().path("sources")) {
+            securitySourceListed = securitySourceListed || "security".equals(source.asText());
+        }
+        assertThat(securitySourceListed)
+                .as("$.sources must include \"security\" once the source is wired and available")
+                .isTrue();
+    }
+
+    @Test
+    void unauthenticatedRequestCapturesNoPrincipal() {
+        Response unauthorized = probe().get("/secure");
+        assertThat(unauthorized.status()).as("/secure without credentials").isEqualTo(401);
+
+        Response exchanges = probe().get("/bootui/api/http-exchanges");
+        assertThat(exchanges.status())
+                .as("GET /bootui/api/http-exchanges status")
+                .isEqualTo(200);
+        JsonNode secureExchange = firstByPath(exchanges.json().path("exchanges"), "/secure");
+        assertThat(secureExchange).as("captured /secure exchange").isNotNull();
+        assertThat(secureExchange.path("principal").isNull())
+                .as("Part A: an unauthenticated request's captured exchange must carry a null principal")
+                .isTrue();
+    }
+
+    /**
+     * Returns the first (newest, per {@code HttpExchangeBuffer}'s newest-first ordering) exchange whose
+     * path matches, so each test observes only the call it just made even though the buffer is shared
+     * across test methods in this class.
+     */
+    private static JsonNode firstByPath(JsonNode exchanges, String path) {
+        for (JsonNode exchange : exchanges) {
+            if (path.equals(exchange.path("path").asText())) {
+                return exchange;
+            }
+        }
+        return null;
+    }
+
+    /** Same newest-first-wins lookup as {@link #firstByPath}, scoped to a specific entry type + path. */
+    private static JsonNode firstByTypeAndPath(JsonNode entries, String type, String path) {
+        for (JsonNode entry : entries) {
+            if (type.equals(entry.path("type").asText())
+                    && path.equals(entry.path("path").asText())) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private static JsonNode firstOfType(JsonNode entries, String type) {
+        for (JsonNode entry : entries) {
+            if (type.equals(entry.path("type").asText())) {
+                return entry;
+            }
+        }
+        return null;
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/LiveActivityResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/LiveActivityResource.java
@@ -3,14 +3,19 @@ package io.github.jdubois.bootui.quarkus.web;
 import io.github.jdubois.bootui.core.ValueExposure;
 import io.github.jdubois.bootui.core.dto.HttpExchangesReport;
 import io.github.jdubois.bootui.core.dto.LiveActivityReport;
+import io.github.jdubois.bootui.core.dto.SecurityLogEventDto;
 import io.github.jdubois.bootui.core.dto.SqlTraceEntryDto;
 import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
 import io.github.jdubois.bootui.engine.exceptions.ExceptionsService;
+import io.github.jdubois.bootui.engine.panel.BootUiPanels;
+import io.github.jdubois.bootui.engine.security.SecurityEventBuffer;
+import io.github.jdubois.bootui.engine.security.SecurityLogsService;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
 import io.github.jdubois.bootui.engine.web.HttpExchangeBuffer;
 import io.github.jdubois.bootui.engine.web.HttpExchangesService;
 import io.github.jdubois.bootui.engine.web.LiveActivityAssembler;
 import io.github.jdubois.bootui.quarkus.QuarkusExposurePolicy;
+import io.github.jdubois.bootui.quarkus.QuarkusPanelAvailability;
 import io.smallrye.mutiny.Multi;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -27,17 +32,21 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * JAX-RS resource for the Live Activity panel ({@code GET /bootui/api/activity}). The Quarkus analogue of
- * the Spring adapter's {@code LiveActivityController}: it merges the three signals captured on this platform
+ * the Spring adapter's {@code LiveActivityController}: it merges the four signals captured on this platform
  * — HTTP exchanges (via the shared {@link HttpExchangeBuffer}), SQL trace (via the shared
- * {@link SqlTraceRecorder}) and exceptions (via the shared {@link ExceptionStore}) — plus JVM heap into the
- * neutral {@link LiveActivityReport}. SQL trace contributes only when a datasource is configured (the
- * recorder is gated on Agroal); when it is absent the assembler surfaces a warning and SQL entries are
- * omitted. Signal-to-request correlation is data-driven on the OpenTelemetry trace id when present: each
- * captured signal is stamped with the active span's trace id (see {@code QuarkusOtelTraceIdProvider}), and
- * the engine {@link LiveActivityAssembler} nests SQL/exception entries under the request sharing that trace
- * id. The per-request <em>profile</em> drill-down (flipping {@code profileable}) remains Spring-only.
- * Read-only, plus the
- * SSE change-notification stream {@code /stream} that ticks whenever a new HTTP exchange is captured so the
+ * {@link SqlTraceRecorder}), exceptions (via the shared {@link ExceptionStore}), and security/audit events
+ * (via the shared {@link SecurityEventBuffer}) — plus JVM heap into the neutral {@link LiveActivityReport}.
+ * SQL trace contributes only when a datasource is configured (the recorder is gated on Agroal); security
+ * events contribute only when Quarkus's security capability is present and
+ * {@code quarkus.security.events.enabled=true} (the same gate {@code SecurityLogsResource} uses, reused here
+ * via {@link QuarkusPanelAvailability}); when either is absent the assembler surfaces a warning (SQL) or
+ * simply omits the source (security) and its entries are omitted. Signal-to-request correlation is
+ * data-driven on the OpenTelemetry trace id when present: each captured signal is stamped with the active
+ * span's trace id (see {@code QuarkusOtelTraceIdProvider}), and the engine {@link LiveActivityAssembler}
+ * nests SQL/exception/security entries under the request sharing that trace id, also stamping a uniquely
+ * correlated security event's principal onto its parent request as {@code securedPrincipal}. The per-request
+ * <em>profile</em> drill-down (flipping {@code profileable}) remains Spring-only. Read-only, plus the SSE
+ * change-notification stream {@code /stream} that ticks whenever a new HTTP exchange is captured so the
  * shared Vue panel's auto-refresh toggle works identically to Spring.
  */
 @Path("/bootui/api/activity")
@@ -51,8 +60,11 @@ public class LiveActivityResource {
     private final Instance<SqlTraceRecorder> sqlRecorder;
     private final ExceptionStore exceptionStore;
     private final ExceptionsService exceptionsService;
+    private final SecurityEventBuffer securityBuffer;
+    private final QuarkusPanelAvailability panelAvailability;
     private final HttpExchangesService exchanges = new HttpExchangesService();
     private final LiveActivityAssembler assembler = new LiveActivityAssembler();
+    private final SecurityLogsService securityLogs = new SecurityLogsService();
     private final AtomicInteger openStreams = new AtomicInteger();
 
     @Inject
@@ -61,12 +73,16 @@ public class LiveActivityResource {
             QuarkusExposurePolicy exposure,
             Instance<SqlTraceRecorder> sqlRecorder,
             ExceptionStore exceptionStore,
-            ExceptionsService exceptionsService) {
+            ExceptionsService exceptionsService,
+            SecurityEventBuffer securityBuffer,
+            QuarkusPanelAvailability panelAvailability) {
         this.buffer = buffer;
         this.exposure = exposure;
         this.sqlRecorder = sqlRecorder;
         this.exceptionStore = exceptionStore;
         this.exceptionsService = exceptionsService;
+        this.securityBuffer = securityBuffer;
+        this.panelAvailability = panelAvailability;
     }
 
     @GET
@@ -99,12 +115,32 @@ public class LiveActivityResource {
                     : "SQL trace is unavailable until a JDBC datasource is configured.";
         }
 
+        boolean securityAvailable = panelAvailability.isPanelAvailable(BootUiPanels.SECURITY_LOGS);
+        List<SecurityLogEventDto> securityEvents = List.of();
+        if (securityAvailable) {
+            int maxLogs = securityLogs.maxLogs(Integer.MAX_VALUE);
+            securityEvents = securityLogs
+                    .report(
+                            securityBuffer.snapshot(),
+                            maxLogs,
+                            exposure.maskSecrets(),
+                            exposure.valueExposure(),
+                            null,
+                            null,
+                            null,
+                            null,
+                            null)
+                    .events();
+        }
+
         return assembler.report(
                 requests,
                 sqlEntries,
                 sqlAvailable,
                 sqlUnavailableWarning,
                 exceptionsService.report(exceptionStore).groups(),
+                securityEvents,
+                securityAvailable,
                 null,
                 limit == null ? 0 : limit);
     }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusHttpExchangeCaptureFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusHttpExchangeCaptureFilter.java
@@ -3,9 +3,12 @@ package io.github.jdubois.bootui.quarkus.web;
 import io.github.jdubois.bootui.engine.web.CapturedHttpExchange;
 import io.github.jdubois.bootui.engine.web.HttpExchangeBuffer;
 import io.github.jdubois.bootui.spi.TraceIdProvider;
+import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.filters.Filters;
+import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.auth.User;
 import io.vertx.ext.web.RoutingContext;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
@@ -13,6 +16,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.Principal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -36,6 +40,14 @@ import java.util.Map;
  * on the captured exchange so the Live Activity timeline can nest this request's SQL and exceptions under it.
  * The provider is optional: when OpenTelemetry is absent the {@code Instance} is unresolvable and the trace
  * id stays {@code null}, leaving the feed flat.</p>
+ *
+ * <p>The authenticated principal is resolved <em>at {@code bodyEndHandler} time</em> instead — after
+ * routing/business logic has run, so Quarkus's auth mechanism (a core {@code quarkus-vertx-http} concern,
+ * independent of whether the {@code quarkus-security} extension is added) has had a chance to authenticate.
+ * {@link SecurityIdentity} and {@link QuarkusHttpUser} ship as non-optional transitive dependencies of
+ * {@code quarkus-vertx-http}, so this needs no capability gate, unlike the CDI security-event capture in
+ * {@code QuarkusSecurityEventCapture}. An unauthenticated or anonymous request stamps {@code null}, matching
+ * the Spring adapter's {@code HttpExchange.getPrincipal()} contract.</p>
  */
 @ApplicationScoped
 public class QuarkusHttpExchangeCaptureFilter {
@@ -79,7 +91,7 @@ public class QuarkusHttpExchangeCaptureFilter {
                     response.getStatusCode(),
                     durationMs,
                     remoteAddr(rc),
-                    null,
+                    principal(rc),
                     null,
                     requestHeaders,
                     headers(response.headers()),
@@ -98,6 +110,30 @@ public class QuarkusHttpExchangeCaptureFilter {
         }
         try {
             return traceIdProvider.currentTraceId();
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * The authenticated principal's name, or {@code null} when the request is unauthenticated, the resolved
+     * identity is anonymous, or no {@link QuarkusHttpUser} is set on the routing context. Mirrors Spring's
+     * {@code HttpExchange.getPrincipal()} contract (null, not the literal string {@code "anonymous"}), so the
+     * two adapters render this field identically. Fully guarded so capture never disrupts request handling,
+     * mirroring {@link #currentTraceId()}.
+     */
+    private static String principal(RoutingContext rc) {
+        try {
+            User user = rc.user();
+            if (!(user instanceof QuarkusHttpUser quarkusUser)) {
+                return null;
+            }
+            SecurityIdentity identity = quarkusUser.getSecurityIdentity();
+            if (identity == null || identity.isAnonymous()) {
+                return null;
+            }
+            Principal identityPrincipal = identity.getPrincipal();
+            return identityPrincipal == null ? null : identityPrincipal.getName();
         } catch (RuntimeException ex) {
             return null;
         }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusSecurityEventCapture.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusSecurityEventCapture.java
@@ -2,11 +2,13 @@ package io.github.jdubois.bootui.quarkus.web;
 
 import io.github.jdubois.bootui.engine.security.CapturedSecurityEvent;
 import io.github.jdubois.bootui.engine.security.SecurityEventBuffer;
+import io.github.jdubois.bootui.spi.TraceIdProvider;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.spi.runtime.AuthorizationSuccessEvent;
 import io.quarkus.security.spi.runtime.SecurityEvent;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -24,15 +26,25 @@ import java.util.Map;
  * credential-shaped at the edge. Bounding, masking and DTO assembly happen later on the read path in the
  * engine {@code SecurityLogsService}. {@code AuthorizationSuccessEvent} is dropped — it fires per check and
  * would evict the failures worth reviewing.</p>
+ *
+ * <p>When an OpenTelemetry {@link TraceIdProvider} is present (capability-gated), the active span's trace
+ * id is resolved here too and stamped on the captured event so the Live Activity panel can nest it under
+ * the request that produced it — the same correlation mechanism already used for SQL trace and exceptions.
+ * {@code Span.current()} still resolves correctly on this observer's request thread because its context
+ * propagates via the request's own context storage, not thread identity. The provider is optional: when
+ * OpenTelemetry is absent the {@code Instance} is unresolvable and the trace id stays {@code null}, leaving
+ * the event uncorrelated (flat) in the feed.</p>
  */
 @ApplicationScoped
 public class QuarkusSecurityEventCapture {
 
     private final SecurityEventBuffer buffer;
+    private final TraceIdProvider traceIdProvider;
 
     @Inject
-    public QuarkusSecurityEventCapture(SecurityEventBuffer buffer) {
+    public QuarkusSecurityEventCapture(SecurityEventBuffer buffer, Instance<TraceIdProvider> traceIdProvider) {
         this.buffer = buffer;
+        this.traceIdProvider = traceIdProvider.isResolvable() ? traceIdProvider.get() : null;
     }
 
     void onSecurityEvent(@Observes SecurityEvent event) {
@@ -43,7 +55,24 @@ public class QuarkusSecurityEventCapture {
                 Instant.now(),
                 principal(event.getSecurityIdentity()),
                 event.getClass().getSimpleName(),
-                data(event)));
+                data(event),
+                currentTraceId()));
+    }
+
+    /**
+     * The active span's trace id, or {@code null} when OpenTelemetry is absent (no provider) or no span is in
+     * context. Fully guarded so capture never disrupts the security check it observes, mirroring
+     * {@code QuarkusHttpExchangeCaptureFilter#currentTraceId()}.
+     */
+    private String currentTraceId() {
+        if (traceIdProvider == null) {
+            return null;
+        }
+        try {
+            return traceIdProvider.currentTraceId();
+        } catch (RuntimeException ex) {
+            return null;
+        }
     }
 
     private static String principal(SecurityIdentity identity) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityLogsController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityLogsController.java
@@ -89,7 +89,10 @@ public class SecurityLogsController implements ApplicationListener<AuditApplicat
     }
 
     private static CapturedSecurityEvent toCaptured(AuditEvent event) {
-        return new CapturedSecurityEvent(event.getTimestamp(), event.getPrincipal(), event.getType(), event.getData());
+        // Spring's Live Activity correlation is thread-based (see LiveActivityService), not trace-id-based,
+        // so there is no trace id to stamp here; only the Quarkus adapter populates it.
+        return new CapturedSecurityEvent(
+                event.getTimestamp(), event.getPrincipal(), event.getType(), event.getData(), null);
     }
 
     /**

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityCorrelatorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityCorrelatorTests.java
@@ -454,7 +454,7 @@ class LiveActivityCorrelatorTests {
     }
 
     private static SecurityLogEventDto securityEvent(String type, String principal, long epochMillis) {
-        return new SecurityLogEventDto(Instant.ofEpochMilli(epochMillis).toString(), principal, type, List.of());
+        return new SecurityLogEventDto(Instant.ofEpochMilli(epochMillis).toString(), principal, type, List.of(), null);
     }
 
     private static SqlTraceController sqlController(SqlTraceEntryDto... entries) {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityServiceTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityServiceTests.java
@@ -443,7 +443,8 @@ class LiveActivityServiceTests {
     }
 
     private static SecurityLogEventDto securityEvent(String type, String principal, long timestampMillis) {
-        return new SecurityLogEventDto(Instant.ofEpochMilli(timestampMillis).toString(), principal, type, List.of());
+        return new SecurityLogEventDto(
+                Instant.ofEpochMilli(timestampMillis).toString(), principal, type, List.of(), null);
     }
 
     private static ExceptionGroupDto group(String id, String className, long lastSeen) {

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -117,16 +117,22 @@ defenses, value masking). The stream is capped by `bootui.activity.max-entries`,
 `bootui.activity.request-slow-threshold-ms`, and individual sources can be turned off through their existing
 `bootui.panels.*` toggles (a disabled source simply drops out of the stream).
 
-On Quarkus the panel merges the three signals captured on this platform: HTTP requests (from the same Vert.x-fed ring
-buffer as HTTP Exchanges), SQL trace, and exceptions, alongside JVM heap KPIs. SQL trace contributes only when a JDBC
-datasource is configured (the recorder is gated on Agroal); when none is present those entries drop out and the report
-carries a clear note. Signal-to-request correlation works by **trace id**: Spring's thread-per-request anchor is
-unportable on the Vert.x event loop (a thread does not map to a single request), so when `quarkus-opentelemetry` is
-present the adapter stamps the active server span's trace id at each capture point and the engine nests SQL and exception
-entries under the request sharing that trace id — the OpenTelemetry context propagates across the event-loop→worker hop,
-so the same trace id is available even for blocking JDBC on a worker thread. With OpenTelemetry absent, entries carry no
-trace id and the feed renders flat. The per-request **profiler** drawer (the Symfony-style drill-down) remains
-Spring-only.
+On Quarkus the panel merges all four signals: HTTP requests (from the same Vert.x-fed ring buffer as HTTP Exchanges),
+SQL trace, exceptions, and security events, alongside JVM heap KPIs. SQL trace contributes only when a JDBC datasource is
+configured (the recorder is gated on Agroal); when none is present those entries drop out and the report carries a clear
+note. Signal-to-request correlation works by **trace id**: Spring's thread-per-request anchor is unportable on the Vert.x
+event loop (a thread does not map to a single request), so when `quarkus-opentelemetry` is present the adapter stamps the
+active server span's trace id at each capture point — the HTTP filter, the SQL recorder, the exception store, and the CDI
+security-event observer — and the engine nests SQL, exception, and security entries under the request sharing that trace
+id; the OpenTelemetry context propagates across the event-loop→worker hop, so the same trace id is available even for
+blocking JDBC on a worker thread or a security event fired from a CDI observer. A request whose trace id uniquely matches
+a correlated security event is flagged **authenticated** exactly like Spring, naming the audit event's principal; Quarkus's
+own security layer authenticating the caller (surfaced directly on the captured HTTP exchange) takes precedence over a
+correlated audit event when both are known. With OpenTelemetry absent, entries carry no trace id and the feed renders
+flat. The per-request **profiler** drawer (the Symfony-style drill-down) remains Spring-only: it leans on thread-per-request
+serving-thread identity — which the Vert.x event-loop model has no equivalent for — to correlate SQL, exceptions, and
+security events even without distributed tracing configured, so it is not a simple trace-id port (see
+`docs/QUARKUS-SUPPORT.md` for the detailed reasoning).
 
 ![BootUI Live Activity panel](./images/bootui-activity.webp)
 

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -202,11 +202,30 @@ The DTO and UI are reused; the Quarkus adapter rebuilds the capture/source on th
 | `REST API` advisor    | **Implemented** — conventions (status codes, versioning, pagination) shared; the engine models JAX-RS `@Path` resources alongside Spring MVC, and irreducibly-Spring rules (ProblemDetail, ResponseEntity codes) SKIP honestly on JAX-RS |
 | `DB Connection Pools` | Read **Agroal** metrics instead of HikariCP MXBeans                                                                                            |
 | `SQL Trace`           | **Implemented** — two complementary feeders into the shared `SqlTraceRecorder`: an `@Alternative` Agroal `DataSource` wrap (manual JDBC, gated on Agroal) **and** a `@PersistenceUnitExtension` Hibernate `StatementInspector` (ORM SQL, which bypasses the wrapped DataSource; gated on Hibernate). Statement text/type/category/N+1 full-fidelity; per-statement duration/rows/params are best-effort for ORM SQL (the StatementInspector SPI has no execution-end hook). `clear`/`recording` behind the `LocalhostGuard` write floor |
-| `Live Activity`       | **Implemented** — merges the three captured signals (HTTP requests via the Vert.x ring buffer + SQL trace + exceptions) into the shared activity feed; SQL contributes only when a datasource is configured (a clean warning otherwise). **Signal-to-request correlation is trace-id-based, gated on `quarkus-opentelemetry`:** Spring's thread-per-request anchor is unportable on the Vert.x event loop, so instead the adapter stamps the active server span's trace id at each capture point (HTTP filter, SQL recorder, exception store) via a capability-gated `QuarkusOtelTraceIdProvider`, and the engine `LiveActivityAssembler` nests SQL/exception entries under the request sharing that trace id (OTel `Context` propagates across the event-loop→worker hop). With OpenTelemetry absent, trace ids stay null and the feed renders flat (status quo). The per-request **profile** drill-down (`profileable`) stays Spring-only. **Follow-up:** HTTP→security-event correlation is not yet implemented — Quarkus Live Activity has no security signal source today (no Quarkus equivalent of Spring's security audit feed into the activity stream), so there is nothing to correlate yet; once a security signal lands it can join the same trace-id grouping |
+| `Live Activity`       | **Implemented** — merges all four signals (HTTP requests via the Vert.x ring buffer + SQL trace + exceptions + security events) into the shared activity feed; SQL contributes only when a datasource is configured (a clean warning otherwise), and the security source is gated on the Security Logs panel's own availability. **Signal-to-request correlation is trace-id-based, gated on `quarkus-opentelemetry`:** Spring's thread-per-request anchor is unportable on the Vert.x event loop, so instead the adapter stamps the active server span's trace id at each capture point (HTTP filter, SQL recorder, exception store, and the CDI `SecurityEvent` observer) via a capability-gated `QuarkusOtelTraceIdProvider`, and the engine `LiveActivityAssembler` nests SQL/exception/security entries under the request sharing that trace id (OTel `Context` propagates across the event-loop→worker hop, including into the CDI security-event observer). A security event whose trace id uniquely matches one request also stamps that request's `securedPrincipal` (falling back only when the request's own captured principal — see `HTTP Exchanges` below — is null), so the "authenticated" badge lights up from either signal. An ambiguous trace id (shared by more than one in-flight request) is never nested and never stamps a principal, the same guard already used for SQL/exceptions. With OpenTelemetry absent, trace ids stay null and the feed renders flat (status quo). The per-request **profile** drill-down (`profileable`) stays Spring-only — see the note below the table for why. |
 | `HTTP Exchanges`      | **Implemented** — buffer exchanges via a Vert.x filter instead of Actuator's repository                                                       |
 | `Exceptions`          | **Implemented** — captured into the shared `ExceptionStore` by a `java.util.logging` handler (logged throwables) + a Vert.x failure handler (unhandled web failures), deduped across feeders across the whole cause chain; BootUI's own frames self-filtered |
 | `Security Logs`       | Source events from CDI security events instead of Actuator `AuditEventRepository`                                                              |
 | `Log Tail`            | Tail via a JBoss LogManager handler instead of a logback appender                                                                              |
+
+**Why `profileable` (the per-request profiler drill-down) stays `false` on Quarkus.** Spring's `/activity/request/{id}`
+profiler is a Symfony-style join across SQL, exceptions, security audit events, the distributed trace, and timing for one
+request (`LiveActivityCorrelator`) — it is not CPU/flame-graph sampling. Its richness comes from a tiered correlation
+strategy, and three of its four tiers key on **serving-thread identity**: a servlet request runs start-to-finish on one
+worker thread that serves only one request at a time, so SQL, exceptions, and security events observed on that thread
+within its time window belong to it exactly, even with no distributed tracing configured at all (`threadMatched` is a
+first-class field on `RequestProfileSecurityDto`/carried by `RequestProfileExceptionDto`'s `thread`). Quarkus's Vert.x
+event-loop-plus-worker-thread model has no equivalent "the one thread that served this request" identity — handling can
+hop across the event loop and one or more worker threads — so those three tiers have nothing to key on and cannot be
+ported as-is. Only the profiler's *strongest* tier (trace id, used to attach the distributed trace) is inherently
+portable, and — thanks to this same change — Quarkus's captured HTTP/SQL/exception/security records now all carry a
+trace id when `quarkus-opentelemetry` is present, exactly like the `LiveActivityAssembler` correlation above. A
+trace-id-only reduced profile (skip the thread-based tiers, correlate only what shares an exact trace id, and report
+unavailable without one) is therefore technically buildable on top of this PR's infrastructure, but it would only work
+with OpenTelemetry present — unlike Spring's, which works out of the box — and the request/exception/security DTOs'
+`threadMatched`/thread-identity fields would have no faithful Quarkus meaning. Rather than force that mismatch or ship a
+partial/fake port, `profileable` stays `false` and the drill-down stays Spring-only; a trace-id-only Quarkus profiler is
+a plausible, bounded follow-up (see the PR description) rather than something to build inline here.
 
 ### 5.4 Replaced with a Quarkus-native panel (2)
 
@@ -336,8 +355,10 @@ Pentesting, HTTP Probe, MCP Server) need no special ingredients — they work ag
   Spring auto-configuration. Phase 0/1 should validate the route + dev-mode wiring early.
 - **Reactive capture fidelity.** Vert.x-based request/exchange/SQL capture must be verified to match the servlet panels'
   detail (timing, headers, correlation). Correlation is now resolved via the OpenTelemetry trace id (Live Activity nests
-  SQL/exceptions under their request when `quarkus-opentelemetry` is present); the remaining gap is the Spring-only
-  per-request profile drill-down.
+  SQL/exceptions/security events under their request, and stamps `securedPrincipal`, when `quarkus-opentelemetry` is
+  present); the remaining gap is the Spring-only per-request profile drill-down, whose richness leans on
+  thread-per-request serving-thread identity that the Vert.x model has no equivalent for (§5.3 has the detailed
+  reasoning). A reduced trace-id-only profiler is a plausible follow-up but is not implemented.
 - **Module naming & coordinates.** New shared/adapter modules keep `com.julien-dubois.bootui:*` coordinates and
   `io.github.jdubois.bootui.*` packages; the Quarkus extension follows Quarkus's `runtime` / `deployment` convention.
 - **Docs & checks.** The Quarkus application advisor is backed by `docs/QUARKUS-ADVISOR-CHECKS.md` and the Quarkus


### PR DESCRIPTION
## Summary

Quarkus's Live Activity panel merged HTTP requests, SQL trace, and exceptions into one correlated feed — but not security events — and separately had a hardcoded-`null` bug that defeated `securedPrincipal`/`principal` for authenticated requests. This PR fixes both, and documents why the per-request profiler drill-down still can't port.

## Part A — populate `principal` on captured HTTP exchanges

`QuarkusHttpExchangeCaptureFilter` stamped a hardcoded `null` for every captured exchange's `principal`, silently defeating `ActivityEntryDto.securedPrincipal` (Live Activity) and `HttpExchangeDto.principal` (HTTP Exchanges panel) for authenticated requests.

It now resolves the principal at `addBodyEndHandler` time (after routing/auth has run) via `rc.user()` → `QuarkusHttpUser` → `SecurityIdentity` → `identity.getPrincipal().getName()`, returning `null` (not `"anonymous"`) for anonymous/unauthenticated/absent identities — matching Spring's `HttpExchange.getPrincipal()` null-for-unauthenticated contract. Fully guarded against nulls/exceptions, mirroring the existing `currentTraceId()` defensive style in the same class.

**Tested** by a new `@QuarkusTest` against a real secured endpoint: authenticated → principal captured; unauthenticated → `null`.

## Part B — standalone `SECURITY` entries, correlated by trace id

The shared engine `LiveActivityAssembler` (used only by the Quarkus adapter — Spring has its own separate, richer, thread-based `LiveActivityService`) now produces a fourth signal type:

- `CapturedSecurityEvent` and `SecurityLogEventDto` gain an additive, nullable `traceId` field.
- `QuarkusSecurityEventCapture` stamps the active span's trace id onto every captured security event via the same capability-gated `TraceIdProvider`/`QuarkusOtelTraceIdProvider` SPI already used by the HTTP and SQL capture points (verified empirically — the OTel context resolves correctly on the CDI `@Observes SecurityEvent` request thread).
- `LiveActivityAssembler.report(...)` accepts the security source and builds standalone `SECURITY` entries (`toSecurityEntry`: severity `WARN` for event types naming a failure/denial, else `OK`), nested under their owning `REQUEST` entry via the *same* `parentFor(traceId, ...)` helper and ambiguous-trace guard already used for SQL/exceptions (an event whose trace id is shared by more than one in-flight request is never nested).
- A security event whose trace id **uniquely** matches one request also stamps that request's `securedPrincipal` — preferring the request's own principal (Part A) when both are known, falling back to the correlated event's principal otherwise.
- `sources` includes `"security"` once the source is available (gated the same way `SecurityLogsResource` gates itself, via `QuarkusPanelAvailability`).
- `LiveActivityResource` wires `SecurityEventBuffer` + `QuarkusPanelAvailability` into the assembler call.

**Tested**: 6 new `LiveActivityAssemblerTests` cases (unique match nests + stamps principal; ambiguous match nests neither; no trace id stays flat; `FAILURE` → `WARN`; request's own principal wins over a correlated event; `sources` omits `"security"` when unavailable) plus a new end-to-end `@QuarkusTest` (`BootUiQuarkusLiveActivitySecurityCorrelationTest`) against a real Quarkus boot with `quarkus-opentelemetry`, proving Parts A and B together on a live request.

## Part C — `profileable` stays `false` on Quarkus (investigated, documented, not forced)

Investigated whether any Quarkus equivalent exists for Spring's per-request profiler drill-down (`GET /activity/request/{id}`). Turns out it's a Symfony-style signal-correlation view (SQL/exceptions/security/trace/timing for one request) rather than CPU/flame-graph sampling — but three of its four correlation tiers key on **serving-thread identity** (a servlet request runs start-to-finish on one worker thread), which the Vert.x event-loop model has no equivalent for.

Only the profiler's trace-id tier is inherently portable — and thanks to this PR, all four Quarkus signal types now carry trace ids when OpenTelemetry is present. So a **reduced, trace-id-only profiler is a plausible, bounded follow-up** (skip the thread-based tiers, correlate only exact trace-id matches, report unavailable without OTel) built on this PR's infrastructure — but it would only work with OpenTelemetry present (unlike Spring's, which works out of the box via thread identity), and the existing `RequestProfileSecurityDto`/`RequestProfileExceptionDto` DTOs' thread-identity fields (`threadMatched`, `thread`) have no faithful Quarkus meaning. Rather than force that mismatch or ship a partial/fake port in this PR, `profileable` stays `false` and the finding is documented in `docs/QUARKUS-SUPPORT.md` (new note under §5.3) and `docs/FEATURES.md`, following the repo's established honest-degradation convention (GraalVM/CRaC/DevTools/Conditions/Startup-Timeline).

## Verification

- Full reactor build (`./mvnw install`, isolated `.m2`): **BUILD SUCCESS**, 287 test runs, 0 failures — including `SpringApiConformanceTest` (5/5) and `BootUiQuarkusApiConformanceTest` (5/5), so conformance stays green on both adapters.
- All `bootui-quarkus-integration-tests` submodules pass (base, otel, health, micrometer, scheduler, security, cache, flyway, liquibase, datasource), including the pre-existing `BootUiQuarkusLiveActivityCorrelationTest` (SQL/exception correlation, unaffected) and `BootUiQuarkusSecurityLogsCaptureTest` (Security Logs panel, unaffected).
- `./mvnw -pl bootui-core,bootui-engine -am test`: 849 tests, 0 failures.
- `./mvnw spotless:apply` then `spotless:check`: clean, no changes needed.

## Notes

- This PR is self-contained and doesn't depend on or reference any other in-flight PR. If there's a merge conflict with a new Vert.x filter file from a parallel session's panel-access-gating work, that's expected/unrelated.
- No frontend changes needed — `LiveActivity.vue` already renders `securedPrincipal`/`profileable` purely from the DTO, so Quarkus's new "authenticated" badge lights up automatically.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>