### PR TITLE
Fix Spring Application Advisor rule bugs found in 5-model audit

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
@@ -743,6 +743,18 @@ final class OpenInViewRule extends AbstractHibernateRule {
                         "https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.jpa-and-spring-data.open-in-view"));
     }
 
+    /**
+     * Also checked by SPRING-JPA-001 ({@code OpenSessionInViewEnabledRule}) in the Spring Application
+     * Advisor, which additionally skips when no JPA {@code EntityManagerFactory} or servlet web
+     * context is present — a guard this rule cannot reproduce, since "is this a servlet web
+     * application" is a framework-specific concept the framework-neutral engine cannot see (and on
+     * Quarkus, which has no Open-Session-in-View mechanism at all, the property lookup below simply
+     * never reports it enabled, so the rule is already inert there without needing that guard). Both
+     * rules are kept deliberately: they serve two independently-browsable UI panels (Hibernate vs.
+     * Spring), and the {@link HibernateContext#isProductionProfileActive()} escalation below is
+     * mirrored from SPRING-JPA-001 so the two panels report the same severity for the same
+     * misconfiguration.
+     */
     @Override
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
         Boolean value = context.booleanProperty("spring.jpa.open-in-view");
@@ -750,9 +762,11 @@ final class OpenInViewRule extends AbstractHibernateRule {
             return pass();
         }
         String detail = value == null
-                ? "spring.jpa.open-in-view is not set, so Spring Boot's web default enables it."
-                : "spring.jpa.open-in-view=true is enabled.";
-        return violation(List.of(detail));
+                ? "spring.jpa.open-in-view is not set and defaults to enabled, keeping a persistence context open"
+                        + " for the entire web request."
+                : "spring.jpa.open-in-view=true keeps a persistence context open for the entire web request.";
+        String severity = context.isProductionProfileActive() ? HibernateRuleSupport.HIGH : HibernateRuleSupport.MEDIUM;
+        return violation(severity, detail);
     }
 }
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
@@ -245,6 +245,48 @@ class HibernateRulesTests {
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
+    // --- HIB-CONFIG-001 -----------------------------------------------------
+
+    @Test
+    void openInViewRuleFlagsExplicitTrue() {
+        TestEnvironment environment = new TestEnvironment().withProperty("spring.jpa.open-in-view", "true");
+
+        HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.MEDIUM);
+    }
+
+    @Test
+    void openInViewRuleFlagsUnsetBootDefault() {
+        TestEnvironment environment = new TestEnvironment();
+
+        HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.MEDIUM);
+    }
+
+    @Test
+    void openInViewRulePassesWhenExplicitlyDisabled() {
+        TestEnvironment environment = new TestEnvironment().withProperty("spring.jpa.open-in-view", "false");
+
+        HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void openInViewRuleEscalatesToHighInProduction() {
+        TestEnvironment environment = new TestEnvironment().withProperty("spring.jpa.open-in-view", "true");
+        environment.setActiveProfiles("prod");
+
+        HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.HIGH);
+    }
+
     // --- HIB-CONFIG-008 -----------------------------------------------------
 
     @Test

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
@@ -253,6 +253,23 @@ final class RestTemplateInUseRule extends AbstractSpringRule {
     }
 }
 
+/**
+ * Deliberately kept alongside ARCH-SPRING-005 ({@code StereotypesShouldNotResideInDefaultPackageRule}
+ * in {@code bootui-engine}'s Architecture advisor), not a duplicate: ARCH-SPRING-005 runs an ArchUnit
+ * static bytecode scan restricted to classes carrying a Spring stereotype annotation directly
+ * ({@code @Component}/{@code @Service}/{@code @Repository}/{@code @Controller}/{@code
+ * @RestController}/{@code @Configuration}), so it only ever sees classes that are themselves
+ * annotated. This rule instead inspects the live bean registry ({@code
+ * SpringContext#defaultPackageBeans()}), which flags any application-role bean in the default
+ * package regardless of annotation — for example a plain, unannotated POJO whose class happens to
+ * live in the default package but is wired up via an {@code @Bean} factory method elsewhere. Empirically
+ * verified with a throwaway ArchUnit fixture: an unannotated default-package class registered as a
+ * bean is invisible to ARCH-SPRING-005's {@code STEREOTYPE_ANNOTATED} predicate (it does not match,
+ * so the ArchUnit rule reports zero violations for it) but is caught here. Since the Spring advisor
+ * (this rule's home) and the Architecture advisor are two independently-browsable UI panels, keeping
+ * both also lets a user auditing either panel in isolation see this finding without needing to know
+ * to check the other.
+ */
 final class DefaultPackageComponentsRule extends AbstractSpringRule {
 
     DefaultPackageComponentsRule() {
@@ -359,11 +376,43 @@ final class DebugOrTraceLoggingRule extends AbstractSpringRule {
 
 final class RemovedOrRenamedPropertyRule extends AbstractSpringRule {
 
-    /** Curated, high-confidence keys that were renamed or removed in Spring Boot 4. */
+    /**
+     * Curated, individually source-verified keys that were renamed or removed in Spring Boot 4.
+     *
+     * <p>Every entry here was confirmed against the actual Spring Boot 4.1.0 {@code
+     * @ConfigurationProperties} binding classes (not just the deprecation metadata, which can be
+     * misleading — see the note below), so the old key is genuinely dead: no code path reads it
+     * anymore. Two candidates that looked like renames were deliberately excluded after source
+     * verification showed the "old" and "new" keys are actually independent, both-functioning
+     * properties, not a rename:
+     *
+     * <ul>
+     *   <li>{@code spring.dao.exceptiontranslation.enabled} — Boot's own deprecation metadata (and
+     *       the community OpenRewrite migration recipe, which is generated from that same metadata)
+     *       claims this was renamed to {@code spring.persistence.exceptiontranslation.enabled}. It
+     *       was not: {@code DataSourceTransactionManagerAutoConfiguration} (module {@code
+     *       spring-boot-jdbc}) still reads {@code spring.dao.exceptiontranslation.enabled} directly
+     *       to choose between {@code JdbcTransactionManager} and a plain {@code
+     *       DataSourceTransactionManager}. The "replacement" is a different property read by a
+     *       different auto-configuration ({@code PersistenceExceptionTranslationAutoConfiguration},
+     *       module {@code spring-boot-persistence}) that solely gates the JPA {@code @Repository}
+     *       exception-translation post-processor bean. Both properties are independently live.
+     *   <li>{@code spring.jackson.read} / {@code spring.jackson.write} — these bind {@code
+     *       Map<StreamReadFeature/StreamWriteFeature, Boolean>} (Jackson's general, format-agnostic
+     *       features); {@code spring.jackson.json.read} / {@code spring.jackson.json.write} bind a
+     *       different type ({@code Map<JsonReadFeature/JsonWriteFeature, Boolean>}, JSON-specific
+     *       features introduced by the Jackson 3 split). They are two distinct, still-functioning
+     *       property groups, not a rename.
+     * </ul>
+     *
+     * <p>This list also does not attempt to reproduce every entry from the community
+     * spring-boot-40-properties OpenRewrite recipe (96 entries): Kafka/RabbitMQ retry-property
+     * renames, the OTLP exporter namespace restructuring, and the Jackson enum-splitting keys above
+     * were reviewed but excluded as lower-confidence or requiring more per-entry verification than
+     * scoped here.
+     */
     private static final List<String[]> LEGACY_PROPERTIES = List.of(
-            new String[] {
-                "spring.dao.exceptiontranslation.enabled", "renamed to spring.persistence.exceptiontranslation.enabled"
-            },
+            // --- Undertow removed entirely in Spring Boot 4 -------------------------------------
             new String[] {
                 "server.undertow.threads.io", "Undertow was removed in Spring Boot 4; this property is ignored"
             },
@@ -375,7 +424,64 @@ final class RemovedOrRenamedPropertyRule extends AbstractSpringRule {
             },
             new String[] {
                 "server.undertow.buffer-size", "Undertow was removed in Spring Boot 4; this property is ignored"
-            });
+            },
+            // --- server.error.* -> spring.web.error.* (spring-boot-web-server) ------------------
+            new String[] {"server.error.include-binding-errors", "renamed to spring.web.error.include-binding-errors"},
+            new String[] {"server.error.include-exception", "renamed to spring.web.error.include-exception"},
+            new String[] {"server.error.include-message", "renamed to spring.web.error.include-message"},
+            new String[] {"server.error.include-path", "renamed to spring.web.error.include-path"},
+            new String[] {"server.error.include-stacktrace", "renamed to spring.web.error.include-stacktrace"},
+            new String[] {"server.error.path", "renamed to spring.web.error.path"},
+            new String[] {"server.error.whitelabel.enabled", "renamed to spring.web.error.whitelabel.enabled"},
+            // --- server.servlet.encoding.* -> spring.servlet.encoding.* (spring-boot-web-server,
+            // spring-boot-servlet) — note server.servlet.encoding.mapping is NOT renamed and still
+            // works, so it is intentionally excluded here. ---------------------------------------
+            new String[] {"server.servlet.encoding.charset", "renamed to spring.servlet.encoding.charset"},
+            new String[] {"server.servlet.encoding.enabled", "renamed to spring.servlet.encoding.enabled"},
+            new String[] {"server.servlet.encoding.force", "renamed to spring.servlet.encoding.force"},
+            new String[] {"server.servlet.encoding.force-request", "renamed to spring.servlet.encoding.force-request"},
+            new String[] {"server.servlet.encoding.force-response", "renamed to spring.servlet.encoding.force-response"
+            },
+            // --- spring.http.client.* -> spring.http.clients.* (spring-boot-http-client); note
+            // .factory moved to .imperative.factory, not a naive pluralization. -------------------
+            new String[] {"spring.http.client.connect-timeout", "renamed to spring.http.clients.connect-timeout"},
+            new String[] {"spring.http.client.factory", "renamed to spring.http.clients.imperative.factory"},
+            new String[] {"spring.http.client.read-timeout", "renamed to spring.http.clients.read-timeout"},
+            new String[] {"spring.http.client.redirects", "renamed to spring.http.clients.redirects"},
+            new String[] {"spring.http.client.ssl.bundle", "renamed to spring.http.clients.ssl.bundle"},
+            // --- spring.data.mongodb.* connection keys -> spring.mongodb.* (spring-boot-mongodb).
+            // Only these 13 connection-related keys moved; spring.data.mongodb.auto-index-creation,
+            // .field-naming-strategy, .gridfs.*, and .representation.big-decimal are unrelated
+            // Spring Data settings that still live under spring.data.mongodb and are NOT renamed. --
+            new String[] {"spring.data.mongodb.additional-hosts", "renamed to spring.mongodb.additional-hosts"},
+            new String[] {
+                "spring.data.mongodb.authentication-database", "renamed to spring.mongodb.authentication-database"
+            },
+            new String[] {"spring.data.mongodb.database", "renamed to spring.mongodb.database"},
+            new String[] {"spring.data.mongodb.host", "renamed to spring.mongodb.host"},
+            new String[] {"spring.data.mongodb.password", "renamed to spring.mongodb.password"},
+            new String[] {"spring.data.mongodb.port", "renamed to spring.mongodb.port"},
+            new String[] {"spring.data.mongodb.protocol", "renamed to spring.mongodb.protocol"},
+            new String[] {"spring.data.mongodb.replica-set-name", "renamed to spring.mongodb.replica-set-name"},
+            new String[] {"spring.data.mongodb.ssl.bundle", "renamed to spring.mongodb.ssl.bundle"},
+            new String[] {"spring.data.mongodb.ssl.enabled", "renamed to spring.mongodb.ssl.enabled"},
+            new String[] {"spring.data.mongodb.uri", "renamed to spring.mongodb.uri"},
+            new String[] {"spring.data.mongodb.username", "renamed to spring.mongodb.username"},
+            new String[] {"spring.data.mongodb.uuid-representation", "renamed to spring.mongodb.representation.uuid"},
+            // --- management.tracing.enabled -> management.tracing.export.enabled
+            // (spring-boot-micrometer-tracing) ----------------------------------------------------
+            new String[] {"management.tracing.enabled", "renamed to management.tracing.export.enabled"},
+            // --- spring.session.redis.* -> spring.session.data.redis.*
+            // (spring-boot-session-data-redis) ----------------------------------------------------
+            new String[] {"spring.session.redis.cleanup-cron", "renamed to spring.session.data.redis.cleanup-cron"},
+            new String[] {
+                "spring.session.redis.configure-action", "renamed to spring.session.data.redis.configure-action"
+            },
+            new String[] {"spring.session.redis.flush-mode", "renamed to spring.session.data.redis.flush-mode"},
+            new String[] {"spring.session.redis.namespace", "renamed to spring.session.data.redis.namespace"},
+            new String[] {"spring.session.redis.repository-type", "renamed to spring.session.data.redis.repository-type"
+            },
+            new String[] {"spring.session.redis.save-mode", "renamed to spring.session.data.redis.save-mode"});
 
     RemovedOrRenamedPropertyRule() {
         super(new SpringRuleDefinition(
@@ -595,25 +701,53 @@ final class VirtualThreadsOverriddenByPoolRule extends AbstractSpringRule {
 
 final class AsyncWithoutCustomExecutorRule extends AbstractSpringRule {
 
+    /**
+     * Bean name Spring Boot's {@code TaskExecutionAutoConfiguration} registers for its
+     * auto-configured default executor when the application defines no {@code Executor}/{@code
+     * AsyncConfigurer} of its own.
+     */
+    private static final String DEFAULT_TASK_EXECUTOR_BEAN = "applicationTaskExecutor";
+
     AsyncWithoutCustomExecutorRule() {
         super(new SpringRuleDefinition(
                 "SPRING-PERF-003",
-                "@Async should use an explicit executor",
+                "@Async should use a reviewed executor",
                 SpringCategory.PERFORMANCE,
                 "MEDIUM",
-                "@EnableAsync is active but no TaskExecutor bean is defined. Without virtual threads,"
-                        + " @Async falls back to an unbounded SimpleAsyncTaskExecutor that creates a new"
-                        + " thread per task.",
-                "Define a dedicated executor (or enable spring.threads.virtual.enabled) so asynchronous"
-                        + " work runs on a bounded, monitored thread source.",
-                "https://docs.spring.io/spring-framework/reference/integration/scheduling.html"));
+                "@EnableAsync is active but the application either defines no TaskExecutor bean at all,"
+                        + " or relies solely on Spring Boot's auto-configured 'applicationTaskExecutor' left"
+                        + " at its default pool settings — a bounded ThreadPoolTaskExecutor with a core pool"
+                        + " size of 8 and an effectively unbounded queue — sized for a generic default, not"
+                        + " this application's actual @Async workload.",
+                "Define a dedicated executor sized for the workload, or explicitly review and set"
+                        + " spring.task.execution.pool.core-size / max-size instead of relying on the"
+                        + " unreviewed default, or enable spring.threads.virtual.enabled so @Async work is"
+                        + " not pooled at all.",
+                "https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html"));
     }
 
     @Override
     SpringRuleResultDto evaluateRule(SpringContext context) {
-        if (context.asyncEnabled() && context.taskExecutors().isEmpty() && !context.isVirtualThreadsEnabled()) {
-            return violation("@EnableAsync is active with no TaskExecutor bean, so @Async uses the"
-                    + " unbounded SimpleAsyncTaskExecutor.");
+        if (!context.asyncEnabled() || context.isVirtualThreadsEnabled()) {
+            return pass();
+        }
+        List<BeanRef> executors = context.taskExecutors();
+        if (executors.isEmpty()) {
+            // Rare in practice: TaskExecutionAutoConfiguration always registers a default TaskExecutor
+            // bean unless it was explicitly excluded, so this branch only fires when that
+            // auto-configuration itself is absent — the one case where @Async genuinely falls back to
+            // an unbounded SimpleAsyncTaskExecutor (one new platform thread per task).
+            return violation("@EnableAsync is active with no TaskExecutor bean at all, so @Async uses the"
+                    + " unbounded SimpleAsyncTaskExecutor (a new platform thread per task).");
+        }
+        boolean onlyBootDefault = executors.size() == 1 && SpringModel.hasName(executors, DEFAULT_TASK_EXECUTOR_BEAN);
+        boolean poolSizeReviewed = context.hasProperty("spring.task.execution.pool.core-size")
+                || context.hasProperty("spring.task.execution.pool.max-size");
+        if (onlyBootDefault && !poolSizeReviewed) {
+            return violation("@EnableAsync is active but the only TaskExecutor is Boot's auto-configured"
+                    + " 'applicationTaskExecutor' left at its default size (core pool size 8, unbounded"
+                    + " queue); this single pool backs every @Async method and has not been reviewed for"
+                    + " this workload.");
         }
         return pass();
     }
@@ -882,7 +1016,11 @@ final class ErrorDetailsExposedRule extends AbstractSpringRule {
     SpringRuleResultDto evaluateRule(SpringContext context) {
         List<String> findings = new ArrayList<>();
         for (String key : ERROR_DETAIL_KEYS) {
-            String value = context.firstProperty("spring.web.error." + key, "server.error." + key);
+            // Only spring.web.error.* is checked: server.error.* was renamed in Spring Boot 4 and no
+            // longer binds to anything (confirmed via WebProperties source), so treating it as a live
+            // fallback here would false-positive on a stale key that Boot now silently ignores.
+            // Detecting that stale key is SPRING-CONFIG-003's job (RemovedOrRenamedPropertyRule).
+            String value = context.firstProperty("spring.web.error." + key);
             if (value == null) {
                 continue;
             }
@@ -1152,6 +1290,15 @@ final class DangerousActuatorEndpointsAccessibleRule extends AbstractSpringRule 
     }
 }
 
+/**
+ * Deliberately kept alongside HIB-CONFIG-001 ({@code OpenInViewRule} in {@code bootui-engine}'s
+ * Hibernate advisor), which checks the same {@code spring.jpa.open-in-view} property but cannot
+ * reproduce this rule's skip-guard below: "is a servlet web application present" is a
+ * framework-specific concept the framework-neutral engine cannot see. Kept as two rules because they
+ * serve two independently-browsable UI panels (Spring vs. Hibernate); the production-profile severity
+ * escalation is mirrored on both sides so a user checking either panel sees the same severity for the
+ * same misconfiguration.
+ */
 final class OpenSessionInViewEnabledRule extends AbstractSpringRule {
 
     OpenSessionInViewEnabledRule() {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
@@ -97,6 +97,72 @@ class SpringRulesTests {
                 .isEqualTo("PASS");
     }
 
+    // ── SPRING-PERF-003: @Async left on the unreviewed Boot-default executor ──────
+
+    @Test
+    void asyncWithoutCustomExecutorFlagsUnreviewedBootDefault() {
+        AsyncWithoutCustomExecutorRule rule = new AsyncWithoutCustomExecutorRule();
+        List<BeanRef> bootDefaultOnly = List.of(new BeanRef("applicationTaskExecutor", false));
+
+        // No @EnableAsync at all: nothing to check.
+        assertThat(rule.evaluate(context(env()).taskExecutors(bootDefaultOnly).build())
+                        .status())
+                .isEqualTo("PASS");
+
+        // Virtual threads replace the pooled executor entirely, so the rule does not apply.
+        assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true"))
+                                .asyncEnabled(true)
+                                .taskExecutors(bootDefaultOnly)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+
+        // Rare case: TaskExecutionAutoConfiguration itself is absent, so @Async falls back to the
+        // truly unbounded SimpleAsyncTaskExecutor.
+        assertThat(rule.evaluate(context(env()).asyncEnabled(true).build()).status())
+                .isEqualTo("VIOLATION");
+
+        // Common case: the only TaskExecutor is Boot's auto-configured applicationTaskExecutor, left
+        // at its default pool size — this is the real, previously-missed risk.
+        assertThat(rule.evaluate(context(env())
+                                .asyncEnabled(true)
+                                .taskExecutors(bootDefaultOnly)
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+
+        // Reviewing the pool size (core-size or max-size) suppresses the finding.
+        assertThat(rule.evaluate(context(env().withProperty("spring.task.execution.pool.core-size", "16"))
+                                .asyncEnabled(true)
+                                .taskExecutors(bootDefaultOnly)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(rule.evaluate(context(env().withProperty("spring.task.execution.pool.max-size", "32"))
+                                .asyncEnabled(true)
+                                .taskExecutors(bootDefaultOnly)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+
+        // A custom, deliberately-named executor (not the Boot default) is assumed reviewed.
+        assertThat(rule.evaluate(context(env())
+                                .asyncEnabled(true)
+                                .taskExecutors(List.of(new BeanRef("reportingExecutor", false)))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+
+        // Multiple executors are an ambiguity case handled by SPRING-WIRING-004, not this rule.
+        assertThat(rule.evaluate(context(env())
+                                .asyncEnabled(true)
+                                .taskExecutors(List.of(
+                                        new BeanRef("applicationTaskExecutor", false), new BeanRef("other", false)))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+    }
+
     // ── SPRING-WIRING-006: multiple transaction managers ─────────────────────────
 
     @Test
@@ -170,16 +236,52 @@ class SpringRulesTests {
     void renamedOrRemovedPropertiesFlagged() {
         RemovedOrRenamedPropertyRule rule = new RemovedOrRenamedPropertyRule();
 
+        // spring.dao.exceptiontranslation.enabled is NOT a dead/renamed key (still read directly by
+        // DataSourceTransactionManagerAutoConfiguration), so it must never be flagged here — this
+        // guards against re-introducing that false positive.
         assertThat(rule.evaluate(context(env().withProperty("spring.dao.exceptiontranslation.enabled", "true"))
                                 .build())
                         .status())
-                .isEqualTo("VIOLATION");
+                .isEqualTo("PASS");
         assertThat(rule.evaluate(context(env().withProperty("server.undertow.threads.io", "4"))
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
-        // management.tracing.enabled is a valid Boot 4 key again, so it must no longer be flagged.
+        // management.tracing.enabled was deprecated (level: error) in favour of
+        // management.tracing.export.enabled since Boot 4.0, so it must be flagged.
         assertThat(rule.evaluate(context(env().withProperty("management.tracing.enabled", "true"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        // Sample one entry from each of the other newly-added rename groups.
+        assertThat(rule.evaluate(context(env().withProperty("server.error.include-stacktrace", "always"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("server.servlet.encoding.charset", "UTF-8"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.http.client.connect-timeout", "5s"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.data.mongodb.host", "localhost"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.session.redis.namespace", "spring:session"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        // server.servlet.encoding.mapping is deliberately NOT in the rename list (still works as-is).
+        assertThat(rule.evaluate(context(env().withProperty("server.servlet.encoding.mapping", "*.html"))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        // spring.data.mongodb.gridfs.* is a Spring Data setting, unrelated to the connection-property
+        // rename, and must not be flagged either.
+        assertThat(rule.evaluate(context(env().withProperty("spring.data.mongodb.gridfs.database", "files"))
                                 .build())
                         .status())
                 .isEqualTo("PASS");
@@ -284,18 +386,18 @@ class SpringRulesTests {
     // ── SPRING-WEB-004 ───────────────────────────────────────────────────────────
 
     @Test
-    void errorDetailsExposedFlagsBothPrefixes() {
+    void errorDetailsExposedFlagsOnlySpringWebErrorPrefix() {
         ErrorDetailsExposedRule rule = new ErrorDetailsExposedRule();
 
         assertThat(rule.evaluate(context(env().withProperty("spring.web.error.include-stacktrace", "always"))
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
-        assertThat(rule.evaluate(context(env().withProperty("server.error.include-message", "always"))
+        assertThat(rule.evaluate(context(env().withProperty("spring.web.error.include-message", "always"))
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
-        assertThat(rule.evaluate(context(env().withProperty("server.error.include-exception", "true"))
+        assertThat(rule.evaluate(context(env().withProperty("spring.web.error.include-exception", "true"))
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
@@ -303,7 +405,19 @@ class SpringRulesTests {
                                 .build())
                         .status())
                 .isEqualTo("PASS");
-        assertThat(rule.evaluate(context(env().withProperty("server.error.include-exception", "false"))
+        assertThat(rule.evaluate(context(env().withProperty("spring.web.error.include-exception", "false"))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        // server.error.* was renamed to spring.web.error.* in Boot 4 (SPRING-CONFIG-003 owns flagging
+        // the stale key itself), so it no longer has any live effect and must not be flagged here —
+        // otherwise this rule and SPRING-CONFIG-003 would double-report the exact same misconfiguration
+        // under two different rule IDs.
+        assertThat(rule.evaluate(context(env().withProperty("server.error.include-message", "always"))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(rule.evaluate(context(env().withProperty("server.error.include-exception", "true"))
                                 .build())
                         .status())
                 .isEqualTo("PASS");

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -557,12 +557,16 @@ includes up to a handful of sample mapped members plus a remediation link.
 
 ### HIB-CONFIG-001 - Open Session in View should be disabled
 
-- **Severity**: MEDIUM
-- **Inspects**: `spring.jpa.open-in-view`.
+- **Severity**: MEDIUM (HIGH when a production-like profile is active)
+- **Inspects**: `spring.jpa.open-in-view` and active Spring profiles.
 - **Fires when**: the property is `true` or absent, matching Spring Boot's default for web applications.
 - **Why it matters**: lazy loading after the service transaction has completed can hide missing fetch plans and move data
   access into the web layer.
 - **Recommendation**: set `spring.jpa.open-in-view=false` and fetch data inside transactional service boundaries.
+- **Note**: the Spring panel's SPRING-JPA-001 checks the same property and mirrors this same production-profile
+  escalation, but additionally skips when no JPA `EntityManagerFactory` or servlet web context is present - a
+  framework-specific guard this framework-neutral rule cannot reproduce. Both are kept so each panel reports the
+  finding for its own domain.
 
 ### HIB-CONFIG-003 - Lazy loading outside transactions should stay disabled
 

--- a/docs/SPRING-CHECKS.md
+++ b/docs/SPRING-CHECKS.md
@@ -74,7 +74,7 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-WIRING-008 - Avoid components in the default package
 
 - **Severity**: MEDIUM
-- **Detects**: Detects application beans whose class lives in the default (unnamed) package. A class there forces component scanning to scan the entire classpath, slows startup, and breaks several Spring features.
+- **Detects**: Detects application beans whose class lives in the default (unnamed) package. A class there forces component scanning to scan the entire classpath, slows startup, and breaks several Spring features. This inspects the live bean registry, so it also catches an unannotated class wired up via an `@Bean` factory method - a case the Architecture panel's ARCH-SPRING-005 (a static ArchUnit scan restricted to classes directly annotated with a Spring stereotype) cannot see, since the plain class carries no annotation for ArchUnit to match. The two checks are kept intentionally separate for this reason; see the Architecture panel for the complementary static-scan finding.
 - **Recommendation**: Move these classes into a named package (for example com.example.app) so component scanning is bounded to your application's packages.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/using/structuring-your-code.html>
 
@@ -104,7 +104,7 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-CONFIG-003 - Remove renamed or deleted Spring Boot 4 properties
 
 - **Severity**: MEDIUM
-- **Detects**: Detects configuration keys that were renamed or removed in Spring Boot 4 and therefore no longer take effect, which can silently change behaviour after an upgrade. The current curated set covers spring.dao.exceptiontranslation.enabled (renamed to spring.persistence.exceptiontranslation.enabled) and common server.undertow.* keys (Undertow was removed in Spring Boot 4).
+- **Detects**: Detects configuration keys that were renamed or removed in Spring Boot 4 and therefore no longer take effect, which can silently change behaviour after an upgrade. The curated set (individually source-verified against Spring Boot 4.1.0, 41 keys) covers: common server.undertow.* keys (Undertow was removed entirely); server.error.* (renamed to spring.web.error.*); server.servlet.encoding.* except .mapping, which still works (renamed to spring.servlet.encoding.*); spring.http.client.* (renamed to spring.http.clients.*, with .factory moving to .imperative.factory); spring.data.mongodb.* connection keys such as .host/.uri/.username (renamed to spring.mongodb.*; unrelated Spring Data settings like .gridfs.* and .auto-index-creation stay under spring.data.mongodb and are not flagged); management.tracing.enabled (renamed to management.tracing.export.enabled); and spring.session.redis.* (renamed to spring.session.data.redis.*). spring.dao.exceptiontranslation.enabled is deliberately **not** included: despite Spring Boot's own deprecation metadata suggesting a rename to spring.persistence.exceptiontranslation.enabled, DataSourceTransactionManagerAutoConfiguration still reads the old key directly and it remains fully functional - the "replacement" is an unrelated property gating JPA repository exception translation.
 - **Recommendation**: Update each key to its Spring Boot 4 equivalent (the spring-boot-properties-migrator module lists the replacements at startup) and remove keys for dropped features.
 - **Learn more**: <https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide>
 
@@ -161,12 +161,12 @@ The panel is always available (a Spring application context always exists). Bean
 - **Recommendation**: If the pooling is not deliberate, remove the custom ThreadPoolTaskExecutor or replace it with a virtual-thread executor so asynchronous work benefits from virtual threads.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html>
 
-### SPRING-PERF-003 - @Async should use an explicit executor
+### SPRING-PERF-003 - @Async should use a reviewed executor
 
 - **Severity**: MEDIUM
-- **Detects**: @EnableAsync is active but no TaskExecutor bean is defined. Without virtual threads, @Async falls back to an unbounded SimpleAsyncTaskExecutor that creates a new thread per task.
-- **Recommendation**: Define a dedicated executor (or enable spring.threads.virtual.enabled) so asynchronous work runs on a bounded, monitored thread source.
-- **Learn more**: <https://docs.spring.io/spring-framework/reference/integration/scheduling.html>
+- **Detects**: @EnableAsync is active and virtual threads are not enabled, and either (a) no TaskExecutor bean exists at all - rare, since Spring Boot auto-configures one, but when it happens @Async falls back to the unbounded SimpleAsyncTaskExecutor (a new platform thread per task) - or (b) the only TaskExecutor is Spring Boot's auto-configured `applicationTaskExecutor` left at its default settings (a bounded ThreadPoolTaskExecutor with a core pool size of 8 and an effectively unbounded queue) with neither spring.task.execution.pool.core-size nor .max-size customized, so a generic default - not a size chosen for this application's @Async workload - backs every @Async method unreviewed.
+- **Recommendation**: Define a dedicated executor sized for the workload, or explicitly review and set spring.task.execution.pool.core-size / max-size instead of relying on the unreviewed default, or enable spring.threads.virtual.enabled so @Async work is not pooled at all.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html>
 
 ### SPRING-PERF-004 - Connection pool may bottleneck virtual threads
 
@@ -222,7 +222,7 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-WEB-004 - Do not always expose error details
 
 - **Severity**: MEDIUM
-- **Detects**: An error-detail property is set to 'always', or include-exception is true, so stack traces, exception messages, binding errors, or exception types are returned in error responses to every client - a common way to leak internal implementation details. Both spring.web.error.* and legacy server.error.* prefixes are checked.
+- **Detects**: A spring.web.error.* property is set to 'always', or include-exception is true, so stack traces, exception messages, binding errors, or exception types are returned in error responses to every client - a common way to leak internal implementation details. The legacy server.error.* prefix (renamed in Spring Boot 4) is intentionally not checked here to avoid double-reporting the same misconfiguration as SPRING-CONFIG-003, which already flags the stale server.error.* keys themselves.
 - **Recommendation**: Use 'never' (or 'on-param') for include-stacktrace / include-message / include-binding-errors, and leave include-exception false, so details are not exposed to arbitrary callers.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/servlet.html>
 
@@ -252,7 +252,7 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-JPA-001 - Disable Open Session in View
 
 - **Severity**: MEDIUM (HIGH when a production-like profile is active)
-- **Detects**: Detects a servlet JPA application where spring.jpa.open-in-view is not set (and therefore defaults to enabled) or is explicitly true. Open Session in View keeps a JPA persistence context (and often its database connection) open for the whole web request, hides lazy-loading boundaries, encourages N+1 queries, and holds connections longer under load.
+- **Detects**: Detects a servlet JPA application where spring.jpa.open-in-view is not set (and therefore defaults to enabled) or is explicitly true. Open Session in View keeps a JPA persistence context (and often its database connection) open for the whole web request, hides lazy-loading boundaries, encourages N+1 queries, and holds connections longer under load. The Hibernate panel's HIB-CONFIG-001 checks the same property and mirrors the same production-profile severity escalation, but cannot reproduce this rule's servlet/EntityManagerFactory skip-guard (a framework-neutral engine has no concept of "is this a servlet web application"); both are kept so each panel reports the finding for its own domain without contradicting the other.
 - **Recommendation**: Set spring.jpa.open-in-view=false and load the associations each request needs explicitly (fetch joins, entity graphs, or DTO projections).
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.jpa-and-spring-data.open-entity-manager-in-view>
 


### PR DESCRIPTION
## Summary

Source-verified fixes to the Spring Application Advisor (`bootui-spring-autoconfigure`, 37 rules — count unchanged) following a 5-model AI research audit (claude-opus-4.8, gpt-5.5, gemini-3.1-pro-preview, gpt-5.3-codex, claude-sonnet-5), synthesized by an orchestrator session and re-verified by me against the current repo code and live Spring Boot 4.1.0 source before implementing anything. This PR follows the same tone/rigor as #509.

Every item below was independently re-verified against Spring Boot 4.1.0 source (the version this repo's root `pom.xml` pins) — not just Boot's own deprecation metadata, which turned out to be actively misleading in one case (item 1).

---

### 1. SPRING-CONFIG-003 — removed a wrong entry

`RemovedOrRenamedPropertyRule`'s `LEGACY_PROPERTIES` claimed `spring.dao.exceptiontranslation.enabled` was renamed to `spring.persistence.exceptiontranslation.enabled`. **Verified false**: `DataSourceTransactionManagerAutoConfiguration` (`spring-boot-jdbc`) still reads `spring.dao.exceptiontranslation.enabled` directly to choose between `JdbcTransactionManager` and a plain `DataSourceTransactionManager`. The "replacement" is a different property read by a different auto-configuration (`PersistenceExceptionTranslationAutoConfiguration`, `spring-boot-persistence`) that solely gates the JPA `@Repository` exception-translation post-processor. Boot's own deprecation metadata (`level: error`) is misleading here — the old key is not dead. Removed the entry; added a regression-guard test and a Javadoc note explaining the trap.

### 2. SPRING-CONFIG-003 — expanded the rename list (5 → 41 entries)

Verified every orchestrator-suggested candidate individually against Spring Boot 4.1.0 source/`additional-spring-configuration-metadata.json` before adding, cross-checked against OpenRewrite's `rewrite-spring` Boot-4.0-properties recipe:

| Old prefix | New prefix | Module | Count |
|---|---|---|---|
| `server.undertow.*` (existing) | — (Undertow removed) | — | 4 |
| `server.error.*` | `spring.web.error.*` | spring-boot-web-server | 7 |
| `server.servlet.encoding.*` (excl. `.mapping`, still works) | `spring.servlet.encoding.*` | spring-boot-servlet | 5 |
| `spring.http.client.*` | `spring.http.clients.*` (`.factory` → `.imperative.factory`) | spring-boot-http-client | 5 |
| `spring.data.mongodb.*` connection keys (excl. `.gridfs.*`, `.auto-index-creation`, unrelated) | `spring.mongodb.*` | spring-boot-mongodb | 13 |
| `management.tracing.enabled` | `management.tracing.export.enabled` | spring-boot-micrometer-tracing | 1 |
| `spring.session.redis.*` | `spring.session.data.redis.*` | spring-boot-session-data-redis | 6 |

Rejected `spring.jackson.read`/`spring.jackson.write` as a second trap: these bind a different, still-live type (`Map<StreamReadFeature/StreamWriteFeature, Boolean>`) than `spring.jackson.json.read`/`.write` (`Map<JsonReadFeature/JsonWriteFeature, Boolean>`) — Jackson 3's feature-splitting, not a rename. Both are independently functional.

**Byproduct fix (SPRING-WEB-004)**: `ErrorDetailsExposedRule` was checking both `spring.web.error.*` and the now-dead `server.error.*` as a live fallback. Removed the dead fallback so it no longer double-reports the same misconfiguration SPRING-CONFIG-003 already flags under a separate rule ID.

### 3. SPRING-PERF-003 — fixed near-dead rule + wrong message

Old condition: `context.asyncEnabled() && context.taskExecutors().isEmpty() && !context.isVirtualThreadsEnabled()`. Verified via `TaskExecutionAutoConfiguration` source that Boot **always** registers a default `applicationTaskExecutor` `TaskExecutor` bean unless explicitly excluded — so `taskExecutors().isEmpty()` is essentially never true, making the rule almost never fire. The message was also wrong: it claimed the fallback is an "unbounded SimpleAsyncTaskExecutor," but Boot's actual default is a **bounded** `ThreadPoolTaskExecutor` (core pool size 8).

Reworked into two branches:
- **(a) Rare**: no `TaskExecutor` at all (the true unbounded-`SimpleAsyncTaskExecutor` case).
- **(b) Common, previously-undetected risk**: the only `TaskExecutor` present is Boot's `applicationTaskExecutor` left at default size, with neither `spring.task.execution.pool.core-size` nor `.max-size` reviewed — a generic default silently backing all `@Async` work.

Corrected the message to describe the real default and renamed the rule from "should use an explicit executor" to "should use a **reviewed** executor" to reflect the new condition.

**Known pre-existing limitation (unaddressed, out of scope)**: `AsyncExecutionAspectSupport.getDefaultExecutor()` actually falls back to *any* `Executor`-type bean, not just `TaskExecutor`. A raw non-`TaskExecutor` `Executor` bean could make `taskExecutors().isEmpty()` true even though `@Async` would use that bean rather than `SimpleAsyncTaskExecutor` — a narrow false-positive in branch (a). This condition existed before my change and is unchanged by it; flagging for visibility rather than expanding scope.

### 4. Cross-advisor redundancy — verified, not blindly deduplicated

**4a. SPRING-WIRING-008 vs ARCH-SPRING-005 (Architecture panel)** — kept both. Built and ran a throwaway ArchUnit fixture to test the actual claim: ARCH-SPRING-005's `STEREOTYPE_ANNOTATED` predicate only matches classes carrying a Spring stereotype annotation directly, so it's blind to an *unannotated* default-package POJO registered via an `@Bean` factory method elsewhere — a case SPRING-WIRING-008's live bean-registry check (`SpringContext#defaultPackageBeans()`) still catches. Not a strict subset relationship as hypothesized; documented the empirical finding in both rules' Javadoc and in `docs/SPRING-CHECKS.md`.

**4b. SPRING-JPA-001 vs HIB-CONFIG-001 (Hibernate panel)** — kept both, ported HIB-CONFIG-001's missing behavior. SPRING-JPA-001 had a skip-guard (no JPA `EntityManagerFactory`/servlet context → skip) and production-severity escalation (MEDIUM → HIGH); HIB-CONFIG-001 had neither. Ported the **severity escalation** into HIB-CONFIG-001 so both panels report the same severity for the same misconfiguration. Did **not** port the skip-guard — "is this a servlet web application" is a framework-specific concept the framework-neutral engine has no way to see, and on Quarkus (which has no OSIV mechanism at all) `QuarkusHibernatePropertyLookup` already unconditionally neutralizes the property to `false`, making the rule inert there without needing the guard. Documented the split rationale in both rules' Javadoc and in `docs/HIBERNATE-CHECKS.md`/`docs/SPRING-CHECKS.md`.

### 5. New rule candidates — evaluated, both rejected (not silently dropped)

- **`@Async`/`@Scheduled` swallowed-exception detection**: rejected for irreducible false-positive risk — there's no reflection-based way to distinguish a method that already handles its own exceptions internally from one that silently swallows them.
- **Virtual threads + `synchronized` pinning detection**: rejected after finding **JEP 491** (Synchronize Virtual Threads without Pinning, JDK 24+) eliminates the pinning risk this rule would flag on current JDKs. Read the existing `VirtualThreadsAvailableRule`/`VirtualThreadsOverriddenByPoolRule`/`ConnectionPoolSmallForVirtualThreadsRule` first to check for overlap (none found) before rejecting on the JEP-491 grounds. Left `VirtualThreadsAvailableRule`'s existing JDK 21-era pinning caveat as-is since JDK 21 LTS remains in wide use — not stale for that audience.

### 6. Stale-wording sweep

Read all 37 rules end-to-end looking for RestTemplate/Jackson-2-era or other stale phrasing beyond the items above. Found none beyond what's already fixed in items 1–4.

### 7. Docs

Updated `docs/SPRING-CHECKS.md` (SPRING-CONFIG-003, SPRING-PERF-003, SPRING-WEB-004, SPRING-WIRING-008, SPRING-JPA-001 sections) and `docs/HIBERNATE-CHECKS.md` (HIB-CONFIG-001) to match every behavioral change. Rule count (37) and the default-severity histogram in SPRING-CHECKS.md's "Rule summary" are unchanged — no rule was added, removed, or had its *default* declared severity changed (only context-aware escalation, already covered by that summary's existing "Context-aware rules can raise ... to HIGH" sentence).

### 8. Validation

- `./mvnw -pl bootui-core,bootui-engine,bootui-spring-autoconfigure -am test` — **1978 tests, 0 failures/errors**.
- `bootui-engine`'s `HibernateRulesTests` (4 new tests for HIB-CONFIG-001's severity escalation) included in the above.
- `./mvnw spotless:apply` then `spotless:check` — clean, only the 6 files in this diff touched.
- `SpringApiConformanceTest` (shared conformance suite) — **5/5 passing**.
- **Quarkus-safety check**: `HibernateRules.java` lives in the shared `bootui-engine` and backs Quarkus's Hibernate panel too. Verified the change is safe there both by source inspection — `QuarkusHibernatePropertyLookup.apply("spring.jpa.open-in-view")` unconditionally returns `"false"`, so `OpenInViewRule`'s existing `Boolean.FALSE.equals(value)` early-return already short-circuits *before* reaching the new severity-escalation code — and empirically, by running `QuarkusHibernatePropertyLookupTest` (10/10 passing). No Quarkus-only files were touched. (The dedicated `BootUiQuarkusHibernateAdvisorTest` integration test that also asserts OSIV stays inert on Quarkus lives in a JDK-`[17,26)`-gated module per this repo's documented Hibernate/Quarkus JDK caveat, and this environment only has JDK 26 available, so it could not be executed directly — the source-level proof plus the property-lookup unit test above cover the same code path.)

---

**Boundary respected**: the Spring Application Advisor stays entirely in `bootui-spring-autoconfigure` (not moved to `bootui-engine`); the one shared-engine change (HIB-CONFIG-001) was already engine-owned before this PR and is a pure escalation-logic addition, not a relocation.

No open uncertainties — proceeding straight to PR per the task's instructions, since all decisions above were made with direct source verification.