### PR TITLE
Fix Memory advisor rules: correctness, false-positive, and new leak-detection checks

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCollector.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCollector.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.engine.memory;
 
 import io.github.jdubois.bootui.core.dto.HeapClassHistogramEntryDto;
 import io.github.jdubois.bootui.core.dto.ThreadDumpReport;
+import io.github.jdubois.bootui.engine.memory.MemoryContext.BufferPoolSnapshot;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.ClassLoadingData;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.GcSample;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.GcTrend;
@@ -172,7 +173,13 @@ final class MemoryCollector {
         long directUsed = 0;
         long directCapacity = 0;
         long directCount = 0;
+        List<BufferPoolSnapshot> bufferPools = new ArrayList<>();
         for (BufferPoolMXBean bufferPool : ManagementFactory.getPlatformMXBeans(BufferPoolMXBean.class)) {
+            bufferPools.add(new BufferPoolSnapshot(
+                    bufferPool.getName(),
+                    Math.max(0, bufferPool.getMemoryUsed()),
+                    Math.max(0, bufferPool.getTotalCapacity()),
+                    Math.max(0, bufferPool.getCount())));
             if ("direct".equalsIgnoreCase(bufferPool.getName())) {
                 directUsed += Math.max(0, bufferPool.getMemoryUsed());
                 directCapacity += Math.max(0, bufferPool.getTotalCapacity());
@@ -206,7 +213,8 @@ final class MemoryCollector {
                 inputArgs,
                 gcNames,
                 containerLimit,
-                containerCurrent);
+                containerCurrent,
+                bufferPools);
     }
 
     private ThreadData collectThreads() {
@@ -269,7 +277,9 @@ final class MemoryCollector {
         int availableProcessors = ManagementFactory.getOperatingSystemMXBean().getAvailableProcessors();
         long freeSwap = readOsBeanLong("FreeSwapSpaceSize");
         long totalSwap = readOsBeanLong("TotalSwapSpaceSize");
+        long totalPhysicalMemory = readOsBeanLong("TotalPhysicalMemorySize");
         Boolean useCompressedOops = readVmOptionBoolean("UseCompressedOops");
+        LastGcPause lastGcPause = readLastGcPause();
 
         return new RuntimeData(
                 gc.uptimeMillis(),
@@ -281,7 +291,51 @@ final class MemoryCollector {
                 availableProcessors,
                 freeSwap,
                 totalSwap,
-                useCompressedOops);
+                useCompressedOops,
+                totalPhysicalMemory,
+                lastGcPause.millis(),
+                lastGcPause.collectorName());
+    }
+
+    /**
+     * The duration and originating collector of the single most recent garbage collection (MEM-GC-006's
+     * outlier-pause rule). {@link #unavailable()} on a non-HotSpot JVM or before any collection has run.
+     */
+    private record LastGcPause(long millis, String collectorName) {
+        static LastGcPause unavailable() {
+            return new LastGcPause(-1, null);
+        }
+    }
+
+    /**
+     * Reads the duration of the single most recent garbage collection across all collectors via the
+     * HotSpot-specific {@code com.sun.management.GarbageCollectorMXBean.getLastGcInfo()} extension,
+     * keeping the longest pause (and its collector name) when more than one collector has run since
+     * the JVM started. Unlike the generic scalar reads elsewhere in this class, this directly uses the
+     * {@code com.sun.management} types (there is no generic string-keyed JMX attribute for the
+     * composite "last GC info" value); the whole lookup is wrapped so a non-HotSpot JVM degrades to
+     * {@link LastGcPause#unavailable()} instead of failing this (or any other) scan.
+     */
+    private static LastGcPause readLastGcPause() {
+        try {
+            long longestDurationMillis = -1;
+            String longestCollectorName = null;
+            for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
+                if (bean instanceof com.sun.management.GarbageCollectorMXBean sunBean) {
+                    com.sun.management.GcInfo info = sunBean.getLastGcInfo();
+                    if (info != null && info.getDuration() > longestDurationMillis) {
+                        longestDurationMillis = info.getDuration();
+                        longestCollectorName = bean.getName();
+                    }
+                }
+            }
+            return longestDurationMillis >= 0
+                    ? new LastGcPause(longestDurationMillis, longestCollectorName)
+                    : LastGcPause.unavailable();
+        } catch (RuntimeException | LinkageError ex) {
+            // com.sun.management is a HotSpot extension; degrade gracefully on other JVMs.
+            return LastGcPause.unavailable();
+        }
     }
 
     private static List<HeapClassHistogramEntryDto> parseHistogram(String raw) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryContext.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryContext.java
@@ -22,7 +22,9 @@ record MemoryContext(
         ClassLoadingData classLoading,
         RuntimeData runtime,
         GcSample preHistogramGc,
-        GcTrend gcTrend) {
+        GcTrend gcTrend,
+        BufferPoolTrend bufferPoolTrend,
+        OldGenTrend oldGenTrend) {
 
     MemoryContext {
         memory = memory == null ? MemoryData.empty() : memory;
@@ -33,12 +35,31 @@ record MemoryContext(
         runtime = runtime == null ? RuntimeData.empty() : runtime;
         preHistogramGc = preHistogramGc == null ? GcSample.from(runtime) : preHistogramGc;
         gcTrend = gcTrend == null ? GcTrend.unavailable() : gcTrend;
+        bufferPoolTrend = bufferPoolTrend == null ? BufferPoolTrend.unavailable() : bufferPoolTrend;
+        oldGenTrend = oldGenTrend == null ? OldGenTrend.unavailable() : oldGenTrend;
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the cross-scan buffer-pool-growth
+     * and old-generation-trend rules (MEM-POOL-007 / MEM-HEAP-008); both trends default to
+     * unavailable.
+     */
+    MemoryContext(
+            MemoryData memory,
+            ThreadData threads,
+            HeapContentData heapContent,
+            PostGcHeapData postGcHeap,
+            ClassLoadingData classLoading,
+            RuntimeData runtime,
+            GcSample preHistogramGc,
+            GcTrend gcTrend) {
+        this(memory, threads, heapContent, postGcHeap, classLoading, runtime, preHistogramGc, gcTrend, null, null);
     }
 
     /**
      * Convenience constructor used by tests and any caller that does not provide post-GC or
      * cross-scan data. The post-GC heap reading defaults to unavailable, the pre-histogram GC
-     * sample mirrors the (single) runtime reading, and the GC trend is unavailable.
+     * sample mirrors the (single) runtime reading, and every cross-scan trend is unavailable.
      */
     MemoryContext(
             MemoryData memory,
@@ -52,7 +73,46 @@ record MemoryContext(
     /** Returns a copy of this context with the scanner-computed GC trend attached. */
     MemoryContext withGcTrend(GcTrend trend) {
         return new MemoryContext(
-                memory, threads, heapContent, postGcHeap, classLoading, runtime, preHistogramGc, trend);
+                memory,
+                threads,
+                heapContent,
+                postGcHeap,
+                classLoading,
+                runtime,
+                preHistogramGc,
+                trend,
+                bufferPoolTrend,
+                oldGenTrend);
+    }
+
+    /** Returns a copy of this context with the scanner-computed buffer-pool growth trend attached. */
+    MemoryContext withBufferPoolTrend(BufferPoolTrend trend) {
+        return new MemoryContext(
+                memory,
+                threads,
+                heapContent,
+                postGcHeap,
+                classLoading,
+                runtime,
+                preHistogramGc,
+                gcTrend,
+                trend,
+                oldGenTrend);
+    }
+
+    /** Returns a copy of this context with the scanner-computed old-generation usage trend attached. */
+    MemoryContext withOldGenTrend(OldGenTrend trend) {
+        return new MemoryContext(
+                memory,
+                threads,
+                heapContent,
+                postGcHeap,
+                classLoading,
+                runtime,
+                preHistogramGc,
+                gcTrend,
+                bufferPoolTrend,
+                trend);
     }
 
     int heapUsedPercent() {
@@ -84,6 +144,13 @@ record MemoryContext(
         }
     }
 
+    /**
+     * A single {@code java.nio} buffer pool reading ({@code BufferPoolMXBean}), typically "direct"
+     * or "mapped". Captured per-pool (unlike the aggregated direct-buffer totals below) so
+     * MEM-POOL-007 can track each pool's usage across scans independently.
+     */
+    record BufferPoolSnapshot(String name, long used, long capacity, long count) {}
+
     record MemoryData(
             long heapUsed,
             long heapCommitted,
@@ -99,12 +166,53 @@ record MemoryContext(
             List<String> inputArguments,
             List<String> gcCollectorNames,
             Long containerMemoryLimitBytes,
-            Long containerMemoryCurrentBytes) {
+            Long containerMemoryCurrentBytes,
+            List<BufferPoolSnapshot> bufferPools) {
 
         MemoryData {
             pools = pools == null ? List.of() : List.copyOf(pools);
             inputArguments = inputArguments == null ? List.of() : List.copyOf(inputArguments);
             gcCollectorNames = gcCollectorNames == null ? List.of() : List.copyOf(gcCollectorNames);
+            bufferPools = bufferPools == null ? List.of() : List.copyOf(bufferPools);
+        }
+
+        /**
+         * Backward-compatible constructor for callers that predate per-pool buffer-pool tracking
+         * (MEM-POOL-007's cross-scan growth-without-release rule); defaults to no per-pool readings.
+         */
+        MemoryData(
+                long heapUsed,
+                long heapCommitted,
+                long heapMax,
+                long nonHeapUsed,
+                long nonHeapCommitted,
+                long nonHeapMax,
+                List<MemoryPoolSnapshot> pools,
+                long directBufferUsed,
+                long directBufferCapacity,
+                long directBufferCount,
+                long maxDirectMemoryBytes,
+                List<String> inputArguments,
+                List<String> gcCollectorNames,
+                Long containerMemoryLimitBytes,
+                Long containerMemoryCurrentBytes) {
+            this(
+                    heapUsed,
+                    heapCommitted,
+                    heapMax,
+                    nonHeapUsed,
+                    nonHeapCommitted,
+                    nonHeapMax,
+                    pools,
+                    directBufferUsed,
+                    directBufferCapacity,
+                    directBufferCount,
+                    maxDirectMemoryBytes,
+                    inputArguments,
+                    gcCollectorNames,
+                    containerMemoryLimitBytes,
+                    containerMemoryCurrentBytes,
+                    List.of());
         }
 
         static MemoryData empty() {
@@ -224,8 +332,10 @@ record MemoryContext(
      * Process-level scalars that are cheap single readings from the JVM but are not part of the
      * memory, thread, or heap-content snapshots: JVM uptime, cumulative GC time/count, the pending
      * finalization backlog, the parsed {@code -Xms}/{@code -Xss} sizes used by the native-memory
-     * and GC-overhead rules, plus OS-level metrics (available processors, swap space, and the
-     * UseCompressedOops VM option) collected once per scan for GC and footprint heuristics.
+     * and GC-overhead rules, OS-level metrics (available processors, physical memory, swap space,
+     * and the UseCompressedOops VM option), and the single most recent GC pause duration/collector
+     * (used by MEM-GC-006's outlier-pause rule) collected once per scan for GC and footprint
+     * heuristics.
      */
     record RuntimeData(
             long uptimeMillis,
@@ -237,9 +347,45 @@ record MemoryContext(
             int availableProcessors,
             long freeSwapSpaceBytes,
             long totalSwapSpaceBytes,
-            Boolean useCompressedOops) {
+            Boolean useCompressedOops,
+            long totalPhysicalMemoryBytes,
+            long lastGcPauseMillis,
+            String lastGcPauseCollectorName) {
 
         static final long DEFAULT_THREAD_STACK_BYTES = 1024L * 1024;
+
+        /**
+         * Backward-compatible constructor for callers that predate the total-physical-memory
+         * reading (MEM-GC-004's server-class-machine ergonomics skip) and the last-GC-pause reading
+         * (MEM-GC-006's pause-latency outlier rule). Both default to "unknown"/"unavailable" (-1) so
+         * existing behavior is preserved when these newer fields are not supplied.
+         */
+        RuntimeData(
+                long uptimeMillis,
+                long gcCollectionTimeMillis,
+                long gcCollectionCount,
+                int objectPendingFinalizationCount,
+                long initialHeapBytes,
+                long threadStackBytes,
+                int availableProcessors,
+                long freeSwapSpaceBytes,
+                long totalSwapSpaceBytes,
+                Boolean useCompressedOops) {
+            this(
+                    uptimeMillis,
+                    gcCollectionTimeMillis,
+                    gcCollectionCount,
+                    objectPendingFinalizationCount,
+                    initialHeapBytes,
+                    threadStackBytes,
+                    availableProcessors,
+                    freeSwapSpaceBytes,
+                    totalSwapSpaceBytes,
+                    useCompressedOops,
+                    -1,
+                    -1,
+                    null);
+        }
 
         static RuntimeData empty() {
             return new RuntimeData(0, -1, 0, 0, -1, DEFAULT_THREAD_STACK_BYTES, 1, -1, -1, null);
@@ -314,6 +460,44 @@ record MemoryContext(
                 }
             }
             return new GcTrend(true, deltaGcTime, deltaUptime, deltaGcCount, deltas);
+        }
+    }
+
+    /**
+     * Consecutive-scan growth tracking for {@code java.nio} buffer pools (direct/mapped), used by
+     * MEM-POOL-007 to catch a native-memory leak before a pool's absolute usage crosses
+     * MEM-POOL-003's static high-water threshold. A pool's streak counts how many scans in a row
+     * (including this one) its used-byte reading has strictly increased over the previous scan with
+     * no decrease in between; any decrease, a plateau, or a pool not seen in the previous scan resets
+     * that pool's streak to zero.
+     */
+    record BufferPoolTrend(boolean available, Map<String, Integer> consecutiveIncreaseStreaks) {
+
+        BufferPoolTrend {
+            consecutiveIncreaseStreaks =
+                    consecutiveIncreaseStreaks == null ? Map.of() : Map.copyOf(consecutiveIncreaseStreaks);
+        }
+
+        static BufferPoolTrend unavailable() {
+            return new BufferPoolTrend(false, Map.of());
+        }
+
+        int streakFor(String poolName) {
+            return consecutiveIncreaseStreaks.getOrDefault(poolName, 0);
+        }
+    }
+
+    /**
+     * Consecutive-scan trend for post-GC old-generation usage, used by MEM-HEAP-008 to catch a slow
+     * heap leak well before MEM-HEAP-002's static high-water-mark percentage fires. The streak counts
+     * how many user-triggered scans in a row (each of which forces a full GC before re-reading old-gen
+     * usage, like {@link PostGcHeapData}) have shown a strict increase in post-GC old-generation usage
+     * over the previous scan, independent of the absolute percentage.
+     */
+    record OldGenTrend(boolean available, int consecutiveIncreaseStreak, long lastUsedBytes) {
+
+        static OldGenTrend unavailable() {
+            return new OldGenTrend(false, 0, -1);
         }
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRuleRegistry.java
@@ -8,10 +8,11 @@ final class MemoryRuleRegistry {
             // Heap pressure
             new HighHeapUtilizationRule(),
             new OldGenerationNearMaxRule(),
-            new UnsetOrSmallMaxHeapRule(),
+            new SmallMaxHeapUnderPressureRule(),
             new CompressedOopsCliffRule(),
             new PendingFinalizationBacklogRule(),
             new OverProvisionedHeapRule(),
+            new OldGenerationTrendingUpwardRule(),
             // Native memory
             new CommittedFootprintNearContainerLimitRule(),
             new PlatformThreadStackReservationRule(),
@@ -24,6 +25,7 @@ final class MemoryRuleRegistry {
             new UnboundedMetaspaceInContainerRule(),
             new CompressedClassSpaceRule(),
             new InterpretedJitModeRule(),
+            new BufferPoolGrowthWithoutReleaseRule(),
             // GC configuration
             new MissingHeapSizingInContainerRule(),
             new HighGcOverheadRule(),
@@ -31,6 +33,7 @@ final class MemoryRuleRegistry {
             new UnequalInitialAndMaxHeapRule(),
             new SerialGcOnMultiCoreRule(),
             new G1FullGcFrequencyRule(),
+            new GcPauseLatencyOutlierRule(),
             // Threads
             new DeadlockDetectedRule(),
             new HighBlockedThreadRatioRule(),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRules.java
@@ -192,19 +192,19 @@ final class OldGenerationNearMaxRule extends AbstractMemoryRule {
     }
 }
 
-final class UnsetOrSmallMaxHeapRule extends AbstractMemoryRule {
+final class SmallMaxHeapUnderPressureRule extends AbstractMemoryRule {
 
     private static final long MIN_CONTAINER_LIMIT = MemoryFormat.GIGABYTE;
     private static final int SMALL_HEAP_PERCENT = 15;
     private static final int PRESSURE_PERCENT = 80;
 
-    UnsetOrSmallMaxHeapRule() {
+    SmallMaxHeapUnderPressureRule() {
         super(new MemoryRuleDefinition(
                 "MEM-HEAP-003",
-                "Maximum heap is unset or capped well below the container limit",
+                "Maximum heap is capped well below the container limit",
                 MemoryCategory.HEAP_PRESSURE,
                 "LOW",
-                "Flags when -Xmx is effectively unbounded, or when a small max heap is already under pressure while a much larger container memory limit is available to grow into.",
+                "Flags when a small max heap is already under pressure while a much larger container memory limit is available to grow into. The check prefers post-GC heap occupancy (consistent with MEM-HEAP-001/002) to avoid false positives from transient garbage.",
                 "Set an explicit -Xmx or -XX:MaxRAMPercentage that lets the heap use a sensible share of the container memory limit instead of staying small while under pressure.",
                 "https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html"));
     }
@@ -751,7 +751,7 @@ final class ExcessiveLoadedClassesRule extends AbstractMemoryRule {
                 "Very large number of loaded classes with little unloading",
                 MemoryCategory.CLASS_LOADING,
                 "INFO",
-                "Flags a high loaded-class count combined with little or no class unloading, which can indicate a classloader leak or runaway dynamic class generation and pressures Metaspace. A large class count that is matched by active unloading is treated as a legitimately large application instead.",
+                "Flags a high loaded-class count combined with little or no class unloading, which can indicate a classloader leak or runaway dynamic class generation and pressures Metaspace. A large class count that is matched by active unloading is treated as a legitimately large application instead. Caveat: the threshold is not framework-neutral in practice. Frameworks that generate proxy/lambda/configuration classes at runtime (e.g. Spring Boot's CGLIB/JDK dynamic proxies, autoconfiguration, and lambda forms) structurally load more classes than an equivalent application built with a framework that does most of this at build time (e.g. Quarkus); two applications of the same real size can sit at very different distances from this threshold purely because of framework style, not application growth or a leak.",
                 "If the application does not legitimately use this many classes, look for classloader leaks (redeploys, scripting, proxy generation).",
                 "https://docs.oracle.com/en/java/javase/21/troubleshoot/troubleshoot-class-loading.html"));
     }
@@ -1080,7 +1080,7 @@ final class PlatformThreadStackReservationRule extends AbstractMemoryRule {
                 "Platform thread stacks reserve a large amount of native memory",
                 MemoryCategory.NATIVE_MEMORY,
                 "HIGH",
-                "Estimates the native memory reserved for platform thread stacks (live platform threads times the -Xss/-XX:ThreadStackSize reservation) and flags when stacks alone are a large contributor to the off-heap footprint. This is reservation, not necessarily resident memory, and it is the stacks-only early warning behind the broader MEM-FOOTPRINT-001 total-footprint estimate. Virtual threads are excluded because their stacks live on the heap. Severity is HIGH when a container memory limit is detected (reservation directly competes with the cgroup limit) and MEDIUM otherwise (virtual-memory reservation rarely equals resident set size without a container ceiling).",
+                "Estimates the native memory reserved for platform thread stacks (live platform threads times the -Xss/-XX:ThreadStackSize reservation) and flags when stacks alone are a large contributor to the off-heap footprint. Thread stacks are demand-paged virtual address-space reservations, not committed/resident memory: a JVM with many idle or shallow-call-depth threads can reserve a large amount while only a small fraction of it is ever touched (becomes resident), so a large reservation alone does not prove memory pressure. Virtual threads are excluded because their stacks live on the heap. Severity is HIGH only when the reservation is both a large share (>=20%) of a detected container memory limit AND, combined with memory already resident in the container, fully realizing the reservation would breach that limit (current + reserved >= limit) -- i.e. there is confirmed resident risk, not just a large reservation. Otherwise this is reported at MEDIUM: still worth reviewing, but without confirmed resident risk it may never materialize as actual memory pressure.",
                 "Reduce the platform thread count (bound pools, prefer virtual threads or async I/O) or lower an oversized -Xss so thread stacks do not dominate native memory.",
                 "https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html"));
     }
@@ -1094,21 +1094,31 @@ final class PlatformThreadStackReservationRule extends AbstractMemoryRule {
         long stackBytes = context.runtime().threadStackBytes();
         long reserved = (long) platformThreads * stackBytes;
         Long limit = context.memory().containerMemoryLimitBytes();
+        Long current = context.memory().containerMemoryCurrentBytes();
         boolean relativeBreach = limit != null && limit > 0 && reserved >= limit * CONTAINER_PERCENT_THRESHOLD / 100;
         boolean absoluteBreach = reserved >= ABSOLUTE_THRESHOLD;
         if (relativeBreach || absoluteBreach) {
+            // Confirmed resident risk: fully realizing the reservation, on top of memory already
+            // resident in the container, would breach the container limit. This distinguishes a
+            // genuine near-OOM risk from a large-but-mostly-untouched virtual-memory reservation --
+            // thread stacks are demand-paged, while cgroup accounting tracks resident usage, not
+            // reservations (kernel.org: memory.current is charged/resident memory, not a reservation).
+            boolean confirmedResidentRisk = relativeBreach && current != null && current + reserved >= limit;
+            String severity = confirmedResidentRisk ? MemoryRuleSupport.HIGH : MemoryRuleSupport.MEDIUM;
             String relativeNote = limit != null && limit > 0
                     ? " (" + MemoryFormat.percentOf(reserved, limit) + "% of the container memory limit "
                             + MemoryFormat.bytes(limit) + ")"
                     : "";
-            // Reservation without a container limit is virtual memory, not necessarily resident;
-            // downgrade to MEDIUM to avoid over-alarming on apps that simply have many threads.
-            String severity = relativeBreach ? MemoryRuleSupport.HIGH : MemoryRuleSupport.MEDIUM;
+            String residencyNote = confirmedResidentRisk
+                    ? " Combined with the " + MemoryFormat.bytes(current) + " already resident in the container,"
+                            + " fully realizing this reservation would breach the container limit."
+                    : " This is a virtual-memory reservation, not confirmed resident usage; only a fraction of it"
+                            + " may ever become resident.";
             return violation(
                     severity,
                     platformThreads + " platform threads reserve about " + MemoryFormat.bytes(reserved)
                             + " of stack memory at " + MemoryFormat.bytes(stackBytes) + " each" + relativeNote
-                            + "; thread stacks are a large contributor to the native footprint.");
+                            + "; thread stacks are a large contributor to the native footprint." + residencyNote);
         }
         return pass();
     }
@@ -1263,7 +1273,7 @@ final class ContainerMemoryPressureRule extends AbstractMemoryRule {
                 "Container memory usage is near the cgroup limit",
                 MemoryCategory.NATIVE_MEMORY,
                 "HIGH",
-                "Reads the current cgroup memory usage (memory.current for cgroup v2, memory.usage_in_bytes for v1) and compares it against the detected container memory limit. When usage approaches the limit the container is at risk of an immediate OOM kill by the kernel, which is abrupt and does not trigger JVM OutOfMemoryError handling.",
+                "Reads the current cgroup memory usage (memory.current for cgroup v2, memory.usage_in_bytes for v1) and compares it against the detected container memory limit. When usage approaches the limit the container is at risk of an immediate OOM kill by the kernel, which is abrupt and does not trigger JVM OutOfMemoryError handling. Caveat: raw cgroup current-usage numbers can overstate real memory pressure. cgroup v2's memory.current includes reclaimable page cache, not only the process's own footprint, and cgroup v1's memory.usage_in_bytes is documented by the kernel itself as an approximate 'fuzz value' (the kernel's own guidance for an exact figure is memory.stat's RSS+CACHE breakdown). Treat a reading near the limit as a strong signal to investigate, not an exact resident-set measurement.",
                 "Lower -Xmx/-XX:MaxRAMPercentage, reduce non-heap memory (thread stacks, Metaspace, direct buffers), or raise the container memory limit to restore headroom.",
                 "https://docs.oracle.com/en/java/javase/21/troubleshoot/diagnostic-tools.html"));
     }
@@ -1295,15 +1305,22 @@ final class ContainerMemoryPressureRule extends AbstractMemoryRule {
 
 final class SerialGcOnMultiCoreRule extends AbstractMemoryRule {
 
+    /**
+     * Oracle's historical JVM ergonomics documentation defines a "server-class machine" as one with
+     * 2+ CPUs and at least ~2 GiB of memory; below that threshold Serial GC is the JVM's own correct
+     * default choice, not a misconfiguration. See the class-level {@code learnMoreUrl}.
+     */
+    private static final long SERVER_CLASS_MEMORY_THRESHOLD_BYTES = 2 * MemoryFormat.GIGABYTE;
+
     SerialGcOnMultiCoreRule() {
         super(new MemoryRuleDefinition(
                 "MEM-GC-004",
                 "Serial GC selected on a multi-core system",
                 MemoryCategory.GC_CONFIGURATION,
                 "LOW",
-                "Detects the Serial GC collector (bean names 'Copy' and/or 'MarkSweepCompact') running on a JVM with two or more available processors. Serial GC is single-threaded and can be selected by container ergonomics when the JVM sees only one CPU, but it underutilises multi-core hosts and causes long STW pauses at scale.",
+                "Detects the Serial GC collector (bean names 'Copy' and/or 'MarkSweepCompact') running on a JVM with two or more available processors and roughly 2 GiB or more of memory (container limit, else total physical memory). Serial GC is single-threaded and is JVM ergonomics' own correct default below Oracle's historical 'server-class machine' threshold (fewer than 2 CPUs, or less than ~2 GiB of memory) -- so this rule does not fire in that region. Above both thresholds, staying on Serial GC underutilises multi-core hosts and causes long STW pauses at scale.",
                 "Switch to G1 (-XX:+UseG1GC), ZGC (-XX:+UseZGC), or Parallel GC (-XX:+UseParallelGC) to use all available cores, unless binary size or footprint constraints explicitly require Serial.",
-                "https://docs.oracle.com/en/java/javase/21/gctuning/available-collectors.html"));
+                "https://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html"));
     }
 
     @Override
@@ -1317,8 +1334,28 @@ final class SerialGcOnMultiCoreRule extends AbstractMemoryRule {
         if (cpus < 2) {
             return skipped("Serial GC is expected on a single-CPU system.");
         }
+        long effectiveMemoryBytes = effectiveMemoryBytes(memory, context.runtime());
+        if (effectiveMemoryBytes >= 0 && effectiveMemoryBytes < SERVER_CLASS_MEMORY_THRESHOLD_BYTES) {
+            return skipped("Serial GC is expected below Oracle's historical 'server-class machine' ergonomics"
+                    + " threshold of 2 CPUs and ~2 GiB of memory (available: "
+                    + MemoryFormat.bytes(effectiveMemoryBytes) + ").");
+        }
         return violation("Serial GC is active ('Copy'/'MarkSweepCompact') on a " + cpus
                 + "-CPU system; Serial GC is single-threaded and will leave cores idle during collection pauses.");
+    }
+
+    /**
+     * Prefers the container memory limit (what actually bounds this JVM); falls back to total
+     * physical memory when no container limit is detected. Returns -1 when neither is known, in which
+     * case the rule does not skip (preserving the previous CPU-only behavior).
+     */
+    private static long effectiveMemoryBytes(MemoryData memory, MemoryContext.RuntimeData runtime) {
+        Long containerLimit = memory.containerMemoryLimitBytes();
+        if (containerLimit != null && containerLimit > 0) {
+            return containerLimit;
+        }
+        long totalPhysical = runtime.totalPhysicalMemoryBytes();
+        return totalPhysical > 0 ? totalPhysical : -1;
     }
 }
 
@@ -1334,7 +1371,7 @@ final class G1FullGcFrequencyRule extends AbstractMemoryRule {
                 "G1 Full GC occurred between scans",
                 MemoryCategory.GC_CONFIGURATION,
                 "MEDIUM",
-                "Detects an increase in the 'G1 Old Generation' (Full GC) collection count between two consecutive scans. G1 Full GCs are single-threaded STW stop-the-world pauses triggered by to-space exhaustion, humongous-allocation failure, or concurrent mark failure; even one Full GC per scan window is a sign of heap or tuning pressure. The first scan only establishes a baseline.",
+                "Detects an increase in the 'G1 Old Generation' (Full GC) collection count between two consecutive scans. A G1 Full GC is G1's fallback path, triggered when its normal concurrent-marking/mixed-collection cycle could not keep up with the allocation rate (to-space exhaustion, humongous-allocation failure, or concurrent mark failure). Since JDK 10 (JEP 307, 'Parallel Full GC for G1') this fallback runs on multiple threads, so it is not single-threaded, but it is still a fully stop-the-world pause across the entire heap; even one Full GC per scan window is a sign that G1 failed to reclaim memory through its normal cycle and is a sign of heap or tuning pressure. The first scan only establishes a baseline.",
                 "Increase -Xmx or tune -XX:G1HeapRegionSize to reduce humongous allocations; consider -XX:G1ReservePercent and -XX:InitiatingHeapOccupancyPercent to give G1 more head room for concurrent marking.",
                 "https://docs.oracle.com/en/java/javase/21/gctuning/garbage-first-g1-garbage-collector1.html"));
     }
@@ -1350,8 +1387,9 @@ final class G1FullGcFrequencyRule extends AbstractMemoryRule {
             return pass();
         }
         return violation("G1 Full GC occurred " + fullGcDelta + " time(s) since the last scan (G1 Old Generation"
-                + " collection count increased); Full GCs are single-threaded stop-the-world events"
-                + " caused by to-space exhaustion, humongous-allocation failure, or concurrent mark failure.");
+                + " collection count increased); a Full GC is G1's fully stop-the-world fallback path, triggered"
+                + " when its normal concurrent-marking/mixed-collection cycle could not keep up (to-space"
+                + " exhaustion, humongous-allocation failure, or concurrent mark failure).");
     }
 }
 
@@ -1517,5 +1555,159 @@ final class HighSwapUtilizationRule extends AbstractMemoryRule {
             // attribute may not exist on non-HotSpot JVMs
         }
         return -1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GC configuration (single-pause outlier)
+// ---------------------------------------------------------------------------
+
+final class GcPauseLatencyOutlierRule extends AbstractMemoryRule {
+
+    private static final long PAUSE_THRESHOLD_MILLIS = 1_000L;
+
+    GcPauseLatencyOutlierRule() {
+        super(
+                new MemoryRuleDefinition(
+                        "MEM-GC-006",
+                        "Most recent GC pause was an outlier",
+                        MemoryCategory.GC_CONFIGURATION,
+                        "MEDIUM",
+                        "Reads the duration of the single most recent garbage collection via"
+                                + " com.sun.management.GarbageCollectorMXBean.getLastGcInfo() and flags when that one pause"
+                                + " exceeds " + PAUSE_THRESHOLD_MILLIS + " ms. This complements the lifetime and recent"
+                                + " GC-overhead-ratio checks (MEM-GC-002/MEM-GC-003): a JVM can stay well under those ratio"
+                                + " thresholds on average while still hiding one catastrophic outlier pause, and a single"
+                                + " long stop-the-world pause can itself cause a request-latency spike or health-check"
+                                + " timeout even when overall GC overhead looks healthy. This is a single-sample reading"
+                                + " taken fresh on every scan, not a cross-scan trend.",
+                        "Capture GC logs (-Xlog:gc*:file=gc.log:time,level,tags) around the outlier and check the reported"
+                                + " cause; consider a lower-pause-target collector (G1's -XX:MaxGCPauseMillis, ZGC, or"
+                                + " Shenandoah) or reduce the allocation/promotion rate that triggered the long pause.",
+                        "https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/GarbageCollectorMXBean.html"));
+    }
+
+    @Override
+    io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
+        long pauseMillis = context.runtime().lastGcPauseMillis();
+        if (pauseMillis < 0) {
+            return skipped("The most recent GC pause duration is not available (requires a HotSpot JVM and at"
+                    + " least one collection since JVM start).");
+        }
+        if (pauseMillis < PAUSE_THRESHOLD_MILLIS) {
+            return pass();
+        }
+        String collectorName = context.runtime().lastGcPauseCollectorName();
+        String collectorNote = collectorName != null && !collectorName.isBlank() ? " (" + collectorName + ")" : "";
+        return violation("The most recent GC pause took " + pauseMillis + " ms" + collectorNote
+                + ", a single-pause outlier at or above the " + PAUSE_THRESHOLD_MILLIS
+                + " ms threshold; this can cause a latency spike independent of average GC overhead.");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Memory pools (buffer pool growth trend)
+// ---------------------------------------------------------------------------
+
+final class BufferPoolGrowthWithoutReleaseRule extends AbstractMemoryRule {
+
+    private static final int GROWTH_STREAK_THRESHOLD = 3;
+
+    BufferPoolGrowthWithoutReleaseRule() {
+        super(
+                new MemoryRuleDefinition(
+                        "MEM-POOL-007",
+                        "Buffer pool usage has grown on every recent scan without release",
+                        MemoryCategory.MEMORY_POOLS,
+                        "MEDIUM",
+                        "Tracks each java.nio buffer pool's (BufferPoolMXBean, typically 'direct' and 'mapped') used-byte"
+                                + " reading across scans and flags a pool whose usage has strictly increased on every one of"
+                                + " the last " + GROWTH_STREAK_THRESHOLD + " consecutive scans with no decrease in"
+                                + " between -- the classic native-memory-leak signature of leaked direct/mapped ByteBuffers"
+                                + " (common with NIO channel or Netty-style misuse where buffers are allocated but never"
+                                + " released). This can catch a leak while the pool is still well under MEM-POOL-003's"
+                                + " static high-water threshold, since a monotonic trend is a stronger signal than any"
+                                + " single absolute reading. Escalates to HIGH when the growing pool is the 'direct' pool"
+                                + " and MEM-POOL-003's static threshold has also been crossed. Requires several consecutive"
+                                + " user-triggered scans to build a trend; the first scans only establish the baseline.",
+                        "Audit code paths that allocate direct or mapped ByteBuffers (including NIO channels and libraries"
+                                + " like Netty) for missing release/cleaner calls, and confirm the pool eventually plateaus"
+                                + " or shrinks under normal load instead of only ever growing.",
+                        "https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/BufferPoolMXBean.html"));
+    }
+
+    @Override
+    io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
+        MemoryContext.BufferPoolTrend trend = context.bufferPoolTrend();
+        if (!trend.available()) {
+            return skipped("No previous scan to compare; re-run the scan several times to measure buffer-pool growth.");
+        }
+        List<MemoryContext.BufferPoolSnapshot> pools = context.memory().bufferPools();
+        List<String> details = new ArrayList<>();
+        boolean escalateToHigh = false;
+        boolean directPoolAtStaticThreshold = MemoryRuleSupport.VIOLATION.equals(
+                new DirectBufferGrowthRule().evaluate(context).status());
+        for (MemoryContext.BufferPoolSnapshot pool : pools) {
+            int streak = trend.streakFor(pool.name());
+            if (streak < GROWTH_STREAK_THRESHOLD) {
+                continue;
+            }
+            boolean isDirectPool = "direct".equalsIgnoreCase(pool.name());
+            if (isDirectPool && directPoolAtStaticThreshold) {
+                escalateToHigh = true;
+            }
+            details.add("'" + pool.name() + "' buffer pool usage grew on " + streak
+                    + " consecutive scans without a decrease (now " + MemoryFormat.bytes(pool.used())
+                    + "); this is the classic native-memory-leak signature for leaked direct/mapped buffers.");
+        }
+        if (details.isEmpty()) {
+            return pass();
+        }
+        return violation(escalateToHigh ? MemoryRuleSupport.HIGH : MemoryRuleSupport.MEDIUM, details);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Heap pressure (old-generation usage trend)
+// ---------------------------------------------------------------------------
+
+final class OldGenerationTrendingUpwardRule extends AbstractMemoryRule {
+
+    private static final int GROWTH_STREAK_THRESHOLD = 3;
+
+    OldGenerationTrendingUpwardRule() {
+        super(new MemoryRuleDefinition(
+                "MEM-HEAP-008",
+                "Post-GC old-generation usage is trending upward across scans",
+                MemoryCategory.HEAP_PRESSURE,
+                "MEDIUM",
+                "Tracks post-GC old-generation usage (the same reading MEM-HEAP-002 compares against a static"
+                        + " percentage) across consecutive user-triggered scans and flags a monotonic increase over"
+                        + " the last " + GROWTH_STREAK_THRESHOLD + " consecutive scans with no decrease in between,"
+                        + " independent of the absolute percentage. This is the standard textbook Java heap-leak"
+                        + " diagnostic -- retained-size growth across successive full GCs -- and can catch a slow"
+                        + " leak (for example, one climbing steadily through 40% old-generation usage) well before"
+                        + " MEM-HEAP-002's static high-water-mark threshold fires. Requires several consecutive"
+                        + " scans to build a trend; the first scans only establish the baseline.",
+                "Take a heap dump and compare successive class histograms (the Heap Dump panel) to find the"
+                        + " retained-object type driving the growth, and confirm with a profiler whether this is a"
+                        + " real leak or a temporarily growing cache/working set.",
+                "https://docs.oracle.com/en/java/javase/21/troubleshoot/troubleshooting-memory-leaks.html"));
+    }
+
+    @Override
+    io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
+        MemoryContext.OldGenTrend trend = context.oldGenTrend();
+        if (!trend.available()) {
+            return skipped("No previous scan to compare; re-run the scan several times to measure the"
+                    + " old-generation trend.");
+        }
+        if (trend.consecutiveIncreaseStreak() < GROWTH_STREAK_THRESHOLD) {
+            return pass();
+        }
+        return violation("Post-GC old-generation usage has increased on " + trend.consecutiveIncreaseStreak()
+                + " consecutive scans without a decrease (now " + MemoryFormat.bytes(trend.lastUsedBytes())
+                + "); this is the classic retained-size-growth signature of a slow heap leak, independent of the"
+                + " current percentage of the old-generation pool's maximum.");
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryScanner.java
@@ -53,6 +53,24 @@ public final class MemoryScanner {
      */
     private MemoryContext.GcSample previousGcSample;
 
+    /**
+     * Cross-scan state for MEM-POOL-007's buffer-pool growth-without-release trend: each pool's used
+     * bytes and consecutive-increase streak as of the previous scan. Guarded by {@link #scan()}.
+     */
+    private Map<String, Long> previousBufferPoolUsed = Map.of();
+
+    private Map<String, Integer> previousBufferPoolStreaks = Map.of();
+    private boolean previousBufferPoolSampleAvailable;
+
+    /**
+     * Cross-scan state for MEM-HEAP-008's post-GC old-generation usage trend. Guarded by
+     * {@link #scan()}.
+     */
+    private long previousOldGenUsedBytes = -1;
+
+    private int previousOldGenStreak;
+    private boolean previousOldGenSampleAvailable;
+
     MemoryScanner(MemoryCollector collector, Clock clock) {
         this(collector::collect, clock);
     }
@@ -105,7 +123,11 @@ public final class MemoryScanner {
                 ? MemoryContext.GcTrend.unavailable()
                 : MemoryContext.GcTrend.between(previousGcSample, context.preHistogramGc());
         previousGcSample = currentSample;
-        MemoryContext evaluated = context.withGcTrend(trend);
+        MemoryContext.BufferPoolTrend bufferPoolTrend =
+                computeBufferPoolTrend(context.memory().bufferPools());
+        MemoryContext.OldGenTrend oldGenTrend = computeOldGenTrend(context.postGcHeap());
+        MemoryContext evaluated =
+                context.withGcTrend(trend).withBufferPoolTrend(bufferPoolTrend).withOldGenTrend(oldGenTrend);
 
         List<MemoryRuleResultDto> results = MemoryRuleRegistry.activeRules().stream()
                 .map(rule -> rule.evaluate(evaluated))
@@ -117,6 +139,67 @@ public final class MemoryScanner {
             message += " Some rules could not be evaluated.";
         }
         return report(status, message, clock.millis(), summary(evaluated), results.size(), results);
+    }
+
+    /**
+     * Computes each buffer pool's consecutive-increase streak against the previous scan's readings
+     * (MEM-POOL-007's native-buffer-leak signal). A pool's streak grows only when its used-byte
+     * reading strictly increased since the previous scan; a decrease, a plateau, or a pool absent from
+     * the previous scan resets that pool's streak to zero. The very first scan of a new scanner
+     * instance has no previous sample to compare against, so it seeds the baseline and reports
+     * {@link MemoryContext.BufferPoolTrend#unavailable()}.
+     */
+    private MemoryContext.BufferPoolTrend computeBufferPoolTrend(List<MemoryContext.BufferPoolSnapshot> pools) {
+        Map<String, Long> currentUsed = new LinkedHashMap<>();
+        for (MemoryContext.BufferPoolSnapshot pool : pools) {
+            currentUsed.put(pool.name(), pool.used());
+        }
+
+        Map<String, Integer> streaks = new LinkedHashMap<>();
+        for (Map.Entry<String, Long> entry : currentUsed.entrySet()) {
+            String name = entry.getKey();
+            long used = entry.getValue();
+            Long previous = previousBufferPoolUsed.get(name);
+            int streak =
+                    (previous != null && used > previous) ? previousBufferPoolStreaks.getOrDefault(name, 0) + 1 : 0;
+            streaks.put(name, streak);
+        }
+
+        MemoryContext.BufferPoolTrend trend = previousBufferPoolSampleAvailable
+                ? new MemoryContext.BufferPoolTrend(true, streaks)
+                : MemoryContext.BufferPoolTrend.unavailable();
+
+        previousBufferPoolUsed = currentUsed;
+        previousBufferPoolStreaks = streaks;
+        previousBufferPoolSampleAvailable = true;
+        return trend;
+    }
+
+    /**
+     * Computes the post-GC old-generation usage trend against the previous scan (MEM-HEAP-008's
+     * leak-trend signal). Only advances the streak when this scan's post-GC old-generation reading is
+     * available; a scan where it is not (histogram not run, or the collector exposes no old-gen pool)
+     * leaves the previous sample untouched so one unavailable scan does not erase a real accumulating
+     * trend. As with the other cross-scan trends, the first available sample seeds the baseline and
+     * reports {@link MemoryContext.OldGenTrend#unavailable()}.
+     */
+    private MemoryContext.OldGenTrend computeOldGenTrend(MemoryContext.PostGcHeapData postGcHeap) {
+        if (!postGcHeap.oldGenAvailable()) {
+            return MemoryContext.OldGenTrend.unavailable();
+        }
+        long used = postGcHeap.oldGenUsed();
+        MemoryContext.OldGenTrend trend;
+        if (previousOldGenSampleAvailable) {
+            int streak = used > previousOldGenUsedBytes ? previousOldGenStreak + 1 : 0;
+            trend = new MemoryContext.OldGenTrend(true, streak, used);
+            previousOldGenStreak = streak;
+        } else {
+            trend = MemoryContext.OldGenTrend.unavailable();
+            previousOldGenStreak = 0;
+        }
+        previousOldGenUsedBytes = used;
+        previousOldGenSampleAvailable = true;
+        return trend;
     }
 
     private MemoryReport report(

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryRulesTests.java
@@ -153,7 +153,9 @@ class MemoryRulesTests {
     }
 
     @Test
-    void stackReservationLargeRelativeToContainerIsHigh() {
+    void stackReservationLargeRelativeToContainerWithoutCurrentUsageIsMedium() {
+        // Container current-usage is unknown (containerMemoryCurrentBytes not supplied), so the rule
+        // cannot confirm resident risk and must not escalate to HIGH from the ratio breach alone.
         ThreadData threads = threads(300);
         MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 1 * GB, List.of("-Xmx2g"));
         MemoryContext context = context(memory, threads, PostGcHeapData.unavailable(), healthyRuntime());
@@ -161,7 +163,40 @@ class MemoryRulesTests {
         MemoryRuleResultDto result = find(scan(context), "MEM-FOOTPRINT-002");
 
         assertThat(result).isNotNull();
+        assertThat(result.severity()).isEqualTo("MEDIUM");
+        assertThat(result.sampleViolations().get(0)).contains("virtual-memory reservation, not confirmed");
+    }
+
+    @Test
+    void stackReservationWithConfirmedResidentRiskIsHigh() {
+        // 300 threads * 1 MiB stack = 300 MiB reservation, >=20% of the 1 GiB limit (ratio breach).
+        // 800 MiB already resident + 300 MiB reservation = 1100 MiB >= the 1 GiB limit, so fully
+        // realizing the reservation would breach the container limit: confirmed resident risk.
+        ThreadData threads = threads(300);
+        MemoryData memory = memoryWithCurrent(256 * MB, 2 * GB, 1 * GB, 800 * MB);
+        MemoryContext context = context(memory, threads, PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-FOOTPRINT-002");
+
+        assertThat(result).isNotNull();
         assertThat(result.severity()).isEqualTo("HIGH");
+        assertThat(result.sampleViolations().get(0)).contains("already resident");
+    }
+
+    @Test
+    void stackReservationLargeButLittleResidentUsageIsNotEscalatedToHigh() {
+        // Regression test for the audited false positive: many idle/shallow threads reserve a large
+        // amount of virtual address space (2 GiB of 4 GiB limit, an easy ratio breach) while actual
+        // resident usage is small (300 MiB), so realizing the whole reservation would not come close
+        // to breaching the limit (2348 MiB < 4096 MiB). This must stay MEDIUM, not HIGH.
+        ThreadData threads = threads(2048);
+        MemoryData memory = memoryWithCurrent(256 * MB, 2 * GB, 4 * GB, 300 * MB);
+        MemoryContext context = context(memory, threads, PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-FOOTPRINT-002");
+
+        assertThat(result).isNotNull();
+        assertThat(result.severity()).isEqualTo("MEDIUM");
     }
 
     @Test
@@ -481,6 +516,33 @@ class MemoryRulesTests {
         assertThat(find(scan(context), "MEM-GC-004")).isNull();
     }
 
+    @Test
+    void serialGcOnMultiCoreWithSmallContainerMemoryIsSkipped() {
+        // Below Oracle's historical "server-class machine" threshold (2 CPUs AND ~2 GiB memory):
+        // a 512 MiB container limit means Serial GC is the JVM's own correct ergonomics choice here,
+        // even though 4 CPUs are visible.
+        MemoryData memory =
+                memory(256 * MB, 2 * GB, List.of(), 512 * MB, List.of(), List.of("Copy", "MarkSweepCompact"));
+        RuntimeData runtime = runtimeWithCpus(4);
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
+
+        assertThat(find(scan(context), "MEM-GC-004")).isNull();
+    }
+
+    @Test
+    void serialGcOnMultiCoreWithSufficientContainerMemoryIsFlagged() {
+        // 4 CPUs and a 4 GiB container limit are both above the "server-class machine" threshold, so
+        // Serial GC is a genuine misconfiguration here.
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of(), List.of("Copy", "MarkSweepCompact"));
+        RuntimeData runtime = runtimeWithCpus(4);
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-GC-004");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("4-CPU");
+    }
+
     // --- MEM-GC-005: G1 Full GC frequency ---------------------------------------------------
 
     @Test
@@ -496,6 +558,12 @@ class MemoryRulesTests {
 
         assertThat(result).isNotNull();
         assertThat(result.sampleViolations().get(0)).contains("2 time(s)");
+        // MEM-GC-005 no longer characterizes the G1 fallback Full GC as single-threaded (parallelized
+        // since JDK 10's JEP 307); it must instead frame the concern around the stop-the-world fallback.
+        assertThat(result.sampleViolations().get(0)).doesNotContainIgnoringCase("single-threaded");
+        assertThat(result.description()).containsIgnoringCase("not single-threaded");
+        assertThat(result.description()).containsIgnoringCase("stop-the-world");
+        assertThat(result.description()).contains("JEP 307");
     }
 
     @Test
@@ -600,6 +668,425 @@ class MemoryRulesTests {
         assertThat(find(scan(context), "MEM-POOL-006")).isNull();
     }
 
+    // --- MEM-POOL-001: Metaspace saturation (test coverage gap) ------------------------------
+
+    @Test
+    void metaspaceNearMaxIsFlagged() {
+        MemoryPoolSnapshot metaspace = new MemoryPoolSnapshot("Metaspace", 90 * MB, 95 * MB, 100 * MB);
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(metaspace), null, List.of());
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-POOL-001");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("90% full");
+    }
+
+    @Test
+    void metaspaceBelowThresholdIsNotFlagged() {
+        MemoryPoolSnapshot metaspace = new MemoryPoolSnapshot("Metaspace", 50 * MB, 60 * MB, 100 * MB);
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(metaspace), null, List.of());
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-POOL-001")).isNull();
+    }
+
+    @Test
+    void metaspaceWithoutConfiguredMaxIsSkipped() {
+        MemoryPoolSnapshot metaspace = new MemoryPoolSnapshot("Metaspace", 90 * MB, 95 * MB, -1);
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(metaspace), null, List.of());
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-POOL-001")).isNull();
+    }
+
+    // --- MEM-POOL-002: code cache saturation (test coverage gap) -----------------------------
+
+    @Test
+    void codeCacheSegmentNearMaxIsFlagged() {
+        MemoryPoolSnapshot segment = new MemoryPoolSnapshot("CodeHeap 'non-nmethods'", 5 * MB, 5 * MB, 5 * MB);
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(segment), null, List.of());
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-POOL-002");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("CodeHeap 'non-nmethods'");
+    }
+
+    @Test
+    void codeCacheBelowThresholdIsNotFlagged() {
+        MemoryPoolSnapshot segment = new MemoryPoolSnapshot("CodeHeap 'non-nmethods'", 2 * MB, 3 * MB, 5 * MB);
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(segment), null, List.of());
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-POOL-002")).isNull();
+    }
+
+    @Test
+    void noCodeCachePoolIsSkipped() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), null, List.of());
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-POOL-002")).isNull();
+    }
+
+    // --- MEM-POOL-003: direct buffer growth (test coverage gap) ------------------------------
+
+    @Test
+    void directBufferNearExplicitCapIsFlagged() {
+        MemoryData memory = new MemoryData(
+                256 * MB,
+                256 * MB,
+                2 * GB,
+                64 * MB,
+                80 * MB,
+                256 * MB,
+                List.of(),
+                90 * MB,
+                90 * MB,
+                20,
+                100 * MB,
+                List.of("-XX:MaxDirectMemorySize=100m"),
+                List.of("G1 Young Generation"),
+                null,
+                null);
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-POOL-003");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("MaxDirectMemorySize");
+    }
+
+    @Test
+    void directBufferNearEffectiveHeapCapIsFlagged() {
+        // -XX:MaxDirectMemorySize is unset, so HotSpot's effective default cap equals max heap (-Xmx).
+        MemoryData memory = new MemoryData(
+                256 * MB,
+                256 * MB,
+                1 * GB,
+                64 * MB,
+                80 * MB,
+                256 * MB,
+                List.of(),
+                900 * MB,
+                900 * MB,
+                20,
+                -1,
+                List.of("-Xmx1g"),
+                List.of("G1 Young Generation"),
+                null,
+                null);
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-POOL-003");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("effective default cap");
+    }
+
+    @Test
+    void modestDirectBufferUsageIsNotFlagged() {
+        MemoryData memory = new MemoryData(
+                256 * MB,
+                256 * MB,
+                2 * GB,
+                64 * MB,
+                80 * MB,
+                256 * MB,
+                List.of(),
+                10 * MB,
+                10 * MB,
+                5,
+                100 * MB,
+                List.of("-XX:MaxDirectMemorySize=100m"),
+                List.of("G1 Young Generation"),
+                null,
+                null);
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-POOL-003")).isNull();
+    }
+
+    // --- MEM-GC-001: missing heap sizing in container (test coverage gap) --------------------
+
+    @Test
+    void containerLimitWithoutHeapSizingIsFlagged() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of());
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-GC-001");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("-Xmx");
+    }
+
+    @Test
+    void containerLimitWithExplicitMaxHeapIsNotFlagged() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of("-Xmx2g"));
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-GC-001")).isNull();
+    }
+
+    @Test
+    void containerLimitWithRamPercentageIsNotFlagged() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of("-XX:MaxRAMPercentage=75.0"));
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-GC-001")).isNull();
+    }
+
+    @Test
+    void noContainerLimitIsSkipped() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), null, List.of());
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-GC-001")).isNull();
+    }
+
+    // --- MEM-FOOTPRINT-004: high swap utilization (test coverage gap) ------------------------
+
+    @Test
+    void noSwapConfiguredIsSkipped() {
+        RuntimeData runtime = new RuntimeData(300_000, 1_500, 50, 0, -1, MB, 4, 0, 0, null);
+        MemoryContext context =
+                context(healthyMemoryForSwap(), ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
+
+        assertThat(find(scan(context), "MEM-FOOTPRINT-004")).isNull();
+    }
+
+    @Test
+    void swapStatsUnavailableIsSkipped() {
+        RuntimeData runtime = new RuntimeData(300_000, 1_500, 50, 0, -1, MB, 4, -1, -1, null);
+        MemoryContext context =
+                context(healthyMemoryForSwap(), ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
+
+        assertThat(find(scan(context), "MEM-FOOTPRINT-004")).isNull();
+    }
+
+    @Test
+    void swapBelowThresholdIsNotFlagged() {
+        // 10% swap used (well under the 50% threshold), regardless of JVM footprint.
+        RuntimeData runtime = new RuntimeData(300_000, 1_500, 50, 0, -1, MB, 4, 900 * MB, 1 * GB, null);
+        MemoryContext context =
+                context(healthyMemoryForSwap(), ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
+
+        assertThat(find(scan(context), "MEM-FOOTPRINT-004")).isNull();
+    }
+
+    @Test
+    void highSwapWithFootprintExceedingFreePhysicalIsFlagged() {
+        // 90% swap used, well above the 50% threshold. The committed footprint is set to an
+        // unrealistically large value (hundreds of petabytes) so that it exceeds the free physical
+        // memory of any real test/CI machine, deterministically exercising the violation branch
+        // without needing to mock the live OperatingSystemMXBean read.
+        long hugeFootprint = 900_000L * GB;
+        MemoryData memory = new MemoryData(
+                hugeFootprint,
+                hugeFootprint,
+                hugeFootprint * 2,
+                0,
+                0,
+                0,
+                List.of(),
+                0,
+                0,
+                0,
+                -1,
+                List.of(),
+                List.of("G1 Young Generation"),
+                null,
+                null);
+        RuntimeData runtime = new RuntimeData(300_000, 1_500, 50, 0, -1, MB, 4, 100 * MB, 1 * GB, null);
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-FOOTPRINT-004");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("90%");
+    }
+
+    // --- MEM-CLASS-001: excessive loaded classes (test coverage gap) -------------------------
+
+    @Test
+    void manyLoadedClassesWithLittleUnloadingIsFlagged() {
+        MemoryContext context = classLoadingContext(60_000, 60_000, 100);
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-CLASS-001");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("60000 classes");
+        // The framework-fairness caveat (item 6): Spring-style runtime proxy/autoconfiguration class
+        // generation structurally loads more classes than an equivalent build-time framework, so the
+        // description must call this out rather than implying the threshold is framework-neutral.
+        assertThat(result.description()).containsIgnoringCase("framework");
+    }
+
+    @Test
+    void manyLoadedClassesWithActiveUnloadingIsNotFlagged() {
+        // 700 unloaded out of 60,000 loaded is >= the 1% (1-in-100) unloading ratio, so this reads as
+        // a legitimately large application rather than a classloader leak.
+        MemoryContext context = classLoadingContext(60_000, 60_000, 700);
+
+        assertThat(find(scan(context), "MEM-CLASS-001")).isNull();
+    }
+
+    @Test
+    void modestLoadedClassCountIsNotFlagged() {
+        MemoryContext context = classLoadingContext(10_000, 10_000, 0);
+
+        assertThat(find(scan(context), "MEM-CLASS-001")).isNull();
+    }
+
+    // --- MEM-GC-006: GC pause-latency outlier (new rule) -------------------------------------
+
+    @Test
+    void gcPauseAboveThresholdIsFlagged() {
+        RuntimeData runtime = runtimeWithLastGcPause(1_500, "G1 Young Generation");
+        MemoryContext context = context(
+                memory(256 * MB, 2 * GB, List.of(), null, List.of()),
+                ThreadData.empty(),
+                PostGcHeapData.unavailable(),
+                runtime);
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-GC-006");
+
+        assertThat(result).isNotNull();
+        assertThat(result.severity()).isEqualTo("MEDIUM");
+        assertThat(result.sampleViolations().get(0)).contains("1500 ms").contains("G1 Young Generation");
+    }
+
+    @Test
+    void gcPauseBelowThresholdIsNotFlagged() {
+        RuntimeData runtime = runtimeWithLastGcPause(200, "G1 Young Generation");
+        MemoryContext context = context(
+                memory(256 * MB, 2 * GB, List.of(), null, List.of()),
+                ThreadData.empty(),
+                PostGcHeapData.unavailable(),
+                runtime);
+
+        assertThat(find(scan(context), "MEM-GC-006")).isNull();
+    }
+
+    @Test
+    void gcPauseUnavailableIsSkipped() {
+        MemoryContext context = context(
+                memory(256 * MB, 2 * GB, List.of(), null, List.of()),
+                ThreadData.empty(),
+                PostGcHeapData.unavailable(),
+                healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-GC-006")).isNull();
+    }
+
+    // --- MEM-POOL-007: buffer pool growth without release (new rule) -------------------------
+
+    @Test
+    void directBufferPoolGrowingEveryScanWithoutReleaseIsFlaggedMedium() {
+        MemoryScanner scanner = new MemoryScanner(
+                sequence(
+                        bufferPoolContext(100 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext(150 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext(200 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext(250 * MB, 10 * MB, 1 * GB)),
+                CLOCK);
+
+        scanner.scan();
+        scanner.scan();
+        scanner.scan();
+        MemoryRuleResultDto result = find(scanner.scan(), "MEM-POOL-007");
+
+        assertThat(result).isNotNull();
+        assertThat(result.severity()).isEqualTo("MEDIUM");
+        assertThat(result.sampleViolations().get(0)).contains("'direct'").contains("3 consecutive scans");
+    }
+
+    @Test
+    void directBufferPoolGrowingAndCrossingStaticThresholdEscalatesToHigh() {
+        // Same growth streak as above, but the aggregate direct-buffer capacity is also >= 80% of
+        // -XX:MaxDirectMemorySize, so MEM-POOL-003's static threshold is independently crossed too.
+        MemoryScanner scanner = new MemoryScanner(
+                sequence(
+                        bufferPoolContext(100 * MB, 900 * MB, 1 * GB),
+                        bufferPoolContext(150 * MB, 900 * MB, 1 * GB),
+                        bufferPoolContext(200 * MB, 900 * MB, 1 * GB),
+                        bufferPoolContext(250 * MB, 900 * MB, 1 * GB)),
+                CLOCK);
+
+        scanner.scan();
+        scanner.scan();
+        scanner.scan();
+        MemoryRuleResultDto result = find(scanner.scan(), "MEM-POOL-007");
+
+        assertThat(result).isNotNull();
+        assertThat(result.severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void bufferPoolUsageThatDipsResetsTheStreakAndIsNotFlagged() {
+        MemoryScanner scanner = new MemoryScanner(
+                sequence(
+                        bufferPoolContext(100 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext(150 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext(120 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext(180 * MB, 10 * MB, 1 * GB)),
+                CLOCK);
+
+        scanner.scan();
+        scanner.scan();
+        scanner.scan();
+
+        assertThat(find(scanner.scan(), "MEM-POOL-007")).isNull();
+    }
+
+    // --- MEM-HEAP-008: old-generation usage trending upward (new rule) -----------------------
+
+    @Test
+    void oldGenerationUsageIncreasingEveryScanIsFlagged() {
+        MemoryScanner scanner = new MemoryScanner(
+                sequence(
+                        oldGenContext(100 * MB),
+                        oldGenContext(150 * MB),
+                        oldGenContext(200 * MB),
+                        oldGenContext(250 * MB)),
+                CLOCK);
+
+        scanner.scan();
+        scanner.scan();
+        scanner.scan();
+        MemoryRuleResultDto result = find(scanner.scan(), "MEM-HEAP-008");
+
+        assertThat(result).isNotNull();
+        assertThat(result.severity()).isEqualTo("MEDIUM");
+        assertThat(result.sampleViolations().get(0)).contains("3 consecutive scans");
+    }
+
+    @Test
+    void oldGenerationUsageThatDipsResetsTheStreakAndIsNotFlagged() {
+        MemoryScanner scanner = new MemoryScanner(
+                sequence(
+                        oldGenContext(100 * MB),
+                        oldGenContext(150 * MB),
+                        oldGenContext(120 * MB),
+                        oldGenContext(180 * MB)),
+                CLOCK);
+
+        scanner.scan();
+        scanner.scan();
+        scanner.scan();
+
+        assertThat(find(scanner.scan(), "MEM-HEAP-008")).isNull();
+    }
+
+    @Test
+    void oldGenerationTrendFirstScanIsNotFlagged() {
+        MemoryScanner scanner = new MemoryScanner(sequence(oldGenContext(100 * MB)), CLOCK);
+
+        assertThat(find(scanner.scan(), "MEM-HEAP-008")).isNull();
+    }
+
     // --- helpers -----------------------------------------------------------------------------
 
     private MemoryReport scan(MemoryContext context) {
@@ -667,6 +1154,61 @@ class MemoryRulesTests {
 
     private static RuntimeData runtimeWithCpus(int cpus) {
         return new RuntimeData(300_000, 1_500, 50, 0, -1, MB, cpus, -1, -1, null);
+    }
+
+    private static RuntimeData runtimeWithLastGcPause(long millis, String collectorName) {
+        return new RuntimeData(300_000, 1_500, 50, 0, -1, MB, 4, -1, -1, null, -1, millis, collectorName);
+    }
+
+    private static MemoryData healthyMemoryForSwap() {
+        return memory(256 * MB, 2 * GB, List.of(), null, List.of());
+    }
+
+    private static MemoryContext classLoadingContext(int loadedClasses, long totalLoadedClasses, long unloadedClasses) {
+        return new MemoryContext(
+                healthyMemoryForSwap(),
+                ThreadData.empty(),
+                HeapContentData.unavailable(),
+                PostGcHeapData.unavailable(),
+                new ClassLoadingData(loadedClasses, totalLoadedClasses, unloadedClasses),
+                healthyRuntime(),
+                null,
+                GcTrend.unavailable());
+    }
+
+    /**
+     * Builds a context carrying a single "direct" {@link MemoryContext.BufferPoolSnapshot} reading
+     * (for MEM-POOL-007's cross-scan growth trend) alongside the aggregate direct-buffer scalars
+     * MEM-POOL-003 reads, so tests can independently control whether the static threshold also fires.
+     */
+    private static MemoryContext bufferPoolContext(
+            long directPoolUsed, long directBufferCapacity, long maxDirectMemoryBytes) {
+        MemoryData memory = new MemoryData(
+                256 * MB,
+                256 * MB,
+                2 * GB,
+                64 * MB,
+                80 * MB,
+                256 * MB,
+                List.of(),
+                directBufferCapacity,
+                directBufferCapacity,
+                10,
+                maxDirectMemoryBytes,
+                List.of(),
+                List.of("G1 Young Generation"),
+                null,
+                null,
+                List.of(new MemoryContext.BufferPoolSnapshot("direct", directPoolUsed, directPoolUsed, 10)));
+        return context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+    }
+
+    private static MemoryContext oldGenContext(long postGcOldGenUsedBytes) {
+        return context(
+                healthyMemoryForSwap(),
+                ThreadData.empty(),
+                new PostGcHeapData(true, postGcOldGenUsedBytes, true, postGcOldGenUsedBytes),
+                healthyRuntime());
     }
 
     private static ThreadData threads(int total) {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryScannerTests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 class MemoryScannerTests {
 
-    private static final int RULE_COUNT = 32;
+    private static final int RULE_COUNT = 35;
     private static final long MB = 1024L * 1024;
     private static final long GB = 1024L * 1024 * 1024;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-06T08:00:00Z"), ZoneOffset.UTC);

--- a/docs/MEMORY-CHECKS.md
+++ b/docs/MEMORY-CHECKS.md
@@ -10,6 +10,10 @@ This advisor is complementary to the **Live Memory** and **Threads** panels: tho
 
 The panel is always available (the JVM always exposes memory and thread beans). Readings that a particular JVM does not expose — a class histogram, per-thread CPU time, cumulative GC time, a previous-GC baseline, a container memory limit — are skipped gracefully and reported rather than failing the panel. The class histogram is only collected on an explicit scan. The Rule results panel lists only checks that found findings, ordered by severity, finding count, and rule id.
 
+## Known limitations
+
+- **Container-limit detection assumes the process's cgroup is the container root.** Every container-aware check (MEM-FOOTPRINT-001/002/003/004, MEM-GC-001, MEM-GC-004, MEM-POOL-004) reads fixed root-level cgroup paths (for example `/sys/fs/cgroup/memory.max`), which is correct under the default modern Docker/Kubernetes setup where the process's own cgroup **is** the container root. It is not correct under `--cgroupns=host` or some older/nested container runtimes, where the process's actual cgroup lives elsewhere in the hierarchy; in that situation these hardcoded root paths silently read as "no container memory limit detected" instead of a reported error, which is a silent false negative across every container-aware rule above. A full fix would resolve the process's own cgroup path via `/proc/self/cgroup` and `/proc/self/mountinfo` rather than assuming the root path; this is a known gap, not yet implemented.
+
 ## Severity scale
 
 - **CRITICAL** - an active fault (such as a deadlock) that is already harming the application.
@@ -64,6 +68,13 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 - **Recommendation**: Consider lowering -Xmx (or -XX:MaxRAMPercentage) closer to the observed post-GC live set to free host memory; alternatively, confirm the oversized heap is intentional to absorb allocation bursts or reduce GC frequency.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/gctuning/factors-affecting-garbage-collection-performance.html>
 
+### MEM-HEAP-008 - Post-GC old-generation usage is trending upward across scans
+
+- **Severity**: MEDIUM
+- **Detects**: Tracks post-GC old-generation usage (the same reading MEM-HEAP-002 compares against a static percentage) across consecutive user-triggered scans and flags a monotonic increase over the last 3 consecutive scans with no decrease in between, independent of the absolute percentage. This is the standard textbook Java heap-leak diagnostic — retained-size growth across successive full GCs — and can catch a slow leak (for example, one climbing steadily through 40% old-generation usage) well before MEM-HEAP-002's static high-water-mark threshold fires. Requires several consecutive scans to build a trend; the first scans only establish the baseline.
+- **Recommendation**: Take a heap dump and compare successive class histograms (the Heap Dump panel) to find the retained-object type driving the growth, and confirm with a profiler whether this is a real leak or a temporarily growing cache/working set.
+- **Learn more**: <https://docs.oracle.com/en/java/javase/21/troubleshoot/troubleshooting-memory-leaks.html>
+
 ## Native memory
 
 ### MEM-FOOTPRINT-001 - Committed native footprint is close to the container limit
@@ -75,15 +86,15 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 
 ### MEM-FOOTPRINT-002 - Platform thread stacks reserve a large amount of native memory
 
-- **Severity**: HIGH (when a container memory limit is detected); MEDIUM (no container limit — reservation is virtual memory, not necessarily resident)
-- **Detects**: Estimates native memory reserved for platform thread stacks (live platform threads times the -Xss/-XX:ThreadStackSize reservation) and flags when stacks alone reserve at least 1 GiB or at least 20% of the detected container memory limit. The actual stack size is read from the live `ThreadStackSize` JVM option via HotSpot JMX when available, falling back to any -Xss/-XX:ThreadStackSize command-line flag, and finally to a 1 MiB compile-time default. Severity is HIGH when a container limit is present because virtual-memory reservation is capped and competes with the cgroup limit; without a container limit reservation rarely equals resident set size, so the finding is downgraded to MEDIUM. Virtual threads are excluded because their stacks live on the heap.
+- **Severity**: MEDIUM; HIGH only when the reservation is also a confirmed resident risk (see below)
+- **Detects**: Estimates native memory reserved for platform thread stacks (live platform threads times the -Xss/-XX:ThreadStackSize reservation) and flags when stacks alone reserve at least 1 GiB or at least 20% of the detected container memory limit. The actual stack size is read from the live `ThreadStackSize` JVM option via HotSpot JMX when available, falling back to any -Xss/-XX:ThreadStackSize command-line flag, and finally to a 1 MiB compile-time default. Thread stacks are demand-paged virtual-memory reservations, not committed/resident memory (kernel.org: cgroup `memory.current` tracks charged/resident memory, not reservations; the `/proc` docs' own VmSize-vs-VmRSS example shows a roughly 10x virtual-vs-resident gap) — a JVM with many idle or shallow-call-depth threads can reserve a large amount of stack memory while only a small fraction of it is ever touched (becomes resident), so a large reservation alone does not prove memory pressure. Severity is HIGH only when the reservation is both a large share (>=20%) of a detected container memory limit **and**, combined with memory already resident in the container, fully realizing the reservation would breach that limit (`current + reserved >= limit`) — i.e. there is confirmed resident risk, not just a large reservation. Otherwise the finding is reported at MEDIUM: still worth reviewing, but without confirmed resident risk it may never materialize as actual memory pressure. Virtual threads are excluded because their stacks live on the heap.
 - **Recommendation**: Reduce the platform thread count (bound pools, prefer virtual threads or async I/O) or lower an oversized -Xss so thread stacks do not dominate native memory.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html>
 
 ### MEM-FOOTPRINT-003 - Container memory usage is near the cgroup limit
 
 - **Severity**: HIGH
-- **Detects**: Reads current container memory usage from cgroup files (cgroup v2: `memory.current`; cgroup v1: `memory.usage_in_bytes`) and compares it against the detected container memory limit. When usage reaches 90% of the limit the container is at immediate risk of an OOM kill by the kernel, which is abrupt and does not invoke JVM OutOfMemoryError handling or heap-dump logic.
+- **Detects**: Reads current container memory usage from cgroup files (cgroup v2: `memory.current`; cgroup v1: `memory.usage_in_bytes`) and compares it against the detected container memory limit. When usage reaches 90% of the limit the container is at immediate risk of an OOM kill by the kernel, which is abrupt and does not invoke JVM OutOfMemoryError handling or heap-dump logic. Caveat: raw cgroup current-usage numbers can overstate real memory pressure — cgroup v2's `memory.current` includes reclaimable page cache, not only the process's own footprint, and cgroup v1's `memory.usage_in_bytes` is documented by the kernel itself as an approximate "fuzz value" (the kernel's own guidance for an exact figure is `memory.stat`'s RSS+CACHE breakdown). Treat a reading near the limit as a strong signal to investigate, not an exact resident-set measurement.
 - **Recommendation**: Lower -Xmx/-XX:MaxRAMPercentage, reduce non-heap footprint (thread stacks, Metaspace, direct buffers), or raise the container memory limit to restore headroom.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/troubleshoot/diagnostic-tools.html>
 
@@ -138,6 +149,13 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 - **Recommendation**: Remove -Xint, -XX:-UseCompiler, or -XX:TieredStopAtLevel<4 from production JVM arguments unless specifically required for a diagnostic session.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/vm/java-virtual-machine-technology-overview.html>
 
+### MEM-POOL-007 - Buffer pool usage has grown on every recent scan without release
+
+- **Severity**: MEDIUM (HIGH when the growing pool is the "direct" pool and MEM-POOL-003's static threshold has also been crossed)
+- **Detects**: Tracks each java.nio buffer pool's (`BufferPoolMXBean`, typically "direct" and "mapped") used-byte reading across scans and flags a pool whose usage has strictly increased on every one of the last 3 consecutive scans with no decrease in between — the classic native-memory-leak signature of leaked direct/mapped `ByteBuffer`s (common with NIO channel or Netty-style misuse where buffers are allocated but never released). This can catch a leak while the pool is still well under MEM-POOL-003's static high-water threshold, since a monotonic trend is a stronger signal than any single absolute reading. Requires several consecutive user-triggered scans to build a trend; the first scans only establish the baseline.
+- **Recommendation**: Audit code paths that allocate direct or mapped ByteBuffers (including NIO channels and libraries like Netty) for missing release/cleaner calls, and confirm the pool eventually plateaus or shrinks under normal load instead of only ever growing.
+- **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/BufferPoolMXBean.html>
+
 ## GC configuration
 
 ### MEM-GC-001 - Heap sizing is left to default container ergonomics
@@ -164,16 +182,23 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-GC-004 - Serial GC selected on a multi-core system
 
 - **Severity**: LOW
-- **Detects**: The Serial GC collector (GarbageCollectorMXBean names "Copy" and/or "MarkSweepCompact") running on a JVM with two or more available processors. Serial GC is single-threaded and can be selected automatically by container ergonomics when the JVM detects only one CPU; it underutilises multi-core hosts and causes long STW pauses.
+- **Detects**: The Serial GC collector (GarbageCollectorMXBean names "Copy" and/or "MarkSweepCompact") running on a JVM with two or more available processors **and** roughly 2 GiB or more of memory (the detected container memory limit, else total physical memory). Oracle's historical JVM ergonomics documentation defines a "server-class machine" as 2+ CPUs and ~2 GiB+ of memory; below that threshold Serial GC is the JVM's own correct ergonomic default, not a misconfiguration, so the rule does not fire there — this avoids false positives on small containers (for example 2 vCPUs with a 512 MiB–1 GiB memory limit) that legitimately get Serial GC by ergonomics. Above both thresholds, staying on Serial GC underutilises multi-core hosts and causes long STW pauses.
 - **Recommendation**: Switch to G1 (-XX:+UseG1GC), ZGC (-XX:+UseZGC), or Parallel GC (-XX:+UseParallelGC) to use all available cores, unless binary size or footprint constraints explicitly require Serial.
-- **Learn more**: <https://docs.oracle.com/en/java/javase/21/gctuning/available-collectors.html>
+- **Learn more**: <https://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html>
 
 ### MEM-GC-005 - G1 Full GC occurred between scans
 
 - **Severity**: MEDIUM
-- **Detects**: An increase in the "G1 Old Generation" GarbageCollectorMXBean collection count between two consecutive scans. G1 Full GCs are single-threaded stop-the-world events triggered by to-space exhaustion, humongous-allocation failure, or concurrent mark failure; even one Full GC per scan window indicates heap or tuning pressure. The first scan only establishes a baseline.
+- **Detects**: An increase in the "G1 Old Generation" GarbageCollectorMXBean collection count between two consecutive scans. A G1 Full GC is G1's fallback path, triggered when its normal concurrent-marking/mixed-collection cycle could not keep up with the allocation rate (to-space exhaustion, humongous-allocation failure, or concurrent mark failure). Since JDK 10 (JEP 307, "Parallel Full GC for G1") this fallback runs on multiple threads, so it is not single-threaded — but it is still a fully stop-the-world pause across the entire heap; even one Full GC per scan window is a sign that G1 failed to reclaim memory through its normal cycle and indicates heap or tuning pressure. The first scan only establishes a baseline.
 - **Recommendation**: Increase -Xmx or tune -XX:G1HeapRegionSize to reduce humongous allocations; consider -XX:G1ReservePercent and -XX:InitiatingHeapOccupancyPercent to give G1 more headroom for concurrent marking.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/gctuning/garbage-first-g1-garbage-collector1.html>
+
+### MEM-GC-006 - Most recent GC pause was an outlier
+
+- **Severity**: MEDIUM
+- **Detects**: Reads the duration of the single most recent garbage collection via `com.sun.management.GarbageCollectorMXBean.getLastGcInfo()` and flags when that one pause exceeds 1000 ms. This complements the lifetime and recent GC-overhead-*ratio* checks (MEM-GC-002/MEM-GC-003): a JVM can stay well under those ratio thresholds on average while still hiding one catastrophic outlier pause, and a single long stop-the-world pause can itself cause a request-latency spike or health-check timeout even when overall GC overhead looks healthy. This is a single-sample reading taken fresh on every scan, not a cross-scan trend, so it is skipped when no collection has happened yet or on non-HotSpot JVMs without this MXBean extension.
+- **Recommendation**: Capture GC logs (-Xlog:gc*:file=gc.log:time,level,tags) around the outlier and check the reported cause; consider a lower-pause-target collector (G1's -XX:MaxGCPauseMillis, ZGC, or Shenandoah) or reduce the allocation/promotion rate that triggered the long pause.
+- **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/GarbageCollectorMXBean.html>
 
 ### MEM-HEAP-005 - Initial and maximum heap differ for a low-latency collector
 
@@ -249,7 +274,7 @@ Heap-content checks require a class histogram, which is collected only on an exp
 ### MEM-CLASS-001 - Very large number of loaded classes with little unloading
 
 - **Severity**: INFO
-- **Detects**: A high loaded-class count combined with little or no class unloading, which can indicate a classloader leak or runaway dynamic class generation and pressures Metaspace. A large class count that is matched by active unloading is treated as a legitimately large application instead.
+- **Detects**: A high loaded-class count combined with little or no class unloading, which can indicate a classloader leak or runaway dynamic class generation and pressures Metaspace. A large class count that is matched by active unloading is treated as a legitimately large application instead. Caveat: the threshold is not framework-neutral in practice — frameworks that generate proxy/lambda/configuration classes at runtime (for example Spring Boot's CGLIB/JDK dynamic proxies, autoconfiguration, and lambda forms) structurally load more classes than an equivalent application built with a framework that does most of this at build time (for example Quarkus); two applications of the same real size can sit at very different distances from this threshold purely because of framework style, not application growth or a leak.
 - **Recommendation**: If the application does not legitimately use this many classes, look for classloader leaks (redeploys, scripting, proxy generation).
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/troubleshoot/troubleshoot-class-loading.html>
 


### PR DESCRIPTION
## Context

This implements a synthesized, cross-checked audit of the framework-neutral **Memory advisor** (`bootui-engine/.../engine/memory/`). Five independent LLM reviewers (claude-opus-4.8, gpt-5.5, gemini-3.1-pro-preview, gpt-5.3-codex, claude-sonnet-5) each researched current OpenJDK/Oracle/kernel.org docs and critiqued every rule; this PR implements the resulting action list. All changes are confined to `bootui-engine` — the ruleset is 100% `java.lang.management`/`com.sun.management` MXBean reads, so **no Spring or Quarkus adapter changes are needed**.

## Correctness fixes (MUST-FIX)

1. **MEM-GC-005 (`G1FullGcFrequencyRule`) — stale "single-threaded" claim removed.** G1's fallback Full GC was single-threaded only before JDK 10; [JEP 307](https://openjdk.org/jeps/307) ("Parallel Full GC for G1") parallelized it. The description/doc now frame the rationale around it still being a **fully stop-the-world fallback path** (G1 failed to keep up via its normal concurrent/mixed-GC cycle), not thread count. The detection mechanism itself (G1 Old Generation `GarbageCollectorMXBean` delta) was independently verified against HotSpot source as correct and non-over-firing, so it is **unchanged**.

2. **MEM-HEAP-003 — doc/code drift fixed.** The in-code description and title referenced an "unbounded heap" branch already removed from `evaluateRule()`. Renamed `UnsetOrSmallMaxHeapRule` → `SmallMaxHeapUnderPressureRule` and rewrote the description to describe only the max-heap-vs-container-limit ratio check that actually runs today. `docs/MEMORY-CHECKS.md` was already accurate for this rule (verified, no change needed there).

3. **MEM-FOOTPRINT-002 (`PlatformThreadStackReservationRule`) — false-positive-prone HIGH escalation fixed.** Thread stacks are a demand-paged **virtual-memory reservation**, not resident memory (kernel.org: `memory.current` tracks charged/resident memory, not reservations; `/proc` docs show a typical ~10x VmSize-vs-VmRSS gap). A JVM with many idle/shallow threads could hit the old ratio-only HIGH threshold while being nowhere near actual OOM risk. **Fix:** HIGH now requires *both* the existing ratio breach (`reserved >= limit * 20%`) **and** confirmed resident risk (`current + reserved >= limit`, using the already-available `containerMemoryCurrentBytes()`); the ratio breach alone downgrades to MEDIUM with clearer "reservation, not resident" language.
   - **Design note:** the task text also floated a literal "compare reservation against current usage instead of the limit" reading. I checked this against a counter-example (e.g. current=100MiB, reserved=50MiB, limit=1GiB: `reserved >= current` fires HIGH despite reservation being only 5% of the limit) and found it fires more, not less, than the ratio-only baseline — the opposite of the intended false-positive fix. The dual-condition design above was used instead, since it only escalates when both a large *relative* reservation and a *plausible resident outcome* are present.

4. **MEM-GC-004 (`SerialGcOnMultiCoreRule`) — incomplete ergonomics check fixed.** Oracle's historical ["server-class machine"](https://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html) definition (below which Serial GC is the JVM's own correct default) is **2+ CPUs AND ~2 GiB+ memory** — not CPU count alone. The rule now also reads effective memory (container limit, else total physical memory via a new `RuntimeData.totalPhysicalMemoryBytes`) and skips when it's under ~2 GiB, so small containers that legitimately get Serial GC by ergonomics are no longer flagged. Learn-more URL updated to Oracle's server-class-machine doc.

5. **Cgroup current-usage imprecision — caveat added.** cgroup v2's `memory.current` includes reclaimable page cache; cgroup v1's `memory.usage_in_bytes` is a kernel-documented "fuzz value" (exact figure requires `memory.stat`'s RSS+CACHE). Added a one-line caveat to `ContainerMemoryPressureRule`'s (MEM-FOOTPRINT-003) description and to `docs/MEMORY-CHECKS.md`. Implemented as a **doc/description-only** fix per the task's explicit low-risk escape hatch — no `memory.stat` parsing was added (would need cgroup v1/v2 branch handling for marginal precision gain).

## Recommended additions

6. **MEM-CLASS-001 (`ExcessiveLoadedClassesRule`) — framework-fairness caveat.** Added a one-line note that the 50,000-class threshold isn't framework-neutral: Spring Boot's CGLIB/JDK-proxy/autoconfiguration/lambda-form runtime class generation vs. Quarkus's build-time approach means two equivalently-sized apps can sit at very different distances from the threshold. Severity (INFO) and threshold unchanged.

7. **Container cgroup-namespace detection gap — documented as a known limitation.** `ContainerMemoryLimitDetector` only checks root-level cgroup paths, assuming the process's cgroup IS the container root (true for default Docker/K8s, not under `--cgroupns=host` or some nested runtimes — a silent false-negative across every container-aware rule). Added a new "Known limitations" section to `docs/MEMORY-CHECKS.md`. Per the task's guidance, only documented — a full fix needs `/proc/self/cgroup` + `/proc/self/mountinfo` resolution, out of scope for this round.

## New rules

All three are pure MXBean reads (no new instrumentation), reusing the scanner's existing single-previous-sample cross-scan mechanism (the same pattern already used by MEM-GC-003/005), wired via backward-compatible additive record constructors in `MemoryContext` (`RuntimeData`, `MemoryData`, `MemoryContext` itself all gained new trailing fields with an old-arity delegating constructor, so no existing call site needed updating).

8. **MEM-GC-006 — GC pause-latency outlier (MEDIUM).** Reads `com.sun.management.GarbageCollectorMXBean.getLastGcInfo().getDuration()` and flags the most recent single GC pause when it exceeds 1000ms — independent of and complementary to the existing overhead-*ratio* rules (MEM-GC-002/003), which can stay under threshold while hiding one catastrophic outlier pause.

9. **MEM-POOL-007 — buffer pool growth without release (MEDIUM/HIGH).** Retains each `BufferPoolMXBean` pool's prior `getMemoryUsed()` and flags a pool that has grown on every one of the last 3 consecutive scans with no decrease — the classic native-buffer-leak signature (leaked direct/mapped `ByteBuffer`s from NIO/Netty misuse), catchable before crossing MEM-POOL-003's static high-water threshold. Escalates to HIGH when the growing pool is `direct` and MEM-POOL-003's static threshold has also been crossed.

10. **MEM-HEAP-008 — post-GC old-gen usage trending upward (MEDIUM).** Retains the previous scan's post-GC old-gen usage (the same reading MEM-HEAP-002 compares to a static percentage) and flags a monotonic increase across the last 3 consecutive user-triggered scans, independent of the absolute percentage — the standard textbook Java heap-leak diagnostic, catching a slow leak well before MEM-HEAP-002's static threshold fires.

**Skipped: MEM-THREAD-005** (thread-creation-churn rate). The task explicitly marked this the lowest-consensus, "implement only if time permits" item. Skipped in favor of shipping items 1–10 and the test-coverage backfill (item 12) with full test coverage and documentation rather than spreading thinner across all 11 items.

## Test coverage gap (item 12)

Added dedicated unit tests for the six rules flagged as having only indirect/integration coverage: **MEM-POOL-001, MEM-POOL-002, MEM-POOL-003, MEM-GC-001, MEM-FOOTPRINT-004, MEM-CLASS-001** — plus full coverage for all three new rules and the changed behavior of items 1, 3, 4.

## Verification

- `./mvnw -Dmaven.repo.local=.m2 -pl bootui-core,bootui-engine -am test` → **1031/1031 passing** (`MemoryScannerTests.RULE_COUNT` updated 32 → 35).
- `./mvnw -Dmaven.repo.local=.m2 -ntp -pl bootui-core,bootui-engine -am spotless:check` → passes, no formatting changes needed.
- `EngineBoundaryArchitectureTests` / `SpiBoundaryArchitectureTests` pass, confirming the new `com.sun.management` import (used defensively, wrapped in try/catch for non-HotSpot JVMs) does not violate the engine's framework-neutrality boundary.
- `docs/MEMORY-CHECKS.md` updated for every changed/added rule; all 35 rules verified present and correctly grouped.
- A full reactor `install` was also run; all modules succeeded except `bootui-quarkus-integration-tests`, which failed solely due to port 8081 contention from an unrelated, concurrently-running sibling worktree build on the same host (confirmed via process inspection — not a regression from this change, and unrelated to the Memory advisor).

## Files changed

- `MemoryContext.java` — new backward-compatible fields/records for cross-scan trends and new MXBean readings.
- `MemoryCollector.java` — captures all buffer pools, total physical memory, last-GC-pause info.
- `MemoryScanner.java` — computes buffer-pool-growth and old-gen trends across scans.
- `MemoryRules.java` — items 1–6 fixed, 3 new rules added (35 total, was 32).
- `MemoryRuleRegistry.java` — registers the 3 new rules, updates the renamed reference.
- `MemoryRulesTests.java` / `MemoryScannerTests.java` — new/updated tests, rule-count bump.
- `docs/MEMORY-CHECKS.md` — synced entries for changed rules, new entries for added rules, new "Known limitations" section.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>