### PR TITLE
Fix Vulnerabilities advisor: OSV severity/pagination correctness, EPSS enrichment, fix-availability signal

### DIFF
--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyVulnerabilityDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyVulnerabilityDto.java
@@ -4,6 +4,21 @@ import java.util.List;
 
 /**
  * One vulnerability advisory affecting a dependency.
+ *
+ * <p>{@code fixAvailable} is derived from comparing the dependency's currently-resolved version against
+ * {@code fixedVersions}: {@code true} when at least one fixed version is newer, {@code false} when
+ * {@code fixedVersions} is empty (the advisory was fetched successfully but no fix has been published
+ * upstream yet) &mdash; it exists so the UI can render an explicit "no fix yet" state instead of leaving an
+ * empty {@code fixedVersions} list ambiguous between "checked, no fix" and "unknown".
+ *
+ * <p>{@code epssScore}/{@code epssPercentile} are FIRST.org <a href="https://www.first.org/epss/">EPSS</a>
+ * (Exploit Prediction Scoring System) figures for a CVE-aliased advisory: the modeled probability (0-1)
+ * that the vulnerability will be exploited in the wild in the next 30 days, and the percentile that
+ * probability ranks against every other scored CVE. Both are {@code null} until a scan looks them up (only
+ * for advisories with a {@code CVE-*} alias), or when the lookup is disabled, fails, or finds no data for
+ * the CVE. CVSS ({@code severity}/{@code score}) measures severity-if-exploited; EPSS measures
+ * likelihood-of-exploitation &mdash; deliberately separate, complementary fields rather than one merged
+ * score.
  */
 public record DependencyVulnerabilityDto(
         String id,
@@ -14,8 +29,41 @@ public record DependencyVulnerabilityDto(
         List<String> aliases,
         List<String> references,
         List<String> fixedVersions,
+        boolean fixAvailable,
+        Double epssScore,
+        Double epssPercentile,
         boolean dismissed) {
 
+    public DependencyVulnerabilityDto(
+            String id,
+            String summary,
+            String details,
+            String severity,
+            Double score,
+            List<String> aliases,
+            List<String> references,
+            List<String> fixedVersions,
+            boolean fixAvailable) {
+        this(
+                id,
+                summary,
+                details,
+                severity,
+                score,
+                aliases,
+                references,
+                fixedVersions,
+                fixAvailable,
+                null,
+                null,
+                false);
+    }
+
+    /**
+     * Legacy convenience constructor for call sites (mostly tests) that don't need to set
+     * {@code fixAvailable} explicitly; it defaults to {@code false}, matching every existing caller, which
+     * also passes an empty {@code fixedVersions} list.
+     */
     public DependencyVulnerabilityDto(
             String id,
             String summary,
@@ -30,6 +78,33 @@ public record DependencyVulnerabilityDto(
 
     public DependencyVulnerabilityDto withDismissed(boolean dismissed) {
         return new DependencyVulnerabilityDto(
-                id, summary, details, severity, score, aliases, references, fixedVersions, dismissed);
+                id,
+                summary,
+                details,
+                severity,
+                score,
+                aliases,
+                references,
+                fixedVersions,
+                fixAvailable,
+                epssScore,
+                epssPercentile,
+                dismissed);
+    }
+
+    public DependencyVulnerabilityDto withEpss(Double epssScore, Double epssPercentile) {
+        return new DependencyVulnerabilityDto(
+                id,
+                summary,
+                details,
+                severity,
+                score,
+                aliases,
+                references,
+                fixedVersions,
+                fixAvailable,
+                epssScore,
+                epssPercentile,
+                dismissed);
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScore.java
@@ -33,11 +33,17 @@ import java.util.Map;
  * Score equation: scores are derived from a roughly 270-entry "MacroVector" lookup table (six equivalence
  * classes, each assigned by boolean conditions on the supplied metrics) with interpolation against
  * "highest/lowest severity vector" reference data from FIRST's non-public expert-elicitation study.
- * Reproducing that faithfully from the written specification alone &mdash; without executing FIRST's own
- * reference implementation &mdash; risks a silently-wrong score for a security-sensitive feature, so v4.0
- * vectors are not scored here. {@link DependencyReports#parseScore(String)} explicitly returns {@code null}
- * for {@code CVSS:4.x} vectors, and callers fall back to the {@code database_specific.severity} label for
- * those advisories.
+ * Reproducing that faithfully from the written specification alone risks a silently-wrong score for a
+ * security-sensitive feature, so v4.0 vectors are not scored here. Should a future contributor want to add
+ * v4.0 support, FIRST now publishes a reference implementation and test vectors in its
+ * <a href="https://github.com/FIRSTdotorg/cvss-resources">cvss-resources</a> repository, and independent
+ * community ports such as <a
+ * href="https://github.com/org-metaeffekt/metaeffekt-universal-cvss-calculator">org-metaeffekt/metaeffekt-universal-cvss-calculator</a>
+ * and <a href="https://github.com/pandatix/js-cvss">pandatix/js-cvss</a> exist to cross-check a from-scratch
+ * Java port against &mdash; but validating a new implementation against those is future work, not something
+ * this codebase does today. {@link DependencyReports#parseScore(String)} explicitly returns {@code null} for
+ * {@code CVSS:4.x} vectors, and callers fall back to the {@code database_specific.severity} label for those
+ * advisories.
  *
  * <p>CVSS v2 vectors (unprefixed, e.g. {@code "AV:N/AC:L/Au:N/C:P/I:P/A:P"}) are likewise not scored: the
  * format was superseded in 2015 and zero occurrences were found across a 170-advisory sample of real

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
@@ -7,6 +7,7 @@ import io.github.jdubois.bootui.core.dto.DependencySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -245,5 +246,97 @@ public final class DependencyReports {
                 (int) activeCount,
                 highestSeverity(markedVulnerabilities),
                 markedVulnerabilities);
+    }
+
+    /**
+     * Whether at least one of {@code fixedVersions} is newer than {@code currentVersion}, using the
+     * lightweight {@link MavenVersionComparator} (BootUI takes no dependency on Maven's own
+     * {@code ComparableVersion}). Backs {@link DependencyVulnerabilityDto#fixAvailable()}, which lets the UI
+     * distinguish "OSV reports no fix yet" ({@code fixedVersions} empty &mdash; this returns {@code false})
+     * from a genuine upgrade target.
+     *
+     * <p>An inconclusive per-version comparison (blank/unparseable input) is treated as "a fix is
+     * available": OSV positively reported a {@code fixed} event for this advisory, so failing to parse the
+     * version string is not grounds to hide that signal.
+     *
+     * @return {@code false} when {@code fixedVersions} is {@code null}/empty; otherwise {@code true} unless
+     *     every entry can be positively confirmed to be no newer than {@code currentVersion}
+     */
+    public static boolean fixAvailable(String currentVersion, List<String> fixedVersions) {
+        if (fixedVersions == null || fixedVersions.isEmpty()) {
+            return false;
+        }
+        for (String fixedVersion : fixedVersions) {
+            Integer compared = MavenVersionComparator.compare(currentVersion, fixedVersion);
+            if (compared == null || compared < 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Every distinct {@code CVE-*} alias referenced by any vulnerability across {@code dependencies},
+     * preserving first-seen order. Feeds an adapter's batched FIRST.org EPSS lookup (one request per scan,
+     * mirroring the OSV batch query) &mdash; EPSS is scored only per-CVE, so non-CVE aliases (bare
+     * {@code GHSA-*}/{@code OSV-*} ids with no CVE cross-reference) are not included.
+     */
+    public static List<String> cveAliases(List<DependencyDto> dependencies) {
+        Set<String> ids = new LinkedHashSet<>();
+        for (DependencyDto dependency : dependencies) {
+            for (DependencyVulnerabilityDto vulnerability : dependency.vulnerabilities()) {
+                for (String alias : vulnerability.aliases()) {
+                    if (alias != null && alias.startsWith("CVE-")) {
+                        ids.add(alias);
+                    }
+                }
+            }
+        }
+        return List.copyOf(ids);
+    }
+
+    /**
+     * Returns a copy of {@code dependencies} with each vulnerability's {@code epssScore}/{@code
+     * epssPercentile} set from the first of its {@code aliases} found in {@code epssByCve} &mdash; the
+     * counterpart to {@link #cveAliases} on the write side of the same adapter-fetched EPSS lookup. A
+     * vulnerability whose alias(es) have no entry in {@code epssByCve} (lookup disabled, failed, or the CVE
+     * has no published EPSS score) is returned unchanged, i.e. with {@code null} EPSS fields.
+     *
+     * @return {@code dependencies} unchanged if {@code epssByCve} is {@code null}/empty
+     */
+    public static List<DependencyDto> applyEpssScores(
+            List<DependencyDto> dependencies, Map<String, EpssScore> epssByCve) {
+        if (epssByCve == null || epssByCve.isEmpty()) {
+            return dependencies;
+        }
+        return dependencies.stream()
+                .map(dependency -> applyEpssScores(dependency, epssByCve))
+                .toList();
+    }
+
+    private static DependencyDto applyEpssScores(DependencyDto dependency, Map<String, EpssScore> epssByCve) {
+        List<DependencyVulnerabilityDto> updated = dependency.vulnerabilities().stream()
+                .map(vulnerability -> applyEpssScore(vulnerability, epssByCve))
+                .toList();
+        return new DependencyDto(
+                dependency.groupId(),
+                dependency.artifactId(),
+                dependency.version(),
+                dependency.packageName(),
+                dependency.source(),
+                dependency.vulnerabilityCount(),
+                dependency.highestSeverity(),
+                updated);
+    }
+
+    private static DependencyVulnerabilityDto applyEpssScore(
+            DependencyVulnerabilityDto vulnerability, Map<String, EpssScore> epssByCve) {
+        for (String alias : vulnerability.aliases()) {
+            EpssScore epssScore = epssByCve.get(alias);
+            if (epssScore != null) {
+                return vulnerability.withEpss(epssScore.probability(), epssScore.percentile());
+            }
+        }
+        return vulnerability;
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/EpssScore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/EpssScore.java
@@ -1,0 +1,13 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+/**
+ * One CVE's FIRST.org EPSS (Exploit Prediction Scoring System) figures, fetched by an adapter's
+ * {@code GET https://api.first.org/data/v1/epss?cve=...} call and applied back onto the matching
+ * {@link io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto} via
+ * {@link DependencyReports#applyEpssScores}. Not a DTO itself (never serialized directly) &mdash; just the
+ * engine-side carrier that keeps the adapter's JSON parsing decoupled from the DTO's field shape.
+ *
+ * @param probability the modeled probability (0.0-1.0) of exploitation in the next 30 days
+ * @param percentile the percentile (0.0-1.0) that probability ranks against every other scored CVE
+ */
+public record EpssScore(double probability, double percentile) {}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/MavenVersionComparator.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/MavenVersionComparator.java
@@ -1,0 +1,71 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import java.math.BigInteger;
+
+/**
+ * Minimal version comparator for Maven-style dotted version strings (e.g. {@code "2.17.1"}), used only to
+ * derive {@link DependencyReports#fixAvailable(String, java.util.List)} &mdash; whether at least one of an
+ * advisory's {@code fixedVersions} is newer than the dependency's currently-resolved version.
+ *
+ * <p>This is deliberately lightweight rather than a full implementation of Maven's own version-ordering
+ * rules (as in {@code org.apache.maven.artifact.versioning.ComparableVersion}, which BootUI does not
+ * depend on): each version is split on non-alphanumeric separators (typically {@code .} and {@code -}), and
+ * same-position segments are compared numerically when both are all-digit, falling back to a
+ * case-insensitive string compare otherwise, with a missing trailing segment treated as smaller (so
+ * {@code "1.2"} sorts below {@code "1.2.1"}). This handles the common case of plain dotted-numeric Maven
+ * versions correctly &mdash; including the classic lexical-compare bug where {@code "1.9"} would otherwise
+ * look "greater" than {@code "1.10"} &mdash; without attempting qualifier/pre-release precedence
+ * (`-alpha`/`-rc`/`-SNAPSHOT` ordering, etc).
+ */
+final class MavenVersionComparator {
+
+    private MavenVersionComparator() {}
+
+    /**
+     * @return a negative number, zero, or a positive number as {@code left} is older, equal to, or newer
+     *     than {@code right}; {@code null} if either version is blank (comparison not possible)
+     */
+    static Integer compare(String left, String right) {
+        if (left == null || left.isBlank() || right == null || right.isBlank()) {
+            return null;
+        }
+        String[] leftParts = left.trim().split("[.\\-_]");
+        String[] rightParts = right.trim().split("[.\\-_]");
+        int length = Math.max(leftParts.length, rightParts.length);
+        for (int i = 0; i < length; i++) {
+            String leftPart = i < leftParts.length ? leftParts[i] : "";
+            String rightPart = i < rightParts.length ? rightParts[i] : "";
+            int compared = compareSegment(leftPart, rightPart);
+            if (compared != 0) {
+                return compared;
+            }
+        }
+        return 0;
+    }
+
+    private static int compareSegment(String left, String right) {
+        boolean leftNumeric = isNumeric(left);
+        boolean rightNumeric = isNumeric(right);
+        if (leftNumeric && rightNumeric) {
+            return new BigInteger(left).compareTo(new BigInteger(right));
+        }
+        if (leftNumeric != rightNumeric) {
+            // A present numeric segment outranks a missing/non-numeric one at the same position -- this is
+            // what makes a shorter version (e.g. "1.2", trailing segment absent) sort below "1.2.1".
+            return leftNumeric ? 1 : -1;
+        }
+        return left.compareToIgnoreCase(right);
+    }
+
+    private static boolean isNumeric(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
@@ -6,6 +6,7 @@ import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
+import io.github.jdubois.bootui.engine.vulnerabilities.EpssScore;
 import io.github.jdubois.bootui.engine.vulnerabilities.VulnerabilityScanner;
 import java.io.IOException;
 import java.net.URI;
@@ -16,11 +17,16 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * Queries OSV.dev for known vulnerabilities affecting the application's Maven dependencies — the Quarkus
@@ -28,12 +34,14 @@ import java.util.Set;
  *
  * <p>It is a faithful port: same OSV protocol ({@code POST /v1/querybatch} for the Maven-ecosystem package
  * queries, then {@code GET /v1/vulns/{id}} per advisory), same bounded limits, same status taxonomy
- * ({@code SCANNED} / {@code PARTIAL} when package or advisory limits truncate the results or one or more
- * individual advisory fetches fail / {@code ERROR} preserving the local inventory only when the initial
- * batch query itself fails), the same withdrawn-advisory filtering, and the same delegation of all
- * aggregation/ordering to the framework-neutral engine {@link DependencyReports}. The only deltas from the
- * Spring source are the JSON library — <strong>Jackson 2</strong> ({@code com.fasterxml.jackson}, provided
- * by {@code quarkus-rest-jackson}) instead of Spring Boot 4's Jackson 3 ({@code tools.jackson}), so
+ * ({@code SCANNED} / {@code PARTIAL} when package or advisory limits truncate the results, OSV pagination
+ * hits its safety bound, or one or more individual advisory fetches fail / {@code ERROR} preserving the
+ * local inventory only when the initial batch query itself fails), the same withdrawn-advisory filtering,
+ * package-level-severity preference, {@code /v1/querybatch} pagination and hard 1,000-query batch-size
+ * partitioning, FIRST.org EPSS enrichment, and fix-availability derivation, delegating all
+ * aggregation/ordering/shaping to the framework-neutral engine {@link DependencyReports}. The only deltas
+ * from the Spring source are the JSON library — <strong>Jackson 2</strong> ({@code com.fasterxml.jackson},
+ * provided by {@code quarkus-rest-jackson}) instead of Spring Boot 4's Jackson 3 ({@code tools.jackson}), so
  * {@code JsonNode.asText()} replaces {@code asString()} — and that settings come from a
  * {@link QuarkusVulnerabilitySettings} record rather than {@code BootUiProperties}. It uses the JDK
  * {@link HttpClient}, so no framework HTTP type leaks in.</p>
@@ -44,6 +52,39 @@ import java.util.Set;
  */
 public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
+    /** OSV.dev's hard per-request cap on the number of queries in one {@code /v1/querybatch} call; a
+     * larger batch is rejected with HTTP 400 for the request as a whole, so the (already {@code
+     * maxPackages}-bounded) package list is partitioned into chunks at most this large. */
+    private static final int MAX_QUERYBATCH_SIZE = 1000;
+
+    /**
+     * Safety bound on OSV {@code /v1/querybatch} pagination rounds per chunk, guarding against an
+     * unbounded {@code next_page_token} chain from a misbehaving or adversarial base URI. Real OSV.dev
+     * pagination triggers only when an individual query matches more than 1,000 vulnerabilities or a batch
+     * matches more than 3,000 total, and resolves in a handful of rounds; if this bound is hit, the
+     * affected query's results are used as far as they were fetched and the scan degrades to
+     * {@code PARTIAL} rather than looping forever.
+     */
+    private static final int MAX_QUERY_BATCH_PAGES = 20;
+
+    /**
+     * Maximum CVE ids per FIRST.org EPSS request. EPSS's own {@code limit} query parameter caps how many
+     * rows come back in one response (default 100, independent of how many CVEs were queried) -- each
+     * request pins {@code limit} to the chunk size so nothing is silently dropped, while chunking keeps
+     * the query string a reasonable length and matches the default {@code maxAdvisories}, keeping the
+     * common case to one request.
+     */
+    private static final int EPSS_CHUNK_SIZE = 200;
+
+    /**
+     * Bound on how many {@code GET /v1/vulns/{id}} advisory-detail requests run concurrently. OSV.dev
+     * documents no rate limit, but fetching hundreds of distinct advisories one at a time -- fully
+     * sequential, one blocking call at a time -- meant a scan with many advisories could take up to
+     * {@code maxAdvisories} times the request timeout in a bad-network scenario. A small fixed pool keeps
+     * the fan-out bounded and predictable rather than opening one thread per advisory.
+     */
+    private static final int ADVISORY_FETCH_CONCURRENCY = 10;
+
     private final QuarkusVulnerabilitySettings settings;
 
     private final HttpClient httpClient;
@@ -51,6 +92,8 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private final ObjectMapper objectMapper;
 
     private final URI baseUri;
+
+    private final URI epssBaseUri;
 
     public OsvVulnerabilityScanner(QuarkusVulnerabilitySettings settings) {
         this(
@@ -68,20 +111,43 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
         this.baseUri = baseUri;
+        this.epssBaseUri = URI.create(settings.epssBaseUri());
     }
 
+    URI epssBaseUri() {
+        return epssBaseUri;
+    }
+
+    /**
+     * Reference {@code type} values (OSV schema) preferred, in order, as the canonical link for an
+     * advisory: {@code ADVISORY} is the advisory's own page, {@code FIX} is the next-most-authoritative
+     * (a commit/PR that fixed it), and every other type (WEB, REPORT, ARTICLE, ...) sorts after, in the
+     * order OSV returned them. This only reorders the list so {@code references.get(0)} &mdash; the link
+     * the UI renders the advisory id as &mdash; is the most canonical one available; the {@code type} field
+     * itself is not threaded through to the DTO.
+     */
+    private static final List<String> REFERENCE_TYPE_PRIORITY = List.of("ADVISORY", "FIX");
+
     private static List<String> references(JsonNode references) {
-        List<String> values = new ArrayList<>();
         if (!references.isArray()) {
-            return values;
+            return List.of();
         }
-        for (JsonNode reference : references) {
+        List<JsonNode> ordered = new ArrayList<>();
+        references.forEach(ordered::add);
+        ordered.sort(Comparator.comparingInt(reference -> referenceTypeRank(text(reference, "type"))));
+        List<String> values = new ArrayList<>();
+        for (JsonNode reference : ordered) {
             String url = text(reference, "url");
             if (url != null) {
                 values.add(url);
             }
         }
         return values.stream().distinct().limit(20).toList();
+    }
+
+    private static int referenceTypeRank(String type) {
+        int index = REFERENCE_TYPE_PRIORITY.indexOf(type);
+        return index >= 0 ? index : REFERENCE_TYPE_PRIORITY.size();
     }
 
     private static List<String> fixedVersions(JsonNode affected, String packageName) {
@@ -145,13 +211,27 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return text == null || text.isBlank() ? null : text;
     }
 
-    private static String scanMessage(boolean limited, int failedFetches) {
-        if (!limited && failedFetches == 0) {
+    private static Double parseDouble(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private static String scanMessage(boolean limited, boolean paginationTruncated, int failedFetches) {
+        if (!limited && !paginationTruncated && failedFetches == 0) {
             return "Scan completed against OSV.dev.";
         }
         List<String> reasons = new ArrayList<>();
         if (limited) {
             reasons.add("configured package or advisory limits were applied");
+        }
+        if (paginationTruncated) {
+            reasons.add("some advisories were paginated and not fully fetched");
         }
         if (failedFetches > 0) {
             reasons.add(failedFetches + (failedFetches == 1 ? " advisory fetch failed" : " advisory fetches failed"));
@@ -169,14 +249,22 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
         }
         try {
-            Map<String, List<String>> vulnerabilityIds = queryBatch(packages);
+            QueryBatchResult queryResult = queryBatch(packages);
+            Map<String, List<String>> vulnerabilityIds = queryResult.idsByPackage();
             VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
             List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
+            enriched = applyEpss(enriched);
             boolean limited = packages.size() < dependencies.size()
                     || uniqueIds(vulnerabilityIds).size() > Math.max(1, settings.maxAdvisories());
-            String status = limited || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";
+            String status =
+                    limited || queryResult.paginationTruncated() || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";
             return DependencyReports.report(
-                    true, status, scanMessage(limited, fetched.failedFetches()), scannedAt, packages.size(), enriched);
+                    true,
+                    status,
+                    scanMessage(limited, queryResult.paginationTruncated(), fetched.failedFetches()),
+                    scannedAt,
+                    packages.size(),
+                    enriched);
         } catch (IOException ex) {
             return DependencyReports.report(
                     true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
@@ -187,13 +275,89 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
     }
 
-    private Map<String, List<String>> queryBatch(List<DependencyDto> dependencies)
+    /**
+     * The result of one or more {@code /v1/querybatch} calls: the vulnerability ids found for each queried
+     * package, and whether any query's results were truncated because pagination exceeded
+     * {@link #MAX_QUERY_BATCH_PAGES} (which the scan reports as {@code PARTIAL} rather than presenting an
+     * incomplete result set as complete).
+     */
+    private record QueryBatchResult(Map<String, List<String>> idsByPackage, boolean paginationTruncated) {}
+
+    /** One outstanding OSV query awaiting a further page of results. */
+    private record PendingQuery(DependencyDto dependency, String pageToken) {}
+
+    private QueryBatchResult queryBatch(List<DependencyDto> dependencies) throws IOException, InterruptedException {
+        Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
+        boolean paginationTruncated = false;
+        for (int start = 0; start < dependencies.size(); start += MAX_QUERYBATCH_SIZE) {
+            List<DependencyDto> chunk =
+                    dependencies.subList(start, Math.min(dependencies.size(), start + MAX_QUERYBATCH_SIZE));
+            QueryBatchResult chunkResult = queryBatchChunk(chunk);
+            idsByPackage.putAll(chunkResult.idsByPackage());
+            paginationTruncated = paginationTruncated || chunkResult.paginationTruncated();
+        }
+        return new QueryBatchResult(idsByPackage, paginationTruncated);
+    }
+
+    /**
+     * Queries OSV for one chunk of at most {@link #MAX_QUERYBATCH_SIZE} dependencies, following each
+     * query's own {@code next_page_token} (per the
+     * <a href="https://google.github.io/osv.dev/post-v1-querybatch/">querybatch pagination contract</a>)
+     * until every query is exhausted or {@link #MAX_QUERY_BATCH_PAGES} rounds have elapsed.
+     */
+    private QueryBatchResult queryBatchChunk(List<DependencyDto> dependencies)
             throws IOException, InterruptedException {
-        List<Map<String, Object>> queries = new ArrayList<>();
+        Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
         for (DependencyDto dependency : dependencies) {
-            queries.add(Map.of(
-                    "package", Map.of("ecosystem", "Maven", "name", dependency.packageName()),
-                    "version", dependency.version()));
+            idsByPackage.put(key(dependency), new ArrayList<>());
+        }
+        List<PendingQuery> pending = dependencies.stream()
+                .map(dependency -> new PendingQuery(dependency, null))
+                .toList();
+        boolean paginationTruncated = false;
+        int page = 0;
+        while (!pending.isEmpty()) {
+            if (page >= MAX_QUERY_BATCH_PAGES) {
+                paginationTruncated = true;
+                break;
+            }
+            JsonNode results = queryBatchRequest(pending);
+            List<PendingQuery> nextPending = new ArrayList<>();
+            for (int i = 0; i < pending.size(); i++) {
+                PendingQuery query = pending.get(i);
+                JsonNode result = results.path(i);
+                List<String> ids = idsByPackage.get(key(query.dependency()));
+                JsonNode vulns = result.path("vulns");
+                if (vulns.isArray()) {
+                    for (JsonNode vulnerability : vulns) {
+                        String id = text(vulnerability, "id");
+                        if (id != null) {
+                            ids.add(id);
+                        }
+                    }
+                }
+                String nextPageToken = text(result, "next_page_token");
+                if (nextPageToken != null) {
+                    nextPending.add(new PendingQuery(query.dependency(), nextPageToken));
+                }
+            }
+            pending = nextPending;
+            page++;
+        }
+        return new QueryBatchResult(idsByPackage, paginationTruncated);
+    }
+
+    private JsonNode queryBatchRequest(List<PendingQuery> pending) throws IOException, InterruptedException {
+        List<Map<String, Object>> queries = new ArrayList<>();
+        for (PendingQuery query : pending) {
+            DependencyDto dependency = query.dependency();
+            Map<String, Object> queryBody = new LinkedHashMap<>();
+            queryBody.put("package", Map.of("ecosystem", "Maven", "name", dependency.packageName()));
+            queryBody.put("version", dependency.version());
+            if (query.pageToken() != null) {
+                queryBody.put("page_token", query.pageToken());
+            }
+            queries.add(queryBody);
         }
         String body = objectMapper.writeValueAsString(Map.of("queries", queries));
         HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("/v1/querybatch"))
@@ -206,55 +370,75 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             throw new IOException("OSV query returned HTTP " + response.statusCode());
         }
-
-        JsonNode results = objectMapper.readTree(response.body()).path("results");
-        Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
-        for (int i = 0; i < dependencies.size(); i++) {
-            DependencyDto dependency = dependencies.get(i);
-            List<String> ids = new ArrayList<>();
-            JsonNode result = results.path(i).path("vulns");
-            if (result.isArray()) {
-                for (JsonNode vulnerability : result) {
-                    String id = text(vulnerability, "id");
-                    if (id != null) {
-                        ids.add(id);
-                    }
-                }
-            }
-            idsByPackage.put(key(dependency), ids);
-        }
-        return idsByPackage;
+        return objectMapper.readTree(response.body()).path("results");
     }
 
+    /**
+     * Fetches every distinct advisory's detail, fanned out across a small bounded thread pool instead of
+     * one blocking call at a time. The lookup {@link Map} this returns is keyed by advisory id and is
+     * always re-sorted downstream ({@link DependencyReports#VULNERABILITY_ORDER} in {@link #enrich}), so
+     * the order advisories finish fetching in has no effect on the final result -- only the id set and
+     * failure count matter, both of which are order-independent to compute.
+     */
     private VulnerabilityFetchResult fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
             throws InterruptedException {
-        Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
-        int failedFetches = 0;
-        for (String id : uniqueIds(vulnerabilityIds).stream()
+        List<String> ids = uniqueIds(vulnerabilityIds).stream()
                 .limit(Math.max(1, settings.maxAdvisories()))
-                .toList()) {
-            JsonNode vulnerability;
-            try {
-                vulnerability = fetchVulnerability(id);
-            } catch (IOException ex) {
-                // A single flaky/rate-limited/malformed advisory fetch shouldn't discard every other
-                // advisory already fetched successfully; count it and degrade to PARTIAL instead of
-                // aborting the whole scan to ERROR. (Jackson 2's JsonProcessingException already extends
-                // IOException, so a malformed-JSON response is covered by this same catch.)
-                failedFetches++;
-                continue;
-            }
-            if (isWithdrawn(vulnerability)) {
-                // A withdrawn OSV record is no longer considered a valid finding; OSV does not filter
-                // these out of query results itself, so consumers must.
-                continue;
-            }
-            String vulnerabilityId = text(vulnerability, "id");
-            if (vulnerabilityId != null) {
-                vulnerabilities.put(vulnerabilityId, vulnerability);
-            }
+                .toList();
+        if (ids.isEmpty()) {
+            return new VulnerabilityFetchResult(Map.of(), 0);
         }
-        return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
+        ExecutorService executor = Executors.newFixedThreadPool(Math.min(ADVISORY_FETCH_CONCURRENCY, ids.size()));
+        try {
+            List<Future<JsonNode>> futures = new ArrayList<>(ids.size());
+            for (String id : ids) {
+                futures.add(executor.submit(() -> fetchVulnerabilityOrNull(id)));
+            }
+            Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
+            int failedFetches = 0;
+            for (Future<JsonNode> future : futures) {
+                JsonNode vulnerability;
+                try {
+                    vulnerability = future.get();
+                } catch (ExecutionException ex) {
+                    // Only fetchVulnerabilityOrNull's own (already-handled) failures reach here as a
+                    // null result; an ExecutionException means the task itself threw unexpectedly.
+                    failedFetches++;
+                    continue;
+                }
+                if (vulnerability == null) {
+                    // A single flaky/rate-limited/malformed advisory fetch shouldn't discard every other
+                    // advisory already fetched successfully; count it and degrade to PARTIAL instead of
+                    // aborting the whole scan to ERROR. (Jackson 2's JsonProcessingException already
+                    // extends IOException, so a malformed-JSON response is covered by the same path.)
+                    failedFetches++;
+                    continue;
+                }
+                if (isWithdrawn(vulnerability)) {
+                    // A withdrawn OSV record is no longer considered a valid finding; OSV does not filter
+                    // these out of query results itself, so consumers must.
+                    continue;
+                }
+                String vulnerabilityId = text(vulnerability, "id");
+                if (vulnerabilityId != null) {
+                    vulnerabilities.put(vulnerabilityId, vulnerability);
+                }
+            }
+            return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private JsonNode fetchVulnerabilityOrNull(String id) {
+        try {
+            return fetchVulnerability(id);
+        } catch (IOException ex) {
+            return null;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
     }
 
     private JsonNode fetchVulnerability(String id) throws IOException, InterruptedException {
@@ -283,7 +467,8 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
     private DependencyVulnerabilityDto vulnerability(JsonNode node, DependencyDto dependency) {
         String id = text(node, "id");
-        Severity severity = severity(node);
+        Severity severity = severity(node, dependency.packageName());
+        List<String> fixedVersions = fixedVersions(node.path("affected"), dependency.packageName());
         return new DependencyVulnerabilityDto(
                 id,
                 text(node, "summary"),
@@ -292,7 +477,8 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 severity.score(),
                 stringArray(node.path("aliases")),
                 references(node.path("references")),
-                fixedVersions(node.path("affected"), dependency.packageName()));
+                fixedVersions,
+                DependencyReports.fixAvailable(dependency.version(), fixedVersions));
     }
 
     private List<DependencyDto> enrich(
@@ -321,24 +507,126 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return enriched;
     }
 
-    private Severity severity(JsonNode node) {
+    /**
+     * Resolves a vulnerability's severity, preferring a package-scoped entry over the top-level one.
+     *
+     * <p>Per the <a href="https://ossf.github.io/osv-schema/#severity">OSV schema</a>, {@code
+     * affected[].severity} applies to one specific package and "if any package level severity fields are
+     * set, the top level severity field MUST NOT be set" -- so an advisory can carry severity that only
+     * shows up once the affected package is known. Ignoring it (as the top-level-only lookup used to)
+     * silently misses or under-ranks the CVSS for any advisory that only publishes package-level severity.
+     */
+    private Severity severity(JsonNode node, String packageName) {
+        Severity fromPackage = severityFromArray(packageSeverityArray(node.path("affected"), packageName));
+        if (fromPackage != null) {
+            return fromPackage;
+        }
+        Severity fromTopLevel = severityFromArray(node.path("severity"));
+        if (fromTopLevel != null) {
+            return fromTopLevel;
+        }
         String databaseSeverity = text(node.path("database_specific"), "severity");
-        String normalized = DependencyReports.normalizeSeverity(databaseSeverity);
-        Double score = null;
-        JsonNode severities = node.path("severity");
-        if (severities.isArray()) {
-            for (JsonNode severityNode : severities) {
-                String value = text(severityNode, "score");
-                Double parsed = DependencyReports.parseScore(value);
-                if (parsed != null) {
-                    score = parsed;
-                    normalized = DependencyReports.normalizeSeverity(parsed);
-                    break;
-                }
+        return new Severity(DependencyReports.normalizeSeverity(databaseSeverity), null);
+    }
+
+    /**
+     * The first non-empty {@code severity[]} array among {@code affected[]} entries matching {@code
+     * packageName} (Maven ecosystem), or {@code null} if none carries package-level severity.
+     */
+    private static JsonNode packageSeverityArray(JsonNode affected, String packageName) {
+        if (!affected.isArray()) {
+            return null;
+        }
+        for (JsonNode item : affected) {
+            JsonNode pkg = item.path("package");
+            if (!"Maven".equals(text(pkg, "ecosystem")) || !packageName.equals(text(pkg, "name"))) {
+                continue;
+            }
+            JsonNode severity = item.path("severity");
+            if (severity.isArray() && !severity.isEmpty()) {
+                return severity;
             }
         }
-        return new Severity(normalized, score);
+        return null;
+    }
+
+    private static Severity severityFromArray(JsonNode severities) {
+        if (severities == null || !severities.isArray()) {
+            return null;
+        }
+        for (JsonNode severityNode : severities) {
+            String value = text(severityNode, "score");
+            Double parsed = DependencyReports.parseScore(value);
+            if (parsed != null) {
+                return new Severity(DependencyReports.normalizeSeverity(parsed), parsed);
+            }
+        }
+        return null;
     }
 
     private record Severity(String label, Double score) {}
+
+    /**
+     * Enriches CVE-aliased vulnerabilities with FIRST.org EPSS exploit-probability scores, one batched
+     * request per distinct CVE set per scan (mirroring the existing OSV batch-query pattern). EPSS is a
+     * best-effort secondary signal layered on top of the OSV-derived results: any failure (disabled,
+     * network error, malformed response) leaves the affected vulnerabilities without EPSS fields and never
+     * changes the scan's status or message -- only OSV outcomes do that.
+     */
+    private List<DependencyDto> applyEpss(List<DependencyDto> dependencies) {
+        if (!settings.epssEnabled()) {
+            return dependencies;
+        }
+        List<String> cveIds = DependencyReports.cveAliases(dependencies);
+        if (cveIds.isEmpty()) {
+            return dependencies;
+        }
+        Map<String, EpssScore> epssByCve = fetchEpssScores(cveIds);
+        return DependencyReports.applyEpssScores(dependencies, epssByCve);
+    }
+
+    private Map<String, EpssScore> fetchEpssScores(List<String> cveIds) {
+        Map<String, EpssScore> scores = new LinkedHashMap<>();
+        for (int start = 0; start < cveIds.size(); start += EPSS_CHUNK_SIZE) {
+            List<String> chunk = cveIds.subList(start, Math.min(cveIds.size(), start + EPSS_CHUNK_SIZE));
+            try {
+                scores.putAll(fetchEpssChunk(chunk));
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (IOException ex) {
+                // EPSS is a best-effort enrichment on top of the OSV scan; stop trying further chunks but
+                // keep whatever scores were already fetched rather than failing the scan. (Jackson 2's
+                // JsonProcessingException already extends IOException.)
+                break;
+            }
+        }
+        return scores;
+    }
+
+    private Map<String, EpssScore> fetchEpssChunk(List<String> cveIds) throws IOException, InterruptedException {
+        String query = "cve=" + String.join(",", cveIds) + "&limit=" + cveIds.size();
+        HttpRequest request = HttpRequest.newBuilder(epssBaseUri.resolve("/data/v1/epss?" + query))
+                .timeout(settings.requestTimeout())
+                .GET()
+                .build();
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("EPSS query returned HTTP " + response.statusCode());
+        }
+        JsonNode data = objectMapper.readTree(response.body()).path("data");
+        Map<String, EpssScore> scores = new LinkedHashMap<>();
+        if (data.isArray()) {
+            for (JsonNode entry : data) {
+                String cve = text(entry, "cve");
+                Double probability = parseDouble(text(entry, "epss"));
+                Double percentile = parseDouble(text(entry, "percentile"));
+                if (cve != null && probability != null && percentile != null) {
+                    scores.put(cve, new EpssScore(probability, percentile));
+                }
+            }
+        }
+        return scores;
+    }
 }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusVulnerabilitySettings.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusVulnerabilitySettings.java
@@ -15,10 +15,19 @@ import org.eclipse.microprofile.config.Config;
  * endpoint and is overridable (notably so the integration test can point it at a loopback stub).</p>
  */
 public record QuarkusVulnerabilitySettings(
-        boolean osvEnabled, Duration requestTimeout, int maxPackages, int maxAdvisories, String baseUri) {
+        boolean osvEnabled,
+        Duration requestTimeout,
+        int maxPackages,
+        int maxAdvisories,
+        String baseUri,
+        boolean epssEnabled,
+        String epssBaseUri) {
 
     /** Public OSV.dev API endpoint. */
     public static final String DEFAULT_BASE_URI = "https://api.osv.dev";
+
+    /** Public FIRST.org EPSS API endpoint. */
+    public static final String DEFAULT_EPSS_BASE_URI = "https://api.first.org";
 
     public static QuarkusVulnerabilitySettings from(Config config) {
         return new QuarkusVulnerabilitySettings(
@@ -31,6 +40,10 @@ public record QuarkusVulnerabilitySettings(
                 config.getOptionalValue("bootui.vulnerabilities.max-advisories", Integer.class)
                         .orElse(200),
                 config.getOptionalValue("bootui.vulnerabilities.osv-base-uri", String.class)
-                        .orElse(DEFAULT_BASE_URI));
+                        .orElse(DEFAULT_BASE_URI),
+                config.getOptionalValue("bootui.vulnerabilities.epss-enabled", Boolean.class)
+                        .orElse(Boolean.TRUE),
+                config.getOptionalValue("bootui.vulnerabilities.epss-base-uri", String.class)
+                        .orElse(DEFAULT_EPSS_BASE_URI));
     }
 }

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
@@ -50,7 +50,11 @@ class OsvVulnerabilityScannerTest {
     }
 
     private QuarkusVulnerabilitySettings settings(int maxPackages, int maxAdvisories) {
-        return new QuarkusVulnerabilitySettings(true, Duration.ofSeconds(5), maxPackages, maxAdvisories, baseUri);
+        // epssBaseUri intentionally points at the same loopback stub as baseUri: unless a test registers
+        // a "/data/v1/epss" context, the request 404s and EPSS enrichment fails silently (by design), so
+        // it never reaches the real network during tests.
+        return new QuarkusVulnerabilitySettings(
+                true, Duration.ofSeconds(5), maxPackages, maxAdvisories, baseUri, true, baseUri);
     }
 
     private OsvVulnerabilityScanner scanner(int maxPackages, int maxAdvisories) {
@@ -70,12 +74,32 @@ class OsvVulnerabilityScannerTest {
         try (InputStream in = exchange.getRequestBody()) {
             in.readAllBytes();
         }
+        writeResponse(exchange, status, body);
+    }
+
+    /**
+     * Writes a response without touching the request body — for handlers that already fully drained
+     * {@link HttpExchange#getRequestBody()} themselves (e.g. to inspect the request to build a dynamic
+     * response). Calling {@link HttpExchange#getRequestBody()} a second time after the stream was already
+     * read and closed once causes {@code com.sun.net.httpserver.HttpServer} to abort the exchange without
+     * ever sending a response, surfacing on the client as a spurious
+     * "HTTP/1.1 header parser received no bytes" failure — so those handlers must call this method instead
+     * of {@link #respond(HttpExchange, int, String)}.
+     */
+    private void writeResponse(HttpExchange exchange, int status, String body) throws IOException {
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
         exchange.getResponseHeaders().add("Content-Type", "application/json");
+        // Force the client to open a fresh connection per request instead of reusing a keep-alive one:
+        // com.sun.net.httpserver.HttpServer intermittently corrupts response framing for a second
+        // request reusing the same persistent connection, surfacing as a client-side
+        // "HTTP/1.1 header parser received no bytes" failure (observed with back-to-back querybatch
+        // chunk requests). This is a test-stub-only workaround; OSV.dev's real server is unaffected.
+        exchange.getResponseHeaders().add("Connection", "close");
         exchange.sendResponseHeaders(status, bytes.length);
         try (OutputStream out = exchange.getResponseBody()) {
             out.write(bytes);
         }
+        exchange.close();
     }
 
     private static int severityCount(DependenciesReport report, String severity) {
@@ -297,5 +321,316 @@ class OsvVulnerabilityScannerTest {
         assertThat(report.dependencies().get(0).vulnerabilities())
                 .extracting(DependencyVulnerabilityDto::id)
                 .containsExactly("V-OK");
+    }
+
+    @Test
+    void prefersPackageLevelSeverityOverTopLevelSeverity() {
+        // Per the OSV schema, affected[].severity applies to one specific package and, when present,
+        // supersedes the top-level severity[] field. This advisory carries a MEDIUM top-level score and a
+        // CRITICAL package-level score for the queried package -- the package-level one must win.
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-pkg-sev\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-pkg-sev",
+                "{\"id\":\"GHSA-pkg-sev\","
+                        + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N\"}],"
+                        + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"},"
+                        + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"}]}]}");
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        DependencyVulnerabilityDto vulnerability =
+                report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
+        assertThat(vulnerability.score()).isEqualTo(9.8d);
+    }
+
+    @Test
+    void fallsBackToTopLevelSeverityWhenAffectedEntryHasNoPackageLevelSeverity() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-no-pkg-sev\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-no-pkg-sev",
+                "{\"id\":\"GHSA-no-pkg-sev\","
+                        + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N\"}],"
+                        + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"}}]}");
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        DependencyVulnerabilityDto vulnerability =
+                report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.severity()).isEqualTo("MEDIUM");
+        assertThat(vulnerability.score()).isEqualTo(5.4d);
+    }
+
+    @Test
+    void followsOsvQuerybatchPaginationUntilNextPageTokenIsAbsent() {
+        server.createContext("/v1/querybatch", exchange -> {
+            int call = queryBatchCalls.getAndIncrement();
+            if (call == 0) {
+                respond(
+                        exchange,
+                        200,
+                        "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-page-1\"}],\"next_page_token\":\"p2\"}]}");
+            } else {
+                respond(exchange, 200, "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-page-2\"}]}]}");
+            }
+        });
+        handle("/v1/vulns/GHSA-page-1", "{\"id\":\"GHSA-page-1\",\"database_specific\":{\"severity\":\"HIGH\"}}");
+        handle("/v1/vulns/GHSA-page-2", "{\"id\":\"GHSA-page-2\",\"database_specific\":{\"severity\":\"LOW\"}}");
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        // Both pages must be merged into the final result, and pagination completing within the safety
+        // bound must not degrade the scan status.
+        assertThat(report.status()).isEqualTo("SCANNED");
+        assertThat(queryBatchCalls.get()).isEqualTo(2);
+        assertThat(report.dependencies().get(0).vulnerabilities())
+                .extracting(DependencyVulnerabilityDto::id)
+                .containsExactlyInAnyOrder("GHSA-page-1", "GHSA-page-2");
+    }
+
+    @Test
+    void degradesToPartialWhenOsvPaginationExceedsTheSafetyBound() {
+        // A misbehaving/adversarial server that hands back an unbounded chain of next_page_token must not
+        // hang the scan forever; it should stop after a bounded number of rounds and degrade to PARTIAL.
+        server.createContext("/v1/querybatch", exchange -> {
+            int call = queryBatchCalls.incrementAndGet();
+            respond(
+                    exchange,
+                    200,
+                    "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-inf-" + call + "\"}],\"next_page_token\":\"tok-" + call
+                            + "\"}]}");
+        });
+        server.createContext("/v1/vulns/", exchange -> {
+            String id = exchange.getRequestURI().getPath().substring("/v1/vulns/".length());
+            respond(exchange, 200, "{\"id\":\"" + id + "\",\"database_specific\":{\"severity\":\"LOW\"}}");
+        });
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        assertThat(report.status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains("paginated");
+        // The safety bound (20 rounds) must have kicked in rather than looping forever.
+        assertThat(queryBatchCalls.get()).isEqualTo(20);
+    }
+
+    @Test
+    void partitionsQuerybatchRequestsWhenThePackageListExceedsOsvsHardBatchLimit() {
+        AtomicInteger totalQueries = new AtomicInteger();
+        server.createContext("/v1/querybatch", exchange -> {
+            queryBatchCalls.incrementAndGet();
+            String requestBody;
+            try (InputStream in = exchange.getRequestBody()) {
+                requestBody = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            }
+            int queryCount = requestBody.split("\"package\"", -1).length - 1;
+            totalQueries.addAndGet(queryCount);
+            StringBuilder resultsArray = new StringBuilder("[");
+            for (int i = 0; i < queryCount; i++) {
+                if (i > 0) {
+                    resultsArray.append(",");
+                }
+                resultsArray.append("{\"vulns\":[]}");
+            }
+            resultsArray.append("]");
+            writeResponse(exchange, 200, "{\"results\":" + resultsArray + "}");
+        });
+
+        List<DependencyDto> dependencies = new ArrayList<>();
+        for (int i = 0; i < 1500; i++) {
+            dependencies.add(dependency("org.acme", "widget" + i, "1.0.0"));
+        }
+
+        DependenciesReport report = scanner(1500, 200).scan(dependencies);
+
+        // 1500 packages must be partitioned into 2 requests of <=1000 each (OSV's hard per-request cap),
+        // not sent as a single oversized batch that OSV.dev would reject with HTTP 400.
+        assertThat(queryBatchCalls.get()).isEqualTo(2);
+        assertThat(totalQueries.get()).isEqualTo(1500);
+        assertThat(report.scan().packagesScanned()).isEqualTo(1500);
+    }
+
+    @Test
+    void epssEnrichesCveAliasedVulnerabilityWithProbabilityAndPercentile() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-epss\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-epss",
+                "{\"id\":\"GHSA-epss\",\"aliases\":[\"CVE-2021-44228\"],\"database_specific\":{\"severity\":\"CRITICAL\"}}");
+        server.createContext("/data/v1/epss", exchange -> {
+            assertThat(exchange.getRequestURI().getQuery()).contains("CVE-2021-44228");
+            respond(
+                    exchange,
+                    200,
+                    "{\"data\":[{\"cve\":\"CVE-2021-44228\",\"epss\":\"0.944500000\",\"percentile\":\"0.999900000\"}]}");
+        });
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        DependencyVulnerabilityDto vulnerability =
+                report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.epssScore()).isEqualTo(0.9445d);
+        assertThat(vulnerability.epssPercentile()).isEqualTo(0.9999d);
+    }
+
+    @Test
+    void epssFailureDoesNotDegradeScanStatusOrDiscardOsvResults() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-epss-down\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-epss-down",
+                "{\"id\":\"GHSA-epss-down\",\"aliases\":[\"CVE-2021-44228\"],\"database_specific\":{\"severity\":\"CRITICAL\"}}");
+        server.createContext("/data/v1/epss", exchange -> respond(exchange, 503, "boom"));
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        assertThat(report.status()).isEqualTo("SCANNED");
+        DependencyVulnerabilityDto vulnerability =
+                report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
+        assertThat(vulnerability.epssScore()).isNull();
+        assertThat(vulnerability.epssPercentile()).isNull();
+    }
+
+    @Test
+    void epssDisabledSkipsTheEpssRequestEntirely() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-epss-off\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-epss-off",
+                "{\"id\":\"GHSA-epss-off\",\"aliases\":[\"CVE-2021-44228\"],\"database_specific\":{\"severity\":\"CRITICAL\"}}");
+        AtomicInteger epssCalls = new AtomicInteger();
+        server.createContext("/data/v1/epss", exchange -> {
+            epssCalls.incrementAndGet();
+            respond(exchange, 200, "{\"data\":[]}");
+        });
+
+        QuarkusVulnerabilitySettings settings =
+                new QuarkusVulnerabilitySettings(true, Duration.ofSeconds(5), 250, 200, baseUri, false, baseUri);
+        DependenciesReport report =
+                new OsvVulnerabilityScanner(settings).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        assertThat(epssCalls.get()).isZero();
+        assertThat(report.dependencies().get(0).vulnerabilities().get(0).epssScore())
+                .isNull();
+    }
+
+    @Test
+    void fixAvailableIsFalseWhenOsvReportsNoFixedVersions() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-no-fix\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-no-fix",
+                "{\"id\":\"GHSA-no-fix\",\"database_specific\":{\"severity\":\"HIGH\"},"
+                        + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"},"
+                        + "\"ranges\":[{\"events\":[{\"introduced\":\"0\"}]}]}]}");
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        DependencyVulnerabilityDto vulnerability =
+                report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.fixedVersions()).isEmpty();
+        assertThat(vulnerability.fixAvailable()).isFalse();
+    }
+
+    @Test
+    void fixAvailableIsFalseWhenTheCurrentVersionIsAlreadyAtOrAboveEveryFixedVersion() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-already-fixed\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-already-fixed",
+                "{\"id\":\"GHSA-already-fixed\",\"database_specific\":{\"severity\":\"HIGH\"},"
+                        + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"},"
+                        + "\"ranges\":[{\"events\":[{\"introduced\":\"0\"},{\"fixed\":\"1.0.0\"}]}]}]}");
+
+        // Dependency is already at version 1.2.0, above the advertised "fixed" 1.0.0.
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.2.0")));
+
+        DependencyVulnerabilityDto vulnerability =
+                report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.fixedVersions()).containsExactly("1.0.0");
+        assertThat(vulnerability.fixAvailable()).isFalse();
+    }
+
+    @Test
+    void prefersAnAdvisoryReferenceOverWebOrFixReferencesAsTheCanonicalFirstLink() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-refs-0001\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-refs-0001",
+                "{\"id\":\"GHSA-refs-0001\",\"database_specific\":{\"severity\":\"HIGH\"},"
+                        + "\"references\":["
+                        + "{\"type\":\"WEB\",\"url\":\"https://example.com/web\"},"
+                        + "{\"type\":\"FIX\",\"url\":\"https://example.com/fix\"},"
+                        + "{\"type\":\"ADVISORY\",\"url\":\"https://example.com/advisory\"},"
+                        + "{\"type\":\"REPORT\",\"url\":\"https://example.com/report\"}],"
+                        + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"}}]}");
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        DependencyVulnerabilityDto vulnerability =
+                report.dependencies().get(0).vulnerabilities().get(0);
+        // ADVISORY sorts first (the canonical page), FIX second, then WEB/REPORT keep OSV's original order.
+        assertThat(vulnerability.references())
+                .containsExactly(
+                        "https://example.com/advisory",
+                        "https://example.com/fix",
+                        "https://example.com/web",
+                        "https://example.com/report");
+    }
+
+    @Test
+    void fetchesManyDistinctAdvisoriesConcurrentlyWithoutLosingOrMisattributingAny() {
+        // More advisories than the bounded fetch pool (10) so the fan-out actually queues work rather
+        // than trivially running everything in parallel at once -- exercising the pool's reuse path.
+        int advisoryCount = 25;
+        StringBuilder vulnsJson = new StringBuilder();
+        for (int i = 0; i < advisoryCount; i++) {
+            if (i > 0) {
+                vulnsJson.append(",");
+            }
+            vulnsJson.append("{\"id\":\"GHSA-conc-").append(i).append("\"}");
+        }
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[" + vulnsJson + "]}]}");
+        List<String> expectedIds = new ArrayList<>();
+        for (int i = 0; i < advisoryCount; i++) {
+            String id = "GHSA-conc-" + i;
+            expectedIds.add(id);
+            String severity = i % 2 == 0 ? "HIGH" : "LOW";
+            handle(
+                    "/v1/vulns/" + id,
+                    "{\"id\":\"" + id + "\",\"database_specific\":{\"severity\":\"" + severity + "\"}}");
+        }
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        assertThat(report.status()).isEqualTo("SCANNED");
+        assertThat(report.dependencies().get(0).vulnerabilities()).hasSize(advisoryCount);
+        assertThat(report.dependencies().get(0).vulnerabilities())
+                .extracting("id")
+                .containsExactlyInAnyOrderElementsOf(expectedIds);
+    }
+
+    @Test
+    void countsConcurrentAdvisoryFetchFailuresCorrectlyAcrossTheBoundedPool() {
+        // A mix of successes and failures spread across more advisories than the pool size, to confirm
+        // the failure counter and PARTIAL degradation are unaffected by fanning the fetches out.
+        int advisoryCount = 16;
+        int failingCount = 5;
+        StringBuilder vulnsJson = new StringBuilder();
+        for (int i = 0; i < advisoryCount; i++) {
+            if (i > 0) {
+                vulnsJson.append(",");
+            }
+            vulnsJson.append("{\"id\":\"GHSA-mix-").append(i).append("\"}");
+        }
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[" + vulnsJson + "]}]}");
+        for (int i = 0; i < advisoryCount; i++) {
+            String id = "GHSA-mix-" + i;
+            if (i < failingCount) {
+                server.createContext("/v1/vulns/" + id, exchange -> respond(exchange, 503, "{}"));
+            } else {
+                handle("/v1/vulns/" + id, "{\"id\":\"" + id + "\",\"database_specific\":{\"severity\":\"HIGH\"}}");
+            }
+        }
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        assertThat(report.status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains(failingCount + " advisory fetches failed");
+        assertThat(report.dependencies().get(0).vulnerabilities()).hasSize(advisoryCount - failingCount);
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -648,6 +648,20 @@ public class BootUiProperties {
          */
         private String osvBaseUri = "https://api.osv.dev";
 
+        /**
+         * Allow enriching CVE-aliased advisories with FIRST.org EPSS (exploit-probability) scores during a
+         * scan. Same on-demand-only network behaviour as {@code osvEnabled}: only called from the
+         * user-initiated scan action, never on page render.
+         */
+        private boolean epssEnabled = true;
+
+        /**
+         * Base URI of the FIRST.org EPSS API queried during a scan. Configurable mainly so tests can point
+         * at a local stub; defaults to the public EPSS endpoint, and matches the Quarkus adapter's
+         * {@code bootui.vulnerabilities.epss-base-uri} key.
+         */
+        private String epssBaseUri = "https://api.first.org";
+
         public boolean isOsvEnabled() {
             return osvEnabled;
         }
@@ -686,6 +700,22 @@ public class BootUiProperties {
 
         public void setOsvBaseUri(String osvBaseUri) {
             this.osvBaseUri = osvBaseUri;
+        }
+
+        public boolean isEpssEnabled() {
+            return epssEnabled;
+        }
+
+        public void setEpssEnabled(boolean epssEnabled) {
+            this.epssEnabled = epssEnabled;
+        }
+
+        public String getEpssBaseUri() {
+            return epssBaseUri;
+        }
+
+        public void setEpssBaseUri(String epssBaseUri) {
+            this.epssBaseUri = epssBaseUri;
         }
     }
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -5,6 +5,7 @@ import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
+import io.github.jdubois.bootui.engine.vulnerabilities.EpssScore;
 import io.github.jdubois.bootui.engine.vulnerabilities.VulnerabilityScanner;
 import java.io.IOException;
 import java.net.URI;
@@ -15,11 +16,45 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.*;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 final class OsvVulnerabilityScanner implements VulnerabilityScanner {
+
+    /** OSV.dev's hard per-request cap on the number of queries in one {@code /v1/querybatch} call; a
+     * larger batch is rejected with HTTP 400 for the request as a whole, so the (already {@code
+     * maxPackages}-bounded) package list is partitioned into chunks at most this large. */
+    private static final int MAX_QUERYBATCH_SIZE = 1000;
+
+    /**
+     * Safety bound on OSV {@code /v1/querybatch} pagination rounds per chunk, guarding against an
+     * unbounded {@code next_page_token} chain from a misbehaving or adversarial {@code osv-base-uri}.
+     * Real OSV.dev pagination triggers only when an individual query matches more than 1,000
+     * vulnerabilities or a batch matches more than 3,000 total, and resolves in a handful of rounds; if
+     * this bound is hit, the affected query's results are used as far as they were fetched and the scan
+     * degrades to {@code PARTIAL} rather than looping forever.
+     */
+    private static final int MAX_QUERY_BATCH_PAGES = 20;
+
+    /**
+     * Maximum CVE ids per FIRST.org EPSS request. EPSS's own {@code limit} query parameter caps how many
+     * rows come back in one response (default 100, independent of how many CVEs were queried) -- each
+     * request pins {@code limit} to the chunk size so nothing is silently dropped, while chunking keeps
+     * the query string a reasonable length and matches the default {@code maxAdvisories}, keeping the
+     * common case to one request.
+     */
+    private static final int EPSS_CHUNK_SIZE = 200;
+
+    /**
+     * Bound on how many {@code GET /v1/vulns/{id}} advisory-detail requests run concurrently. OSV.dev
+     * documents no rate limit, but fetching hundreds of distinct advisories one at a time -- fully
+     * sequential, one blocking call at a time -- meant a scan with many advisories could take up to
+     * {@code maxAdvisories} times the request timeout in a bad-network scenario. A small fixed pool keeps
+     * the fan-out bounded and predictable rather than opening one thread per advisory.
+     */
+    private static final int ADVISORY_FETCH_CONCURRENCY = 10;
 
     private final BootUiProperties.Vulnerabilities properties;
 
@@ -28,6 +63,8 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private final ObjectMapper objectMapper;
 
     private final URI baseUri;
+
+    private final URI epssBaseUri;
 
     OsvVulnerabilityScanner(BootUiProperties.Vulnerabilities properties) {
         this(
@@ -48,24 +85,47 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
         this.baseUri = baseUri;
+        this.epssBaseUri = URI.create(properties.getEpssBaseUri());
     }
 
     URI baseUri() {
         return baseUri;
     }
 
+    URI epssBaseUri() {
+        return epssBaseUri;
+    }
+
+    /**
+     * Reference {@code type} values (OSV schema) preferred, in order, as the canonical link for an
+     * advisory: {@code ADVISORY} is the advisory's own page, {@code FIX} is the next-most-authoritative
+     * (a commit/PR that fixed it), and every other type (WEB, REPORT, ARTICLE, ...) sorts after, in the
+     * order OSV returned them. This only reorders the list so {@code references.get(0)} &mdash; the link
+     * the UI renders the advisory id as &mdash; is the most canonical one available; the {@code type} field
+     * itself is not threaded through to the DTO.
+     */
+    private static final List<String> REFERENCE_TYPE_PRIORITY = List.of("ADVISORY", "FIX");
+
     private static List<String> references(JsonNode references) {
-        List<String> values = new ArrayList<>();
         if (!references.isArray()) {
-            return values;
+            return List.of();
         }
-        for (JsonNode reference : references) {
+        List<JsonNode> ordered = new ArrayList<>();
+        references.forEach(ordered::add);
+        ordered.sort(Comparator.comparingInt(reference -> referenceTypeRank(text(reference, "type"))));
+        List<String> values = new ArrayList<>();
+        for (JsonNode reference : ordered) {
             String url = text(reference, "url");
             if (url != null) {
                 values.add(url);
             }
         }
         return values.stream().distinct().limit(20).toList();
+    }
+
+    private static int referenceTypeRank(String type) {
+        int index = REFERENCE_TYPE_PRIORITY.indexOf(type);
+        return index >= 0 ? index : REFERENCE_TYPE_PRIORITY.size();
     }
 
     private static List<String> fixedVersions(JsonNode affected, String packageName) {
@@ -129,13 +189,27 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return text == null || text.isBlank() ? null : text;
     }
 
-    private static String scanMessage(boolean limited, int failedFetches) {
-        if (!limited && failedFetches == 0) {
+    private static Double parseDouble(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private static String scanMessage(boolean limited, boolean paginationTruncated, int failedFetches) {
+        if (!limited && !paginationTruncated && failedFetches == 0) {
             return "Scan completed against OSV.dev.";
         }
         List<String> reasons = new ArrayList<>();
         if (limited) {
             reasons.add("configured package or advisory limits were applied");
+        }
+        if (paginationTruncated) {
+            reasons.add("some advisories were paginated and not fully fetched");
         }
         if (failedFetches > 0) {
             reasons.add(failedFetches + (failedFetches == 1 ? " advisory fetch failed" : " advisory fetches failed"));
@@ -154,14 +228,22 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
         }
         try {
-            Map<String, List<String>> vulnerabilityIds = queryBatch(packages);
+            QueryBatchResult queryResult = queryBatch(packages);
+            Map<String, List<String>> vulnerabilityIds = queryResult.idsByPackage();
             VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
             List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
+            enriched = applyEpss(enriched);
             boolean limited = packages.size() < dependencies.size()
                     || uniqueIds(vulnerabilityIds).size() > Math.max(1, properties.getMaxAdvisories());
-            String status = limited || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";
+            String status =
+                    limited || queryResult.paginationTruncated() || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";
             return DependencyReports.report(
-                    true, status, scanMessage(limited, fetched.failedFetches()), scannedAt, packages.size(), enriched);
+                    true,
+                    status,
+                    scanMessage(limited, queryResult.paginationTruncated(), fetched.failedFetches()),
+                    scannedAt,
+                    packages.size(),
+                    enriched);
         } catch (IOException | JacksonException ex) {
             return DependencyReports.report(
                     true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
@@ -172,13 +254,89 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
     }
 
-    private Map<String, List<String>> queryBatch(List<DependencyDto> dependencies)
+    /**
+     * The result of one or more {@code /v1/querybatch} calls: the vulnerability ids found for each queried
+     * package, and whether any query's results were truncated because pagination exceeded
+     * {@link #MAX_QUERY_BATCH_PAGES} (which the scan reports as {@code PARTIAL} rather than presenting an
+     * incomplete result set as complete).
+     */
+    private record QueryBatchResult(Map<String, List<String>> idsByPackage, boolean paginationTruncated) {}
+
+    /** One outstanding OSV query awaiting a further page of results. */
+    private record PendingQuery(DependencyDto dependency, String pageToken) {}
+
+    private QueryBatchResult queryBatch(List<DependencyDto> dependencies) throws IOException, InterruptedException {
+        Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
+        boolean paginationTruncated = false;
+        for (int start = 0; start < dependencies.size(); start += MAX_QUERYBATCH_SIZE) {
+            List<DependencyDto> chunk =
+                    dependencies.subList(start, Math.min(dependencies.size(), start + MAX_QUERYBATCH_SIZE));
+            QueryBatchResult chunkResult = queryBatchChunk(chunk);
+            idsByPackage.putAll(chunkResult.idsByPackage());
+            paginationTruncated = paginationTruncated || chunkResult.paginationTruncated();
+        }
+        return new QueryBatchResult(idsByPackage, paginationTruncated);
+    }
+
+    /**
+     * Queries OSV for one chunk of at most {@link #MAX_QUERYBATCH_SIZE} dependencies, following each
+     * query's own {@code next_page_token} (per the
+     * <a href="https://google.github.io/osv.dev/post-v1-querybatch/">querybatch pagination contract</a>)
+     * until every query is exhausted or {@link #MAX_QUERY_BATCH_PAGES} rounds have elapsed.
+     */
+    private QueryBatchResult queryBatchChunk(List<DependencyDto> dependencies)
             throws IOException, InterruptedException {
-        List<Map<String, Object>> queries = new ArrayList<>();
+        Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
         for (DependencyDto dependency : dependencies) {
-            queries.add(Map.of(
-                    "package", Map.of("ecosystem", "Maven", "name", dependency.packageName()),
-                    "version", dependency.version()));
+            idsByPackage.put(key(dependency), new ArrayList<>());
+        }
+        List<PendingQuery> pending = dependencies.stream()
+                .map(dependency -> new PendingQuery(dependency, null))
+                .toList();
+        boolean paginationTruncated = false;
+        int page = 0;
+        while (!pending.isEmpty()) {
+            if (page >= MAX_QUERY_BATCH_PAGES) {
+                paginationTruncated = true;
+                break;
+            }
+            JsonNode results = queryBatchRequest(pending);
+            List<PendingQuery> nextPending = new ArrayList<>();
+            for (int i = 0; i < pending.size(); i++) {
+                PendingQuery query = pending.get(i);
+                JsonNode result = results.path(i);
+                List<String> ids = idsByPackage.get(key(query.dependency()));
+                JsonNode vulns = result.path("vulns");
+                if (vulns.isArray()) {
+                    for (JsonNode vulnerability : vulns) {
+                        String id = text(vulnerability, "id");
+                        if (id != null) {
+                            ids.add(id);
+                        }
+                    }
+                }
+                String nextPageToken = text(result, "next_page_token");
+                if (nextPageToken != null) {
+                    nextPending.add(new PendingQuery(query.dependency(), nextPageToken));
+                }
+            }
+            pending = nextPending;
+            page++;
+        }
+        return new QueryBatchResult(idsByPackage, paginationTruncated);
+    }
+
+    private JsonNode queryBatchRequest(List<PendingQuery> pending) throws IOException, InterruptedException {
+        List<Map<String, Object>> queries = new ArrayList<>();
+        for (PendingQuery query : pending) {
+            DependencyDto dependency = query.dependency();
+            Map<String, Object> queryBody = new LinkedHashMap<>();
+            queryBody.put("package", Map.of("ecosystem", "Maven", "name", dependency.packageName()));
+            queryBody.put("version", dependency.version());
+            if (query.pageToken() != null) {
+                queryBody.put("page_token", query.pageToken());
+            }
+            queries.add(queryBody);
         }
         String body = objectMapper.writeValueAsString(Map.of("queries", queries));
         HttpRequest request = HttpRequest.newBuilder(baseUri.resolve("/v1/querybatch"))
@@ -191,54 +349,74 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             throw new IOException("OSV query returned HTTP " + response.statusCode());
         }
-
-        JsonNode results = objectMapper.readTree(response.body()).path("results");
-        Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
-        for (int i = 0; i < dependencies.size(); i++) {
-            DependencyDto dependency = dependencies.get(i);
-            List<String> ids = new ArrayList<>();
-            JsonNode result = results.path(i).path("vulns");
-            if (result.isArray()) {
-                for (JsonNode vulnerability : result) {
-                    String id = text(vulnerability, "id");
-                    if (id != null) {
-                        ids.add(id);
-                    }
-                }
-            }
-            idsByPackage.put(key(dependency), ids);
-        }
-        return idsByPackage;
+        return objectMapper.readTree(response.body()).path("results");
     }
 
+    /**
+     * Fetches every distinct advisory's detail, fanned out across a small bounded thread pool instead of
+     * one blocking call at a time. The lookup {@link Map} this returns is keyed by advisory id and is
+     * always re-sorted downstream ({@link DependencyReports#VULNERABILITY_ORDER} in {@link #enrich}), so
+     * the order advisories finish fetching in has no effect on the final result -- only the id set and
+     * failure count matter, both of which are order-independent to compute.
+     */
     private VulnerabilityFetchResult fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
             throws InterruptedException {
-        Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
-        int failedFetches = 0;
-        for (String id : uniqueIds(vulnerabilityIds).stream()
+        List<String> ids = uniqueIds(vulnerabilityIds).stream()
                 .limit(Math.max(1, properties.getMaxAdvisories()))
-                .toList()) {
-            JsonNode vulnerability;
-            try {
-                vulnerability = fetchVulnerability(id);
-            } catch (IOException | JacksonException ex) {
-                // A single flaky/rate-limited/malformed advisory fetch shouldn't discard every other
-                // advisory already fetched successfully; count it and degrade to PARTIAL instead of
-                // aborting the whole scan to ERROR.
-                failedFetches++;
-                continue;
-            }
-            if (isWithdrawn(vulnerability)) {
-                // A withdrawn OSV record is no longer considered a valid finding; OSV does not filter
-                // these out of query results itself, so consumers must.
-                continue;
-            }
-            String vulnerabilityId = text(vulnerability, "id");
-            if (vulnerabilityId != null) {
-                vulnerabilities.put(vulnerabilityId, vulnerability);
-            }
+                .toList();
+        if (ids.isEmpty()) {
+            return new VulnerabilityFetchResult(Map.of(), 0);
         }
-        return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
+        ExecutorService executor = Executors.newFixedThreadPool(Math.min(ADVISORY_FETCH_CONCURRENCY, ids.size()));
+        try {
+            List<Future<JsonNode>> futures = new ArrayList<>(ids.size());
+            for (String id : ids) {
+                futures.add(executor.submit(() -> fetchVulnerabilityOrNull(id)));
+            }
+            Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
+            int failedFetches = 0;
+            for (Future<JsonNode> future : futures) {
+                JsonNode vulnerability;
+                try {
+                    vulnerability = future.get();
+                } catch (ExecutionException ex) {
+                    // Only fetchVulnerabilityOrNull's own (already-handled) failures reach here as a
+                    // null result; an ExecutionException means the task itself threw unexpectedly.
+                    failedFetches++;
+                    continue;
+                }
+                if (vulnerability == null) {
+                    // A single flaky/rate-limited/malformed advisory fetch shouldn't discard every other
+                    // advisory already fetched successfully; count it and degrade to PARTIAL instead of
+                    // aborting the whole scan to ERROR.
+                    failedFetches++;
+                    continue;
+                }
+                if (isWithdrawn(vulnerability)) {
+                    // A withdrawn OSV record is no longer considered a valid finding; OSV does not filter
+                    // these out of query results itself, so consumers must.
+                    continue;
+                }
+                String vulnerabilityId = text(vulnerability, "id");
+                if (vulnerabilityId != null) {
+                    vulnerabilities.put(vulnerabilityId, vulnerability);
+                }
+            }
+            return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private JsonNode fetchVulnerabilityOrNull(String id) {
+        try {
+            return fetchVulnerability(id);
+        } catch (IOException | JacksonException ex) {
+            return null;
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return null;
+        }
     }
 
     private JsonNode fetchVulnerability(String id) throws IOException, InterruptedException {
@@ -267,7 +445,8 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
     private DependencyVulnerabilityDto vulnerability(JsonNode node, DependencyDto dependency) {
         String id = text(node, "id");
-        Severity severity = severity(node);
+        Severity severity = severity(node, dependency.packageName());
+        List<String> fixedVersions = fixedVersions(node.path("affected"), dependency.packageName());
         return new DependencyVulnerabilityDto(
                 id,
                 text(node, "summary"),
@@ -276,7 +455,8 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 severity.score(),
                 stringArray(node.path("aliases")),
                 references(node.path("references")),
-                fixedVersions(node.path("affected"), dependency.packageName()));
+                fixedVersions,
+                DependencyReports.fixAvailable(dependency.version(), fixedVersions));
     }
 
     private List<DependencyDto> enrich(
@@ -305,24 +485,125 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return enriched;
     }
 
-    private Severity severity(JsonNode node) {
+    /**
+     * Resolves a vulnerability's severity, preferring a package-scoped entry over the top-level one.
+     *
+     * <p>Per the <a href="https://ossf.github.io/osv-schema/#severity">OSV schema</a>, {@code
+     * affected[].severity} applies to one specific package and "if any package level severity fields are
+     * set, the top level severity field MUST NOT be set" -- so an advisory can carry severity that only
+     * shows up once the affected package is known. Ignoring it (as the top-level-only lookup used to)
+     * silently misses or under-ranks the CVSS for any advisory that only publishes package-level severity.
+     */
+    private Severity severity(JsonNode node, String packageName) {
+        Severity fromPackage = severityFromArray(packageSeverityArray(node.path("affected"), packageName));
+        if (fromPackage != null) {
+            return fromPackage;
+        }
+        Severity fromTopLevel = severityFromArray(node.path("severity"));
+        if (fromTopLevel != null) {
+            return fromTopLevel;
+        }
         String databaseSeverity = text(node.path("database_specific"), "severity");
-        String normalized = DependencyReports.normalizeSeverity(databaseSeverity);
-        Double score = null;
-        JsonNode severities = node.path("severity");
-        if (severities.isArray()) {
-            for (JsonNode severityNode : severities) {
-                String value = text(severityNode, "score");
-                Double parsed = DependencyReports.parseScore(value);
-                if (parsed != null) {
-                    score = parsed;
-                    normalized = DependencyReports.normalizeSeverity(parsed);
-                    break;
-                }
+        return new Severity(DependencyReports.normalizeSeverity(databaseSeverity), null);
+    }
+
+    /**
+     * The first non-empty {@code severity[]} array among {@code affected[]} entries matching {@code
+     * packageName} (Maven ecosystem), or {@code null} if none carries package-level severity.
+     */
+    private static JsonNode packageSeverityArray(JsonNode affected, String packageName) {
+        if (!affected.isArray()) {
+            return null;
+        }
+        for (JsonNode item : affected) {
+            JsonNode pkg = item.path("package");
+            if (!"Maven".equals(text(pkg, "ecosystem")) || !packageName.equals(text(pkg, "name"))) {
+                continue;
+            }
+            JsonNode severity = item.path("severity");
+            if (severity.isArray() && !severity.isEmpty()) {
+                return severity;
             }
         }
-        return new Severity(normalized, score);
+        return null;
+    }
+
+    private static Severity severityFromArray(JsonNode severities) {
+        if (severities == null || !severities.isArray()) {
+            return null;
+        }
+        for (JsonNode severityNode : severities) {
+            String value = text(severityNode, "score");
+            Double parsed = DependencyReports.parseScore(value);
+            if (parsed != null) {
+                return new Severity(DependencyReports.normalizeSeverity(parsed), parsed);
+            }
+        }
+        return null;
     }
 
     private record Severity(String label, Double score) {}
+
+    /**
+     * Enriches CVE-aliased vulnerabilities with FIRST.org EPSS exploit-probability scores, one batched
+     * request per distinct CVE set per scan (mirroring the existing OSV batch-query pattern). EPSS is a
+     * best-effort secondary signal layered on top of the OSV-derived results: any failure (disabled,
+     * network error, malformed response) leaves the affected vulnerabilities without EPSS fields and never
+     * changes the scan's status or message -- only OSV outcomes do that.
+     */
+    private List<DependencyDto> applyEpss(List<DependencyDto> dependencies) {
+        if (!properties.isEpssEnabled()) {
+            return dependencies;
+        }
+        List<String> cveIds = DependencyReports.cveAliases(dependencies);
+        if (cveIds.isEmpty()) {
+            return dependencies;
+        }
+        Map<String, EpssScore> epssByCve = fetchEpssScores(cveIds);
+        return DependencyReports.applyEpssScores(dependencies, epssByCve);
+    }
+
+    private Map<String, EpssScore> fetchEpssScores(List<String> cveIds) {
+        Map<String, EpssScore> scores = new LinkedHashMap<>();
+        for (int start = 0; start < cveIds.size(); start += EPSS_CHUNK_SIZE) {
+            List<String> chunk = cveIds.subList(start, Math.min(cveIds.size(), start + EPSS_CHUNK_SIZE));
+            try {
+                scores.putAll(fetchEpssChunk(chunk));
+            } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+                break;
+            } catch (IOException | JacksonException ex) {
+                // EPSS is a best-effort enrichment on top of the OSV scan; stop trying further chunks but
+                // keep whatever scores were already fetched rather than failing the scan.
+                break;
+            }
+        }
+        return scores;
+    }
+
+    private Map<String, EpssScore> fetchEpssChunk(List<String> cveIds) throws IOException, InterruptedException {
+        String query = "cve=" + String.join(",", cveIds) + "&limit=" + cveIds.size();
+        HttpRequest request = HttpRequest.newBuilder(epssBaseUri.resolve("/data/v1/epss?" + query))
+                .timeout(properties.getRequestTimeout())
+                .GET()
+                .build();
+        HttpResponse<String> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("EPSS query returned HTTP " + response.statusCode());
+        }
+        JsonNode data = objectMapper.readTree(response.body()).path("data");
+        Map<String, EpssScore> scores = new LinkedHashMap<>();
+        if (data.isArray()) {
+            for (JsonNode entry : data) {
+                String cve = text(entry, "cve");
+                Double probability = parseDouble(text(entry, "epss"));
+                Double percentile = parseDouble(text(entry, "percentile"));
+                if (cve != null && probability != null && percentile != null) {
+                    scores.put(cve, new EpssScore(probability, percentile));
+                }
+            }
+        }
+        return scores;
+    }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -12,7 +12,9 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.ObjectMapper;
@@ -66,10 +68,21 @@ class OsvVulnerabilityScannerTests {
             exchange.getResponseBody().write(body);
             exchange.close();
         });
+        server.createContext("/data/v1/epss", exchange -> {
+            byte[] body = """
+                {"data":[{"cve":"CVE-2026-0001","epss":"0.023450000","percentile":"0.921300000"}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
         server.start();
 
         BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
         properties.setRequestTimeout(Duration.ofSeconds(2));
+        // Points EPSS at the same loopback stub as OSV -- never the real FIRST.org API in a unit test.
+        properties.setEpssBaseUri("http://localhost:" + server.getAddress().getPort());
         OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
                 properties,
                 HttpClient.newHttpClient(),
@@ -86,8 +99,11 @@ class OsvVulnerabilityScannerTests {
                 .extracting("count")
                 .isEqualTo(1);
         assertThat(report.dependencies().get(0).highestSeverity()).isEqualTo("HIGH");
-        assertThat(report.dependencies().get(0).vulnerabilities().get(0).fixedVersions())
-                .containsExactly("1.0.1");
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.fixedVersions()).containsExactly("1.0.1");
+        assertThat(vulnerability.fixAvailable()).isTrue();
+        assertThat(vulnerability.epssScore()).isEqualTo(0.02345d);
+        assertThat(vulnerability.epssPercentile()).isEqualTo(0.9213d);
     }
 
     @Test
@@ -383,5 +399,633 @@ class OsvVulnerabilityScannerTests {
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains("1 advisory fetch failed");
         assertThat(report.dependencies().get(0).vulnerabilities()).isEmpty();
+    }
+
+    @Test
+    void prefersPackageLevelSeverityOverTopLevelSeverity() throws Exception {
+        // Per the OSV schema, affected[].severity applies to one specific package and, when present,
+        // supersedes the top-level severity[] field. This advisory carries a MEDIUM top-level score and a
+        // CRITICAL package-level score for the queried package -- the package-level one must win.
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-PKG-SEV"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-PKG-SEV", exchange -> {
+            byte[] body = """
+                {
+                  "id": "GHSA-PKG-SEV",
+                  "severity": [{ "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N" }],
+                  "affected": [
+                    {
+                      "package": { "ecosystem": "Maven", "name": "org.example:sample" },
+                      "severity": [{ "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
+        assertThat(vulnerability.score()).isEqualTo(9.8d);
+    }
+
+    @Test
+    void fallsBackToTopLevelSeverityWhenAffectedEntryHasNoPackageLevelSeverity() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-NO-PKG-SEV"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-NO-PKG-SEV", exchange -> {
+            byte[] body = """
+                {
+                  "id": "GHSA-NO-PKG-SEV",
+                  "severity": [{ "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N" }],
+                  "affected": [
+                    { "package": { "ecosystem": "Maven", "name": "org.example:sample" } }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.severity()).isEqualTo("MEDIUM");
+        assertThat(vulnerability.score()).isEqualTo(5.4d);
+    }
+
+    @Test
+    void followsOsvQuerybatchPaginationUntilNextPageTokenIsAbsent() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        AtomicInteger calls = new AtomicInteger();
+        server.createContext("/v1/querybatch", exchange -> {
+            int call = calls.getAndIncrement();
+            String responseBody;
+            if (call == 0) {
+                responseBody = """
+                    {"results":[{"vulns":[{"id":"GHSA-PAGE-1"}],"next_page_token":"page-2"}]}
+                    """;
+            } else {
+                responseBody = """
+                    {"results":[{"vulns":[{"id":"GHSA-PAGE-2"}]}]}
+                    """;
+            }
+            byte[] body = responseBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        registerAdvisory("GHSA-PAGE-1", "HIGH");
+        registerAdvisory("GHSA-PAGE-2", "LOW");
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        // Both pages must be merged into the final result, and pagination completing within the safety
+        // bound must not degrade the scan status.
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
+        assertThat(calls.get()).isEqualTo(2);
+        assertThat(report.dependencies().get(0).vulnerabilities())
+                .extracting("id")
+                .containsExactlyInAnyOrder("GHSA-PAGE-1", "GHSA-PAGE-2");
+    }
+
+    @Test
+    void degradesToPartialWhenOsvPaginationExceedsTheSafetyBound() throws Exception {
+        // A misbehaving/adversarial server that hands back an unbounded chain of next_page_token must not
+        // hang the scan forever; it should stop after a bounded number of rounds and degrade to PARTIAL.
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        AtomicInteger calls = new AtomicInteger();
+        server.createContext("/v1/querybatch", exchange -> {
+            int call = calls.incrementAndGet();
+            byte[] body = ("{\"results\":[{\"vulns\":[{\"id\":\"GHSA-INF-" + call + "\"}],\"next_page_token\":\"tok-"
+                            + call + "\"}]}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/", exchange -> {
+            String id = exchange.getRequestURI().getPath().substring("/v1/vulns/".length());
+            byte[] body = ("{\"id\":\"" + id + "\",\"database_specific\":{\"severity\":\"LOW\"}}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains("paginated");
+        // The safety bound (20 rounds) must have kicked in rather than looping forever.
+        assertThat(calls.get()).isEqualTo(20);
+    }
+
+    @Test
+    void partitionsQuerybatchRequestsWhenThePackageListExceedsOsvsHardBatchLimit() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        AtomicInteger calls = new AtomicInteger();
+        AtomicInteger totalQueries = new AtomicInteger();
+        server.createContext("/v1/querybatch", exchange -> {
+            calls.incrementAndGet();
+            String requestBody = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+            // Count query objects the crude-but-sufficient way: each has one "package" key.
+            int queryCount = requestBody.split("\"package\"", -1).length - 1;
+            totalQueries.addAndGet(queryCount);
+            // Respond with as many empty result entries as there were queries (order doesn't matter here).
+            String results = "vulns\":[]}".repeat(0);
+            StringBuilder resultsArray = new StringBuilder("[");
+            for (int i = 0; i < queryCount; i++) {
+                if (i > 0) {
+                    resultsArray.append(",");
+                }
+                resultsArray.append("{\"vulns\":[]}");
+            }
+            resultsArray.append("]");
+            byte[] body = ("{\"results\":" + resultsArray + "}").getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(5));
+        properties.setMaxPackages(1500);
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        List<DependencyDto> dependencies = new ArrayList<>();
+        for (int i = 0; i < 1500; i++) {
+            dependencies.add(dependency("org.example", "sample" + i, "1.0.0"));
+        }
+
+        DependenciesReport report = scanner.scan(dependencies);
+
+        // 1500 packages must be partitioned into 2 requests of <=1000 each (OSV's hard per-request cap),
+        // not sent as a single oversized batch that OSV.dev would reject with HTTP 400.
+        assertThat(calls.get()).isEqualTo(2);
+        assertThat(totalQueries.get()).isEqualTo(1500);
+        assertThat(report.scan().packagesScanned()).isEqualTo(1500);
+    }
+
+    @Test
+    void epssEnrichesCveAliasedVulnerabilityWithProbabilityAndPercentile() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-EPSS"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-EPSS", exchange -> {
+            byte[] body = """
+                {"id":"GHSA-EPSS","aliases":["CVE-2021-44228"],"database_specific":{"severity":"CRITICAL"}}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/data/v1/epss", exchange -> {
+            assertThat(exchange.getRequestURI().getQuery()).contains("CVE-2021-44228");
+            byte[] body = """
+                {"data":[{"cve":"CVE-2021-44228","epss":"0.944500000","percentile":"0.999900000"}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        properties.setEpssBaseUri("http://localhost:" + server.getAddress().getPort());
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.epssScore()).isEqualTo(0.9445d);
+        assertThat(vulnerability.epssPercentile()).isEqualTo(0.9999d);
+    }
+
+    @Test
+    void epssFailureDoesNotDegradeScanStatusOrDiscardOsvResults() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-EPSS-DOWN"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-EPSS-DOWN", exchange -> {
+            byte[] body = """
+                {"id":"GHSA-EPSS-DOWN","aliases":["CVE-2021-44228"],"database_specific":{"severity":"CRITICAL"}}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/data/v1/epss", exchange -> {
+            byte[] body = "boom".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(503, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        properties.setEpssBaseUri("http://localhost:" + server.getAddress().getPort());
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
+        assertThat(vulnerability.epssScore()).isNull();
+        assertThat(vulnerability.epssPercentile()).isNull();
+    }
+
+    @Test
+    void epssDisabledSkipsTheEpssRequestEntirely() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-EPSS-OFF"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-EPSS-OFF", exchange -> {
+            byte[] body = """
+                {"id":"GHSA-EPSS-OFF","aliases":["CVE-2021-44228"],"database_specific":{"severity":"CRITICAL"}}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        AtomicInteger epssCalls = new AtomicInteger();
+        server.createContext("/data/v1/epss", exchange -> {
+            epssCalls.incrementAndGet();
+            byte[] body = "{\"data\":[]}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        properties.setEpssBaseUri("http://localhost:" + server.getAddress().getPort());
+        properties.setEpssEnabled(false);
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(epssCalls.get()).isZero();
+        assertThat(report.dependencies().get(0).vulnerabilities().get(0).epssScore())
+                .isNull();
+    }
+
+    @Test
+    void fixAvailableIsFalseWhenOsvReportsNoFixedVersions() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-NO-FIX"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-NO-FIX", exchange -> {
+            byte[] body = """
+                {
+                  "id": "GHSA-NO-FIX",
+                  "database_specific": { "severity": "HIGH" },
+                  "affected": [
+                    {
+                      "package": { "ecosystem": "Maven", "name": "org.example:sample" },
+                      "ranges": [{ "events": [{ "introduced": "0" }] }]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.fixedVersions()).isEmpty();
+        assertThat(vulnerability.fixAvailable()).isFalse();
+    }
+
+    @Test
+    void fixAvailableIsFalseWhenTheCurrentVersionIsAlreadyAtOrAboveEveryFixedVersion() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-ALREADY-FIXED"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-ALREADY-FIXED", exchange -> {
+            byte[] body = """
+                {
+                  "id": "GHSA-ALREADY-FIXED",
+                  "database_specific": { "severity": "HIGH" },
+                  "affected": [
+                    {
+                      "package": { "ecosystem": "Maven", "name": "org.example:sample" },
+                      "ranges": [{ "events": [{ "introduced": "0" }, { "fixed": "1.0.0" }] }]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                // Dependency is already at version 1.2.0, above the advertised "fixed" 1.0.0.
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.2.0")));
+
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        assertThat(vulnerability.fixedVersions()).containsExactly("1.0.0");
+        assertThat(vulnerability.fixAvailable()).isFalse();
+    }
+
+    @Test
+    void prefersAnAdvisoryReferenceOverWebOrFixReferencesAsTheCanonicalFirstLink() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                {"results":[{"vulns":[{"id":"GHSA-REFS-0001"}]}]}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-REFS-0001", exchange -> {
+            byte[] body = """
+                {
+                  "id": "GHSA-REFS-0001",
+                  "database_specific": { "severity": "HIGH" },
+                  "references": [
+                    { "type": "WEB", "url": "https://example.com/web" },
+                    { "type": "FIX", "url": "https://example.com/fix" },
+                    { "type": "ADVISORY", "url": "https://example.com/advisory" },
+                    { "type": "REPORT", "url": "https://example.com/report" }
+                  ],
+                  "affected": [
+                    { "package": { "ecosystem": "Maven", "name": "org.example:sample" } }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
+        // ADVISORY sorts first (the canonical page), FIX second, then WEB/REPORT keep OSV's original order.
+        assertThat(vulnerability.references())
+                .containsExactly(
+                        "https://example.com/advisory",
+                        "https://example.com/fix",
+                        "https://example.com/web",
+                        "https://example.com/report");
+    }
+
+    @Test
+    void fetchesManyDistinctAdvisoriesConcurrentlyWithoutLosingOrMisattributingAny() throws Exception {
+        // More advisories than the bounded fetch pool (10) so the fan-out actually queues work rather
+        // than trivially running everything in parallel at once -- exercising the pool's reuse path.
+        int advisoryCount = 25;
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        StringBuilder vulnsJson = new StringBuilder();
+        for (int i = 0; i < advisoryCount; i++) {
+            if (i > 0) {
+                vulnsJson.append(",");
+            }
+            vulnsJson.append("{\"id\":\"GHSA-CONC-").append(i).append("\"}");
+        }
+        String queryBatchBody = "{\"results\":[{\"vulns\":[" + vulnsJson + "]}]}";
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = queryBatchBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        for (int i = 0; i < advisoryCount; i++) {
+            registerAdvisory("GHSA-CONC-" + i, i % 2 == 0 ? "HIGH" : "LOW");
+        }
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(5));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
+        assertThat(report.dependencies().get(0).vulnerabilities()).hasSize(advisoryCount);
+        List<String> expectedIds = new ArrayList<>();
+        for (int i = 0; i < advisoryCount; i++) {
+            expectedIds.add("GHSA-CONC-" + i);
+        }
+        assertThat(report.dependencies().get(0).vulnerabilities())
+                .extracting("id")
+                .containsExactlyInAnyOrderElementsOf(expectedIds);
+    }
+
+    @Test
+    void countsConcurrentAdvisoryFetchFailuresCorrectlyAcrossTheBoundedPool() throws Exception {
+        // A mix of successes and failures spread across more advisories than the pool size, to confirm
+        // the failure counter and PARTIAL degradation are unaffected by fanning the fetches out.
+        int advisoryCount = 16;
+        int failingCount = 5;
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        StringBuilder vulnsJson = new StringBuilder();
+        for (int i = 0; i < advisoryCount; i++) {
+            if (i > 0) {
+                vulnsJson.append(",");
+            }
+            vulnsJson.append("{\"id\":\"GHSA-MIX-").append(i).append("\"}");
+        }
+        String queryBatchBody = "{\"results\":[{\"vulns\":[" + vulnsJson + "]}]}";
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = queryBatchBody.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        for (int i = 0; i < advisoryCount; i++) {
+            String id = "GHSA-MIX-" + i;
+            if (i < failingCount) {
+                server.createContext("/v1/vulns/" + id, exchange -> {
+                    byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(503, body.length);
+                    exchange.getResponseBody().write(body);
+                    exchange.close();
+                });
+            } else {
+                registerAdvisory(id, "HIGH");
+            }
+        }
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(5));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains(failingCount + " advisory fetches failed");
+        assertThat(report.dependencies().get(0).vulnerabilities()).hasSize(advisoryCount - failingCount);
     }
 }

--- a/bootui-spring-sample-app/e2e/tests/vulnerabilities.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/vulnerabilities.spec.js
@@ -136,7 +136,7 @@ function dependency(groupId, artifactId, version) {
   }
 }
 
-function vulnerability(id, severity, summary, fixedVersion, aliases = []) {
+function vulnerability(id, severity, summary, fixedVersion, aliases = [], fixAvailable = true) {
   return {
     id,
     summary,
@@ -145,6 +145,11 @@ function vulnerability(id, severity, summary, fixedVersion, aliases = []) {
     score: null,
     aliases,
     references: ['https://example.com/advisory'],
-    fixedVersions: [fixedVersion]
+    fixedVersions: [fixedVersion],
+    // Every call site here uses a fixedVersion strictly newer than the mocked dependency's current
+    // version, i.e. a genuine upgrade target -- so fixAvailable defaults to true, matching what the
+    // real DependencyReports.fixAvailable() derivation would compute for these fixtures. Override it
+    // explicitly for a scenario that should render "already on a fixed version" or "No fix published yet".
+    fixAvailable
   }
 }

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
@@ -3,7 +3,7 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 
 import Vulnerabilities from './Vulnerabilities.vue'
 
-function vulnerability(id, severity, dismissed = false) {
+function vulnerability(id, severity, dismissed = false, overrides = {}) {
   return {
     id,
     summary: `${id} summary`,
@@ -13,7 +13,11 @@ function vulnerability(id, severity, dismissed = false) {
     aliases: [],
     references: [],
     fixedVersions: [],
-    dismissed
+    fixAvailable: false,
+    epssScore: null,
+    epssPercentile: null,
+    dismissed,
+    ...overrides
   }
 }
 
@@ -175,5 +179,119 @@ describe('Vulnerabilities', () => {
       expect.objectContaining({method: 'DELETE'})
     )
     expect(wrapper.text()).toContain('Dismiss')
+  })
+
+  it('renders the numeric CVSS base score next to the severity badge', async () => {
+    const scored = dependency(
+      'org.example:scored',
+      '1.0.0',
+      [vulnerability('GHSA-scored-0001', 'HIGH', false, {score: 8.1})],
+      'HIGH'
+    )
+    const {wrapper} = await mountWithReports([report([scored])])
+
+    expect(wrapper.text()).toContain('HIGH · 8.1')
+  })
+
+  it('omits the CVSS score suffix when the advisory carries no score', async () => {
+    const unscored = dependency(
+      'org.example:unscored',
+      '1.0.0',
+      [vulnerability('GHSA-unscored-0001', 'HIGH', false, {score: null})],
+      'HIGH'
+    )
+    const {wrapper} = await mountWithReports([report([unscored])])
+
+    expect(wrapper.text()).not.toContain('·')
+  })
+
+  it('renders an EPSS badge with likelihood-of-exploitation when epssScore is present', async () => {
+    const withEpss = dependency(
+      'org.example:epss',
+      '1.0.0',
+      [
+        vulnerability('CVE-2021-44228', 'CRITICAL', false, {
+          score: 10.0,
+          aliases: ['CVE-2021-44228'],
+          epssScore: 0.023,
+          epssPercentile: 0.92
+        })
+      ],
+      'CRITICAL'
+    )
+    const {wrapper} = await mountWithReports([report([withEpss])])
+
+    expect(wrapper.text()).toContain('2.3% EPSS')
+    const badge = wrapper.findAll('.badge').find((b) => b.text().includes('EPSS'))
+    expect(badge.attributes('title')).toContain('92nd percentile')
+  })
+
+  it('omits the EPSS badge entirely when epssScore is null', async () => {
+    const noEpss = dependency(
+      'org.example:no-epss',
+      '1.0.0',
+      [vulnerability('GHSA-no-epss-0001', 'HIGH', false, {epssScore: null})],
+      'HIGH'
+    )
+    const {wrapper} = await mountWithReports([report([noEpss])])
+
+    expect(wrapper.text()).not.toContain('EPSS')
+  })
+
+  it('shows "No fix published yet" when fixedVersions is empty', async () => {
+    const noFix = dependency(
+      'org.example:no-fix',
+      '1.0.0',
+      [vulnerability('GHSA-no-fix-0001', 'HIGH', false, {fixedVersions: [], fixAvailable: false})],
+      'HIGH'
+    )
+    const {wrapper} = await mountWithReports([report([noFix])])
+
+    expect(wrapper.text()).toContain('No fix published yet')
+  })
+
+  it('shows the upgrade target when a newer fixed version is available', async () => {
+    const fixable = dependency(
+      'org.example:fixable',
+      '1.0.0',
+      [vulnerability('GHSA-fixable-0001', 'HIGH', false, {fixedVersions: ['1.2.0'], fixAvailable: true})],
+      'HIGH'
+    )
+    const {wrapper} = await mountWithReports([report([fixable])])
+
+    expect(wrapper.text()).toContain('fixed in 1.2.0')
+    expect(wrapper.text()).not.toContain('No fix published yet')
+  })
+
+  it('shows "already on a fixed version" when fixedVersions is non-empty but fixAvailable is false', async () => {
+    const alreadyFixed = dependency(
+      'org.example:already-fixed',
+      '2.0.0',
+      [vulnerability('GHSA-already-fixed-0001', 'HIGH', false, {fixedVersions: ['1.5.0'], fixAvailable: false})],
+      'HIGH'
+    )
+    const {wrapper} = await mountWithReports([report([alreadyFixed])])
+
+    expect(wrapper.text()).toContain('already on a fixed version')
+    expect(wrapper.text()).not.toContain('No fix published yet')
+  })
+
+  it('links a CVE alias to NVD and a GHSA alias to GitHub Advisories', async () => {
+    const aliased = dependency(
+      'org.example:aliased',
+      '1.0.0',
+      [
+        vulnerability('GHSA-aliased-0001', 'CRITICAL', false, {
+          aliases: ['CVE-2021-44228', 'GHSA-aliased-0001']
+        })
+      ],
+      'CRITICAL'
+    )
+    const {wrapper} = await mountWithReports([report([aliased])])
+
+    const cveLink = wrapper.findAll('a').find((a) => a.text() === 'CVE-2021-44228')
+    const ghsaLink = wrapper.findAll('a').find((a) => a.text() === 'GHSA-aliased-0001')
+    expect(cveLink.attributes('href')).toBe('https://nvd.nist.gov/vuln/detail/CVE-2021-44228')
+    expect(ghsaLink.attributes('href')).toBe('https://github.com/advisories/GHSA-aliased-0001')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -122,6 +122,68 @@ function scanTime() {
   return formatClockTime(data.value.scan.scannedAt)
 }
 
+function formatScore(score) {
+  return score != null ? score.toFixed(1) : null
+}
+
+function formatEpssPercent(score) {
+  return score != null ? `${(score * 100).toFixed(1)}%` : null
+}
+
+// Ordinal suffix (1st, 2nd, 3rd, 4th, 11th, 12th, 13th, ...) for the EPSS percentile tooltip.
+function ordinal(n) {
+  const mod100 = n % 100
+  if (mod100 >= 11 && mod100 <= 13) return `${n}th`
+  switch (n % 10) {
+    case 1:
+      return `${n}st`
+    case 2:
+      return `${n}nd`
+    case 3:
+      return `${n}rd`
+    default:
+      return `${n}th`
+  }
+}
+
+function epssBadgeText(vulnerability) {
+  const percent = formatEpssPercent(vulnerability.epssScore)
+  return percent ? `${percent} EPSS` : null
+}
+
+// FIRST.org EPSS (https://www.first.org/epss/) estimates likelihood-of-exploitation in the next 30
+// days, complementing CVSS's severity-if-exploited score. Only set for CVE-aliased advisories.
+function epssTooltip(vulnerability) {
+  const percent = formatEpssPercent(vulnerability.epssScore)
+  if (!percent) return ''
+  if (vulnerability.epssPercentile == null) {
+    return `${percent} likelihood of exploitation in the next 30 days (EPSS)`
+  }
+  const percentile = ordinal(Math.round(vulnerability.epssPercentile * 100))
+  return `${percent} likelihood of exploitation in the next 30 days, ${percentile} percentile (EPSS)`
+}
+
+const aliasLinkBuilders = [
+  {prefix: 'CVE-', href: (alias) => `https://nvd.nist.gov/vuln/detail/${alias}`},
+  {prefix: 'GHSA-', href: (alias) => `https://github.com/advisories/${alias}`}
+]
+
+function aliasHref(alias) {
+  const builder = aliasLinkBuilders.find((entry) => alias.startsWith(entry.prefix))
+  return builder ? builder.href(alias) : null
+}
+
+// Precomputes each alias's link + separator so the template can do a plain single-variable
+// v-for (no index arithmetic inline, which vue-tsc can't reliably type against a loosely-typed
+// prop array).
+function aliasItems(vulnerability) {
+  return vulnerability.aliases.map((alias, index) => ({
+    alias,
+    href: aliasHref(alias),
+    showSeparator: index > 0
+  }))
+}
+
 async function loadDependencies() {
   try {
     data.value = await getJson('api/vulnerabilities')
@@ -279,9 +341,19 @@ onMounted(loadDependencies)
                       class="mb-2"
                     >
                       <div class="d-flex flex-wrap align-items-center gap-2">
-                        <span :class="severityClass(vulnerability.severity)" class="badge">{{
-                          vulnerability.severity
-                        }}</span>
+                        <span :class="severityClass(vulnerability.severity)" class="badge">
+                          {{ vulnerability.severity
+                          }}<template v-if="formatScore(vulnerability.score)">
+                            · {{ formatScore(vulnerability.score) }}</template
+                          >
+                        </span>
+                        <span
+                          v-if="epssBadgeText(vulnerability)"
+                          :title="epssTooltip(vulnerability)"
+                          class="badge text-bg-light border"
+                        >
+                          <i class="bi-graph-up-arrow me-1"></i>{{ epssBadgeText(vulnerability) }}
+                        </span>
                         <a
                           v-if="vulnerability.references.length"
                           :href="vulnerability.references[0]"
@@ -291,9 +363,16 @@ onMounted(loadDependencies)
                           {{ vulnerability.id }}
                         </a>
                         <span v-else class="fw-semibold">{{ vulnerability.id }}</span>
-                        <span v-if="vulnerability.fixedVersions.length" class="small text-muted">
+                        <span
+                          v-if="vulnerability.fixedVersions.length && vulnerability.fixAvailable"
+                          class="small text-muted"
+                        >
                           fixed in {{ vulnerability.fixedVersions.join(', ') }}
                         </span>
+                        <span v-else-if="vulnerability.fixedVersions.length" class="small text-muted">
+                          already on a fixed version (&ge; {{ vulnerability.fixedVersions.join(', ') }})
+                        </span>
+                        <span v-else class="small text-muted fst-italic">No fix published yet</span>
                         <span v-if="vulnerability.dismissed" class="badge text-bg-light border">Dismissed</span>
                         <button
                           :disabled="dismissLoading"
@@ -310,7 +389,11 @@ onMounted(loadDependencies)
                         {{ vulnerability.summary || vulnerability.details || 'No advisory summary available.' }}
                       </div>
                       <div v-if="vulnerability.aliases.length" class="small text-muted">
-                        {{ vulnerability.aliases.join(', ') }}
+                        <template v-for="item in aliasItems(vulnerability)" :key="item.alias">
+                          <span v-if="item.showSeparator">, </span>
+                          <a v-if="item.href" :href="item.href" rel="noreferrer" target="_blank">{{ item.alias }}</a>
+                          <span v-else>{{ item.alias }}</span>
+                        </template>
                       </div>
                     </div>
                   </div>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -462,17 +462,51 @@ ordered by severity first (dismissed findings sink to the bottom regardless of s
 advisories alphabetized within the same severity.
 
 Severity is derived from [OSV.dev](https://osv.dev/)'s `severity[]` entries, whose `score` field is a CVSS vector string
-for `CVSS_V3`/`CVSS_V4` types (for example `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`), never a bare number. A CVSS
-v3.0/v3.1 vector is parsed into a real numeric Base Score using the formula from the
+for `CVSS_V3`/`CVSS_V4` types (for example `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`), never a bare number. Per the
+[OSV schema](https://ossf.github.io/osv-schema/#severity), a package-level `affected[].severity` entry — when present for
+the specific dependency being scored — takes priority over the advisory's top-level `severity[]` (the schema states the
+two are mutually exclusive, and some advisories only carry severity at the package level), so the scanner looks there
+first before falling back to the top-level array. A CVSS v3.0/v3.1 vector (from either level) is parsed into a real
+numeric Base Score using the formula from the
 [FIRST.org CVSS v3.1 specification](https://www.first.org/cvss/v3-1/specification-document); CVSS v4.0 has no
 closed-form Base Score equation (its MacroVector lookup table is a much larger undertaking) and legacy CVSS v2 is
 essentially unseen in real Maven-ecosystem OSV advisories, so both fall back to the advisory's
 `database_specific.severity` label (`CRITICAL`/`HIGH`/`MODERATE`/`LOW`, normalized to BootUI's `MEDIUM` label) when no
-v3 score is present. An advisory with neither a parseable CVSS v3 score nor a `database_specific` label renders as
-`UNKNOWN` rather than being silently dropped. Advisories carrying a `withdrawn` timestamp are excluded from results
-entirely, since OSV does not filter withdrawn records out of its API responses itself. A single advisory detail fetch
-that fails (network hiccup, rate limiting) no longer aborts the whole scan: it is counted and the scan degrades to
-`PARTIAL`, keeping every advisory that *did* fetch successfully instead of discarding the whole result.
+v3 score is present at either level. An advisory with neither a parseable CVSS v3 score nor a `database_specific` label
+renders as `UNKNOWN` rather than being silently dropped. Advisories carrying a `withdrawn` timestamp are excluded from
+results entirely, since OSV does not filter withdrawn records out of its API responses itself. A single advisory detail
+fetch that fails (network hiccup, rate limiting) no longer aborts the whole scan: it is counted and the scan degrades to
+`PARTIAL`, keeping every advisory that *did* fetch successfully instead of discarding the whole result. Advisory detail
+fetches (`GET /v1/vulns/{id}`) run with a small bounded concurrency (up to 10 at a time) rather than one at a time, so a
+dependency tree with many distinct advisories no longer risks a scan taking up to `maxAdvisories` times the request
+timeout in a bad-network scenario; OSV.dev documents no rate limit for this endpoint.
+
+OSV's `/v1/querybatch` endpoint paginates when an individual query matches more than 1,000 vulnerabilities or the whole
+batch exceeds 3,000 total, returning a `next_page_token` per affected query. The scanner follows that token with
+follow-up `/v1/querybatch` calls, merging every page back into one result set, bounded by a fixed page-count safety
+limit so a pathological advisory can't loop the scan forever (degrading to `PARTIAL` if the bound is hit before
+pagination is exhausted, rather than silently truncating). Independently, OSV also enforces a hard limit of 1,000
+queries per `/v1/querybatch` request; the scanner partitions the (already `max-packages`-bounded) package list into
+batches of at most 1,000 before querying, so configuring `max-packages` above 1,000 no longer causes OSV to reject the
+whole batch with an HTTP 400.
+
+Each advisory whose `aliases` includes a `CVE-*` id is additionally enriched with
+[EPSS](https://www.first.org/epss/) (Exploit Prediction Scoring System) data from FIRST.org's free, unauthenticated API
+— one batched `GET /data/v1/epss?cve=...` request per scan, alongside the OSV calls, following the same
+"network call only on the user-initiated scan action" pattern. EPSS reports the modeled probability that a CVE will be
+exploited in the wild in the next 30 days, plus the percentile that probability ranks against every other scored CVE —
+a likelihood-of-exploitation signal that deliberately complements (rather than replaces) CVSS's severity-if-exploited
+score, and is rendered as a secondary badge next to the severity/CVSS badge (for example "2.3% EPSS", with a tooltip
+spelling out the percentile). EPSS lookups can be disabled independently of OSV scanning via
+`bootui.vulnerabilities.epss-enabled=false`, and a failed or unreachable EPSS request never fails the scan or discards
+the OSV results — it simply omits the badge for that scan.
+
+Each advisory also carries a derived `fixAvailable` boolean, computed by comparing the dependency's currently-resolved
+version against the advisory's `fixedVersions` with a lightweight Maven-version-aware comparison. This lets the UI
+distinguish three states unambiguously: a genuine upgrade target ("fixed in `x.y.z`"), a dependency that already sits at
+or above every fixed version OSV reported ("already on a fixed version"), and an advisory with no `fixedVersions` at all
+("No fix published yet") — previously all three collapsed into the same blank space in the UI, which was ambiguous
+between "no fix exists yet" and "we don't know."
 
 Like every other advisor, a vulnerability can be **dismissed** when it does not apply to your project (already
 patched downstream, accepted risk, or a fix not yet available upstream) — see the shared dismiss/restore explanation
@@ -484,12 +518,22 @@ patch-version bump of the still-vulnerable dependency. Dismissed vulnerabilities
 _Restore_ button) rather than disappearing, and are excluded from the per-dependency and panel-level vulnerable counts.
 
 On Quarkus the panel is identical, listing the local inventory first and contacting OSV.dev only on the user-initiated
-scan, over the same report contract, the same CVSS/withdrawn/partial-failure handling, and the same dismiss/restore
-workflow. The one platform difference is dependency discovery: the Spring adapter scans the classpath for
-`META-INF/maven/*/pom.properties`, which is unreliable under the Quarkus runtime classloader, so the Quarkus inventory
-is captured at build time from the application's resolved runtime dependency model and read back at runtime (mirroring
-the Architecture panel's build-time base-package discovery). The OSV lookup itself is identical, and
-`bootui.vulnerabilities.osv-enabled=false` disables on-demand scanning on both adapters.
+scan, over the same report contract, the same CVSS/withdrawn/partial-failure handling, the same pagination/batch-
+chunking, the same EPSS enrichment, and the same dismiss/restore workflow. The one platform difference is dependency
+discovery: the Spring adapter scans the classpath for `META-INF/maven/*/pom.properties`, which is unreliable under the
+Quarkus runtime classloader, so the Quarkus inventory is captured at build time from the application's resolved runtime
+dependency model and read back at runtime (mirroring the Architecture panel's build-time base-package discovery). The
+OSV and EPSS lookups are identical, and `bootui.vulnerabilities.osv-enabled=false` /
+`bootui.vulnerabilities.epss-enabled=false` disable on-demand scanning / EPSS enrichment on both adapters.
+
+Two known limitations, documented honestly rather than hidden: the dependency inventory on both adapters is
+coordinate-based (one resolved JAR = one Maven `groupId:artifactId:version`), so a vulnerable library that has been
+relocated or repackaged inside a shaded/uber JAR carries no `pom.properties`/build-time coordinate of its own and is
+invisible to the inventory — the same reduced-fidelity honesty precedent already applied to other panels (for example
+Cache, Beans). And direct-vs-transitive dependency provenance ("introduced through") is not yet tracked on either
+adapter: Quarkus could source it from its existing build-time application dependency graph, but Spring's classpath-based
+inventory has no equivalent dependency graph today (adding one would need POM/Maven-plugin integration, a much larger
+change), so this is deferred rather than shipped as a Quarkus-only asymmetry for now.
 
 ![BootUI Vulnerabilities panel](./images/bootui-vulnerabilities.webp)
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -543,9 +543,25 @@ Features:
 - Show scan status, vulnerable dependency count, advisory count, severity breakdown, advisory links, aliases, and fixed
   versions when available.
 - Derive severity from a real CVSS v3.0/v3.1 Base Score computed from the advisory's CVSS vector (per the FIRST.org
-  specification) when present, falling back to the advisory's `database_specific` severity label otherwise; render
-  `UNKNOWN` only when neither is available, never silently drop the finding.
+  specification) when present, preferring a package-level `affected[].severity` entry matching the scanned dependency
+  over the advisory's top-level `severity[]` (the OSV schema states the two are mutually exclusive), falling back to
+  the advisory's `database_specific` severity label when no CVSS vector is present at either level; render `UNKNOWN`
+  only when none of these is available, never silently drop the finding.
 - Exclude advisories marked `withdrawn` by OSV from results and counts.
+- Follow OSV `/v1/querybatch` pagination (`next_page_token`) until every query is exhausted or a bounded page-count
+  safety limit is hit, and partition the outgoing package list into batches of at most 1,000 queries (OSV's documented
+  hard limit per request), merging every page/batch back into one result set.
+- Fetch distinct advisory details (`GET /v1/vulns/{id}`) with a small bounded concurrency (up to 10 at a time) instead of
+  one at a time, so scans against a dependency tree with many distinct advisories stay responsive.
+- Enrich each CVE-aliased advisory with FIRST.org [EPSS](https://www.first.org/epss/) exploit-probability data
+  (probability + percentile) in one batched request per scan, alongside the OSV calls; EPSS is a likelihood-of-
+  exploitation signal that deliberately complements, rather than replaces, the CVSS severity-if-exploited score. EPSS
+  lookups can be disabled independently of OSV scanning, and a failed/unreachable EPSS request never fails the scan or
+  discards the underlying OSV results — it just omits the EPSS figures.
+- Derive an explicit `fixAvailable` signal per advisory by comparing the dependency's currently-resolved version
+  against the advisory's `fixedVersions` (lightweight Maven-version-aware comparison), so the UI can render an
+  unambiguous "no fix published yet" state instead of leaving an empty `fixedVersions` list ambiguous between "checked,
+  none published" and "unknown".
 - Support disabling OSV scans with `bootui.vulnerabilities.osv-enabled=false`.
 - Allow dismissing/restoring an individual vulnerability finding for a specific dependency, excluding it from the
   vulnerable count and severity rollups until restored, consistent with the dismiss/restore workflow shared by every
@@ -559,6 +575,14 @@ Acceptance criteria:
   inventory; a failure fetching one advisory's details does not discard advisories that were already fetched
   successfully, degrading the scan to a partial-success status instead of an outright error.
 - Scan size is bounded by configuration so large classpaths remain responsive.
+
+Known limitation: the dependency inventory on both adapters is coordinate-based (one resolved JAR = one artifact
+coordinate). A vulnerable library relocated/repackaged inside a shaded or uber JAR has no `pom.properties`/build-time
+coordinate of its own, so it is invisible to the inventory and cannot be flagged — the same reduced-fidelity honesty
+precedent already documented for other panels (for example Cache, Beans). Direct-vs-transitive dependency provenance
+("introduced through") is not yet tracked on either adapter; Quarkus could source it from its build-time application
+dependency graph, but Spring's classpath-based inventory has no equivalent graph today, so this is deferred rather than
+shipped asymmetrically.
 
 ### 5.12 Scheduled Tasks Inspector
 
@@ -1345,6 +1369,8 @@ Initial properties:
 | `bootui.vulnerabilities.request-timeout`        | `10s`                                   | Timeout applied to each OSV request.                                                              |
 | `bootui.vulnerabilities.max-packages`           | `250`                                   | Maximum packages sent in one OSV batch query.                                                     |
 | `bootui.vulnerabilities.max-advisories`         | `200`                                   | Maximum advisory detail documents fetched after a query.                                          |
+| `bootui.vulnerabilities.epss-enabled`           | `true`                                  | Allow the batched FIRST.org EPSS exploit-probability lookup during a scan.                        |
+| `bootui.vulnerabilities.epss-base-uri`          | `https://api.first.org`                | Base URI of the FIRST.org EPSS API queried during a scan.                                         |
 | `bootui.github.api-enabled`                  | `true`                                  | Allow GitHub panel refresh calls to GitHub APIs.                                                  |
 | `bootui.github.request-timeout`              | `5s`                                    | Timeout for each GitHub API request and local `gh auth token` lookup.                             |
 | `bootui.github.max-pull-requests`            | `10`                                    | Maximum open pull requests returned in one GitHub refresh.                                        |


### PR DESCRIPTION
## Background

Prompted by an independent audit of the Vulnerabilities advisor by 5 LLMs (claude-opus-4.8, gpt-5.5, gemini-3.1-pro-preview, gpt-5.3-codex, claude-sonnet-5) against the current [OSV.dev API docs](https://google.github.io/osv.dev/post-v1-querybatch/), the [OSV schema](https://ossf.github.io/osv-schema/#severity), FIRST's [CVSS v3.1 spec](https://www.first.org/cvss/v3-1/specification-document), and a live NVD API cross-check of real CVEs (Log4Shell etc.). `CvssV3BaseScore`'s core scoring math was independently verified correct and is **untouched** (only its v4.0-exclusion Javadoc was reworded).

There's no dedicated `docs/*-CHECKS.md` for this advisor; `docs/FEATURES.md` and `docs/SPECIFICATION.md` are updated instead.

## MUST-FIX (unanimous 5/5, both adapters kept in sync)

- **Package-level OSV severity.** `severity()` now checks `affected[].severity` for the specific dependency's package before falling back to the top-level `severity[]`, per the OSV schema ("if any package-level severity fields are set, the top-level severity field MUST NOT be set"). Previously a package-only-severity advisory silently fell through to `UNKNOWN`.
- **Full `/v1/querybatch` pagination.** Follows `next_page_token` per query until exhausted or a bounded safety limit (20 rounds) is hit, degrading to `PARTIAL` with a clear message if the bound is reached instead of silently truncating results.

## Strong new features (5/5 or 4/5 unanimous)

- **EPSS enrichment.** Each CVE-aliased advisory is enriched with FIRST.org's exploit-probability data (one batched `GET /data/v1/epss` request per scan, chunked at 200 CVEs), rendered as a secondary badge with a percentile tooltip next to the CVSS severity badge. Configurable via `bootui.vulnerabilities.epss-enabled`/`epss-base-uri`; failures never affect scan status or discard OSV results.
- **Explicit `fixAvailable` signal.** Derived by comparing the dependency's current version against `fixedVersions` (lightweight Maven-version-aware comparator), letting the UI distinguish "fixed in x.y.z" / "already on a fixed version" / "No fix published yet" instead of a blank, ambiguous state.

## Deferred (documented rationale)

- **Item 5 — direct-vs-transitive dependency tracking.** Quarkus could source this from its existing build-time dependency graph (`CurateOutcomeBuildItem`), but Spring's classpath-based `DependencyCatalog` has no dependency-graph capability today and would need a much larger change (POM/Maven-plugin integration) to add one. Documented as a known limitation in `docs/FEATURES.md`/`docs/SPECIFICATION.md` rather than shipped as a Quarkus-only asymmetry, per the task's explicit permission to scope this down or defer.

## Stretch goals completed (all of 6-12)

- **#6** OSV's hard 1,000-query/request batch limit is now respected by partitioning the (already `max-packages`-bounded) package list before querying.
- **#7** `references[].type` now sorts `ADVISORY` first, then `FIX`, before truncating to 20 — so the canonical first reference link is the most authoritative one OSV returned.
- **#8** The numeric CVSS base score now renders next to the severity badge in `Vulnerabilities.vue`.
- **#9** Advisory detail fetches (`GET /v1/vulns/{id}`) now run with small bounded concurrency (up to 10 at a time) instead of fully sequentially, so a scan against a dependency tree with many distinct advisories no longer risks taking up to `maxAdvisories` × request-timeout in a bad-network scenario. Added dedicated tests exercising 16-25 concurrent advisories (exceeding the pool size) for both success and mixed-failure scenarios.
- **#10** The shaded/uber-JAR blind spot (coordinate-based inventory can't see relocated/repackaged libraries) is now documented as a known limitation.
- **#11** CVE/GHSA aliases are now clickable links to NVD / GitHub Advisories.
- **#12** `CvssV3BaseScore`'s v4.0-exclusion Javadoc reworded to mention FIRST's `cvss-resources` repo and community ports (`org-metaeffekt/metaeffekt-universal-cvss-calculator`, `pandatix/js-cvss`) as candidate future validation references, without changing any behavior.

## Incidental fixes discovered during implementation

- Fixed a Quarkus test-infrastructure bug where dynamic-response test handlers double-read/closed the `HttpExchange` request body, silently aborting exchanges under `com.sun.net.httpserver.HttpServer`.
- Fixed a `vue-tsc`/`vite-plugin-checker` build-time type error (`TS2365`) in the new alias-link template caused by ambiguous `v-for` index typing; refactored to a precomputed `aliasItems()` helper to avoid inline index arithmetic in the template.

## Verification

- `bootui-core`, `bootui-engine`, `bootui-spring-autoconfigure`, `bootui-quarkus` module tests all pass (Spring: 22/22, Quarkus: 23/23 for the OSV scanner suite specifically; stable across repeated runs).
- Frontend: full Vitest suite passes (359/359, 65 files), `npm run build` succeeds (vue-tsc type-check clean).
- `./mvnw spotless:apply`/`spotless:check` clean across the whole reactor.
- `npm run format`/`format:check` clean for the frontend.

Both adapters' `OsvVulnerabilityScanner.java` were kept behaviorally in sync throughout.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>