### PR TITLE
Reduce Central-publishing checksum fanout to fit the new monthly file quota

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,15 @@
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>${central.autoPublish}</autoPublish>
                         <skip>${maven.deploy.skip}</skip>
+                        <!--
+                            Sonatype only mandates md5+sha1 checksums (sha256/sha512 are optional, see
+                            https://central.sonatype.org/publish/requirements/#provide-file-checksums). The
+                            plugin's default ("all") generates all four, roughly doubling the checksum/signature
+                            file fanout per artifact and eating into Central's new monthly file-count quota
+                            (see https://central.sonatype.org/publish/maven-central-publishing-limits/) for no
+                            validation benefit. "required" drops sha256/sha512 while staying fully compliant.
+                        -->
+                        <checksums>required</checksums>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## What does this PR do?

Configures `central-publishing-maven-plugin` to only generate the checksums Sonatype actually mandates (md5+sha1), dropping the optional sha256/sha512 files.

## Why is this change needed?

Sonatype is rolling out new Maven Central publishing limits (usage visibility since June 16 2026, rate limiting from Aug 11 2026): roughly 80 MB, 1000 files, and 7 releases per month for free accounts, evaluated as a 3-month rolling average per organization (https://central.sonatype.org/publish/maven-central-publishing-limits/).

I audited BootUI's actual published footprint per release (8 modules survive after #477's demo/test skip fix): ~174 files and ~8.3 MB. Of those 174 files, 145 (83%) are checksum/signature companions (`.asc .md5 .sha1 .sha256 .sha512` per artifact) rather than real content - and Sonatype's own requirements only mandate md5+sha1 (https://central.sonatype.org/publish/requirements/#provide-file-checksums); sha256/sha512 are optional. At 174 files/release the file-count quota alone caps us at 5 releases/month, tighter than Sonatype's flat 7-releases/month cap.

`central-publishing-maven-plugin` has a documented `checksums` option (`all` / `required` / `none`) for exactly this - `required` keeps only md5+sha1.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (not applicable - build/release plumbing only, no runtime behavior change)
- [x] Verified via `help:effective-pom -Prelease` that `bootui-core` (a publishable module) resolves `<checksums>required</checksums>` under the injected `central-publishing-maven-plugin` execution
- [x] `./mvnw validate -pl bootui-core,bootui-engine -am -Prelease` passes (confirms the pom still parses/resolves correctly)
- [ ] Added or updated tests where applicable (not applicable - no test surface for a plugin config value)

## Result

Drops published files per release from 174 to 116 (-33%), raising the achievable release cadence from 5 to 7 releases/month (Sonatype's separate 7-releases/month cap then becomes the binding constraint). GPG signing and the mandatory md5/sha1 checksums are untouched, so published artifacts remain fully Central-compliant; no functional/runtime change.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (not needed - internal release plumbing only)
- [x] Public API kept backward compatible, or a migration note added to the PR description (no API changes)
- [x] No secrets, tokens, or local paths committed