### PR TITLE
Add per-panel access gating to the Quarkus adapter

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/McpPanelPolicy.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/McpPanelPolicy.java
@@ -4,12 +4,12 @@ package io.github.jdubois.bootui.spi;
  * Resolves whether an MCP tool may be invoked, mirroring the per-panel enable / read-only toggles the
  * browser UI and REST API obey.
  *
- * <p>This is the framework-neutral gate behind {@code tools/call}. The Spring Boot adapter implements
- * it over {@code bootui.panels.*} (so a tool whose backing panel is disabled or whose action is
- * read-only is refused exactly like {@code PanelAccessFilter} blocks the equivalent HTTP request); the
- * Quarkus adapter, which has no per-panel enable/read-only model yet, implements it as always-enabled
- * and never-read-only — the shared {@code LocalhostGuard} write floor remains the only gate on a
- * state-changing MCP call there.
+ * <p>This is the framework-neutral gate behind {@code tools/call}. Both adapters implement it over
+ * {@code bootui.panels.*} (so a tool whose backing panel is disabled or whose action is read-only is
+ * refused exactly like the equivalent HTTP request is blocked — {@code PanelAccessFilter} on Spring
+ * Boot, {@code QuarkusPanelAccessFilter} on Quarkus) plus the global {@code bootui.read-only} switch;
+ * the shared {@code LocalhostGuard} write floor remains an additional, independent gate on any
+ * state-changing MCP call on both adapters.
  */
 public interface McpPanelPolicy {
 

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -9,6 +9,7 @@ import io.github.jdubois.bootui.quarkus.QuarkusBasePackageProvider;
 import io.github.jdubois.bootui.quarkus.QuarkusDependencyProvider;
 import io.github.jdubois.bootui.quarkus.QuarkusExposurePolicy;
 import io.github.jdubois.bootui.quarkus.QuarkusMemoryRuntimeConfig;
+import io.github.jdubois.bootui.quarkus.QuarkusPanelAccessFilter;
 import io.github.jdubois.bootui.quarkus.QuarkusPanelAvailability;
 import io.github.jdubois.bootui.quarkus.QuarkusServerPortSupplier;
 import io.github.jdubois.bootui.quarkus.QuarkusTelemetrySettings;
@@ -221,6 +222,7 @@ class BootUiQuarkusProcessor {
                         QuarkusMcpTools.class,
                         QuarkusMcpEnvelope.class,
                         BootUiQuarkusSafetyFilter.class,
+                        QuarkusPanelAccessFilter.class,
                         BootUiQuarkusStartupBanner.class)
                 .setUnremovable()
                 .build());

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilterTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilterTest.java
@@ -1,0 +1,309 @@
+package io.github.jdubois.bootui.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.jdubois.bootui.engine.panel.BootUiPanels;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * White-box binding tests for {@link QuarkusPanelAccessFilter}, mirroring the Spring adapter's
+ * {@code PanelAccessFilterTests} scenario-for-scenario at behavioral parity (same config keys, same
+ * canonical JSON 403 shape and reason strings). Lives in the integration-tests module (same package as
+ * the runtime class) because Mockito is only a test dependency there, matching
+ * {@link BootUiQuarkusSafetyFilterTest}'s convention.
+ */
+class QuarkusPanelAccessFilterTest {
+
+    // --- basic enabled/disabled gating --------------------------------------------------------------
+
+    @Test
+    void allowsEnabledPanelReadRequest() {
+        RoutingContext rc = mockRequest("GET", "/bootui/api/memory");
+        QuarkusPanelAccessFilter filter = newFilter(Map.of());
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    @Test
+    void blocksDisabledPanelReadRequest() {
+        RoutingContext rc = mockRequest("GET", "/bootui/api/memory");
+        HttpServerResponse resp = rc.response();
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.panels.memory.enabled", "false"));
+
+        filter.handle(rc);
+
+        assertBlocked(resp, "memory", "Panel is disabled via bootui.panels.memory.enabled=false");
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void blocksDisabledPanelActionRequest() {
+        RoutingContext rc = mockRequest("POST", "/bootui/api/loggers/io.github.jdubois.bootui");
+        HttpServerResponse resp = rc.response();
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.panels.loggers.enabled", "false"));
+
+        filter.handle(rc);
+
+        assertBlocked(resp, "loggers", "Panel is disabled via bootui.panels.loggers.enabled=false");
+        verify(rc, never()).next();
+    }
+
+    // --- per-panel read-only -------------------------------------------------------------------------
+
+    @Test
+    void allowsReadOnlyPanelReadRequest() {
+        RoutingContext rc = mockRequest("GET", "/bootui/api/memory");
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.panels.memory.read-only", "true"));
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    @Test
+    void blocksReadOnlyPanelActionRequest() {
+        RoutingContext rc = mockRequest("POST", "/bootui/api/memory/scan");
+        HttpServerResponse resp = rc.response();
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.panels.memory.read-only", "true"));
+
+        filter.handle(rc);
+
+        assertBlocked(resp, "memory", "Panel is read-only via bootui.panels.memory.read-only=true");
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void perPanelReadOnlyBlocksPentestingScanAction() {
+        RoutingContext rc = mockRequest("POST", "/bootui/api/pentesting/scan");
+        HttpServerResponse resp = rc.response();
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.panels.pentesting.read-only", "true"));
+
+        filter.handle(rc);
+
+        assertBlocked(resp, "pentesting", "Panel is read-only via bootui.panels.pentesting.read-only=true");
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void perPanelReadOnlyAllowsPentestingReportRead() {
+        RoutingContext rc = mockRequest("GET", "/bootui/api/pentesting");
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.panels.pentesting.read-only", "true"));
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    // --- global read-only ----------------------------------------------------------------------------
+
+    @Test
+    void globalReadOnlyBlocksEveryQuarkusActionCapablePanelAction() {
+        Map<String, ActionRequest> actionRequestsByPanel = actionRequestsByPanel();
+
+        // Completeness self-check: every actionCapable panel in the shared registry must be triaged into
+        // exactly one of the fixture map, the not-applicable-on-Quarkus set, or the no-write-path-yet set
+        // (Config). This fails loudly if a new action-capable panel is added to the registry without being
+        // triaged, instead of silently under-covering it.
+        assertThat(actionRequestsByPanel.keySet())
+                .containsExactlyInAnyOrderElementsOf(BootUiPanels.all().stream()
+                        .filter(BootUiPanels.Panel::actionCapable)
+                        .map(BootUiPanels.Panel::id)
+                        .filter(id -> !NOT_APPLICABLE_ON_QUARKUS.contains(id))
+                        .filter(id -> !NO_WRITE_PATH_ON_QUARKUS_YET.contains(id))
+                        .toList());
+
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.read-only", "true"));
+        for (Map.Entry<String, ActionRequest> entry : actionRequestsByPanel.entrySet()) {
+            RoutingContext rc =
+                    mockRequest(entry.getValue().method(), entry.getValue().uri());
+            HttpServerResponse resp = rc.response();
+
+            filter.handle(rc);
+
+            assertBlocked(resp, entry.getKey(), "BootUI is read-only via bootui.read-only=true");
+        }
+    }
+
+    @Test
+    void globalReadOnlyDoesNotBlockAPanelWithoutActions() {
+        RoutingContext rc = mockRequest("GET", "/bootui/api/metrics");
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.read-only", "true"));
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    // --- bypasses --------------------------------------------------------------------------------------
+
+    @Test
+    void overviewShellEndpointIsNeverGatedByPanelToggle() {
+        // GET /bootui/api/overview is the shell's framework-neutral chrome data source (and CSRF-cookie
+        // primer), so disabling the Overview dashboard panel must not 403 it. BootUiPanels.OVERVIEW
+        // registers no API prefix, so BootUiPanels.byApiPath("/overview") never resolves a Panel and this
+        // filter's panel == null branch lets it through untouched, exactly like the Spring filter.
+        RoutingContext rc = mockRequest("GET", "/bootui/api/overview");
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.panels.overview.enabled", "false"));
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    @Test
+    void skipsCorePanelMetadataEndpoint() {
+        RoutingContext rc = mockRequest("GET", "/bootui/api/panels");
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.read-only", "true"));
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    @Test
+    void ignoresRequestsOutsideTheBootuiApiSurface() {
+        // The static UI shell under /bootui/** (not /bootui/api/**) is never gated by a panel toggle.
+        RoutingContext rc = mockRequest("GET", "/bootui/index.html");
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.read-only", "true"));
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    // --- root-path handling --------------------------------------------------------------------------
+
+    @Test
+    void guardsPanelAccessUnderANonDefaultRootPath() {
+        // Under quarkus.http.root-path=/app the console is served at /app/bootui/**; the filter must strip
+        // the prefix (shared QuarkusRootPath helper) and still apply per-panel gating.
+        RoutingContext rc = mockRequest("POST", "/app/bootui/api/cache/clear");
+        HttpServerResponse resp = rc.response();
+        QuarkusPanelAccessFilter filter =
+                newFilter(Map.of("quarkus.http.root-path", "/app", "bootui.panels.cache.enabled", "false"));
+
+        filter.handle(rc);
+
+        assertBlocked(resp, "cache", "Panel is disabled via bootui.panels.cache.enabled=false");
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void ignoresNonBootuiPathsUnderANonDefaultRootPath() {
+        RoutingContext rc = mockRequest("POST", "/app/other");
+        QuarkusPanelAccessFilter filter =
+                newFilter(Map.of("quarkus.http.root-path", "/app", "bootui.read-only", "true"));
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------------
+
+    /**
+     * Action-capable panels in the shared registry that have zero Quarkus {@code @Path} resources at all
+     * (deliberately not ported: GraalVM/CRaC compile native images and target the Spring startup model
+     * respectively; DevTools and HTTP Sessions have no Quarkus analogue).
+     */
+    private static final Set<String> NOT_APPLICABLE_ON_QUARKUS =
+            Set.of(BootUiPanels.HTTP_SESSIONS, BootUiPanels.GRAALVM, BootUiPanels.DEVTOOLS, BootUiPanels.CRAC);
+
+    /** Action-capable in the shared registry (Spring has a write path), but Quarkus has none yet. */
+    private static final Set<String> NO_WRITE_PATH_ON_QUARKUS_YET = Set.of(BootUiPanels.CONFIG);
+
+    private static QuarkusPanelAccessFilter newFilter(Map<String, String> properties) {
+        return new QuarkusPanelAccessFilter(configOf(properties));
+    }
+
+    private static Config configOf(Map<String, String> properties) {
+        return new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(properties, "test", 100))
+                .build();
+    }
+
+    private static RoutingContext mockRequest(String method, String path) {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.method()).thenReturn(HttpMethod.valueOf(method));
+
+        HttpServerResponse response = mock(HttpServerResponse.class, RETURNS_SELF);
+
+        RoutingContext rc = mock(RoutingContext.class);
+        when(rc.normalizedPath()).thenReturn(path);
+        when(rc.request()).thenReturn(request);
+        when(rc.response()).thenReturn(response);
+        return rc;
+    }
+
+    private static void assertBlocked(HttpServerResponse response, String expectedPanelId, String expectedReason) {
+        verify(response).setStatusCode(403);
+        verify(response).putHeader("Content-Type", "application/json");
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        verify(response).end(body.capture());
+        assertThat(body.getValue())
+                .isEqualTo("{\"error\":\"BootUI panel access denied\",\"panel\":\"" + expectedPanelId
+                        + "\",\"reason\":\"" + expectedReason + "\"}");
+    }
+
+    /**
+     * The Quarkus-verified action-request fixture, one representative endpoint per real, available,
+     * action-capable Quarkus panel — the Quarkus analogue of Spring's {@code actionRequestsByPanel()},
+     * re-derived from the actual {@code @POST}/{@code @DELETE} JAX-RS resources rather than copied from
+     * Spring (paths can differ — e.g. Spring's {@code dev-services} path has an extra {@code services/}
+     * segment that the real Quarkus resource does not).
+     */
+    private static Map<String, ActionRequest> actionRequestsByPanel() {
+        Map<String, ActionRequest> requests = new LinkedHashMap<>();
+        requests.put("heap-dump", new ActionRequest("POST", "/bootui/api/heap-dump/capture"));
+        requests.put("threads", new ActionRequest("POST", "/bootui/api/threads/download"));
+        requests.put("memory", new ActionRequest("POST", "/bootui/api/memory/scan"));
+        requests.put("loggers", new ActionRequest("POST", "/bootui/api/loggers/io.github.jdubois.bootui"));
+        requests.put("security", new ActionRequest("POST", "/bootui/api/security/scan"));
+        requests.put("pentesting", new ActionRequest("POST", "/bootui/api/pentesting/scan"));
+        requests.put("hibernate", new ActionRequest("POST", "/bootui/api/hibernate/scan"));
+        requests.put("cache", new ActionRequest("POST", "/bootui/api/cache/clear"));
+        requests.put("traces", new ActionRequest("DELETE", "/bootui/api/traces"));
+        requests.put("exceptions", new ActionRequest("DELETE", "/bootui/api/exceptions"));
+        requests.put("http-probe", new ActionRequest("POST", "/bootui/api/http-probe"));
+        requests.put("architecture", new ActionRequest("POST", "/bootui/api/architecture/scan"));
+        requests.put("vulnerabilities", new ActionRequest("POST", "/bootui/api/vulnerabilities/scan"));
+        requests.put("dev-services", new ActionRequest("POST", "/bootui/api/dev-services/demo/restart"));
+        requests.put("flyway", new ActionRequest("POST", "/bootui/api/flyway/migrate"));
+        requests.put("liquibase", new ActionRequest("POST", "/bootui/api/liquibase/update"));
+        requests.put("github", new ActionRequest("POST", "/bootui/api/github/refresh"));
+        requests.put("rest-api", new ActionRequest("POST", "/bootui/api/rest-api/scan"));
+        requests.put("spring", new ActionRequest("POST", "/bootui/api/spring/scan"));
+        requests.put("sql-trace", new ActionRequest("POST", "/bootui/api/sql-trace/clear"));
+        requests.put("mcp-server", new ActionRequest("POST", "/bootui/api/mcp-server/toggle"));
+        return requests;
+    }
+
+    private record ActionRequest(String method, String uri) {}
+}

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/QuarkusMcpPanelPolicyBootTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/QuarkusMcpPanelPolicyBootTest.java
@@ -1,0 +1,81 @@
+package io.github.jdubois.bootui.quarkus.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.net.URL;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real-boot, end-to-end proof that a disabled panel's MCP tool is refused through the <em>full</em>
+ * production wiring: the JSON-RPC bridge ({@code McpBridgeResource}) → the shared engine
+ * {@code McpDispatcher} → {@code QuarkusMcpPanelPolicy} → the same {@code QuarkusPanelAccessConfig} that
+ * backs {@link io.github.jdubois.bootui.quarkus.QuarkusPanelAccessFilter}. The policy's delegation logic in
+ * isolation is unit-tested by {@code QuarkusMcpPanelPolicyTest} (5 scenarios: default-enabled, disabled,
+ * default-not-read-only, per-panel read-only, global read-only); this class instead pins that
+ * {@code BootUiMcpProducer} actually wires the real config-backed policy into the dispatcher end-to-end,
+ * mirroring the existing {@link BootUiQuarkusMcpResourceTest} real-HTTP conventions.
+ */
+@QuarkusTest
+@TestProfile(QuarkusMcpPanelPolicyBootTest.DisabledMemoryPanelProfile.class)
+class QuarkusMcpPanelPolicyBootTest {
+
+    private static final Map<String, String> JSON = Map.of("Content-Type", "application/json");
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    private BootUiHttpProbe probe() {
+        return new BootUiHttpProbe(baseUrl.toExternalForm());
+    }
+
+    private void setServerEnabled(boolean enabled) {
+        Response response =
+                probe().request("POST", "/bootui/api/mcp-server/toggle", JSON, "{\"enabled\":" + enabled + "}");
+        assertThat(response.status()).isEqualTo(200);
+    }
+
+    private Response rpc(String body) {
+        return probe().request("POST", "/bootui/api/mcp", JSON, body);
+    }
+
+    @Test
+    void disabledPanelToolCallIsRefusedThroughTheFullMcpStack() {
+        setServerEnabled(true);
+        Response response =
+                rpc("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"memory_scan\"}}");
+
+        assertThat(response.status()).isEqualTo(200);
+        JsonNode result = response.json().path("result");
+        assertThat(result.path("isError").asBoolean())
+                .as("a disabled panel's tool call must be refused")
+                .isTrue();
+        assertThat(result.path("content").get(0).path("text").asText())
+                .isEqualTo("Panel is disabled via bootui.panels.memory.enabled=false");
+    }
+
+    @Test
+    void unaffectedToolIsStillCallable() {
+        // Sanity check: disabling one panel (memory) must not affect an unrelated tool.
+        setServerEnabled(true);
+        Response response =
+                rpc("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"get_health\"}}");
+
+        assertThat(response.status()).isEqualTo(200);
+        assertThat(response.json().path("result").path("isError").asBoolean()).isFalse();
+    }
+
+    public static final class DisabledMemoryPanelProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("bootui.panels.memory.enabled", "false");
+        }
+    }
+}

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/QuarkusPanelAccessFilterBootTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/QuarkusPanelAccessFilterBootTest.java
@@ -1,0 +1,101 @@
+package io.github.jdubois.bootui.quarkus.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.net.URL;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real-boot (over-loopback) checks that {@code io.github.jdubois.bootui.quarkus.QuarkusPanelAccessFilter}
+ * is wired into the live Vert.x request chain and enforces {@code bootui.panels.memory.enabled} at
+ * behavioral parity with the Spring adapter's {@code PanelAccessFilter}. The exhaustive per-panel/
+ * per-config-key matrix is covered by the white-box {@code QuarkusPanelAccessFilterTest}; this class only
+ * proves what a plain unit test of {@code handle(RoutingContext)} cannot: that the filter is actually
+ * registered on the live filter chain, and — critically — that it runs <em>after</em>
+ * {@code BootUiQuarkusSafetyFilter}, so a request that fails both the safety guard and panel gating is
+ * rejected with the safety filter's reason, never the panel filter's.
+ */
+@QuarkusTest
+@TestProfile(QuarkusPanelAccessFilterBootTest.DisabledMemoryPanelProfile.class)
+class QuarkusPanelAccessFilterBootTest {
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    private BootUiHttpProbe probe() {
+        return new BootUiHttpProbe(baseUrl.toExternalForm());
+    }
+
+    @Test
+    void disabledPanelReadIsRejectedWithCanonicalJsonBody() {
+        Response response = probe().get("/bootui/api/memory");
+
+        assertThat(response.status()).as("disabled panel GET must be 403").isEqualTo(403);
+        assertThat(response.isJson())
+                .as("403 content-type must be JSON (%s)", response.contentType())
+                .isTrue();
+        assertThat(response.json().path("error").asText()).isEqualTo("BootUI panel access denied");
+        assertThat(response.json().path("panel").asText()).isEqualTo("memory");
+        assertThat(response.json().path("reason").asText())
+                .isEqualTo("Panel is disabled via bootui.panels.memory.enabled=false");
+    }
+
+    @Test
+    void disabledPanelActionIsAlsoRejected() {
+        Response response = probe().post("/bootui/api/memory/scan", Map.of());
+
+        assertThat(response.status()).as("disabled panel POST must be 403").isEqualTo(403);
+        assertThat(response.json().path("panel").asText()).isEqualTo("memory");
+    }
+
+    @Test
+    void overviewBypassesPanelGatingEvenWhenAnotherPanelIsDisabled() {
+        // The Overview shell-chrome endpoint is never gated by any panel's toggle (BootUiPanels.OVERVIEW
+        // registers no API prefix), regardless of other panels being disabled.
+        Response response = probe().get("/bootui/api/overview");
+
+        assertThat(response.status()).as("Overview must never be panel-gated").isEqualTo(200);
+    }
+
+    @Test
+    void unaffectedPanelIsNotOverBlocked() {
+        // Sanity check: disabling one panel (memory) must not affect an unrelated panel.
+        Response response = probe().get("/bootui/api/cache");
+
+        assertThat(response.status())
+                .as("an unrelated panel must be unaffected")
+                .isEqualTo(200);
+    }
+
+    @Test
+    void safetyFilterRejectionWinsOverDisabledPanelGating() {
+        // memory is disabled AND this is a cross-site write: the safety filter (higher priority, runs
+        // first) must reject it before the panel-access filter (lower priority) ever runs, so the body
+        // carries the safety filter's cross-site message, not the panel-disabled reason.
+        Response response = probe().post(
+                        "/bootui/api/memory/scan",
+                        Map.of("Origin", "http://evil.example.com", "Sec-Fetch-Site", "cross-site"));
+
+        assertThat(response.status()).as("cross-site POST must be 403").isEqualTo(403);
+        assertThat(response.json().path("error").asText())
+                .as("the safety filter's rejection must win, not the panel-access filter's")
+                .isEqualTo("BootUI rejected a cross-site request to a state-changing endpoint.");
+        assertThat(response.json().has("panel"))
+                .as("the safety filter's JSON body has no \"panel\" field")
+                .isFalse();
+    }
+
+    public static final class DisabledMemoryPanelProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("bootui.panels.memory.enabled", "false");
+        }
+    }
+}

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/QuarkusPanelAccessFilterRootPathBootTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/QuarkusPanelAccessFilterRootPathBootTest.java
@@ -1,0 +1,65 @@
+package io.github.jdubois.bootui.quarkus.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.net.URL;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real-boot proof that {@code io.github.jdubois.bootui.quarkus.QuarkusPanelAccessFilter} keeps enforcing
+ * panel gating when the host application runs under a non-default {@code quarkus.http.root-path} —
+ * mirroring {@code BootUiQuarkusSafetyFilterRootPathBootTest} for the panel-access filter (and the Spring
+ * adapter's {@code honorsCustomApiPathAndContextPath} test). Both global Vert.x filters share the same
+ * {@code QuarkusRootPath} prefix-stripping helper; this pins that the panel-access filter's use of it is
+ * wired correctly end-to-end, not just unit-tested in isolation.
+ */
+@QuarkusTest
+@TestProfile(QuarkusPanelAccessFilterRootPathBootTest.RootPathDisabledMemoryProfile.class)
+class QuarkusPanelAccessFilterRootPathBootTest {
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    /** The HTTP server root (scheme://host:port), independent of how {@code baseUrl} renders the root-path. */
+    private BootUiHttpProbe probe() {
+        String serverRoot = baseUrl.getProtocol() + "://" + baseUrl.getHost() + ":" + baseUrl.getPort();
+        return new BootUiHttpProbe(serverRoot);
+    }
+
+    @Test
+    void disabledPanelUnderTheRootPathIsRejected() {
+        Response response = probe().get("/app/bootui/api/memory");
+
+        assertThat(response.status())
+                .as("a disabled panel under the root-path-prefixed console must still be gated")
+                .isEqualTo(403);
+        assertThat(response.json().path("panel").asText()).isEqualTo("memory");
+        assertThat(response.json().path("reason").asText())
+                .isEqualTo("Panel is disabled via bootui.panels.memory.enabled=false");
+    }
+
+    @Test
+    void overviewUnderTheRootPathIsStillNeverGated() {
+        Response response = probe().get("/app/bootui/api/overview");
+
+        assertThat(response.status())
+                .as("Overview must stay ungated under a non-default root-path too")
+                .isEqualTo(200);
+    }
+
+    public static final class RootPathDisabledMemoryProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.http.root-path", "/app",
+                    "bootui.panels.memory.enabled", "false");
+        }
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiQuarkusSafetyFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiQuarkusSafetyFilter.java
@@ -148,23 +148,11 @@ public class BootUiQuarkusSafetyFilter {
      * still sees the full path. Without stripping, {@link #isBootUiRequest} would not recognize the
      * prefixed path and the guard would be skipped (fail-open). The root-path is read live and
      * <em>fails closed</em>: a missing/blank value normalizes to {@code ""} (no prefix), which still guards
-     * the default {@code /bootui} surface.
+     * the default {@code /bootui} surface. Delegates to {@link QuarkusRootPath}, shared with
+     * {@link QuarkusPanelAccessFilter} so the two filters can never drift in root-path handling.
      */
     String bootUiRelativePath(String normalizedPath) {
-        if (normalizedPath == null) {
-            return null;
-        }
-        String prefix = normalizeRootPath(rootPath());
-        if (prefix.isEmpty()) {
-            return normalizedPath;
-        }
-        if (normalizedPath.equals(prefix)) {
-            return "/";
-        }
-        if (normalizedPath.startsWith(prefix + "/")) {
-            return normalizedPath.substring(prefix.length());
-        }
-        return normalizedPath;
+        return QuarkusRootPath.stripPrefix(normalizedPath, QuarkusRootPath.normalize(rootPath()));
     }
 
     private String rootPath() {
@@ -173,17 +161,7 @@ public class BootUiQuarkusSafetyFilter {
 
     /** Normalizes a {@code quarkus.http.root-path} value to a strip-prefix ({@code ""} for the default). */
     static String normalizeRootPath(String raw) {
-        if (raw == null || raw.isBlank()) {
-            return "";
-        }
-        String trimmed = raw.trim();
-        if (!trimmed.startsWith("/")) {
-            trimmed = "/" + trimmed;
-        }
-        while (trimmed.length() > 1 && trimmed.endsWith("/")) {
-            trimmed = trimmed.substring(0, trimmed.length() - 1);
-        }
-        return trimmed.equals("/") ? "" : trimmed;
+        return QuarkusRootPath.normalize(raw);
     }
 
     /**

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessConfig.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessConfig.java
@@ -1,0 +1,79 @@
+package io.github.jdubois.bootui.quarkus;
+
+import org.eclipse.microprofile.config.Config;
+import org.jboss.logging.Logger;
+
+/**
+ * Reads the per-panel and global BootUI access-control settings live from MicroProfile {@link Config} —
+ * the Quarkus analogue of the Spring adapter's {@code BootUiProperties.isPanelEnabled} /
+ * {@code isPanelReadOnly} / {@code panelDisabledReason} / {@code panelReadOnlyReason} methods, at
+ * behavioral parity.
+ *
+ * <p>Config surface: {@code bootui.panels.<id>.enabled} (default {@code true}),
+ * {@code bootui.panels.<id>.read-only} (default {@code false}), and the global
+ * {@code bootui.read-only} (default {@code false}) which forces every action-capable panel read-only
+ * regardless of its own per-panel setting. Values are read live (per call), matching the "live-policy SPI"
+ * idiom already used by {@link QuarkusExposurePolicy}, so a runtime config change takes effect on the next
+ * request with no restart. A missing or invalid value <em>fails closed</em> to the same default as an
+ * absent key — never widening access on a typo.
+ *
+ * <p>This is a plain class (not itself a CDI bean, so it needs no producer/qualifier wiring), constructed
+ * inline wherever it is needed ({@link QuarkusPanelAccessFilter}, {@link QuarkusPanelAvailability}, and
+ * {@code QuarkusMcpPanelPolicy} in the sibling {@code mcp} package) — mirroring how
+ * {@code QuarkusCopilotProperties} is used elsewhere in this adapter — so all three call sites share
+ * byte-identical enable/read-only semantics without duplicating the MicroProfile Config reads.
+ */
+public final class QuarkusPanelAccessConfig {
+
+    private static final Logger LOG = Logger.getLogger(QuarkusPanelAccessConfig.class);
+
+    static final String GLOBAL_READ_ONLY_KEY = "bootui.read-only";
+
+    private final Config config;
+
+    public QuarkusPanelAccessConfig(Config config) {
+        this.config = config;
+    }
+
+    /** Whether the panel with the given id is enabled. Defaults to {@code true} (opt-out model). */
+    public boolean isPanelEnabled(String id) {
+        return booleanValue("bootui.panels." + id + ".enabled", true);
+    }
+
+    /**
+     * Whether the panel with the given id is read-only: either the global {@code bootui.read-only} switch
+     * is on, or the panel's own {@code bootui.panels.<id>.read-only} is set.
+     */
+    public boolean isPanelReadOnly(String id) {
+        return isGlobalReadOnly() || booleanValue("bootui.panels." + id + ".read-only", false);
+    }
+
+    /** The reason a disabled panel is blocked, matching Spring's message byte-for-byte. */
+    public String panelDisabledReason(String id) {
+        return "Panel is disabled via bootui.panels." + id + ".enabled=false";
+    }
+
+    /**
+     * The reason a read-only panel's action is blocked: the global reason when {@code bootui.read-only}
+     * is on, otherwise the per-panel reason — matching Spring's message byte-for-byte.
+     */
+    public String panelReadOnlyReason(String id) {
+        if (isGlobalReadOnly()) {
+            return "BootUI is read-only via bootui.read-only=true";
+        }
+        return "Panel is read-only via bootui.panels." + id + ".read-only=true";
+    }
+
+    private boolean isGlobalReadOnly() {
+        return booleanValue(GLOBAL_READ_ONLY_KEY, false);
+    }
+
+    private boolean booleanValue(String key, boolean defaultValue) {
+        try {
+            return config.getOptionalValue(key, Boolean.class).orElse(defaultValue);
+        } catch (IllegalArgumentException ex) {
+            LOG.warnf("Ignoring invalid BootUI property '%s'; falling back to %s.", key, defaultValue);
+            return defaultValue;
+        }
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilter.java
@@ -1,0 +1,129 @@
+package io.github.jdubois.bootui.quarkus;
+
+import io.github.jdubois.bootui.engine.panel.BootUiPanels;
+import io.github.jdubois.bootui.engine.panel.BootUiPanels.Panel;
+import io.quarkus.vertx.http.runtime.filters.Filters;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import java.util.Set;
+import org.eclipse.microprofile.config.Config;
+
+/**
+ * Applies per-panel enabled and read-only settings to BootUI API routes — the Quarkus analogue of the
+ * Spring adapter's {@code PanelAccessFilter}, at behavioral parity: same config keys
+ * ({@code bootui.panels.<id>.enabled} / {@code .read-only}, plus the global {@code bootui.read-only}),
+ * same panel resolution via the shared {@link BootUiPanels#byApiPath(String)} registry, and the same
+ * canonical JSON 403 body shape ({@code {"error":"BootUI panel access denied","panel":"<id>","reason":"<reason>"}}).
+ *
+ * <p>Registered as a global Vert.x route filter (via the {@link Filters} event), like
+ * {@link BootUiQuarkusSafetyFilter}, so it sees every request before routing. It runs at a
+ * <strong>lower</strong> priority than the safety filter ({@value #PRIORITY} vs. the safety filter's
+ * {@code 1000}) so the localhost/Host/CSRF checks always evaluate first: a request that fails both the
+ * safety guard and panel gating is rejected by the safety filter, which never calls
+ * {@link RoutingContext#next()}, so this filter never even runs for it.
+ *
+ * <p>Only requests under {@code /bootui/api/**} are considered (mirroring the Spring filter's
+ * {@code shouldNotFilter}); the static UI shell under {@code /bootui/**} is never gated by a panel toggle.
+ * A request path that does not resolve to a registered {@link Panel} — notably {@code GET
+ * /bootui/api/overview} (the Overview panel registers no API prefix on purpose), the
+ * {@code /bootui/api/panels} manifest endpoint itself, and any future non-panel endpoint — passes through
+ * untouched, exactly like the Spring filter.
+ */
+@ApplicationScoped
+public class QuarkusPanelAccessFilter {
+
+    private static final Set<String> SAFE_METHODS = Set.of("GET", "HEAD", "OPTIONS");
+
+    private static final String API_PATH = "/bootui/api";
+
+    /**
+     * Runs after the safety filter (priority {@code 1000}) so localhost/Host/CSRF rejection always wins,
+     * but before {@link QuarkusHttpExchangeCaptureFilter} (priority {@code 900}) has no ordering
+     * requirement either way since it only records, never short-circuits.
+     */
+    private static final int PRIORITY = 950;
+
+    private final Config config;
+    private final QuarkusPanelAccessConfig accessConfig;
+
+    @Inject
+    public QuarkusPanelAccessFilter(Config config) {
+        this.config = config;
+        this.accessConfig = new QuarkusPanelAccessConfig(config);
+    }
+
+    public void register(@Observes Filters filters) {
+        filters.register(this::handle, PRIORITY);
+    }
+
+    void handle(RoutingContext rc) {
+        String apiRelativePath = apiRelativePath(rc);
+        if (apiRelativePath == null) {
+            rc.next();
+            return;
+        }
+
+        Panel panel = BootUiPanels.byApiPath(apiRelativePath).orElse(null);
+        if (panel == null) {
+            rc.next();
+            return;
+        }
+
+        if (!accessConfig.isPanelEnabled(panel.id())) {
+            writeBlockedResponse(rc, panel.id(), accessConfig.panelDisabledReason(panel.id()));
+            return;
+        }
+
+        String method = rc.request().method().name();
+        if (panel.actionCapable() && !SAFE_METHODS.contains(method) && accessConfig.isPanelReadOnly(panel.id())) {
+            writeBlockedResponse(rc, panel.id(), accessConfig.panelReadOnlyReason(panel.id()));
+            return;
+        }
+
+        rc.next();
+    }
+
+    /**
+     * Resolves the request path relative to {@code /bootui/api}, after stripping the configured
+     * {@code quarkus.http.root-path} prefix (shared with {@link BootUiQuarkusSafetyFilter} via
+     * {@link QuarkusRootPath}). Returns {@code null} when the request is not under {@code /bootui/api} at
+     * all (mirrors the Spring filter's {@code shouldNotFilter}/{@code isBootUiApiRequest} check), including
+     * requests to the static UI shell under {@code /bootui/**}.
+     */
+    private String apiRelativePath(RoutingContext rc) {
+        String path = QuarkusRootPath.stripPrefix(rc.normalizedPath(), QuarkusRootPath.normalize(rootPath()));
+        if (path == null) {
+            return null;
+        }
+        if (path.equals(API_PATH)) {
+            return "/";
+        }
+        if (!path.startsWith(API_PATH + "/")) {
+            return null;
+        }
+        return path.substring(API_PATH.length());
+    }
+
+    private String rootPath() {
+        return config.getOptionalValue(QuarkusRootPath.ROOT_PATH_KEY, String.class)
+                .orElse("/");
+    }
+
+    private void writeBlockedResponse(RoutingContext rc, String panelId, String reason) {
+        HttpServerResponse response = rc.response();
+        response.setStatusCode(403)
+                .putHeader("Content-Type", "application/json")
+                .end("{\"error\":\"" + escape("BootUI panel access denied") + "\",\"panel\":\"" + escape(panelId)
+                        + "\",\"reason\":\"" + escape(reason) + "\"}");
+    }
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAvailability.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAvailability.java
@@ -45,12 +45,18 @@ import org.eclipse.microprofile.config.Config;
  * engine {@code PentestingScanner}, whose framework-neutral value comes from two synthetic loopback probes
  * (security headers, cookies, CORS, TRACE, technology disclosure), so the Quarkus adapter supplies only the
  * live server port + context path and a deliberately neutral endpoint/security/config snapshot (the
- * Spring-Security and Actuator checks stay inert on Quarkus). Read-only is not yet modelled, so no panel is
- * read-only ({@code readOnlyReason} stays {@code null})
- * — note Traces (its buffer can be cleared), Loggers (a logger level can be set), HTTP Probe (it issues a
- * request), Architecture (it runs a scan and dismisses rules), Pentesting (it runs a scan), Vulnerabilities
- * (it runs an OSV scan) and Cache (it clears caches) are
- * action-capable, plus the Memory advisor (it runs a scan), so they are the Quarkus panels exposing state-changing actions.</p>
+ * Spring-Security and Actuator checks stay inert on Quarkus) — note Traces (its buffer can be cleared),
+ * Loggers (a logger level can be set), HTTP Probe (it issues a request), Architecture (it runs a scan and
+ * dismisses rules), Pentesting (it runs a scan), Vulnerabilities (it runs an OSV scan) and Cache (it clears
+ * caches) are action-capable, plus the Memory advisor (it runs a scan), so they are the Quarkus panels
+ * exposing state-changing actions. Per-panel enabled/read-only gating is modelled exactly like the Spring
+ * adapter's {@code PanelAccessFilter}: {@code enabled} reflects the live
+ * {@code bootui.panels.<id>.enabled} config (default {@code true}), and {@code readOnly}/{@code
+ * readOnlyReason} reflect the OR of the live {@code bootui.panels.<id>.read-only} / global {@code
+ * bootui.read-only} config (default {@code false}) with the Configuration panel's own inherent
+ * read-only-ness (it has no write path on Quarkus at all yet, unrelated to this config — see below); both
+ * are computed by {@link QuarkusPanelAccessConfig}, shared with {@link QuarkusPanelAccessFilter} so the
+ * manifest and the enforcing filter can never disagree.</p>
  *
  * <p>The <strong>Hibernate</strong> (ORM mapping) advisor is available <em>dynamically</em>: unlike the
  * statically-available panels above, it is lit up only when the application actually uses Hibernate ORM. The
@@ -339,6 +345,7 @@ public class QuarkusPanelAvailability {
     private final boolean restApiPresent;
     private final boolean copilotPanelAvailable;
     private final boolean claudeCodePanelAvailable;
+    private final QuarkusPanelAccessConfig accessConfig;
 
     @Inject
     public QuarkusPanelAvailability(Config config) {
@@ -369,6 +376,7 @@ public class QuarkusPanelAvailability {
         QuarkusClaudeCodeProperties claude = new QuarkusClaudeCodeProperties(config);
         this.copilotPanelAvailable = agentDirectoryPresent(copilot);
         this.claudeCodePanelAvailable = agentDirectoryPresent(claude);
+        this.accessConfig = new QuarkusPanelAccessConfig(config);
     }
 
     private static boolean agentDirectoryPresent(io.github.jdubois.bootui.spi.agent.AgentSessionProperties settings) {
@@ -392,12 +400,25 @@ public class QuarkusPanelAvailability {
                 BootUiPanels.all().stream().map(this::toDto).toList());
     }
 
+    /**
+     * Builds the manifest entry for a single panel: {@code available} is platform-specific (computed by
+     * {@link #isPanelAvailable}); {@code enabled} and {@code readOnly} are config-driven, computed the same
+     * way regardless of availability (mirroring the Spring adapter's {@code PanelsController.panel()},
+     * which does not gate {@code enabled}/{@code readOnly} on availability either). The Configuration
+     * panel's own inherent read-only-ness (it has no write path on Quarkus yet — a separate, unrelated gap)
+     * is preserved as-is and OR'd with the new config-driven read-only check.
+     */
     private PanelDto toDto(BootUiPanels.Panel panel) {
         boolean available = isPanelAvailable(panel.id());
         String unavailableReason = available ? null : unavailableReason(panel.id());
-        boolean readOnly = available && BootUiPanels.CONFIG.equals(panel.id());
-        String readOnlyReason = readOnly ? CONFIG_READONLY : null;
-        return new PanelDto(panel.id(), panel.title(), available, unavailableReason, true, readOnly, readOnlyReason);
+        boolean enabled = accessConfig.isPanelEnabled(panel.id());
+        boolean configReadOnly = available && BootUiPanels.CONFIG.equals(panel.id());
+        boolean accessReadOnly = panel.actionCapable() && accessConfig.isPanelReadOnly(panel.id());
+        boolean readOnly = configReadOnly || accessReadOnly;
+        String readOnlyReason = configReadOnly
+                ? CONFIG_READONLY
+                : (accessReadOnly ? accessConfig.panelReadOnlyReason(panel.id()) : null);
+        return new PanelDto(panel.id(), panel.title(), available, unavailableReason, enabled, readOnly, readOnlyReason);
     }
 
     /**

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusRootPath.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusRootPath.java
@@ -1,0 +1,59 @@
+package io.github.jdubois.bootui.quarkus;
+
+/**
+ * Shared helper for stripping the configured {@code quarkus.http.root-path} prefix from a request path.
+ *
+ * <p>Quarkus mounts the whole application — including BootUI's JAX-RS resources and its static UI —
+ * under {@code quarkus.http.root-path}, so under a non-default root-path (e.g. {@code /app}) the console
+ * is served at {@code /app/bootui/**} while the global Vert.x filters that guard it still see the full
+ * path. Both {@link BootUiQuarkusSafetyFilter} and {@link QuarkusPanelAccessFilter} need to strip this
+ * prefix before applying their own path-based checks; this class is the single implementation so the two
+ * filters can never silently drift in how they interpret a non-default root-path.
+ */
+final class QuarkusRootPath {
+
+    static final String ROOT_PATH_KEY = "quarkus.http.root-path";
+
+    private QuarkusRootPath() {}
+
+    /**
+     * Normalizes a {@code quarkus.http.root-path} value to a strip-prefix ({@code ""} for the default). A
+     * missing/blank value normalizes to {@code ""} (no prefix), which still guards the default
+     * {@code /bootui} surface — the root-path is read live and <em>fails closed</em>.
+     */
+    static String normalize(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "";
+        }
+        String trimmed = raw.trim();
+        if (!trimmed.startsWith("/")) {
+            trimmed = "/" + trimmed;
+        }
+        while (trimmed.length() > 1 && trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed.equals("/") ? "" : trimmed;
+    }
+
+    /**
+     * Removes {@code rootPathPrefix} (already {@link #normalize(String) normalized}) from
+     * {@code normalizedPath} so path-based checks are root-path-relative. Without stripping, a filter
+     * matching on a literal {@code /bootui} prefix would not recognize the root-path-prefixed path and
+     * would be skipped entirely (fail-open).
+     */
+    static String stripPrefix(String normalizedPath, String rootPathPrefix) {
+        if (normalizedPath == null) {
+            return null;
+        }
+        if (rootPathPrefix.isEmpty()) {
+            return normalizedPath;
+        }
+        if (normalizedPath.equals(rootPathPrefix)) {
+            return "/";
+        }
+        if (normalizedPath.startsWith(rootPathPrefix + "/")) {
+            return normalizedPath.substring(rootPathPrefix.length());
+        }
+        return normalizedPath;
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/BootUiMcpProducer.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/BootUiMcpProducer.java
@@ -1,6 +1,8 @@
 package io.github.jdubois.bootui.quarkus.mcp;
 
 import io.github.jdubois.bootui.engine.mcp.McpDispatcher;
+import io.github.jdubois.bootui.quarkus.QuarkusPanelAccessConfig;
+import io.github.jdubois.bootui.spi.McpPanelPolicy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
@@ -11,9 +13,10 @@ import org.eclipse.microprofile.config.Config;
  *
  * <p>Mirrors the Spring adapter's {@code McpConfiguration} {@code @Bean} methods: it builds the live
  * {@link McpServerState} from {@code bootui.mcp.enabled} and the framework- and JSON-free engine
- * {@link McpDispatcher} from the Quarkus tool catalog, the always-enabled {@link QuarkusMcpPanelPolicy}
- * (Quarkus has no per-panel toggle yet), the BootUI version, Quarkus-flavored {@code initialize}
- * instructions, and the {@code bootui.mcp.max-results} cap.
+ * {@link McpDispatcher} from the Quarkus tool catalog, the config-driven {@link QuarkusMcpPanelPolicy}
+ * (gating {@code tools/call} on the same {@code bootui.panels.*} / {@code bootui.read-only} settings the
+ * browser UI and {@code QuarkusPanelAccessFilter} obey), the BootUI version, Quarkus-flavored
+ * {@code initialize} instructions, and the {@code bootui.mcp.max-results} cap.
  *
  * <p>{@link McpServerState} is annotation-free and produced here as a {@code @Singleton} rather than
  * being CDI-scoped itself, to avoid the ambiguity of a class being both {@code @ApplicationScoped} and
@@ -41,7 +44,8 @@ public class BootUiMcpProducer {
     public McpDispatcher mcpDispatcher(QuarkusMcpTools tools, Config config) {
         int maxResults =
                 config.getOptionalValue("bootui.mcp.max-results", Integer.class).orElse(200);
-        return new McpDispatcher(tools.tools(), new QuarkusMcpPanelPolicy(), serverVersion(), INSTRUCTIONS, maxResults);
+        McpPanelPolicy policy = new QuarkusMcpPanelPolicy(new QuarkusPanelAccessConfig(config));
+        return new McpDispatcher(tools.tools(), policy, serverVersion(), INSTRUCTIONS, maxResults);
     }
 
     private static String serverVersion() {

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpPanelPolicy.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpPanelPolicy.java
@@ -1,36 +1,45 @@
 package io.github.jdubois.bootui.quarkus.mcp;
 
+import io.github.jdubois.bootui.quarkus.QuarkusPanelAccessConfig;
 import io.github.jdubois.bootui.spi.McpPanelPolicy;
 
 /**
- * Quarkus {@link McpPanelPolicy}: the Quarkus adapter has no per-panel enable / read-only model yet
- * (there is no {@code PanelAccessFilter} equivalent), so every tool's backing panel is reported
- * enabled and never read-only. The shared {@code LocalhostGuard} write floor remains the only gate on
- * a state-changing MCP call here.
+ * Quarkus {@link McpPanelPolicy}: gates an MCP {@code tools/call} on the same
+ * {@code bootui.panels.*} enable / read-only toggles (plus the global {@code bootui.read-only}) that
+ * the browser UI and {@code QuarkusPanelAccessFilter} obey, so a tool whose backing panel is disabled
+ * (or whose action is read-only) is refused for identical reasons — mirroring the Spring adapter's
+ * {@code SpringMcpPanelPolicy}, which delegates the same four methods straight to
+ * {@code BootUiProperties}.
  *
- * <p>Panel <em>availability</em> is still enforced — but at the catalog level: {@code QuarkusMcpTools}
- * only advertises a tool when {@code QuarkusPanelAvailability.isPanelAvailable(panelId)} is true, so an
- * unavailable panel's tool never reaches this policy.
+ * <p>Panel <em>availability</em> is still enforced separately, at the catalog level: {@code
+ * QuarkusMcpTools} only advertises a tool when {@code QuarkusPanelAvailability.isPanelAvailable(panelId)}
+ * is true, so an unavailable panel's tool never reaches this policy.
  */
 public final class QuarkusMcpPanelPolicy implements McpPanelPolicy {
 
+    private final QuarkusPanelAccessConfig accessConfig;
+
+    public QuarkusMcpPanelPolicy(QuarkusPanelAccessConfig accessConfig) {
+        this.accessConfig = accessConfig;
+    }
+
     @Override
     public boolean isEnabled(String panelId) {
-        return true;
+        return accessConfig.isPanelEnabled(panelId);
     }
 
     @Override
     public String disabledReason(String panelId) {
-        return null;
+        return accessConfig.panelDisabledReason(panelId);
     }
 
     @Override
     public boolean isReadOnly(String panelId) {
-        return false;
+        return accessConfig.isPanelReadOnly(panelId);
     }
 
     @Override
     public String readOnlyReason(String panelId) {
-        return null;
+        return accessConfig.panelReadOnlyReason(panelId);
     }
 }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/McpServerResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/McpServerResource.java
@@ -5,6 +5,7 @@ import io.github.jdubois.bootui.core.dto.McpToolInfo;
 import io.github.jdubois.bootui.engine.mcp.McpDispatcher;
 import io.github.jdubois.bootui.engine.mcp.McpProtocol;
 import io.github.jdubois.bootui.engine.mcp.McpTool;
+import io.github.jdubois.bootui.quarkus.QuarkusPanelAccessConfig;
 import io.github.jdubois.bootui.quarkus.mcp.McpServerState;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -26,21 +27,25 @@ import org.eclipse.microprofile.config.Config;
  * lifetime of the running application; the toggle is gated by the shared {@code LocalhostGuard} write
  * floor enforced by {@code BootUiQuarkusSafetyFilter}.
  *
- * <p>Quarkus has no per-panel enable/read-only model yet, so each tool's {@code panelEnabled} is
- * reported {@code true} and {@code panelReadOnly} {@code false} — the catalog itself is already gated
- * by panel availability when it is built ({@code QuarkusMcpTools}).
+ * <p>Each tool's {@code panelEnabled}/{@code panelReadOnly} are read live from the same
+ * {@code bootui.panels.*} / {@code bootui.read-only} config {@code QuarkusPanelAccessFilter} enforces
+ * (via {@link QuarkusPanelAccessConfig}), mirroring the Spring adapter's {@code
+ * McpServerController.buildStatus()} exactly — the catalog itself is separately gated by panel
+ * <em>availability</em> when it is built ({@code QuarkusMcpTools}).
  */
 @Path("/bootui/api/mcp-server")
 public class McpServerResource {
 
     private final McpServerState state;
     private final McpDispatcher dispatcher;
+    private final QuarkusPanelAccessConfig accessConfig;
     private final int maxResults;
 
     @Inject
     public McpServerResource(McpServerState state, McpDispatcher dispatcher, Config config) {
         this.state = state;
         this.dispatcher = dispatcher;
+        this.accessConfig = new QuarkusPanelAccessConfig(config);
         this.maxResults = Math.max(
                 1,
                 config.getOptionalValue("bootui.mcp.max-results", Integer.class).orElse(200));
@@ -64,7 +69,7 @@ public class McpServerResource {
 
     private McpServerStatus buildStatus() {
         List<McpToolInfo> toolInfos =
-                dispatcher.tools().stream().map(McpServerResource::toInfo).toList();
+                dispatcher.tools().stream().map(this::toInfo).toList();
         return new McpServerStatus(
                 state.isEnabled(),
                 state.configuredMode(),
@@ -79,9 +84,14 @@ public class McpServerResource {
                 toolInfos);
     }
 
-    private static McpToolInfo toInfo(McpTool tool) {
-        // Quarkus has no per-panel enable/read-only toggle: panelEnabled=true, panelReadOnly=false.
-        return new McpToolInfo(tool.name(), tool.description(), tool.panelId(), tool.action(), true, false);
+    private McpToolInfo toInfo(McpTool tool) {
+        return new McpToolInfo(
+                tool.name(),
+                tool.description(),
+                tool.panelId(),
+                tool.action(),
+                accessConfig.isPanelEnabled(tool.panelId()),
+                accessConfig.isPanelReadOnly(tool.panelId()));
     }
 
     private static String serverVersion() {

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessConfigTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessConfigTest.java
@@ -1,0 +1,78 @@
+package io.github.jdubois.bootui.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link QuarkusPanelAccessConfig}, pinning parity with Spring's {@code BootUiProperties}. */
+class QuarkusPanelAccessConfigTest {
+
+    @Test
+    void panelIsEnabledByDefault() {
+        QuarkusPanelAccessConfig config = new QuarkusPanelAccessConfig(StubConfig.empty());
+
+        assertThat(config.isPanelEnabled("memory")).isTrue();
+    }
+
+    @Test
+    void panelIsDisabledWhenItsEnabledFlagIsFalse() {
+        QuarkusPanelAccessConfig config =
+                new QuarkusPanelAccessConfig(new StubConfig(Map.of("bootui.panels.memory.enabled", "false")));
+
+        assertThat(config.isPanelEnabled("memory")).isFalse();
+        assertThat(config.panelDisabledReason("memory"))
+                .isEqualTo("Panel is disabled via bootui.panels.memory.enabled=false");
+    }
+
+    @Test
+    void otherPanelsStayEnabledWhenOnlyOnePanelIsDisabled() {
+        QuarkusPanelAccessConfig config =
+                new QuarkusPanelAccessConfig(new StubConfig(Map.of("bootui.panels.memory.enabled", "false")));
+
+        assertThat(config.isPanelEnabled("architecture")).isTrue();
+    }
+
+    @Test
+    void panelIsNotReadOnlyByDefault() {
+        QuarkusPanelAccessConfig config = new QuarkusPanelAccessConfig(StubConfig.empty());
+
+        assertThat(config.isPanelReadOnly("memory")).isFalse();
+    }
+
+    @Test
+    void panelIsReadOnlyWhenItsOwnReadOnlyFlagIsSet() {
+        QuarkusPanelAccessConfig config =
+                new QuarkusPanelAccessConfig(new StubConfig(Map.of("bootui.panels.memory.read-only", "true")));
+
+        assertThat(config.isPanelReadOnly("memory")).isTrue();
+        assertThat(config.panelReadOnlyReason("memory"))
+                .isEqualTo("Panel is read-only via bootui.panels.memory.read-only=true");
+    }
+
+    @Test
+    void otherPanelsStayWritableWhenOnlyOnePanelIsReadOnly() {
+        QuarkusPanelAccessConfig config =
+                new QuarkusPanelAccessConfig(new StubConfig(Map.of("bootui.panels.memory.read-only", "true")));
+
+        assertThat(config.isPanelReadOnly("architecture")).isFalse();
+    }
+
+    @Test
+    void globalReadOnlyForcesEveryPanelReadOnly() {
+        QuarkusPanelAccessConfig config =
+                new QuarkusPanelAccessConfig(new StubConfig(Map.of("bootui.read-only", "true")));
+
+        assertThat(config.isPanelReadOnly("memory")).isTrue();
+        assertThat(config.isPanelReadOnly("architecture")).isTrue();
+        assertThat(config.panelReadOnlyReason("memory")).isEqualTo("BootUI is read-only via bootui.read-only=true");
+    }
+
+    @Test
+    void globalReadOnlyReasonWinsOverPerPanelReasonWhenBothAreSet() {
+        QuarkusPanelAccessConfig config = new QuarkusPanelAccessConfig(
+                new StubConfig(Map.of("bootui.read-only", "true", "bootui.panels.memory.read-only", "true")));
+
+        assertThat(config.panelReadOnlyReason("memory")).isEqualTo("BootUI is read-only via bootui.read-only=true");
+    }
+}

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAvailabilityTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAvailabilityTest.java
@@ -244,4 +244,71 @@ class QuarkusPanelAvailabilityTest {
                 .isTrue();
         assertThat(pools.unavailableReason()).isNull();
     }
+
+    @Test
+    void panelIsEnabledByDefault() {
+        assertThat(manifestById().get(BootUiPanels.MEMORY).enabled()).isTrue();
+    }
+
+    @Test
+    void panelEnabledReflectsTheConfigDrivenPerPanelToggle() {
+        StubConfig disabled = new StubConfig(Map.of("bootui.panels.memory.enabled", "false"));
+        Map<String, PanelDto> panels = manifestById(disabled);
+
+        assertThat(panels.get(BootUiPanels.MEMORY).enabled())
+                .as("Memory is disabled via bootui.panels.memory.enabled=false")
+                .isFalse();
+        assertThat(panels.get(BootUiPanels.ARCHITECTURE).enabled())
+                .as("Other panels stay enabled")
+                .isTrue();
+    }
+
+    @Test
+    void actionCapablePanelReadOnlyReflectsTheConfigDrivenPerPanelToggle() {
+        StubConfig readOnly = new StubConfig(Map.of("bootui.panels.memory.read-only", "true"));
+        PanelDto memory = manifestById(readOnly).get(BootUiPanels.MEMORY);
+
+        assertThat(memory.readOnly()).isTrue();
+        assertThat(memory.readOnlyReason()).isEqualTo("Panel is read-only via bootui.panels.memory.read-only=true");
+    }
+
+    @Test
+    void nonActionCapablePanelIsNeverReadOnlyEvenIfItsOwnReadOnlyFlagIsSet() {
+        // Health has no action endpoints, so the per-panel read-only toggle (like Spring's PanelsController)
+        // never surfaces as readOnly=true for it.
+        StubConfig readOnly = new StubConfig(Map.of("bootui.panels.health.read-only", "true"));
+        PanelDto health = manifestById(readOnly).get(BootUiPanels.HEALTH);
+
+        assertThat(health.readOnly()).isFalse();
+        assertThat(health.readOnlyReason()).isNull();
+    }
+
+    @Test
+    void globalReadOnlyForcesEveryActionCapablePanelReadOnly() {
+        StubConfig globalReadOnly = new StubConfig(Map.of("bootui.read-only", "true"));
+        Map<String, PanelDto> panels = manifestById(globalReadOnly);
+
+        PanelDto memory = panels.get(BootUiPanels.MEMORY);
+        assertThat(memory.readOnly()).isTrue();
+        assertThat(memory.readOnlyReason()).isEqualTo("BootUI is read-only via bootui.read-only=true");
+    }
+
+    @Test
+    void globalReadOnlyDoesNotAffectNonActionCapablePanels() {
+        StubConfig globalReadOnly = new StubConfig(Map.of("bootui.read-only", "true"));
+        PanelDto health = manifestById(globalReadOnly).get(BootUiPanels.HEALTH);
+
+        assertThat(health.readOnly()).isFalse();
+        assertThat(health.readOnlyReason()).isNull();
+    }
+
+    @Test
+    void configPanelStaysInherentlyReadOnlyRegardlessOfTheNewConfigDrivenToggle() {
+        // Pre-existing, unrelated behavior: Quarkus's Configuration panel has no write path at all yet, so it
+        // must stay read-only even with no bootui.panels.config.read-only / bootui.read-only set.
+        PanelDto config = manifestById().get(BootUiPanels.CONFIG);
+        assertThat(config.readOnly()).isTrue();
+        assertThat(config.readOnlyReason())
+                .containsIgnoringCase("Runtime config overrides are not available on Quarkus");
+    }
 }

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpPanelPolicyTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpPanelPolicyTest.java
@@ -1,0 +1,61 @@
+package io.github.jdubois.bootui.quarkus.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.quarkus.QuarkusPanelAccessConfig;
+import io.github.jdubois.bootui.quarkus.StubConfig;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link QuarkusMcpPanelPolicy}, pinning that it delegates to the same
+ * {@link QuarkusPanelAccessConfig} config surface {@code QuarkusPanelAccessFilter} enforces on plain HTTP
+ * requests — mirroring the Spring adapter's {@code SpringMcpPanelPolicy} test contract.
+ */
+class QuarkusMcpPanelPolicyTest {
+
+    private static QuarkusMcpPanelPolicy policy(Map<String, String> values) {
+        return new QuarkusMcpPanelPolicy(new QuarkusPanelAccessConfig(new StubConfig(values)));
+    }
+
+    @Test
+    void toolIsEnabledByDefault() {
+        QuarkusMcpPanelPolicy policy = policy(Map.of());
+
+        assertThat(policy.isEnabled("memory")).isTrue();
+    }
+
+    @Test
+    void toolIsRefusedWhenItsBackingPanelIsDisabled() {
+        QuarkusMcpPanelPolicy policy = policy(Map.of("bootui.panels.memory.enabled", "false"));
+
+        assertThat(policy.isEnabled("memory")).isFalse();
+        assertThat(policy.disabledReason("memory"))
+                .isEqualTo("Panel is disabled via bootui.panels.memory.enabled=false");
+    }
+
+    @Test
+    void actionToolIsNotReadOnlyByDefault() {
+        QuarkusMcpPanelPolicy policy = policy(Map.of());
+
+        assertThat(policy.isReadOnly("memory")).isFalse();
+    }
+
+    @Test
+    void actionToolIsRefusedWhenItsBackingPanelIsReadOnly() {
+        QuarkusMcpPanelPolicy policy = policy(Map.of("bootui.panels.memory.read-only", "true"));
+
+        assertThat(policy.isReadOnly("memory")).isTrue();
+        assertThat(policy.readOnlyReason("memory"))
+                .isEqualTo("Panel is read-only via bootui.panels.memory.read-only=true");
+    }
+
+    @Test
+    void globalReadOnlyRefusesEveryActionTool() {
+        QuarkusMcpPanelPolicy policy = policy(Map.of("bootui.read-only", "true"));
+
+        assertThat(policy.isReadOnly("memory")).isTrue();
+        assertThat(policy.isReadOnly("architecture")).isTrue();
+        assertThat(policy.readOnlyReason("memory")).isEqualTo("BootUI is read-only via bootui.read-only=true");
+    }
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -830,7 +830,7 @@ contexts, and labels). Multiple or named datasources appear independently.
 
 The panel also exposes a confirmation-gated `update` action that applies pending change sets. It is available by default
 for trusted local sessions and is blocked by `bootui.read-only=true` or `bootui.panels.liquibase.read-only=true`
-(per-panel read-only gating is Spring-only today). The panel fails closed per database when its history cannot be read
+(enforced identically on Spring and Quarkus). The panel fails closed per database when its history cannot be read
 and degrades to a clear empty state when Liquibase is not on the classpath or no Liquibase databases are present.
 
 ![BootUI Liquibase panel](./images/bootui-liquibase.webp)

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -44,7 +44,6 @@ equivalents).
 | Key(s)                                                                       | Scope                      | Notes                                                                                                                                      |
 | ---------------------------------------------------------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `bootui.enabled`, `bootui.enabled-profiles`, `bootui.disabled-profiles`      | Spring only                | Quarkus activates by build-time launch mode.                                                                                             |
-| `bootui.panels.<id>.enabled` / `.read-only`, `bootui.read-only`              | Spring only                | Quarkus has no per-panel access filter yet; the shared localhost write-guard still applies to every mutating request.                    |
 | `bootui.force-web`, `bootui.startup.enabled`, `bootui.startup.capacity`      | Spring only                | Driven by Spring `EnvironmentPostProcessor`s with no Quarkus analogue.                                                                   |
 | `bootui.free-on-idle.enabled` / `.timeout`                                   | Spring only                | The idle-buffer-release optimization is Spring-only.                                                                                     |
 | `bootui.dev-services.restart-enabled` / `.log-tail-bytes`                    | Spring only                | Quarkus Dev Services are build-time; the panel has no log-tail or restart controls.                                                      |
@@ -69,7 +68,11 @@ default — on both adapters. This includes the safety keys (`bootui.allow-non-l
 `bootui.vulnerabilities.*` (including `osv-base-uri`, default `https://api.osv.dev`),
 `bootui.sql-trace.*`, `bootui.telemetry.*` (except `max-request-bytes`), `bootui.heap-dump.*`,
 `bootui.exceptions.*`, `bootui.security-logs.*`, `bootui.cache.*`, `bootui.mcp.*`, `bootui.ai.*`,
-`bootui.copilot.*`, and `bootui.claude-code.*` families.
+`bootui.copilot.*`, and `bootui.claude-code.*` families. It also includes the per-panel access keys —
+`bootui.panels.<id>.enabled` / `.read-only` and the global `bootui.read-only` — which are enforced on
+Quarkus by `QuarkusPanelAccessFilter` at full behavioral parity with Spring's `PanelAccessFilter` (same
+config keys, same `BootUiPanels` path resolution, same canonical JSON 403 body); see "Panel access
+settings" below.
 
 ## Global settings
 
@@ -97,6 +100,8 @@ default — on both adapters. This includes the safety keys (`bootui.allow-non-l
 | `bootui.monitoring.exclude-self` | `true`                                  | Hide BootUI's own beans, mappings, loggers, metrics, traces, and related runtime data from monitoring panels.                   |
 
 ## Panel access settings
+
+Enforced identically on Spring and Quarkus (`PanelAccessFilter` / `QuarkusPanelAccessFilter`).
 
 | Group           | Panel                     | Panel id                    | Enable property                                   | Read-only property                        |
 | --------------- | ------------------------- | --------------------------- | ------------------------------------------------- | ----------------------------------------- |

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -142,9 +142,16 @@ Small interfaces the shared engine calls; each framework implements them. Names 
 | `LocalhostGuardBinding`        | Feeds request metadata to the shared guard                           | servlet `Filter`                                            | Vert.x handler                               |
 
 The framework-neutral safety **decision** (loopback check, `Host`/allowed-hosts validation, `Origin`/`Sec-Fetch-Site`
-CSRF defense, panel access rules) is extracted into a shared `LocalhostGuard` in `bootui-engine`, reusing the existing
-`CidrRange` / `ContainerGatewayDetector` / `BootUiPanels` logic. Each framework only supplies request metadata and writes
-the deny response.
+CSRF defense) is extracted into a shared `LocalhostGuard` in `bootui-engine`, reusing the existing `CidrRange` /
+`ContainerGatewayDetector` logic. Each framework only supplies request metadata and writes the deny response.
+
+Per-panel **access** rules (`bootui.panels.<id>.enabled` / `.read-only`, plus the global `bootui.read-only`) are a
+separate, sibling mechanism — implemented on Spring as `PanelAccessFilter` and, at full behavioral parity (same config
+keys, same canonical JSON 403 body), on Quarkus as `QuarkusPanelAccessFilter`. Both bind to the same shared
+`BootUiPanels` registry to resolve a request path to a panel id and its `actionCapable()` flag, and both run as a
+second filter *after* the loopback/Host/CSRF guard (`QuarkusPanelAccessFilter` is registered at a lower Vert.x filter
+priority than `BootUiQuarkusSafetyFilter`, so a request failing both checks is rejected by the safety guard, not the
+panel-access filter).
 
 ## 5. The Quarkus panel set
 
@@ -248,6 +255,13 @@ adapters).
 - **Loopback safety preserved.** The shared `LocalhostGuard` enforces the same loopback / allowed-hosts / CSRF rules; the
   Quarkus adapter binds it as a high-priority Vert.x handler on `/bootui/*` and `/bootui/api/*`, failing closed for
   non-loopback callers — matching `LocalhostOnlyFilter`'s `Integer.MIN_VALUE` servlet ordering.
+- **Per-panel access gating at parity.** `QuarkusPanelAccessFilter` enforces `bootui.panels.<id>.enabled` /
+  `.read-only` and the global `bootui.read-only`, mirroring Spring's `PanelAccessFilter` exactly (same config keys,
+  same `BootUiPanels` path resolution, same canonical `{"error":"BootUI panel access denied","panel":"<id>",
+  "reason":"<reason>"}` JSON 403 body). It runs as a lower-priority Vert.x filter than `BootUiQuarkusSafetyFilter`, so
+  the loopback/Host/CSRF guard always evaluates first. `QuarkusPanelAvailability` and `QuarkusMcpPanelPolicy` (the MCP
+  tool gate) both read the same config, so a disabled or read-only panel is refused consistently across the REST API,
+  the `/bootui/api/panels` manifest, and the MCP bridge.
 
 ## 7. Code-sharing scorecard
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -277,9 +277,10 @@ bootui.trust-container-gateway=AUTO     # auto-trust the container gateway in de
 The [Running inside a Docker container](#running-inside-a-docker-container) guidance below applies to Quarkus too —
 use the same keys (only the Spring-specific activation note differs; on Quarkus, dev mode is already active).
 
-A few capabilities are **Spring-only today**: per-panel `bootui.panels.*` enable / read-only toggles, the
-`bootui.read-only` master switch, and runtime configuration overrides (the Configuration panel is read-only on
-Quarkus). Everything else behaves the same across both frameworks.
+A few capabilities are **Spring-only today**: runtime configuration overrides (the Configuration panel is read-only
+on Quarkus — there is no write path yet). Per-panel `bootui.panels.*` enable / read-only toggles and the
+`bootui.read-only` master switch are enforced identically on both frameworks. Everything else behaves the same across
+both frameworks.
 
 ### Which panels are available on Quarkus
 


### PR DESCRIPTION
## Summary

Closes the last major cross-adapter parity gap in BootUI's safety model: **per-panel access gating**
(`bootui.panels.<id>.enabled` / `.read-only`, plus the global `bootui.read-only`) was Spring-only —
the Quarkus adapter had no equivalent to `PanelAccessFilter`. This PR ports it at full behavioral
parity, verified by tests mirroring Spring's exact test contract (`PanelAccessFilterTests`).

## What changed

**New production code**
- `QuarkusPanelAccessFilter` — a global Vert.x route filter (priority `950`, so it always runs
  *after* `BootUiQuarkusSafetyFilter`'s loopback/Host/CSRF checks at priority `1000`) that resolves
  the request path to a `Panel` via the shared `BootUiPanels.byApiPath(...)` registry and blocks
  disabled panels (GET+POST) or a read-only panel's action requests (POST/DELETE/etc — never
  GET/HEAD/OPTIONS). Renders the same canonical
  `{"error":"BootUI panel access denied","panel":"<id>","reason":"<reason>"}` JSON 403 body Spring
  renders.
- `QuarkusPanelAccessConfig` — shared MicroProfile Config reader with the same
  `isPanelEnabled`/`isPanelReadOnly`/`panelDisabledReason`/`panelReadOnlyReason` semantics as
  Spring's `BootUiProperties`, reused by the filter, `QuarkusPanelAvailability`, and
  `QuarkusMcpPanelPolicy` so all three agree byte-for-byte and fail closed on invalid config.
- `QuarkusRootPath` — small shared helper extracted from `BootUiQuarkusSafetyFilter` for
  `quarkus.http.root-path` stripping, now reused by both filters instead of duplicating the logic.

**Wiring**
- `QuarkusPanelAvailability.toDto()` now computes `enabled`/`readOnly`/`readOnlyReason` from live
  config instead of hardcoding `enabled=true`, mirroring Spring's `PanelsController`, while
  preserving the Configuration panel's pre-existing (and unrelated) inherent read-only carve-out.
- `QuarkusMcpPanelPolicy` replaces its always-enabled/never-read-only stub with real delegation to
  `QuarkusPanelAccessConfig`, so a disabled or read-only panel's MCP tool is refused with the same
  reason a browser request would get.
- `BootUiQuarkusProcessor` registers `QuarkusPanelAccessFilter` as an unremovable CDI bean alongside
  the existing safety filter.

**Tests — 149 passing in the integration-tests reactor, 0 regressions**
- `QuarkusPanelAccessFilterTest` (14 Mockito white-box tests): enabled/disabled/read-only panels,
  all 21 real Quarkus action-capable panel endpoints blocked under global `bootui.read-only=true`
  (with a completeness self-check against `BootUiPanels.all()`), the Overview/panels-manifest
  bypass, and root-path stripping.
- `QuarkusPanelAccessFilterBootTest` / `QuarkusPanelAccessFilterRootPathBootTest` (`@QuarkusTest`,
  real HTTP): includes proof that the safety filter's rejection wins over panel gating when a
  request would fail both checks.
- `QuarkusPanelAccessConfigTest`, `QuarkusMcpPanelPolicyTest`, an extended
  `QuarkusPanelAvailabilityTest`, and `QuarkusMcpPanelPolicyBootTest` (end-to-end JSON-RPC bridge →
  dispatcher → policy → config).

**Docs**
- Updated `docs/QUARKUS-SUPPORT.md`, `docs/PROPERTIES.md`, `docs/SETUP.md`, and `docs/FEATURES.md`
  to remove now-stale "Spring only" / "no Quarkus `PanelAccessFilter` yet" claims about this gating
  layer. Panel-availability semantics in `docs/FEATURES.md` are untouched — this PR is only about
  the enable/read-only toggle layer.

## Verification

- `./mvnw -pl bootui-quarkus,bootui-quarkus-deployment,bootui-quarkus-integration-tests -am install`
  → **BUILD SUCCESS**, all 18 reactor modules green.
- `bootui-quarkus-integration-tests/base` module: **149/149 tests passed**.
- `bootui-quarkus` module's own unit tests: **110/110 tests passed**.
- `./mvnw spotless:apply` then `./mvnw spotless:check` → clean across the whole reactor.

## Scope notes

- The Configuration panel's own read-only-ness (it has no write path on Quarkus yet) is a separate,
  pre-existing gap and is out of scope here — this PR preserves that behavior as-is.
- Per-panel *availability* (which panels are live on Quarkus at all) is unrelated to this change and
  untouched.