### PR TITLE
Fix Architecture advisor: dedupe printStackTrace/layering rules, fix CDI logger false positives, add Thread + assertion rules

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistry.java
@@ -41,12 +41,13 @@ final class ArchitectureRuleRegistry {
             new NoPublicMutableStaticFieldsRule(),
             new UtilityClassesShouldBeFinalWithPrivateConstructorRule(),
             new ConfigurationPropertiesShouldBeImmutableRule(),
-            new LayeredArchitectureDirectionRule(),
             new LiteModeBeanMethodsShouldNotCallSiblingBeanMethodsRule(),
             new LifecycleCallbacksShouldNotBeProxyDrivenRule(),
             new AsyncAndTransactionalShouldNotBeCombinedRule(),
             new BeanPostProcessorFactoryMethodsShouldBeStaticRule(),
-            new InternalPackagesShouldNotBeAccessedExternallyRule());
+            new InternalPackagesShouldNotBeAccessedExternallyRule(),
+            new NoDirectThreadInstantiationRule(),
+            new AssertionsShouldHaveDetailMessageRule());
 
     private ArchitectureRuleRegistry() {}
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
@@ -6,15 +6,17 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noFields;
-import static com.tngtech.archunit.library.Architectures.layeredArchitecture;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.MethodCallTarget;
 import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
+import com.tngtech.archunit.core.domain.JavaConstructorCall;
 import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaMethodCall;
@@ -315,18 +317,26 @@ final class NoJodaTimeRule extends AbstractArchitectureRule {
 }
 
 /**
- * Flags calls to {@code Throwable.printStackTrace()}, which writes to the standard error stream and
- * bypasses structured logging.
+ * Flags calls to the {@code Throwable.printStackTrace(PrintStream)} / {@code printStackTrace(PrintWriter)}
+ * overloads, which bypass structured logging.
+ *
+ * <p>Deliberately scoped to the arg-taking overloads only. ArchUnit's built-in {@code
+ * GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS} (see {@link NoStandardStreamsRule},
+ * ARCH-CODE-001) already matches the no-arg {@code printStackTrace()} call specifically (its {@code
+ * ACCESS_STANDARD_STREAMS} condition ORs in a {@code callOfPrintStackTrace} check guarded by {@code
+ * rawParameterTypes(new Class[0])}), so matching the no-arg overload here too would double-report the
+ * exact same call site under two rule IDs. Requiring at least one parameter keeps this rule
+ * complementary to ARCH-CODE-001 instead of overlapping it.</p>
  */
 final class NoPrintStackTraceRule extends AbstractArchitectureRule {
 
     NoPrintStackTraceRule() {
         super(new ArchitectureRuleDefinition(
                 "ARCH-CODE-005",
-                "Classes should not call Throwable.printStackTrace()",
+                "Classes should not call Throwable.printStackTrace(PrintStream/PrintWriter)",
                 ArchitectureCategory.CODING_PRACTICES,
                 "LOW",
-                "Detects calls to Throwable.printStackTrace(), which write to System.err and bypass structured logging.",
+                "Detects calls to the Throwable.printStackTrace(PrintStream) or printStackTrace(PrintWriter) overloads, which bypass structured logging. The no-arg printStackTrace() overload is covered by ARCH-CODE-001 (it writes directly to System.err).",
                 "Log the exception through the project logging facade (e.g. SLF4J) instead of calling printStackTrace().",
                 "https://docs.spring.io/spring-boot/reference/features/logging.html"));
     }
@@ -335,21 +345,33 @@ final class NoPrintStackTraceRule extends AbstractArchitectureRule {
     ArchRule rule(ArchitectureContext context) {
         return noClasses()
                 .should()
-                .callMethodWhere(new DescribedPredicate<JavaMethodCall>("Throwable.printStackTrace() is called") {
-                    @Override
-                    public boolean test(JavaMethodCall call) {
-                        MethodCallTarget target = call.getTarget();
-                        return target.getName().equals("printStackTrace")
-                                && target.getOwner().isAssignableTo(Throwable.class);
-                    }
-                })
-                .as("Classes should not call Throwable.printStackTrace()");
+                .callMethodWhere(
+                        new DescribedPredicate<JavaMethodCall>(
+                                "Throwable.printStackTrace(PrintStream) or printStackTrace(PrintWriter) is called") {
+                            @Override
+                            public boolean test(JavaMethodCall call) {
+                                MethodCallTarget target = call.getTarget();
+                                return target.getName().equals("printStackTrace")
+                                        && target.getOwner().isAssignableTo(Throwable.class)
+                                        && !target.getRawParameterTypes().isEmpty();
+                            }
+                        })
+                .as("Classes should not call Throwable.printStackTrace(PrintStream/PrintWriter)");
     }
 }
 
 /**
  * Flags calls that forcibly terminate the JVM ({@code System.exit(int)}, {@code Runtime.exit(int)},
  * or {@code Runtime.halt(int)}), which bypass orderly application and container shutdown.
+ *
+ * <p>{@code System.exit(int)} is exempt when called directly from a static {@code main} method: this
+ * is Spring Boot's own officially documented pattern for propagating an {@code ExitCodeGenerator}
+ * result from CLI/batch applications, {@code System.exit(SpringApplication.exit(context, ...))}. See
+ * the Spring Boot reference docs, "Application Exit":
+ * https://docs.spring.io/spring-boot/reference/features/spring-application.html#features.spring-application.application-exit
+ * . A {@code System.exit} call from anywhere else &mdash; a service, controller, or other
+ * business-logic class &mdash; is still flagged, as are all {@code Runtime.exit}/{@code Runtime.halt}
+ * calls regardless of origin.
  */
 final class NoSystemExitRule extends AbstractArchitectureRule {
 
@@ -359,8 +381,14 @@ final class NoSystemExitRule extends AbstractArchitectureRule {
                 "Classes should not forcibly terminate the JVM",
                 ArchitectureCategory.CODING_PRACTICES,
                 "HIGH",
-                "Detects calls to System.exit(int), Runtime.exit(int), or Runtime.halt(int), which abruptly terminate the JVM and bypass orderly shutdown.",
-                "Let the container or application framework manage the lifecycle instead of calling System.exit() or Runtime.exit()/halt().",
+                "Detects calls to System.exit(int), Runtime.exit(int), or Runtime.halt(int), which abruptly"
+                        + " terminate the JVM and bypass orderly shutdown. Exempts System.exit(int) called directly"
+                        + " from a static main method, which is Spring Boot's documented"
+                        + " System.exit(SpringApplication.exit(context, ...)) exit-code idiom for CLI/batch apps.",
+                "Let the container or application framework manage the lifecycle instead of calling System.exit() or"
+                        + " Runtime.exit()/halt(). If you do need to propagate a process exit code from a CLI/batch"
+                        + " application, call System.exit(SpringApplication.exit(context, ...)) from the static main"
+                        + " method only.",
                 "https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#exit(int)"));
     }
 
@@ -368,12 +396,30 @@ final class NoSystemExitRule extends AbstractArchitectureRule {
     ArchRule rule(ArchitectureContext context) {
         return noClasses()
                 .should()
-                .callMethod(System.class, "exit", int.class)
+                .callMethodWhere(
+                        new DescribedPredicate<JavaMethodCall>(
+                                "System.exit(int) is called from a method other than a static main entry point") {
+                            @Override
+                            public boolean test(JavaMethodCall call) {
+                                return isSystemExit(call.getTarget()) && !isStaticMainMethod(call.getOrigin());
+                            }
+                        })
                 .orShould()
                 .callMethod(Runtime.class, "exit", int.class)
                 .orShould()
                 .callMethod(Runtime.class, "halt", int.class)
                 .as("Classes should not forcibly terminate the JVM");
+    }
+
+    private static boolean isSystemExit(MethodCallTarget target) {
+        return target.getName().equals("exit")
+                && target.getOwner().isEquivalentTo(System.class)
+                && target.getRawParameterTypes().size() == 1
+                && target.getRawParameterTypes().get(0).isEquivalentTo(int.class);
+    }
+
+    private static boolean isStaticMainMethod(JavaCodeUnit origin) {
+        return origin.getName().equals("main") && origin.getModifiers().contains(JavaModifier.STATIC);
     }
 }
 
@@ -707,9 +753,30 @@ final class InterfacesShouldNotHaveInterfaceSuffixRule extends AbstractArchitect
 }
 
 /**
- * Flags loggers that are not private static final.
+ * Flags loggers that are not private static final, except for two well-known alternate patterns.
+ *
+ * <p>Container-managed injection points ({@code @Inject}/{@code @Autowired}/{@code @Resource}) are
+ * exempt entirely: a field wired by the container is non-static by construction, so the idiomatic
+ * Quarkus CDI pattern {@code @Inject Logger log;} is not a violation. See the Quarkus Logging guide's
+ * "logging with injection" section: https://quarkus.io/guides/logging#logging-with-injection .
+ *
+ * <p>A {@code protected}, non-static, {@code final} logger declared in an abstract base class and
+ * initialized via {@code LoggerFactory.getLogger(getClass())} is also accepted as an alternate valid
+ * pattern: subclasses inherit the field and each logs under its own runtime class name, which requires
+ * the field to be an instance (non-static) member. The SLF4J FAQ explicitly declines to recommend
+ * static over instance loggers ("we no longer recommend one approach over the other") and documents
+ * instance loggers as IOC-friendly: https://www.slf4j.org/faq.html#declared_static . This is
+ * implemented as an alternate passing condition alongside the primary private/static/final rule, not a
+ * weakening of it: a plain non-final, non-static, non-injected, non-abstract-base-class logger field
+ * (e.g. a mutable public field) still fails.
  */
 final class LoggersShouldBePrivateStaticFinalRule extends AbstractArchitectureRule {
+
+    private static final Set<String> CONTAINER_MANAGED_ANNOTATIONS = Set.of(
+            "jakarta.inject.Inject",
+            "javax.inject.Inject",
+            "org.springframework.beans.factory.annotation.Autowired",
+            "jakarta.annotation.Resource");
 
     LoggersShouldBePrivateStaticFinalRule() {
         super(new ArchitectureRuleDefinition(
@@ -717,9 +784,16 @@ final class LoggersShouldBePrivateStaticFinalRule extends AbstractArchitectureRu
                 "Loggers should be private static final",
                 ArchitectureCategory.CODING_PRACTICES,
                 "LOW",
-                "Detects logger fields (SLF4J, Log4j2, Commons Logging, JBoss Logging, java.util.logging, or Logback) that are not private, static, and final.",
-                "Make logger fields private, static, and final to avoid visibility issues and unnecessary allocations.",
-                "https://www.slf4j.org/manual.html"));
+                "Detects logger fields (SLF4J, Log4j2, Commons Logging, JBoss Logging, java.util.logging, or"
+                        + " Logback) that are not private, static, and final. Exempts container-managed injection"
+                        + " points (@Inject/@Autowired/@Resource, e.g. Quarkus's `@Inject Logger log;`) and a"
+                        + " protected, non-static, final logger declared in an abstract base class and initialized"
+                        + " via LoggerFactory.getLogger(getClass()) so each subclass logs under its own name.",
+                "Make logger fields private, static, and final. For a logger shared with subclasses, declare it"
+                        + " protected, non-static, and final in an abstract base class, initialized with"
+                        + " LoggerFactory.getLogger(getClass()). Container-managed logger injection points are"
+                        + " exempt because the container wires them, not the class itself.",
+                "https://www.slf4j.org/faq.html#declared_static"));
     }
 
     @Override
@@ -736,13 +810,59 @@ final class LoggersShouldBePrivateStaticFinalRule extends AbstractArchitectureRu
                 .haveRawType("org.jboss.logging.Logger")
                 .or()
                 .haveRawType("ch.qos.logback.classic.Logger")
-                .should()
-                .bePrivate()
-                .andShould()
-                .beStatic()
-                .andShould()
-                .beFinal()
+                .should(
+                        new ArchCondition<JavaField>("be private, static and final; a container-managed injection"
+                                + " point; or a protected instance logger in an abstract base class") {
+                            @Override
+                            public void check(JavaField field, ConditionEvents events) {
+                                if (isContainerManagedInjectionPoint(field)
+                                        || isPrivateStaticFinal(field)
+                                        || isProtectedAbstractBaseClassLogger(field)) {
+                                    return;
+                                }
+                                events.add(SimpleConditionEvent.violated(
+                                        field,
+                                        "Logger field " + field.getFullName()
+                                                + " should be private, static, and final (or,"
+                                                + " for a base-class logger shared with subclasses, protected, final, and"
+                                                + " initialized via LoggerFactory.getLogger(getClass()) in an abstract"
+                                                + " class)"));
+                            }
+                        })
                 .allowEmptyShould(true);
+    }
+
+    private static boolean isContainerManagedInjectionPoint(JavaField field) {
+        return CONTAINER_MANAGED_ANNOTATIONS.stream().anyMatch(field::isAnnotatedWith);
+    }
+
+    private static boolean isPrivateStaticFinal(JavaField field) {
+        Set<JavaModifier> modifiers = field.getModifiers();
+        return modifiers.contains(JavaModifier.PRIVATE)
+                && modifiers.contains(JavaModifier.STATIC)
+                && modifiers.contains(JavaModifier.FINAL);
+    }
+
+    private static boolean isProtectedAbstractBaseClassLogger(JavaField field) {
+        Set<JavaModifier> modifiers = field.getModifiers();
+        if (!modifiers.contains(JavaModifier.PROTECTED)
+                || modifiers.contains(JavaModifier.STATIC)
+                || !modifiers.contains(JavaModifier.FINAL)) {
+            return false;
+        }
+        if (!field.getOwner().getModifiers().contains(JavaModifier.ABSTRACT)) {
+            return false;
+        }
+        return field.getAccessesToSelf().stream()
+                .filter(access -> access.getAccessType() == JavaFieldAccess.AccessType.SET)
+                .map(JavaFieldAccess::getOrigin)
+                .anyMatch(LoggersShouldBePrivateStaticFinalRule::callsGetClass);
+    }
+
+    private static boolean callsGetClass(JavaCodeUnit origin) {
+        return origin.getMethodCallsFromSelf().stream()
+                .anyMatch(call -> call.getTarget().getName().equals("getClass")
+                        && call.getTarget().getRawParameterTypes().isEmpty());
     }
 }
 
@@ -757,7 +877,7 @@ final class NoTestFrameworkDependenciesRule extends AbstractArchitectureRule {
                 "Application classes should not depend on test frameworks",
                 ArchitectureCategory.CODING_PRACTICES,
                 "MEDIUM",
-                "Detects dependencies from application classes to common test-only APIs such as JUnit, Mockito, AssertJ, Spring Test, Hamcrest, or Testcontainers.",
+                "Detects dependencies from application classes to common test-only APIs such as JUnit, Mockito, AssertJ, Hamcrest, Testcontainers, Spring Test, Quarkus's @QuarkusTest, or RestAssured.",
                 "Move test helpers and assertions to test sources; production code should not depend on test frameworks.",
                 "https://www.archunit.org/userguide/html/000_Index.html"));
     }
@@ -774,7 +894,9 @@ final class NoTestFrameworkDependenciesRule extends AbstractArchitectureRule {
                         "org.hamcrest..",
                         "org.springframework.boot.test..",
                         "org.springframework.test..",
-                        "org.testcontainers..");
+                        "org.testcontainers..",
+                        "io.quarkus.test..",
+                        "io.restassured..");
     }
 }
 
@@ -1349,51 +1471,6 @@ final class ConfigurationPropertiesShouldBeImmutableRule extends AbstractArchite
 }
 
 /**
- * Flags dependencies among {@code @Controller} / {@code @RestController}, {@code @Service}, and
- * {@code @Repository} beans that do not follow the canonical web -&gt; service -&gt; repository
- * direction.
- *
- * <p>This is the holistic, slice-based complement to the individual stereotype dependency rules:
- * each stereotype layer may be accessed only from itself or the layer immediately above it, so the
- * dependency graph between the three layers stays directed and downward. Only dependencies whose
- * source and target are both annotated stereotypes are considered, so plain classes never trigger
- * a violation.</p>
- */
-final class LayeredArchitectureDirectionRule extends AbstractArchitectureRule {
-
-    LayeredArchitectureDirectionRule() {
-        super(new ArchitectureRuleDefinition(
-                "ARCH-SPRING-016",
-                "Layered architecture dependencies should flow from web to service to repository",
-                ArchitectureCategory.SPRING_STEREOTYPES,
-                "MEDIUM",
-                "Detects dependencies among @Controller/@RestController, @Service, and @Repository beans that violate the web -> service -> repository direction.",
-                "Keep dependencies flowing downward: controllers depend on services, services depend on repositories, and lower layers never depend on higher ones.",
-                "https://www.archunit.org/userguide/html/000_Index.html#_layer_checks"));
-    }
-
-    @Override
-    ArchRule rule(ArchitectureContext context) {
-        return layeredArchitecture()
-                .consideringOnlyDependenciesInLayers()
-                .withOptionalLayers(true)
-                .layer("Web")
-                .definedBy(SpringStereotypes.CONTROLLER_ANNOTATED)
-                .layer("Service")
-                .definedBy(SpringStereotypes.SERVICE_ANNOTATED)
-                .layer("Persistence")
-                .definedBy(SpringStereotypes.REPOSITORY_ANNOTATED)
-                .whereLayer("Web")
-                .mayOnlyBeAccessedByLayers("Web")
-                .whereLayer("Service")
-                .mayOnlyBeAccessedByLayers("Web", "Service")
-                .whereLayer("Persistence")
-                .mayOnlyBeAccessedByLayers("Service", "Persistence")
-                .as("Layered architecture dependencies should flow from web to service to repository");
-    }
-}
-
-/**
  * Flags direct calls between {@code @Bean} methods declared in the same class when that class is not
  * a full {@code @Configuration(proxyBeanMethods=true)}. In lite mode such a call is a plain method
  * invocation, so the Spring container does not intercept it and a second, unmanaged instance is
@@ -1691,5 +1768,68 @@ final class InternalPackagesShouldNotBeAccessedExternallyRule extends AbstractAr
             }
         }
         return null;
+    }
+}
+
+/**
+ * Flags direct {@code new Thread(...)} construction (including instantiating a class that extends
+ * {@code Thread}) from application code.
+ *
+ * <p>An unmanaged thread bypasses pool sizing, naming, and uncaught-exception handling, and sits
+ * outside both frameworks' managed-concurrency story: Spring's {@code TaskExecutor} / {@code @Async}
+ * (and {@code spring.threads.virtual.enabled} on Java 21+), or Quarkus's {@code ManagedExecutor} /
+ * {@code @RunOnVirtualThread}. This mirrors Effective Java Item 80, "Prefer executors, tasks, and
+ * streams to threads", and the JDK {@code java.util.concurrent.Executor} Javadoc. See the Quarkus
+ * context-propagation guide: https://quarkus.io/guides/context-propagation .
+ */
+final class NoDirectThreadInstantiationRule extends AbstractArchitectureRule {
+
+    NoDirectThreadInstantiationRule() {
+        super(new ArchitectureRuleDefinition(
+                "ARCH-CODE-017",
+                "Classes should not directly instantiate Thread",
+                ArchitectureCategory.CODING_PRACTICES,
+                "MEDIUM",
+                "Detects new Thread(...) construction (including instantiating a Thread subclass), which bypasses pool sizing/naming/uncaught-exception handling and does not participate in Spring's TaskExecutor/@Async or Quarkus's ManagedExecutor/@RunOnVirtualThread managed-concurrency model.",
+                "Use a managed executor instead of instantiating Thread directly: java.util.concurrent.ExecutorService/Executors, Spring's TaskExecutor or @Async, or Quarkus's ManagedExecutor or @RunOnVirtualThread.",
+                "https://quarkus.io/guides/context-propagation"));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return noClasses()
+                .should()
+                .callConstructorWhere(new DescribedPredicate<JavaConstructorCall>("a Thread constructor is called") {
+                    @Override
+                    public boolean test(JavaConstructorCall call) {
+                        return call.getTarget().getOwner().isAssignableTo(Thread.class);
+                    }
+                })
+                .as("Classes should not directly instantiate Thread");
+    }
+}
+
+/**
+ * Flags {@code assert} statements (compiled as a no-arg {@code new AssertionError()}) that have no
+ * detail message, which produce near-useless failure diagnostics.
+ *
+ * <p>Wires in ArchUnit's own ready-made {@code GeneralCodingRules.ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE}.
+ */
+final class AssertionsShouldHaveDetailMessageRule extends AbstractArchitectureRule {
+
+    AssertionsShouldHaveDetailMessageRule() {
+        super(new ArchitectureRuleDefinition(
+                "ARCH-CODE-018",
+                "Assertions should have a detail message",
+                ArchitectureCategory.CODING_PRACTICES,
+                "INFO",
+                "Detects assert statements (compiled as new AssertionError() with no arguments) that have no detail message, which produce near-useless failure diagnostics.",
+                "Add a detail message, e.g. \"assert x > 0 : \\\"x must be positive\\\";\", so a failure explains what was expected.",
+                "https://www.archunit.org/userguide/html/000_Index.html"));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return GeneralCodingRules.ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE;
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistryTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistryTests.java
@@ -50,11 +50,12 @@ class ArchitectureRuleRegistryTests {
                         "ARCH-CODE-014",
                         "ARCH-CODE-015",
                         "ARCH-SPRING-015",
-                        "ARCH-SPRING-016",
                         "ARCH-SPRING-017",
                         "ARCH-SPRING-018",
                         "ARCH-SPRING-019",
                         "ARCH-SPRING-021",
+                        "ARCH-CODE-017",
+                        "ARCH-CODE-018",
                         "ARCH-MOD-001");
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
@@ -9,6 +9,7 @@ import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.PrintWriter;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -19,7 +20,9 @@ import org.springframework.aop.framework.AopContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.Async;
@@ -98,6 +101,36 @@ class ArchitectureRulesTests {
     }
 
     @Test
+    void noStandardStreamsFlagsNoArgPrintStackTraceExclusively() {
+        ArchitectureRuleResultDto standardStreamsResult =
+                evaluate(new NoStandardStreamsRule(), NoArgPrintStackTraceCaller.class);
+        ArchitectureRuleResultDto printStackTraceResult =
+                evaluate(new NoPrintStackTraceRule(), NoArgPrintStackTraceCaller.class);
+
+        assertThat(standardStreamsResult.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(standardStreamsResult.id()).isEqualTo("ARCH-CODE-001");
+        assertThat(printStackTraceResult.status())
+                .as("the no-arg printStackTrace() overload is exclusively covered by ARCH-CODE-001, so"
+                        + " ARCH-CODE-005 must not also fire on the same call site")
+                .isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void noPrintStackTraceFlagsArgTakingOverloadExclusively() {
+        ArchitectureRuleResultDto printStackTraceResult =
+                evaluate(new NoPrintStackTraceRule(), WriterArgPrintStackTraceCaller.class);
+        ArchitectureRuleResultDto standardStreamsResult =
+                evaluate(new NoStandardStreamsRule(), WriterArgPrintStackTraceCaller.class);
+
+        assertThat(printStackTraceResult.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(printStackTraceResult.id()).isEqualTo("ARCH-CODE-005");
+        assertThat(standardStreamsResult.status())
+                .as("the printStackTrace(PrintWriter) overload is exclusively covered by ARCH-CODE-005, so"
+                        + " ARCH-CODE-001 must not also fire on the same call site")
+                .isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
     void loggersShouldBePrivateStaticFinalFlagsMutableOrVisibleLoggers() {
         ArchitectureRuleResultDto result =
                 evaluate(new LoggersShouldBePrivateStaticFinalRule(), VisibleLoggerComponent.class);
@@ -118,6 +151,41 @@ class ArchitectureRulesTests {
     }
 
     @Test
+    void loggersShouldBePrivateStaticFinalExemptsContainerManagedInjectionPoints() {
+        ArchitectureRuleResultDto result =
+                evaluate(new LoggersShouldBePrivateStaticFinalRule(), ContainerManagedLoggerComponent.class);
+
+        assertThat(result.status())
+                .as("@Inject/@Autowired/@Resource logger fields are wired by the container, e.g. Quarkus's"
+                        + " idiomatic `@Inject Logger log;`, so they are exempt from the private/static/final"
+                        + " requirement")
+                .isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void loggersShouldBePrivateStaticFinalAllowsProtectedInstanceLoggerInAbstractBaseClass() {
+        ArchitectureRuleResultDto result =
+                evaluate(new LoggersShouldBePrivateStaticFinalRule(), AbstractLoggingBaseComponent.class);
+
+        assertThat(result.status())
+                .as("a protected, final, non-static logger initialized via LoggerFactory.getLogger(getClass())"
+                        + " in an abstract base class is a well-known SLF4J idiom for subclass-shared loggers")
+                .isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void loggersShouldBePrivateStaticFinalStillFlagsPlainPublicInstanceLogger() {
+        ArchitectureRuleResultDto result =
+                evaluate(new LoggersShouldBePrivateStaticFinalRule(), PublicInstanceLoggerComponent.class);
+
+        assertThat(result.status())
+                .as("a non-final, non-static, non-injected, non-abstract-base-class public logger field is"
+                        + " neither recognized alternate pattern, so it must still be flagged")
+                .isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-012");
+    }
+
+    @Test
     void noTestFrameworkDependenciesFlagsMainCodeUsingTestApis() {
         ArchitectureRuleResultDto result = evaluate(new NoTestFrameworkDependenciesRule(), TestFrameworkUser.class);
 
@@ -125,6 +193,21 @@ class ArchitectureRulesTests {
         assertThat(result.id()).isEqualTo("ARCH-CODE-013");
         assertThat(result.sampleViolations())
                 .anySatisfy(sample -> assertThat(sample).contains("org.junit"));
+    }
+
+    @Test
+    void noTestFrameworkDependenciesFlagsMainCodeUsingQuarkusTestApi() {
+        ArchitectureRuleResultDto result =
+                evaluate(new NoTestFrameworkDependenciesRule(), QuarkusTestFrameworkUser.class);
+
+        assertThat(result.status())
+                .as("io.quarkus.test.. must be flagged the same way org.springframework.boot.test.. already is,"
+                        + " so a Quarkus app leaking @QuarkusTest into main sources gets the same warning a Spring"
+                        + " app leaking @SpringBootTest already does")
+                .isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-013");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("io.quarkus.test.junit.QuarkusTest"));
     }
 
     @Test
@@ -329,29 +412,6 @@ class ArchitectureRulesTests {
     }
 
     @Test
-    void layeredArchitectureDirectionFlagsWebDependingDirectlyOnPersistence() {
-        ArchitectureRuleResultDto result =
-                evaluate(new LayeredArchitectureDirectionRule(), LayeredController.class, LayeredRepository.class);
-
-        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
-        assertThat(result.id()).isEqualTo("ARCH-SPRING-016");
-        assertThat(result.violationCount()).isPositive();
-        assertThat(result.sampleViolations())
-                .anySatisfy(sample -> assertThat(sample).contains("LayeredRepository"));
-    }
-
-    @Test
-    void layeredArchitectureDirectionPassesForCanonicalWebToServiceToRepositoryChain() {
-        ArchitectureRuleResultDto result = evaluate(
-                new LayeredArchitectureDirectionRule(),
-                CompliantController.class,
-                CompliantService.class,
-                CompliantRepository.class);
-
-        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
-    }
-
-    @Test
     void noSystemExitFlagsRuntimeExitAndHalt() {
         ArchitectureRuleResultDto result = evaluate(new NoSystemExitRule(), JvmTerminator.class);
 
@@ -361,6 +421,30 @@ class ArchitectureRulesTests {
         assertThat(result.sampleViolations())
                 .anySatisfy(sample -> assertThat(sample).contains("exit"))
                 .anySatisfy(sample -> assertThat(sample).contains("halt"));
+    }
+
+    @Test
+    void noSystemExitExemptsSystemExitCalledDirectlyFromStaticMain() {
+        ArchitectureRuleResultDto result = evaluate(new NoSystemExitRule(), SpringExitLauncher.class);
+
+        assertThat(result.status())
+                .as("System.exit(SpringApplication.exit(context, ...)) from a static main method is Spring"
+                        + " Boot's own documented CLI/batch exit-code idiom, so it must not be flagged")
+                .isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void noSystemExitStillFlagsSystemExitFromNonMainMethod() {
+        ArchitectureRuleResultDto result = evaluate(new NoSystemExitRule(), NonMainSystemExitCaller.class);
+
+        assertThat(result.status())
+                .as("a System.exit call from a service/controller/business-logic method (not the static main"
+                        + " entry point) must still be flagged")
+                .isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-006");
+        assertThat(result.violationCount()).isEqualTo(1);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("exit"));
     }
 
     @Test
@@ -652,6 +736,54 @@ class ArchitectureRulesTests {
         assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
     }
 
+    @Test
+    void noDirectThreadInstantiationFlagsNewThread() {
+        ArchitectureRuleResultDto result = evaluate(new NoDirectThreadInstantiationRule(), DirectThreadCreator.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-017");
+        assertThat(result.severity()).isEqualTo("MEDIUM");
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("Thread"));
+    }
+
+    @Test
+    void noDirectThreadInstantiationFlagsThreadSubclassInstantiation() {
+        ArchitectureRuleResultDto result = evaluate(
+                new NoDirectThreadInstantiationRule(), CustomThreadInstantiator.class, CustomThreadSubclass.class);
+
+        assertThat(result.status())
+                .as("isAssignableTo(Thread.class) must also catch instantiating a class that extends Thread,"
+                        + " not just the Thread constructor itself")
+                .isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-017");
+    }
+
+    @Test
+    void noDirectThreadInstantiationPassesForManagedExecutorUsage() {
+        ArchitectureRuleResultDto result = evaluate(new NoDirectThreadInstantiationRule(), ManagedExecutorUser.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void assertionsShouldHaveDetailMessageFlagsMessagelessAssertion() {
+        ArchitectureRuleResultDto result =
+                evaluate(new AssertionsShouldHaveDetailMessageRule(), MessagelessAssertionUser.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-018");
+        assertThat(result.severity()).isEqualTo("INFO");
+    }
+
+    @Test
+    void assertionsShouldHaveDetailMessagePassesForMessageBearingAssertion() {
+        ArchitectureRuleResultDto result =
+                evaluate(new AssertionsShouldHaveDetailMessageRule(), MessageBearingAssertionUser.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
     private static ArchitectureRuleResultDto evaluate(ArchitectureRule rule, Class<?>... classes) {
         JavaClasses importedClasses = new ClassFileImporter().importClasses(classes);
         return rule.evaluate(
@@ -688,6 +820,20 @@ class ArchitectureRulesTests {
 
     private interface PaymentPort {}
 
+    private static class NoArgPrintStackTraceCaller {
+
+        void log(Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static class WriterArgPrintStackTraceCaller {
+
+        void log(Exception e, PrintWriter writer) {
+            e.printStackTrace(writer);
+        }
+    }
+
     private static class VisibleLoggerComponent {
 
         static final Logger LOGGER = LoggerFactory.getLogger(VisibleLoggerComponent.class);
@@ -698,10 +844,35 @@ class ArchitectureRulesTests {
         private static final Logger LOGGER = LoggerFactory.getLogger(WellFormedLoggerComponent.class);
     }
 
+    private static class ContainerManagedLoggerComponent {
+
+        @Inject
+        Logger injectedLogger;
+
+        @Autowired
+        Logger autowiredLogger;
+
+        @Resource
+        Logger resourceLogger;
+    }
+
+    private abstract static class AbstractLoggingBaseComponent {
+
+        protected final Logger logger = LoggerFactory.getLogger(getClass());
+    }
+
+    private static class PublicInstanceLoggerComponent {
+
+        public Logger logger = LoggerFactory.getLogger(getClass());
+    }
+
     private static class TestFrameworkUser {
 
         private final org.junit.jupiter.api.TestInfo testInfo = null;
     }
+
+    @io.quarkus.test.junit.QuarkusTest
+    private static class QuarkusTestFrameworkUser {}
 
     @Repository
     private static class RepositoryDependingOnService {
@@ -864,48 +1035,27 @@ class ArchitectureRulesTests {
     @ConfigurationProperties(prefix = "demo.immutable")
     private record ImmutableConfigurationProperties(String name, int size) {}
 
-    @RestController
-    private static class LayeredController {
-
-        LayeredController(LayeredRepository repository) {
-            this.repository = repository;
-        }
-
-        private final LayeredRepository repository;
-    }
-
-    @Repository
-    private static class LayeredRepository {}
-
-    @RestController
-    private static class CompliantController {
-
-        CompliantController(CompliantService service) {
-            this.service = service;
-        }
-
-        private final CompliantService service;
-    }
-
-    @Service
-    private static class CompliantService {
-
-        CompliantService(CompliantRepository repository) {
-            this.repository = repository;
-        }
-
-        private final CompliantRepository repository;
-    }
-
-    @Repository
-    private static class CompliantRepository {}
-
     private static class JvmTerminator {
 
         void terminate() {
             System.exit(0);
             Runtime.getRuntime().exit(1);
             Runtime.getRuntime().halt(2);
+        }
+    }
+
+    private static class SpringExitLauncher {
+
+        public static void main(String[] args) {
+            ConfigurableApplicationContext context = SpringApplication.run(SpringExitLauncher.class, args);
+            System.exit(SpringApplication.exit(context));
+        }
+    }
+
+    private static class NonMainSystemExitCaller {
+
+        void shutdown() {
+            System.exit(1);
         }
     }
 
@@ -1117,6 +1267,43 @@ class ArchitectureRulesTests {
         @Scheduled(fixedDelay = 1000)
         io.smallrye.mutiny.Multi<String> multi() {
             return null;
+        }
+    }
+
+    private static class DirectThreadCreator {
+
+        void start() {
+            new Thread(() -> {}).start();
+        }
+    }
+
+    private static class CustomThreadSubclass extends Thread {}
+
+    private static class CustomThreadInstantiator {
+
+        void start() {
+            new CustomThreadSubclass().start();
+        }
+    }
+
+    private static class ManagedExecutorUser {
+
+        void submit() {
+            java.util.concurrent.Executors.newFixedThreadPool(2).submit(() -> {});
+        }
+    }
+
+    private static class MessagelessAssertionUser {
+
+        void check(int x) {
+            assert x > 0;
+        }
+    }
+
+    private static class MessageBearingAssertionUser {
+
+        void check(int x) {
+            assert x > 0 : "x must be positive";
         }
     }
 }

--- a/bootui-engine/src/test/java/io/quarkus/test/junit/QuarkusTest.java
+++ b/bootui-engine/src/test/java/io/quarkus/test/junit/QuarkusTest.java
@@ -1,0 +1,17 @@
+package io.quarkus.test.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Minimal test stub standing in for the absent Quarkus {@code quarkus-junit5} library's
+ * {@code @QuarkusTest} annotation, so the ARCH-CODE-013 test-framework-allowlist fixture can compile
+ * and exercise the "io.quarkus.test.. is a disallowed test-framework package" detection without pulling
+ * the real (heavyweight) dependency into this framework-neutral module's test scope. Not the real
+ * annotation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface QuarkusTest {}

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -59,9 +59,10 @@ Severity reflects the worst plausible impact if the finding is real, not the lik
 
 - **CRITICAL** — supported for the most severe correctness or safety problems. No active check currently emits this
   severity.
-- **HIGH** — a serious structural problem with clear maintenance impact.
-- **MEDIUM** — weakens maintainability or layering and usually warrants a fix (e.g. package cycles, field injection,
-  layering inversions).
+- **HIGH** — a serious structural problem with clear maintenance impact (e.g. package cycles — see ARCH-PKG-001 — or
+  forcibly terminating the JVM).
+- **MEDIUM** — weakens maintainability or layering and usually warrants a fix (e.g. field injection, layering
+  inversions).
 - **LOW** — defense-in-depth / hygiene gap (e.g. standard-stream use, generic exceptions, `java.util.logging`).
 - **INFO** — informational convention prompt (e.g. legacy library use, deprecated APIs).
 
@@ -129,11 +130,14 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Fires when**: a class references Joda-Time types instead of `java.time`.
 - **Recommendation**: migrate Joda-Time usage to the standard `java.time` API.
 
-### ARCH-CODE-005 — Classes should not call Throwable.printStackTrace()
+### ARCH-CODE-005 — Classes should not call Throwable.printStackTrace(PrintStream/PrintWriter)
 
 - **Severity**: LOW
-- **Inspects**: calls to `Throwable.printStackTrace()` on any exception type.
-- **Fires when**: a class calls `printStackTrace()` instead of logging the exception.
+- **Inspects**: calls to the `Throwable.printStackTrace(PrintStream)` or `printStackTrace(PrintWriter)` overloads.
+- **Fires when**: a class calls one of the arg-taking `printStackTrace` overloads instead of logging the exception. The
+  no-arg `printStackTrace()` overload is deliberately **not** matched here: it is already covered by ARCH-CODE-001
+  (ArchUnit's built-in standard-streams check matches the no-arg overload directly), so this rule only reports the
+  overloads ARCH-CODE-001 does not, instead of double-reporting the same no-arg call site under two rule IDs.
 - **Recommendation**: log the exception through the project logging facade (e.g. SLF4J) so the stack trace is structured
   and configurable.
 
@@ -142,8 +146,15 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Severity**: HIGH
 - **Inspects**: calls to `System.exit(int)`, `Runtime.exit(int)`, or `Runtime.halt(int)`.
 - **Fires when**: a class abruptly terminates the JVM instead of letting the framework manage shutdown.
+  `System.exit(int)` is exempt when called directly from a static `main` method: this is Spring Boot's own officially
+  documented pattern for propagating an `ExitCodeGenerator` result from CLI/batch applications,
+  `System.exit(SpringApplication.exit(context, ...))` — see the Spring Boot reference docs,
+  ["Application Exit"](https://docs.spring.io/spring-boot/reference/features/spring-application.html#features.spring-application.application-exit).
+  A `System.exit` call from anywhere else — a service, controller, or other business-logic class — is still flagged, as
+  are all `Runtime.exit`/`Runtime.halt` calls regardless of origin.
 - **Recommendation**: let the container or application framework manage the lifecycle instead of calling
-  `System.exit()`, `Runtime.exit()`, or `Runtime.halt()`.
+  `System.exit()`, `Runtime.exit()`, or `Runtime.halt()`. If you do need to propagate a process exit code from a
+  CLI/batch application, call `System.exit(SpringApplication.exit(context, ...))` from the static `main` method only.
 
 ### ARCH-CODE-007 — Classes should not access JDK-internal APIs
 
@@ -189,15 +200,26 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Severity**: LOW
 - **Inspects**: logger fields whose raw type is SLF4J, Log4j2, Commons Logging, JBoss Logging, `java.util.logging`, or
   Logback.
-- **Fires when**: a logger field is not `private`, `static`, and `final`.
+- **Fires when**: a logger field is not `private`, `static`, and `final` — with two recognized alternate patterns.
+  Container-managed injection points (`@Inject`/`@Autowired`/`@Resource`, e.g. Quarkus's idiomatic `@Inject Logger
+  log;`) are exempt entirely, since a field wired by the container is non-static by construction — see the
+  [Quarkus Logging guide's "logging with injection" section](https://quarkus.io/guides/logging#logging-with-injection).
+  A `protected`, non-static, `final` logger declared in an abstract base class and initialized via
+  `LoggerFactory.getLogger(getClass())` is also accepted: subclasses inherit the field and each logs under its own
+  runtime class name, which requires the field to be an instance member; the SLF4J FAQ explicitly declines to
+  recommend static over instance loggers ("we no longer recommend one approach over the other") and documents instance
+  loggers as IOC-friendly — see the [SLF4J FAQ](https://www.slf4j.org/faq.html#declared_static). A plain non-final,
+  non-static, non-injected, non-abstract-base-class logger field (e.g. a mutable public field) still fails.
 - **Recommendation**: make logger fields `private static final` to avoid accidental external access and per-instance
-  logger allocations.
+  logger allocations. For a logger shared with subclasses, declare it `protected`, non-static, and `final` in an
+  abstract base class, initialized with `LoggerFactory.getLogger(getClass())`. Container-managed logger injection
+  points are exempt because the container wires them, not the class itself.
 
 ### ARCH-CODE-013 — Application classes should not depend on test frameworks
 
 - **Severity**: MEDIUM
 - **Inspects**: dependencies on common test-only APIs such as JUnit, Mockito, AssertJ, Hamcrest, Spring Test, Spring Boot
-  Test, or Testcontainers.
+  Test, Testcontainers, Quarkus's `@QuarkusTest` (`io.quarkus.test..`), or RestAssured (`io.restassured..`).
 - **Fires when**: an application class references a test framework type.
 - **Why it matters**: production code that depends on test frameworks is usually an accidental source-set leak and can
   pull unnecessary or unavailable test libraries into runtime code.
@@ -238,6 +260,33 @@ include up to a handful of sample detail lines from ArchUnit.
   Spring annotations anywhere on its classpath.
 - **Recommendation**: prefer constructor injection so dependencies are explicit, final, and easy to test; CDI containers
   such as Quarkus' Arc inject constructor parameters just as readily as fields.
+
+### ARCH-CODE-017 — Classes should not directly instantiate Thread
+
+- **Severity**: MEDIUM
+- **Inspects**: `new Thread(...)` constructor calls, including instantiating a class that extends `Thread`.
+- **Fires when**: application code directly constructs a `Thread` (or a `Thread` subclass) instead of using a managed
+  executor.
+- **Why it matters**: an unmanaged thread bypasses pool sizing, naming, and uncaught-exception handling, and sits
+  outside both frameworks' managed-concurrency story — Spring's `TaskExecutor` / `@Async` (and
+  `spring.threads.virtual.enabled` on Java 21+), or Quarkus's `ManagedExecutor` / `@RunOnVirtualThread`. This mirrors
+  [Effective Java Item 80](https://www.oreilly.com/library/view/effective-java-3rd/9780134686097/), "Prefer executors,
+  tasks, and streams to threads", and the JDK `java.util.concurrent.Executor` Javadoc. See the
+  [Quarkus context-propagation guide](https://quarkus.io/guides/context-propagation).
+- **Recommendation**: use a managed executor instead of instantiating `Thread` directly:
+  `java.util.concurrent.ExecutorService`/`Executors`, Spring's `TaskExecutor` or `@Async`, or Quarkus's
+  `ManagedExecutor` or `@RunOnVirtualThread`.
+
+### ARCH-CODE-018 — Assertions should have a detail message
+
+- **Severity**: INFO
+- **Inspects**: `assert` statements, which compile to a no-arg `new AssertionError()` when they have no detail message
+  (via ArchUnit's built-in `GeneralCodingRules.ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE`).
+- **Fires when**: a class contains an `assert` statement with no detail message (`assert x > 0;`), which produces a
+  near-useless failure diagnostic. An `assert` with a message (`assert x > 0 : "x must be positive";`) compiles to the
+  message-taking overload and is not matched.
+- **Recommendation**: add a detail message, e.g. `assert x > 0 : "x must be positive";`, so a failure explains what was
+  expected.
 
 ## Spring stereotypes
 
@@ -410,19 +459,15 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Recommendation**: bind configuration through a record or a constructor with `final` fields so configuration state is
   immutable.
 
-### ARCH-SPRING-016 — Layered architecture dependencies should flow from web to service to repository
-
-- **Severity**: MEDIUM
-- **Inspects**: dependencies among `@Controller` / `@RestController` (web), `@Service` (service), and `@Repository`
-  (persistence) beans. Only dependencies whose source and target are both stereotype-annotated are considered, so plain
-  classes never trigger a violation.
-- **Fires when**: a dependency runs against the canonical `web → service → repository` direction — for example a
-  controller depending directly on a repository (skipping the service layer), a repository depending on a service, or any
-  lower layer depending on a higher one.
-- **Why it matters**: this is the holistic, slice-based complement to the individual stereotype dependency rules; keeping
-  the three stereotype layers in a single downward direction preserves a clean, testable layering.
-- **Recommendation**: keep dependencies flowing downward — controllers depend on services, services depend on
-  repositories, and lower layers never depend on higher ones.
+> **Removed: ARCH-SPRING-016** ("Layered architecture dependencies should flow from web to service to repository"). This
+> holistic rule used ArchUnit's `layeredArchitecture()` over the same three stereotype layers (web/service/persistence)
+> that ARCH-SPRING-002 (controllers → repositories), ARCH-SPRING-003 (repositories → controllers), ARCH-SPRING-006
+> (services → controllers), and ARCH-SPRING-007 (repositories → services) already check individually. Its violation set
+> was verified to be the exact union of what those four pairwise rules already catch, so every real violation was being
+> reported **twice** — once under its specific pairwise rule ID, once under ARCH-SPRING-016 — inflating the panel's
+> violation and severity counts. The rule was removed and the four granular pairwise rules were kept, since they give
+> clearer, more specific per-pair messages (e.g. "Controller X depends on Repository Y" is more actionable than a
+> generic layer-violation message).
 
 ### ARCH-SPRING-017 — Lite-mode @Bean methods should not call sibling @Bean methods
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -257,14 +257,14 @@ configuration, imports the compiled classes from that package, and evaluates a f
 architecture hygiene rules: package cycles between slices, general coding practices (no standard streams, generic
 exceptions, `java.util.logging`, JodaTime, `printStackTrace`, `System.exit`, JDK-internal APIs, legacy date/time, or
 deprecated APIs, poorly named exceptions/interfaces, mutable/visible loggers, production dependencies on test
-frameworks, public mutable static fields, non-final utility classes, or standard-annotation (`jakarta.inject.Inject` /
-`@Resource`) field injection), and Spring stereotype/proxy heuristics (no `@Autowired`/`@Value` field
-injection, controllers should not depend on repositories, repositories should not depend on controllers or services,
-services should not depend on controllers, services and repositories should stay servlet-agnostic, no self-invocation or
-unproxyable proxy annotations, async/scheduled method signatures should be supported, async should stay out of
-configuration classes, stereotypes should stay outside the default package, `@ConfigurationProperties` classes should be
-immutable, stereotype dependencies should flow web → service → repository, and code should avoid
-`AopContext.currentProxy()`). When BootUI is installed through
+frameworks, public mutable static fields, non-final utility classes, standard-annotation (`jakarta.inject.Inject` /
+`@Resource`) field injection, direct `Thread` instantiation, or message-less assertions), and Spring stereotype/proxy
+heuristics (no `@Autowired`/`@Value` field injection, controllers should not depend on repositories, repositories
+should not depend on controllers or services, services should not depend on controllers, services and repositories
+should stay servlet-agnostic, no self-invocation or unproxyable proxy annotations, async/scheduled method signatures
+should be supported, async should stay out of configuration classes, stereotypes should stay outside the default
+package, `@ConfigurationProperties` classes should be immutable, and code should avoid `AopContext.currentProxy()`).
+When BootUI is installed through
 `bootui-spring-boot-starter`, ArchUnit is included transitively; the panel is available when a base package is resolvable
 and the scan runs on demand, caching the last report.
 


### PR DESCRIPTION
Audited by 5 independent AI models (Claude Opus 4.8, GPT-5.5, Gemini 3.1 Pro, GPT-5.3-Codex, Claude Sonnet 5) as part of a full advisor-ruleset audit. Every finding below was re-verified against the current codebase before implementing (line numbers in the original audit reports were approximate).

## Fixes to existing rules

1. **ARCH-CODE-005 / ARCH-CODE-001 double-counting on `printStackTrace()`** — ArchUnit's built-in `GeneralCodingRules.NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS` (ARCH-CODE-001) already matches the no-arg `printStackTrace()` overload. Narrowed ARCH-CODE-005's predicate to only match arg-taking overloads (`printStackTrace(PrintStream)` / `printStackTrace(PrintWriter)`), so a plain `e.printStackTrace()` now fires **only** ARCH-CODE-001, while `e.printStackTrace(somePrintWriter)` fires **only** ARCH-CODE-005.
   - *Test design note*: ArchUnit's `ACCESS_STANDARD_STREAMS` also ORs in a `System.out`/`System.err` **field-access** check, so `e.printStackTrace(System.out)` would still trip ARCH-CODE-001 via that clause, independent of the printStackTrace-specific check. I used a `PrintWriter` parameter (no `System.out`/`err` reference) in the new test instead, so it cleanly proves ARCH-CODE-005 fires alone.

2. **ARCH-CODE-012 logger false positives** (two distinct modes, both fixed):
   - Exempted container-managed injection points (`@Inject`/`@Autowired`/`@Resource`) entirely — e.g. Quarkus's idiomatic `@Inject Logger log;` is non-static by construction (see the [Quarkus Logging guide](https://quarkus.io/guides/logging#logging-with-injection)).
   - Added a second valid pattern: `protected`, non-static, `final` logger in an **abstract base class**, initialized via `LoggerFactory.getLogger(getClass())` — the SLF4J-endorsed base-class idiom (see the [SLF4J FAQ](https://www.slf4j.org/faq.html#declared_static)). Implemented as an alternate passing condition, not a weakening of the primary `private static final` rule — a plain public/non-final/non-static/non-injected logger still fails.

3. **ARCH-CODE-006 false-positive on Spring Boot's exit idiom** — `System.exit(SpringApplication.exit(context, ...))` called directly from a static `main` method is Spring Boot's own documented CLI/batch exit-code pattern (see ["Application Exit"](https://docs.spring.io/spring-boot/reference/features/spring-application.html#features.spring-application.application-exit)). Exempted `System.exit` only when the call origin is a static `main` method; a `System.exit` call from any other method (service, controller, etc.) is still flagged, as are all `Runtime.exit`/`Runtime.halt` calls unconditionally.

4. **ARCH-CODE-013 missing Quarkus test-framework entries** — added `io.quarkus.test..` (home of `@QuarkusTest`) and `io.restassured..` to the allowlist, closing a cross-framework fairness gap where a Quarkus app leaking test annotations into main sources previously got no warning.

5. **ARCH-SPRING-016 removed** — empirically verified (via a throwaway violating fixture, since deleted) that its violation set is the **exact union** of ARCH-SPRING-002 (controllers→repositories), 003 (repositories→controllers), 006 (services→controllers), and 007 (repositories→services). Every real violation was being reported **twice**: once under its specific pairwise ID, once under 016. Removed the holistic rule and kept the four pairwise rules, since their per-pair messages ("Controller X depends on Repository Y") are more actionable than 016's generic layer-violation message. Documented the removal + rationale inline in `docs/ARCHITECTURE-CHECKS.md`.

6. **Doc severity-scale legend inconsistency** — `docs/ARCHITECTURE-CHECKS.md`'s own legend listed "package cycles" as the MEDIUM example, while `ARCH-PKG-001` (`FreeOfPackageCyclesRule`) is registered at HIGH. Fixed the **documentation**, not the rule (HIGH is correct/defensible for cycles — see [ArchUnit's cycle-check docs](https://www.archunit.org/userguide/html/000_Index.html#_cycle_checks)): moved "package cycles" to the HIGH example, referencing ARCH-PKG-001 explicitly.

## New rules

1. **ARCH-CODE-017 — No direct `Thread` instantiation** (MEDIUM) — the strongest consensus finding of the audit (4 of 5 agents proposed it independently). Flags `new Thread(...)` (including `Thread` subclass instantiation). Unmanaged threads bypass pool sizing/naming/uncaught-exception handling and sit outside both frameworks' managed-concurrency story (Spring `TaskExecutor`/`@Async`; Quarkus `ManagedExecutor`/`@RunOnVirtualThread`) — see Effective Java Item 80 and the [Quarkus context-propagation guide](https://quarkus.io/guides/context-propagation). Pure JDK type check, framework-neutral, zero CDI-neutrality risk.

2. **ARCH-CODE-018 — Assertions should have a detail message** (INFO) — zero-implementation-risk: wires in ArchUnit's ready-made `GeneralCodingRules.ASSERTIONS_SHOULD_HAVE_DETAIL_MESSAGE`. Flags message-less `assert x > 0;`; `assert x > 0 : "x must be positive";` passes.

## Testing

- Added 13 new test methods (true-positive + false-positive/true-negative fixtures) to `ArchitectureRulesTests`, including a fixture using the **real** `SpringApplication.run`/`.exit` for the `System.exit` exemption test, and a hand-authored `io.quarkus.test.junit.QuarkusTest` stub annotation (following the existing `io.smallrye.mutiny.Uni` / `io.reactivex.Flowable` stub precedent in this test module, since `bootui-engine` has no real Quarkus test dependency) for the allowlist fixture.
- `ArchitectureRuleRegistryTests` updated for the new rule-ID list (016 removed, 017/018 added).
- Full `bootui-core`/`bootui-engine` suite: **1009/1009 tests passing**, including `ArchitectureCdiNeutralityTests` (critical CDI/Quarkus false-positive regression guard) and `EngineBoundaryArchitectureTests` (framework-neutrality guard) — both green.
- `spotless:apply`/`spotless:check`: clean across the whole reactor.
- `SpringApiConformanceTest` (`bootui-spring-sample-app`): 55/55 passing.
- Attempted the Quarkus `@QuarkusTest` conformance suite; 7 unrelated tests failed to boot due to `Port already bound: 8081` — traced to another parallel worktree session's `quarkus:dev` process on this shared machine, not this change (confirmed via `ps`/`lsof`; the conformance golden fixtures key only on panel id/`actionCapable`, not rule IDs/counts, so this change can't affect them).

## Docs

Updated `docs/ARCHITECTURE-CHECKS.md` (severity legend, ARCH-CODE-005/006/012/013 descriptions, ARCH-SPRING-016 removal + consolidation note, two new ARCH-CODE-017/018 entries) and `docs/FEATURES.md` (Architecture panel description: removed the ARCH-SPRING-016 phrase, added the two new rules).

---
*Implemented on behalf of an orchestrating session that synthesized findings from 5 independent AI audits of the Architecture advisor ruleset.*