### PR TITLE
Collapse capture/transform self-traffic classifiers into one shared instance

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/telemetry/SelfTelemetryClassifier.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/telemetry/SelfTelemetryClassifier.java
@@ -10,18 +10,22 @@ import java.util.Set;
  * Framework-neutral classifier that recognizes telemetry produced by BootUI itself, so a console
  * never reports on its own {@code /bootui/**} traffic.
  *
- * <p>This holds only the path/span/trace matching logic shared by two distinct call sites, which
- * are intentionally configured differently:</p>
- * <ul>
- *   <li><b>Capture</b> ({@link BootUiSpanExporter} and the OTLP receiver) drops self spans using the
- *       {@code bootui.telemetry.exclude-self-spans} flag and the hardcoded {@code "/bootui"} base
- *       path &mdash; see {@link #forPaths(String, String)}.</li>
- *   <li><b>Transform</b> (the Traces read API) filters self traces using the
- *       {@code bootui.monitoring.exclude-self} flag and the operator-configured {@code bootui.path}.</li>
- * </ul>
+ * <p>Each adapter builds <strong>exactly one</strong> instance from the operator-configured
+ * {@code bootui.path} / {@code bootui.api-path} and shares it between every call site that needs
+ * self-traffic recognition &mdash; capture ({@link BootUiSpanExporter}, the OTLP receiver) and
+ * transform (the Traces read API, and, via each adapter's broader self-data filter, the Beans,
+ * Mappings, Loggers, and Metrics panels). A single shared instance guarantees capture and transform
+ * can never disagree on which paths are BootUI's own, which two independently-configured instances
+ * previously could when {@code bootui.path} was customized.</p>
  *
- * <p>Both are byte-identical on default deployments but diverge when {@code bootui.path} is
- * customized or only one flag is toggled, so the two classifiers must stay separate instances.</p>
+ * <p>The two call sites still apply <em>different flags</em> on top of the same path-matching logic,
+ * because they answer different questions: capture (via {@link BootUiSpanExporter}) ANDs
+ * {@link #isBootUiSpan(NormalizedSpan)} with the telemetry-specific
+ * {@code bootui.telemetry.exclude-self-spans} flag to decide whether to keep a span in the bounded
+ * store at all, while {@link #shouldInclude(boolean)} / {@link #shouldIncludeTrace(Collection)} use
+ * this classifier's own {@code excludeSelf} field &mdash; sourced from the general
+ * {@code bootui.monitoring.exclude-self} flag shared by every monitoring panel &mdash; to decide
+ * whether already-stored data is displayed.</p>
  */
 public final class SelfTelemetryClassifier {
 
@@ -35,11 +39,6 @@ public final class SelfTelemetryClassifier {
     public SelfTelemetryClassifier(boolean excludeSelf, String path, String apiPath) {
         this.excludeSelf = excludeSelf;
         this.selfPaths = selfPaths(path, apiPath);
-    }
-
-    /** Capture-side classifier: always excludes self, over the hardcoded {@code "/bootui"} base path. */
-    public static SelfTelemetryClassifier forPaths(String path, String apiPath) {
-        return new SelfTelemetryClassifier(true, path, apiPath);
     }
 
     /** Classifier that includes everything (self-exclusion disabled). */

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/telemetry/BootUiSpanExporterTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/telemetry/BootUiSpanExporterTests.java
@@ -19,7 +19,7 @@ class BootUiSpanExporterTests {
 
     private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
 
-    private static final SelfTelemetryClassifier SELF = SelfTelemetryClassifier.forPaths("/bootui", "/bootui/api");
+    private static final SelfTelemetryClassifier SELF = new SelfTelemetryClassifier(true, "/bootui", "/bootui/api");
 
     private static final TelemetrySettings ENABLED = TelemetrySettings.of(true, true, 500, 500, 4096);
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/telemetry/TracesServiceTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/telemetry/TracesServiceTests.java
@@ -12,7 +12,7 @@ class TracesServiceTests {
 
     private static final TelemetrySettings ENABLED = TelemetrySettings.of(true, true, 500, 500, 4096);
 
-    private static final SelfTelemetryClassifier SELF = SelfTelemetryClassifier.forPaths("/bootui", "/bootui/api");
+    private static final SelfTelemetryClassifier SELF = new SelfTelemetryClassifier(true, "/bootui", "/bootui/api");
 
     @Test
     void summaryExposesHttpPathFromRootServerSpan() {

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiEngineProducer.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiEngineProducer.java
@@ -273,15 +273,17 @@ public class BootUiEngineProducer {
      * request through an {@link Instance} (mirroring the Spring adapter's {@code ObjectProvider} handle):
      * absent &rarr; {@code null} &rarr; the engine renders the panel as unavailable; present &rarr; the live
      * composite registry is read on every report. The meter-visibility predicate is the shared engine
-     * {@link MeterSelfFilter} built from the same transform-side {@link SelfTelemetryClassifier} the Traces
-     * read model uses (honoring {@code bootui.monitoring.exclude-self} and {@code bootui.path}), so the panel
-     * never reports BootUI's own {@code /bootui/**} traffic — exactly as the Spring adapter feeds
-     * {@code BootUiSelfDataFilter::shouldIncludeMeter}.
+     * {@link MeterSelfFilter} built from the single {@link SelfTelemetryClassifier} bean produced in
+     * {@link BootUiTelemetryProducer} (honoring {@code bootui.monitoring.exclude-self} and
+     * {@code bootui.path}) — the same instance the Traces read model and the capture-side span processor
+     * use — so the panel never reports BootUI's own {@code /bootui/**} traffic, exactly as the Spring
+     * adapter feeds {@code BootUiSelfDataFilter::shouldIncludeMeter}.
      */
     @Produces
     @Singleton
-    public MetricsReportProvider metricsReportProvider(Instance<MeterRegistry> registries, Config config) {
-        MeterSelfFilter meterFilter = new MeterSelfFilter(transformClassifier(config));
+    public MetricsReportProvider metricsReportProvider(
+            Instance<MeterRegistry> registries, SelfTelemetryClassifier selfClassifier) {
+        MeterSelfFilter meterFilter = new MeterSelfFilter(selfClassifier);
         return new MetricsReportProvider(() -> resolveRegistry(registries), meterFilter::shouldIncludeMeter);
     }
 
@@ -295,15 +297,6 @@ public class BootUiEngineProducer {
             // Multiple registries (e.g. several Micrometer backends): pick the first, like the Spring adapter.
             return registries.stream().findFirst().orElse(null);
         }
-    }
-
-    private static SelfTelemetryClassifier transformClassifier(Config config) {
-        boolean excludeSelf = config.getOptionalValue("bootui.monitoring.exclude-self", Boolean.class)
-                .orElse(Boolean.TRUE);
-        String path = config.getOptionalValue("bootui.path", String.class).orElse("/bootui");
-        String apiPath =
-                config.getOptionalValue("bootui.api-path", String.class).orElse("/bootui/api");
-        return new SelfTelemetryClassifier(excludeSelf, path, apiPath);
     }
 
     @Produces
@@ -646,15 +639,18 @@ public class BootUiEngineProducer {
      *
      * <p>Cache metrics are read live from the same {@link MeterRegistry} the Metrics panel uses (present only
      * when the application adds a {@code quarkus-micrometer} registry), through the identical
-     * {@link MeterSelfFilter} self-visibility predicate, so BootUI's own meters stay hidden — exactly as the
-     * Spring adapter feeds {@code BootUiSelfDataFilter::shouldIncludeMeter}.</p>
+     * {@link MeterSelfFilter} self-visibility predicate built from the shared {@link SelfTelemetryClassifier}
+     * bean, so BootUI's own meters stay hidden — exactly as the Spring adapter feeds
+     * {@code BootUiSelfDataFilter::shouldIncludeMeter}.</p>
      */
     @Produces
     @Singleton
     public CacheService cacheService(
-            Instance<CacheProvider> cacheProviders, Instance<MeterRegistry> registries, Config config) {
+            Instance<CacheProvider> cacheProviders,
+            Instance<MeterRegistry> registries,
+            SelfTelemetryClassifier selfClassifier) {
         CacheProvider provider = cacheProviders.isUnsatisfied() ? null : cacheProviders.get();
-        MeterSelfFilter meterFilter = new MeterSelfFilter(transformClassifier(config));
+        MeterSelfFilter meterFilter = new MeterSelfFilter(selfClassifier);
         return new CacheService(provider, () -> resolveRegistry(registries), meterFilter::shouldIncludeMeter);
     }
 

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiOtelProducer.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiOtelProducer.java
@@ -7,7 +7,6 @@ import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
-import org.eclipse.microprofile.config.Config;
 
 /**
  * OpenTelemetry capture wiring for the Quarkus adapter: produces the in-process {@link SpanProcessor} that
@@ -34,13 +33,10 @@ public class BootUiOtelProducer {
 
     @Produces
     @Singleton
-    public SpanProcessor bootUiSpanProcessor(TelemetryStore store, QuarkusTelemetrySettings settings, Config config) {
-        String apiPath =
-                config.getOptionalValue("bootui.api-path", String.class).orElse("/bootui/api");
-        // Capture-side classification (BF1): the base path is hardcoded to "/bootui", exactly as the Spring
-        // exporter does — distinct from the operator-configured transform classifier in
-        // BootUiTelemetryProducer.
-        SelfTelemetryClassifier captureClassifier = SelfTelemetryClassifier.forPaths("/bootui", apiPath);
-        return SimpleSpanProcessor.create(new BootUiSpanExporter(store, captureClassifier, settings));
+    public SpanProcessor bootUiSpanProcessor(
+            TelemetryStore store, QuarkusTelemetrySettings settings, SelfTelemetryClassifier selfClassifier) {
+        // Capture-side classification (BF1) now shares the same instance as every transform/display
+        // consumer — produced once in BootUiTelemetryProducer — instead of building its own.
+        return SimpleSpanProcessor.create(new BootUiSpanExporter(store, selfClassifier, settings));
     }
 }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiTelemetryProducer.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiTelemetryProducer.java
@@ -28,10 +28,12 @@ import org.eclipse.microprofile.config.Config;
  * <ul>
  *   <li>The store and the traces transform share the live {@link QuarkusTelemetrySettings} bean (telemetry
  *       enabled flag + retention limits read per call).</li>
- *   <li>The traces transform's self-trace classifier is built from the operator-configured
- *       {@code bootui.path}/{@code bootui.api-path} and {@code bootui.monitoring.exclude-self} — the
- *       <em>transform</em> classification (BF1), distinct from the capture-side classifier in
- *       {@link BootUiOtelProducer} which is hardcoded to {@code "/bootui"}.</li>
+ *   <li>{@link #selfTelemetryClassifier(Config)} is the <strong>single shared</strong> self-traffic
+ *       classifier for the whole Quarkus adapter, built once from the operator-configured
+ *       {@code bootui.path}/{@code bootui.api-path} and {@code bootui.monitoring.exclude-self}.
+ *       {@link BootUiEngineProducer} (Metrics, Cache) and the OTel-gated {@link BootUiOtelProducer}
+ *       (capture) inject this same instance rather than building their own, so capture and every
+ *       transform/display panel can never disagree on which paths are BootUI's own.</li>
  *   <li>The AI usage settings are supplied fresh per request so {@code bootui.ai.*} and
  *       {@code bootui.telemetry.enabled} overrides are honored live.</li>
  * </ul>
@@ -45,10 +47,28 @@ public class BootUiTelemetryProducer {
         return new TelemetryStore(settings);
     }
 
+    /**
+     * The single shared self-traffic classifier for the whole Quarkus adapter &mdash; injected by both the
+     * capture side ({@link BootUiOtelProducer}) and every transform/display consumer ({@link
+     * BootUiEngineProducer}, {@link #tracesService}) instead of each building its own. See the class-level
+     * javadoc.
+     */
     @Produces
     @Singleton
-    public TracesService tracesService(TelemetryStore store, QuarkusTelemetrySettings settings, Config config) {
-        return new TracesService(store, settings, transformClassifier(config));
+    public SelfTelemetryClassifier selfTelemetryClassifier(Config config) {
+        boolean excludeSelf = config.getOptionalValue("bootui.monitoring.exclude-self", Boolean.class)
+                .orElse(Boolean.TRUE);
+        String path = config.getOptionalValue("bootui.path", String.class).orElse("/bootui");
+        String apiPath =
+                config.getOptionalValue("bootui.api-path", String.class).orElse("/bootui/api");
+        return new SelfTelemetryClassifier(excludeSelf, path, apiPath);
+    }
+
+    @Produces
+    @Singleton
+    public TracesService tracesService(
+            TelemetryStore store, QuarkusTelemetrySettings settings, SelfTelemetryClassifier selfClassifier) {
+        return new TracesService(store, settings, selfClassifier);
     }
 
     @Produces
@@ -63,14 +83,5 @@ public class BootUiTelemetryProducer {
                 config.getOptionalValue("bootui.ai.show-content-capture-banner", Boolean.class)
                         .orElse(Boolean.TRUE));
         return new AiUsageService(store, aiSettings, System::currentTimeMillis);
-    }
-
-    private static SelfTelemetryClassifier transformClassifier(Config config) {
-        boolean excludeSelf = config.getOptionalValue("bootui.monitoring.exclude-self", Boolean.class)
-                .orElse(Boolean.TRUE);
-        String path = config.getOptionalValue("bootui.path", String.class).orElse("/bootui");
-        String apiPath =
-                config.getOptionalValue("bootui.api-path", String.class).orElse("/bootui/api");
-        return new SelfTelemetryClassifier(excludeSelf, path, apiPath);
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiOpenTelemetryConfiguration.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiOpenTelemetryConfiguration.java
@@ -1,8 +1,8 @@
 package io.github.jdubois.bootui.autoconfigure;
 
+import io.github.jdubois.bootui.autoconfigure.monitoring.BootUiSelfDataFilter;
 import io.github.jdubois.bootui.autoconfigure.otlp.SpringTelemetrySettings;
 import io.github.jdubois.bootui.engine.telemetry.BootUiSpanExporter;
-import io.github.jdubois.bootui.engine.telemetry.SelfTelemetryClassifier;
 import io.github.jdubois.bootui.engine.telemetry.TelemetryStore;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -21,9 +21,9 @@ class BootUiOpenTelemetryConfiguration {
             name = "enabled",
             havingValue = "true",
             matchIfMissing = true)
-    SpanExporter bootUiSpanExporter(TelemetryStore store, BootUiProperties properties) {
-        SelfTelemetryClassifier captureClassifier =
-                SelfTelemetryClassifier.forPaths("/bootui", properties.getApiPath());
-        return new BootUiSpanExporter(store, captureClassifier, new SpringTelemetrySettings(properties));
+    SpanExporter bootUiSpanExporter(
+            TelemetryStore store, BootUiProperties properties, BootUiSelfDataFilter selfDataFilter) {
+        return new BootUiSpanExporter(
+                store, selfDataFilter.telemetryClassifier(), new SpringTelemetrySettings(properties));
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OtlpReceiverController.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.monitoring.BootUiSelfDataFilter;
 import io.github.jdubois.bootui.autoconfigure.otlp.OtlpSpanDecoder;
 import io.github.jdubois.bootui.engine.telemetry.NormalizedSpan;
 import io.github.jdubois.bootui.engine.telemetry.SelfTelemetryClassifier;
@@ -11,6 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -45,10 +47,26 @@ public class OtlpReceiverController {
 
     private final BootUiProperties properties;
 
+    private final SelfTelemetryClassifier selfClassifier;
+
+    /**
+     * Convenience constructor for manual/test wiring outside a Spring context; shares no state with
+     * any other component, so it builds its own default {@link BootUiSelfDataFilter}.
+     */
     public OtlpReceiverController(TelemetryStore store, OtlpSpanDecoder decoder, BootUiProperties properties) {
+        this(store, decoder, properties, BootUiSelfDataFilter.defaults());
+    }
+
+    @Autowired
+    public OtlpReceiverController(
+            TelemetryStore store,
+            OtlpSpanDecoder decoder,
+            BootUiProperties properties,
+            BootUiSelfDataFilter selfDataFilter) {
         this.store = store;
         this.decoder = decoder;
         this.properties = properties;
+        this.selfClassifier = selfDataFilter.telemetryClassifier();
     }
 
     private static ResponseEntity<byte[]> okResponse() {
@@ -78,11 +96,9 @@ public class OtlpReceiverController {
         try {
             List<NormalizedSpan> spans = decoder.decode(body);
             boolean excludeSelf = telemetry.isExcludeSelfSpans();
-            SelfTelemetryClassifier captureClassifier =
-                    SelfTelemetryClassifier.forPaths("/bootui", properties.getApiPath());
             int kept = 0;
             for (NormalizedSpan span : spans) {
-                boolean selfSpan = excludeSelf && captureClassifier.isBootUiSpan(span);
+                boolean selfSpan = excludeSelf && selfClassifier.isBootUiSpan(span);
                 if (store.add(span, selfSpan)) {
                     kept++;
                 }


### PR DESCRIPTION
## What does this PR do?

Collapses the duplicated `SelfTelemetryClassifier` construction (capture vs. transform) into a single shared instance per adapter.

## Why is this change needed?

Both adapters independently built a `SelfTelemetryClassifier` for capture (span export, OTLP receiver) and again for transform (Traces, Metrics, Cache, and other monitoring panels). Quarkus alone had 5 separate construction sites, including a private `transformClassifier(Config)` method copy-pasted verbatim across `BootUiEngineProducer` and `BootUiTelemetryProducer`.

The duplication caused a real, provable bug: capture always hardcoded the literal `"/bootui"` base path via `SelfTelemetryClassifier.forPaths()`, while transform correctly read the operator-configured `bootui.path`. Customizing `bootui.path` made capture and transform silently disagree on what counts as BootUI's own traffic.

Closes #

## Approach

- **Engine**: drop the capture-only `forPaths()` factory; rewrite the class javadoc to describe the single-shared-instance design.
- **Spring**: `BootUiOpenTelemetryConfiguration` and `OtlpReceiverController` now inject the existing `BootUiSelfDataFilter` bean and reuse its `telemetryClassifier()` instead of building their own (also fixes the OTLP controller rebuilding the classifier on every request).
- **Quarkus**: add one `@Produces @Singleton SelfTelemetryClassifier` bean in `BootUiTelemetryProducer`; remove the duplicated private `transformClassifier()` method from `BootUiEngineProducer` and `BootUiTelemetryProducer`; `metricsReportProvider`, `cacheService`, `tracesService`, and `bootUiSpanProcessor` all inject the same instance.

The two config flags (`bootui.telemetry.exclude-self-spans` for capture, `bootui.monitoring.exclude-self` for transform) are intentionally kept separate — only the path-matching *implementation* is unified, not the behavior toggles.

## How was it tested?

- [x] `./mvnw clean install` passes locally (core, engine, Spring adapter, Quarkus adapter + deployment)
- [x] Ran the Quarkus `base`/`otel`/`micrometer`/`cache` `@QuarkusTest` integration modules (180 tests) to exercise real CDI/Arc bean resolution for the new shared producer
- [x] Added or updated tests where applicable (updated `BootUiSpanExporterTests`/`TracesServiceTests` for the removed factory method; existing `OtlpReceiverControllerTests`/`OtlpReceiverEndToEndTests`/`BootUiAutoConfigurationTests` pass unchanged against the new constructor overload)
- [x] `spotless:check` passes

## Screenshots (UI changes)

N/A - backend-only refactor, no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes - N/A, internal implementation detail with no visible behavior change
- [x] Public API kept backward compatible, or a migration note added to the PR description - `OtlpReceiverController`'s original 3-arg constructor is preserved as a convenience overload; no public API changes
- [x] No secrets, tokens, or local paths committed