### PR TITLE
Fix Hibernate advisor: correct Quarkus property aliases, fix UUID id double-reporting, add composite-id and NaturalId rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Three new Hibernate advisor rules**, from a second, deeper audit pass dedicated to the Hibernate advisor alone:
+  `HIB-ID-007` (composite identifier classes — `@EmbeddedId`/`@IdClass` — must be `Serializable`, expose a public no-arg
+  constructor, and override both `equals` and `hashCode`, HIGH), `HIB-CONFIG-018` (bind-parameter logging should not be
+  left on in production — `org.hibernate.orm.jdbc.bind`/the legacy SQL binder logger at `TRACE`, or
+  `quarkus.hibernate-orm.log.bind-parameters=true`, HIGH), and `HIB-ENTITY-009` (a unique business-key column with no
+  `@NaturalId`-annotated attribute is a missed lookup-performance opportunity, INFO). The Hibernate advisor now has 69
+  rules, up from 66.
+
+### Changed
+
+- **Second Hibernate advisor audit pass**, cross-validated by 5 independent AI models (Claude Opus 4.8, GPT-5.5,
+  Gemini 3.1 Pro, GPT-5.3-Codex, Claude Sonnet 5) auditing the ruleset against official Hibernate ORM/Quarkus/Spring
+  Data docs and Hibernate's own GitHub source: expanded the Quarkus adapter's `QuarkusHibernatePropertyLookup` with 7
+  more confirmed Hibernate-property aliases that were previously unreadable on Quarkus and so guaranteed false
+  positives for operators who had actually configured them correctly — `default_batch_fetch_size`, `jdbc.time_zone`,
+  `generate_statistics`, `query.fail_on_pagination_over_collection_fetch`, `query.in_clause_parameter_padding`,
+  `cache.use_query_cache`, and `cache.use_second_level_cache` (the last two both map to Quarkus' single unified
+  `second-level-caching-enabled` toggle) — plus a generic `quarkus.hibernate-orm.unsupported-properties."..."` fallback
+  for keys with no first-class Quarkus option (e.g. `hibernate.order_inserts`/`order_updates`), confirmed end-to-end by
+  a live-boot test asserting Hibernate's own `SessionFactoryOptions` picks the values up. Also fixed: `HIB-ID-004`
+  double-reported every UUID-typed identifier alongside `HIB-ID-005` and asserted an AUTO-strategy rationale that's
+  wrong for UUID ids (now correctly deferred to `HIB-ID-005`); `HIB-ID-005`'s UUID remediation recommended
+  `@UuidGenerator(style = TIME)` as "index-friendly," but `TIME` is an RFC 4122 v1 style with the same index
+  fragmentation problem as random UUIDs — the truly index-friendly `VERSION_6`/`VERSION_7` styles only exist on
+  Hibernate 7.0+, so the remediation is now version-gated to the running Hibernate version; `HIB-ENTITY-005` false
+  positived on every property-access (getter-mapped) entity because its field-vs-method heuristic only worked for the
+  reflection-based scan path, not the real `EntityManagerFactory`-metamodel path — it now keys off an explicit
+  field-access flag; `HIB-MAP-010` incorrectly treated `@OrderBy` as an equally valid alternative to `@OrderColumn` for
+  avoiding delete-and-reinsert list updates, when only `@OrderColumn` actually persists an index (this was already
+  inconsistent with the sibling `HIB-MAP-004` rule's own bag-detection logic); and `HIB-FETCH-004` was downgraded from
+  MEDIUM to INFO after review showed it fired on any entity merely declaring 2+ lazy bag collections, a common and safe
+  pattern — the actual failure mode (`MultipleBagFetchException`) is already covered by `HIB-QUERY-007`, which fires
+  only when bags are actually join-fetched together.
+
 ## [1.9.0] - 2026-07-03
 
 Feature release headlined by **optional durable JDBC persistence for Live Activity** on both adapters — the feed can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   left on in production — `org.hibernate.orm.jdbc.bind`/the legacy SQL binder logger at `TRACE`, or
   `quarkus.hibernate-orm.log.bind-parameters=true`, HIGH), and `HIB-ENTITY-009` (a unique business-key column with no
   `@NaturalId`-annotated attribute is a missed lookup-performance opportunity, INFO). The Hibernate advisor now has 69
-  rules, up from 66.
+  rules, up from 66 (#511).
 
 ### Changed
 
@@ -41,7 +41,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   inconsistent with the sibling `HIB-MAP-004` rule's own bag-detection logic); and `HIB-FETCH-004` was downgraded from
   MEDIUM to INFO after review showed it fired on any entity merely declaring 2+ lazy bag collections, a common and safe
   pattern — the actual failure mode (`MultipleBagFetchException`) is already covered by `HIB-QUERY-007`, which fires
-  only when bags are actually join-fetched together.
+  only when bags are actually join-fetched together (#511).
 
 ## [1.9.0] - 2026-07-03
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateAttributeModel.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateAttributeModel.java
@@ -20,6 +20,7 @@ public record HibernateAttributeModel(
         Type genericType,
         String persistentAttributeType,
         boolean publicMember,
+        boolean fieldMember,
         List<Annotation> annotations) {
 
     private static final String BASIC = "jakarta.persistence.Basic";
@@ -54,6 +55,9 @@ public record HibernateAttributeModel(
     static HibernateAttributeModel fromMember(String name, Member member, String persistentAttributeType) {
         RawType rawType = rawType(member);
         String entityName = member.getDeclaringClass().getName();
+        // The JPA metamodel always reports the plain attribute name here (e.g. "id"), never a "()"-suffixed
+        // method name, even when the entity uses property (getter) access - so field-vs-property access can
+        // only be told apart from the resolved Member's actual runtime type, not from the name shape.
         return new HibernateAttributeModel(
                 entityName,
                 name,
@@ -61,6 +65,7 @@ public record HibernateAttributeModel(
                 rawType.genericType(),
                 persistentAttributeType,
                 Modifier.isPublic(member.getModifiers()),
+                member instanceof Field,
                 annotations(member));
     }
 
@@ -72,6 +77,7 @@ public record HibernateAttributeModel(
                 field.getGenericType(),
                 persistentAttributeType(field),
                 Modifier.isPublic(field.getModifiers()),
+                true,
                 List.of(field.getAnnotations()));
     }
 
@@ -83,6 +89,7 @@ public record HibernateAttributeModel(
                 method.getGenericReturnType(),
                 persistentAttributeType(method),
                 Modifier.isPublic(method.getModifiers()),
+                false,
                 List.of(method.getAnnotations()));
     }
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateContext.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateContext.java
@@ -169,6 +169,27 @@ record HibernateContext(
         }
         return false;
     }
+
+    /**
+     * True when Hibernate's bind-parameter binder logger is at TRACE, the only level at which
+     * {@code org.hibernate.engine.jdbc.internal.JdbcBindingLogging} actually logs bound parameter values
+     * (it gates every value-logging call on {@code Logger.isTraceEnabled()}, never DEBUG). Unlike
+     * {@link #isSqlLoggingEnabled()} — which treats DEBUG-or-TRACE on either the SQL or binder category as
+     * "some SQL logging is happening", a coarser performance signal — this check is deliberately narrower and
+     * TRACE-only, because it exists to catch a security/data-leak risk (bound values, which may hold PII,
+     * credentials, or tokens, being written to application logs), not merely verbose statement logging.
+     */
+    boolean isBindParameterLoggingEnabled() {
+        for (String key : List.of(
+                "logging.level.org.hibernate.orm.jdbc.bind",
+                "logging.level.org.hibernate.type.descriptor.sql.BasicBinder")) {
+            String value = firstProperty(key);
+            if (value != null && "trace".equalsIgnoreCase(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }
 
 record HibernateRuntimeVersion(String display, Integer major, Integer minor) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
@@ -19,6 +19,7 @@ final class HibernateRuleRegistry {
             new GeneratedValueWithoutStrategyRule(),
             new UuidIdentifierGeneratorRule(),
             new IdentityDisablesBatchingRule(),
+            new CompositeIdentifierContractRule(),
             // Mapping
             new UnidirectionalOneToManyRule(),
             new ManyToManyListRule(),
@@ -50,6 +51,7 @@ final class HibernateRuleRegistry {
             new PrimitiveIdentifierOrVersionRule(),
             new AssignedIdPersistableRule(),
             new MissingVersionRule(),
+            new NaturalIdCandidateRule(),
 
             // Query
             new ModifyingClearAutomaticallyRule(),
@@ -77,6 +79,7 @@ final class HibernateRuleRegistry {
             new DeferDatasourceInitializationRule(),
             new FailOnPaginationOverCollectionFetchRule(),
             new FormatSqlInProductionRule(),
+            new BindParameterLoggingInProductionRule(),
 
             // Caching
             new CacheAssociationCoverageRule(),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.hibernate;
 
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -673,11 +674,11 @@ final class MultipleBagCollectionRule extends AbstractHibernateRule {
         super(
                 new HibernateRuleDefinition(
                         "HIB-FETCH-004",
-                        "Entities should avoid multiple bag collections",
+                        "Review entities with multiple bag collections",
                         HibernateCategory.FETCHING,
-                        "MEDIUM",
-                        "Detects entities with two or more unordered List/Collection associations.",
-                        "Fetch at most one bag collection per query, add @OrderColumn when list order is persistent, or split loading into targeted queries.",
+                        "INFO",
+                        "Detects entities with two or more unordered List/Collection associations (bags). Declaring multiple bags is common and safe on its own - the risk is only realized if two of them are ever join-fetched in the same query, which throws MultipleBagFetchException. HIB-QUERY-007 already flags that specific case (JOIN FETCH of 2+ collections in the same query); this is an informational reminder to keep it that way.",
+                        "No action is required unless you plan to fetch these together: never JOIN FETCH more than one of these collections in the same query. Add @OrderColumn when list order is persistent, or use Set<> if you do need to fetch two of them eagerly in one query.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#fetching-strategies"));
     }
 
@@ -1349,7 +1350,7 @@ final class GeneratedValueWithoutStrategyRule extends AbstractHibernateRule {
                         "@GeneratedValue should declare an explicit strategy",
                         HibernateCategory.IDENTIFIERS,
                         "MEDIUM",
-                        "Detects @GeneratedValue without an explicit strategy, which defaults to AUTO. Hibernate's GeneratorBinder always resolves AUTO to its own SequenceStyleGenerator - a database SEQUENCE where the dialect supports one (PostgreSQL, Oracle, H2, SQL Server) or a slower table-based fallback otherwise (e.g. MySQL) - never the database's native IDENTITY/auto-increment column.",
+                        "Detects @GeneratedValue without an explicit strategy, which defaults to AUTO. For a numeric identifier, Hibernate's GeneratorBinder always resolves AUTO to its own SequenceStyleGenerator - a database SEQUENCE where the dialect supports one (PostgreSQL, Oracle, H2, SQL Server) or a slower table-based fallback otherwise (e.g. MySQL) - never the database's native IDENTITY/auto-increment column. UUID-typed identifiers are a distinct case Hibernate resolves to UuidGenerator instead; HIB-ID-005 owns that finding so it is excluded here.",
                         "Pick the strategy that fits the database (SEQUENCE with allocationSize on Postgres/Oracle, IDENTITY only when truly required) and set it explicitly instead of relying on AUTO's dialect-dependent sequence-or-table fallback.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#identifiers-generators-auto"));
     }
@@ -1366,6 +1367,12 @@ final class GeneratedValueWithoutStrategyRule extends AbstractHibernateRule {
                 // Panache's own PanacheEntity declares "@Id @GeneratedValue public Long id" with no explicit
                 // strategy; the application inherits it as-is and cannot annotate it, so it is not a real finding.
                 if (HibernateRuleModelSupport.isFrameworkDeclaredPanacheIdentifier(attribute)) {
+                    continue;
+                }
+                // AUTO on a UUID-typed identifier resolves to Hibernate's UuidGenerator, not a sequence; that
+                // case - and its own remediation - belongs exclusively to HIB-ID-005, so double-reporting the
+                // same attribute here (with a rationale that is factually wrong for UUID ids) is avoided.
+                if (attribute.isUuidType()) {
                     continue;
                 }
                 String strategy = attribute.annotationValueName(generated, "strategy");
@@ -1388,20 +1395,24 @@ final class UuidIdentifierGeneratorRule extends AbstractHibernateRule {
                         HibernateCategory.IDENTIFIERS,
                         "LOW",
                         "Detects UUID identifiers that rely on @GeneratedValue without the Hibernate @UuidGenerator strategy.",
-                        "Annotate UUID identifiers with @UuidGenerator (TIME for index-friendly v6/v7-style values) instead of inheriting the JPA default, which yields random v4 UUIDs that fragment B-tree indexes.",
+                        "Annotate UUID identifiers with @UuidGenerator instead of inheriting the JPA default, which yields random v4 UUIDs that fragment B-tree indexes. On Hibernate 7.0+, prefer style = VERSION_7 (VERSION_6 is also acceptable) for monotonic, index-friendly values; before 7.0, only style = TIME is available - it produces an RFC 4122 version 1 UUID, which is not materially more index-friendly than a random UUID.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#identifiers-generators-uuid"));
     }
 
     @Override
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
         List<String> details = new ArrayList<>();
+        String recommendedStyle = context.hibernateVersion().isAtLeastMajorMinor(7, 0)
+                ? "style = VERSION_7 (or VERSION_6): monotonic, index-friendly"
+                : "style = TIME (only pre-7.0 option); RFC 4122 v1, no more index-friendly than random";
         for (HibernateEntityModel entity : context.entities()) {
             for (HibernateAttributeModel attribute : entity.attributes()) {
                 if (!attribute.hasId() || !attribute.isUuidType()) {
                     continue;
                 }
                 if (attribute.hasGeneratedValue() && !attribute.hasUuidGenerator()) {
-                    details.add(attribute.description() + " is a UUID identifier without @UuidGenerator.");
+                    details.add(attribute.description() + " is a UUID id without @UuidGenerator; use @UuidGenerator("
+                            + recommendedStyle + ").");
                 }
             }
         }
@@ -1415,11 +1426,11 @@ final class ElementCollectionListOrderRule extends AbstractHibernateRule {
         super(
                 new HibernateRuleDefinition(
                         "HIB-MAP-010",
-                        "@ElementCollection List should persist order",
+                        "@ElementCollection List should persist order with @OrderColumn",
                         HibernateCategory.MAPPING,
                         "MEDIUM",
-                        "Detects @ElementCollection List attributes that do not declare @OrderColumn or @OrderBy, so Hibernate treats every change as a delete-and-reinsert.",
-                        "Add @OrderColumn for index-tracked lists or @OrderBy for query-time ordering; otherwise prefer Set<> or be aware that mutations rewrite the entire collection table.",
+                        "Detects @ElementCollection List attributes that do not declare @OrderColumn, so Hibernate cannot compute a minimal diff on mutation and instead deletes and reinserts the entire collection. @OrderBy is not an equivalent fix: it only adds a query-time SQL ORDER BY and is never persisted, so it does not change this mutation behavior at all.",
+                        "Add @OrderColumn to persist the list's index so Hibernate can update rows in place. @OrderBy does not solve the mutation cost - keep it only if you also want read-time ordering, alongside @OrderColumn, not instead of it. Otherwise prefer Set<> if insertion order does not matter.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#collections-list"));
     }
 
@@ -1428,12 +1439,11 @@ final class ElementCollectionListOrderRule extends AbstractHibernateRule {
         List<String> details = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
             for (HibernateAttributeModel attribute : entity.attributes()) {
-                if (attribute.isElementCollection()
-                        && attribute.isListAttribute()
-                        && !attribute.hasOrderColumn()
-                        && !attribute.hasOrderBy()) {
-                    details.add(attribute.description()
-                            + " is an @ElementCollection List without @OrderColumn or @OrderBy.");
+                if (attribute.isElementCollection() && attribute.isListAttribute() && !attribute.hasOrderColumn()) {
+                    details.add(attribute.description() + " is an @ElementCollection List without @OrderColumn"
+                            + (attribute.hasOrderBy()
+                                    ? " (its @OrderBy only affects read-time ordering and does not fix this)."
+                                    : "."));
                 }
             }
         }
@@ -1759,7 +1769,10 @@ final class PublicPersistentFieldRule extends AbstractHibernateRule {
         List<String> details = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
             for (HibernateAttributeModel attribute : entity.attributes()) {
-                if (attribute.publicMember() && !attribute.name().endsWith("()") && !attribute.isTransient()) {
+                // fieldMember (not the "()"-suffixed name heuristic) is what actually distinguishes field
+                // access from property (getter) access; property-access entities resolve their attributes
+                // from a public getter Method, which is fully JPA/Hibernate-instrumented and not a finding.
+                if (attribute.publicMember() && attribute.fieldMember() && !attribute.isTransient()) {
                     details.add(attribute.description() + " is exposed as a public field.");
                 }
             }
@@ -2155,6 +2168,32 @@ final class FormatSqlInProductionRule extends AbstractHibernateRule {
         }
         if (context.isPropertyTrue("spring.jpa.properties.hibernate.format_sql", "hibernate.format_sql")) {
             return violation(List.of("hibernate.format_sql is enabled while a production profile is active."));
+        }
+        return pass();
+    }
+}
+
+final class BindParameterLoggingInProductionRule extends AbstractHibernateRule {
+
+    BindParameterLoggingInProductionRule() {
+        super(new HibernateRuleDefinition(
+                "HIB-CONFIG-018",
+                "Bind-parameter logging should be off in production",
+                HibernateCategory.CONFIGURATION,
+                "HIGH",
+                "Detects TRACE logging for org.hibernate.orm.jdbc.bind (or the legacy org.hibernate.type.descriptor.sql.BasicBinder binder logger, or the Quarkus-native quarkus.hibernate-orm.log.bind-parameters convenience flag) while a production-like profile is active. At TRACE, Hibernate logs every bound parameter value, which can leak PII, credentials, or tokens passed as query parameters into application logs.",
+                "Keep bind-parameter logging off in production; only enable it temporarily, in a non-production environment, while diagnosing a specific issue.",
+                "https://quarkus.io/guides/hibernate-orm"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        if (!context.isProductionProfileActive()) {
+            return pass();
+        }
+        if (context.isBindParameterLoggingEnabled()) {
+            return violation(
+                    List.of("Bind-parameter logging is enabled at TRACE while a production profile is active."));
         }
         return pass();
     }
@@ -2622,6 +2661,85 @@ final class MissingVersionRule extends AbstractHibernateRule {
     }
 }
 
+final class NaturalIdCandidateRule extends AbstractHibernateRule {
+
+    private static final String NATURAL_ID = "org.hibernate.annotations.NaturalId";
+
+    NaturalIdCandidateRule() {
+        super(new HibernateRuleDefinition(
+                "HIB-ENTITY-009",
+                "Unique business-key columns should consider @NaturalId",
+                HibernateCategory.ENTITY_DESIGN,
+                "INFO",
+                "Detects entities with a @Column(unique = true) attribute, or a @Table(uniqueConstraints = ...) constraint, that have no attribute annotated org.hibernate.annotations.NaturalId.",
+                "If the unique column is a genuine business key (for example email, ISBN, order number), annotate it with org.hibernate.annotations.NaturalId so Hibernate can resolve the entity from the natural-id lookup/cache instead of a full JPQL query. This is advisory: not every unique column is a natural lookup key, so only apply it where it fits.",
+                "https://docs.hibernate.org/orm/current/userguide/html_single/Hibernate_User_Guide.html#naturalid"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        List<String> details = new ArrayList<>();
+        for (HibernateEntityModel entity : context.entities()) {
+            boolean hasNaturalId =
+                    entity.attributes().stream().anyMatch(attribute -> attribute.annotation(NATURAL_ID) != null);
+            if (hasNaturalId) {
+                continue;
+            }
+            for (HibernateAttributeModel attribute : entity.attributes()) {
+                Annotation column = attribute.columnAnnotation();
+                if (column != null && Boolean.TRUE.equals(attribute.annotationBooleanValue(column, "unique"))) {
+                    details.add(
+                            attribute.description()
+                                    + " is a unique column with no @NaturalId attribute on this entity; if it is a business key (email, ISBN, order number, ...), consider org.hibernate.annotations.NaturalId.");
+                }
+            }
+            Set<String> tableUniqueColumns = tableUniqueConstraintColumns(entity.javaType());
+            if (!tableUniqueColumns.isEmpty()) {
+                details.add(
+                        entity.name() + " declares a @Table unique constraint on column(s) "
+                                + String.join(", ", tableUniqueColumns)
+                                + " with no @NaturalId attribute; if this is a business key, consider org.hibernate.annotations.NaturalId.");
+            }
+        }
+        return violation(details);
+    }
+
+    // Optional JPA type: compare by class name instead of hard-referencing a class that may be absent at runtime.
+    @SuppressWarnings("java:S1872")
+    private Set<String> tableUniqueConstraintColumns(Class<?> javaType) {
+        Set<String> columns = new LinkedHashSet<>();
+        Class<?> current = javaType;
+        while (current != null && current != Object.class) {
+            for (Annotation ann : current.getDeclaredAnnotations()) {
+                if (!"jakarta.persistence.Table".equals(ann.annotationType().getName())) {
+                    continue;
+                }
+                try {
+                    Annotation[] constraints = (Annotation[])
+                            ann.annotationType().getMethod("uniqueConstraints").invoke(ann);
+                    for (Annotation constraint : constraints) {
+                        Object names = constraint
+                                .annotationType()
+                                .getMethod("columnNames")
+                                .invoke(constraint);
+                        if (names instanceof String[] columnNames) {
+                            for (String name : columnNames) {
+                                if (name != null && !name.isBlank()) {
+                                    columns.add(name.trim().toLowerCase(Locale.ROOT));
+                                }
+                            }
+                        }
+                    }
+                } catch (ReflectiveOperationException ex) {
+                    throw new IllegalStateException(ex);
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return columns;
+    }
+}
+
 final class IdentityDisablesBatchingRule extends AbstractHibernateRule {
 
     IdentityDisablesBatchingRule() {
@@ -2659,6 +2777,100 @@ final class IdentityDisablesBatchingRule extends AbstractHibernateRule {
             }
         }
         return violation(details);
+    }
+}
+
+final class CompositeIdentifierContractRule extends AbstractHibernateRule {
+
+    private static final String EMBEDDED_ID = "jakarta.persistence.EmbeddedId";
+    private static final String ID_CLASS = "jakarta.persistence.IdClass";
+
+    CompositeIdentifierContractRule() {
+        super(
+                new HibernateRuleDefinition(
+                        "HIB-ID-007",
+                        "Composite identifier classes must satisfy the JPA contract",
+                        HibernateCategory.IDENTIFIERS,
+                        "HIGH",
+                        "Detects @EmbeddedId / @IdClass primary-key classes that are not Serializable, lack a public no-arg constructor, or do not override both equals and hashCode. JPA and Hibernate require all four for a composite identifier class to work correctly.",
+                        "Make the composite identifier class implement Serializable, declare a public no-arg constructor, and override both equals and hashCode over every identifier field; violating any of these can silently break entity equality, second-level caching, and collection lookups.",
+                        "https://docs.hibernate.org/orm/current/userguide/html_single/Hibernate_User_Guide.html#identifiers-composite"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        List<String> details = new ArrayList<>();
+        Set<Class<?>> checked = new HashSet<>();
+        for (HibernateEntityModel entity : context.entities()) {
+            for (HibernateAttributeModel attribute : entity.attributes()) {
+                if (attribute.annotation(EMBEDDED_ID) != null) {
+                    checkCompositeIdClass(
+                            attribute.rawType(), attribute.description() + " (@EmbeddedId)", checked, details);
+                }
+            }
+            Class<?> idClass = idClassValue(entity.annotationInHierarchy(ID_CLASS));
+            if (idClass != null) {
+                checkCompositeIdClass(idClass, entity.name() + " (@IdClass)", checked, details);
+            }
+        }
+        return violation(details);
+    }
+
+    private static void checkCompositeIdClass(
+            Class<?> idClass, String description, Set<Class<?>> checked, List<String> details) {
+        if (idClass == null || !checked.add(idClass)) {
+            return;
+        }
+        List<String> problems = new ArrayList<>();
+        if (!Serializable.class.isAssignableFrom(idClass)) {
+            problems.add("not Serializable");
+        }
+        if (!hasPublicNoArgConstructor(idClass)) {
+            problems.add("no public no-arg ctor");
+        }
+        if (!overrides(idClass, "equals", Object.class)) {
+            problems.add("no equals() override");
+        }
+        if (!overrides(idClass, "hashCode")) {
+            problems.add("no hashCode() override");
+        }
+        if (!problems.isEmpty()) {
+            // Simple name only: the entity description already gives full package context, and this keeps
+            // the (truncation-bounded) detail message well within HibernateRuleSupport.detail()'s budget.
+            details.add(
+                    description + ": id class " + idClass.getSimpleName() + " is " + String.join(", ", problems) + ".");
+        }
+    }
+
+    private static boolean hasPublicNoArgConstructor(Class<?> type) {
+        try {
+            // getConstructor() (as opposed to getDeclaredConstructor()) only ever returns public constructors,
+            // so success alone already proves the "public no-arg constructor" requirement.
+            type.getConstructor();
+            return true;
+        } catch (NoSuchMethodException ex) {
+            return false;
+        }
+    }
+
+    private static boolean overrides(Class<?> type, String name, Class<?>... parameterTypes) {
+        try {
+            return type.getMethod(name, parameterTypes).getDeclaringClass() != Object.class;
+        } catch (NoSuchMethodException ex) {
+            return false;
+        }
+    }
+
+    private static Class<?> idClassValue(Annotation annotation) {
+        if (annotation == null) {
+            return null;
+        }
+        try {
+            Object value = annotation.annotationType().getMethod("value").invoke(annotation);
+            return value instanceof Class<?> classValue ? classValue : null;
+        } catch (ReflectiveOperationException | RuntimeException ex) {
+            return null;
+        }
     }
 }
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
@@ -4,21 +4,32 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.OrderColumn;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
+import java.io.Serializable;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import org.hibernate.annotations.NaturalId;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Persistable;
 
@@ -396,6 +407,40 @@ class HibernateRulesTests {
                 .anySatisfy(sample -> assertThat(sample).contains("customer_id"));
     }
 
+    // --- HIB-MAP-010 --------------------------------------------------------
+
+    @Test
+    void elementCollectionListOrderRulePassesWithOrderColumn() {
+        HibernateRuleResultDto result = new ElementCollectionListOrderRule()
+                .evaluate(context(new TestEnvironment(), OrderColumnElementCollectionEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void elementCollectionListOrderRuleFlagsPlainListWithNoOrderingAnnotation() {
+        HibernateRuleResultDto result = new ElementCollectionListOrderRule()
+                .evaluate(context(new TestEnvironment(), UnorderedElementCollectionEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("without @OrderColumn"));
+    }
+
+    @Test
+    void elementCollectionListOrderRuleFlagsOrderByAloneBecauseItIsNotPersisted() {
+        // @OrderBy only adds a query-time SQL ORDER BY and is never persisted, so Hibernate still cannot
+        // compute a minimal diff on mutation - it is not a valid alternative to @OrderColumn.
+        HibernateRuleResultDto result = new ElementCollectionListOrderRule()
+                .evaluate(context(new TestEnvironment(), OrderByOnlyElementCollectionEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample)
+                        .contains("without @OrderColumn")
+                        .contains("@OrderBy only affects read-time ordering"));
+    }
+
     // --- HIB-ENTITY-005 ------------------------------------------------------
     //
     // isPanacheFieldAccessRewriteActive() is a raw Class.forName classpath probe, so its "Panache present"
@@ -427,6 +472,27 @@ class HibernateRulesTests {
                 .anySatisfy(sample -> assertThat(sample).contains("persistentName"));
         assertThat(result.sampleViolations())
                 .noneSatisfy(sample -> assertThat(sample).contains("cachedFlag"));
+    }
+
+    @Test
+    void publicPersistentFieldRuleIgnoresPropertyAccessGetters() throws NoSuchMethodException {
+        // HibernateEntityModel.fromClass() (used by every other fixture via the context(...) helper) walks
+        // fields and methods separately, so it cannot reproduce the real bug: the actual scan path,
+        // JpaMetamodelReader.toAttributeModel(), resolves one Member per JPA attribute via
+        // attribute.getJavaMember() and always passes the plain attribute name ("name", never "name()"), even
+        // when that Member is a public getter Method for a property-access (getter-mapped) entity. Building
+        // the attribute with HibernateAttributeModel.fromMember(...) directly - exactly as JpaMetamodelReader
+        // does - reproduces that path here.
+        Method getter = PropertyAccessEntity.class.getDeclaredMethod("getName");
+        HibernateAttributeModel propertyAttribute = HibernateAttributeModel.fromMember("name", getter, "BASIC");
+        HibernateEntityModel entity = new HibernateEntityModel(
+                PropertyAccessEntity.class.getName(), PropertyAccessEntity.class, List.of(propertyAttribute));
+        HibernateContext context = new HibernateContext(
+                List.of(entity), List.of(), new TestEnvironment().lookup(), List.of(), "7.3.9.Final");
+
+        HibernateRuleResultDto result = new PublicPersistentFieldRule().evaluate(context);
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
     @Test
@@ -482,9 +548,72 @@ class HibernateRulesTests {
     }
 
     @Test
+    void generatedValueWithoutStrategyRuleSkipsUuidIdentifiersSoOnlyHibId005OwnsThem() {
+        // A UUID-typed @Id @GeneratedValue with no explicit strategy resolves to Hibernate's UuidGenerator, not
+        // a sequence, so HIB-ID-004's "AUTO always resolves to a sequence" rationale does not apply to it; that
+        // finding belongs exclusively to HIB-ID-005, which is asserted separately below.
+        HibernateContext context = context(new TestEnvironment(), UuidIdentifierEntity.class);
+
+        HibernateRuleResultDto result = new GeneratedValueWithoutStrategyRule().evaluate(context);
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    // --- HIB-ID-005 -----------------------------------------------------------
+
+    @Test
+    void uuidIdentifierGeneratorRuleFlagsUuidIdWithoutUuidGeneratorAndOnlyThatRuleFires() {
+        HibernateContext context = context(new TestEnvironment(), UuidIdentifierEntity.class);
+
+        HibernateRuleResultDto uuidResult = new UuidIdentifierGeneratorRule().evaluate(context);
+        HibernateRuleResultDto generatedValueResult = new GeneratedValueWithoutStrategyRule().evaluate(context);
+
+        assertThat(uuidResult.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(uuidResult.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("is a UUID id without @UuidGenerator"));
+        assertThat(generatedValueResult.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void uuidIdentifierGeneratorRuleRecommendsVersion7OnHibernate7AndAbove() {
+        HibernateEntityModel entity = HibernateEntityModel.fromClass(UuidIdentifierEntity.class);
+        HibernateContext context = new HibernateContext(
+                List.of(entity), List.of(), new TestEnvironment().lookup(), List.of(), "7.0.0.Final");
+
+        HibernateRuleResultDto result = new UuidIdentifierGeneratorRule().evaluate(context);
+
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample ->
+                        assertThat(sample).contains("style = VERSION_7").doesNotContain("style = TIME"));
+    }
+
+    @Test
+    void uuidIdentifierGeneratorRuleRecommendsTimeStyleBeforeHibernate7() {
+        HibernateEntityModel entity = HibernateEntityModel.fromClass(UuidIdentifierEntity.class);
+        HibernateContext context = new HibernateContext(
+                List.of(entity), List.of(), new TestEnvironment().lookup(), List.of(), "6.6.5.Final");
+
+        HibernateRuleResultDto result = new UuidIdentifierGeneratorRule().evaluate(context);
+
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample)
+                        .contains("style = TIME")
+                        .contains("no more index-friendly than random")
+                        .doesNotContain("VERSION_7")
+                        .doesNotContain("VERSION_6"));
+    }
+
+    @Test
     void isFrameworkDeclaredPanacheIdentifierMatchesBothOrmAndReactiveBaseClasses() {
         HibernateAttributeModel ormIdentifier = new HibernateAttributeModel(
-                "io.quarkus.hibernate.orm.panache.PanacheEntity", "id", Long.class, Long.class, null, true, List.of());
+                "io.quarkus.hibernate.orm.panache.PanacheEntity",
+                "id",
+                Long.class,
+                Long.class,
+                null,
+                true,
+                true,
+                List.of());
         HibernateAttributeModel reactiveIdentifier = new HibernateAttributeModel(
                 "io.quarkus.hibernate.reactive.panache.PanacheEntity",
                 "id",
@@ -492,9 +621,10 @@ class HibernateRulesTests {
                 Long.class,
                 null,
                 true,
+                true,
                 List.of());
-        HibernateAttributeModel applicationOwnedIdentifier =
-                new HibernateAttributeModel("com.example.Order", "id", Long.class, Long.class, null, false, List.of());
+        HibernateAttributeModel applicationOwnedIdentifier = new HibernateAttributeModel(
+                "com.example.Order", "id", Long.class, Long.class, null, false, true, List.of());
 
         assertThat(HibernateRuleModelSupport.isFrameworkDeclaredPanacheIdentifier(ormIdentifier))
                 .isTrue();
@@ -571,6 +701,146 @@ class HibernateRulesTests {
         assertThat(HibernateRuleModelSupport.isSpringDataPersistableAvailable()).isTrue();
     }
 
+    // --- HIB-ID-007 -------------------------------------------------------------
+
+    @Test
+    void compositeIdentifierContractRulePassesForWellFormedEmbeddedId() {
+        HibernateRuleResultDto result = new CompositeIdentifierContractRule()
+                .evaluate(context(new TestEnvironment(), WellFormedEmbeddedIdEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void compositeIdentifierContractRuleFlagsEmbeddedIdViolatingTheFullContract() {
+        HibernateRuleResultDto result = new CompositeIdentifierContractRule()
+                .evaluate(context(new TestEnvironment(), BrokenEmbeddedIdEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.HIGH);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample)
+                        .contains("not Serializable")
+                        .contains("no public no-arg ctor")
+                        .contains("no equals() override")
+                        .contains("no hashCode() override"));
+    }
+
+    @Test
+    void compositeIdentifierContractRulePassesForWellFormedIdClass() {
+        HibernateRuleResultDto result = new CompositeIdentifierContractRule()
+                .evaluate(context(new TestEnvironment(), WellFormedIdClassEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void compositeIdentifierContractRuleFlagsIdClassMissingOnlySerializable() {
+        HibernateRuleResultDto result = new CompositeIdentifierContractRule()
+                .evaluate(context(new TestEnvironment(), BrokenIdClassEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("not Serializable"));
+        assertThat(result.sampleViolations())
+                .noneSatisfy(sample -> assertThat(sample).contains("override"));
+    }
+
+    // --- HIB-CONFIG-018 ----------------------------------------------------------
+
+    @Test
+    void bindParameterLoggingInProductionRuleFlagsTraceBinderLoggingInProduction() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty("logging.level.org.hibernate.orm.jdbc.bind", "TRACE");
+        environment.setActiveProfiles("prod");
+
+        HibernateRuleResultDto result = new BindParameterLoggingInProductionRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.HIGH);
+    }
+
+    @Test
+    void bindParameterLoggingInProductionRuleFlagsLegacyBasicBinderTraceLoggingInProduction() {
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty("logging.level.org.hibernate.type.descriptor.sql.BasicBinder", "trace");
+        environment.setActiveProfiles("production");
+
+        HibernateRuleResultDto result = new BindParameterLoggingInProductionRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void bindParameterLoggingInProductionRulePassesWhenNotInProduction() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty("logging.level.org.hibernate.orm.jdbc.bind", "TRACE");
+
+        HibernateRuleResultDto result = new BindParameterLoggingInProductionRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void bindParameterLoggingInProductionRulePassesWhenLoggingNotEnabledInProduction() {
+        TestEnvironment environment = new TestEnvironment();
+        environment.setActiveProfiles("prod");
+
+        HibernateRuleResultDto result = new BindParameterLoggingInProductionRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void bindParameterLoggingInProductionRulePassesForDebugLevelInProduction() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty("logging.level.org.hibernate.orm.jdbc.bind", "DEBUG");
+        environment.setActiveProfiles("prod");
+
+        HibernateRuleResultDto result = new BindParameterLoggingInProductionRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    // --- HIB-ENTITY-009 ----------------------------------------------------------
+
+    @Test
+    void naturalIdCandidateRuleFlagsUniqueColumnWithoutNaturalId() {
+        HibernateRuleResultDto result = new NaturalIdCandidateRule()
+                .evaluate(context(new TestEnvironment(), UniqueColumnWithoutNaturalIdEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("email").contains("unique column"));
+    }
+
+    @Test
+    void naturalIdCandidateRulePassesWhenNaturalIdIsDeclared() {
+        HibernateRuleResultDto result =
+                new NaturalIdCandidateRule().evaluate(context(new TestEnvironment(), NaturalIdEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void naturalIdCandidateRuleFlagsTableLevelUniqueConstraintWithoutNaturalId() {
+        HibernateRuleResultDto result = new NaturalIdCandidateRule()
+                .evaluate(context(new TestEnvironment(), TableUniqueConstraintEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("isbn"));
+    }
+
+    @Test
+    void naturalIdCandidateRulePassesWhenNoUniqueColumnDeclared() {
+        HibernateRuleResultDto result =
+                new NaturalIdCandidateRule().evaluate(context(new TestEnvironment(), SequenceEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
     // --- Fixtures -----------------------------------------------------------
 
     /** Copies {@code template} onto a different declaring class name, without needing a real class of that name. */
@@ -582,6 +852,7 @@ class HibernateRulesTests {
                 template.genericType(),
                 template.persistentAttributeType(),
                 template.publicMember(),
+                template.fieldMember(),
                 template.annotations());
     }
 
@@ -683,10 +954,46 @@ class HibernateRulesTests {
     }
 
     @Entity
+    static class OrderColumnElementCollectionEntity {
+        @Id
+        Long id;
+
+        @ElementCollection
+        @OrderColumn(name = "tag_order")
+        List<String> tags;
+    }
+
+    @Entity
+    static class UnorderedElementCollectionEntity {
+        @Id
+        Long id;
+
+        @ElementCollection
+        List<String> tags;
+    }
+
+    @Entity
+    static class OrderByOnlyElementCollectionEntity {
+        @Id
+        Long id;
+
+        @ElementCollection
+        @OrderBy("name")
+        List<String> tags;
+    }
+
+    @Entity
     static class AutoGeneratedValueEntity {
         @Id
         @GeneratedValue
         Long id;
+    }
+
+    @Entity
+    static class UuidIdentifierEntity {
+        @Id
+        @GeneratedValue
+        UUID id;
     }
 
     @Entity
@@ -754,5 +1061,152 @@ class HibernateRulesTests {
         public boolean cachedFlag;
     }
 
+    /**
+     * Entity using property (getter) access - "name" is backed by a public getter Method, not a field. This is
+     * fully supported, instrumented JPA/Hibernate behavior and must not be treated as an exposed public field.
+     */
+    @Entity
+    static class PropertyAccessEntity {
+        private Long id;
+        private String name;
+
+        @Id
+        public Long getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
     static class Child {}
+
+    /** Well-formed composite identifier class: implements Serializable, public no-arg ctor, equals + hashCode. */
+    static class WellFormedEmbeddedIdKey implements Serializable {
+        private Long orderId;
+        private Long lineNumber;
+
+        public WellFormedEmbeddedIdKey() {}
+
+        WellFormedEmbeddedIdKey(Long orderId, Long lineNumber) {
+            this.orderId = orderId;
+            this.lineNumber = lineNumber;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof WellFormedEmbeddedIdKey key
+                    && java.util.Objects.equals(orderId, key.orderId)
+                    && java.util.Objects.equals(lineNumber, key.lineNumber);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(orderId, lineNumber);
+        }
+    }
+
+    @Entity
+    static class WellFormedEmbeddedIdEntity {
+        @EmbeddedId
+        WellFormedEmbeddedIdKey id;
+    }
+
+    /** Composite identifier class violating every part of the JPA contract HIB-ID-007 checks. */
+    static class BrokenEmbeddedIdKey {
+        private final Long orderId;
+
+        BrokenEmbeddedIdKey(Long orderId) {
+            this.orderId = orderId;
+        }
+    }
+
+    @Entity
+    static class BrokenEmbeddedIdEntity {
+        @EmbeddedId
+        BrokenEmbeddedIdKey id;
+    }
+
+    /** Well-formed @IdClass identifier class. */
+    static class WellFormedIdClassKey implements Serializable {
+        private Long orderId;
+        private Long lineNumber;
+
+        public WellFormedIdClassKey() {}
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof WellFormedIdClassKey;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+    }
+
+    @Entity
+    @IdClass(WellFormedIdClassKey.class)
+    static class WellFormedIdClassEntity {
+        @Id
+        Long orderId;
+
+        @Id
+        Long lineNumber;
+    }
+
+    /** @IdClass identifier class missing only Serializable - has a public no-arg ctor and overrides equals/hashCode. */
+    static class BrokenIdClassKey {
+
+        public BrokenIdClassKey() {}
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof BrokenIdClassKey;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+    }
+
+    @Entity
+    @IdClass(BrokenIdClassKey.class)
+    static class BrokenIdClassEntity {
+        @Id
+        Long orderId;
+
+        @Id
+        Long lineNumber;
+    }
+
+    @Entity
+    static class UniqueColumnWithoutNaturalIdEntity {
+        @Id
+        Long id;
+
+        @Column(unique = true)
+        String email;
+    }
+
+    @Entity
+    static class NaturalIdEntity {
+        @Id
+        Long id;
+
+        @NaturalId
+        @Column(unique = true)
+        String email;
+    }
+
+    @Entity
+    @Table(uniqueConstraints = @UniqueConstraint(columnNames = "isbn"))
+    static class TableUniqueConstraintEntity {
+        @Id
+        Long id;
+
+        String isbn;
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Test;
 
 class HibernateScannerTests {
 
-    private static final int RULE_COUNT = 66;
+    private static final int RULE_COUNT = 69;
     private static final String AFFECTED_HIBERNATE_VERSION = "7.3.9.Final";
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 

--- a/bootui-engine/src/test/java/org/hibernate/annotations/NaturalId.java
+++ b/bootui-engine/src/test/java/org/hibernate/annotations/NaturalId.java
@@ -1,0 +1,13 @@
+package org.hibernate.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface NaturalId {
+
+    boolean mutable() default false;
+}

--- a/bootui-quarkus-integration-tests/hibernate/src/main/resources/application.properties
+++ b/bootui-quarkus-integration-tests/hibernate/src/main/resources/application.properties
@@ -7,3 +7,10 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:hibdemo;DB_CLOSE_DELAY=-1
 # Exercises QuarkusHibernatePropertyLookup's flagship value translation: the engine's ddl-auto rule only knows
 # the JPA value vocabulary, so drop-and-create is mapped to the engine's risky create-drop value.
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
+
+# Exercises three more QuarkusHibernatePropertyLookup aliases end to end against a real SmallRye Config: without
+# them, HIB-FETCH-002/HIB-CONFIG-007/HIB-CONFIG-013 would false-positive on every Quarkus scan even though these
+# are correctly configured using the native Quarkus property name.
+quarkus.hibernate-orm.fetch.batch-size=16
+quarkus.hibernate-orm.statistics=true
+quarkus.hibernate-orm.jdbc.timezone=UTC

--- a/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHibernateAdvisorTest.java
+++ b/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHibernateAdvisorTest.java
@@ -23,7 +23,10 @@ import org.junit.jupiter.api.Test;
  * metamodel (via the capability-gated {@code QuarkusEntityDiscovery}) and runs the shared engine rule registry,
  * that a known annotation-driven advisory fires against the deliberately-imperfect {@link org.acme.hibdemo.Product}
  * entity, and — crucially — that the Spring-only Open-Session-in-View rule {@code HIB-CONFIG-001} stays inert,
- * proving {@code QuarkusHibernatePropertyLookup}'s OSIV neutralization works against a live SmallRye Config.</p>
+ * proving {@code QuarkusHibernatePropertyLookup}'s OSIV neutralization works against a live SmallRye Config. It
+ * also proves three more {@code QuarkusHibernatePropertyLookup} aliases end to end (batch fetching, statistics,
+ * JDBC time zone — see {@code application.properties}): {@code HIB-FETCH-002}/{@code HIB-CONFIG-007}/
+ * {@code HIB-CONFIG-013} would each false-positive on every Quarkus scan without them.</p>
  */
 @QuarkusTest
 class BootUiQuarkusHibernateAdvisorTest {
@@ -90,6 +93,19 @@ class BootUiQuarkusHibernateAdvisorTest {
                 .as("Open-Session-in-View (HIB-CONFIG-001) must stay inert on Quarkus — there is no OSIV, so the"
                         + " property lookup reports it disabled and the rule passes")
                 .doesNotContain("HIB-CONFIG-001");
+        assertThat(violationIds)
+                .as("quarkus.hibernate-orm.fetch.batch-size=16 (application.properties) must be read back as"
+                        + " hibernate.default_batch_fetch_size, so the Product.tags lazy @ManyToMany collection is"
+                        + " covered and HIB-FETCH-002 does not false-positive")
+                .doesNotContain("HIB-FETCH-002");
+        assertThat(violationIds)
+                .as("quarkus.hibernate-orm.statistics=true must be read back as hibernate.generate_statistics, so"
+                        + " HIB-CONFIG-007 does not false-positive")
+                .doesNotContain("HIB-CONFIG-007");
+        assertThat(violationIds)
+                .as("quarkus.hibernate-orm.jdbc.timezone=UTC must be read back as hibernate.jdbc.time_zone, so"
+                        + " HIB-CONFIG-013 does not false-positive")
+                .doesNotContain("HIB-CONFIG-013");
 
         // The result is cached, so a subsequent GET reflects the scan without re-running it.
         Response cached = probe().get("/bootui/api/hibernate");

--- a/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest.java
+++ b/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest.java
@@ -1,0 +1,92 @@
+package io.github.jdubois.bootui.quarkus.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManagerFactory;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Live-runtime spike (HIB-CONFIG-005, see docs/HIBERNATE-CHECKS.md) proving that Quarkus' generic
+ * {@code quarkus.hibernate-orm.unsupported-properties."..."} escape hatch — the fallback
+ * {@code QuarkusHibernatePropertyLookup} uses for {@code hibernate.order_inserts}/{@code hibernate.order_updates},
+ * which have no first-class {@code quarkus.hibernate-orm.*} equivalent — actually reaches vanilla Hibernate ORM's
+ * own bootstrapped {@link org.hibernate.boot.spi.SessionFactoryOptions}, not just that BootUI's own property
+ * lookup reads the SmallRye Config value back. Bytecode inspection of the shipped
+ * {@code quarkus-hibernate-orm-deployment} jar already showed {@code FastBootMetadataBuilder} merges
+ * {@code unsupported-properties} verbatim into Hibernate's build-time settings; this test is the corroborating
+ * live-boot proof: it unwraps the actual {@link EntityManagerFactory} to a real Hibernate {@link SessionFactory}
+ * and reads {@code isOrderInsertsEnabled()}/{@code isOrderUpdatesEnabled()} directly off it, then separately
+ * confirms the BootUI-side read-back (HIB-CONFIG-005 does not fire) so both halves of the pipeline are pinned.
+ */
+@QuarkusTest
+@TestProfile(BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest.OrderedBatchingProfile.class)
+class BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest {
+
+    private static final Map<String, String> JSON_HEADERS = Map.of("Content-Type", "application/json");
+
+    @Inject
+    EntityManagerFactory entityManagerFactory;
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    private BootUiHttpProbe probe() {
+        return new BootUiHttpProbe(baseUrl.toExternalForm());
+    }
+
+    @Test
+    void unsupportedPropertiesPassthroughReachesHibernatesOwnSessionFactoryOptions() {
+        SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
+
+        assertThat(sessionFactory.getSessionFactoryOptions().isOrderInsertsEnabled())
+                .as("quarkus.hibernate-orm.unsupported-properties.\"hibernate.order_inserts\"=true must reach"
+                        + " Hibernate's own SessionFactoryOptions, not just BootUI's property lookup")
+                .isTrue();
+        assertThat(sessionFactory.getSessionFactoryOptions().isOrderUpdatesEnabled())
+                .as("quarkus.hibernate-orm.unsupported-properties.\"hibernate.order_updates\"=true must reach"
+                        + " Hibernate's own SessionFactoryOptions, not just BootUI's property lookup")
+                .isTrue();
+    }
+
+    @Test
+    void hibConfig005DoesNotFalsePositiveWhenOrderingIsSetViaTheUnsupportedPropertiesPassthrough() {
+        Response scan = probe().post("/bootui/api/hibernate/scan", JSON_HEADERS);
+        assertThat(scan.status()).as("POST /bootui/api/hibernate/scan status").isEqualTo(200);
+
+        List<String> violationIds = new ArrayList<>();
+        for (JsonNode node : scan.json().path("results")) {
+            violationIds.add(node.path("id").asText());
+        }
+        assertThat(violationIds)
+                .as("hibernate.order_inserts/order_updates reached via the unsupported-properties passthrough"
+                        + " (with batching also configured via quarkus.hibernate-orm.jdbc.statement-batch-size)"
+                        + " must be read back so HIB-CONFIG-005 does not false-positive")
+                .doesNotContain("HIB-CONFIG-005");
+    }
+
+    public static final class OrderedBatchingProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.hibernate-orm.jdbc.statement-batch-size",
+                    "25",
+                    "quarkus.hibernate-orm.unsupported-properties.\"hibernate.order_inserts\"",
+                    "true",
+                    "quarkus.hibernate-orm.unsupported-properties.\"hibernate.order_updates\"",
+                    "true");
+        }
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookup.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookup.java
@@ -31,14 +31,39 @@ import org.eclipse.microprofile.config.Config;
  *       {@code HIB-MAP-017}/{@code HIB-MAP-018} rules read the enable-lazy-initialization keys above to decide
  *       whether the enhancer is active; without this mapping they would read {@code null} (falsy) and flag every
  *       lazy/non-owning {@code @OneToOne} as a false positive on every Quarkus scan.</li>
+ *   <li><strong>Maps batch fetching, JDBC time zone, statistics, IN-clause padding, pagination-over-collection
+ *       and second-level/query caching</strong> to their real {@code quarkus.hibernate-orm.*} equivalents (all
+ *       confirmed by decompiling the {@code quarkus-hibernate-orm}/{@code -deployment} 3.33.2.1 jars — see the
+ *       per-alias notes on {@link #KEY_ALIASES}). Before this mapping existed, {@code HIB-FETCH-002} and
+ *       {@code HIB-CONFIG-007}/{@code -009}/{@code -010}/{@code -011}/{@code -013}/{@code -016} could never
+ *       observe an operator's setting on Quarkus, no matter which native property name they used.</li>
+ *   <li><strong>Reads the Quarkus-native {@code quarkus.hibernate-orm.log.bind-parameters} convenience
+ *       flag</strong> (and its deprecated {@code .bind-param} alias) as the synthetic {@code "trace"} value of
+ *       the neutral {@code logging.level.org.hibernate.orm.jdbc.bind} key, matching Hibernate's own
+ *       {@code JdbcBindingLogging}, which only ever logs bound parameter values when
+ *       {@code Logger.isTraceEnabled()} — so {@code HIB-CONFIG-018} sees bind-parameter logging as enabled
+ *       however the operator configured it.</li>
+ *   <li><strong>Falls back to the {@code quarkus.hibernate-orm.unsupported-properties."..."} escape
+ *       hatch</strong> for any {@code hibernate.*} key with no first-class Quarkus config option. Decompiling
+ *       {@code FastBootMetadataBuilder#createBuildTimeSettings} confirms Quarkus merges this map verbatim into
+ *       Hibernate's real bootstrap settings, so a key set this way genuinely reaches Hibernate (unlike a bare,
+ *       un-namespaced property in {@code application.properties}, which Quarkus never forwards). This is how an
+ *       operator's {@code hibernate.order_inserts}/{@code order_updates} (HIB-CONFIG-005) or
+ *       {@code hibernate.cache.region.factory_class} (HIB-CONFIG-010) setting can be read back even though
+ *       Quarkus has no dedicated config property for either — see {@link #unsupportedPropertiesFallback}.</li>
  * </ul>
  *
  * <p>Every other engine key falls through to a raw MicroProfile Config read, which returns {@code null} for
  * the Spring-only concerns the engine also probes (Hikari auto-commit, JTA, defer-datasource-initialization)
- * — correctly leaving those rules inert on Quarkus. A handful of lower-value config rules (slow-query
- * threshold, ordered batching, second-level cache) have no clean {@code quarkus.hibernate-orm.*} equivalent
- * and remain unmapped; their advice still applies but they cite the Spring/native-Hibernate property name.
- * That bounded limitation is documented in {@code docs/FEATURES.md}.</p>
+ * — correctly leaving those rules inert on Quarkus. A few config rules genuinely have no
+ * {@code quarkus.hibernate-orm.*} equivalent <em>and</em> no realistic {@code unsupported-properties} path
+ * either, because they key off a Hikari-specific property Agroal has no equivalent for at all (
+ * {@code spring.datasource.hikari.auto-commit}, read directly by {@code HIB-CONFIG-008}) or a pool
+ * implementation-specific concept (Hibernate's built-in pool vs. Agroal, {@code HIB-CONFIG-014}'s
+ * {@code hibernate.connection.pool_size} advice still applies verbatim since that property, if force-set via
+ * {@code unsupported-properties}, reaches Hibernate exactly as documented — only the Hikari-specific
+ * auto-commit *signal* this rule also inspects has no Agroal analogue). That bounded limitation is documented
+ * in {@code docs/FEATURES.md}.</p>
  */
 public final class QuarkusHibernatePropertyLookup implements Function<String, String> {
 
@@ -61,18 +86,76 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
             "spring.jpa.properties.hibernate.bytecode.enhancer.enableLazyInitialization",
             "hibernate.bytecode.enhancer.enableLazyInitialization");
 
-    // Engine key -> quarkus.hibernate-orm.* equivalent. Verified against the Quarkus 3.33 Hibernate ORM
-    // configuration reference; the first two are exercised by the Quarkus sample app.
-    private static final Map<String, String> KEY_ALIASES = Map.of(
-            "spring.jpa.hibernate.ddl-auto", SCHEMA_STRATEGY_KEY,
-            "spring.jpa.properties.hibernate.hbm2ddl.auto", SCHEMA_STRATEGY_KEY,
-            "hibernate.hbm2ddl.auto", SCHEMA_STRATEGY_KEY,
-            "spring.jpa.show-sql", "quarkus.hibernate-orm.log.sql",
-            "hibernate.show_sql", "quarkus.hibernate-orm.log.sql",
-            "hibernate.format_sql", "quarkus.hibernate-orm.log.format-sql",
-            "spring.jpa.properties.hibernate.format_sql", "quarkus.hibernate-orm.log.format-sql",
-            "hibernate.jdbc.batch_size", "quarkus.hibernate-orm.jdbc.statement-batch-size",
-            "spring.jpa.properties.hibernate.jdbc.batch_size", "quarkus.hibernate-orm.jdbc.statement-batch-size");
+    // The engine's HibernateContext exposes bind-parameter-value logging as the neutral property key
+    // "logging.level.org.hibernate.orm.jdbc.bind", checked for a "trace" value (Hibernate's own
+    // JdbcBindingLogging only ever logs bound values when Logger.isTraceEnabled()). Quarkus offers a
+    // dedicated convenience flag instead of a log-category level; either name enables it (confirmed via the
+    // quarkus-hibernate-orm-deployment 3.33.2.1 config model: both quarkus.hibernate-orm.log.bind-param
+    // (deprecated) and .bind-parameters (current) exist, and HibernateOrmConfigLog#isAnyPropertySet() ORs
+    // them together).
+    private static final String BIND_PARAMETER_LOGGING_KEY = "logging.level.org.hibernate.orm.jdbc.bind";
+
+    private static final String BIND_PARAMETERS_PROPERTY = "quarkus.hibernate-orm.log.bind-parameters";
+
+    private static final String LEGACY_BIND_PARAM_PROPERTY = "quarkus.hibernate-orm.log.bind-param";
+
+    // Hibernate property keys have no first-class quarkus.hibernate-orm.* option but ARE genuinely readable
+    // if an operator sets them through Quarkus' generic "unsupported properties" escape hatch, which
+    // FastBootMetadataBuilder merges verbatim into Hibernate's real bootstrap settings
+    // (RecordedConfig.getQuarkusConfigUnsupportedProperties() -> Map.putAll(...), confirmed by decompiling
+    // quarkus-hibernate-orm-3.33.2.1.jar). unsupportedPropertiesFallback() below tries this for any
+    // otherwise-unmapped hibernate.* key.
+    private static final String UNSUPPORTED_PROPERTIES_PREFIX = "quarkus.hibernate-orm.unsupported-properties.\"";
+
+    private static final String SPRING_JPA_PROPERTIES_PREFIX = "spring.jpa.properties.";
+
+    // second-level caching: Quarkus has a single quarkus.hibernate-orm.second-level-caching-enabled toggle,
+    // not one property per Hibernate cache setting. Decompiling HibernateProcessorUtil#configureCaching()
+    // confirms this ONE boolean drives both hibernate.cache.use_second_level_cache AND
+    // hibernate.cache.use_query_cache via Properties#putIfAbsent(...); there is no separate
+    // "query-cache-enabled" property in Quarkus (verified against the generated config-doc model — only
+    // second-level-caching-enabled exists).
+    private static final String SECOND_LEVEL_CACHING_KEY = "quarkus.hibernate-orm.second-level-caching-enabled";
+
+    // Engine key -> quarkus.hibernate-orm.* equivalent. Every mapping below is verified against the actual
+    // quarkus-hibernate-orm{,-deployment} 3.33.2.1 jars (bytecode disassembly plus the generated
+    // META-INF/quarkus-config-doc/quarkus-config-model.json), not just documentation.
+    private static final Map<String, String> KEY_ALIASES = Map.ofEntries(
+            Map.entry("spring.jpa.hibernate.ddl-auto", SCHEMA_STRATEGY_KEY),
+            Map.entry("spring.jpa.properties.hibernate.hbm2ddl.auto", SCHEMA_STRATEGY_KEY),
+            Map.entry("hibernate.hbm2ddl.auto", SCHEMA_STRATEGY_KEY),
+            Map.entry("spring.jpa.show-sql", "quarkus.hibernate-orm.log.sql"),
+            Map.entry("hibernate.show_sql", "quarkus.hibernate-orm.log.sql"),
+            Map.entry("hibernate.format_sql", "quarkus.hibernate-orm.log.format-sql"),
+            Map.entry("spring.jpa.properties.hibernate.format_sql", "quarkus.hibernate-orm.log.format-sql"),
+            Map.entry("hibernate.jdbc.batch_size", "quarkus.hibernate-orm.jdbc.statement-batch-size"),
+            Map.entry(
+                    "spring.jpa.properties.hibernate.jdbc.batch_size",
+                    "quarkus.hibernate-orm.jdbc.statement-batch-size"),
+            Map.entry("hibernate.default_batch_fetch_size", "quarkus.hibernate-orm.fetch.batch-size"),
+            Map.entry(
+                    "spring.jpa.properties.hibernate.default_batch_fetch_size",
+                    "quarkus.hibernate-orm.fetch.batch-size"),
+            Map.entry("hibernate.jdbc.time_zone", "quarkus.hibernate-orm.jdbc.timezone"),
+            Map.entry("spring.jpa.properties.hibernate.jdbc.time_zone", "quarkus.hibernate-orm.jdbc.timezone"),
+            Map.entry("hibernate.generate_statistics", "quarkus.hibernate-orm.statistics"),
+            Map.entry("spring.jpa.properties.hibernate.generate_statistics", "quarkus.hibernate-orm.statistics"),
+            Map.entry(
+                    "hibernate.query.fail_on_pagination_over_collection_fetch",
+                    "quarkus.hibernate-orm.query.fail-on-pagination-over-collection-fetch"),
+            Map.entry(
+                    "spring.jpa.properties.hibernate.query.fail_on_pagination_over_collection_fetch",
+                    "quarkus.hibernate-orm.query.fail-on-pagination-over-collection-fetch"),
+            Map.entry(
+                    "hibernate.query.in_clause_parameter_padding",
+                    "quarkus.hibernate-orm.query.in-clause-parameter-padding"),
+            Map.entry(
+                    "spring.jpa.properties.hibernate.query.in_clause_parameter_padding",
+                    "quarkus.hibernate-orm.query.in-clause-parameter-padding"),
+            Map.entry("hibernate.cache.use_query_cache", SECOND_LEVEL_CACHING_KEY),
+            Map.entry("spring.jpa.properties.hibernate.cache.use_query_cache", SECOND_LEVEL_CACHING_KEY),
+            Map.entry("hibernate.cache.use_second_level_cache", SECOND_LEVEL_CACHING_KEY),
+            Map.entry("spring.jpa.properties.hibernate.cache.use_second_level_cache", SECOND_LEVEL_CACHING_KEY));
 
     private final Config config;
 
@@ -90,12 +173,19 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
         if (ENHANCEMENT_ENABLED_KEYS.contains(key)) {
             return "true";
         }
+        if (BIND_PARAMETER_LOGGING_KEY.equals(key)) {
+            return isBindParameterLoggingEnabled() ? "trace" : raw(key);
+        }
         String quarkusKey = KEY_ALIASES.get(key);
         if (SCHEMA_STRATEGY_KEY.equals(quarkusKey)) {
             String value = schemaStrategy();
             return "drop-and-create".equalsIgnoreCase(value) ? "create-drop" : value;
         }
-        return raw(quarkusKey != null ? quarkusKey : key);
+        if (quarkusKey != null) {
+            return raw(quarkusKey);
+        }
+        String direct = raw(key);
+        return direct != null ? direct : unsupportedPropertiesFallback(key);
     }
 
     /**
@@ -107,6 +197,31 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
     private String schemaStrategy() {
         String value = raw(SCHEMA_STRATEGY_KEY);
         return value != null ? value : raw(LEGACY_GENERATION_KEY);
+    }
+
+    /**
+     * Reports whether Quarkus' convenience bind-parameter-logging flag is enabled, checking both the current
+     * and deprecated property names (Quarkus itself treats them as equivalent).
+     */
+    private boolean isBindParameterLoggingEnabled() {
+        return "true".equalsIgnoreCase(raw(BIND_PARAMETERS_PROPERTY))
+                || "true".equalsIgnoreCase(raw(LEGACY_BIND_PARAM_PROPERTY));
+    }
+
+    /**
+     * Falls back to Quarkus' generic {@code quarkus.hibernate-orm.unsupported-properties."..."} escape hatch
+     * for a native Hibernate property key with no first-class {@code quarkus.hibernate-orm.*} option. Only
+     * applies to keys that are (once any {@code spring.jpa.properties.} prefix is stripped) a bare
+     * {@code hibernate.*} property, since that is the only key shape this passthrough can plausibly carry.
+     */
+    private String unsupportedPropertiesFallback(String key) {
+        String hibernateKey = key.startsWith(SPRING_JPA_PROPERTIES_PREFIX)
+                ? key.substring(SPRING_JPA_PROPERTIES_PREFIX.length())
+                : key;
+        if (!hibernateKey.startsWith("hibernate.")) {
+            return null;
+        }
+        return raw(UNSUPPORTED_PROPERTIES_PREFIX + hibernateKey + "\"");
     }
 
     private String raw(String key) {

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookupTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookupTest.java
@@ -120,4 +120,145 @@ class QuarkusHibernatePropertyLookupTest {
         assertThat(lookup(Map.of()).apply("spring.jpa.hibernate.ddl-auto")).isNull();
         assertThat(lookup(Map.of()).apply("spring.jpa.show-sql")).isNull();
     }
+
+    @Test
+    void mapsDefaultBatchFetchSizeToQuarkusFetchBatchSize() {
+        // Confirmed by decompiling quarkus-hibernate-orm-deployment-3.33.2.1.jar: this is a real, currently
+        // existing quarkus.hibernate-orm.* property (HIB-FETCH-002 previously false-positived on every
+        // Quarkus scan because this key was missing from the alias map).
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of("quarkus.hibernate-orm.fetch.batch-size", "16"));
+
+        assertThat(lookup.apply("hibernate.default_batch_fetch_size")).isEqualTo("16");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.default_batch_fetch_size"))
+                .isEqualTo("16");
+    }
+
+    @Test
+    void mapsJdbcTimeZoneToQuarkusJdbcTimezone() {
+        // HIB-CONFIG-013.
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of("quarkus.hibernate-orm.jdbc.timezone", "UTC"));
+
+        assertThat(lookup.apply("hibernate.jdbc.time_zone")).isEqualTo("UTC");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.jdbc.time_zone"))
+                .isEqualTo("UTC");
+    }
+
+    @Test
+    void mapsGenerateStatisticsToQuarkusStatistics() {
+        // HIB-CONFIG-007.
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of("quarkus.hibernate-orm.statistics", "true"));
+
+        assertThat(lookup.apply("hibernate.generate_statistics")).isEqualTo("true");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.generate_statistics"))
+                .isEqualTo("true");
+    }
+
+    @Test
+    void mapsFailOnPaginationOverCollectionFetchToItsQuarkusEquivalent() {
+        // HIB-CONFIG-016.
+        QuarkusHibernatePropertyLookup lookup =
+                lookup(Map.of("quarkus.hibernate-orm.query.fail-on-pagination-over-collection-fetch", "true"));
+
+        assertThat(lookup.apply("hibernate.query.fail_on_pagination_over_collection_fetch"))
+                .isEqualTo("true");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.query.fail_on_pagination_over_collection_fetch"))
+                .isEqualTo("true");
+    }
+
+    @Test
+    void mapsInClauseParameterPaddingToItsQuarkusEquivalent() {
+        // HIB-CONFIG-009.
+        QuarkusHibernatePropertyLookup lookup =
+                lookup(Map.of("quarkus.hibernate-orm.query.in-clause-parameter-padding", "true"));
+
+        assertThat(lookup.apply("hibernate.query.in_clause_parameter_padding")).isEqualTo("true");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.query.in_clause_parameter_padding"))
+                .isEqualTo("true");
+    }
+
+    @Test
+    void mapsBothCacheFlagsToTheUnifiedSecondLevelCachingToggle() {
+        // HIB-CONFIG-010/HIB-CONFIG-011. Quarkus has a SINGLE quarkus.hibernate-orm.second-level-caching-enabled
+        // toggle, not one property per Hibernate cache setting: decompiling HibernateProcessorUtil's
+        // configureCaching() shows this one boolean drives both hibernate.cache.use_second_level_cache AND
+        // hibernate.cache.use_query_cache via Properties#putIfAbsent(...). There is no separate
+        // "query-cache-enabled" property in Quarkus 3.33 (an earlier draft of this fix assumed there was;
+        // the generated quarkus-config-model.json confirms only second-level-caching-enabled exists).
+        QuarkusHibernatePropertyLookup lookup =
+                lookup(Map.of("quarkus.hibernate-orm.second-level-caching-enabled", "false"));
+
+        assertThat(lookup.apply("hibernate.cache.use_query_cache")).isEqualTo("false");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.cache.use_query_cache"))
+                .isEqualTo("false");
+        assertThat(lookup.apply("hibernate.cache.use_second_level_cache")).isEqualTo("false");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.cache.use_second_level_cache"))
+                .isEqualTo("false");
+    }
+
+    @Test
+    void reportsBindParameterLoggingEnabledFromTheQuarkusNativeConvenienceFlag() {
+        // HIB-CONFIG-018. quarkus.hibernate-orm.log.bind-parameters triggers a build-time
+        // LogCategoryBuildItem("org.hibernate.orm.jdbc.bind", Level.TRACE, ...) (confirmed by decompiling
+        // HibernateOrmProcessor#produceLoggingCategories()), so the neutral engine key must read back "trace".
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of("quarkus.hibernate-orm.log.bind-parameters", "true"));
+
+        assertThat(lookup.apply("logging.level.org.hibernate.orm.jdbc.bind")).isEqualTo("trace");
+    }
+
+    @Test
+    void reportsBindParameterLoggingEnabledFromTheDeprecatedQuarkusFlag() {
+        // quarkus.hibernate-orm.log.bind-param is deprecated but still honored (HibernateOrmConfigLog's
+        // isAnyPropertySet() ORs bindParam() and bindParameters() together).
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of("quarkus.hibernate-orm.log.bind-param", "true"));
+
+        assertThat(lookup.apply("logging.level.org.hibernate.orm.jdbc.bind")).isEqualTo("trace");
+    }
+
+    @Test
+    void doesNotReportBindParameterLoggingEnabledWhenNeitherQuarkusFlagIsSet() {
+        assertThat(lookup(Map.of()).apply("logging.level.org.hibernate.orm.jdbc.bind"))
+                .isNull();
+        assertThat(lookup(Map.of("quarkus.hibernate-orm.log.bind-parameters", "false"))
+                        .apply("logging.level.org.hibernate.orm.jdbc.bind"))
+                .isNull();
+    }
+
+    @Test
+    void fallsBackToTheUnsupportedPropertiesEscapeHatchForHibernateKeysWithNoQuarkusEquivalent() {
+        // Confirmed by decompiling FastBootMetadataBuilder: RecordedConfig#getQuarkusConfigUnsupportedProperties()
+        // is merged verbatim (Map#putAll) into Hibernate's real bootstrap settings, so a key configured this way
+        // genuinely reaches Hibernate. hibernate.order_inserts/order_updates (HIB-CONFIG-005) and
+        // hibernate.cache.region.factory_class (HIB-CONFIG-010) have no first-class quarkus.hibernate-orm.*
+        // option, but ARE readable if set through this passthrough.
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of(
+                "quarkus.hibernate-orm.unsupported-properties.\"hibernate.order_inserts\"", "true",
+                "quarkus.hibernate-orm.unsupported-properties.\"hibernate.order_updates\"", "true",
+                "quarkus.hibernate-orm.unsupported-properties.\"hibernate.cache.region.factory_class\"",
+                        "org.hibernate.cache.jcache.internal.JCacheRegionFactory"));
+
+        assertThat(lookup.apply("hibernate.order_inserts")).isEqualTo("true");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.order_updates"))
+                .isEqualTo("true");
+        assertThat(lookup.apply("hibernate.cache.region.factory_class"))
+                .isEqualTo("org.hibernate.cache.jcache.internal.JCacheRegionFactory");
+    }
+
+    @Test
+    void returnsNullFromTheUnsupportedPropertiesFallbackWhenNothingIsConfigured() {
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of());
+
+        assertThat(lookup.apply("hibernate.order_inserts")).isNull();
+        assertThat(lookup.apply("hibernate.cache.region.factory_class")).isNull();
+    }
+
+    @Test
+    void doesNotApplyTheUnsupportedPropertiesFallbackToNonHibernateKeys() {
+        // The fallback only ever targets hibernate.* keys (after stripping any spring.jpa.properties. prefix);
+        // a key like spring.datasource.hikari.auto-commit must stay null, not spuriously probe
+        // quarkus.hibernate-orm.unsupported-properties."spring.datasource.hikari.auto-commit".
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of(
+                "quarkus.hibernate-orm.unsupported-properties.\"spring.datasource.hikari.auto-commit\"", "false"));
+
+        assertThat(lookup.apply("spring.datasource.hikari.auto-commit")).isNull();
+    }
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -366,22 +366,33 @@ mappings. See [HIBERNATE-CHECKS.md](HIBERNATE-CHECKS.md) for the full rule catal
 On Quarkus the panel is identical, running the same shared rule engine over the same report contract when
 `quarkus-hibernate-orm` is present: entities are discovered from the live JPA `EntityManagerFactory` metamodel (across
 all persistence units, de-duplicated by identity), and most mapping/identifier/fetch rules apply unchanged. A few
-platform differences are worth noting. First, persistence configuration is read through a key-mapping layer that
-translates the Spring property names the rules expect onto their Quarkus equivalents — `ddl-auto`/`hbm2ddl.auto` →
-`quarkus.hibernate-orm.schema-management.strategy` (or the deprecated `quarkus.hibernate-orm.database.generation`,
-including the `drop-and-create` ↔ `create-drop` value alias),
-`show-sql` → `quarkus.hibernate-orm.log.sql`, `format_sql` → `quarkus.hibernate-orm.log.format-sql`, and `batch_size` →
-`quarkus.hibernate-orm.jdbc.statement-batch-size`. Unmapped configuration rules find no value and stay silent, and
-their INFO advisories may still cite the Spring-flavored property name. Second, the Open-Session-in-View check is
-correctly **inert** on Quarkus: Quarkus has no OSIV concept, so the effective state is always disabled and the rule never
-fires (on Spring a missing `spring.jpa.open-in-view` defaults to the web-on behaviour). Third, bytecode enhancement is
-always considered enabled on Quarkus — it enhances every entity unconditionally at build time with no config-based
-opt-out — so the two lazy-`@OneToOne` findings that depend on enhancement being disabled never fire there. Fourth, and
-specific to **Panache** active-record entities: once a Panache extension (`quarkus-hibernate-orm-panache` or
-`quarkus-hibernate-reactive-panache`) is on the classpath, its build-time bytecode rewrite makes public-field access on
-any Hibernate-managed class behave like a getter/setter call app-wide, so the public-persistent-field finding does not
-fire; and the `@GeneratedValue`-without-strategy finding ignores the `id` field Panache's own base entity declares
-(an application-declared identifier is still checked normally). Spring Data repository hints (missing-strategy-aware
+platform differences are worth noting. First, persistence configuration is read through a key-mapping layer
+(`QuarkusHibernatePropertyLookup`) that translates the Spring/native-Hibernate property names the rules expect onto
+their Quarkus equivalents — `ddl-auto`/`hbm2ddl.auto` → `quarkus.hibernate-orm.schema-management.strategy` (or the
+deprecated `quarkus.hibernate-orm.database.generation`, including the `drop-and-create` ↔ `create-drop` value alias),
+`show-sql` → `quarkus.hibernate-orm.log.sql`, `format_sql` → `quarkus.hibernate-orm.log.format-sql`, `batch_size` →
+`quarkus.hibernate-orm.jdbc.statement-batch-size`, `default_batch_fetch_size` → `quarkus.hibernate-orm.fetch.batch-size`,
+`jdbc.time_zone` → `quarkus.hibernate-orm.jdbc.timezone`, `generate_statistics` → `quarkus.hibernate-orm.statistics`,
+`query.in_clause_parameter_padding` → `quarkus.hibernate-orm.query.in-clause-parameter-padding`,
+`query.fail_on_pagination_over_collection_fetch` →
+`quarkus.hibernate-orm.query.fail-on-pagination-over-collection-fetch`, and both `cache.use_query_cache` and
+`cache.use_second_level_cache` → Quarkus' single unified `quarkus.hibernate-orm.second-level-caching-enabled` toggle.
+A native `quarkus.hibernate-orm.log.bind-parameters` flag is also read as the neutral bind-parameter-logging signal. For
+any other `hibernate.*` key with no first-class Quarkus config option (for example `hibernate.order_inserts` /
+`hibernate.order_updates`), the lookup falls back to Quarkus' generic
+`quarkus.hibernate-orm.unsupported-properties."..."` escape hatch, which a live-boot test confirmed reaches Hibernate's
+own bootstrapped settings. Only a handful of genuinely Hikari/Spring-specific signals stay unmapped (Hikari's
+auto-commit setting, which Agroal has no equivalent for) and their INFO advisories may still cite the Spring-flavored
+property name. Second, the Open-Session-in-View check is correctly **inert** on Quarkus: Quarkus has no OSIV concept,
+so the effective state is always disabled and the rule never fires (on Spring a missing `spring.jpa.open-in-view`
+defaults to the web-on behaviour). Third, bytecode enhancement is always considered enabled on Quarkus — it enhances
+every entity unconditionally at build time with no config-based opt-out — so the two lazy-`@OneToOne` findings that
+depend on enhancement being disabled never fire there. Fourth, and specific to **Panache** active-record entities:
+once a Panache extension (`quarkus-hibernate-orm-panache` or `quarkus-hibernate-reactive-panache`) is on the
+classpath, its build-time bytecode rewrite makes public-field access on any Hibernate-managed class behave like a
+getter/setter call app-wide, so the public-persistent-field finding does not fire; and the
+`@GeneratedValue`-without-strategy finding ignores the `id` field Panache's own base entity declares (an
+application-declared identifier is still checked normally). Spring Data repository hints (missing-strategy-aware
 `isNew()` detection for assigned identifiers) are specific to Spring Data JPA's `save()` semantics: without Spring Data
 Commons on the classpath — the normal case for a Panache app, whose `persist()` has no such ambiguity — that whole
 check is skipped rather than reported.

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -58,15 +58,20 @@ includes up to a handful of sample mapped members plus a remediation link.
   generated SQL itself; the `org.hibernate.limitInMemory` query hint restores the pre-7.4 in-memory behavior. The check
   is skipped (not silently dropped) on 7.4+ runtimes, and the skip reason explains why.
 
-### HIB-FETCH-004 - Entities should avoid multiple bag collections
+### HIB-FETCH-004 - Review entities with multiple bag collections
 
-- **Severity**: MEDIUM
+- **Severity**: INFO
 - **Inspects**: `@OneToMany` and `@ManyToMany` collection attributes.
-- **Fires when**: an entity declares two or more unordered `List` / `Collection` associations without `@OrderColumn`.
-- **Why it matters**: fetching multiple bag collections together is fragile and can lead to cartesian products or
-  `MultipleBagFetchException`.
-- **Recommendation**: fetch at most one bag collection per query, persist list order with `@OrderColumn`, or split loading
-  into targeted queries.
+- **Fires when**: an entity declares two or more unordered `List` / `Collection` associations (bags) without
+  `@OrderColumn`.
+- **Why it matters**: declaring multiple bags is common and safe on its own - the risk is only realized if two of them
+  are ever join-fetched in the same query, which throws `MultipleBagFetchException`. HIB-QUERY-007 already flags that
+  specific case (`JOIN FETCH` of 2+ collections in the same query); this rule is downgraded to an informational reminder
+  to keep it that way rather than standing as a violation on ordinary, safe aggregate-root entities that never fetch
+  both bags together.
+- **Recommendation**: no action is required unless you plan to fetch these together: never `JOIN FETCH` more than one of
+  these collections in the same query. Add `@OrderColumn` when list order is persistent, or use `Set<>` if you do need
+  to fetch two of them eagerly in one query.
 
 ### HIB-FETCH-002 - Batch fetching should cover lazy secondary-select associations
 
@@ -80,6 +85,9 @@ includes up to a handful of sample mapped members plus a remediation link.
   is traversed across multiple owner rows.
 - **Recommendation**: set a bounded global batch-fetch size or targeted `@BatchSize` for associations traversed across
   multiple owners; use explicit fetch plans or paged/filtered queries for a single oversized collection.
+- **Quarkus**: `hibernate.default_batch_fetch_size` maps to `quarkus.hibernate-orm.fetch.batch-size` via
+  `QuarkusHibernatePropertyLookup`, so a global batch-fetch size configured with the native Quarkus property name is
+  read back correctly and this rule does not false-positive.
 
 ### HIB-FETCH-005 - @Lob attributes should be loaded lazily
 
@@ -133,19 +141,23 @@ includes up to a handful of sample mapped members plus a remediation link.
 ### HIB-ID-004 - @GeneratedValue should declare an explicit strategy
 
 - **Severity**: MEDIUM
-- **Inspects**: identifier attributes annotated with `@GeneratedValue`.
+- **Inspects**: identifier attributes annotated with `@GeneratedValue`, excluding `UUID`-typed identifiers.
 - **Fires when**: `strategy` is omitted (or set to `AUTO`).
-- **Why it matters**: `AUTO` never resolves to the database's native `IDENTITY`/auto-increment column. Hibernate's
-  `GeneratorBinder` always maps the JPA `AUTO` strategy to its own `SequenceStyleGenerator`, which uses a real database
-  `SEQUENCE` where the dialect supports one (PostgreSQL, Oracle, H2, SQL Server, ...) and falls back to a slower,
-  row-locking table-based emulation otherwise (e.g. MySQL, which has no native sequence object) - verified directly
-  against the current Hibernate ORM source (`correspondingGeneratorName(GenerationType)` in `GeneratorBinder`, whose
-  `default` case - covering `AUTO` - always returns `SequenceStyleGenerator`, never `IDENTITY`) and the ORM user guide's
-  "Interpreting AUTO" section. Leaving the strategy on `AUTO` means silently accepting whichever of those two Hibernate
-  picks for the current database, instead of a strategy the team has actually reviewed.
+- **Why it matters**: for numeric identifiers, `AUTO` never resolves to the database's native `IDENTITY`/auto-increment
+  column. Hibernate's `GeneratorBinder` always maps the JPA `AUTO` strategy to its own `SequenceStyleGenerator`, which
+  uses a real database `SEQUENCE` where the dialect supports one (PostgreSQL, Oracle, H2, SQL Server, ...) and falls back
+  to a slower, row-locking table-based emulation otherwise (e.g. MySQL, which has no native sequence object) - verified
+  directly against the current Hibernate ORM source (`correspondingGeneratorName(GenerationType)` in `GeneratorBinder`,
+  whose `default` case - covering `AUTO` - always returns `SequenceStyleGenerator`, never `IDENTITY`) and the ORM user
+  guide's "Interpreting AUTO" section. Leaving the strategy on `AUTO` means silently accepting whichever of those two
+  Hibernate picks for the current database, instead of a strategy the team has actually reviewed.
 - **Recommendation**: pick the strategy that fits the target database (for example `SEQUENCE` with `allocationSize` on
   Postgres/Oracle, `IDENTITY` only when truly required) and set it explicitly instead of relying on `AUTO`'s
   dialect-dependent sequence-or-table fallback.
+- **UUID identifiers**: skipped entirely - for a `UUID`-typed identifier, Hibernate 6 interprets `AUTO` as the
+  `UuidGenerator`, not a sequence, so this rule's "sequence-or-table fallback" rationale does not apply. HIB-ID-005 owns
+  the UUID case exclusively, so a `UUID @Id @GeneratedValue` with no explicit strategy is flagged only once, by
+  HIB-ID-005, with UUID-specific guidance instead of a misleading sequence/table warning.
 - **Quarkus/Panache**: skipped for the `id` field inherited as-is from Panache's own `PanacheEntity` (ORM or Reactive),
   which declares `@Id @GeneratedValue public Long id;` with no explicit strategy and cannot be annotated by the
   application. A custom identifier the application declares itself (including on a `PanacheEntityBase` subclass) is
@@ -154,12 +166,21 @@ includes up to a handful of sample mapped members plus a remediation link.
 ### HIB-ID-005 - UUID identifiers should use @UuidGenerator
 
 - **Severity**: LOW
-- **Inspects**: `UUID` identifier attributes annotated with `@GeneratedValue`.
+- **Inspects**: `UUID` identifier attributes annotated with `@GeneratedValue`, and the runtime Hibernate ORM version.
 - **Fires when**: the attribute is not also annotated with `@UuidGenerator`.
-- **Why it matters**: the JPA default generates random UUIDs (v4), which fragment B-tree indexes; Hibernate's
-  `@UuidGenerator(style = TIME)` yields index-friendly identifiers.
-- **Recommendation**: annotate UUID identifiers with `@UuidGenerator` and pick the style that matches the target
-  database.
+- **Why it matters**: the JPA default generates random UUIDs (v4), which fragment B-tree indexes.
+- **Recommendation (Hibernate 7.0+)**: annotate the identifier with `@UuidGenerator(style = VERSION_7)` (`VERSION_6` is
+  also acceptable). Both styles are monotonic, index-friendly UUID variants and only exist starting in Hibernate 7.0
+  (both `@Incubating`) - confirmed by diffing `UuidGenerator.java` between the 6.6 branch (only `AUTO`/`RANDOM`/`TIME`)
+  and the 7.0 branch (adds `VERSION_6`/`VERSION_7`).
+- **Recommendation (before Hibernate 7.0)**: `style = TIME` is the only style available. It produces an RFC 4122
+  **version 1** UUID (per `@UuidGenerator`'s own Javadoc: "time-based generation strategy consistent with RFC 4122
+  version 1, but with IP address instead of MAC address"), which places the fast-changing `time_low` field first and is
+  **not materially more index-friendly than a random (v4) UUID** - it does not yield the monotonic ordering that makes
+  `VERSION_6`/`VERSION_7` genuinely index-friendly. The recommendation is annotated with this caveat rather than
+  presenting `TIME` as a real fix.
+- **Version detection**: the runtime Hibernate ORM version is read from `HibernateContext`/`HibernateEntityModel` the
+  same way HIB-FETCH-003/HIB-CONFIG-016 gate their Hibernate-7.4 pagination behavior.
 
 ### HIB-ID-006 - GenerationType.IDENTITY disables JDBC batch inserts
 
@@ -171,6 +192,20 @@ includes up to a handful of sample mapped members plus a remediation link.
   preventing JDBC insert batching for those entities despite the configured batch size.
 - **Recommendation**: switch IDENTITY identifiers to `SEQUENCE` with a pooled `allocationSize` so Hibernate can batch
   inserts, or drop the JDBC batch-size expectation for these entities.
+
+### HIB-ID-007 - Composite identifier classes must satisfy the JPA contract
+
+- **Severity**: HIGH
+- **Inspects**: `@EmbeddedId` attribute types and `@IdClass` values (including inherited from a superclass).
+- **Fires when**: the composite identifier class is not `Serializable`, has no public no-arg constructor, or does not
+  override both `equals` and `hashCode`.
+- **Why it matters**: JPA and Hibernate require all four for a composite identifier class to work correctly - this is a
+  pure, deterministic contract check with essentially zero false-positive risk. Violating any of these can silently
+  break entity equality, second-level caching, and collection lookups.
+- **Recommendation**: make the composite identifier class implement `Serializable`, declare a public no-arg constructor,
+  and override both `equals` and `hashCode` over every identifier field.
+- **Quarkus/Panache**: applies identically - this check inspects only the identifier class via reflection, with no
+  framework-specific behavior.
 
 ## Mapping
 
@@ -260,15 +295,19 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Why it matters**: `Optional` is a return-type convenience, not a stable persistent attribute type.
 - **Recommendation**: map the underlying nullable type and expose `Optional` from a non-persistent getter if desired.
 
-### HIB-MAP-010 - @ElementCollection List should persist order
+### HIB-MAP-010 - @ElementCollection List should persist order with @OrderColumn
 
 - **Severity**: MEDIUM
 - **Inspects**: `@ElementCollection` attributes typed as `List`.
-- **Fires when**: the list has neither `@OrderColumn` nor `@OrderBy`.
-- **Why it matters**: without an ordering strategy, Hibernate treats any change to the list as a delete-and-reinsert of
-  the entire collection table.
-- **Recommendation**: add `@OrderColumn` for index-tracked lists or `@OrderBy` for query-time ordering, or switch the
-  attribute to a `Set`.
+- **Fires when**: the list does not declare `@OrderColumn` - regardless of whether it declares `@OrderBy`.
+- **Why it matters**: without `@OrderColumn`, Hibernate cannot compute a minimal diff on mutation and instead deletes and
+  reinserts the entire collection table. `@OrderBy` is **not** an equivalent fix: it only adds a query-time SQL
+  `ORDER BY` and is never persisted, so it does nothing to change this mutation behavior. The sibling rule HIB-MAP-004's
+  `isBagAttribute()` helper already treats only `@OrderColumn` as removing bag semantics and deliberately ignores
+  `@OrderBy`, so this rule now matches that same standard instead of presenting `@OrderBy` as an alternative.
+- **Recommendation**: add `@OrderColumn` to persist the list's index so Hibernate can update rows in place. `@OrderBy`
+  does not solve the mutation cost - keep it only if you also want read-time ordering, alongside `@OrderColumn`, not
+  instead of it. Otherwise prefer `Set<>` if insertion order does not matter.
 
 ### HIB-MAP-011 - Entity classes should not be final
 
@@ -418,10 +457,13 @@ includes up to a handful of sample mapped members plus a remediation link.
 ### HIB-ENTITY-005 - Persistent fields should not be public
 
 - **Severity**: LOW
-- **Inspects**: entity attributes reachable as public fields.
-- **Fires when**: a persistent field is `public`. A field annotated `@Transient` is never flagged - it is not
-  written to the database, so it carries none of the accessor-bypass risk this check targets (for example a public
-  `@Transient` flag field used by a hand-written `isNew()`/`Persistable` implementation).
+- **Inspects**: entity attributes backed by a `java.lang.reflect.Field` that is `public`.
+- **Fires when**: a field-access persistent field is `public`. A field annotated `@Transient` is never flagged - it is
+  not written to the database, so it carries none of the accessor-bypass risk this check targets (for example a public
+  `@Transient` flag field used by a hand-written `isNew()`/`Persistable` implementation). Property-access (getter-mapped)
+  attributes are never flagged either, even when the underlying getter method is `public` - the metamodel resolves those
+  attributes from a `Method`, not a `Field`, and public getters are the normal, fully JPA/Hibernate-instrumented way to
+  expose a property-access attribute.
 - **Why it matters**: public fields let callers bypass Hibernate's instrumentation for lazy loading and dirty tracking.
 - **Recommendation**: keep persistent fields private (or package-private) and expose mutators when needed; this
   preserves proxy substitution and bytecode-enhancer guarantees.
@@ -472,6 +514,21 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Recommendation**: add a `@Version` attribute (for example a `Long` or `Instant`) so concurrent updates fail fast with
   an optimistic-lock exception; skip this only for append-only, read-only, or reference data where lost updates cannot
   occur.
+
+### HIB-ENTITY-009 - Unique business-key columns should consider @NaturalId
+
+- **Severity**: INFO
+- **Inspects**: `@Column(unique = true)` attributes and entity-level `@Table(uniqueConstraints = @UniqueConstraint(...))`
+  declarations.
+- **Fires when**: a unique column exists and no attribute on the entity is annotated
+  `org.hibernate.annotations.NaturalId`.
+- **Why it matters**: a unique business key (email, ISBN, order number) is frequently queried by value.
+  `@NaturalId` lets Hibernate resolve the entity from the natural-id cache/lookup without needing a full JPQL query - a
+  well-documented performance pattern. This is advisory, not a defect: a unique column is not always a natural lookup
+  key, so the finding is INFO severity.
+- **Recommendation**: consider annotating the business-key attribute(s) with `@NaturalId` so lookups by that value can
+  use Hibernate's natural-id resolution instead of a full query.
+- **Quarkus/Panache**: applies identically - this check inspects only annotation metadata via reflection.
 
 ## Query
 
@@ -588,6 +645,13 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Fires when**: a positive batch size is configured but either ordering property is not `true`.
 - **Why it matters**: batches are grouped by SQL/table shape; interleaved entity types reduce batch efficiency.
 - **Recommendation**: enable both ordering properties when batching writes across multiple entity types.
+- **Quarkus**: `hibernate.order_inserts`/`hibernate.order_updates` have no first-class `quarkus.hibernate-orm.*`
+  equivalent, but `QuarkusHibernatePropertyLookup` falls back to Quarkus' generic
+  `quarkus.hibernate-orm.unsupported-properties."hibernate.order_inserts"` (and `"hibernate.order_updates"`) escape
+  hatch. A live-boot spike against `bootui-quarkus-integration-tests` confirmed this end to end: with
+  `quarkus.hibernate-orm.jdbc.statement-batch-size` and both `unsupported-properties` entries set, Hibernate's own
+  `SessionFactoryOptions.isOrderInsertsEnabled()`/`isOrderUpdatesEnabled()` both report `true` at runtime, and this
+  rule correctly does not fire.
 
 ### HIB-CONFIG-006 - Slow query logging should be available in development
 
@@ -605,6 +669,9 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Why it matters**: statistics expose query counts, fetch counts, and cache hit ratios useful during performance tuning.
 - **Recommendation**: enable statistics in development or performance-test profiles when investigating data-access
   behavior.
+- **Quarkus**: `hibernate.generate_statistics` maps to `quarkus.hibernate-orm.statistics` via
+  `QuarkusHibernatePropertyLookup`, so this rule no longer false-positives when statistics are enabled with the
+  native Quarkus property name.
 
 ### HIB-CONFIG-008 - Connection providers should disable auto-commit explicitly
 
@@ -625,6 +692,10 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Fires when**: such a query exists and `hibernate.query.in_clause_parameter_padding` is not enabled.
 - **Why it matters**: variable-length `IN` predicates can produce many SQL shapes and reduce plan-cache reuse.
 - **Recommendation**: enable IN-clause parameter padding when the database benefits from statement plan reuse.
+- **Quarkus**: `hibernate.query.in_clause_parameter_padding` maps to
+  `quarkus.hibernate-orm.query.in-clause-parameter-padding` via `QuarkusHibernatePropertyLookup`, so the property is
+  read correctly. The repository-scanning half of this rule only inspects Spring Data JPQL query methods, so it has
+  nothing to flag on a Panache-based Quarkus app regardless of the property value.
 
 ### HIB-CONFIG-010 - Query cache requires a second-level cache provider
 
@@ -635,6 +706,11 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Why it matters**: query caching depends on the second-level cache infrastructure and proper entity caching.
 - **Recommendation**: disable query caching or configure a region factory and cache entities returned by cacheable entity
   queries.
+- **Quarkus**: `hibernate.cache.use_query_cache` maps to `quarkus.hibernate-orm.second-level-caching-enabled` via
+  `QuarkusHibernatePropertyLookup` — Quarkus exposes a single unified toggle for second-level/query caching, not a
+  separate query-cache property, so both the query-cache and second-level-cache reads resolve to the same Quarkus
+  setting. `hibernate.cache.region.factory_class` has no first-class Quarkus equivalent but is still reachable via
+  the `unsupported-properties` fallback if explicitly configured.
 
 ### HIB-CONFIG-011 - Cacheable entities should declare an explicit cache strategy
 
@@ -644,6 +720,9 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Why it matters**: cache concurrency behavior should be explicit for cached entities.
 - **Recommendation**: add a Hibernate cache concurrency strategy, or remove `@Cacheable` when the entity should not use the
   second-level cache.
+- **Quarkus**: `hibernate.cache.use_second_level_cache` maps to the same
+  `quarkus.hibernate-orm.second-level-caching-enabled` toggle as HIB-CONFIG-010, so the precondition check for
+  "second-level caching appears configured" is read correctly on Quarkus too.
 
 ### HIB-CONFIG-002 - Schema generation should not mutate non-test databases
 
@@ -677,6 +756,9 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Fires when**: neither property is set.
 - **Why it matters**: without a fixed zone, JDBC binds and reads use the JVM default zone, so results vary across hosts.
 - **Recommendation**: pin `hibernate.jdbc.time_zone=UTC` (or another fixed zone) for deterministic timestamp handling.
+- **Quarkus**: `hibernate.jdbc.time_zone` maps to `quarkus.hibernate-orm.jdbc.timezone` via
+  `QuarkusHibernatePropertyLookup`, so this rule no longer false-positives when the zone is pinned with the native
+  Quarkus property name.
 
 ### HIB-CONFIG-014 - Hibernate's built-in connection pool should not be used
 
@@ -715,6 +797,9 @@ includes up to a handful of sample mapped members plus a remediation link.
   the generated SQL by default, so the in-memory blowup this safety net guards against no longer happens without opting
   back in via `org.hibernate.limitInMemory`. The check is skipped (not silently dropped) on 7.4+ runtimes, and the skip
   reason explains why.
+- **Quarkus**: `hibernate.query.fail_on_pagination_over_collection_fetch` maps to
+  `quarkus.hibernate-orm.query.fail-on-pagination-over-collection-fetch` via `QuarkusHibernatePropertyLookup`, so this
+  rule no longer false-positives when the safety net is enabled with the native Quarkus property name.
 
 ### HIB-CONFIG-017 - Disable SQL formatting in production
 
@@ -725,6 +810,20 @@ includes up to a handful of sample mapped members plus a remediation link.
   logging is disabled, so it is wasted work in production.
 - **Recommendation**: disable `hibernate.format_sql` in production profiles and keep it enabled only for local development
   where readable SQL helps.
+
+### HIB-CONFIG-018 - Bind-parameter logging should be off in production
+
+- **Severity**: HIGH
+- **Inspects**: TRACE-level logging for `org.hibernate.orm.jdbc.bind` (and the legacy
+  `org.hibernate.type.descriptor.sql.BasicBinder` binder logger), plus the active Spring/Quarkus profile.
+- **Fires when**: a production-like profile is active and bind-parameter logging is enabled at TRACE.
+- **Why it matters**: at TRACE, Hibernate logs every bound parameter value - this can leak PII, credentials, or tokens
+  passed as query parameters into application logs.
+- **Recommendation**: keep bind-parameter logging off in production; only enable it temporarily, in a non-production
+  environment, while diagnosing a specific issue.
+- **Quarkus**: also detects the Quarkus-native `quarkus.hibernate-orm.log.bind-parameters` convenience flag (and its
+  deprecated `.bind-param` alias), which `QuarkusHibernatePropertyLookup` reports as the neutral TRACE logger state -
+  Quarkus's own guide explicitly warns against enabling this in production.
 
 ## Caching
 


### PR DESCRIPTION
## Context

This is a second, deeper audit pass dedicated to the Hibernate advisor alone: **5 independent AI models** (Claude Opus 4.8, GPT-5.5, Gemini 3.1 Pro, GPT-5.3-Codex, Claude Sonnet 5) each independently audited the ruleset (56 rules at the time) against official Hibernate ORM/Quarkus/Spring Data docs, Vlad Mihalcea's blog, and Hibernate ORM's own GitHub source (one agent went as far as `javap`-decompiling the actual `quarkus-hibernate-orm-deployment-3.33.2.1.jar` to verify Quarkus property names). Findings were synthesized and prioritized by cross-model consensus and citation quality. The Hibernate advisor now has **69 rules**, up from 66.

## Fixes to existing rules

1. **[Unanimous 5/5 consensus — the single strongest finding] Quarkus property-lookup alias expansion.** `QuarkusHibernatePropertyLookup`'s `KEY_ALIASES` map was missing 7 confirmed-real Quarkus aliases, causing guaranteed false positives on Quarkus for operators who had correctly configured these settings using the native Quarkus property name:
   - `hibernate.default_batch_fetch_size` → `quarkus.hibernate-orm.fetch.batch-size` (fixes `HIB-FETCH-002`)
   - `hibernate.jdbc.time_zone` → `quarkus.hibernate-orm.jdbc.timezone` (fixes `HIB-CONFIG-013`)
   - `hibernate.generate_statistics` → `quarkus.hibernate-orm.statistics` (fixes `HIB-CONFIG-007`)
   - `hibernate.query.fail_on_pagination_over_collection_fetch` → matching Quarkus key (fixes `HIB-CONFIG-016`)
   - `hibernate.query.in_clause_parameter_padding` → matching Quarkus key (fixes `HIB-CONFIG-009`)
   - `hibernate.cache.use_query_cache` / `hibernate.cache.use_second_level_cache` → Quarkus' single unified `quarkus.hibernate-orm.second-level-caching-enabled` toggle (fixes `HIB-CONFIG-010`/`011`) — decompiling `HibernateProcessorUtil#configureCaching()` confirmed there is only ONE Quarkus property driving both, not two separate ones as one research report assumed.

   Also added a generic `quarkus.hibernate-orm.unsupported-properties."..."` fallback for keys with no first-class Quarkus option. The task asked for a live spike to validate whether `hibernate.order_inserts`/`order_updates` (`HIB-CONFIG-005`) are reachable this way — **I built and ran a live-boot integration test** (`BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest`, in the Docker-free `bootui-quarkus-integration-tests/hibernate` module) that configures both via the passthrough and asserts Hibernate's own `SessionFactoryOptions.isOrderInsertsEnabled()`/`isOrderUpdatesEnabled()` report `true` at runtime. **Confirmed working end-to-end** — the log even shows Quarkus's own `FastBootHibernatePersistenceProvider` applying the unsupported properties. Corrected the class Javadoc, which incorrectly claimed these properties had no Quarkus equivalent.

2. **`HIB-ID-004` double-reported every UUID-typed identifier alongside `HIB-ID-005`**, with a rationale that's factually wrong for UUID ids (AUTO resolves UUID ids to `UuidGenerator`, not a sequence). Now skips UUID-typed identifiers, leaving `HIB-ID-005` as the sole owner of that case.

3. **`HIB-ID-005`'s UUID remediation recommended `@UuidGenerator(style = TIME)` as "index-friendly" / "v6/v7-style"** — factually wrong; `TIME` is an RFC 4122 **v1** style with the same index-fragmentation problem as random UUIDs. The genuinely index-friendly `VERSION_6`/`VERSION_7` styles only exist starting Hibernate **7.0+** (confirmed by diffing `UuidGenerator.java` between the 6.6 and 7.0 branches). Remediation is now version-gated to the actual running Hibernate version.

4. **`HIB-ENTITY-005` false-positived on every property-access (getter-mapped) entity.** Its field-vs-method heuristic (`name().endsWith("()")`) only correctly distinguished fields from methods on the reflection-based scan path — the real `EntityManagerFactory`-metamodel path always reports the plain attribute name, even for a getter-backed property. Added an explicit `fieldMember` flag to `HibernateAttributeModel`, set only on the true field-access path, and switched the rule to key off it instead of the string-suffix heuristic.

5. **`HIB-MAP-010` incorrectly treated `@OrderBy` as an equally valid alternative to `@OrderColumn`.** `@OrderBy` only adds a query-time SQL `ORDER BY` — never persisted — so it doesn't fix the delete-and-reinsert-on-mutation problem this rule exists to catch (already inconsistent with the sibling `HIB-MAP-004` rule's own bag-detection logic, which correctly ignores `@OrderBy`). Removed the escape condition; reworded remediation to stop presenting `@OrderBy` as a fix.

6. **`HIB-FETCH-004` was over-broad**, firing on any entity merely *declaring* 2+ lazy bag collections — common and safe. The actual failure mode (`MultipleBagFetchException`) only happens when bags are *join-fetched together*, which is already precisely covered by `HIB-QUERY-007`. Downgraded from MEDIUM to INFO and reframed as a "review before you JOIN FETCH these together" reminder rather than a standing violation.

## New rules

- **`HIB-ID-007`** (HIGH) — composite identifier classes (`@EmbeddedId`/`@IdClass`) must be `Serializable`, expose a public no-arg constructor, and override both `equals`/`hashCode`. A pure JPA contract check with near-zero false-positive risk.
- **`HIB-CONFIG-018`** (HIGH) — bind-parameter logging (`org.hibernate.orm.jdbc.bind`/legacy binder logger at `TRACE`, or Quarkus' `quarkus.hibernate-orm.log.bind-parameters=true`) should not be left on in production; it can leak PII/credentials/tokens into application logs.
- **`HIB-ENTITY-009`** (INFO, advisory) — a unique business-key column (`@Column(unique = true)` or a `@Table` unique constraint) with no `@NaturalId`-annotated attribute is a missed lookup-performance opportunity.

A fourth proposed rule (bidirectional `@OneToMany` missing `mappedBy` creating an unintended extra join table) was investigated and found to be a **genuine duplicate** of the existing `HIB-MAP-001` — skipped.

## Testing

- Added/updated unit tests at both the property-lookup level (`QuarkusHibernatePropertyLookupTest`) and the rule level (`HibernateRulesTests`), including true-positive and true-negative fixtures for every fix and new rule.
- Added a new live-boot Quarkus integration test (`BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest`) proving the `unsupported-properties` passthrough for `order_inserts`/`order_updates` reaches Hibernate's real `SessionFactoryOptions`.
- `docs/HIBERNATE-CHECKS.md` fully updated — all 69 rule IDs cross-verified against code (zero mismatches either direction).
- `docs/FEATURES.md`'s Quarkus Hibernate section updated to reflect the expanded alias coverage.
- `./mvnw -pl bootui-core,bootui-engine -am test`: **1019/1019 passing**.
- `./mvnw -pl bootui-quarkus,bootui-quarkus-deployment -am install`: green.
- Full Quarkus integration-test reactor (all 12 submodules incl. `hibernate`, JDK 17): green.
- `SpringApiConformanceTest` (5/5) and `BootUiQuarkusApiConformanceTest` (5/5): green.
- `spotless:apply`/`spotless:check`: clean.

---
Audited by 5 independent AI models (Claude Opus 4.8, GPT-5.5, Gemini 3.1 Pro, GPT-5.3-Codex, Claude Sonnet 5) as part of a full advisor-ruleset audit.