### PR TITLE
Fix GraalVM advisor: stale doc URLs, Spring-AOT wording, dependency-scanner fat-jar gap, 2 new checks

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmCheckRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmCheckRegistry.java
@@ -13,6 +13,7 @@ final class GraalVmCheckRegistry {
             new ClassLoaderUsageCheck(),
             new DeepReflectionCheck(),
             new AnnotationReflectionCheck(),
+            new UnsafeAllocateInstanceCheck(),
             new DynamicProxyCheck(),
             new ResourceAccessCheck(),
             new ResourceBundleCheck(),
@@ -33,6 +34,7 @@ final class GraalVmCheckRegistry {
             new MethodHandleUsageCheck(),
             new SecurityProviderCheck(),
             new JmxUsageCheck(),
+            new JmxDynamicMBeanCheck(),
             new ForeignFunctionUsageCheck());
 
     private GraalVmCheckRegistry() {}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmChecks.java
@@ -108,7 +108,7 @@ final class ReflectionUsageCheck extends AbstractArchUnitGraalVmCheck {
                 "MEDIUM",
                 "Detects calls to the reflection API (Class.forName, Method.invoke, Field value get/set, Class.getDeclared*, Constructor.newInstance) that GraalVM cannot resolve at build time. Reflective metadata accessors such as Field.getName() are intentionally ignored.",
                 "Register the reflectively accessed types in reachability-metadata.json, or for application code register them with Spring's RuntimeHints (e.g. via @ImportRuntimeHints / RuntimeHintsRegistrar). Spring AOT already covers Spring-managed beans.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -154,7 +154,7 @@ final class DynamicProxyCheck extends AbstractArchUnitGraalVmCheck {
                 "MEDIUM",
                 "Detects calls to Proxy.newProxyInstance and Proxy.getProxyClass, which create JDK dynamic proxies whose interface lists must be known to native-image. When the interface array is a compile-time constant, native-image may auto-register the proxy; runtime-computed interface sets always need explicit metadata.",
                 "Declare the proxied interfaces in reachability-metadata.json, or for application code register them with Spring's RuntimeHints (RuntimeHints.proxies().registerJdkProxy(...) via @ImportRuntimeHints). Spring's own proxy mechanisms are covered by Spring AOT.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/DynamicProxy/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -189,7 +189,7 @@ final class ResourceAccessCheck extends AbstractArchUnitGraalVmCheck {
                 "LOW",
                 "Detects calls to Class/ClassLoader getResource and getResourceAsStream, whose resources must be embedded in the native image to be available at runtime. Calls with a constant resource name are often already detected automatically by native-image; runtime-computed names always need registration.",
                 "Register the loaded resource paths (as globs) in reachability-metadata.json, or for application code register them with Spring's RuntimeHints (RuntimeHints.resources() via @ImportRuntimeHints) so native-image bundles them.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Resources/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -309,7 +309,7 @@ final class ClassLoaderUsageCheck extends AbstractArchUnitGraalVmCheck {
                 "MEDIUM",
                 "Detects calls to ClassLoader.loadClass, which load classes by name at run time; native-image cannot discover such types statically.",
                 "Register the dynamically loaded types under reflection in reachability-metadata.json, or replace ClassLoader.loadClass with direct class literals where possible.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -345,7 +345,7 @@ final class DeepReflectionCheck extends AbstractArchUnitGraalVmCheck {
                 "MEDIUM",
                 "Detects deep reflection that bypasses access checks: AccessibleObject.setAccessible/trySetAccessible and MethodHandles.privateLookupIn, which native-image must be told about to keep the members reachable.",
                 "Register the accessed members (with allowWrite where needed) under reflection in reachability-metadata.json and ensure the required module opens are configured; prefer public APIs over deep reflection.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -394,7 +394,7 @@ final class AnnotationReflectionCheck extends AbstractArchUnitGraalVmCheck {
                 "LOW",
                 "Detects reflective annotation queries on reflected members (Method, Field, Constructor, Parameter), whose annotations native-image only retains when the element is registered for reflection.",
                 "Register the inspected members under reflection in reachability-metadata.json so their annotations are available at run time.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -420,6 +420,45 @@ final class AnnotationReflectionCheck extends AbstractArchUnitGraalVmCheck {
 }
 
 /**
+ * Flags calls to {@code Unsafe.allocateInstance(Class)} on {@code sun.misc.Unsafe} or
+ * {@code jdk.internal.misc.Unsafe}. Unsafe allocation constructs an instance without invoking any
+ * constructor, bypassing the construction path that native-image's reachability analysis tracks, so
+ * the allocated type needs its own {@code unsafeAllocated} reflection metadata in addition to normal
+ * type registration.
+ */
+final class UnsafeAllocateInstanceCheck extends AbstractArchUnitGraalVmCheck {
+
+    UnsafeAllocateInstanceCheck() {
+        super(new GraalVmCheckDefinition(
+                "GRAAL-REFLECT-005",
+                "Unsafe.allocateInstance bypasses construction and needs unsafeAllocated metadata",
+                GraalVmCategory.REFLECTION,
+                "MEDIUM",
+                "Detects calls to Unsafe.allocateInstance(Class) on sun.misc.Unsafe or jdk.internal.misc.Unsafe. This constructs an instance without invoking any constructor, which bypasses the construction path native-image's reachability analysis tracks; without metadata this throws MissingReflectionRegistrationError at run time.",
+                "Register the allocated type under reflection in reachability-metadata.json with \"unsafeAllocated\": true (in addition to its normal type registration), or replace Unsafe.allocateInstance with a public constructor or factory method where possible.",
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
+    }
+
+    @Override
+    ArchRule rule(GraalVmContext context) {
+        return noClasses()
+                .should()
+                .callMethodWhere(new DescribedPredicate<JavaMethodCall>("Unsafe.allocateInstance() is called") {
+                    @Override
+                    public boolean test(JavaMethodCall call) {
+                        MethodCallTarget target = call.getTarget();
+                        if (!"allocateInstance".equals(target.getName())) {
+                            return false;
+                        }
+                        String ownerName = target.getOwner().getName();
+                        return "sun.misc.Unsafe".equals(ownerName) || "jdk.internal.misc.Unsafe".equals(ownerName);
+                    }
+                })
+                .as("Classes should not use Unsafe.allocateInstance without unsafeAllocated metadata");
+    }
+}
+
+/**
  * Flags {@code ResourceBundle.getBundle}, whose localized {@code .properties} files must be embedded
  * in the native image (with all locale variants) to be available at run time.
  */
@@ -433,7 +472,7 @@ final class ResourceBundleCheck extends AbstractArchUnitGraalVmCheck {
                 "LOW",
                 "Detects calls to ResourceBundle.getBundle, whose localized .properties files must be registered so native-image embeds them.",
                 "Register the bundle base names under bundles in reachability-metadata.json so native-image includes every locale variant.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Resources/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -470,7 +509,7 @@ final class ServiceLoaderCheck extends AbstractArchUnitGraalVmCheck {
                 "LOW",
                 "Detects calls to ServiceLoader.load, which discover providers via META-INF/services; native-image must reach the provider configuration and reflectively instantiate the implementations.",
                 "Ensure the META-INF/services provider files are on the classpath and register the provider implementations under reflection in reachability-metadata.json.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -529,7 +568,7 @@ final class BuildTimeInitializationCheck extends AbstractArchUnitGraalVmCheck {
                         "Static initializer I/O or thread starts may break build-time initialization",
                         GraalVmCategory.BUILD_TIME_INIT,
                         "LOW",
-                        "Detects static initializers that perform file I/O (java.io file streams or filesystem-touching java.nio.file.Files calls) or start threads/processes directly. Since GraalVM 21.3+ classes are run-time-initialized by default, this only applies when the class is explicitly initialized at build time via --initialize-at-build-time or Spring AOT's build-time-init list.",
+                        "Detects static initializers that perform file I/O (java.io file streams or filesystem-touching java.nio.file.Files calls) or start threads/processes directly. Since GraalVM 21.3+ classes are run-time-initialized by default, this only applies when the class is explicitly initialized at build time via the native-image --initialize-at-build-time flag. Spring AOT is one way to arrive at that configuration (it can compute and pass the flag for Spring-managed classes on the application's behalf), but the flag itself — not Spring AOT — is the actual mechanism native-image reads, so this also applies to build-time initialization configured directly or by other means.",
                         "If the class is listed under --initialize-at-build-time, move the side effect out of the static initializer or switch the class to --initialize-at-run-time so the I/O or thread starts when the application runs rather than during the native build.",
                         "https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/ClassInitialization/"));
     }
@@ -617,20 +656,23 @@ final class NativeMethodCheck implements GraalVmCheck {
 /**
  * Flags runtime bytecode/class generation (e.g. {@code ClassLoader.defineClass},
  * {@code MethodHandles.Lookup.defineClass/defineHiddenClass}, CGLIB {@code Enhancer}, ByteBuddy,
- * Javassist). A closed-world native image has no compiler at run time, so classes cannot be generated
- * or defined after the build.
+ * Javassist). A closed-world native image has no compiler at run time, so these calls have no
+ * general-purpose support. The native-image agent's experimental "Predefined Classes" mode is a
+ * narrow, best-effort escape hatch (see {@code GraalVmCheckDefinition#learnMoreUrl}), not a general
+ * fix: it replays only the exact bytecode traced ahead of time, so it cannot help when generation is
+ * name/bytecode-varying (e.g. driven by counters or timestamps).
  */
 final class RuntimeClassGenerationCheck extends AbstractArchUnitGraalVmCheck {
 
     RuntimeClassGenerationCheck() {
         super(new GraalVmCheckDefinition(
                 "GRAAL-CLASSGEN-001",
-                "Runtime class generation is unsupported in native images",
+                "Runtime class generation has no general-purpose support in native images",
                 GraalVmCategory.CLASS_GENERATION,
                 "HIGH",
-                "Detects runtime bytecode/class generation (ClassLoader.defineClass, MethodHandles.Lookup.defineClass/defineHiddenClass, CGLIB Enhancer, ByteBuddy, Javassist), which a closed-world native image cannot perform at run time because it has no compiler.",
-                "Generate the classes at build time (e.g. via Spring AOT / build-time processing) instead of at run time, or replace the dynamically generated types with statically compiled equivalents. No metadata enables runtime class definition in a native image.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/Compatibility/"));
+                "Detects runtime bytecode/class generation (ClassLoader.defineClass, MethodHandles.Lookup.defineClass/defineHiddenClass, CGLIB Enhancer, ByteBuddy, Javassist). A closed-world native image has no compiler at run time, so these calls are not supported for arbitrary, build-time-unknown bytecode. The native-image agent's experimental \"Predefined Classes\" mode (experimental-class-define-support) can trace and replay a bounded set of previously-seen classes, but it is best-effort, cannot handle bytecode/names that vary between runs, and is not a substitute for build-time class generation.",
+                "Generate the classes at build time (e.g. via Spring AOT / build-time processing) instead of at run time, or replace the dynamically generated types with statically compiled equivalents. If runtime class generation truly cannot be avoided, evaluate the native-image agent's experimental Predefined Classes support as a narrow fallback — but note its known limitations (single load per class loader per execution, no build-time initialization, no support for varying bytecode/names) before relying on it.",
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/ExperimentalAgentOptions/"));
     }
 
     @Override
@@ -685,7 +727,7 @@ final class BuildTimeStateCaptureCheck extends AbstractArchUnitGraalVmCheck {
                         "Static initializer captures build-machine state",
                         GraalVmCategory.BUILD_TIME_INIT,
                         "LOW",
-                        "Detects static initializers that read environment- or time-sensitive state (System.getenv/getProperty, current time, java.time now(), default Locale/TimeZone, InetAddress, Random/SecureRandom seeds, UUID.randomUUID). Since GraalVM 21.3+ classes are run-time-initialized by default, this is only a concern when the class is explicitly initialized at build time via --initialize-at-build-time or Spring AOT's build-time-init list.",
+                        "Detects static initializers that read environment- or time-sensitive state (System.getenv/getProperty, current time, java.time now(), default Locale/TimeZone, InetAddress, Random/SecureRandom seeds, UUID.randomUUID). Since GraalVM 21.3+ classes are run-time-initialized by default, this is only a concern when the class is explicitly initialized at build time via the native-image --initialize-at-build-time flag. Spring AOT is one way to arrive at that configuration (it can compute and pass the flag for Spring-managed classes on the application's behalf), but the flag itself — not Spring AOT — is the actual mechanism native-image reads, so this also applies to build-time initialization configured directly or by other means.",
                         "If the class is listed under --initialize-at-build-time, move the state capture into a runtime code path or switch the class to --initialize-at-run-time so the values are read when the native image starts rather than baked in during the build.",
                         "https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/ClassInitialization/"));
     }
@@ -926,7 +968,7 @@ final class SpringAotConditionedBeansCheck implements GraalVmCheck {
             "MEDIUM",
             "Detects @Profile or @ConditionalOnProperty on @Configuration/@Component classes or @Bean methods. Spring AOT evaluates these conditions once at build time; if the active profiles or application properties differ between the AOT build and the production runtime, the conditioned beans may be unexpectedly absent or present in the native image.",
             "Ensure the profiles and properties active during the AOT build (native-image compilation) match the intended production configuration, or restructure the configuration to use explicit build-time selection rather than runtime conditions.",
-            "https://docs.spring.io/spring-boot/reference/packaging/native-image/introduction.html");
+            "https://docs.spring.io/spring-boot/reference/packaging/native-image/introducing-graalvm-native-images.html");
 
     private static final List<String> SPRING_COMPONENT_ANNOTATIONS = List.of(
             "org.springframework.context.annotation.Configuration",
@@ -1057,7 +1099,7 @@ final class SpelUsageCheck extends AbstractArchUnitGraalVmCheck {
         super(new GraalVmCheckDefinition(
                 "GRAAL-SPEL-001",
                 "Programmatic SpEL expression parsing relies on reflection with no AOT visibility",
-                GraalVmCategory.REFLECTION,
+                GraalVmCategory.SPRING_AOT,
                 "MEDIUM",
                 "Detects calls to ExpressionParser.parseExpression / parseRaw (SpEL programmatic API); runtime-parsed expressions use reflection to access object properties that is not visible to native-image, and the SpEL bytecode compiler is unsupported in native images.",
                 "Replace programmatic SpEL with direct Java code or annotation-driven evaluation (@PreAuthorize, @Value, @Cacheable) that Spring AOT processes statically. If programmatic SpEL is required, register all reflectively accessed types under reflection in reachability-metadata.json.",
@@ -1116,7 +1158,7 @@ final class MethodHandleUsageCheck extends AbstractArchUnitGraalVmCheck {
                 "MEDIUM",
                 "Detects calls to MethodHandles.Lookup.findVirtual/findStatic/findConstructor/unreflect* and related lookup methods; non-constant method handles require reflection metadata for the target members that is not visible to the existing REFLECT checks.",
                 "Register the target members under reflection in reachability-metadata.json so native-image retains the necessary member descriptors. For compile-time-constant handles, native-image may fold the lookup automatically.",
-                "https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/"));
+                "https://www.graalvm.org/latest/reference-manual/native-image/metadata/"));
     }
 
     @Override
@@ -1190,7 +1232,7 @@ final class JmxUsageCheck extends AbstractArchUnitGraalVmCheck {
                         "LOW",
                         "Detects calls to ManagementFactory.getPlatformMBeanServer and MBeanServer.registerMBean; JMX is disabled by default in native images and requires --enable-monitoring=jmxserver plus MBean reflection metadata.",
                         "Add --enable-monitoring=jmxserver to the native-image build arguments and register all MBean interfaces and implementations under reflection in reachability-metadata.json.",
-                        "https://www.graalvm.org/latest/reference-manual/native-image/guides/build-and-run-native-executable-with-jmx/"));
+                        "https://www.graalvm.org/latest/reference-manual/native-image/guides/build-and-run-native-executable-with-remote-jmx/"));
     }
 
     @Override
@@ -1213,6 +1255,57 @@ final class JmxUsageCheck extends AbstractArchUnitGraalVmCheck {
                             }
                         })
                 .as("Classes should not use JMX without native-image monitoring configuration");
+    }
+}
+
+/**
+ * Flags application classes assignable to {@code javax.management.DynamicMBean} (which also matches
+ * Model MBeans, since {@code javax.management.modelmbean.ModelMBean} extends {@code DynamicMBean}),
+ * other than classes based on the JDK's {@code javax.management.StandardMBean} wrapper. Native-image's
+ * JMX support only covers MXBeans and standard (interface-naming-convention) MBeans; dynamic and model
+ * MBeans define their management interface at run time, which the closed-world analysis cannot see.
+ */
+final class JmxDynamicMBeanCheck implements GraalVmCheck {
+
+    private static final GraalVmCheckDefinition DEFINITION = new GraalVmCheckDefinition(
+            "GRAAL-JMX-002",
+            "Dynamic/model MBeans are not supported by native-image JMX",
+            GraalVmCategory.JMX,
+            "HIGH",
+            "Detects application classes assignable to javax.management.DynamicMBean (including Model MBeans, since ModelMBean extends DynamicMBean), other than classes based on the JDK's StandardMBean wrapper. GraalVM's native-image JMX support only covers MXBeans and standard (interface-naming-convention) MBeans; dynamic and model MBeans are unsupported because they define their management interface at run time.",
+            "Replace the dynamic/model MBean with a standard MBean (a FooMBean interface plus a Foo implementation, or javax.management.StandardMBean composition) or an MXBean; both work with --enable-monitoring=jmxserver. There is no metadata registration that makes a dynamic or model MBean work in a native image.",
+            "https://www.graalvm.org/latest/reference-manual/native-image/guides/build-and-run-native-executable-with-remote-jmx/");
+
+    @Override
+    public GraalVmCheckDefinition definition() {
+        return DEFINITION;
+    }
+
+    @Override
+    public GraalVmFindingDto evaluate(GraalVmContext context) {
+        try {
+            List<String> samples = new ArrayList<>();
+            int count = 0;
+            for (JavaClass javaClass : context.classes()) {
+                // StandardMBean itself implements DynamicMBean, so subclasses of the JDK's supported
+                // StandardMBean wrapper are deliberately excluded here.
+                boolean isDynamicMBean = javaClass.isAssignableTo("javax.management.DynamicMBean")
+                        && !javaClass.isAssignableTo("javax.management.StandardMBean");
+                if (isDynamicMBean) {
+                    count++;
+                    if (samples.size() < GraalVmCheckSupport.maxSampleOccurrences()) {
+                        samples.add(GraalVmCheckSupport.detail(
+                                javaClass.getName() + " is assignable to javax.management.DynamicMBean"));
+                    }
+                }
+            }
+            if (count == 0) {
+                return GraalVmCheckSupport.ok(DEFINITION);
+            }
+            return GraalVmCheckSupport.review(DEFINITION, count, samples);
+        } catch (RuntimeException | LinkageError ex) {
+            return GraalVmCheckSupport.error(DEFINITION, "Check could not be evaluated: " + ex.getMessage());
+        }
     }
 }
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmDependencyScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmDependencyScanner.java
@@ -17,6 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,11 +33,19 @@ import java.util.regex.Pattern;
  * <p>The scan only opens JAR files (never the exploded application classes) and is bounded so a very
  * large classpath cannot make the panel expensive; if the bound is hit the survey reports a
  * truncation warning rather than silently dropping entries.</p>
+ *
+ * <p>A single classpath entry can expand into several reported dependencies: when it is a Spring Boot
+ * fat/uber jar, {@code java.class.path} only ever contains the outer launcher jar (Spring Boot's
+ * {@code LaunchedURLClassLoader} resolves {@code BOOT-INF/lib/*.jar} through custom {@code nested:}
+ * URLs that never populate that system property), so the outer jar is expanded into one inspected
+ * dependency per nested library jar instead of being mis-reported as a single dependency named after
+ * the application's own launcher jar.</p>
  */
 final class GraalVmDependencyScanner {
 
     private static final String METADATA_PREFIX = "META-INF/native-image/";
     private static final String MAVEN_POM_PREFIX = "META-INF/maven/";
+    private static final String NESTED_LIBRARY_PREFIX = "BOOT-INF/lib/";
     private static final int MAX_DEPENDENCIES = 500;
     private static final String REPOSITORY_BROWSER_BASE_URL =
             "https://github.com/oracle/graalvm-reachability-metadata/tree/master/metadata/";
@@ -130,7 +139,22 @@ final class GraalVmDependencyScanner {
                 truncated = true;
                 break;
             }
-            inspected.add(inspect(file));
+            List<InspectedDependency> found = inspect(file);
+            int remaining = MAX_DEPENDENCIES - inspected.size();
+            if (found.size() >= remaining) {
+                // A single fat/uber jar can expand into more nested dependencies than the remaining
+                // budget; take only as many as fit and stop, same as the single-dependency case below.
+                inspected.addAll(found.subList(0, remaining));
+                truncated = true;
+                progress.set(new Progress(
+                        true,
+                        "dependencies.inspect",
+                        inspected.size(),
+                        0,
+                        "Inspecting classpath JARs (" + inspected.size() + " found)."));
+                break;
+            }
+            inspected.addAll(found);
             progress.set(new Progress(
                     true,
                     "dependencies.inspect",
@@ -227,11 +251,19 @@ final class GraalVmDependencyScanner {
                 null);
     }
 
-    private InspectedDependency inspect(File jar) {
+    /**
+     * Inspects one classpath JAR. Ordinarily this reports exactly one dependency, but a Spring Boot
+     * fat/uber jar reports one dependency per {@code BOOT-INF/lib/} nested jar instead: the outer
+     * launcher jar is the application's own archive, not a third-party dependency, and {@code
+     * java.class.path} would otherwise cause every bundled dependency to be silently missed (see the
+     * class-level Javadoc).
+     */
+    private List<InspectedDependency> inspect(File jar) {
         try (JarFile jarFile = new JarFile(jar)) {
             boolean hasMetadataJson = false;
             boolean hasBuildArgs = false;
-            Coordinates coordinates = null;
+            List<Coordinates> pomCandidates = new ArrayList<>();
+            List<JarEntry> nestedLibraryEntries = new ArrayList<>();
             Enumeration<JarEntry> entries = jarFile.entries();
             while (entries.hasMoreElements()) {
                 JarEntry entry = entries.nextElement();
@@ -244,33 +276,106 @@ final class GraalVmDependencyScanner {
                         hasBuildArgs = true;
                     }
                 }
-                if (coordinates == null && name.startsWith(MAVEN_POM_PREFIX) && name.endsWith("/pom.properties")) {
-                    coordinates = readPomProperties(jarFile, entry).orElse(null);
+                if (name.startsWith(MAVEN_POM_PREFIX) && name.endsWith("/pom.properties")) {
+                    readPomProperties(jarFile, entry).ifPresent(pomCandidates::add);
                 }
-                if (hasMetadataJson && coordinates != null) {
-                    break;
+                if (!entry.isDirectory() && isNestedLibraryJar(name)) {
+                    nestedLibraryEntries.add(entry);
                 }
             }
+            if (!nestedLibraryEntries.isEmpty()) {
+                List<InspectedDependency> nested = new ArrayList<>(nestedLibraryEntries.size());
+                for (JarEntry nestedEntry : nestedLibraryEntries) {
+                    nested.add(inspectNestedLibrary(jarFile, nestedEntry));
+                }
+                return nested;
+            }
+            Coordinates coordinates =
+                    selectPomCoordinates(jar.getName(), pomCandidates).orElse(null);
             if (coordinates == null) {
                 coordinates = coordinatesFromMavenRepositoryPath(jar).orElse(null);
             }
             if (coordinates == null) {
                 coordinates = coordinatesFromJarName(jar.getName()).orElse(null);
             }
-            if (hasMetadataJson) {
-                return new InspectedDependency(jar.getName(), true, SHIPS_NOTE, coordinates);
-            }
-            if (hasBuildArgs) {
-                return new InspectedDependency(jar.getName(), false, BUILD_ARGS_NOTE, coordinates);
-            }
-            return new InspectedDependency(jar.getName(), false, MISSING_NOTE, coordinates);
+            return List.of(toInspectedDependency(jar.getName(), hasMetadataJson, hasBuildArgs, coordinates));
         } catch (Exception ex) {
-            return new InspectedDependency(jar.getName(), false, "Could not read JAR: " + ex.getMessage(), null);
+            return List.of(
+                    new InspectedDependency(jar.getName(), false, "Could not read JAR: " + ex.getMessage(), null));
         }
+    }
+
+    /**
+     * Inspects a single {@code BOOT-INF/lib/} nested jar entry of a fat/uber jar without extracting it
+     * to disk: {@link JarInputStream} reads the nested jar's own entries (and, for the rare case of a
+     * nested jar that is itself a shaded/uber jar, its own nested candidates would simply not be
+     * recursed into further -- one level of nesting matches how Spring Boot repackaging actually
+     * works).
+     */
+    private InspectedDependency inspectNestedLibrary(JarFile outerJarFile, JarEntry nestedEntry) {
+        String nestedName = nestedLibraryDisplayName(nestedEntry.getName());
+        try (JarInputStream nestedJar = new JarInputStream(outerJarFile.getInputStream(nestedEntry))) {
+            boolean hasMetadataJson = false;
+            boolean hasBuildArgs = false;
+            List<Coordinates> pomCandidates = new ArrayList<>();
+            JarEntry inner;
+            while ((inner = nestedJar.getNextJarEntry()) != null) {
+                String name = inner.getName();
+                if (name.startsWith(METADATA_PREFIX)) {
+                    String lower = name.toLowerCase(Locale.ROOT);
+                    if (lower.endsWith(".json")) {
+                        hasMetadataJson = true;
+                    } else if (lower.endsWith("native-image.properties")) {
+                        hasBuildArgs = true;
+                    }
+                }
+                if (name.startsWith(MAVEN_POM_PREFIX) && name.endsWith("/pom.properties")) {
+                    readPomProperties(nestedJar).ifPresent(pomCandidates::add);
+                }
+            }
+            Coordinates coordinates =
+                    selectPomCoordinates(nestedName, pomCandidates).orElse(null);
+            if (coordinates == null) {
+                coordinates = coordinatesFromJarName(nestedName).orElse(null);
+            }
+            return toInspectedDependency(nestedName, hasMetadataJson, hasBuildArgs, coordinates);
+        } catch (Exception ex) {
+            return new InspectedDependency(nestedName, false, "Could not read nested JAR: " + ex.getMessage(), null);
+        }
+    }
+
+    private InspectedDependency toInspectedDependency(
+            String name, boolean hasMetadataJson, boolean hasBuildArgs, Coordinates coordinates) {
+        if (hasMetadataJson) {
+            return new InspectedDependency(name, true, SHIPS_NOTE, coordinates);
+        }
+        if (hasBuildArgs) {
+            return new InspectedDependency(name, false, BUILD_ARGS_NOTE, coordinates);
+        }
+        return new InspectedDependency(name, false, MISSING_NOTE, coordinates);
+    }
+
+    private static boolean isNestedLibraryJar(String entryName) {
+        return entryName.startsWith(NESTED_LIBRARY_PREFIX)
+                && entryName.toLowerCase(Locale.ROOT).endsWith(".jar")
+                && entryName.indexOf('/', NESTED_LIBRARY_PREFIX.length()) < 0;
+    }
+
+    private static String nestedLibraryDisplayName(String entryName) {
+        int lastSlash = entryName.lastIndexOf('/');
+        return lastSlash >= 0 ? entryName.substring(lastSlash + 1) : entryName;
     }
 
     private Optional<Coordinates> readPomProperties(JarFile jarFile, JarEntry entry) {
         try (InputStream input = jarFile.getInputStream(entry)) {
+            return readPomProperties(input);
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<Coordinates> readPomProperties(InputStream input) {
+        try {
             Properties properties = new Properties();
             properties.load(input);
             Coordinates coordinates = new Coordinates(
@@ -281,6 +386,38 @@ final class GraalVmDependencyScanner {
         } catch (Exception ex) {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Picks the coordinates to report when a jar contains more than one {@code pom.properties}. A
+     * shaded/uber jar (e.g. built with the Maven Shade or Gradle Shadow plugin) commonly bundles each
+     * relocated dependency's own {@code META-INF/maven/<groupId>/<artifactId>/pom.properties} alongside
+     * its own, so naively taking "the first one found" can misreport the shaded jar under one of the
+     * dependencies it relocated -- entry order in a JAR's central directory is a build-tool artifact,
+     * not a documented contract. Preferring the candidate whose {@code artifactId}/{@code version}
+     * matches the jar's own file name recovers the jar's own coordinates in the common case where the
+     * shade plugin's default "artifactId-version.jar" naming was left untouched; when no candidate
+     * matches the file name (or the file name itself does not parse), this falls back to the first
+     * descriptor found, matching the scanner's previous behavior for the common single-pom.properties
+     * case.
+     */
+    private Optional<Coordinates> selectPomCoordinates(String jarFileName, List<Coordinates> candidates) {
+        if (candidates.isEmpty()) {
+            return Optional.empty();
+        }
+        if (candidates.size() == 1) {
+            return Optional.of(candidates.get(0));
+        }
+        Optional<Coordinates> ownNameGuess = coordinatesFromJarName(jarFileName);
+        if (ownNameGuess.isPresent()) {
+            for (Coordinates candidate : candidates) {
+                if (candidate.artifactId().equals(ownNameGuess.get().artifactId())
+                        && candidate.version().equals(ownNameGuess.get().version())) {
+                    return Optional.of(candidate);
+                }
+            }
+        }
+        return Optional.of(candidates.get(0));
     }
 
     private Optional<Coordinates> coordinatesFromMavenRepositoryPath(File jar) {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/GraalVmChecksTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/GraalVmChecksTests.java
@@ -14,6 +14,7 @@ import io.github.jdubois.bootui.engine.graalvm.fixtures.CleanComponent;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.DeepReflector;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.DevOnlyConfiguration;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.DynamicClassLoader;
+import io.github.jdubois.bootui.engine.graalvm.fixtures.DynamicMBeanUser;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.FieldMetadataReader;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.FieldValueAccessor;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.FilesMetadataInitializer;
@@ -30,10 +31,12 @@ import io.github.jdubois.bootui.engine.graalvm.fixtures.SecondaryContextCreator;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.SecurityProviderRegistrar;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.ServiceConsumer;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.SpelUser;
+import io.github.jdubois.bootui.engine.graalvm.fixtures.StandardMBeanSubclass;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.StateCapturingInitializer;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.StaticInitializerComponent;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.SupplierBeanDefiner;
 import io.github.jdubois.bootui.engine.graalvm.fixtures.UnrelatedSupplierHolder;
+import io.github.jdubois.bootui.engine.graalvm.fixtures.UnsafeAllocator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -79,6 +82,16 @@ class GraalVmChecksTests {
         assertThat(finding.id()).isEqualTo("GRAAL-REFLECT-004");
         assertThat(finding.status()).isEqualTo("REVIEW");
         assertThat(evaluate(new AnnotationReflectionCheck(), CleanComponent.class)
+                        .status())
+                .isEqualTo("OK");
+    }
+
+    @Test
+    void unsafeAllocateInstanceCheckDetectsAllocateInstanceCall() {
+        GraalVmFindingDto finding = evaluate(new UnsafeAllocateInstanceCheck(), UnsafeAllocator.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-REFLECT-005");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        assertThat(evaluate(new UnsafeAllocateInstanceCheck(), CleanComponent.class)
                         .status())
                 .isEqualTo("OK");
     }
@@ -264,6 +277,9 @@ class GraalVmChecksTests {
         GraalVmFindingDto finding = evaluate(new SpelUsageCheck(), SpelUser.class);
         assertThat(finding.id()).isEqualTo("GRAAL-SPEL-001");
         assertThat(finding.severity()).isEqualTo("MEDIUM");
+        // SpEL reachability is a Spring-library-specific concern (not general JDK reflection), so
+        // this check is grouped under Spring AOT rather than Reflection.
+        assertThat(finding.category()).isEqualTo(GraalVmCategory.SPRING_AOT.label());
         assertThat(finding.status()).isEqualTo("REVIEW");
         assertThat(evaluate(new SpelUsageCheck(), CleanComponent.class).status())
                 .isEqualTo("OK");
@@ -296,6 +312,21 @@ class GraalVmChecksTests {
         assertThat(finding.severity()).isEqualTo("LOW");
         assertThat(finding.status()).isEqualTo("REVIEW");
         assertThat(evaluate(new JmxUsageCheck(), CleanComponent.class).status()).isEqualTo("OK");
+    }
+
+    @Test
+    void jmxDynamicMBeanCheckDetectsDynamicMBeanButExcludesStandardMBeanSubclasses() {
+        GraalVmFindingDto finding = evaluate(new JmxDynamicMBeanCheck(), DynamicMBeanUser.class);
+        assertThat(finding.id()).isEqualTo("GRAAL-JMX-002");
+        assertThat(finding.severity()).isEqualTo("HIGH");
+        assertThat(finding.status()).isEqualTo("REVIEW");
+        // A StandardMBean subclass also implements DynamicMBean transitively, but it is the JDK's
+        // supported standard-MBean pattern and must not be flagged.
+        assertThat(evaluate(new JmxDynamicMBeanCheck(), StandardMBeanSubclass.class)
+                        .status())
+                .isEqualTo("OK");
+        assertThat(evaluate(new JmxDynamicMBeanCheck(), CleanComponent.class).status())
+                .isEqualTo("OK");
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/GraalVmDependencyScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/GraalVmDependencyScannerTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.GraalVmDependencyDto;
 import io.github.jdubois.bootui.engine.graalvm.GraalVmDependencyScanner.DependencySurvey;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -233,6 +234,99 @@ class GraalVmDependencyScannerTests {
     }
 
     @Test
+    void fatJarExpandsBootInfLibNestedDependenciesInsteadOfTheLauncherJar(@TempDir Path dir) throws IOException {
+        byte[] depWithMetadata = jarBytes(Map.of(
+                "META-INF/native-image/com.example/dep-a/reachability-metadata.json",
+                "[]",
+                "META-INF/maven/com.example/dep-a/pom.properties",
+                "groupId=com.example\nartifactId=dep-a\nversion=1.0.0\n"));
+        byte[] depWithoutMetadata = jarBytes(Map.of("com/example/dep/Dep.class", "data"));
+
+        Path fatJar = jarWithNestedJars(
+                dir,
+                "app-0.0.1-SNAPSHOT.jar",
+                Map.of("BOOT-INF/classes/com/example/App.class", "data"),
+                Map.of(
+                        "BOOT-INF/lib/dep-a-1.0.0.jar", depWithMetadata,
+                        "BOOT-INF/lib/dep-b-2.0.0.jar", depWithoutMetadata));
+
+        DependencySurvey survey = new GraalVmDependencyScanner(fatJar::toString).scan();
+
+        assertThat(survey.dependencies()).hasSize(2);
+        assertThat(survey.dependencies().stream()
+                        .map(GraalVmDependencyDto::name)
+                        .toList())
+                .containsExactlyInAnyOrder("dep-a-1.0.0.jar", "dep-b-2.0.0.jar");
+        GraalVmDependencyDto depA = survey.dependencies().stream()
+                .filter(dependency -> dependency.name().equals("dep-a-1.0.0.jar"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(depA.shipsMetadata()).isTrue();
+        assertThat(depA.coordinates()).isEqualTo("com.example:dep-a:1.0.0");
+        GraalVmDependencyDto depB = survey.dependencies().stream()
+                .filter(dependency -> dependency.name().equals("dep-b-2.0.0.jar"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(depB.shipsMetadata()).isFalse();
+    }
+
+    @Test
+    void fatJarNestedLibraryWithoutMavenCoordinatesFallsBackToItsOwnFileName(@TempDir Path dir) throws IOException {
+        byte[] depWithoutPom = jarBytes(Map.of("com/example/dep/Dep.class", "data"));
+
+        Path fatJar = jarWithNestedJars(
+                dir,
+                "app.jar",
+                Map.of("BOOT-INF/classes/com/example/App.class", "data"),
+                Map.of("BOOT-INF/lib/no-pom-lib-4.5.6.jar", depWithoutPom));
+
+        DependencySurvey survey = new GraalVmDependencyScanner(fatJar::toString).scan();
+
+        assertThat(survey.dependencies()).hasSize(1);
+        GraalVmDependencyDto dependency = survey.dependencies().get(0);
+        assertThat(dependency.name()).isEqualTo("no-pom-lib-4.5.6.jar");
+        // No pom.properties inside the nested jar itself: falls back to parsing the nested entry's own
+        // file name, exactly like a top-level classpath jar without bundled Maven coordinates would.
+        assertThat(dependency.coordinates()).isEqualTo("no-pom-lib:4.5.6");
+    }
+
+    @Test
+    void shadedJarWithMultiplePomPropertiesPrefersTheOneMatchingItsOwnFileName(@TempDir Path dir) throws IOException {
+        Path jar = jar(
+                dir,
+                "myapp-shaded-1.0.0.jar",
+                Map.of(
+                        "META-INF/maven/com.example/relocated-lib/pom.properties",
+                        "groupId=com.example\nartifactId=relocated-lib\nversion=2.0.0\n",
+                        "META-INF/maven/com.example/myapp-shaded/pom.properties",
+                        "groupId=com.example\nartifactId=myapp-shaded\nversion=1.0.0\n"));
+
+        GraalVmDependencyDto dependency = onlyDependency(jar);
+
+        assertThat(dependency.coordinates()).isEqualTo("com.example:myapp-shaded:1.0.0");
+    }
+
+    @Test
+    void shadedJarFallsBackToFirstPomPropertiesWhenNoneMatchTheFileName(@TempDir Path dir) throws IOException {
+        Path jar = jar(
+                dir,
+                "unrelated-name.jar",
+                Map.of(
+                        "META-INF/maven/com.example/first/pom.properties",
+                        "groupId=com.example\nartifactId=first\nversion=1.0.0\n",
+                        "META-INF/maven/com.example/second/pom.properties",
+                        "groupId=com.example\nartifactId=second\nversion=2.0.0\n"));
+
+        GraalVmDependencyDto dependency = onlyDependency(jar);
+
+        // Neither pom.properties matches the jar's own file name (it does not follow the Maven
+        // "artifactId-version.jar" convention at all), so this pins the deterministic fallback: the
+        // first descriptor encountered by JAR entry order is reported, matching the scanner's previous
+        // behavior for this genuinely ambiguous case.
+        assertThat(dependency.coordinates()).isIn("com.example:first:1.0.0", "com.example:second:2.0.0");
+    }
+
+    @Test
     void emptyClasspathProducesEmptyUntruncatedSurvey() {
         DependencySurvey survey = new GraalVmDependencyScanner(() -> "").scan();
 
@@ -254,6 +348,40 @@ class GraalVmDependencyScannerTests {
             for (Map.Entry<String, String> entry : entries.entrySet()) {
                 out.putNextEntry(new JarEntry(entry.getKey()));
                 out.write(entry.getValue().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+    /** Builds a jar's raw bytes in memory, for embedding as a {@code BOOT-INF/lib/} nested entry. */
+    private static byte[] jarBytes(Map<String, String> entries) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (JarOutputStream out = new JarOutputStream(baos)) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                out.putNextEntry(new JarEntry(entry.getKey()));
+                out.write(entry.getValue().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    /** Builds a fat/uber jar with plain text entries plus binary (nested-jar) entries, unmodified. */
+    private static Path jarWithNestedJars(
+            Path dir, String name, Map<String, String> textEntries, Map<String, byte[]> nestedJarEntries)
+            throws IOException {
+        Files.createDirectories(dir);
+        Path jar = dir.resolve(name);
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+            for (Map.Entry<String, String> entry : textEntries.entrySet()) {
+                out.putNextEntry(new JarEntry(entry.getKey()));
+                out.write(entry.getValue().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                out.closeEntry();
+            }
+            for (Map.Entry<String, byte[]> entry : nestedJarEntries.entrySet()) {
+                out.putNextEntry(new JarEntry(entry.getKey()));
+                out.write(entry.getValue());
                 out.closeEntry();
             }
         }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/fixtures/DynamicMBeanUser.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/fixtures/DynamicMBeanUser.java
@@ -1,0 +1,47 @@
+package io.github.jdubois.bootui.engine.graalvm.fixtures;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.DynamicMBean;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.ReflectionException;
+
+/** Triggers GRAAL-JMX-002 by implementing {@link DynamicMBean} directly. */
+public class DynamicMBeanUser implements DynamicMBean {
+
+    @Override
+    public Object getAttribute(String attribute)
+            throws AttributeNotFoundException, MBeanException, ReflectionException {
+        return null;
+    }
+
+    @Override
+    public void setAttribute(Attribute attribute)
+            throws AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException {
+        // no-op fixture
+    }
+
+    @Override
+    public AttributeList getAttributes(String[] attributes) {
+        return new AttributeList();
+    }
+
+    @Override
+    public AttributeList setAttributes(AttributeList attributes) {
+        return new AttributeList();
+    }
+
+    @Override
+    public Object invoke(String actionName, Object[] params, String[] signature)
+            throws MBeanException, ReflectionException {
+        return null;
+    }
+
+    @Override
+    public MBeanInfo getMBeanInfo() {
+        return null;
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/fixtures/StandardMBeanSubclass.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/fixtures/StandardMBeanSubclass.java
@@ -1,0 +1,25 @@
+package io.github.jdubois.bootui.engine.graalvm.fixtures;
+
+import javax.management.NotCompliantMBeanException;
+import javax.management.StandardMBean;
+
+/**
+ * Does not trigger GRAAL-JMX-002: subclassing {@link StandardMBean} is the JDK's supported pattern
+ * for standard MBeans, even though {@code StandardMBean} itself implements {@code DynamicMBean}.
+ */
+public class StandardMBeanSubclass extends StandardMBean implements SampleMBean {
+
+    protected StandardMBeanSubclass() throws NotCompliantMBeanException {
+        super(SampleMBean.class);
+    }
+
+    @Override
+    public String getName() {
+        return "sample";
+    }
+}
+
+/** Standard MBean management interface, following the {@code FooMBean} naming convention. */
+interface SampleMBean {
+    String getName();
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/fixtures/UnsafeAllocator.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/fixtures/UnsafeAllocator.java
@@ -1,0 +1,9 @@
+package io.github.jdubois.bootui.engine.graalvm.fixtures;
+
+/** Triggers GRAAL-REFLECT-005 by calling {@code Unsafe.allocateInstance(Class)} directly. */
+public class UnsafeAllocator {
+
+    public Object allocate(sun.misc.Unsafe unsafe) throws InstantiationException {
+        return unsafe.allocateInstance(String.class);
+    }
+}

--- a/docs/GRAALVM-READINESS-CHECKS.md
+++ b/docs/GRAALVM-READINESS-CHECKS.md
@@ -5,11 +5,14 @@ readiness and can generate a `reachability-metadata.json` scaffold from the scan
 with BootUI today, what it inspects, when it fires, and what to do about it.
 
 Each check is a small class registered in
-[`GraalVmCheckRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmCheckRegistry.java)
+[`GraalVmCheckRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmCheckRegistry.java)
 and implemented in
-[`GraalVmChecks.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/GraalVmChecks.java).
+[`GraalVmChecks.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmChecks.java).
 The list intentionally stays compact and reviewable; adding a new check means adding one focused class plus a registry
-entry.
+entry. The rule engine (checks, categories, the dependency scanner, and the reachability-metadata scaffold generator) is
+framework-neutral and lives in `bootui-engine`; today it is surfaced only through thin Spring adapter wiring in
+`bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/graalvm/` (the controller, the
+Dockerfile generator, and the source-tree writer).
 
 ## What BootUI does
 
@@ -21,12 +24,20 @@ invoked, caching the last report in the controller.
 
 In addition to the checks, the scan does two things:
 
-- **Surveys classpath dependencies** (when the _Include dependencies_ toggle is on; it is off by default) to report which
+- **Surveys classpath dependencies** (when the _Include dependencies_ toggle is on; it is on by default) to report which
   third-party JARs already ship bundled reachability metadata under `META-INF/native-image/`. BootUI counts metadata only
   when a `.json` file exists under that directory; a JAR that only has `native-image.properties` is reported as bundling
   native-image build arguments, not reachability metadata. The survey opens only classpath JARs, stops after 500 JARs,
   and adds a warning when that cap is hit; libraries without bundled metadata may need your own configuration, repository
-  metadata, or the tracing agent.
+  metadata, or the tracing agent. A single classpath entry can expand into several reported dependencies: when the
+  application runs as a Spring Boot fat/uber jar, `java.class.path` only ever contains the outer launcher jar (Spring
+  Boot's `LaunchedURLClassLoader` resolves `BOOT-INF/lib/*.jar` through custom `nested:` URLs that never populate that
+  system property), so the survey expands the launcher jar into one inspected dependency per nested `BOOT-INF/lib/`
+  library instead of misreporting it as a single dependency named after the application's own launcher jar. When a
+  shaded/uber jar (built with, for example, the Maven Shade or Gradle Shadow plugin) bundles more than one
+  `META-INF/maven/<groupId>/<artifactId>/pom.properties` — one for itself and one for each dependency it relocated into
+  itself — the survey prefers the descriptor whose `artifactId`/`version` matches the jar's own file name, recovering the
+  shaded jar's own coordinates in the common case rather than misreporting it under one of the dependencies it relocated.
 - **Builds a `reachability-metadata.json` scaffold** from the application's own classes — reflection and serialization
   candidates plus the standard externalized-configuration resource globs — which you can download from the panel.
 - **Installs the scaffold into the source tree** when the application is detectably running from an exploded build (for
@@ -76,6 +87,31 @@ native-image configuration.
 - Spring-managed beans are already covered by Spring AOT, so findings that overlap with Spring's own AOT processing may
   be safe to ignore.
 
+## Detecting missing metadata at development time
+
+BootUI's checks are static, build-independent heuristics; they cannot see reflection driven by runtime-only data (for
+example, a class name read from a config file), so a clean scan is not a guarantee that a native image will run
+correctly. GraalVM's own recommended complement to static analysis is to make missing metadata fail loudly during
+development instead of surfacing as a silent runtime bug:
+
+- Pass **`--exact-reachability-metadata`** (or, to scope it to specific packages,
+  `--exact-reachability-metadata=<comma-separated-package-list>`) to `native-image` at build time to opt in to the
+  stricter, more debuggable reachability-metadata mode. GraalVM documents this as becoming the default behavior in a
+  future release.
+- Run the native image with **`-XX:MissingRegistrationReportingMode=Warn`** to see every place a registration is
+  missing without crashing, or with **`-XX:MissingRegistrationReportingMode=Exit`** — recommended for automated
+  tests — to make the application print the error with a full stack trace and exit immediately the first time a
+  missing registration is hit, including ones a broad `catch (Throwable t)` would otherwise silently swallow.
+
+See the ["Reachability Metadata" reference](https://www.graalvm.org/latest/reference-manual/native-image/metadata/) for
+the authoritative, up-to-date flag documentation. BootUI does not implement this as an automated check: unlike every
+other check on this page, which fires only when a specific risky bytecode/reflection construct is present, these flags
+are a blanket recommendation for essentially every native-image build regardless of what the code does — there is no
+bytecode condition to scan for, so an automated check would either fire unconditionally (defeating the panel's
+"only show what needs review" design) or require parsing the project's build file (`pom.xml` / `build.gradle`) to
+detect existing native-image arguments, a data source no other check depends on. It is listed here as a recommended
+practice to pair with the panel's static checks, not as a 28th check.
+
 ## The generated `reachability-metadata.json`
 
 The scaffold uses the modern unified
@@ -98,10 +134,10 @@ Severity reflects the worst plausible impact if the finding is real, not the lik
 - **CRITICAL** — a construct with the most severe native-image impact if the finding is real. No active GraalVM check
   currently emits this severity.
 - **HIGH** — a construct native images generally cannot support or Spring AOT cannot capture at run time (runtime class
-  generation, runtime classpath scanning, runtime instance suppliers, secondary context creation).
+  generation, runtime classpath scanning, runtime instance suppliers, secondary context creation, dynamic/model MBeans).
 - **MEDIUM** — a construct GraalVM cannot resolve at build time that will usually fail at run time without metadata
-  (reflection, dynamic class loading, deep reflection, dynamic proxies, active JDK serialization, SpEL, method handles,
-  frozen AOT conditions, custom security providers, runtime singleton registration).
+  (reflection, dynamic class loading, deep reflection, unsafe allocation, dynamic proxies, active JDK serialization, SpEL,
+  method handles, frozen AOT conditions, custom security providers, runtime singleton registration).
 - **LOW** — a construct that often needs extra configuration (runtime resource loading, resource bundles, service
   loading, reflective annotation access, static-initializer side effects, native access, native methods, JMX, foreign
   functions).
@@ -157,6 +193,17 @@ a handful of sample detail lines.
   element is registered for reflection.
 - **Recommendation**: register the inspected members under `reflection` in `reachability-metadata.json` so their
   annotations are available at run time.
+
+### GRAAL-REFLECT-005 — Unsafe.allocateInstance bypasses construction and needs unsafeAllocated metadata
+
+- **Severity**: MEDIUM
+- **Inspects**: calls to `allocateInstance(Class)` on `sun.misc.Unsafe` or `jdk.internal.misc.Unsafe`.
+- **Fires when**: a class allocates an instance via `Unsafe` instead of a constructor. Unsafe allocation bypasses the
+  construction path native-image's reachability analysis tracks, so the allocated type needs its own metadata; otherwise
+  the call throws `MissingReflectionRegistrationError` at run time.
+- **Recommendation**: register the allocated type under `reflection` in `reachability-metadata.json` with
+  `"unsafeAllocated": true` (in addition to its normal type registration), or replace `Unsafe.allocateInstance` with a
+  public constructor or factory method where possible.
 
 ## Dynamic proxies
 
@@ -238,8 +285,11 @@ a handful of sample detail lines.
   Lightweight `Files` metadata predicates such as `exists`, `isDirectory`, and `isReadable` are intentionally ignored;
   side effects in helper methods or lambdas are out of scope.
 - **Fires when**: a class runs I/O or starts a thread/process from its static initializer. Since GraalVM 21.3+ classes
-  are run-time-initialized by default, this only applies when the class is explicitly initialized at build time via
-  `--initialize-at-build-time` or Spring AOT's build-time-init list.
+  are run-time-initialized by default, this only applies when the class is explicitly initialized at build time via the
+  native-image `--initialize-at-build-time` flag. Spring AOT is one way to arrive at that configuration (it can compute
+  and pass the flag for Spring-managed classes on the application's behalf), but the flag itself — not Spring AOT — is
+  the actual mechanism native-image reads, so this also applies to build-time initialization configured directly or by
+  other means.
 - **Recommendation**: if the class is listed under `--initialize-at-build-time`, move the side effect out of the static
   initializer or switch the class to `--initialize-at-run-time` so the I/O or thread starts when the application runs
   rather than during the native build.
@@ -251,9 +301,11 @@ a handful of sample detail lines.
   `getProperties`, current time, `java.time` `now()`, default `Locale` / `TimeZone`, `InetAddress`, `Random` /
   `SecureRandom` constructors or `next*` calls, `UUID.randomUUID`).
 - **Fires when**: a class captures those values in a static initializer. Since GraalVM 21.3+ classes are
-  run-time-initialized by default, this is only a concern when the class is explicitly initialized at build time via
-  `--initialize-at-build-time` or Spring AOT's build-time-init list; GraalVM's simulated class-init safely refuses
-  unsafe initializers in ambiguous cases.
+  run-time-initialized by default, this is only a concern when the class is explicitly initialized at build time via the
+  native-image `--initialize-at-build-time` flag. Spring AOT is one way to arrive at that configuration (it can compute
+  and pass the flag for Spring-managed classes on the application's behalf), but the flag itself — not Spring AOT — is
+  the actual mechanism native-image reads, so this also applies to build-time initialization configured directly or by
+  other means; GraalVM's simulated class-init safely refuses unsafe initializers in ambiguous cases.
 - **Recommendation**: if the class is listed under `--initialize-at-build-time`, move the state capture into a runtime
   code path or switch the class to `--initialize-at-run-time` so the values are read when the native image starts
   rather than baked in during the build.
@@ -292,16 +344,22 @@ a handful of sample detail lines.
 
 ## Class generation
 
-### GRAAL-CLASSGEN-001 — Runtime class generation is unsupported in native images
+### GRAAL-CLASSGEN-001 — Runtime class generation has no general-purpose support in native images
 
 - **Severity**: HIGH
 - **Inspects**: runtime bytecode/class generation (`ClassLoader.defineClass`, `MethodHandles.Lookup.defineClass` /
   `defineHiddenClass` / `defineHiddenClassWithClassData`, CGLIB `Enhancer`, ByteBuddy, Javassist).
-- **Fires when**: a class generates or defines classes at run time; a closed-world native image cannot perform that work
-  because it has no compiler.
+- **Fires when**: a class generates or defines classes at run time. A closed-world native image has no compiler at run
+  time, so these calls are not supported for arbitrary, build-time-unknown bytecode. The native-image agent's
+  experimental ["Predefined Classes"](https://www.graalvm.org/latest/reference-manual/native-image/metadata/ExperimentalAgentOptions/)
+  mode (`experimental-class-define-support`) can trace and replay a bounded set of previously-seen classes, but it is
+  best-effort: it replays only the exact bytecode traced ahead of time, allows only one class definition per class
+  loader per execution, has no build-time-initialization support, and cannot help when classes are generated with
+  varying names or bytecode (e.g. driven by counters or timestamps) — so it is a narrow escape hatch, not a general fix.
 - **Recommendation**: generate the classes at build time (e.g. via Spring AOT / build-time processing) instead of at run
-  time, or replace the dynamically generated types with statically compiled equivalents. No metadata enables runtime
-  class definition in a native image.
+  time, or replace the dynamically generated types with statically compiled equivalents. If runtime class generation
+  truly cannot be avoided, evaluate the native-image agent's experimental Predefined Classes support as a narrow
+  fallback — but note its known limitations before relying on it.
 
 ## Classpath scanning
 
@@ -362,11 +420,13 @@ a handful of sample detail lines.
 - **Recommendation**: consolidate configuration into the main application context processed by Spring AOT, or use
   `@Import` / `@ImportResource` to include additional configuration statically at build time.
 
-## SpEL / Expression language
-
 ### GRAAL-SPEL-001 — Programmatic SpEL expression parsing relies on reflection with no AOT visibility
 
 - **Severity**: MEDIUM
+- **Category**: this check moved from `Reflection` to `Spring AOT` — SpEL reachability is a Spring-library-specific
+  concern (the SpEL bytecode compiler and reflective property access are part of Spring's own AOT story), not a
+  general-purpose reflection construct. The check ID is unchanged (`GRAAL-SPEL-001`, not renumbered into the
+  `SPRING-AOT-*` sequence) because check IDs are stable identifiers persisted in user dismissals.
 - **Inspects**: calls to `ExpressionParser.parseExpression` and `parseRaw` (the SpEL programmatic parsing API).
 - **Fires when**: a class parses a SpEL expression at run time; the parsed expression uses reflection to access object
   properties that is not visible to native-image, and the SpEL bytecode compiler is unsupported in native images.
@@ -411,3 +471,18 @@ a handful of sample detail lines.
   plus MBean reflection metadata.
 - **Recommendation**: add `--enable-monitoring=jmxserver` to the native-image build arguments and register all MBean
   interfaces and implementations under `reflection` in `reachability-metadata.json`.
+
+### GRAAL-JMX-002 — Dynamic/model MBeans are not supported by native-image JMX
+
+- **Severity**: HIGH
+- **Inspects**: application classes assignable to `javax.management.DynamicMBean` (this also covers Model MBeans, since
+  `ModelMBean` extends `DynamicMBean`), other than classes based on the JDK's `StandardMBean` wrapper (`StandardMBean`
+  itself implements `DynamicMBean`, so a naive assignability check would otherwise misflag the JDK's own supported
+  "standard MBean via subclassing" pattern).
+- **Fires when**: a class implements or extends a dynamic/model MBean type. GraalVM's native-image JMX support only
+  covers MXBeans and standard (interface-naming-convention) MBeans; dynamic and model MBeans define their management
+  interface at run time, which is unsupported because there is no metadata registration that makes a dynamic or model
+  MBean work in a native image.
+- **Recommendation**: replace the dynamic/model MBean with a standard MBean (a `FooMBean` interface plus a `Foo`
+  implementation, or `javax.management.StandardMBean` composition/subclassing) or an MXBean; both work with
+  `--enable-monitoring=jmxserver`.


### PR DESCRIPTION
Audited by 5 independent AI models (Claude Opus 4.8, GPT-5.5, Gemini 3.1 Pro, GPT-5.3-Codex, Claude Sonnet 5) as part of a full advisor-ruleset audit, synthesized by an orchestrating session. Every finding below was re-verified against the current codebase **and** current official GraalVM documentation (fetched live, not trusted from the audit reports) before implementing.

**Scope note up front**: the audit unanimously flagged porting this advisor to Quarkus as a major opportunity (~20 of 25 checks are pure JVM/bytecode scans with no Spring dependency, and the engine already uses the Quarkus-wired `BasePackageProvider` SPI). This was raised separately with the project owner, who explicitly decided to keep this advisor Spring-only for now. **This PR does not touch `bootui-quarkus`/`bootui-quarkus-deployment`, does not add a `QuarkusPanelAvailability` flag, and is scoped entirely to rule-content fixes and new-check additions within the existing Spring-served advisor.**

## Fixes to existing rules

1. **11 stale `learnMoreUrl`s** — GraalVM consolidated its old per-feature `dynamic-features/{Reflection,DynamicProxy,Resources}/` pages into the unified `reference-manual/native-image/metadata/` page; updated every check that linked to the old pages. Also fixed a renamed JMX guide (`...-with-jmx/` → `...-with-remote-jmx/`) and a renamed Spring Boot native-image intro page. All new URLs verified live (200) via curl.

2. **Unified reachability-metadata.json framing** — verified as already correct throughout the checks and docs; no changes needed (the audit's concern about stale per-feature-file wording didn't hold up against the current code).

3. **`RuntimeClassGenerationCheck` (GRAAL-CLASSGEN-001) overstated absoluteness** — softened to acknowledge the native-image agent's experimental **"Predefined Classes"** mode (`experimental-class-define-support`) as a narrow, best-effort escape hatch. Verified word-for-word against the live `ExperimentalAgentOptions.md` GraalVM source: "loading a predefined class only once per execution, by just a single class loader," "cannot be initialized at build time," "generated with varying data in their name or bytecode... can generally not be matched." `learnMoreUrl` now points at that page.

4. **`BuildTimeInitializationCheck`/`BuildTimeStateCaptureCheck` (GRAAL-INIT-001/002)** — reworded to lead with the framework-neutral native-image `--initialize-at-build-time` flag as the actual mechanism; Spring AOT is now framed as "one way to arrive at that configuration" rather than the mechanism itself. This also makes the checks read correctly as framework-neutral, consistent with where the code actually lives (`bootui-engine`).

5. **`SpelUsageCheck` (GRAAL-SPEL-001) miscategorized** — moved from `GraalVmCategory.REFLECTION` to `GraalVmCategory.SPRING_AOT`, since SpEL reachability (the SpEL bytecode compiler + reflective property access) is a Spring-library-specific concern, not general-purpose reflection. Check ID kept stable (`GRAAL-SPEL-001`, not renumbered into `SPRING-AOT-*`) because IDs are persisted in user dismissals.

6. **Doc source-path drift** — `docs/GRAALVM-READINESS-CHECKS.md` linked `GraalVmCheckRegistry`/`GraalVmChecks.java` under the old `bootui-spring-autoconfigure` path; corrected to the actual `bootui-engine` location. Pure doc-accuracy fix — does not imply or require any change to how the panel is wired/served.

7. **`GraalVmDependencyScanner` gaps**:
   - **(a) Fat-jar blind spot — fixed.** `java.class.path` only ever contains the outer Spring Boot launcher jar (`LaunchedURLClassLoader` resolves `BOOT-INF/lib/*.jar` via custom `nested:` URLs that never populate that system property), so every bundled dependency was previously invisible to the survey. Now expands the launcher jar into one reported dependency per nested `BOOT-INF/lib/` library, reading each nested jar via `JarInputStream` without extracting to disk.
   - **(b) Shaded/relocated coordinates — fixed.** A shaded/uber jar (Maven Shade / Gradle Shadow) can bundle more than one `pom.properties` — its own plus each relocated dependency's. The scanner now prefers the descriptor whose `artifactId`/`version` matches the jar's own file name, recovering the shaded jar's own coordinates instead of misreporting it under a relocated dependency. Falls back to first-found when no candidate matches (preserving prior behavior for the common single-`pom.properties` case).
   - **(c) Single-filename-per-entry assumption — confirmed safe, no change needed.** Used `gh api search/code` against `oracle/graalvm-reachability-metadata`: **0** results for any legacy per-feature config file (`reflect-config.json`, `proxy-config.json`, `jni-config.json`, `resource-config.json`, `serialization-config.json`) vs. **1192** results for `reachability-metadata.json`. The repository has fully migrated to one file per entry.

## New rules

1. **GRAAL-REFLECT-005 (MEDIUM) — `Unsafe.allocateInstance` bypasses construction and needs `unsafeAllocated` metadata.** Detects `sun.misc.Unsafe`/`jdk.internal.misc.Unsafe#allocateInstance(Class)`. Verified `unsafeAllocated: true` is a real, currently-documented `reachability-metadata.json` reflection field (confirmed word-for-word against the live GraalVM `ReachabilityMetadata.md` source, including its dedicated "Unsafe Allocation of a Type" section and JSON schema table).

2. **GRAAL-JMX-002 (HIGH) — dynamic/model MBeans are not supported by native-image JMX.** Detects application classes assignable to `javax.management.DynamicMBean` (which transitively covers `ModelMBean`), explicitly excluding classes based on the JDK's `StandardMBean` wrapper (which itself implements `DynamicMBean` — a naive assignability check would otherwise misflag the JDK's own supported pattern). Implemented as a direct/manual `GraalVmCheck` rather than an ArchUnit rule after discovering ArchUnit's `beAssignableTo(DescribedPredicate)` evaluates the predicate against the **whole ancestor hierarchy**, not just the class under test — which would have made a `StandardMBean`-subclass exclusion unreliable.

## Skipped/deferred candidates (researched, not implemented)

- **`MethodHandles.Lookup.defineHiddenClass` detection** — already covered by the existing `GRAAL-CLASSGEN-001` check (its inspected-API list already includes `defineHiddenClass`/`defineHiddenClassWithClassData`); no new check needed.
- **AWT/Swing usage detection** — skipped. No canonical, current GraalVM doc page defines AWT/Swing native-image support status precisely enough to write an accurate, well-bounded check message, and the bytecode-scan condition (which AWT/Swing APIs specifically break vs. partially work) is not cleanly specifiable.
- **`--exact-reachability-metadata` / `-XX:MissingRegistrationReportingMode` advisory** — documented as a new prose section ("Detecting missing metadata at development time") instead of an automated check. Unlike every other check, these flags are a blanket recommendation for essentially every native-image build regardless of what the code does — there's no bytecode condition to scan for. Exact flag names/values verified word-for-word against the live GraalVM `ReachabilityMetadata.md` source: `--exact-reachability-metadata` (optionally `=<packages>`) and `-XX:MissingRegistrationReportingMode=Warn|Exit`.

## Incidental fix

Found and fixed a pre-existing doc bug while editing the same sentence for 7a/7b: `docs/GRAALVM-READINESS-CHECKS.md` said the "Include dependencies" toggle "is off by default," but `GraalVm.vue` (`ref(true)`) and `GraalVmController.java` (`defaultValue = "true"`) confirm it's actually **on** by default — matching `docs/FEATURES.md`'s existing correct statement.

## Check count

25 → **27** checks (2 new: GRAAL-REFLECT-005, GRAAL-JMX-002). No hardcoded count strings existed elsewhere needing correction.

## Testing

- `./mvnw -pl bootui-engine -am test`: **1004/1004 passing**, including `EngineBoundaryArchitectureTests`/`SpiBoundaryArchitectureTests` (framework-neutrality guards — confirm no Spring/Quarkus leakage into the engine).
- `./mvnw -B -ntp spotless:apply` / `spotless:check`: clean across the whole reactor.
- `SpringApiConformanceTest` (`bootui-spring-sample-app`): **5/5 passing**.
- `BootUiQuarkusApiConformanceTest` (`bootui-quarkus-integration-tests`): **5/5 passing** — confirms the Quarkus adapter remains untouched and unaffected, as intended by the scope decision.

## Docs

`docs/GRAALVM-READINESS-CHECKS.md` updated throughout: severity scale (new checks), new GRAAL-REFLECT-005/GRAAL-JMX-002 entries, reworded GRAAL-INIT-001/002, rewritten GRAAL-CLASSGEN-001, GRAAL-SPEL-001 relocated into the Spring AOT section (with an explanatory note on the ID-stability rationale), corrected engine source-code path, fixed the toggle-default bug, and a new "Detecting missing metadata at development time" section.

---
*Implemented on behalf of an orchestrating session that synthesized findings from 5 independent AI audits of the GraalVM Readiness advisor ruleset.*