### PR TITLE
Suppress static BootUI shell in Quarkus production builds

### DIFF
--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.quarkus.deployment;
 
 import io.github.jdubois.bootui.quarkus.BootUiEngineProducer;
+import io.github.jdubois.bootui.quarkus.BootUiProdShellGuardFilter;
 import io.github.jdubois.bootui.quarkus.BootUiQuarkusSafetyFilter;
 import io.github.jdubois.bootui.quarkus.BootUiQuarkusStartupBanner;
 import io.github.jdubois.bootui.quarkus.BootUiTelemetryProducer;
@@ -93,13 +94,28 @@ import org.jboss.jandex.Type;
  * (fail-closed), matching the Spring adapter's dev/local-only activation. {@code @QuarkusTest} runs in
  * {@link LaunchMode#TEST}, so the conformance suite still exercises the wired console.</p>
  *
- * <p>The shared Vue bundle under {@code META-INF/resources/bootui/} is served by Quarkus' static-resource
- * handler regardless of launch mode; suppressing even the static shell in production is a follow-up to
- * this tracer bullet (the data-bearing {@code /bootui/api/**} endpoints are already prod-gated here). The
- * static handler only answers the directory index {@code /bootui/} (trailing slash); {@code /bootui}
- * without the trailing slash previously 404'd, so {@code QuarkusIndexResource} — a {@code @Path("/bootui")}
- * JAX-RS resource discovered from the same indexed jar and therefore gated identically to the rest of the
- * console — answers it directly instead of redirecting (see its Javadoc).</p>
+ * <p>One thing is <em>not</em> gated by that early return: the shared Vue bundle under
+ * {@code META-INF/resources/bootui/} is served by Quarkus' built-in static-resource handler regardless of
+ * launch mode — that handler is wired unconditionally by {@code quarkus-vertx-http} for any classpath
+ * resource under {@code META-INF/resources/**}, completely independently of this processor, and Quarkus
+ * offers no build-time mechanism to exclude a single path from that scan
+ * ({@code AdditionalStaticResourceBuildItem}/{@code StaticResourcesBuildItem} are additive-only). Left
+ * alone this would leave the empty SPA shell's {@code index.html}/JS/CSS reachable in production, just
+ * with no working API behind it. {@link #registerProdShellGuard} closes that gap: it registers
+ * {@code BootUiProdShellGuardFilter}, a global Vert.x route filter, via its own build step that is
+ * deliberately <strong>not</strong> gated by launch mode — the opposite polarity from every build step
+ * above, so the filter is present in {@link LaunchMode#NORMAL} too. The launch-mode decision instead lives
+ * inside the filter itself (see its Javadoc): in {@link LaunchMode#NORMAL} it answers a plain 404 for
+ * {@code /bootui} and any {@code /bootui/**} path (the static shell, {@code /bootui/api/**}, everything);
+ * in every other launch mode it is an immediate no-op pass-through, so dev/{@code @QuarkusTest} behavior is
+ * entirely unaffected. Net effect: {@code /bootui}/{@code /bootui/**} is a plain 404 in production, at
+ * parity with the Spring adapter (which never registers any BootUI route when inactive, so nothing is
+ * reachable there either).</p>
+ *
+ * <p>In dev/test, the static handler only answers the directory index {@code /bootui/} (trailing slash);
+ * {@code /bootui} without the trailing slash previously 404'd, so {@code QuarkusIndexResource} — a
+ * {@code @Path("/bootui")} JAX-RS resource discovered from the same indexed jar and therefore gated
+ * identically to the rest of the console — answers it directly instead of redirecting (see its Javadoc).</p>
  */
 class BootUiQuarkusProcessor {
 
@@ -226,6 +242,31 @@ class BootUiQuarkusProcessor {
                         BootUiQuarkusStartupBanner.class)
                 .setUnremovable()
                 .build());
+    }
+
+    /**
+     * Registers {@link BootUiProdShellGuardFilter}, the global Vert.x route filter that keeps
+     * {@code /bootui}/{@code /bootui/**} a plain 404 in production even though Quarkus' built-in
+     * static-resource handler serves the shared Vue bundle under {@code META-INF/resources/bootui/}
+     * unconditionally (see the class Javadoc for the full story). Deliberately a <strong>separate,
+     * always-on</strong> build step with no {@link LaunchModeBuildItem} parameter and no early return —
+     * the opposite polarity from {@link #registerConsole} above, which is skipped entirely in
+     * {@link LaunchMode#NORMAL}. If this bean were folded into {@code registerConsole} instead, it would be
+     * skipped in production right along with everything else, and the whole point is for it to be present
+     * there.
+     *
+     * <p>No {@link IndexDependencyBuildItem} is needed for this: unlike JAX-RS {@code @Path} resource
+     * discovery, an {@link AdditionalBeanBuildItem}'s classes are ad-hoc Jandex-indexed by Arc's own
+     * {@code BeanArchiveProcessor} regardless of whether the containing jar was separately indexed, so the
+     * filter and its {@code @Observes Filters} registration method are discovered in every launch mode from
+     * this build step alone.
+     */
+    @BuildStep
+    AdditionalBeanBuildItem registerProdShellGuard() {
+        return AdditionalBeanBuildItem.builder()
+                .addBeanClasses(BootUiProdShellGuardFilter.class)
+                .setUnremovable()
+                .build();
     }
 
     /**

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/BootUiProdShellGuardFilterTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/BootUiProdShellGuardFilterTest.java
@@ -1,0 +1,203 @@
+package io.github.jdubois.bootui.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.runtime.LaunchMode;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import java.util.Map;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+
+/**
+ * White-box binding tests for {@link BootUiProdShellGuardFilter} (hence the same package as the runtime
+ * class, even though it lives in the integration-tests module). The filter's launch-mode decision is
+ * constructor-injected rather than read from the static {@link LaunchMode#current()}, so these tests can
+ * exercise both the {@link LaunchMode#NORMAL} (production) branch and every other launch mode
+ * deterministically, without touching any process-global state — see
+ * {@code BootUiQuarkusProdShellGuardBootTest} (in the separate
+ * {@code bootui-quarkus-prod-shell-guard-integration-tests} module — not linkable from here, since a
+ * {@code QuarkusProdModeTest}-based test cannot share a module/Surefire fork with this module's
+ * {@code @QuarkusTest} classes) for the complementary real-boot proof that this actually behaves correctly
+ * in a genuine {@link LaunchMode#NORMAL} build.
+ */
+class BootUiProdShellGuardFilterTest {
+
+    // --- production: the guarded surface ------------------------------------------------------------
+
+    @Test
+    void production404sTheStaticShellRoot() {
+        RoutingContext rc = mockRequest("/bootui");
+        HttpServerResponse resp = rc.response();
+        BootUiProdShellGuardFilter filter = newFilter(Map.of(), LaunchMode.NORMAL);
+
+        filter.handle(rc);
+
+        verify(resp).setStatusCode(404);
+        verify(resp).end();
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void production404sTheStaticShellDirectoryIndex() {
+        RoutingContext rc = mockRequest("/bootui/");
+        HttpServerResponse resp = rc.response();
+        BootUiProdShellGuardFilter filter = newFilter(Map.of(), LaunchMode.NORMAL);
+
+        filter.handle(rc);
+
+        verify(resp).setStatusCode(404);
+        verify(resp).end();
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void production404sAStaticAsset() {
+        RoutingContext rc = mockRequest("/bootui/index.html");
+        HttpServerResponse resp = rc.response();
+        BootUiProdShellGuardFilter filter = newFilter(Map.of(), LaunchMode.NORMAL);
+
+        filter.handle(rc);
+
+        verify(resp).setStatusCode(404);
+        verify(resp).end();
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void production404sTheApiSurfaceTooAsDefenseInDepth() {
+        // /bootui/api/** is already unreachable in production because nothing registers it, but the guard
+        // covers it anyway (it is not scoped to only the static shell) as a defense-in-depth backstop.
+        RoutingContext rc = mockRequest("/bootui/api/overview");
+        HttpServerResponse resp = rc.response();
+        BootUiProdShellGuardFilter filter = newFilter(Map.of(), LaunchMode.NORMAL);
+
+        filter.handle(rc);
+
+        verify(resp).setStatusCode(404);
+        verify(resp).end();
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void productionDoesNotTouchLookalikePaths() {
+        RoutingContext rc = mockRequest("/bootui-other");
+        BootUiProdShellGuardFilter filter = newFilter(Map.of(), LaunchMode.NORMAL);
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    @Test
+    void productionDoesNotTouchUnrelatedPaths() {
+        RoutingContext rc = mockRequest("/other");
+        BootUiProdShellGuardFilter filter = newFilter(Map.of(), LaunchMode.NORMAL);
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    // --- dev/test: complete pass-through -------------------------------------------------------------
+
+    @Test
+    void developmentNeverTouchesTheStaticShell() {
+        RoutingContext rc = mockRequest("/bootui/");
+        BootUiProdShellGuardFilter filter = newFilter(Map.of(), LaunchMode.DEVELOPMENT);
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+        // The pass-through must be immediate: it must not even inspect the request path.
+        verify(rc, never()).normalizedPath();
+    }
+
+    @Test
+    void testLaunchModeNeverTouchesTheStaticShell() {
+        RoutingContext rc = mockRequest("/bootui/index.html");
+        BootUiProdShellGuardFilter filter = newFilter(Map.of(), LaunchMode.TEST);
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+        verify(rc, never()).normalizedPath();
+    }
+
+    // --- root-path handling --------------------------------------------------------------------------
+
+    @Test
+    void productionGuardsTheShellUnderANonDefaultRootPath() {
+        // Under quarkus.http.root-path=/app the shell is served at /app/bootui/**; the guard must strip
+        // the prefix and still 404 it (fail-open regression guard, mirroring BootUiQuarkusSafetyFilter).
+        RoutingContext rc = mockRequest("/app/bootui/index.html");
+        HttpServerResponse resp = rc.response();
+        BootUiProdShellGuardFilter filter = newFilter(Map.of("quarkus.http.root-path", "/app"), LaunchMode.NORMAL);
+
+        filter.handle(rc);
+
+        verify(resp).setStatusCode(404);
+        verify(rc, never()).next();
+    }
+
+    @Test
+    void productionIgnoresNonShellPathsUnderANonDefaultRootPath() {
+        RoutingContext rc = mockRequest("/app/other");
+        BootUiProdShellGuardFilter filter = newFilter(Map.of("quarkus.http.root-path", "/app"), LaunchMode.NORMAL);
+
+        filter.handle(rc);
+
+        verify(rc).next();
+        verify(rc.response(), never()).setStatusCode(anyInt());
+    }
+
+    // --- isBootUiPath scope ----------------------------------------------------------------------------
+
+    @Test
+    void scopeCoversTheWholeBootuiSurfaceButNotLookalikePaths() {
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath("/bootui")).isTrue();
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath("/bootui/")).isTrue();
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath("/bootui/index.html"))
+                .isTrue();
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath("/bootui/api/overview"))
+                .isTrue();
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath("/bootui-other")).isFalse();
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath("/bootuixyz")).isFalse();
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath("/other")).isFalse();
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath("/")).isFalse();
+        assertThat(BootUiProdShellGuardFilter.isBootUiPath(null)).isFalse();
+    }
+
+    // --- helpers ---------------------------------------------------------------------------------------
+
+    private static BootUiProdShellGuardFilter newFilter(Map<String, String> properties, LaunchMode launchMode) {
+        return new BootUiProdShellGuardFilter(configOf(properties), launchMode);
+    }
+
+    private static Config configOf(Map<String, String> properties) {
+        return new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(properties, "test", 100))
+                .build();
+    }
+
+    private static RoutingContext mockRequest(String path) {
+        HttpServerResponse response = mock(HttpServerResponse.class, RETURNS_SELF);
+
+        RoutingContext rc = mock(RoutingContext.class);
+        when(rc.normalizedPath()).thenReturn(path);
+        when(rc.response()).thenReturn(response);
+        return rc;
+    }
+}

--- a/bootui-quarkus-integration-tests/pom.xml
+++ b/bootui-quarkus-integration-tests/pom.xml
@@ -17,7 +17,10 @@
         extension set on its classpath to prove BootUI panel light-up in isolation: the base module deliberately
         has no optional extensions (everything fails closed), and each per-extension module adds exactly one
         (otel, health, micrometer, scheduler, cache, flyway, liquibase, datasource). The Hibernate module also
-        lives here but is wired into the reactor only on a Hibernate-capable JDK (see the root pom profile).</description>
+        lives here but is wired into the reactor only on a Hibernate-capable JDK (see the root pom profile).
+        prod-shell-guard is different in kind, not in extension set: it holds the one test that boots a genuine
+        LaunchMode.NORMAL artifact via QuarkusProdModeTest, kept out of every other module because Quarkus
+        refuses to mix that mechanism with @QuarkusTest in the same Surefire fork.</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -34,5 +37,6 @@
         <module>flyway</module>
         <module>liquibase</module>
         <module>datasource</module>
+        <module>prod-shell-guard</module>
     </modules>
 </project>

--- a/bootui-quarkus-integration-tests/prod-shell-guard/pom.xml
+++ b/bootui-quarkus-integration-tests/prod-shell-guard/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.julien-dubois.bootui</groupId>
+        <artifactId>bootui-parent</artifactId>
+        <version>1.8.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>bootui-quarkus-prod-shell-guard-integration-tests</artifactId>
+    <name>BootUI :: Quarkus Extension (Prod Shell Guard Integration Tests)</name>
+    <description>Holds the one test in the whole bootui-quarkus-integration-tests reactor that boots a genuine
+        LaunchMode.NORMAL (production) artifact via QuarkusProdModeTest, proving BootUiProdShellGuardFilter
+        actually 404s /bootui and /bootui/** in a real production process (not just LaunchMode.TEST, which is
+        all every @QuarkusTest elsewhere in this reactor can exercise). Kept in its own module/JVM fork on
+        purpose: Quarkus's own test-framework ExclusivityChecker throws IllegalStateException if a
+        QuarkusProdModeTest and a @QuarkusTest run in the same JUnit Platform launcher session (i.e. the same
+        Surefire fork), so this test cannot live alongside base's (or any other submodule's) @QuarkusTest
+        classes. Never published.</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
+             quarkus-vertx-http transitively, so QuarkusProdModeTest's packaged artifact serves /bootui/ and
+             /bootui/api/** with no extra deps, exactly as a real host application would. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- The shared, framework-neutral HTTP probe used to assert the production process's responses. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-conformance</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- QuarkusProdModeTest/ProdModeTestResults: the standard Quarkus extension-author mechanism for
+             building and (optionally) running a REAL production-mode (LaunchMode.NORMAL) artifact from a
+             JUnit5 test. Transitively brings junit-jupiter-api/params/engine and shrinkwrap-depchain, so no
+             separate JUnit Jupiter or quarkus-junit5 dependency is needed here (this module deliberately has
+             no @QuarkusTest classes at all - see the class-level Javadoc on the exclusivity constraint). Note
+             the artifactId: this Quarkus version relocated it from quarkus-junit5-internal. -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+              Install the JBoss LogManager as the JVM's java.util.logging LogManager for the test fork.
+              QuarkusProdModeTest's own static initializer requires this (it casts the root
+              java.util.logging.Logger to org.jboss.logmanager.Logger), so this is not optional here the way
+              it might be for a plain @QuarkusTest module.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/bootui-quarkus-integration-tests/prod-shell-guard/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusProdShellGuardBootTest.java
+++ b/bootui-quarkus-integration-tests/prod-shell-guard/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusProdShellGuardBootTest.java
@@ -1,0 +1,96 @@
+package io.github.jdubois.bootui.quarkus.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import io.quarkus.test.QuarkusProdModeTest;
+import java.util.Map;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Runs in a genuine {@link io.quarkus.runtime.LaunchMode#NORMAL} (production) process rather than
+ * {@code LaunchMode.TEST} — every {@code @QuarkusTest} elsewhere in the {@code bootui-quarkus-integration-tests}
+ * reactor can only exercise {@code LaunchMode.TEST}. {@link QuarkusProdModeTest} is the standard Quarkus
+ * extension-author mechanism for exactly this: it builds a real production artifact (using this module's own
+ * resolved dependencies, so {@code bootui-quarkus}/{@code bootui-ui} are included automatically, exactly as
+ * they would be for a real host application) and, with {@code setRun(true)}, launches it as a real
+ * {@code java -jar} subprocess, waiting for the "Installed features" startup line before handing control back
+ * to the test.
+ *
+ * <p>This proves the fix end-to-end: without {@code BootUiProdShellGuardFilter}, {@code GET /bootui/} in this
+ * exact setup would return {@code 200} with the shared Vue shell's {@code index.html} (that <em>is</em> what
+ * {@code BootUiQuarkusTracerBulletSmokeTest} asserts happens under {@code LaunchMode.TEST}, and the static
+ * handler serving it is wired identically in production — that is the whole bug). Here, in a real
+ * {@code LaunchMode.NORMAL} process, it must be a plain {@code 404} instead.
+ *
+ * <p><b>Why this class lives in its own module.</b> Quarkus's test framework tracks which test mechanism is in
+ * use per JUnit Platform launcher session (i.e. per Surefire fork) and refuses to mix them:
+ * {@code io.quarkus.test.ExclusivityChecker} throws {@code IllegalStateException} if a
+ * {@code QuarkusTestExtension}-based test ({@code @QuarkusTest}, used throughout {@code base} and every other
+ * sibling module) and a {@link QuarkusProdModeTest}-based test run in the same JVM. So this class cannot live
+ * alongside {@code base}'s {@code @QuarkusTest} classes — {@code bootui-quarkus-prod-shell-guard-integration-tests}
+ * exists solely to give it an isolated Surefire fork.
+ *
+ * <p>Runs on a dedicated port ({@value #PORT}) rather than the default {@code 8081} to avoid any ambiguity with
+ * the port other modules' {@code @QuarkusTest}s bind to. A minimal {@code application.properties} is supplied
+ * explicitly via {@link StringAsset} (naming the app) so the build is self-contained and not dependent on any
+ * incidental classpath resource.
+ */
+class BootUiQuarkusProdShellGuardBootTest {
+
+    private static final int PORT = 8083;
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot(jar -> jar.add(
+                    new StringAsset("quarkus.application.name=bootui-quarkus-prod-shell-guard-it\n"),
+                    "application.properties"))
+            .setApplicationName("bootui-quarkus-prod-shell-guard-it")
+            .setRuntimeProperties(Map.of("quarkus.http.port", String.valueOf(PORT)))
+            .setRun(true);
+
+    private BootUiHttpProbe probe() {
+        return new BootUiHttpProbe("http://localhost:" + PORT);
+    }
+
+    @Test
+    void productionShellDirectoryIndexIs404() {
+        Response response = probe().get("/bootui/");
+        assertThat(response.status())
+                .as("GET /bootui/ must be a plain 404 in production, not the static shell's index.html")
+                .isEqualTo(404);
+    }
+
+    @Test
+    void productionShellNoTrailingSlashIs404() {
+        // Also proves QuarkusIndexResource (the dev/test /bootui-without-trailing-slash JAX-RS resource) is
+        // correctly absent here: it is only ever discovered by the launch-mode-gated registerConsole build
+        // step, so there is nothing for the guard filter to be "backing up" on this path in production.
+        Response response = probe().get("/bootui");
+        assertThat(response.status())
+                .as("GET /bootui (no trailing slash) must be a plain 404 in production")
+                .isEqualTo(404);
+    }
+
+    @Test
+    void productionStaticAssetIs404() {
+        Response response = probe().get("/bootui/index.html");
+        assertThat(response.status())
+                .as("GET /bootui/index.html must be a plain 404 in production, not the shell asset")
+                .isEqualTo(404);
+    }
+
+    @Test
+    void productionApiSurfaceIs404() {
+        // Already unreachable in production because nothing registers it (registerConsole is skipped
+        // entirely), but asserted here too so this test pins the guard's full-surface coverage, not just
+        // the static-shell gap it was written to close.
+        Response response = probe().get("/bootui/api/overview");
+        assertThat(response.status())
+                .as("GET /bootui/api/overview must be a plain 404 in production")
+                .isEqualTo(404);
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiProdShellGuardFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiProdShellGuardFilter.java
@@ -1,0 +1,114 @@
+package io.github.jdubois.bootui.quarkus;
+
+import io.quarkus.runtime.LaunchMode;
+import io.quarkus.vertx.http.runtime.filters.Filters;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.Config;
+
+/**
+ * Keeps the whole {@code /bootui} surface dark in production, including the parts that are reachable for
+ * reasons {@link BootUiQuarkusSafetyFilter} and {@link QuarkusPanelAccessFilter} cannot fix: those two
+ * (like the rest of the console) are only wired in dev/test, and the data-bearing {@code /bootui/api/**}
+ * endpoints are already unreachable in {@link LaunchMode#NORMAL} simply because nothing registers them —
+ * but the shared Vue bundle under {@code META-INF/resources/bootui/} is still served by Quarkus'
+ * <strong>built-in</strong> static-resource handler regardless of launch mode. That handler is wired
+ * unconditionally by {@code quarkus-vertx-http} for any classpath resource under
+ * {@code META-INF/resources/**}, completely independently of this extension's own build steps, and
+ * Quarkus offers no build-time mechanism to exclude a single path from it (see
+ * {@code BootUiQuarkusProcessor}'s class Javadoc for the full investigation). Left alone, that would leave
+ * the empty SPA shell's {@code index.html}/JS/CSS reachable in production, just with no working API behind
+ * it — this filter is what turns that into a plain 404, at parity with the Spring adapter (which never
+ * registers any BootUI route when inactive, so nothing is reachable there either).
+ *
+ * <p>This bean is registered by its own, deliberately <strong>always-on</strong> build step
+ * ({@code BootUiQuarkusProcessor#registerProdShellGuard}) — unlike every other BootUI bean/resource, which
+ * is only wired in dev/test. The launch-mode decision is made once, at construction, from the
+ * CDI-injected {@link LaunchMode} (Quarkus' own {@code LaunchModeProducer} always provides this, in every
+ * launch mode) and stored in {@link #launchMode}; {@link #handle} is an immediate no-op pass-through
+ * whenever that is not {@link LaunchMode#NORMAL}, so dev/{@code @QuarkusTest} behavior (including the
+ * shell being served, and everything the shared conformance suite exercises) is entirely unaffected. This
+ * single, easy-to-audit check is the reason the security decision lives inside the filter rather than in a
+ * build-time gate: it cannot be defeated by accidentally getting a build step's launch-mode polarity
+ * backwards, since there is no alternate polarity here at all — the bean is unconditionally present, and
+ * only its runtime behavior changes.
+ *
+ * <p>Registered as a global Vert.x HTTP route filter (via the {@link Filters} event), exactly like
+ * {@link BootUiQuarkusSafetyFilter}, so it runs before route dispatch — including before Quarkus' static-
+ * resource route — for every request, in every launch mode. The {@code quarkus.http.root-path} prefix is
+ * stripped before matching (shared {@link QuarkusRootPath} helper), so a host application running under a
+ * non-default root-path is still fully covered in production.
+ */
+@ApplicationScoped
+public class BootUiProdShellGuardFilter {
+
+    private static final String BASE_PATH = "/bootui";
+
+    /**
+     * Run early, before route dispatch (including the static-resource route), matching
+     * {@link BootUiQuarkusSafetyFilter}'s priority. The exact value relative to the other BootUI filters
+     * does not matter: this filter only ever does meaningful work in {@link LaunchMode#NORMAL}, where
+     * {@link BootUiQuarkusSafetyFilter} and {@link QuarkusPanelAccessFilter} are never wired at all, and in
+     * every other launch mode this filter is an immediate pass-through.
+     */
+    private static final int PRIORITY = 1000;
+
+    private final Config config;
+    private final LaunchMode launchMode;
+
+    @Inject
+    public BootUiProdShellGuardFilter(Config config, LaunchMode launchMode) {
+        this.config = config;
+        this.launchMode = launchMode;
+    }
+
+    public void register(@Observes Filters filters) {
+        filters.register(this::handle, PRIORITY);
+    }
+
+    void handle(RoutingContext rc) {
+        if (launchMode != LaunchMode.NORMAL) {
+            // Dev/test: the console is meant to be fully reachable, so never touch the request.
+            rc.next();
+            return;
+        }
+
+        String path = rc.normalizedPath();
+        // Cheap pre-check: unlike BootUiQuarkusSafetyFilter (which is prod-dark), this filter is active
+        // for every request in production, so avoid the root-path-aware Config lookup below for the vast
+        // majority of unrelated requests. A path that cannot possibly contain the console under any
+        // root-path prefix is let through immediately; a false positive here just falls through to the
+        // precise check, which is always correct.
+        if (path == null || !path.contains(BASE_PATH)) {
+            rc.next();
+            return;
+        }
+
+        String relativePath = QuarkusRootPath.stripPrefix(path, QuarkusRootPath.normalize(rootPath()));
+        if (isBootUiPath(relativePath)) {
+            rc.response().setStatusCode(404).end();
+            return;
+        }
+        rc.next();
+    }
+
+    /**
+     * Returns {@code true} for the whole BootUI surface — the static shell and {@code /bootui/api/**}
+     * alike — using the same strict boundary check as {@link BootUiQuarkusSafetyFilter#isBootUiRequest}
+     * (an exact match or a {@code /}-delimited sub-path), so a lookalike path such as {@code /bootui-other}
+     * is left alone.
+     */
+    static boolean isBootUiPath(String path) {
+        if (path == null) {
+            return false;
+        }
+        return path.equals(BASE_PATH) || path.startsWith(BASE_PATH + "/");
+    }
+
+    private String rootPath() {
+        return config.getOptionalValue(QuarkusRootPath.ROOT_PATH_KEY, String.class)
+                .orElse("/");
+    }
+}

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -267,6 +267,24 @@ adapters).
 - **Dev-mode-only extension.** The `bootui-quarkus-deployment` module registers BootUI's routes and beans **only in dev
   mode** via `@BuildStep`. This is the natural Quarkus analogue of BootUI's "active only in `dev`/`local`, fail closed"
   rule, and it means BootUI is simply absent from production/native builds.
+- **The static shell is dark in production too, not just the API.** The launch-mode-gated `@BuildStep`s above stop
+  BootUI's own CDI beans/JAX-RS resources from being wired in `LaunchMode.NORMAL`, but the compiled Vue bundle at
+  `META-INF/resources/bootui/` used to remain reachable regardless: Quarkus' built-in static-resource handler serves any
+  classpath resource under `META-INF/resources/**` unconditionally, wired by `quarkus-vertx-http` independently of this
+  extension's build steps, and Quarkus offers no build-time mechanism to exclude a single path from that scan. Left
+  alone, a production deployment would still answer `GET /bootui/` with the empty SPA shell's `index.html`/JS/CSS — no
+  working API behind it, but reachable. `BootUiProdShellGuardFilter` closes this: a CDI Vert.x filter registered by its
+  own **always-on** `@BuildStep` (deliberately *not* launch-mode-gated, the opposite polarity from every other build
+  step in the extension), whose `handle()` method reads a CDI-injected `LaunchMode` and answers a plain `404` for
+  `/bootui`/`/bootui/**` only when it is `LaunchMode.NORMAL` — an immediate no-op pass-through otherwise, so
+  dev/`@QuarkusTest` behavior is unaffected. Net effect: `/bootui`/`/bootui/**` is a plain 404 in production, at parity
+  with the Spring adapter (which never registers any BootUI route when inactive, so nothing is reachable there either).
+  Proven by a genuine `LaunchMode.NORMAL` build+run via `QuarkusProdModeTest`
+  (`BootUiQuarkusProdShellGuardBootTest`, in the dedicated `bootui-quarkus-prod-shell-guard-integration-tests`
+  module — kept separate from every `@QuarkusTest`-based module because Quarkus's own test framework refuses to mix
+  `QuarkusProdModeTest` and `@QuarkusTest` in the same Surefire fork), alongside a white-box unit suite
+  (`BootUiProdShellGuardFilterTest`, in `bootui-quarkus-integration-tests`) — see `BootUiQuarkusProcessor`'s class
+  Javadoc for the full investigation.
 - **Native is therefore a non-issue.** Quarkus dev mode always runs on the JVM, so the bytecode-scanning advisors,
   classpath Maven metadata (`Vulnerabilities`), and JVM MXBeans all work exactly as on Spring. The native-image
   limitations (no runtime classpath scan, stripped metadata) only apply to production native images, which BootUI never


### PR DESCRIPTION
## Root cause

In `LaunchMode.NORMAL` the Quarkus adapter already keeps `/bootui/api/**` fully dark — `BootUiQuarkusProcessor`'s launch-mode-gated `@BuildStep`s skip wiring any CDI beans or JAX-RS resources entirely. But the compiled Vue shell at `META-INF/resources/bootui/**` was still served in production: Quarkus' built-in static-resource handler is wired **unconditionally** by `quarkus-vertx-http` for any classpath resource under `META-INF/resources/**`, completely independent of this extension's build steps. Quarkus has no build-time mechanism to exclude a single path from that scan (`AdditionalStaticResourceBuildItem`/`StaticResourcesBuildItem` are additive-only — confirmed by reading the 3.33.2.1 sources).

So a production deployment would answer `GET /bootui/` with the empty SPA shell's `index.html`/JS/CSS — no working API behind it, but reachable. This was a real fail-closed asymmetry with the Spring adapter, which never registers any BootUI route when inactive, so nothing is reachable there either.

`QuarkusIndexResource` (the `/bootui` no-trailing-slash JAX-RS handler) was verified to **already** be correctly prod-gated, both by inspection (it's only produced from inside the launch-mode-gated `registerConsole` build step) and empirically via a negative-control run (see below) — no change needed there.

## Fix

`BootUiProdShellGuardFilter` — a global Vert.x route filter registered by its own **always-on** `@BuildStep` (`registerProdShellGuard`), deliberately **not** launch-mode-gated (the opposite polarity from every other build step in this extension). It constructor-injects Quarkus' own `LaunchMode` (CDI-available in every launch mode via `LaunchModeProducer`) and is an immediate `rc.next()` pass-through unless `launchMode == LaunchMode.NORMAL`, in which case it answers a plain 404 for `/bootui` and any `/bootui/**` path.

The key enabler: an `AdditionalBeanBuildItem`'s classes are ad-hoc Jandex-indexed by Arc's own `BeanArchiveProcessor` regardless of `IndexDependencyBuildItem`, so a new, always-on build step can wire this CDI bean correctly even in `LaunchMode.NORMAL` — the "CDI is gated in production" premise only held for `registerConsole`'s own implementation, not as an inherent Arc limitation.

## Testing

- **`BootUiProdShellGuardFilterTest`** (11 tests, white-box, mocked `Config`/`LaunchMode`): production 404 coverage (shell root, directory index, static asset, API surface as defense-in-depth), lookalike/unrelated path pass-through, complete dev/test pass-through (asserts `normalizedPath()` is never even called), root-path-aware matching under a non-default `quarkus.http.root-path`.
- **`BootUiQuarkusProdShellGuardBootTest`** (4 tests): a genuine `LaunchMode.NORMAL` build+run via Quarkus' own `QuarkusProdModeTest` — builds a real production artifact from this module's resolved dependencies and launches it as an actual `java -jar` subprocess, then asserts 404 for `/bootui/`, `/bootui`, `/bootui/index.html`, `/bootui/api/overview` over real HTTP.
- **This test needed its own new module**, `bootui-quarkus-prod-shell-guard-integration-tests`: Quarkus' `ExclusivityChecker` throws `IllegalStateException` if a `QuarkusProdModeTest`-based test and a `@QuarkusTest`-based test run in the same JUnit Platform launcher session (i.e. the same Surefire fork) — and every other submodule here is `@QuarkusTest`-based. I discovered this the hard way: my first full-reactor run failed with exactly that error until I split the test into its own module (matching the reactor's existing per-concern-module convention).
- **Negative control** (the most convincing evidence the tests are meaningful, not just trivially green): I temporarily disabled `registerProdShellGuard`, rebuilt, and reran the prod-mode test. Result: 2 of 4 tests failed with `expected: 404 but was: 200` for `/bootui/` and `/bootui/index.html`, while `/bootui` (no trailing slash) and `/bootui/api/overview` still correctly 404'd — independently confirming `QuarkusIndexResource` and the absent API routes really are already prod-gated on their own. I then restored the fix and reconfirmed all green.

### Full verification run (this change)

```
./mvnw -Dmaven.repo.local=.m2 -pl bootui-quarkus,bootui-quarkus-deployment -am install
→ BUILD SUCCESS (110 + 8 tests, plus bootui-core/-engine/-ui as dependencies)

cd bootui-quarkus-integration-tests && ../mvnw -Dmaven.repo.local=../.m2 test
→ BUILD SUCCESS across all 12 modules (base, otel, health, micrometer, scheduler,
  security, cache, flyway, liquibase, datasource, prod-shell-guard) — zero regressions

./mvnw -Dmaven.repo.local=.m2 spotless:apply && spotless:check
→ clean, BUILD SUCCESS
```

(`-Dmaven.repo.local` used per this repo's own "Isolating parallel worktrees" convention, since several sibling sessions are building the same reactor version in parallel.)

## Docs

- `BootUiQuarkusProcessor`'s class Javadoc rewritten to describe the resolved gap (previously listed as a known follow-up).
- `docs/QUARKUS-SUPPORT.md`'s "Activation & safety on Quarkus" section gained a bullet documenting the bug, the fix, and the new tests.

## Scope note

This PR addresses only the production static-shell-suppression gap. It was delegated from a coordinator session running several sibling sessions in parallel on other, non-overlapping Quarkus/Spring parity gaps.