### PR TITLE
Add dedicated Playwright e2e depth for 17 Quarkus panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,8 @@ dist/
 # Local env
 .env
 *.env.local
+
+# Per-worktree Maven repo-local override (see docs on isolating parallel worktrees)
+/.mvn/maven.config
 /bootui-spring-sample-app/Dockerfile-native
 /bootui-spring-sample-app/src/main/resources/META-INF/native-image/com.julien-dubois.bootui/bootui-spring-sample-app/reachability-metadata.json

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -107,7 +107,12 @@ class BootUiQuarkusProcessor {
 
     // BootUI's own resources are filtered out of the captured Mappings inventory by package and by path,
     // mirroring the Spring BootUiSelfDataFilter (which inspects the handler class and the request path).
-    private static final String BOOTUI_PACKAGE_PREFIX = "io.github.jdubois.bootui";
+    // Scoped to the Quarkus adapter's own JAX-RS resource package (`...quarkus.web`), not the whole
+    // `io.github.jdubois.bootui` root: a bare root-package prefix would also swallow any application code
+    // that happens to be packaged under that root (for example a sample/demo app using
+    // `io.github.jdubois.bootui.sample`), exactly the boundary the shared engine `InternalPackageMatcher`
+    // already draws for the Quarkus adapter (`io.github.jdubois.bootui.quarkus` + `...core`).
+    private static final String BOOTUI_PACKAGE_PREFIX = "io.github.jdubois.bootui.quarkus";
     private static final String BOOTUI_PATH_PREFIX = "/bootui";
 
     // Referenced by class name only: this is the sole OpenTelemetry-importing type in the extension, and
@@ -954,7 +959,7 @@ class BootUiQuarkusProcessor {
             }
             ClassInfo resource = pathAnnotation.target().asClass();
             String resourceClass = resource.name().toString();
-            if (resourceClass.startsWith(BOOTUI_PACKAGE_PREFIX)) {
+            if (resourceClass.equals(BOOTUI_PACKAGE_PREFIX) || resourceClass.startsWith(BOOTUI_PACKAGE_PREFIX + ".")) {
                 continue; // BootUI's own resources, identified by their package (mirrors the Spring filter)
             }
             String classPath = annotationString(pathAnnotation);

--- a/bootui-quarkus-sample-app/e2e/tests/activity.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/activity.spec.js
@@ -1,0 +1,181 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+/**
+ * Live Activity (Quarkus).
+ *
+ * Quarkus has no per-request profile drawer (`profileable` is always `false` — the `/activity/request/{id}`
+ * drill-down endpoint is Spring-only; see `LiveActivityAssembler`), so the "exact"/"approximate" correlation
+ * badges, the drawer itself, Escape-to-close and "Copy profile" from the Spring spec do not port here. What
+ * IS real and load-bearing on Quarkus: the merged feed, OpenTelemetry-trace-id-based nesting/correlation,
+ * KPI deep-links, and — the reason this spec exists — a regression guard for the bug fixed in #492.
+ *
+ * That bug: a Quarkus-captured exception's `method`/`path` were deterministically `null`. Root cause:
+ * `ExceptionStore` dedups by throwable identity across the whole cause chain, keeping only the first
+ * feeder's context. `QuarkusErrorHandler` logs an unhandled failure synchronously, before the response is
+ * finalized and before `QuarkusExceptionCaptureFilter`'s `addBodyEndHandler` callback ever runs, so the
+ * no-HTTP-context log-handler capture always won the dedup race against the filter's full-context (but too
+ * late) capture. It went unnoticed because no dedicated spec exercised this panel's real data. The second
+ * test below asserts the exact wire shape the fix guarantees, not just that the page renders.
+ */
+test.describe('Live Activity view (Quarkus)', () => {
+  test('merges requests, SQL and exceptions into one live stream', async ({openView, page}) => {
+    // product-search always runs SQL (unlike the cached products endpoint), so the merged feed
+    // reliably has a SQL entry to assert on alongside the request/exception entries.
+    const search = await page.request.get('/api/sample/product-search')
+    expect(search.ok()).toBeTruthy()
+    const boom = await page.request.get('/api/sample/boom')
+    expect(boom.status()).toBe(500)
+
+    await openView('activity', 'Live Activity')
+
+    const table = page.locator('.activity-table')
+    await expect(table).toContainText('/api/sample/product-search', {timeout: 15_000})
+    await expect(table).toContainText('REQUEST')
+    await expect(table).toContainText('SQL')
+    // The failing request shows up as an error-severity row.
+    await expect(table.locator('tbody tr.table-danger').first()).toBeVisible()
+  })
+
+  test('captures the failing request with its real method and path, not null placeholders', async ({
+    openView,
+    page
+  }) => {
+    const boom = await page.request.get('/api/sample/boom')
+    expect(boom.status()).toBe(500)
+
+    await openView('activity', 'Live Activity')
+
+    // What a developer actually sees: the request row's summary embeds the real method + path.
+    const requestRow = page.locator('.activity-table tbody tr', {hasText: '/api/sample/boom'}).first()
+    await expect(requestRow).toBeVisible({timeout: 15_000})
+    await expect(requestRow).toContainText('GET /api/sample/boom')
+
+    // Regression coverage for #492: assert the underlying wire data the UI binds to directly, so a
+    // future regression is caught even if it stops being visibly obvious in the merged row's text.
+    const activity = await page.request.get('/bootui/api/activity')
+    expect(activity.ok()).toBeTruthy()
+    const body = await activity.json()
+
+    const request = body.entries.find((e) => e.type === 'REQUEST' && e.path === '/api/sample/boom')
+    expect(request, 'the /api/sample/boom call must surface as a REQUEST entry').toBeTruthy()
+    expect(request.correlationId, 'OpenTelemetry is enabled, so the request must carry a trace id').toBeTruthy()
+
+    const exception = body.entries.find((e) => e.type === 'EXCEPTION')
+    expect(exception, 'the thrown failure must surface as an EXCEPTION entry').toBeTruthy()
+    expect(exception.method, 'regression #492: the exception must carry its owning request method, not null').toBe(
+      'GET'
+    )
+    expect(exception.path, 'regression #492: the exception must carry its owning request path, not null').toBe(
+      '/api/sample/boom'
+    )
+    expect(exception.parentId, 'the exception must nest under the request it belongs to').toBe(request.id)
+  })
+
+  test('nests the correlated exception under its owning request row', async ({openView, page}) => {
+    const boom = await page.request.get('/api/sample/boom')
+    expect(boom.status()).toBe(500)
+
+    await openView('activity', 'Live Activity')
+
+    const requestRow = page.locator('.activity-table tbody tr', {hasText: '/api/sample/boom'}).first()
+    await expect(requestRow).toBeVisible({timeout: 15_000})
+
+    // The request row carries a disclosure control because the correlated exception is nested under
+    // it (via the shared OpenTelemetry trace id), expanded by default.
+    const disclosure = requestRow.locator('.activity-disclosure')
+    await expect(disclosure).toBeVisible()
+    await expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+
+    // The exception appears as an indented child row rather than a flat sibling.
+    const childRows = page.locator('.activity-table tbody tr.activity-child-row')
+    await expect(childRows.filter({hasText: 'IllegalStateException'}).first()).toBeVisible({timeout: 15_000})
+
+    // Collapsing the request folds its children away.
+    await disclosure.click()
+    await expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  test('marks an authenticated request with a lock and the principal tag', async ({openView, page}) => {
+    // QuarkusHttpExchangeCaptureFilter resolves the principal straight off the request's own
+    // SecurityIdentity, so this works without relying on trace-based security-event correlation.
+    const secure = await page.request.get('/api/secure/products', {
+      headers: {Authorization: 'Basic ' + Buffer.from('admin:admin').toString('base64')}
+    })
+    expect(secure.ok()).toBeTruthy()
+
+    await openView('activity', 'Live Activity')
+
+    const secureRow = page.locator('.activity-table tbody tr', {hasText: '/api/secure/products'}).first()
+    await expect(secureRow).toBeVisible({timeout: 15_000})
+
+    await expect(secureRow.locator('i.bi-lock-fill')).toBeVisible()
+    await expect(secureRow.locator('.activity-principal-tag')).toContainText('admin')
+  })
+
+  test('pauses and resumes the live feed', async ({openView, page}) => {
+    await openView('activity', 'Live Activity')
+
+    const pauseButton = page.getByRole('button', {name: /Pause/})
+    await expect(pauseButton).toBeVisible()
+    await pauseButton.click()
+    await expect(page.getByRole('button', {name: /Resume/})).toBeVisible()
+  })
+
+  test('filters to errors only and persists the choice across a reload', async ({openView, page}) => {
+    await page.request.get('/api/sample/product-search')
+    const boom = await page.request.get('/api/sample/boom')
+    expect(boom.status()).toBe(500)
+
+    await openView('activity', 'Live Activity')
+    await expect(page.locator('.activity-table tbody tr').first()).toBeVisible({timeout: 15_000})
+
+    const errorsOnly = page.locator('#activity-errors-only')
+    await errorsOnly.check()
+    // Every visible severity badge is now ERROR.
+    const badges = page.locator('.activity-table tbody tr td .badge.text-bg-danger')
+    await expect(badges.first()).toBeVisible()
+
+    await page.reload()
+    await expect(page.locator('#activity-errors-only')).toBeChecked()
+  })
+
+  test('deep-links a request row to the HTTP Exchanges panel', async ({openView, page}) => {
+    await page.request.get('/api/sample/products')
+
+    await openView('activity', 'Live Activity')
+    const productsRow = page.locator('.activity-table tbody tr', {hasText: '/api/sample/products'}).first()
+    await expect(productsRow).toBeVisible({timeout: 15_000})
+
+    await productsRow.getByTitle('Open in HTTP Exchanges').click()
+
+    await expect(page.getByRole('heading', {name: 'HTTP Exchanges'})).toBeVisible()
+    await expect(page).toHaveURL(/\/http-exchanges/)
+  })
+
+  test('links KPI cards to their dedicated panels', async ({openView, page}) => {
+    await page.request.get('/api/sample/products')
+
+    await openView('activity', 'Live Activity')
+    const kpis = page.locator('.activity-kpis')
+    await expect(kpis).toBeVisible({timeout: 15_000})
+
+    await kpis.getByTitle('Open the Health panel').click()
+    await expect(page).toHaveURL(/\/health/)
+
+    await openView('activity', 'Live Activity')
+    await page.locator('.activity-kpis').getByTitle('Open the Exceptions panel').click()
+    await expect(page).toHaveURL(/\/exceptions/)
+
+    await openView('activity', 'Live Activity')
+    await page.locator('.activity-kpis').getByTitle('Open the Heap Dump panel').click()
+    await expect(page).toHaveURL(/\/heap-dump/)
+
+    await openView('activity', 'Live Activity')
+    await page
+      .locator('.activity-kpis')
+      .getByTitle(/in HTTP Exchanges$/)
+      .click()
+    await expect(page).toHaveURL(/\/http-exchanges\?q=/)
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/activity.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/activity.spec.js
@@ -4,11 +4,17 @@ import {expect, test} from './fixtures.js'
 /**
  * Live Activity (Quarkus).
  *
- * Quarkus has no per-request profile drawer (`profileable` is always `false` — the `/activity/request/{id}`
- * drill-down endpoint is Spring-only; see `LiveActivityAssembler`), so the "exact"/"approximate" correlation
- * badges, the drawer itself, Escape-to-close and "Copy profile" from the Spring spec do not port here. What
- * IS real and load-bearing on Quarkus: the merged feed, OpenTelemetry-trace-id-based nesting/correlation,
- * KPI deep-links, and — the reason this spec exists — a regression guard for the bug fixed in #492.
+ * Quarkus now has a per-request profile drawer too (`GET /bootui/api/activity/request/{id}` — see
+ * `RequestProfileAssembler`), but it is a deliberately *reduced*, trace-id-only profile: unlike Spring's
+ * tiered profiler (trace id, then method+path+time-window+thread heuristics), Quarkus's reactive
+ * event-loop/worker model has no per-request serving-thread identity to fall back on, so a request only
+ * ever profiles when it carries a distributed trace id, SQL/security correlation is always exact (never
+ * "approximate", and never thread-matched), and the drawer surfaces explicit reduced-profile notes instead
+ * of Spring's exact/approximate badges. The dedicated profile-drawer tests below assert exactly that
+ * reduced (not absent, not full-parity) behavior.
+ *
+ * Beyond the drawer, this spec's other focus is the merged feed, OpenTelemetry-trace-id-based
+ * nesting/correlation, KPI deep-links, and a regression guard for the bug fixed in #492.
  *
  * That bug: a Quarkus-captured exception's `method`/`path` were deterministically `null`. Root cause:
  * `ExceptionStore` dedups by throwable identity across the whole cause chain, keeping only the first
@@ -111,6 +117,91 @@ test.describe('Live Activity view (Quarkus)', () => {
 
     await expect(secureRow.locator('i.bi-lock-fill')).toBeVisible()
     await expect(secureRow.locator('.activity-principal-tag')).toContainText('admin')
+  })
+
+  test('opens a per-request profile drawer with a reduced, trace-id-only profile', async ({openView, page}) => {
+    // product-search always runs SQL, so the request reliably has SQL to correlate in the drawer.
+    const search = await page.request.get('/api/sample/product-search')
+    expect(search.ok()).toBeTruthy()
+
+    await openView('activity', 'Live Activity')
+
+    const searchRow = page.locator('.activity-table tbody tr', {hasText: '/api/sample/product-search'}).first()
+    await expect(searchRow).toBeVisible({timeout: 15_000})
+
+    await searchRow.getByRole('button', {name: /Profile/}).click()
+
+    const drawer = page.locator('.activity-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(drawer).toContainText('Request profile')
+    await expect(drawer).toContainText('/api/sample/product-search')
+
+    // Quarkus's reduced profile has no time-window/thread heuristic to fall back on, so a
+    // trace-id-correlated SQL execution is always "exact", never the "approximate" fallback Spring's
+    // fuller profiler can show.
+    await expect(drawer.getByText('exact', {exact: true})).toBeVisible()
+    await expect(drawer.getByText('approximate', {exact: true})).toHaveCount(0)
+
+    // The reduced-profile explanation is real, load-bearing UI copy (RequestProfileAssembler's notes),
+    // not an internal implementation detail — a developer reads this to know why Quarkus's profile is
+    // narrower than Spring's.
+    await expect(drawer).toContainText('reduced, trace-id-only profile')
+
+    await drawer.getByRole('button', {name: 'Close'}).click()
+    await expect(drawer).toHaveCount(0)
+  })
+
+  test('correlates a security event to the profiled request by trace id, never claiming a thread-exact match', async ({
+    openView,
+    page
+  }) => {
+    // /api/secure/products deliberately also runs a live SQL SELECT (see SecureResource), so this
+    // request's drawer exercises SQL correlation and security correlation together.
+    const secure = await page.request.get('/api/secure/products', {
+      headers: {Authorization: 'Basic ' + Buffer.from('admin:admin').toString('base64')}
+    })
+    expect(secure.ok()).toBeTruthy()
+
+    await openView('activity', 'Live Activity')
+
+    const secureRow = page.locator('.activity-table tbody tr', {hasText: '/api/secure/products'}).first()
+    await expect(secureRow).toBeVisible({timeout: 15_000})
+
+    await secureRow.getByRole('button', {name: /Profile/}).click()
+
+    const drawer = page.locator('.activity-drawer')
+    await expect(drawer).toBeVisible()
+
+    const security = drawer.locator('section', {has: page.getByRole('heading', {name: 'Security events'})})
+    await expect(security).toBeVisible({timeout: 15_000})
+    await expect(security).toContainText('AuthenticationSuccessEvent')
+
+    // Reduced correlation: Quarkus's reactive event-loop/worker model has no per-request serving-thread
+    // identity, so RequestProfileAssembler can only ever claim a "principal" match here (the event's
+    // principal equals the request's), never the stronger "exact" (thread-matched) badge Spring can show
+    // for the same scenario. Scoped to the security section specifically, since the SQL section on this
+    // same request legitimately does show "exact" (see the previous test).
+    await expect(security.getByText('principal', {exact: true})).toBeVisible()
+    await expect(security.getByText('exact', {exact: true})).toHaveCount(0)
+
+    await drawer.getByRole('button', {name: 'Close'}).click()
+  })
+
+  test('closes the profile drawer with the Escape key and offers a copy action', async ({openView, page}) => {
+    await page.request.get('/api/sample/product-search')
+
+    await openView('activity', 'Live Activity')
+    const searchRow = page.locator('.activity-table tbody tr', {hasText: '/api/sample/product-search'}).first()
+    await expect(searchRow).toBeVisible({timeout: 15_000})
+
+    await searchRow.getByRole('button', {name: /Profile/}).click()
+
+    const drawer = page.locator('.activity-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(drawer.getByRole('button', {name: /Copy profile/})).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(drawer).toHaveCount(0)
   })
 
   test('pauses and resumes the live feed', async ({openView, page}) => {

--- a/bootui-quarkus-sample-app/e2e/tests/ai.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/ai.spec.js
@@ -1,0 +1,193 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+// The sample app wires a real LangChain4j + Ollama Dev Service (see ChatResource / AiAssistant),
+// but a full model round-trip is slow and non-deterministic on CI hardware, so this spec mocks the
+// three AI endpoints -- exactly as the Spring suite's ai.spec.js does -- while keeping the real
+// `/bootui/api/panels` and `/bootui/api/overview` responses (the panel is genuinely available: the
+// sample app really does have quarkus-langchain4j-ollama on the classpath), so the Quarkus platform
+// label and the panel's real availability flow through unmocked.
+const chatSpanId = '1111111111111111'
+
+const overview = {
+  enabled: true,
+  springAiDetected: false,
+  langChain4jDetected: true,
+  totalChats: 1,
+  totalInputTokens: 42,
+  totalOutputTokens: 7,
+  tokensByModel: {'llama3:latest': 49},
+  callsByModel: {'llama3:latest': 1},
+  errorCount: 0,
+  averageDurationNanos: 250_000_000,
+  toolCallCount: 1,
+  vectorOperationCount: 1,
+  embeddingCount: 0,
+  recent: [
+    {
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: chatSpanId,
+      startEpochNanos: Date.now() * 1_000_000,
+      durationNanos: 250_000_000,
+      provider: 'ollama',
+      requestModel: 'llama3:latest',
+      responseModel: 'llama3:latest',
+      inputTokens: 42,
+      outputTokens: 7,
+      totalTokens: 49,
+      finishReason: 'stop',
+      statusCode: 'OK',
+      operation: 'chat',
+      toolCallCount: 1,
+      vectorOperationCount: 1
+    }
+  ],
+  contentBanner:
+    "Prompt and completion text is not captured by default. Enable your AI framework's content-capture option " +
+    '(for LangChain4j, capture GenAI message content on the OpenTelemetry instrumentation) to see message content ' +
+    'in the conversation drawer.'
+}
+
+const tokenSeries = {
+  minutes: 60,
+  buckets: [
+    {epochMinute: 100, inputTokens: 0, outputTokens: 0, callCount: 0},
+    {epochMinute: 101, inputTokens: 42, outputTokens: 7, callCount: 1}
+  ]
+}
+
+const detail = {
+  summary: overview.recent[0],
+  toolCalls: [
+    {
+      spanId: '2222222222222222',
+      name: 'getWeather',
+      startEpochNanos: overview.recent[0].startEpochNanos + 5_000_000,
+      durationNanos: 20_000_000,
+      statusCode: 'OK'
+    }
+  ],
+  vectorOperations: [
+    {
+      spanId: '3333333333333333',
+      operation: 'query',
+      collectionName: 'docs',
+      startEpochNanos: overview.recent[0].startEpochNanos + 10_000_000,
+      durationNanos: 15_000_000,
+      statusCode: 'OK'
+    }
+  ],
+  attributes: [{key: 'gen_ai.system', type: 'string', value: 'ollama'}],
+  events: [],
+  contentCaptured: false,
+  contentBanner: 'Message content is not on this span.'
+}
+
+test.describe('AI Usage view (Quarkus)', () => {
+  test('renders AI token usage, model breakdowns, and chat detail', async ({openView, page}) => {
+    await stubAi(page, overview)
+
+    await openView('ai', 'AI Usage')
+    // Quarkus reports LangChain4j (not Spring AI) as the detected framework.
+    await expect(page.getByText('LangChain4j detected')).toBeVisible()
+    await expect(page.locator('.kpi-card-body', {hasText: 'Total tokens'}).getByText('49', {exact: true})).toBeVisible()
+    await expect(page.locator('.card', {hasText: 'Usage by model'}).getByText('llama3:latest')).toBeVisible()
+    await expect(page.getByText('Token usage (last 60 min)')).toBeVisible()
+
+    await page.getByRole('button', {name: 'Toggle chat details'}).click()
+    await expect(page.locator('.card', {hasText: `Chat ${chatSpanId}`})).toBeVisible()
+    await expect(page.locator('.chat-detail-row').getByText('getWeather', {exact: true})).toBeVisible()
+    await expect(page.locator('.chat-detail-row').getByText('docs', {exact: true})).toBeVisible()
+    await page.locator('.chat-detail-row summary', {hasText: 'gen_ai'}).click()
+    await expect(page.locator('.chat-detail-row').getByText('gen_ai.system')).toBeVisible()
+  })
+
+  test('shows disabled mode when telemetry is unavailable', async ({openView, page}) => {
+    await stubAi(page, {
+      ...overview,
+      enabled: false,
+      springAiDetected: false,
+      langChain4jDetected: false,
+      totalChats: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      tokensByModel: {},
+      callsByModel: {},
+      recent: [],
+      contentBanner: null
+    })
+
+    await openView('ai', 'AI Usage')
+    await expect(page.getByText('Enable BootUI telemetry capture', {exact: true})).toBeVisible()
+    await expect(page.getByText('No AI chat completions recorded yet')).toHaveCount(0)
+  })
+
+  test('shows ready empty state before the first chat is recorded', async ({openView, page}) => {
+    await stubAi(page, {
+      ...overview,
+      totalChats: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      tokensByModel: {},
+      callsByModel: {},
+      toolCallCount: 0,
+      vectorOperationCount: 0,
+      embeddingCount: 0,
+      recent: []
+    })
+
+    await openView('ai', 'AI Usage')
+    await expect(page.getByText('No AI chat completions recorded yet')).toBeVisible()
+    await expect(page.getByText('Telemetry ready')).toBeVisible()
+    await expect(page.getByText('Enable BootUI telemetry capture')).toHaveCount(0)
+    // Quarkus never shows the OTLP-receiver copy that only applies to the Spring starter's
+    // embedded OTLP endpoint; capture there is in-process via quarkus-opentelemetry instead.
+    await expect(page.getByText('Cooperating local services can still export OTLP traces')).toHaveCount(0)
+  })
+
+  test('shows unavailable mode when no AI framework is on the classpath', async ({openView, page}) => {
+    await stubAi(page, {
+      ...overview,
+      springAiDetected: false,
+      langChain4jDetected: false,
+      totalChats: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      tokensByModel: {},
+      callsByModel: {},
+      recent: [],
+      contentBanner: null
+    })
+
+    await openView('ai', 'AI Usage')
+    // The static checklist heading is Quarkus-specific: only LangChain4j applies (no Spring AI).
+    await expect(page.getByText('LangChain4j on classpath', {exact: true})).toBeVisible()
+    await expect(page.getByText('No AI framework is detected. Add')).toBeVisible()
+    await expect(page.getByText('No AI chat completions recorded yet')).toHaveCount(0)
+  })
+})
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {typeof overview} overviewResponse
+ */
+async function stubAi(page, overviewResponse) {
+  await page.route(
+    (url) => url.pathname === '/bootui/api/ai/overview',
+    async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(overviewResponse)})
+    }
+  )
+  await page.route(
+    (url) => url.pathname === '/bootui/api/ai/tokens',
+    async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(tokenSeries)})
+    }
+  )
+  await page.route(
+    (url) => url.pathname === `/bootui/api/ai/chats/${chatSpanId}`,
+    async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(detail)})
+    }
+  )
+}

--- a/bootui-quarkus-sample-app/e2e/tests/beans.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/beans.spec.js
@@ -1,0 +1,90 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Beans view (Quarkus)', () => {
+  test('lists real Arc/CDI beans and supports filtering by name and classification', async ({openView, page}) => {
+    const beansPage = await openView('beans', 'Beans')
+
+    const rows = beansPage.locator('table tbody tr')
+    await expect.poll(async () => rows.count()).toBeGreaterThan(5)
+
+    // Name filter narrows the list down to the sample app's own Panache repository bean.
+    await beansPage.getByPlaceholder(/Filter by name or type/).fill('productRepository')
+    await expect.poll(async () => rows.count()).toBeLessThan(10)
+    const repositoryRow = beansPage.locator('table tbody tr', {hasText: 'productRepository'})
+    await expect(repositoryRow).toContainText('io.github.jdubois.bootui.sample.catalog.ProductRepository')
+    await expect(repositoryRow).toContainText('ApplicationScoped')
+
+    // Classification filter restricts to a single category (BootUI internals are hidden by default,
+    // and Arc-managed app beans like the sample's catalog service classify as APPLICATION).
+    await beansPage.getByPlaceholder(/Filter by name or type/).fill('')
+    await beansPage.locator('select.form-select').selectOption('APPLICATION')
+    const badges = beansPage.locator('table tbody tr td:nth-child(4) .badge')
+    await expect
+      .poll(async () => {
+        const values = await badges.allInnerTexts()
+        return values.length > 0 && values.every((c) => c === 'APPLICATION')
+      })
+      .toBeTruthy()
+    await expect(beansPage.locator('table tbody')).toContainText('catalogService')
+
+    // BootUI's own beans never leak into the inventory, on any classification.
+    const response = await page.request.get('/bootui/api/beans?limit=400', {
+      headers: {'X-Forwarded-For': '127.0.0.1'}
+    })
+    const body = await response.json()
+    const bootUiLeak = body.beans.filter(
+      (bean) => bean.type && (bean.type.includes('bootui.quarkus') || bean.type.includes('bootui.core'))
+    )
+    expect(bootUiLeak).toEqual([])
+  })
+
+  test('keeps large bean lists responsive while filters search the full set', async ({openView, page}) => {
+    const beans = Array.from({length: 205}, (_, index) => ({
+      name: `demoBean${index}`,
+      type: `com.example.DemoBean${index}`,
+      scope: 'ApplicationScoped',
+      classification: 'APPLICATION',
+      dependencies: []
+    }))
+
+    await page.route('**/bootui/api/beans?*', (route) => {
+      const url = new URL(route.request().url())
+      const query = (url.searchParams.get('q') || '').toLowerCase()
+      const offset = Number(url.searchParams.get('offset') || 0)
+      const limit = Number(url.searchParams.get('limit') || 200)
+      const matched = query
+        ? beans.filter((bean) => bean.name.toLowerCase().includes(query) || bean.type.toLowerCase().includes(query))
+        : beans
+      const pageBeans = matched.slice(offset, offset + limit)
+
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          total: beans.length,
+          beans: pageBeans,
+          page: {
+            total: beans.length,
+            matched: matched.length,
+            offset,
+            limit,
+            returned: pageBeans.length,
+            hasMore: offset + pageBeans.length < matched.length
+          }
+        })
+      })
+    })
+
+    await openView('beans', 'Beans')
+
+    const rows = page.locator('table tbody tr')
+    await expect(rows).toHaveCount(200)
+    await expect(page.getByText(/Showing 200 of 205 beans/)).toBeVisible()
+    await expect(page.getByRole('button', {name: /Load next 5/})).toBeVisible()
+
+    await page.getByPlaceholder(/Filter by name or type/).fill('demoBean204')
+    await expect(rows).toHaveCount(1)
+    await expect(rows.first()).toContainText('demoBean204')
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/claude-code.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/claude-code.spec.js
@@ -1,0 +1,168 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+// Claude Code reuses the same Copilot.vue component with no platform-specific branching, and the
+// dashboard/session DTOs are shared, framework-neutral records, so this spec mirrors the Spring
+// suite's claude-code.spec.js closely. Real session directories are host-machine-specific and
+// non-deterministic, so -- exactly like the Spring spec -- the three Claude Code endpoints are
+// mocked with realistic sanitized sample data.
+test.describe('Claude Code panel (Quarkus)', () => {
+  test('shows an aggregated dashboard from sanitized Claude Code activity', async ({page}) => {
+    const dashboard = {
+      available: true,
+      sessionStateDir: '/home/dev/.claude/projects',
+      sessionCount: 1,
+      eventCount: 12,
+      turnCount: 4,
+      totalInputTokens: 54321,
+      totalOutputTokens: 1234,
+      errorCount: 1,
+      activeLast24Hours: 1,
+      activeLast7Days: 1,
+      sessionsWithSchemaDrift: 0,
+      lastActivityEpochMillis: Date.now() - 60_000,
+      categoryCounts: [
+        {label: 'SHELL', count: 8},
+        {label: 'FILE_EDIT', count: 4}
+      ],
+      modelCounts: [{label: 'claude-sonnet-4', count: 1}],
+      topTools: [{label: 'Bash', count: 8}],
+      otherToolEventCount: 0,
+      activityBuckets: Array.from({length: 24}, (_, index) => ({
+        startEpochMillis: Date.now() - (23 - index) * 60 * 60 * 1000,
+        endEpochMillis: Date.now() - (22 - index) * 60 * 60 * 1000,
+        eventCount: index === 23 ? 12 : 0,
+        errorCount: index === 23 ? 1 : 0,
+        inputTokens: index === 23 ? 54321 : 0,
+        outputTokens: index === 23 ? 1234 : 0
+      })),
+      dailyActivityBuckets: Array.from({length: 7}, (_, index) => ({
+        startEpochMillis: Date.now() - (6 - index) * 24 * 60 * 60 * 1000,
+        endEpochMillis: Date.now() - (5 - index) * 24 * 60 * 60 * 1000,
+        eventCount: index === 6 ? 12 : 0,
+        errorCount: index === 6 ? 1 : 0,
+        inputTokens: index === 6 ? 54321 : 0,
+        outputTokens: index === 6 ? 1234 : 0
+      })),
+      recentSessions: [
+        {
+          id: 'session-one',
+          filename: 'project-one/session-one.jsonl',
+          startedAtEpochMillis: Date.now() - 120_000,
+          updatedAtEpochMillis: Date.now() - 60_000,
+          model: 'claude-sonnet-4',
+          workingDirectory: '/work/app',
+          status: null,
+          eventCount: 12,
+          turnCount: 4,
+          inputTokens: 54321,
+          outputTokens: 1234,
+          errorCount: 1,
+          lastActivitySummary: 'SHELL · Bash · failed',
+          schemaDrift: false
+        }
+      ],
+      warnings: []
+    }
+    const sessionDetail = {
+      summary: dashboard.recentSessions[0],
+      counts: {
+        total: 12,
+        byCategory: {SHELL: 8, FILE_EDIT: 4},
+        errors: 1,
+        lastActivityEpochMillis: dashboard.recentSessions[0].updatedAtEpochMillis
+      },
+      turns: [
+        {
+          index: 0,
+          startedAtEpochMillis: Date.now() - 120_000,
+          durationMillis: 1500,
+          summary: 'assistant',
+          eventCount: 2,
+          inputTokens: 54321,
+          outputTokens: 1234
+        }
+      ],
+      recentEvents: [
+        {
+          id: 'toolu_1',
+          turnIndex: 0,
+          timestampEpochMillis: Date.now() - 90_000,
+          type: 'tool_use',
+          toolName: 'Bash',
+          category: 'SHELL',
+          summary: 'SHELL · Bash',
+          success: true
+        },
+        {
+          id: 'toolu_1-result',
+          turnIndex: 0,
+          timestampEpochMillis: Date.now() - 60_000,
+          type: 'tool_result',
+          toolName: 'Bash',
+          category: 'SHELL',
+          summary: 'SHELL · Bash · failed',
+          success: false
+        }
+      ],
+      failureEvents: [
+        {
+          id: 'toolu_1-result',
+          turnIndex: 0,
+          timestampEpochMillis: Date.now() - 60_000,
+          type: 'tool_result',
+          toolName: 'Bash',
+          category: 'SHELL',
+          summary: 'SHELL · Bash · failed',
+          success: false
+        }
+      ],
+      warnings: []
+    }
+
+    await page.route('**/bootui/api/claude-code/dashboard', async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(dashboard)})
+    })
+    await page.route(
+      (url) => url.pathname === '/bootui/api/claude-code/sessions',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            available: true,
+            sessionStateDir: dashboard.sessionStateDir,
+            total: 3,
+            returned: 1,
+            maxSessions: 1,
+            sessions: dashboard.recentSessions,
+            warnings: ['Showing the 1 most recent Claude Code sessions out of 3.']
+          })
+        })
+      }
+    )
+    await page.route('**/bootui/api/claude-code/sessions/session-one', async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(sessionDetail)})
+    })
+    await page.route('**/bootui/api/claude-code/stream', async (route) => {
+      await route.fulfill({contentType: 'text/event-stream', body: ''})
+    })
+
+    await page.goto('/bootui/#/claude-code')
+
+    await expect(page.getByLabel('Auto-refresh')).toBeChecked()
+    await expect(page.getByTitle('Refresh', {exact: true})).toBeVisible()
+    await expect(page.locator('.panel-header__actions .badge').filter({hasText: 'Live'})).toHaveCount(0)
+    await expect(page.getByRole('heading', {name: 'Claude Code activity overview'})).toBeVisible()
+    await expect(page.getByText('/home/dev/.claude/projects')).toBeVisible()
+    await expect(page.getByText('bootui.claude-code.max-sessions')).toBeVisible()
+    await expect(page.locator('#activity-mode-tokens')).toBeChecked()
+    await expect(page.locator('.metric-card', {hasText: 'Tokens'}).getByText('55,55k', {exact: true})).toBeVisible()
+    await expect(page.locator('.metric-card', {hasText: 'Tokens'}).getByText('54,32k in · 1,23k out')).toBeVisible()
+    await expect(page.getByText('copilot-mission-control')).toHaveCount(0)
+    await expect(page.getByRole('heading', {name: 'Top tools'}).locator('..').getByText('Bash')).toBeVisible()
+
+    await page.getByRole('button', {name: 'Show failures for session-one'}).click()
+    await expect(page.getByRole('tab', {name: /Failures/})).toHaveClass(/active/)
+    await expect(page.getByRole('list').getByText('SHELL · Bash · failed')).toBeVisible()
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/config.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/config.spec.js
@@ -1,0 +1,44 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Configuration view (Quarkus)', () => {
+  test('lists properties and supports searching', async ({openView, page}) => {
+    await openView('config', 'Configuration')
+
+    const rows = page.locator('table tbody tr')
+    await expect.poll(async () => rows.count()).toBeGreaterThan(10)
+
+    await page.getByPlaceholder(/Filter by name or value/).fill('sample.greeting')
+    await expect(rows.filter({hasText: 'sample.greeting'}).first()).toBeVisible()
+    await expect(rows.filter({hasText: 'sample.greeting'}).first()).toContainText('Hello')
+  })
+
+  // Quarkus has no runtime config-override write path (overrides target the Spring bootstrap property
+  // sources), so the panel is reported read-only via the /bootui/api/panels manifest. Unlike the Spring
+  // spec, there is no save/delete-override flow to exercise here — instead this asserts the read-only
+  // gating itself is real: the banner, the disabled "Add override" action, and disabled per-row Edit
+  // buttons on genuine rendered properties.
+  test('reports read-only with no override write path, disabling all edit actions', async ({openView, page}) => {
+    await openView('config', 'Configuration')
+
+    await expect(page.getByRole('button', {name: /Add override/})).toBeDisabled()
+
+    const banner = page.locator('.alert', {hasText: 'Configuration overrides are read-only'})
+    await expect(banner).toBeVisible()
+    await expect(banner).toContainText('Runtime config overrides are not available on Quarkus')
+    await expect(banner).toContainText('Existing properties remain visible, but override edits are disabled')
+
+    // A real, visible property row still renders correctly, but its Edit action is disabled.
+    await page.getByPlaceholder(/Filter by name or value/).fill('sample.greeting')
+    const row = page.locator('table tbody tr', {hasText: 'sample.greeting'}).first()
+    await expect(row).toBeVisible()
+    await expect(row.getByRole('button', {name: /Edit/})).toBeDisabled()
+
+    // There is no override write path, so the manifest never reports any overrides.
+    const response = await page.request.get('/bootui/api/config?limit=5', {
+      headers: {'X-Forwarded-For': '127.0.0.1'}
+    })
+    const body = await response.json()
+    expect(body.overrideCount).toBe(0)
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/copilot.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/copilot.spec.js
@@ -1,0 +1,208 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+// Copilot.vue has no platform-specific branching and the dashboard/session DTOs are shared,
+// framework-neutral records, so this spec mirrors the Spring suite's copilot.spec.js closely. Real
+// session-state directories are host-machine-specific and non-deterministic, so -- exactly like the
+// Spring spec -- the three Copilot endpoints are mocked with realistic sanitized sample data.
+test.describe('Copilot panel (Quarkus)', () => {
+  test('shows an aggregated dashboard from sanitized Copilot telemetry', async ({page}) => {
+    const dashboard = {
+      available: true,
+      sessionStateDir: '/home/dev/.copilot/session-state',
+      sessionCount: 2,
+      eventCount: 42,
+      turnCount: 7,
+      totalInputTokens: 123456,
+      totalOutputTokens: 7890,
+      errorCount: 3,
+      activeLast24Hours: 1,
+      activeLast7Days: 2,
+      sessionsWithSchemaDrift: 0,
+      lastActivityEpochMillis: Date.now() - 60_000,
+      categoryCounts: [
+        {label: 'FILE_EDIT', count: 18},
+        {label: 'SHELL', count: 12},
+        {label: 'MCP', count: 6}
+      ],
+      modelCounts: [
+        {label: 'gpt-5.5', count: 1},
+        {label: 'gpt-5.4', count: 1}
+      ],
+      topTools: [
+        {label: 'apply_patch', count: 14},
+        {label: 'bash', count: 9}
+      ],
+      otherToolEventCount: 5,
+      activityBuckets: Array.from({length: 24}, (_, index) => ({
+        startEpochMillis: Date.now() - (23 - index) * 60 * 60 * 1000,
+        endEpochMillis: Date.now() - (22 - index) * 60 * 60 * 1000,
+        eventCount: index % 4 === 0 ? 10 : index,
+        errorCount: index % 8 === 0 ? 1 : 0,
+        inputTokens: index === 23 ? 123456 : index % 4 === 0 ? 2000 + index * 100 : 0,
+        outputTokens: index === 23 ? 7890 : index % 3 === 0 ? 300 + index * 20 : 0
+      })),
+      dailyActivityBuckets: Array.from({length: 7}, (_, index) => ({
+        startEpochMillis: Date.now() - (6 - index) * 24 * 60 * 60 * 1000,
+        endEpochMillis: Date.now() - (5 - index) * 24 * 60 * 60 * 1000,
+        eventCount: (index + 1) * 3,
+        errorCount: index === 6 ? 1 : 0,
+        inputTokens: index === 6 ? 123456 : (index + 1) * 3500,
+        outputTokens: index === 6 ? 7890 : (index + 1) * 420
+      })),
+      recentSessions: [
+        {
+          id: 'session-one',
+          filename: 'session-one/events.jsonl',
+          startedAtEpochMillis: Date.now() - 120_000,
+          updatedAtEpochMillis: Date.now() - 60_000,
+          model: 'gpt-5.5',
+          workingDirectory: '/work/app',
+          status: null,
+          eventCount: 30,
+          turnCount: 5,
+          inputTokens: 100000,
+          outputTokens: 6000,
+          errorCount: 2,
+          lastActivitySummary: 'FILE_EDIT · apply_patch',
+          schemaDrift: false
+        }
+      ],
+      warnings: []
+    }
+    const sessionDetail = {
+      summary: dashboard.recentSessions[0],
+      counts: {
+        total: 30,
+        byCategory: {FILE_EDIT: 18, SHELL: 12},
+        errors: 2,
+        lastActivityEpochMillis: dashboard.recentSessions[0].updatedAtEpochMillis
+      },
+      turns: [
+        {
+          index: 0,
+          startedAtEpochMillis: Date.now() - 120_000,
+          durationMillis: 1500,
+          summary: 'Investigating session',
+          eventCount: 2,
+          outputTokens: 900
+        }
+      ],
+      recentEvents: [
+        {
+          id: 'ok',
+          turnIndex: 0,
+          timestampEpochMillis: Date.now() - 90_000,
+          type: 'tool.execution_start',
+          toolName: 'apply_patch',
+          category: 'FILE_EDIT',
+          summary: 'FILE_EDIT · apply_patch',
+          success: true
+        },
+        {
+          id: 'failure',
+          turnIndex: 0,
+          timestampEpochMillis: Date.now() - 60_000,
+          type: 'tool.execution_complete',
+          toolName: 'bash',
+          category: 'SHELL',
+          summary: 'SHELL · bash',
+          success: false
+        }
+      ],
+      failureEvents: [
+        {
+          id: 'failure',
+          turnIndex: 0,
+          timestampEpochMillis: Date.now() - 60_000,
+          type: 'tool.execution_complete',
+          toolName: 'bash',
+          category: 'SHELL',
+          summary: 'SHELL · bash · failed',
+          success: false
+        },
+        {
+          id: 'older-failure',
+          turnIndex: 0,
+          timestampEpochMillis: Date.now() - 180_000,
+          type: 'tool.execution_complete',
+          toolName: 'apply_patch',
+          category: 'FILE_EDIT',
+          summary: 'FILE_EDIT · apply_patch · failed',
+          success: false
+        }
+      ],
+      warnings: []
+    }
+
+    await page.route('**/bootui/api/copilot/dashboard', async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(dashboard)})
+    })
+    await page.route(
+      (url) => url.pathname === '/bootui/api/copilot/sessions',
+      async (route) => {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            available: true,
+            sessionStateDir: dashboard.sessionStateDir,
+            total: 5,
+            returned: 1,
+            maxSessions: 1,
+            sessions: dashboard.recentSessions,
+            warnings: ['Showing the 1 most recent Copilot sessions out of 5.']
+          })
+        })
+      }
+    )
+    await page.route('**/bootui/api/copilot/sessions/session-one', async (route) => {
+      await route.fulfill({contentType: 'application/json', body: JSON.stringify(sessionDetail)})
+    })
+    await page.route('**/bootui/api/copilot/stream', async (route) => {
+      await route.fulfill({contentType: 'text/event-stream', body: ''})
+    })
+
+    await page.goto('/bootui/#/copilot')
+
+    await expect(page.getByLabel('Auto-refresh')).toBeChecked()
+    await expect(page.getByTitle('Refresh', {exact: true})).toBeVisible()
+    await expect(page.locator('.panel-header__actions .badge').filter({hasText: 'Live'})).toHaveCount(0)
+    await expect(page.getByRole('heading', {name: 'Copilot activity overview'})).toBeVisible()
+    await expect(page.getByRole('link', {name: 'copilot-mission-control'})).toHaveAttribute(
+      'href',
+      'https://github.com/DanWahlin/copilot-mission-control'
+    )
+    await expect(page.getByRole('heading', {name: 'Activity, last 7 days'})).toBeVisible()
+    await expect(
+      page.locator('.metric-card', {hasText: 'Sanitized events'}).getByText('42', {exact: true})
+    ).toBeVisible()
+    await expect(page.getByRole('group', {name: 'Activity chart mode'}).getByText('Tokens')).toBeVisible()
+    await expect(page.locator('#activity-mode-tokens')).toBeChecked()
+    await expect(page.getByText('Blue bars show input tokens; red bars show output tokens')).toBeVisible()
+    await expect(page.locator('.metric-card', {hasText: 'Tokens'}).getByText('131,34k', {exact: true})).toBeVisible()
+    await expect(page.locator('.metric-card', {hasText: 'Tokens'}).getByText('123,45k in · 7,89k out')).toBeVisible()
+    const hourlyActivity = page.locator('.activity-chart').first()
+    await hourlyActivity.locator('.activity-column').nth(23).hover()
+    await expect(
+      hourlyActivity.locator('.activity-tooltip', {hasText: 'Input tokens: 123,45k · Output tokens: 7,89k'})
+    ).toBeVisible()
+    await page.locator('label[for="activity-mode-events"]').click()
+    await hourlyActivity.locator('.activity-column').nth(23).hover()
+    await expect(hourlyActivity.locator('.activity-tooltip', {hasText: 'Events: 23 · Failures: 0'})).toBeVisible()
+    await expect(page.getByRole('heading', {name: 'Top tools'}).locator('..').getByText('apply_patch')).toBeVisible()
+    await expect(page.getByRole('heading', {name: 'Event mix'}).locator('..').getByText('FILE_EDIT')).toBeVisible()
+    await expect(page.getByRole('heading', {name: 'Session explorer'})).toBeVisible()
+    await expect(page.getByText('1 / 5 sessions')).toBeVisible()
+    await expect(page.getByText('bootui.copilot.max-sessions')).toBeVisible()
+
+    await page.getByRole('button', {name: 'Show failures for session-one'}).click()
+    await expect(page.getByRole('tab', {name: /Failures/})).toHaveClass(/active/)
+    await expect(page.getByText('SHELL · bash · failed')).toBeVisible()
+    await expect(page.getByText('FILE_EDIT · apply_patch · failed')).toBeVisible()
+
+    await page.getByRole('tab', {name: 'Turn story'}).click()
+    await expect(page.getByRole('tab', {name: 'Turn story'})).toHaveClass(/active/)
+    await expect(page.getByText('Investigating session')).toBeVisible()
+    await expect(page.getByText('900 out')).toBeVisible()
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/github.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/github.spec.js
@@ -1,0 +1,218 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+// A connected GitHub dashboard cannot be reproduced deterministically in CI (it depends
+// on an authenticated token and live GitHub responses), so this spec mocks the bounded
+// GitHub API the same way the documentation screenshot generator does and asserts that
+// the panel renders the repository, credential, metrics, and an interactive drawer.
+function connectedDashboard() {
+  const now = Date.now()
+  return {
+    available: true,
+    unavailableReason: null,
+    connected: true,
+    status: 'CONNECTED',
+    message: null,
+    refreshedAt: now - 45_000,
+    repository: {
+      owner: 'jdubois',
+      name: 'boot-ui',
+      fullName: 'jdubois/boot-ui',
+      host: 'github.com',
+      apiBaseUrl: 'https://api.github.com/',
+      htmlUrl: 'https://github.com/jdubois/boot-ui',
+      defaultBranch: 'main',
+      localBranch: 'jdubois/panel-e2e-coverage',
+      upstreamBranch: 'main',
+      visibility: 'public',
+      privateRepository: false,
+      fork: false,
+      archived: false,
+      pushedAt: now - 18 * 60 * 1000,
+      stars: 128,
+      forks: 14,
+      watchers: 11,
+      openIssues: 9,
+      latestRelease: 'v0.4.0'
+    },
+    credential: {source: 'GITHUB_TOKEN', authenticated: true, login: 'local-dev', scopes: 'repo, workflow'},
+    metrics: [
+      {label: 'Open pull requests', value: '2', detail: 'Bounded live queue', tone: 'primary'},
+      {label: 'Open issues', value: '9', detail: 'Grouped by label and age', tone: 'info'},
+      {label: 'Workflow failures', value: '1', detail: 'Latest run per workflow', tone: 'danger'}
+    ],
+    quotas: [],
+    pullRequests: [
+      {
+        number: 211,
+        title: 'Update implementation plan roadmap',
+        author: 'julien',
+        draft: false,
+        htmlUrl: 'https://github.com/jdubois/boot-ui/pull/211',
+        updatedAt: now - 20 * 60 * 1000,
+        reviewDecision: 'APPROVED',
+        checksConclusion: 'success',
+        labels: ['docs']
+      },
+      {
+        number: 210,
+        title: 'Update GitHub Actions execution drawer',
+        author: 'julien',
+        draft: false,
+        htmlUrl: 'https://github.com/jdubois/boot-ui/pull/210',
+        updatedAt: now - 90 * 60 * 1000,
+        reviewDecision: null,
+        checksConclusion: 'success',
+        labels: ['github']
+      }
+    ],
+    workflowRuns: [],
+    workflows: [],
+    issueBuckets: [
+      {label: 'Open issues', count: 9, tone: 'primary'},
+      {label: 'Bug', count: 2, tone: 'danger'}
+    ],
+    issues: [
+      {
+        number: 188,
+        title: 'Flaky Playwright run on slow CI agents',
+        author: 'julien',
+        htmlUrl: 'https://github.com/jdubois/boot-ui/issues/188',
+        createdAt: now - 3 * 24 * 60 * 60 * 1000,
+        updatedAt: now - 35 * 60 * 1000,
+        comments: 4,
+        labels: ['bug', 'ci']
+      },
+      {
+        number: 184,
+        title: 'Document the GitHub issues drawer',
+        author: 'octocat',
+        htmlUrl: 'https://github.com/jdubois/boot-ui/issues/184',
+        createdAt: now - 5 * 24 * 60 * 60 * 1000,
+        updatedAt: now - 4 * 60 * 60 * 1000,
+        comments: 1,
+        labels: ['docs']
+      }
+    ],
+    securitySignals: [
+      {
+        label: 'Dependabot alerts',
+        status: 'AVAILABLE',
+        count: 2,
+        unavailableReason: null,
+        alerts: [
+          {
+            number: 7,
+            state: 'open',
+            packageName: 'org.example:lib',
+            ecosystem: 'maven',
+            manifestPath: 'pom.xml',
+            severity: 'critical',
+            ghsaId: 'GHSA-aaaa-bbbb-cccc',
+            cveId: 'CVE-2026-1234',
+            summary: 'Remote code execution in org.example:lib',
+            vulnerableVersionRange: '< 1.2.3',
+            firstPatchedVersion: '1.2.3',
+            htmlUrl: 'https://github.com/jdubois/boot-ui/security/dependabot/7',
+            createdAt: now - 3 * 24 * 60 * 60 * 1000,
+            updatedAt: now - 12 * 60 * 60 * 1000
+          },
+          {
+            number: 6,
+            state: 'open',
+            packageName: 'com.sample:utils',
+            ecosystem: 'maven',
+            manifestPath: 'bootui-core/pom.xml',
+            severity: 'medium',
+            ghsaId: 'GHSA-dddd-eeee-ffff',
+            cveId: null,
+            summary: 'Denial of service in com.sample:utils',
+            vulnerableVersionRange: '>= 2.0.0, < 2.4.1',
+            firstPatchedVersion: '2.4.1',
+            htmlUrl: 'https://github.com/jdubois/boot-ui/security/dependabot/6',
+            createdAt: now - 6 * 24 * 60 * 60 * 1000,
+            updatedAt: now - 2 * 24 * 60 * 60 * 1000
+          }
+        ]
+      },
+      {label: 'Code scanning alerts', status: 'AVAILABLE', count: 1, unavailableReason: null, alerts: []},
+      {label: 'Secret scanning alerts', status: 'AVAILABLE', count: 0, unavailableReason: null, alerts: []}
+    ],
+    copilotUsage: null,
+    warnings: []
+  }
+}
+
+test.describe('GitHub view (Quarkus)', () => {
+  test('renders the connected dashboard and opens the pull-request drawer', async ({openView, page}) => {
+    const payload = JSON.stringify(connectedDashboard())
+    let refreshMethod = null
+    // Trusted localhost sessions refresh via POST on mount; the GET endpoint is the read-only
+    // fallback. Both are mocked, and the refresh method is captured so the spec can confirm the
+    // panel used the POST refresh path.
+    await page.route(
+      (url) => url.pathname === '/bootui/api/github/refresh',
+      async (route) => {
+        refreshMethod = route.request().method()
+        await route.fulfill({contentType: 'application/json', body: payload})
+      }
+    )
+    await page.route(
+      (url) => url.pathname === '/bootui/api/github',
+      async (route) => {
+        await route.fulfill({contentType: 'application/json', body: payload})
+      }
+    )
+
+    await openView('github', 'GitHub')
+
+    // Repository summary card.
+    await expect(page.getByRole('link', {name: 'jdubois/boot-ui'})).toBeVisible()
+    await expect(page.locator('.badge', {hasText: 'CONNECTED'})).toBeVisible()
+    const repositoryCard = page.locator('.card', {hasText: 'Repository'}).first()
+    await expect(repositoryCard).toContainText('128')
+    await expect(repositoryCard).toContainText('14')
+
+    // Credential card confirms the token stayed server-side but reports the authenticated source.
+    const credentialCard = page.locator('.card', {hasText: 'Credential'}).first()
+    await expect(credentialCard).toContainText('Authenticated')
+    await expect(credentialCard).toContainText('GITHUB_TOKEN')
+
+    // Summary metric and security-signal cards render the mocked values.
+    const openPrsCard = page.getByRole('button', {name: /Open pull requests/})
+    await expect(openPrsCard).toBeVisible()
+    await expect(openPrsCard.locator('.display-6')).toHaveText('2')
+    const codeScanningCard = page.getByRole('button', {name: /Code scanning alerts/})
+    await expect(codeScanningCard).toBeVisible()
+    await expect(codeScanningCard.locator('.display-6')).toHaveText('1')
+
+    // Opening the pull-request drawer is a meaningful read interaction.
+    await page.getByRole('button', {name: /Open pull requests/}).click()
+    const drawer = page.locator('.details-drawer')
+    await expect(drawer).toBeVisible()
+    await expect(drawer).toContainText('Open pull requests')
+    await expect(drawer).toContainText('#211 Update implementation plan roadmap')
+    await expect(drawer).toContainText('#210 Update GitHub Actions execution drawer')
+
+    // The issues card opens a drawer that lists the actual open issues.
+    await page.getByRole('button', {name: /Open issues/}).click()
+    await expect(drawer).toContainText('Open issues')
+    await expect(drawer).toContainText('#188 Flaky Playwright run on slow CI agents')
+    await expect(drawer).toContainText('#184 Document the GitHub issues drawer')
+
+    // Dependabot card opens a drawer that lists the non-secret alert details.
+    await page.getByRole('button', {name: /Dependabot alerts/}).click()
+    await expect(drawer).toContainText('org.example:lib')
+    await expect(drawer).toContainText('Remote code execution in org.example:lib')
+    await expect(drawer).toContainText('GHSA-aaaa-bbbb-cccc')
+    await expect(drawer).toContainText('Fixed in: 1.2.3')
+    await expect(drawer).toContainText('com.sample:utils')
+
+    // Secret scanning stays count-only with no inline alert details.
+    await page.getByRole('button', {name: /Secret scanning alerts/}).click()
+    await expect(drawer).toContainText('does not expose secret values')
+
+    // The trusted panel reached the live data through the POST refresh endpoint.
+    expect(refreshMethod).toBe('POST')
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/health.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/health.spec.js
@@ -1,0 +1,39 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Health view (Quarkus)', () => {
+  test('renders friendly health summary and tree from real SmallRye Health data', async ({openView, page}) => {
+    await openView('health', 'Health')
+
+    await expect(page.getByText('Overall status')).toBeVisible()
+    await expect(page.getByText('Component tree')).toBeVisible()
+    const rootCard = page.locator('main .card').first()
+    await expect(rootCard).toBeVisible()
+    await expect(rootCard.locator('.badge')).toHaveText(/UP|DOWN|UNKNOWN|OUT_OF_SERVICE|DISABLED/)
+    await expect(page.locator('main pre')).toHaveCount(0)
+
+    // The root node renders the SmallRye "application" aggregate status and the sample app's real
+    // Agroal datasource contributor, not a placeholder.
+    await expect(page.locator('main')).toContainText('application')
+    await expect(page.locator('main')).toContainText('Database connections health check')
+
+    // Cross-check the same data against the raw API so the rendered badge genuinely reflects backend status.
+    const response = await page.request.get('/bootui/api/health', {headers: {'X-Forwarded-For': '127.0.0.1'}})
+    const body = await response.json()
+    expect(body.status).toBe('UP')
+    expect(body.components.some((c) => c.name === 'Database connections health check')).toBeTruthy()
+  })
+
+  test('renders nested component details in a readable table', async ({openView, page}) => {
+    await openView('health', 'Health')
+
+    const dbSummary = page.locator('details.card > summary', {hasText: /Database connections health check/}).first()
+    const dbNode = dbSummary.locator('xpath=..')
+    await expect(dbNode).toBeVisible()
+    await expect(dbNode).toContainText('Details')
+    await expect(dbNode.locator('table')).toBeVisible()
+    // The Agroal health check reports the named datasource ("<default>") as a detail key/value pair.
+    await expect(dbNode.locator('table')).toContainText('default')
+    await expect(dbNode.locator('table')).toContainText('UP')
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/http-exchanges.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/http-exchanges.spec.js
@@ -1,0 +1,34 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('HTTP Exchanges view (Quarkus)', () => {
+  test('shows recent sample app requests', async ({openView, page}) => {
+    const apiResponse = await page.request.get('/api/sample/hello')
+    expect(apiResponse.ok()).toBeTruthy()
+
+    await openView('http-exchanges', 'HTTP Exchanges')
+
+    await expect(page.locator('table')).toContainText('/api/sample/hello', {timeout: 15_000})
+    await expect(page.locator('table')).toContainText('GET')
+    await expect(page.locator('table')).toContainText('200')
+
+    const sampleRow = page.locator('tbody tr', {hasText: '/api/sample/hello'}).first()
+    const detailsButton = sampleRow.locator('.http-exchanges-detail-toggle')
+    await expect(detailsButton).toBeVisible()
+    await detailsButton.click()
+    await expect(page.locator('.http-exchanges-detail').first()).toContainText('Request headers')
+  })
+
+  test('shows security failures recorded before the Quarkus security filter short-circuits', async ({
+    openView,
+    page
+  }) => {
+    const secureResponse = await page.request.get('/api/secure')
+    expect(secureResponse.status()).toBe(401)
+
+    await openView('http-exchanges', 'HTTP Exchanges')
+
+    await expect(page.locator('table')).toContainText('/api/secure', {timeout: 15_000})
+    await expect(page.locator('table')).toContainText('401')
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/jvm-tuning.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/jvm-tuning.spec.js
@@ -1,0 +1,132 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('JVM Tuning view (Quarkus)', () => {
+  test('renders JVM options and Kubernetes calculator recommendations', async ({
+    openView,
+    page,
+    browserName,
+    context
+  }) => {
+    // Grant clipboard permissions for the copy button. Not all browsers expose them
+    // through the same API; ignore failures gracefully.
+    if (browserName === 'chromium') {
+      try {
+        await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+      } catch {
+        /* no-op */
+      }
+    }
+
+    await openView('jvm-tuning', 'JVM Tuning')
+
+    // Quarkus has no application-wide virtual-threads switch (only per-endpoint
+    // @RunOnVirtualThread), so QuarkusMemoryRuntimeConfig.virtualThreadsProperty() is always
+    // null and the panel deliberately omits the "Virtual threads enabled/not enabled" advisory
+    // entirely (JvmTuning.vue only renders it `v-if="virtualThreadsProperty"`). This is a
+    // genuine, permanent platform difference, not a bug -- assert the box stays absent rather
+    // than porting Spring's "Virtual threads enabled" text check.
+    await expect(page.locator('.virtual-threads-status')).toHaveCount(0)
+
+    const jvmOptionsCard = page.locator('.card', {hasText: 'Bare metal JVM options'}).first()
+    const kubernetesCard = page.locator('.card', {hasText: 'Kubernetes calculator'}).first()
+    const kubernetesYaml = kubernetesCard.locator('.options-box code')
+    await expect(jvmOptionsCard).toBeVisible()
+    await expect(kubernetesCard).toBeVisible()
+    await expect(kubernetesCard).toContainText('Guaranteed')
+    await expect(kubernetesCard.locator('#kubernetesBurstableEnabled')).not.toBeChecked()
+    // SmallRye Health is on the sample app's classpath, so
+    // QuarkusMemoryRuntimeConfig.kubernetesHealthProbesEnabled() is true and the toggle starts checked.
+    await expect(kubernetesCard.locator('#kubernetesActuatorEnabled')).toBeChecked()
+    await expect(kubernetesYaml).toContainText('JAVA_TOOL_OPTIONS')
+    await expect(kubernetesYaml).toContainText('MaxRAMPercentage')
+    // Quarkus renders SmallRye Health's own httpGet probe paths directly (no Spring Actuator
+    // env-var toggle exists on this platform).
+    await expect(kubernetesYaml).toContainText('startupProbe')
+    await expect(kubernetesYaml).toContainText('readinessProbe')
+    await expect(kubernetesYaml).toContainText('/q/health/ready')
+    await expect(kubernetesYaml).toContainText('/q/health/live')
+    await expect(kubernetesYaml).not.toContainText('MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED')
+    await expect(kubernetesYaml).not.toContainText('spring.threads.virtual.enabled=true')
+    await expect(kubernetesYaml).not.toContainText('-Xmx')
+    await expect(kubernetesCard).toContainText('Garbage collector:')
+    await expect(kubernetesCard).toContainText('Sizing notes')
+
+    const optionsBlock = jvmOptionsCard.locator('.options-box code')
+    await expect(optionsBlock).toContainText(/-Xmx|-XX:/)
+    await expect(optionsBlock).not.toContainText('spring.threads.virtual.enabled=true')
+
+    const copyButton = jvmOptionsCard.getByRole('button', {name: /Copy/})
+    await copyButton.click()
+    await expect(page.getByRole('button', {name: /Copied!/})).toBeVisible({timeout: 5_000})
+  })
+
+  test('Kubernetes toggles update the deployment snippet', async ({openView, page}) => {
+    await openView('jvm-tuning', 'JVM Tuning')
+
+    const kubernetesCard = page.locator('.card', {hasText: 'Kubernetes calculator'}).first()
+    const yamlBlock = kubernetesCard.locator('.options-box code')
+    const burstableToggle = kubernetesCard.locator('#kubernetesBurstableEnabled')
+    const actuatorToggle = kubernetesCard.locator('#kubernetesActuatorEnabled')
+
+    await expect(kubernetesCard).toBeVisible()
+    const guaranteedYaml = await yamlBlock.innerText()
+    const guaranteedRequest = guaranteedYaml.match(/requests:\s+memory: "([^"]+)"/)?.[1]
+    expect(guaranteedRequest).toBeTruthy()
+
+    await burstableToggle.check()
+    await expect
+      .poll(
+        async () => {
+          const yaml = await yamlBlock.innerText()
+          return yaml.match(/requests:\s+memory: "([^"]+)"/)?.[1] || ''
+        },
+        {timeout: 5_000}
+      )
+      .not.toBe(guaranteedRequest)
+    await expect(kubernetesCard).toContainText('Burstable')
+
+    // Unchecking the health-probes toggle removes SmallRye Health's startup/readiness/liveness
+    // probe stanzas from the generated manifest (Quarkus has no env-var equivalent to assert
+    // the absence of; the whole `httpGet` probe blocks disappear instead).
+    await actuatorToggle.uncheck()
+    await expect(yamlBlock).not.toContainText('startupProbe')
+    await expect(yamlBlock).not.toContainText('readinessProbe')
+    await expect(yamlBlock).not.toContainText('livenessProbe')
+    await expect(yamlBlock).not.toContainText('/q/health/')
+  })
+
+  test('editing total memory updates the recommended -Xmx', async ({openView, page}) => {
+    await openView('jvm-tuning', 'JVM Tuning')
+
+    const calculatorCard = page.locator('.card', {hasText: 'Bare metal JVM calculator'})
+    const jvmOptionsCard = page.locator('.card', {hasText: 'Bare metal JVM options'}).first()
+    await expect(calculatorCard).toBeVisible()
+
+    const totalInput = calculatorCard.locator('input[type="number"]').first()
+    await expect(totalInput).toBeVisible()
+    await expect(totalInput).not.toHaveValue('')
+
+    const optionsBlock = jvmOptionsCard.locator('.options-box code')
+    const before = await optionsBlock.innerText()
+    const beforeMatch = before.match(/-Xmx(\d+)m/)
+    expect(beforeMatch).not.toBeNull()
+    const beforeXmx = parseInt(beforeMatch[1], 10)
+
+    const currentTotal = parseInt(await totalInput.inputValue(), 10)
+    const newTotal = currentTotal > 1024 ? 512 : currentTotal + 512
+    await totalInput.fill(String(newTotal))
+    await totalInput.blur()
+
+    await expect
+      .poll(
+        async () => {
+          const text = await optionsBlock.innerText()
+          const m = text.match(/-Xmx(\d+)m/)
+          return m ? parseInt(m[1], 10) : 0
+        },
+        {timeout: 5_000}
+      )
+      .not.toBe(beforeXmx)
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/live-memory.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/live-memory.spec.js
@@ -1,0 +1,27 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Live Memory view (Quarkus)', () => {
+  test('renders heap and non-heap live memory cards without tuning panels', async ({openView, page}) => {
+    await openView('live-memory', 'Live Memory')
+
+    await expect(page.locator('.card', {hasText: 'Heap Memory'}).first()).toBeVisible()
+    await expect(page.locator('.card', {hasText: /Non[- ]?Heap/i}).first()).toBeVisible()
+    await expect(page.locator('.card', {hasText: 'Recommended JVM Options'})).toHaveCount(0)
+    await expect(page.locator('.card', {hasText: 'Kubernetes calculator'})).toHaveCount(0)
+  })
+
+  test('renders the memory pools table with usage values', async ({openView, page}) => {
+    await openView('live-memory', 'Live Memory')
+
+    const poolsCard = page.locator('.card', {hasText: 'Memory Pools'})
+    await expect(poolsCard).toBeVisible()
+    await expect(poolsCard.locator('thead')).toContainText('Pool')
+    await expect(poolsCard.locator('thead')).toContainText('Usage')
+
+    const rows = poolsCard.locator('tbody tr')
+    await expect.poll(async () => rows.count()).toBeGreaterThan(0)
+    await expect(rows.first().locator('td').nth(0)).not.toBeEmpty()
+    await expect(rows.first().locator('td').nth(4)).toContainText(/%/)
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/log-tail.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/log-tail.spec.js
@@ -1,0 +1,43 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Log Tail view (Quarkus)', () => {
+  test('connects to the SSE stream, then can pause and resume', async ({openView, page}) => {
+    await openView('log-tail', 'Log Tail')
+
+    const status = page.locator('h2 + .badge, .d-flex .badge').first()
+    await expect(status).toHaveText(/Connected/, {timeout: 15_000})
+
+    // Generate a log line via the sample API.
+    const apiResponse = await page.request.get('/api/sample/hello')
+    expect(apiResponse.ok()).toBeTruthy()
+
+    // We don't strictly require a line to appear (logging.level controls that),
+    // but the pane must remain stable and the pause button must work.
+    await page.getByRole('button', {name: /Pause/}).click()
+    await expect(status).toHaveText(/Paused/)
+
+    await page.getByRole('button', {name: /Resume/}).click()
+    await expect(status).toHaveText(/Connected/, {timeout: 15_000})
+  })
+
+  test('clear empties the log pane', async ({openView, page}) => {
+    await openView('log-tail', 'Log Tail')
+
+    await page.getByRole('button', {name: /Clear/}).click()
+    // Either the empty-state message is shown, or there are no rendered lines.
+    const empty = page.locator('text=No log lines to display.')
+    const lineCount = page.locator('.log-pane code span.d-block')
+    await expect(async () => {
+      const visible = (await empty.count()) + ((await lineCount.count()) === 0 ? 1 : 0)
+      expect(visible).toBeGreaterThan(0)
+    }).toPass()
+  })
+
+  test('level selector exposes the four severity buckets', async ({openView, page}) => {
+    await openView('log-tail', 'Log Tail')
+    const select = page.locator('select.form-select')
+    const options = await select.locator('option').allInnerTexts()
+    expect(options).toEqual(['All', 'Info+', 'Warn+', 'Error'])
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/mappings.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/mappings.spec.js
@@ -1,0 +1,41 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('HTTP mappings view (Quarkus)', () => {
+  test('lists the sample app endpoints and filters them', async ({openView, page}) => {
+    await openView('mappings', 'HTTP mappings')
+
+    const rows = page.locator('table tbody tr')
+    await expect.poll(async () => rows.count()).toBeGreaterThan(5)
+
+    // The sample JAX-RS resources and admin endpoint must be present (these were previously hidden by an
+    // over-broad self-filter that also swallowed the sample app's own io.github.jdubois.bootui.sample
+    // package; this asserts the fix rather than just "the page renders").
+    await expect(page.locator('table tbody')).toContainText('/api/hello')
+    await expect(page.locator('table tbody')).toContainText('/api/secure')
+    await expect(page.locator('table tbody')).toContainText('/api/sample/hello')
+    await expect(page.locator('table tbody')).toContainText('/api/sample/products')
+    await expect(page.locator('table tbody')).toContainText('/admin')
+
+    // Filter to a single endpoint.
+    await page.getByPlaceholder('Filter…').fill('/api/sample/hello')
+    await expect(rows).toHaveCount(1)
+    await expect(rows.first()).toContainText('GET')
+    await expect(rows.first()).toContainText('/api/sample/hello')
+    await expect(rows.first()).toContainText('SampleResource#hello')
+  })
+
+  test('never leaks BootUI\u2019s own /bootui/api routes into the inventory', async ({openView, page}) => {
+    await openView('mappings', 'HTTP mappings')
+
+    await page.getByPlaceholder('Filter…').fill('/bootui')
+    await expect(page.locator('table tbody tr')).toHaveCount(0)
+
+    const response = await page.request.get('/bootui/api/mappings/flat', {
+      headers: {'X-Forwarded-For': '127.0.0.1'}
+    })
+    const body = await response.json()
+    const bootUiLeak = body.mappings.filter((m) => m.pattern.startsWith('/bootui'))
+    expect(bootUiLeak).toEqual([])
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/overview.spec.js
@@ -1,0 +1,89 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Overview view (Quarkus)', () => {
+  test('renders the panel header and the scanner dashboard', async ({openView}) => {
+    const page = await openView('overview', 'Overview')
+
+    await expect(page.locator('.topbar-title')).toContainText('bootui-quarkus-sample')
+    await expect(page.locator('.topbar-subtitle')).toContainText(/Quarkus/)
+    await expect(page.locator('.topbar-subtitle')).toContainText(/Java/)
+
+    // Panel header introduces the advisor dashboard.
+    await expect(page.locator('.panel-header')).toContainText('Run the advisors to score')
+
+    // Overall score box and the on-demand "Run all scanners" action.
+    const overall = page.locator('.overall-card').first()
+    await expect(overall).toContainText('Overall score')
+    await expect(overall.getByRole('button', {name: /Run all scanners/})).toBeVisible()
+
+    // At least the Architecture scanner card is shown for the sample app.
+    const architectureCard = page.locator('.scanner-card', {hasText: 'Architecture'})
+    await expect(architectureCard).toBeVisible()
+    await expect(architectureCard.getByRole('button', {name: /Run scan/})).toBeVisible()
+  })
+
+  test('renders the shared Spring advisor card under its platform-aware "Quarkus" label', async ({openView}) => {
+    const page = await openView('overview', 'Overview')
+
+    // The `spring` scanner id/endpoint is reused on Quarkus (see routes.js meta.titleByPlatform),
+    // but the card title itself must render the Quarkus-specific label, not "Spring".
+    const quarkusCard = page.locator('.scanner-card', {hasText: 'Quarkus'})
+    await expect(quarkusCard).toBeVisible()
+    await expect(quarkusCard.getByRole('button', {name: /Run scan/})).toBeVisible()
+    await expect(page.locator('.scanner-card', {hasText: /^Spring$/})).toHaveCount(0)
+  })
+
+  test('does not run scanners until requested, then scores on demand', async ({openView, page}) => {
+    await openView('overview', 'Overview')
+
+    // Nothing is scored on load.
+    await expect(page.locator('.overall-card').first()).toContainText('0 of')
+
+    const architectureCard = page.locator('.scanner-card', {hasText: 'Architecture'})
+    const scanResponse = page.waitForResponse(
+      (res) => res.url().endsWith('/bootui/api/architecture/scan') && res.request().method() === 'POST'
+    )
+    await architectureCard.getByRole('button', {name: /Run scan/}).click()
+    expect((await scanResponse).ok()).toBeTruthy()
+
+    // The card resolves to a numeric score out of 100.
+    await expect(architectureCard).toContainText('/ 100')
+  })
+
+  test('GitHub card exposes a connect button since a repository is detected', async ({openView, page}) => {
+    await openView('overview', 'Overview')
+
+    // The sample app is checked out from a real git repository, so the GitHub panel is
+    // dynamically available (unlike the Spring spec, this is asserted unconditionally here).
+    const githubCard = page.locator('.scanner-card', {hasText: 'GitHub'})
+    await expect(githubCard).toBeVisible()
+    await expect(githubCard.getByRole('button', {name: /Connect to GitHub/})).toBeVisible()
+  })
+
+  test('reveals an MCP Server tip after running all scanners', async ({openView, page}) => {
+    await openView('overview', 'Overview')
+
+    const overall = page.locator('.overall-card').first()
+    await expect(page.locator('.mcp-tip')).toHaveCount(0)
+
+    await overall.getByRole('button', {name: /Run all scanners/}).click()
+
+    const tip = page.locator('.mcp-tip')
+    await expect(tip).toBeVisible()
+    await expect(tip).toContainText('BootUI MCP Server')
+    await expect(tip.getByRole('link', {name: 'BootUI MCP Server'})).toHaveAttribute('href', /#\/mcp-server$/)
+
+    await tip.getByRole('button', {name: 'Dismiss tip'}).click()
+    await expect(tip).toHaveCount(0)
+  })
+
+  test('links to the BootUI GitHub project with the Quarkus-flavored tagline', async ({openView}) => {
+    const page = await openView('overview', 'Overview')
+
+    await expect(page.getByRole('link', {name: /The missing developer UI for Quarkus/})).toHaveAttribute(
+      'href',
+      'https://github.com/jdubois/boot-ui'
+    )
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/profile-diff.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/profile-diff.spec.js
@@ -1,0 +1,41 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Profile Diff view (Quarkus)', () => {
+  test('renders the active dev profile badge and its real override table', async ({openView, page}) => {
+    await openView('profile-diff', 'Profile Diff')
+
+    await expect(page.locator('text=Loading…')).toHaveCount(0)
+
+    // Quarkus has no separate application-dev.properties file; %profile.-prefixed keys in the
+    // single application.properties serve the same purpose (QuarkusConfigProvider.profileSources()).
+    // The e2e suite always runs the sample app under `quarkus:dev`, so the active profile is
+    // deterministically "dev" -- unlike Spring's spec (which accepts either state depending on how
+    // it was launched), this can assert the real content directly.
+    await expect(page.locator('.badge', {hasText: 'dev'}).first()).toBeVisible()
+
+    const sourceHeading = page.locator('small.text-muted.font-monospace', {hasText: 'application.properties (%dev)'})
+    await expect(sourceHeading).toBeVisible()
+
+    const table = page.locator('table').first()
+    await expect(table).toContainText('sample.retries')
+    await expect(table).toContainText('1')
+
+    await expect(page.locator('.alert', {hasText: /No profile-specific configuration sources found/})).toHaveCount(0)
+    await expect(page.getByPlaceholder(/Filter by property name or value/)).toBeVisible()
+  })
+
+  test('filtering narrows the profile-specific property table', async ({openView, page}) => {
+    await openView('profile-diff', 'Profile Diff')
+
+    const filter = page.getByPlaceholder(/Filter by property name or value/)
+    const table = page.locator('table').first()
+    await expect(table).toContainText('sample.retries')
+
+    await filter.fill('sample.retries')
+    await expect(table).toContainText('sample.retries')
+
+    await filter.fill('no-such-property-xyz')
+    await expect(page.locator('.alert', {hasText: /No profile-specific configuration sources found/})).toBeVisible()
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/scheduled.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/scheduled.spec.js
@@ -1,0 +1,31 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+test.describe('Scheduled tasks view (Quarkus)', () => {
+  test('renders the sample echo scheduled task', async ({openView, page}) => {
+    await openView('scheduled', 'Scheduled Tasks')
+
+    await expect(page.locator('text=Loading…')).toHaveCount(0)
+
+    const row = page.locator('table tbody tr', {hasText: 'FIXED_RATE'})
+    await expect(row).toBeVisible()
+    await expect(row).toContainText('30 s')
+    // Real Jandex-discovered @Scheduled task from the sample app, not a placeholder --
+    // QuarkusScheduledTaskProvider renders the annotated method as `class#method`.
+    await expect(row).toContainText('io.github.jdubois.bootui.sample.scheduling.EchoScheduler#echo')
+  })
+
+  test('filtering by runnable name narrows the table', async ({openView, page}) => {
+    await openView('scheduled', 'Scheduled Tasks')
+
+    const filter = page.getByPlaceholder(/Filter by runnable name or expression/)
+    const rows = page.locator('table tbody tr')
+
+    await filter.fill('EchoScheduler')
+    await expect(rows).toHaveCount(1)
+    await expect(rows.first()).toContainText('echo')
+
+    await filter.fill('no-such-scheduled-task-xyz')
+    await expect(rows).toHaveCount(0)
+  })
+})

--- a/bootui-quarkus-sample-app/e2e/tests/security-logs.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/security-logs.spec.js
@@ -1,0 +1,73 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+function basicAuthHeader(user, password) {
+  return {Authorization: 'Basic ' + Buffer.from(`${user}:${password}`).toString('base64')}
+}
+
+test.describe('Security Logs view (Quarkus)', () => {
+  test('captures real authentication/authorization CDI security events with masked data', async ({openView, page}) => {
+    // Three real security outcomes against the sample app's role-protected /api/secure resource
+    // (@RolesAllowed("admin")), each producing a distinct CDI SecurityEvent that
+    // QuarkusSecurityEventCapture records: a successful admin login, a wrong-password
+    // authentication failure, and a valid-but-insufficient-role authorization failure.
+    const success = await page.request.get('/api/secure', {headers: basicAuthHeader('admin', 'admin')})
+    expect(success.ok()).toBeTruthy()
+
+    const authnFailure = await page.request.get('/api/secure', {headers: basicAuthHeader('admin', 'wrong-password')})
+    expect(authnFailure.status()).toBe(401)
+
+    const authzFailure = await page.request.get('/api/secure', {headers: basicAuthHeader('developer', 'developer')})
+    expect(authzFailure.status()).toBe(403)
+
+    await openView('security-logs', 'Security Logs')
+
+    // Quarkus-specific copy: no AuditEventRepository exists on this platform, so the panel explains
+    // its CDI-security-event sourcing and the logout/session-event gap explicitly.
+    await expect(page.locator('main')).toContainText(
+      'Read-only Quarkus security events captured from CDI authentication/authorization events'
+    )
+    await expect(page.locator('main')).toContainText('This application returns up to 500 recent events per response')
+    await expect(page.locator('main')).toContainText('bootui.security-logs.max-logs')
+    await expect(page.locator('main')).toContainText('logout and session events have no Quarkus equivalent')
+
+    // Type summaries reflect the real event classes Quarkus fires (class simple names, not Spring's
+    // AUTHENTICATION_SUCCESS-style enum strings).
+    await expect(page.locator('.badge', {hasText: /AuthenticationSuccessEvent \d+/})).toBeVisible()
+    await expect(page.locator('.badge', {hasText: /AuthenticationFailureEvent \d+/})).toBeVisible()
+    await expect(page.locator('.badge', {hasText: /AuthorizationFailureEvent \d+/})).toBeVisible()
+
+    // Filter down to the developer authorization failure and inspect its real event data.
+    await page.locator('#security-log-principal').fill('developer')
+    await page.locator('#security-log-type').fill('AuthorizationFailureEvent')
+    await page.getByRole('button', {name: 'Apply'}).click()
+
+    const table = page.locator('table')
+    await expect(table).toBeVisible()
+    const developerRow = page.locator('tbody tr', {hasText: 'developer'}).first()
+    await expect(developerRow).toBeVisible()
+    // Columns are Time / Principal / Type / Event data -- scope to the Type cell specifically,
+    // since the event-data cell also contains the raw property key
+    // "...AuthorizationFailureEvent.CONTEXT" which would otherwise ambiguously match the same text.
+    await expect(developerRow.locator('td').nth(2).locator('.badge')).toHaveClass(/bg-danger/)
+    const developerData = developerRow.locator('td').nth(3)
+    // The failed-role exception name is a plain class name, not a secret -- rendered unmasked.
+    await expect(developerData).toContainText('failure=ForbiddenException')
+    // The raw Quarkus event-property key names the class "AuthorizationFailureEvent", which contains
+    // "auth" -- the shared SecretMasker keyword-pattern heuristic conservatively masks it.
+    await expect(developerData.locator('.bi-shield-lock')).toBeVisible()
+    await expect(developerData).toContainText('******')
+
+    // Clear the principal filter and narrow to the authentication failure instead: Quarkus reports
+    // an unresolved identity's principal as the literal string "anonymous" (distinct from the empty
+    // principal an entirely credential-less request produces).
+    await page.locator('#security-log-principal').fill('anonymous')
+    await page.locator('#security-log-type').fill('AuthenticationFailureEvent')
+    await page.getByRole('button', {name: 'Apply'}).click()
+
+    const anonymousRow = page.locator('tbody tr', {hasText: 'anonymous'}).first()
+    await expect(anonymousRow).toBeVisible()
+    await expect(anonymousRow.locator('td').nth(2).locator('.badge')).toHaveClass(/bg-danger/)
+    await expect(anonymousRow.locator('td').nth(3)).toContainText('failure=AuthenticationFailedException')
+  })
+})

--- a/bootui-quarkus-sample-app/src/main/resources/application.properties
+++ b/bootui-quarkus-sample-app/src/main/resources/application.properties
@@ -102,6 +102,16 @@ quarkus.langchain4j.ollama.timeout=30s
 sample.greeting=Hello
 sample.retries=3
 
+# --- Profile-specific override (Profile Diff panel) -------------------------
+# Quarkus has no separate application-dev.properties file; %profile.-prefixed keys serve the
+# same purpose in one file. This dev-only override (fail fast with fewer retries while
+# iterating locally) gives the Profile Diff panel a real, non-default property to display for
+# the active "dev" profile, mirroring how the Spring sample app's application-dev.properties
+# gives its own Profile Diff spec real content. It must stay a key already declared on
+# SampleSettings (sample.retries) -- SmallRye Config's strict mapping validation rejects any
+# %dev.sample.* key that isn't a known field of the registered "sample" @ConfigMapping root.
+%dev.sample.retries=1
+
 # --- Logging ----------------------------------------------------------------
 quarkus.log.category."io.github.jdubois.bootui".level=DEBUG
 

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/beans/QuarkusBeanProvider.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/beans/QuarkusBeanProvider.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.quarkus.beans;
 
 import io.github.jdubois.bootui.core.dto.BeanSummary;
+import io.github.jdubois.bootui.engine.support.InternalPackageMatcher;
 import io.github.jdubois.bootui.spi.BeanProvider;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.spi.Bean;
@@ -28,8 +29,13 @@ import java.util.Locale;
  * CDI qualifiers have no {@link BeanSummary} field — the DTO is the frozen UI contract — so they are not
  * surfaced. {@code aliases} is therefore always empty. For producer (<code>@Produces</code>) beans Arc reports
  * the declaring class as {@link Bean#getBeanClass()}, so such beans show their producer's class as the type;
- * this also makes the BootUI self-filter robust, since BootUI's own engine services are produced from a
- * single producer class under {@code io.github.jdubois.bootui}.</p>
+ * this also makes the BootUI self-filter robust, since BootUI's own engine services are produced from
+ * producer classes under {@code io.github.jdubois.bootui.quarkus}. The self-filter reuses the shared engine
+ * {@link InternalPackageMatcher} scoped to {@code io.github.jdubois.bootui.quarkus}/{@code .core} (the same
+ * prefixes {@code QuarkusScheduledTaskProvider} and the Log Tail/Exceptions captures use) rather than the
+ * whole {@code io.github.jdubois.bootui} tree, so it does not also swallow application code that happens to
+ * live under that root package (for example a sample/demo app packaged as {@code io.github.jdubois.bootui.sample}),
+ * nor the framework-neutral {@code engine}/{@code spi} packages.</p>
  *
  * <p>The inventory reflects the beans Arc actually retains: Arc removes unused beans at build time as an
  * optimization, so a bean that is never injected (and is not {@code @Unremovable}) does not appear here.
@@ -37,7 +43,8 @@ import java.util.Locale;
  */
 public final class QuarkusBeanProvider implements BeanProvider {
 
-    private static final String BOOTUI_PACKAGE_PREFIX = "io.github.jdubois.bootui";
+    private static final InternalPackageMatcher INTERNAL_PACKAGES =
+            new InternalPackageMatcher(List.of("io.github.jdubois.bootui.quarkus", "io.github.jdubois.bootui.core"));
 
     private static final List<String> FRAMEWORK_PREFIXES =
             List.of("io.quarkus.", "io.vertx.", "org.jboss.", "io.smallrye.", "org.eclipse.microprofile.", "io.netty.");
@@ -63,7 +70,7 @@ public final class QuarkusBeanProvider implements BeanProvider {
         for (Bean<?> bean : beanManager.getBeans(Object.class, Any.Literal.INSTANCE)) {
             Class<?> beanClass = bean.getBeanClass();
             String type = beanClass == null ? null : beanClass.getName();
-            if (type != null && isBootUiBean(type)) {
+            if (type != null && INTERNAL_PACKAGES.matchesName(type)) {
                 continue;
             }
             summaries.add(toSummary(bean, beanClass, type));
@@ -91,15 +98,11 @@ public final class QuarkusBeanProvider implements BeanProvider {
         return scope == null ? null : scope.getSimpleName();
     }
 
-    private boolean isBootUiBean(String type) {
-        return type.equals(BOOTUI_PACKAGE_PREFIX) || type.startsWith(BOOTUI_PACKAGE_PREFIX + ".");
-    }
-
     private String classify(String type) {
         if (type == null) {
             return "OTHER";
         }
-        if (isBootUiBean(type)) {
+        if (INTERNAL_PACKAGES.matchesName(type)) {
             return "BOOTUI";
         }
         for (String prefix : FRAMEWORK_PREFIXES) {

--- a/bootui-ui/src/main/frontend/src/views/SecurityLogs.test.js
+++ b/bootui-ui/src/main/frontend/src/views/SecurityLogs.test.js
@@ -67,4 +67,28 @@ describe('SecurityLogs', () => {
 
     expect(wrapper.text()).toContain('No audit events match the current filters.')
   })
+
+  it('colors Quarkus PascalCase event types the same as Spring SCREAMING_SNAKE_CASE equivalents', async () => {
+    // Regression test: typeBadgeClass() used to compare typeName against ALL-CAPS keywords with a
+    // case-sensitive .includes(), so Quarkus's raw CDI event class names (e.g.
+    // "AuthenticationFailureEvent") never matched and every Quarkus badge silently fell through to
+    // the generic bg-primary color instead of the intended red/green/yellow semantic color.
+    const wrapper = await mountWith(
+      report({
+        events: [
+          event({type: 'AuthenticationSuccessEvent'}),
+          event({type: 'AuthenticationFailureEvent'}),
+          event({type: 'AuthorizationFailureEvent'})
+        ],
+        typeSummaries: [{type: 'AuthenticationSuccessEvent', count: 1}]
+      }),
+      {platform: 'quarkus'}
+    )
+
+    const badges = wrapper.findAll('tbody .badge')
+    expect(badges).toHaveLength(3)
+    expect(badges[0].classes()).toContain('bg-success')
+    expect(badges[1].classes()).toContain('bg-danger')
+    expect(badges[2].classes()).toContain('bg-danger')
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/SecurityLogs.vue
+++ b/bootui-ui/src/main/frontend/src/views/SecurityLogs.vue
@@ -83,9 +83,14 @@ function formatValue(entry) {
 
 function typeBadgeClass(typeName) {
   if (!typeName) return 'bg-secondary'
-  if (typeName.includes('FAILURE') || typeName.includes('DENIED')) return 'bg-danger'
-  if (typeName.includes('SUCCESS')) return 'bg-success'
-  if (typeName.includes('AUTHORIZATION')) return 'bg-warning text-dark'
+  // Case-insensitive on purpose: Spring's audit events use SCREAMING_SNAKE_CASE
+  // (AUTHENTICATION_SUCCESS) but Quarkus's CDI security events use their raw PascalCase class
+  // names (AuthenticationFailureEvent), so a case-sensitive match against all-caps keywords would
+  // silently miss every Quarkus type and fall through to the generic badge color.
+  const upperTypeName = typeName.toUpperCase()
+  if (upperTypeName.includes('FAILURE') || upperTypeName.includes('DENIED')) return 'bg-danger'
+  if (upperTypeName.includes('SUCCESS')) return 'bg-success'
+  if (upperTypeName.includes('AUTHORIZATION')) return 'bg-warning text-dark'
   return 'bg-primary'
 }
 </script>

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -335,12 +335,14 @@ Pentesting, HTTP Probe, MCP Server) need no special ingredients — they work ag
 - **Run:** `./mvnw -pl bootui-quarkus-sample-app -am quarkus:dev` starts Quarkus dev mode and serves the console at
   `http://localhost:8080/bootui` — the analogue of the Spring sample app's `spring-boot:run` smoke-test path. Quarkus
   live reload replaces DevTools for the inner loop. (`-am` builds the upstream `bootui-quarkus` extension first.)
-- **e2e:** a `bootui-quarkus-sample-app/e2e/` Playwright project mirrors `bootui-spring-sample-app/e2e/`. Keep the specs for the
-  ~36 supported panels; drop the specs for panels not shipped on Quarkus (`beans`, `conditions`, `startup`,
-  `profile-diff`, `spring-security`, `data`, `http-sessions`, `graalvm`, `crac`, `devtools`, `security`); add
-  `quarkus-advisor.spec.js` and `quarkus-cache.spec.js`. Reuse the existing `fixtures.js` / `app-shell.spec.js` patterns.
-  To honor the "as much common code as possible" goal, factor the panel-agnostic Playwright helpers into a shared
-  library both suites import, rather than copying them.
+- **e2e:** a `bootui-quarkus-sample-app/e2e/` Playwright project mirrors `bootui-spring-sample-app/e2e/`, with one spec per
+  supported panel plus `quarkus-advisor.spec.js` / `cache.spec.js`; drop specs only for the panels genuinely not shipped
+  on Quarkus (`conditions`, `startup`, `spring-security`, `data`, `http-sessions`, `graalvm`, `crac`, `devtools`) covered
+  instead by `not-applicable.spec.js`. (An earlier revision of this plan also listed `beans`, `profile-diff`, and
+  `security` as drop candidates; all three shipped and now have dedicated specs — see §5 for the authoritative
+  per-panel availability.) Reuse the existing `fixtures.js` / `app-shell.spec.js` patterns. To honor the "as much common
+  code as possible" goal, factor the panel-agnostic Playwright helpers into a shared library both suites import, rather
+  than copying them.
 - **CI:** add a job mirroring the existing Spring e2e job in `.github/workflows/build.yml` — build the extension + sample
   app, `npx playwright install --with-deps chromium`, then `npm test` — so **both** platforms are gated on every build.
 - **Screenshots:** the docs screenshots in `docs/images/bootui-*.webp` are captured from the Spring sample app and stay


### PR DESCRIPTION
## Gap addressed

A parity analysis found that 17 Quarkus panels available per `QuarkusPanelAvailability.java` had **no dedicated
Playwright e2e spec** — they only got the shallow "every panel renders without erroring" smoke assertion in
`app-shell.spec.js`. Spring's e2e suite has 46 spec files with real data/interaction assertions; Quarkus's had 22.
This PR adds a dedicated spec per panel, mirroring the Spring spec's depth (real rendered data, filtering/sorting,
drawers, SSE streams, interactive controls — not visibility-only checks).

## Update: merged `origin/main`, added coverage for a newly-landed feature

After the original 17-panel work was done, `origin/main` picked up 9 new commits (4 sibling PRs, #494–#497) before
this branch merged. The merge itself was clean (zero textual conflicts), but one incoming change,
**#496 "Quarkus: add reduced, trace-id-only per-request profile drill-down"**, added a genuinely new capability to
the very panel this PR prioritizes: Live Activity gained a per-request profile drawer
(`GET /bootui/api/activity/request/{id}`, backed by the new `RequestProfileAssembler`). That directly contradicted
`activity.spec.js`'s own docblock (which said Quarkus has no profile drawer) and left the new feature completely
untested at the e2e level — exactly the kind of silent gap this PR exists to close, so I fixed the comment and
added dedicated coverage rather than leave it:

- **`opens a per-request profile drawer with a reduced, trace-id-only profile`** — asserts the drawer renders real
  request/SQL data, and specifically that SQL correlation always shows **"exact"** (Quarkus has no time-window
  fallback, so it can never show Spring's "approximate" badge), plus the reduced-profile explanation notes.
- **`correlates a security event to the profiled request by trace id, never claiming a thread-exact match`** —
  asserts the Security events section shows the `AuthenticationSuccessEvent` badged **"principal"**, never the
  stronger "exact" (thread-matched) badge Spring's fuller profiler can show — scoped to that section specifically,
  since the same request's SQL section legitimately does show "exact".
- **`closes the profile drawer with the Escape key and offers a copy action`** — Escape-to-close and the Copy
  profile button, mirroring Spring's simpler interaction test.

`activity.spec.js` is now 11 tests (was 8). All verified against a live `quarkus:dev` server; the full 97-test
Quarkus e2e suite (41 spec files, including the sibling's `read-only.spec.js`), the 326-test frontend Vitest suite,
the whole-reactor unit/integration test suite, and `spotless:check` all pass post-merge with zero regressions.

## Panels covered (all 17 — full priority list, all with genuine deep coverage)

| Priority | Panel | Spec | Tests |
|---|---|---|---|
| **1 (highest)** | Live Activity | `activity.spec.js` | 11 |
| 2 | Overview | `overview.spec.js` | 6 |
| 3 | Beans | `beans.spec.js` | 2 |
| 4 | Health | `health.spec.js` | 2 |
| 5 | Mappings | `mappings.spec.js` | 2 |
| 6 | Configuration | `config.spec.js` | 2 |
| 7 | GitHub | `github.spec.js` | 1 |
| 8 | JVM Tuning | `jvm-tuning.spec.js` | 3 |
| 9 | Live Memory | `live-memory.spec.js` | 2 |
| 10 | Log Tail | `log-tail.spec.js` | 3 |
| 11 | HTTP Exchanges | `http-exchanges.spec.js` | 2 |
| 12 | Profile Diff | `profile-diff.spec.js` | 2 |
| 13 | Scheduled Tasks | `scheduled.spec.js` | 2 |
| 14 | Security Logs | `security-logs.spec.js` | 1 |
| 15 | AI Usage | `ai.spec.js` | 4 |
| 16 | Copilot | `copilot.spec.js` | 1 |
| 17 | Claude Code | `claude-code.spec.js` | 1 |

**47 new tests, all passing.** Nothing was dropped or padded with superficial checks.

### Live Activity — the priority spec
This is the panel where a real bug (Quarkus Exceptions' method/path always `null`) went unnoticed for a long time
precisely because no dedicated spec existed — it was only just fixed in #492. `activity.spec.js` specifically
asserts captured HTTP exchanges/exceptions/SQL entries render with **correct method/path/data** (not just "the row
exists"), plus pause/resume, error-only filtering with reload persistence, KPI card deep-links, exception nesting
under its owning request, the authenticated-request lock/principal tag, and (added in the merge update above) the
new per-request profile drawer.

### Real vs. mocked data, panel by panel
Most specs assert against **real data from the live Quarkus dev server**: real Arc/CDI beans (Beans), real
SmallRye Health tree (Health), real JAX-RS mappings (Mappings), real JVM MXBeans (JVM Tuning, Live Memory), real
SmallRye Config properties (Configuration, Profile Diff), real CDI security events over Basic Auth (Security Logs),
real `@Scheduled` task (Scheduled Tasks), real GitHub repo detection (GitHub), real SSE log stream (Log Tail), real
captured HTTP exchanges (HTTP Exchanges).

Three panels are mocked at the network layer, matching Spring's own established pattern for these same panels:
- **AI Usage**: the sample app's Ollama Dev Service runs on an ephemeral port that doesn't match the app's fixed
  `quarkus.langchain4j.ollama.base-url`, so real chat spans aren't reliably producible without an app config change
  that's out of scope here (would risk breaking manual local-Ollama testing workflows). Mirrors Spring's `ai.spec.js`
  approach, adapted for Quarkus's real DTO shape (`langChain4jDetected`) and UI copy (in-process capture note, no
  OTLP-endpoint section).
- **Copilot / Claude Code**: real session data is non-deterministic and environment-dependent (this session's own
  Copilot CLI state has 100 sessions / 110K+ events) and likely absent in CI, so mocking keeps the specs
  reproducible. `Copilot.vue` has zero platform-specific branching, so both specs port from Spring nearly
  byte-identical.

## Three production bugs found and fixed

All three were pre-existing bugs surfaced while building assertions against real data (not introduced by this PR):

1. **Beans panel hid real beans.** `QuarkusBeanProvider.isBootUiBean()` did a bare `io.github.jdubois.bootui` prefix
   check, so it silently hid anything whose FQN merely *started with* that string — not just BootUI's own beans.
   Fixed by scoping to the shared engine `InternalPackageMatcher` over the actual BootUI packages
   (`io.github.jdubois.bootui.quarkus` / `.core`). Verified via 118 passing `bootui-quarkus`/`-deployment` unit tests.

2. **Mappings panel hid real JAX-RS resources.** `BootUiQuarkusProcessor`'s build-time scanner had the identical
   bare-prefix bug in `BOOTUI_PACKAGE_PREFIX`. Fixed with a dotted-boundary check narrowed to the Quarkus adapter's
   own `...quarkus.web` package.

3. **Security Logs badges always rendered the wrong color on Quarkus.** `SecurityLogs.vue`'s `typeBadgeClass()` did
   case-sensitive `.includes()` matching against ALL-CAPS keywords designed for Spring's audit event names
   (`AUTHENTICATION_SUCCESS`). Quarkus's CDI security events use PascalCase class names
   (`AuthenticationFailureEvent`), which never matched, so every Quarkus badge silently fell through to the generic
   `bg-primary` instead of semantic red/green/yellow. Fixed by uppercasing before comparison (verified as a no-op
   for Spring's already-uppercase strings via the existing 3 Vitest tests). Added a 4th regression test in
   `SecurityLogs.test.js` asserting correct colors for 3 Quarkus PascalCase event types — this is now covered by
   both an e2e spec and a unit test.

## Other changes

- **Sample app seed data**: added `%dev.sample.retries=1` to `application.properties` so the Profile Diff panel has
  one real, non-default dev-profile override to display — mirrors how the Spring sample app's
  `application-dev.properties` feeds its own Profile Diff spec. (Discovered along the way: `sample.debug-logging`
  crashes the app under SmallRye Config's strict `@ConfigMapping` validation since it isn't a declared field —
  stuck to the existing `sample.retries` key instead.)
- **`docs/QUARKUS-SUPPORT.md`**: corrected a stale §8.2 planning-era bullet that still listed `beans`/`profile-diff`/
  `security` as e2e specs to *drop* as "not shipped on Quarkus." All three panels shipped since that bullet was
  written and now have dedicated coverage (two from this PR, `security.spec.js` already existed). Checked
  `docs/FEATURES.md` too — no per-panel e2e-coverage claims found there needing updates.
- Genuine Spring/Quarkus platform differences are asserted as **expected**, not bugs: JVM Tuning has no
  virtual-threads property line, Configuration is read-only (no save/override UI), AI Usage reports LangChain4j-only
  detection with in-process capture copy, and Live Activity's profile drawer is asserted as the deliberately
  *reduced*, trace-id-only shape described above (not Spring's fuller tiered profiler).

## How I verified every spec actually passes

- Booted the real Quarkus dev server (JDK 17, Docker for Postgres/Ollama Dev Services) and ran every new spec
  individually — all pass.
- Ran all 17 new specs together — all pass, no cross-test interference.
- After merging `origin/main`, rebuilt the whole reactor with JDK 17 (`clean install`, no skips) — **BUILD SUCCESS**,
  every module's unit/integration tests green (902 + 855 + per-module suites, 0 failures/errors).
- Ran the **full** Quarkus e2e suite (`npm test`, no filter) against the merged code — **97 tests across 41 spec
  files, all pass**, confirming zero regressions to the pre-existing specs plus the sibling's new `read-only.spec.js`.
- Ran the full frontend Vitest suite (**326 tests, 64 files**) — all pass.
- `npm run format` + `format:check` clean in `bootui-quarkus-sample-app/e2e`.
- Repo-wide `./mvnw -B -ntp spotless:check` passes across the whole reactor.

## Explicitly out of scope

`read-only.spec.js` was **not** touched — that's owned by a sibling session covering panel-gating e2e coverage in
parallel on a separate branch (merged into this branch via `origin/main`, left as-is).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>