### PR TITLE
Fix CRaC advisor: eliminate self-defeating Resource-exemption gap, broaden Random/Secret scans, correct thread-freeze framing, add scheduling/dependency/HTTP-client rules

### DIFF
--- a/bootui-engine/pom.xml
+++ b/bootui-engine/pom.xml
@@ -92,6 +92,16 @@
             <artifactId>spring-context</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+          Test-scope only: lets CRaC readiness fixtures implement org.crac.Resource to verify the
+          managed-lifecycle call-site exemption (see ManagedLifecycleCallSites in CracChecks.java).
+          Version is managed by the Spring Boot BOM imported at the root pom.
+        -->
+        <dependency>
+            <groupId>org.crac</groupId>
+            <artifactId>crac</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracCheckRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracCheckRegistry.java
@@ -14,13 +14,16 @@ final class CracCheckRegistry {
             new FileHandleCheck(),
             new SocketConstructionCheck(),
             new ConnectionPoolCheck(),
+            new UnmanagedHttpClientFieldCheck(),
             new CacheManagerCheck(),
             new UnmanagedThreadCheck(),
+            new ScheduledFixedRateTaskCheck(),
             new CapturedTimeCheck(),
             new CapturedConfigurationCheck(),
-            new StaticRandomFieldCheck(),
+            new RandomFieldCheck(),
             new CapturedSecretFieldCheck(),
-            new ResourceRegistrationCheck());
+            new ResourceRegistrationCheck(),
+            new CracDependencyCheck());
 
     private CracCheckRegistry() {}
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracChecks.java
@@ -4,15 +4,18 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.AccessTarget.CodeUnitCallTarget;
+import com.tngtech.archunit.core.domain.JavaAnnotation;
 import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaField;
-import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.domain.JavaStaticInitializer;
 import com.tngtech.archunit.lang.ArchRule;
 import io.github.jdubois.bootui.core.dto.CracFindingDto;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -54,10 +57,58 @@ abstract class AbstractArchUnitCracCheck implements CracCheck {
 }
 
 /**
+ * Shared "this class/call participates in a managed checkpoint/restore lifecycle" logic for the
+ * readiness checks. A class is managed if it implements {@code org.crac.Resource} or a Spring
+ * {@code Lifecycle}/{@code SmartLifecycle}, because Spring (or the application itself, through the
+ * org.crac callbacks) already stops and restarts it around a checkpoint.
+ *
+ * <p>{@link #isExemptCallSite(JavaCall)} additionally scopes the exemption to a call that
+ * <em>originates</em> from one of the managed callback methods themselves ({@code beforeCheckpoint} /
+ * {@code afterRestore} for {@code org.crac.Resource}, {@code start} / {@code stop} for Spring
+ * {@code Lifecycle}). Without this, doing exactly what the affected checks' own recommendation says -
+ * implement the managed interface and re-acquire the resource inside the restore callback - would
+ * permanently and unavoidably keep re-triggering the same finding, because the checks had no way to
+ * recognize that the call happens inside a properly managed restore path. Scoping the exemption to the
+ * callback methods (rather than the whole class) still catches an unrelated leak elsewhere in an
+ * otherwise-managed class.</p>
+ */
+final class ManagedLifecycleCallSites {
+
+    private static final Set<String> MANAGED_TYPES = Set.of(
+            "org.crac.Resource", "org.springframework.context.Lifecycle", "org.springframework.context.SmartLifecycle");
+
+    private static final Set<String> MANAGED_CALLBACK_METHODS =
+            Set.of("beforeCheckpoint", "afterRestore", "start", "stop");
+
+    private ManagedLifecycleCallSites() {}
+
+    static boolean isExemptCallSite(JavaCall<?> call) {
+        JavaCodeUnit origin = call.getOrigin();
+        return MANAGED_CALLBACK_METHODS.contains(origin.getName()) && isManagedClass(call.getOriginOwner());
+    }
+
+    static boolean isManagedClass(JavaClass javaClass) {
+        for (String managedType : MANAGED_TYPES) {
+            if (javaClass.isAssignableTo(managedType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/**
  * Flags direct construction of network sockets ({@code new Socket}, {@code new ServerSocket},
- * {@code new DatagramSocket}, {@code new MulticastSocket}). Open network endpoints must be closed
- * before a checkpoint and re-opened after restore, otherwise the snapshot captures dead file
- * descriptors and the restored process fails or leaks connections.
+ * {@code new DatagramSocket}, {@code new MulticastSocket}) and the NIO channel static {@code open(...)}
+ * factory methods ({@code SocketChannel}, {@code ServerSocketChannel}, {@code DatagramChannel},
+ * {@code AsynchronousSocketChannel}, {@code AsynchronousServerSocketChannel}) that idiomatic NIO code
+ * actually uses instead of a constructor. Open network endpoints must be closed before a checkpoint and
+ * re-opened after restore, otherwise the snapshot captures dead file descriptors and the restored
+ * process fails or leaks connections.
+ *
+ * <p>A call that originates from a managed restore callback ({@code org.crac.Resource.afterRestore()}
+ * or a Spring {@code Lifecycle.start()}) is exempt: re-opening the socket there is the recommended fix,
+ * not a new violation. See {@link ManagedLifecycleCallSites}.</p>
  */
 final class SocketConstructionCheck extends AbstractArchUnitCracCheck {
 
@@ -69,14 +120,21 @@ final class SocketConstructionCheck extends AbstractArchUnitCracCheck {
             "java.nio.channels.ServerSocketChannel",
             "java.nio.channels.SocketChannel");
 
+    private static final Set<String> NIO_CHANNEL_OPEN_TYPES = Set.of(
+            "java.nio.channels.SocketChannel",
+            "java.nio.channels.ServerSocketChannel",
+            "java.nio.channels.DatagramChannel",
+            "java.nio.channels.AsynchronousSocketChannel",
+            "java.nio.channels.AsynchronousServerSocketChannel");
+
     SocketConstructionCheck() {
         super(new CracCheckDefinition(
                 "CRAC-NET-001",
                 "Direct network socket creation must be released at checkpoint",
                 CracCategory.NETWORK,
                 "HIGH",
-                "Detects code that opens network sockets directly (new Socket/ServerSocket/DatagramSocket/MulticastSocket or NIO channels). Open sockets hold OS file descriptors that CRaC refuses to checkpoint unless they are closed first.",
-                "Close the socket in an org.crac.Resource.beforeCheckpoint() callback and re-open it in afterRestore(), or let a managed component (Spring Lifecycle bean, server connector) own the socket so the framework closes it around the checkpoint.",
+                "Detects code that opens network sockets directly (new Socket/ServerSocket/DatagramSocket/MulticastSocket, or the NIO SocketChannel/ServerSocketChannel/DatagramChannel/AsynchronousSocketChannel/AsynchronousServerSocketChannel.open(...) factory methods) outside a managed checkpoint/restore lifecycle. Open sockets hold OS file descriptors that CRaC refuses to checkpoint unless they are closed first.",
+                "Close the socket in an org.crac.Resource.beforeCheckpoint() callback and re-open it in afterRestore(), or let a managed component (Spring Lifecycle bean, server connector) own the socket so the framework closes it around the checkpoint. A call to reopen the socket from inside afterRestore()/start() on a class that implements org.crac.Resource or Spring Lifecycle is the recommended pattern and is not flagged.",
                 "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html"));
     }
 
@@ -87,9 +145,16 @@ final class SocketConstructionCheck extends AbstractArchUnitCracCheck {
                 .callCodeUnitWhere(new DescribedPredicate<JavaCall<?>>("a network socket is constructed") {
                     @Override
                     public boolean test(JavaCall<?> call) {
+                        if (ManagedLifecycleCallSites.isExemptCallSite(call)) {
+                            return false;
+                        }
                         CodeUnitCallTarget target = call.getTarget();
-                        return "<init>".equals(target.getName())
-                                && SOCKET_TYPES.contains(target.getOwner().getName());
+                        String owner = target.getOwner().getName();
+                        String name = target.getName();
+                        if ("<init>".equals(name) && SOCKET_TYPES.contains(owner)) {
+                            return true;
+                        }
+                        return "open".equals(name) && NIO_CHANNEL_OPEN_TYPES.contains(owner);
                     }
                 })
                 .as("Classes should not open network sockets that survive a checkpoint");
@@ -102,6 +167,10 @@ final class SocketConstructionCheck extends AbstractArchUnitCracCheck {
  * {@code FileChannel} / {@code AsynchronousFileChannel} open factory methods). An open file holds an
  * OS file descriptor that CRaC refuses to checkpoint, so it must be closed first — otherwise the
  * checkpoint aborts with {@code CheckpointOpenFileException}.
+ *
+ * <p>A call that originates from a managed restore callback ({@code org.crac.Resource.afterRestore()}
+ * or a Spring {@code Lifecycle.start()}) is exempt: reopening the file there is the recommended fix,
+ * not a new violation. See {@link ManagedLifecycleCallSites}.</p>
  */
 final class FileHandleCheck extends AbstractArchUnitCracCheck {
 
@@ -126,8 +195,8 @@ final class FileHandleCheck extends AbstractArchUnitCracCheck {
                 "Direct file handles must be released at checkpoint",
                 CracCategory.RESOURCES,
                 "HIGH",
-                "Detects code that opens file handles directly (new FileInputStream/FileOutputStream/RandomAccessFile/FileReader/FileWriter/ZipFile/JarFile, or the Files.newInputStream/newOutputStream/newByteChannel and FileChannel/AsynchronousFileChannel.open factory methods). An open file holds an OS file descriptor that CRaC refuses to checkpoint, so it aborts with CheckpointOpenFileException.",
-                "Close the file before the checkpoint (try-with-resources for short-lived handles, or release it in an org.crac.Resource.beforeCheckpoint() callback and reopen it in afterRestore()), or let a managed component own it so the framework closes it around the checkpoint.",
+                "Detects code that opens file handles directly (new FileInputStream/FileOutputStream/RandomAccessFile/FileReader/FileWriter/ZipFile/JarFile, or the Files.newInputStream/newOutputStream/newByteChannel and FileChannel/AsynchronousFileChannel.open factory methods) outside a managed checkpoint/restore lifecycle. An open file holds an OS file descriptor that CRaC refuses to checkpoint, so it aborts with CheckpointOpenFileException.",
+                "Close the file before the checkpoint (try-with-resources for short-lived handles, or release it in an org.crac.Resource.beforeCheckpoint() callback and reopen it in afterRestore()), or let a managed component own it so the framework closes it around the checkpoint. A call to reopen the file from inside afterRestore()/start() on a class that implements org.crac.Resource or Spring Lifecycle is the recommended pattern and is not flagged.",
                 "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html"));
     }
 
@@ -138,6 +207,9 @@ final class FileHandleCheck extends AbstractArchUnitCracCheck {
                 .callCodeUnitWhere(new DescribedPredicate<JavaCall<?>>("a file handle is opened") {
                     @Override
                     public boolean test(JavaCall<?> call) {
+                        if (ManagedLifecycleCallSites.isExemptCallSite(call)) {
+                            return false;
+                        }
                         CodeUnitCallTarget target = call.getTarget();
                         String owner = target.getOwner().getName();
                         String name = target.getName();
@@ -156,9 +228,16 @@ final class FileHandleCheck extends AbstractArchUnitCracCheck {
 
 /**
  * Flags threads, timers, and executor pools created directly rather than through a Spring-managed
- * lifecycle. CRaC pauses Spring {@code Lifecycle} beans before a checkpoint; threads started outside
- * that lifecycle keep running and are captured mid-flight, which often deadlocks or corrupts state
- * after restore.
+ * lifecycle. CRaC is built on CRIU, which freezes <em>every</em> OS thread in the process to take a
+ * checkpoint — no thread "keeps running through" it. The real risk is in what happens just before that
+ * freeze: Spring stops {@code SmartLifecycle} beans gracefully before the checkpoint is even requested,
+ * so managed background work reaches a quiescent, consistent state first. A raw thread or executor has
+ * no such hook, so it is frozen abruptly mid-execution — in whatever state it happens to be in — which
+ * risks deadlocks, stale locks, or inconsistent state on restore.
+ *
+ * <p>A call that originates from a managed restore callback ({@code org.crac.Resource.afterRestore()}
+ * or a Spring {@code Lifecycle.start()}) is exempt: restarting the pool there is the recommended fix,
+ * not a new violation. See {@link ManagedLifecycleCallSites}.</p>
  */
 final class UnmanagedThreadCheck extends AbstractArchUnitCracCheck {
 
@@ -184,8 +263,8 @@ final class UnmanagedThreadCheck extends AbstractArchUnitCracCheck {
                 "Threads or executor pools created outside the Spring lifecycle",
                 CracCategory.THREADS,
                 "MEDIUM",
-                "Detects threads, timers, and executor pools created directly (new Thread/Timer/ThreadPoolExecutor or Executors factory methods). Such threads are not paused by CRaC before a checkpoint and are snapshotted while running.",
-                "Drive background work through Spring (e.g. @Async, TaskExecutor/TaskScheduler beans, @Scheduled) so the lifecycle stops it before checkpoint, or register an org.crac.Resource that quiesces the pool in beforeCheckpoint() and restarts it in afterRestore().",
+                "Detects threads, timers, and executor pools created directly (new Thread/Timer/ThreadPoolExecutor or Executors factory methods) outside a managed checkpoint/restore lifecycle. CRIU (which CRaC is built on) freezes every OS thread to take a checkpoint, so an unmanaged thread is not gracefully stopped first the way a Spring-managed SmartLifecycle bean is — it is captured abruptly mid-execution, in whatever state it happens to be in, which risks deadlocks, stale locks, or inconsistent state after restore.",
+                "Drive background work through Spring (e.g. @Async, TaskExecutor/TaskScheduler beans, @Scheduled) so the lifecycle stops it gracefully before checkpoint, or register an org.crac.Resource that quiesces the pool in beforeCheckpoint() and restarts it in afterRestore(). A call to restart the pool from inside afterRestore()/start() on a class that implements org.crac.Resource or Spring Lifecycle is the recommended pattern and is not flagged.",
                 "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html"));
     }
 
@@ -196,6 +275,9 @@ final class UnmanagedThreadCheck extends AbstractArchUnitCracCheck {
                 .callCodeUnitWhere(new DescribedPredicate<JavaCall<?>>("an unmanaged thread or pool is created") {
                     @Override
                     public boolean test(JavaCall<?> call) {
+                        if (ManagedLifecycleCallSites.isExemptCallSite(call)) {
+                            return false;
+                        }
                         CodeUnitCallTarget target = call.getTarget();
                         String owner = target.getOwner().getName();
                         String name = target.getName();
@@ -295,9 +377,6 @@ final class OpenResourceFieldCheck implements CracCheck {
             "java.lang.Process",
             "java.sql.Connection");
 
-    private static final Set<String> MANAGED_TYPES = Set.of(
-            "org.crac.Resource", "org.springframework.context.Lifecycle", "org.springframework.context.SmartLifecycle");
-
     @Override
     public CracCheckDefinition definition() {
         return DEFINITION;
@@ -309,7 +388,7 @@ final class OpenResourceFieldCheck implements CracCheck {
             List<String> samples = new ArrayList<>();
             int count = 0;
             for (JavaClass javaClass : context.classes()) {
-                if (isManaged(javaClass)) {
+                if (ManagedLifecycleCallSites.isManagedClass(javaClass)) {
                     continue;
                 }
                 for (JavaField field : javaClass.getFields()) {
@@ -339,31 +418,24 @@ final class OpenResourceFieldCheck implements CracCheck {
         }
         return false;
     }
-
-    private static boolean isManaged(JavaClass javaClass) {
-        for (String managed : MANAGED_TYPES) {
-            if (javaClass.isAssignableTo(managed)) {
-                return true;
-            }
-        }
-        return false;
-    }
 }
 
 /**
- * Flags static {@link java.util.Random} / {@link java.security.SecureRandom} fields. Their seed and
- * internal state are frozen into the checkpoint image, so every restored process produces the same
- * "random" sequence — a correctness problem and, for SecureRandom, a security weakness.
+ * Flags {@link java.util.Random} / {@link java.security.SecureRandom} fields, static or instance.
+ * Idiomatic Spring code rarely uses a static PRNG field — the dominant pattern is a singleton-bean
+ * instance field (a {@code @Component}-injected {@code SecureRandom}) — but a checkpoint snapshots
+ * every object reachable from GC roots, not just static state, so an instance field is captured just as
+ * completely as a static one.
  */
-final class StaticRandomFieldCheck implements CracCheck {
+final class RandomFieldCheck implements CracCheck {
 
     private static final CracCheckDefinition DEFINITION = new CracCheckDefinition(
             "CRAC-RANDOM-001",
-            "Static Random/SecureRandom state is frozen into the checkpoint",
+            "Random/SecureRandom state is frozen into the checkpoint",
             CracCategory.RANDOMNESS,
             "HIGH",
-            "Detects static fields of type java.util.Random or java.security.SecureRandom. Their internal state is captured at checkpoint time, so every restored instance replays the same sequence.",
-            "Re-seed or recreate the generator in an org.crac.Resource.afterRestore() callback, or avoid a static instance so a fresh generator is created per restored process.",
+            "Detects fields (static or instance) of type java.util.Random or java.security.SecureRandom. A checkpoint freezes whatever internal state the generator holds at that moment into the image, whether the field is static or an ordinary singleton-bean field.",
+            "A JDK built for CRaC already auto-reseeds a no-arg, never-explicitly-seeded SecureRandom on restore, so plain `new SecureRandom()` usage is commonly safe there without any code change — but confirm your target JDK/runtime actually implements that behavior before relying on it, since it is not guaranteed on every CRaC-capable platform. An explicitly-seeded SecureRandom, or a plain java.util.Random, keeps its frozen state across restore in every case and needs its own fix: re-seed or recreate it in an org.crac.Resource.afterRestore() callback, or avoid caching a shared instance so a fresh generator is created per restored process.",
             "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
 
     @Override
@@ -378,8 +450,7 @@ final class StaticRandomFieldCheck implements CracCheck {
             int count = 0;
             for (JavaClass javaClass : context.classes()) {
                 for (JavaField field : javaClass.getFields()) {
-                    if (field.getModifiers().contains(JavaModifier.STATIC)
-                            && field.getRawType().isAssignableTo("java.util.Random")) {
+                    if (field.getRawType().isAssignableTo("java.util.Random")) {
                         count++;
                         if (samples.size() < CracCheckSupport.maxSampleOccurrences()) {
                             samples.add(CracCheckSupport.detail(javaClass.getName() + "." + field.getName() + " : "
@@ -399,22 +470,23 @@ final class StaticRandomFieldCheck implements CracCheck {
 }
 
 /**
- * Flags static fields that eagerly capture a secret: either a field whose name suggests a secret
- * (token, password, API key, credential) holding a {@code String}/{@code char[]}/{@code byte[]}, or a
- * field whose type is cryptographic key material ({@code SecretKey}, {@code PrivateKey}, {@code
- * KeyStore}, {@code KeyPair}) regardless of name. A secret loaded into a static field at startup is
- * baked into the checkpoint image and shipped with every restored process, so rotation no longer
- * takes effect and the snapshot leaks the value.
+ * Flags fields, static or instance, that eagerly capture a secret: either a field whose name suggests a
+ * secret (token, password, API key, credential) holding a {@code String}/{@code char[]}/{@code byte[]},
+ * or a field whose type is cryptographic key material ({@code SecretKey}, {@code PrivateKey}, {@code
+ * KeyStore}, {@code KeyPair}) regardless of name. A secret loaded at startup — whether into a static
+ * field or a singleton bean's instance field, such as an {@code @Value}-injected credential — is baked
+ * into the checkpoint image and shipped with every restored process, so rotation no longer takes effect
+ * and the snapshot leaks the value.
  */
 final class CapturedSecretFieldCheck implements CracCheck {
 
     private static final CracCheckDefinition DEFINITION = new CracCheckDefinition(
             "CRAC-SECRET-001",
-            "Secrets captured in static fields are frozen into the checkpoint",
+            "Secrets captured in fields are frozen into the checkpoint",
             CracCategory.SECRETS,
             "HIGH",
-            "Detects static fields that capture a secret: a field whose name looks like a secret (token, password, secret, api key, credential, private key) holding a String, char[], or byte[], or a field holding cryptographic key material (SecretKey, PrivateKey, KeyStore, KeyPair) regardless of name. Such values are captured into the checkpoint image and survive in every restored process.",
-            "Load secrets lazily at runtime (or refresh them in an org.crac.Resource.afterRestore() callback) instead of caching them in a static field, so a checkpoint never freezes a credential.",
+            "Detects fields (static or instance) that capture a secret: a field whose name looks like a secret (token, password, secret, api key, credential, private key) holding a String, char[], or byte[], or a field holding cryptographic key material (SecretKey, PrivateKey, KeyStore, KeyPair) regardless of name. A checkpoint snapshots every object reachable from GC roots, so a credential cached in a singleton bean's instance field (e.g. an @Value-injected secret) is captured into the image exactly like a static field would be.",
+            "Load secrets lazily at runtime (or refresh them in an org.crac.Resource.afterRestore() callback) instead of caching them in a field, so a checkpoint never freezes a credential.",
             "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
 
     private static final Pattern SECRET_NAME =
@@ -437,7 +509,7 @@ final class CapturedSecretFieldCheck implements CracCheck {
             int count = 0;
             for (JavaClass javaClass : context.classes()) {
                 for (JavaField field : javaClass.getFields()) {
-                    if (field.getModifiers().contains(JavaModifier.STATIC) && isCapturedSecret(field)) {
+                    if (isCapturedSecret(field)) {
                         count++;
                         if (samples.size() < CracCheckSupport.maxSampleOccurrences()) {
                             samples.add(CracCheckSupport.detail(javaClass.getName() + "." + field.getName() + " : "
@@ -536,7 +608,7 @@ final class ConnectionPoolCheck implements CracCheck {
             CracCategory.POOLS,
             "HIGH",
             "Detects live connection pools and pooled clients (JDBC DataSource, plus R2DBC/Redis/RabbitMQ/Kafka/Mongo/Cassandra/JMS connection factories and similar). A pooled connection that is still open when the checkpoint is taken holds an OS socket that CRaC refuses to snapshot, so the checkpoint aborts with CheckpointOpenSocketException. The backing service must also be reachable both when the checkpoint is taken and when it is restored.",
-            "Ensure no pooled connection is open at checkpoint time: let the pool drain to zero idle connections (for example spring.datasource.hikari.minimum-idle=0) or rely on Spring closing CRaC-aware pools before the checkpoint, and keep the database/cache reachable at both checkpoint and restore. Take the checkpoint after the context refreshes but before traffic opens a connection.",
+            "Ensure no pooled connection is open at checkpoint time: let the pool drain to zero idle connections (for example spring.datasource.hikari.minimum-idle=0), and keep the database/cache reachable at both checkpoint and restore. Take the checkpoint after the context refreshes but before traffic opens a connection. Do not assume the pool closes itself for CRaC: check whether your specific pool/client library has adopted org.crac.Resource natively. As of today, most common pools (including HikariCP and Lettuce, Spring Boot's default JDBC pool and Redis client) do not ship this out of the box, so unless you have verified otherwise for your library's current version, plan to register your own org.crac.Resource wrapper around the DataSource/connection factory bean to close and reopen it around the checkpoint.",
             "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
 
     @Override
@@ -566,9 +638,15 @@ final class ConnectionPoolCheck implements CracCheck {
 }
 
 /**
- * Flags live Spring {@code CacheManager} beans. Cache entries populated before the checkpoint survive
- * into every restored process and may be stale (for example expired tokens or other time-sensitive
- * data), because the checkpoint freezes the cache contents along with the rest of the heap.
+ * Flags live Spring {@code CacheManager} beans that are backed by local, in-heap storage. Cache
+ * entries populated before the checkpoint survive into every restored process and may be stale (for
+ * example expired tokens or other time-sensitive data), because the checkpoint freezes the cache
+ * contents along with the rest of the heap.
+ *
+ * <p>Well-known remote/external-store-backed managers (currently Spring Data Redis's {@code
+ * RedisCacheManager}) are excluded upstream by {@code CracRuntimeInventoryCollector}, because their
+ * entries live outside the JVM heap in an external store and are not frozen by the checkpoint the way a
+ * local manager's (for example {@code ConcurrentMapCacheManager} or Caffeine) are.</p>
  *
  * <p>Like {@link ConnectionPoolCheck} this reads the live {@link CracRuntimeInventory} rather than the
  * imported bytecode, because cache managers are contributed by Spring's cache auto-configuration and
@@ -581,8 +659,8 @@ final class CacheManagerCheck implements CracCheck {
             "In-memory caches may hold stale entries after restore",
             CracCategory.CACHES,
             "LOW",
-            "Detects live Spring CacheManager beans. Cache entries populated before the checkpoint are frozen into the image and survive into every restored process, where they may be stale (for example expired tokens or time-sensitive data).",
-            "Clear or refresh time-sensitive caches in an org.crac.Resource.afterRestore() callback, or use restore-aware expiry, so a restored process does not serve data captured at checkpoint time.",
+            "Detects live Spring CacheManager beans backed by local, in-heap storage (for example ConcurrentMapCacheManager or Caffeine). Cache entries populated before the checkpoint are frozen into the image and survive into every restored process, where they may be stale (for example expired tokens or time-sensitive data). Cache managers backed by a remote/external store (for example Redis) are a lower concern and are not reported here, since their entries live outside the JVM heap and are not frozen into the checkpoint.",
+            "Clear or refresh time-sensitive local caches in an org.crac.Resource.afterRestore() callback, or use restore-aware expiry, so a restored process does not serve data captured at checkpoint time.",
             "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
 
     @Override
@@ -649,5 +727,191 @@ final class CapturedConfigurationCheck extends AbstractArchUnitCracCheck {
                     }
                 })
                 .as("Static initializers should not capture environment or system configuration before a checkpoint");
+    }
+}
+
+/**
+ * Flags {@code @Scheduled} methods that explicitly declare {@code fixedRate} or {@code
+ * fixedRateString}. Spring Framework's checkpoint/restore reference documentation warns that
+ * <em>on-demand</em> checkpoint/restore of an already-running application can produce a catch-up
+ * burst: fixed-rate scheduling computes each execution from a fixed wall-clock point rather than the
+ * end of the previous run, so every execution missed during the idle gap between the checkpoint and a
+ * later restore fires back-to-back immediately after restore.
+ *
+ * <p>This is specific to on-demand checkpoint/restore of an already-running application. Automatic
+ * checkpoint/restore at startup ({@code spring.context.checkpoint=onRefresh}) takes the checkpoint
+ * before the scheduler has started, so no executions have been missed yet at that point.</p>
+ */
+final class ScheduledFixedRateTaskCheck implements CracCheck {
+
+    private static final String SCHEDULED_ANNOTATION = "org.springframework.scheduling.annotation.Scheduled";
+
+    private static final CracCheckDefinition DEFINITION = new CracCheckDefinition(
+            "CRAC-SCHED-001",
+            "Fixed-rate scheduled tasks may run a catch-up burst after restore",
+            CracCategory.THREADS,
+            "MEDIUM",
+            "Detects @Scheduled methods that explicitly declare fixedRate or fixedRateString. Fixed-rate scheduling computes each execution from a fixed wall-clock point rather than the end of the previous run, so on-demand checkpoint/restore of a running application can leave a long idle gap between the checkpoint and a later restore; every execution missed during that gap fires back-to-back immediately after restore.",
+            "If a catch-up burst after restore is not the behavior you want, switch to fixedDelay (or a cron expression), which Spring schedules relative to the end of the previous execution rather than a fixed wall-clock point, so a checkpoint/restore gap does not queue up missed runs. This risk is specific to on-demand checkpoint/restore of an already-running application; automatic checkpoint/restore at startup (spring.context.checkpoint=onRefresh) takes the checkpoint before the scheduler starts and is not affected.",
+            "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html#_on_demand_checkpointrestore_of_a_running_application");
+
+    @Override
+    public CracCheckDefinition definition() {
+        return DEFINITION;
+    }
+
+    @Override
+    public CracFindingDto evaluate(CracContext context) {
+        try {
+            List<String> samples = new ArrayList<>();
+            int count = 0;
+            for (JavaClass javaClass : context.classes()) {
+                for (JavaMethod method : javaClass.getMethods()) {
+                    if (declaresFixedRate(method)) {
+                        count++;
+                        if (samples.size() < CracCheckSupport.maxSampleOccurrences()) {
+                            samples.add(CracCheckSupport.detail(javaClass.getName() + "." + method.getName() + "()"));
+                        }
+                    }
+                }
+            }
+            if (count == 0) {
+                return CracCheckSupport.ok(DEFINITION);
+            }
+            return CracCheckSupport.review(DEFINITION, count, samples);
+        } catch (RuntimeException | LinkageError ex) {
+            return CracCheckSupport.error(DEFINITION, "Check could not be evaluated: " + ex.getMessage());
+        }
+    }
+
+    private static boolean declaresFixedRate(JavaMethod method) {
+        Optional<JavaAnnotation<JavaMethod>> scheduled = method.tryGetAnnotationOfType(SCHEDULED_ANNOTATION);
+        if (scheduled.isEmpty()) {
+            return false;
+        }
+        JavaAnnotation<JavaMethod> annotation = scheduled.get();
+        return annotation.hasExplicitlyDeclaredProperty("fixedRate")
+                || annotation.hasExplicitlyDeclaredProperty("fixedRateString");
+    }
+}
+
+/**
+ * Reports whether the {@code org.crac:crac} API is present on the application's classpath. Without it
+ * an application has no library to implement {@code org.crac.Resource} against, so it cannot hook
+ * {@code beforeCheckpoint()}/{@code afterRestore()} to release and reacquire resources, re-seed
+ * randomness, or refresh secrets around a checkpoint - the fix every other resource/random/secret
+ * finding in this rule set recommends.
+ *
+ * <p>Like {@link ConnectionPoolCheck} and {@link CacheManagerCheck} this reads the live {@link
+ * CracRuntimeInventory} rather than the imported application bytecode, because classpath presence is a
+ * runtime/dependency signal, not something visible in any one class's bytecode.</p>
+ */
+final class CracDependencyCheck implements CracCheck {
+
+    private static final CracCheckDefinition DEFINITION = new CracCheckDefinition(
+            "CRAC-LIFECYCLE-002",
+            "The org.crac:crac API is not on the classpath",
+            CracCategory.LIFECYCLE,
+            "MEDIUM",
+            "Detects whether the org.crac:crac API (org.crac.Core / org.crac.Resource) is present on the application's classpath. A Spring Boot application on a CRaC-enabled JVM does not strictly need this dependency to take an automatic checkpoint, but without it no application class can implement org.crac.Resource, so it cannot hook beforeCheckpoint()/afterRestore() to release and reacquire resources, re-seed randomness, or refresh secrets around a checkpoint.",
+            "Add the org.crac:crac dependency (its version is managed by the Spring Boot BOM) so application classes can implement org.crac.Resource and register with Core.getGlobalContext().register(...) to participate in checkpoint/restore.",
+            "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
+
+    @Override
+    public CracCheckDefinition definition() {
+        return DEFINITION;
+    }
+
+    @Override
+    public CracFindingDto evaluate(CracContext context) {
+        try {
+            if (context.runtime().cracApiPresent()) {
+                return CracCheckSupport.ok(DEFINITION);
+            }
+            return CracCheckSupport.review(
+                    DEFINITION,
+                    1,
+                    List.of(
+                            CracCheckSupport.detail(
+                                    "org.crac.Core is not on the classpath; no application class can implement org.crac.Resource.")));
+        } catch (RuntimeException | LinkageError ex) {
+            return CracCheckSupport.error(DEFINITION, "Check could not be evaluated: " + ex.getMessage());
+        }
+    }
+}
+
+/**
+ * Flags fields that hold a long-lived HTTP/RPC client with its own connection pool or event-loop
+ * threads (the JDK's {@code java.net.http.HttpClient}, Apache HttpClient's {@code
+ * CloseableHttpClient}, OkHttp's {@code OkHttpClient}, Reactor Netty's {@code HttpClient}/{@code
+ * ConnectionProvider}, or gRPC's {@code ManagedChannel}) outside a managed checkpoint/restore
+ * lifecycle. These hold sockets and background threads exactly like the raw socket/pool types {@link
+ * OpenResourceFieldCheck} already covers, but are easy to miss because the client is typically built
+ * once via a builder rather than constructed directly.
+ *
+ * <p>A field on a class that already implements {@code org.crac.Resource} or a Spring {@code
+ * Lifecycle}/{@code SmartLifecycle} is exempt, matching {@link OpenResourceFieldCheck}: the managed
+ * class is expected to close and rebuild the client around the checkpoint itself.</p>
+ */
+final class UnmanagedHttpClientFieldCheck implements CracCheck {
+
+    private static final CracCheckDefinition DEFINITION = new CracCheckDefinition(
+            "CRAC-POOL-002",
+            "HTTP/RPC clients hold sockets and threads that must be released at checkpoint",
+            CracCategory.POOLS,
+            "HIGH",
+            "Detects fields that hold a long-lived HTTP/RPC client with its own connection pool or event-loop threads: the JDK's java.net.http.HttpClient, Apache HttpClient's CloseableHttpClient (4.x and 5.x), OkHttp's OkHttpClient, Reactor Netty's HttpClient/ConnectionProvider, or gRPC's ManagedChannel. Like a raw socket, these hold open OS file descriptors and background threads that CRaC cannot checkpoint while live, but they are easy to miss because the client comes from a builder rather than a bare constructor call.",
+            "Close the client (and its underlying connection pool/event-loop) in an org.crac.Resource.beforeCheckpoint() callback and rebuild it in afterRestore(), or hold it in a Spring Lifecycle/SmartLifecycle bean so the framework stops it before the checkpoint.",
+            "https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html");
+
+    private static final Set<String> HTTP_CLIENT_TYPES = Set.of(
+            "java.net.http.HttpClient",
+            "org.apache.hc.client5.http.impl.classic.CloseableHttpClient",
+            "org.apache.http.impl.client.CloseableHttpClient",
+            "okhttp3.OkHttpClient",
+            "reactor.netty.http.client.HttpClient",
+            "reactor.netty.resources.ConnectionProvider",
+            "io.grpc.ManagedChannel");
+
+    @Override
+    public CracCheckDefinition definition() {
+        return DEFINITION;
+    }
+
+    @Override
+    public CracFindingDto evaluate(CracContext context) {
+        try {
+            List<String> samples = new ArrayList<>();
+            int count = 0;
+            for (JavaClass javaClass : context.classes()) {
+                if (ManagedLifecycleCallSites.isManagedClass(javaClass)) {
+                    continue;
+                }
+                for (JavaField field : javaClass.getFields()) {
+                    if (isHttpClientType(field.getRawType())) {
+                        count++;
+                        if (samples.size() < CracCheckSupport.maxSampleOccurrences()) {
+                            samples.add(CracCheckSupport.detail(javaClass.getName() + "." + field.getName() + " : "
+                                    + field.getRawType().getName()));
+                        }
+                    }
+                }
+            }
+            if (count == 0) {
+                return CracCheckSupport.ok(DEFINITION);
+            }
+            return CracCheckSupport.review(DEFINITION, count, samples);
+        } catch (RuntimeException | LinkageError ex) {
+            return CracCheckSupport.error(DEFINITION, "Check could not be evaluated: " + ex.getMessage());
+        }
+    }
+
+    private static boolean isHttpClientType(JavaClass type) {
+        for (String httpClientType : HTTP_CLIENT_TYPES) {
+            if (type.isAssignableTo(httpClientType)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracRuntimeInventory.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracRuntimeInventory.java
@@ -15,23 +15,34 @@ import java.util.List;
  *
  * @param connectionPoolBeans human-readable {@code beanName : TypeName} entries for detected pool
  *     beans (JDBC {@code DataSource}, Redis/RabbitMQ/Kafka/Mongo/Cassandra/JMS/R2DBC connection
- *     factories and similar pooled clients), empty when none are present
+ *     factories and similar pooled clients; remote-backed cache managers such as Redis's {@code
+ *     RedisCacheManager} are excluded from {@link #cacheManagerBeans} rather than listed here), empty
+ *     when none are present
  * @param cacheManagerBeans human-readable {@code beanName : TypeName} entries for detected cache
- *     manager beans, empty when none are present
+ *     manager beans backed by local, in-heap storage, empty when none are present
+ * @param cracApiPresent whether {@code org.crac:crac} (org.crac.Core/org.crac.Resource) is present on
+ *     the application's classpath; defaults to {@code true} in every convenience constructor and in
+ *     {@link #empty()} so that a collection failure or an unavailable runtime never spuriously reports
+ *     the dependency as missing
  */
-public record CracRuntimeInventory(List<String> connectionPoolBeans, List<String> cacheManagerBeans) {
+public record CracRuntimeInventory(
+        List<String> connectionPoolBeans, List<String> cacheManagerBeans, boolean cracApiPresent) {
 
     public CracRuntimeInventory {
         connectionPoolBeans = connectionPoolBeans == null ? List.of() : List.copyOf(connectionPoolBeans);
         cacheManagerBeans = cacheManagerBeans == null ? List.of() : List.copyOf(cacheManagerBeans);
     }
 
+    public CracRuntimeInventory(List<String> connectionPoolBeans, List<String> cacheManagerBeans) {
+        this(connectionPoolBeans, cacheManagerBeans, true);
+    }
+
     public CracRuntimeInventory(List<String> connectionPoolBeans) {
-        this(connectionPoolBeans, List.of());
+        this(connectionPoolBeans, List.of(), true);
     }
 
     public static CracRuntimeInventory empty() {
-        return new CracRuntimeInventory(List.of(), List.of());
+        return new CracRuntimeInventory(List.of(), List.of(), true);
     }
 
     boolean hasConnectionPools() {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/CracReadinessScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/CracReadinessScannerTests.java
@@ -57,6 +57,9 @@ class CracReadinessScannerTests {
         assertThat(report.classesAnalyzed()).isPositive();
         assertThat(report.findings())
                 .allSatisfy(finding -> assertThat(finding.status()).isEqualTo("REVIEW"));
+        // CRAC-LIFECYCLE-001 is intentionally absent here: ManagedResourceLifecycle and
+        // ManagedClassWithUnrelatedLeak both implement org.crac.Resource, so the "no implementations
+        // found" check now reports OK. See resourceRegistrationCheckIsOkWhenAnImplementerExists().
         assertThat(report.findings())
                 .extracting(CracFindingDto::id)
                 .contains(
@@ -68,13 +71,131 @@ class CracReadinessScannerTests {
                         "CRAC-CONFIG-001",
                         "CRAC-RANDOM-001",
                         "CRAC-SECRET-001",
-                        "CRAC-LIFECYCLE-001");
+                        "CRAC-SCHED-001",
+                        "CRAC-POOL-002");
         assertThat(report.findings().stream().map(CracFindingDto::severity).toList())
                 .isSortedAccordingTo(Comparator.comparingInt(CracReadinessScannerTests::severityRank));
         assertThat(report.severityCounts())
                 .extracting("severity")
                 .containsExactly("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
         assertThat(report.findingsFound()).isEqualTo(report.findings().size());
+    }
+
+    @Test
+    void resourceRegistrationCheckIsOkWhenAnImplementerExists() {
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES));
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        // ManagedResourceLifecycle and ManagedClassWithUnrelatedLeak both implement org.crac.Resource,
+        // so CRAC-LIFECYCLE-001 ("no implementations found") reports OK and is filtered out of findings().
+        assertThat(report.findings()).extracting(CracFindingDto::id).doesNotContain("CRAC-LIFECYCLE-001");
+    }
+
+    @Test
+    void managedLifecycleReopeningResourcesInCallbacksIsExempt() {
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES));
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        // ManagedResourceLifecycle implements org.crac.Resource and re-acquires its socket, file,
+        // executor pool, and HTTP client from afterRestore() - the exact pattern each check's own
+        // recommendation text suggests. None of these should be (re-)flagged.
+        assertThat(findingSamples(report, "CRAC-NET-001"))
+                .noneMatch(sample -> sample.contains("ManagedResourceLifecycle"));
+        assertThat(findingSamples(report, "CRAC-FILE-001"))
+                .noneMatch(sample -> sample.contains("ManagedResourceLifecycle"));
+        assertThat(findingSamples(report, "CRAC-THREAD-001"))
+                .noneMatch(sample -> sample.contains("ManagedResourceLifecycle"));
+        assertThat(findingSamples(report, "CRAC-RES-001"))
+                .noneMatch(sample -> sample.contains("ManagedResourceLifecycle"));
+        assertThat(findingSamples(report, "CRAC-POOL-002"))
+                .noneMatch(sample -> sample.contains("ManagedResourceLifecycle"));
+    }
+
+    @Test
+    void unmanagedLeakInAManagedClassIsStillFlagged() {
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES));
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        // ManagedClassWithUnrelatedLeak implements org.crac.Resource, but opens its socket from an
+        // unrelated method, not from beforeCheckpoint()/afterRestore(); the call-site-scoped exemption
+        // must not let this leak slip through just because the enclosing class is otherwise managed.
+        assertThat(findingSamples(report, "CRAC-NET-001"))
+                .anyMatch(sample -> sample.contains("ManagedClassWithUnrelatedLeak"));
+    }
+
+    @Test
+    void scanFlagsInstanceFieldRandomAndSecretHolders() {
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES));
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        // CRAC-RANDOM-001/CRAC-SECRET-001 used to filter on the STATIC modifier; these fixtures use
+        // ordinary singleton-bean instance fields, the dominant real-world Spring pattern, and must
+        // still be flagged now that the static-only filter has been removed.
+        assertThat(findingSamples(report, "CRAC-RANDOM-001"))
+                .anyMatch(sample -> sample.contains("InstanceRandomHolder"));
+        assertThat(findingSamples(report, "CRAC-SECRET-001"))
+                .anyMatch(sample -> sample.contains("InstanceSecretHolder"));
+    }
+
+    @Test
+    void scanFlagsNioChannelOpenCall() {
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES));
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        // NioChannelOpener uses SocketChannel.open(), the idiomatic NIO factory method, rather than a
+        // constructor; CRAC-NET-001 must detect this alongside the constructor-based fixtures.
+        assertThat(findingSamples(report, "CRAC-NET-001")).anyMatch(sample -> sample.contains("NioChannelOpener"));
+    }
+
+    @Test
+    void scanFlagsFixedRateScheduledMethodButNotFixedDelayOrCron() {
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES));
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        CracFindingDto sched = report.findings().stream()
+                .filter(finding -> "CRAC-SCHED-001".equals(finding.id()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(sched.severity()).isEqualTo("MEDIUM");
+        assertThat(sched.status()).isEqualTo("REVIEW");
+        assertThat(sched.occurrenceCount()).isEqualTo(1);
+        assertThat(sched.sampleOccurrences()).anyMatch(sample -> sample.contains("pollEveryFiveSeconds"));
+        assertThat(sched.sampleOccurrences())
+                .noneMatch(sample -> sample.contains("runFiveSecondsAfterCompletion") || sample.contains("hourlyJob"));
+    }
+
+    @Test
+    void scanFlagsUnmanagedHttpClientField() {
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES));
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        assertThat(findingSamples(report, "CRAC-POOL-002")).anyMatch(sample -> sample.contains("HttpClientHolder"));
+    }
+
+    @Test
+    void scanFlagsMissingCracDependencyWhenInventoryReportsAbsent() {
+        CracRuntimeInventory inventory = new CracRuntimeInventory(List.of(), List.of(), false);
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES), inventory);
+
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        CracFindingDto dependency = report.findings().stream()
+                .filter(finding -> "CRAC-LIFECYCLE-002".equals(finding.id()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(dependency.severity()).isEqualTo("MEDIUM");
+        assertThat(dependency.status()).isEqualTo("REVIEW");
+        assertThat(dependency.occurrenceCount()).isEqualTo(1);
+    }
+
+    @Test
+    void scanDoesNotFlagCracDependencyByDefault() {
+        CracReadinessScanner scanner = scanner(List.of(FIXTURES));
+        CracReadinessReport report = scanner.report(scanner.scan(), RUNTIME);
+
+        // The default CracRuntimeInventory (built by CracRuntimeInventory.empty()) defaults
+        // cracApiPresent to true, so CRAC-LIFECYCLE-002 must not appear absent evidence to the contrary.
+        assertThat(report.findings()).extracting(CracFindingDto::id).doesNotContain("CRAC-LIFECYCLE-002");
     }
 
     @Test
@@ -148,5 +269,13 @@ class CracReadinessScannerTests {
 
     private static int severityRank(String severity) {
         return List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO").indexOf(severity);
+    }
+
+    private static List<String> findingSamples(CracReadinessReport report, String id) {
+        return report.findings().stream()
+                .filter(finding -> id.equals(finding.id()))
+                .findFirst()
+                .map(CracFindingDto::sampleOccurrences)
+                .orElse(List.of());
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/FixedRateScheduledTask.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/FixedRateScheduledTask.java
@@ -1,0 +1,20 @@
+package io.github.jdubois.bootui.engine.crac.fixtures;
+
+import org.springframework.scheduling.annotation.Scheduled;
+
+/**
+ * A fixed-rate scheduled task (CRAC-SCHED-001), alongside a fixed-delay and a cron-based task that
+ * should not be flagged: only an explicitly declared {@code fixedRate}/{@code fixedRateString} risks
+ * a catch-up burst after an on-demand restore.
+ */
+public class FixedRateScheduledTask {
+
+    @Scheduled(fixedRate = 5000)
+    public void pollEveryFiveSeconds() {}
+
+    @Scheduled(fixedDelay = 5000)
+    public void runFiveSecondsAfterCompletion() {}
+
+    @Scheduled(cron = "0 0 * * * *")
+    public void hourlyJob() {}
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/HttpClientHolder.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/HttpClientHolder.java
@@ -1,0 +1,17 @@
+package io.github.jdubois.bootui.engine.crac.fixtures;
+
+import java.net.http.HttpClient;
+
+/**
+ * Holds a long-lived JDK {@link HttpClient} in a field without any managed lifecycle
+ * (CRAC-POOL-002). Built via a static factory rather than a bare constructor, so it is easy to miss
+ * next to the raw socket/file checks.
+ */
+public class HttpClientHolder {
+
+    private final HttpClient client = HttpClient.newHttpClient();
+
+    public HttpClient getClient() {
+        return client;
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/InstanceRandomHolder.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/InstanceRandomHolder.java
@@ -1,0 +1,17 @@
+package io.github.jdubois.bootui.engine.crac.fixtures;
+
+import java.security.SecureRandom;
+
+/**
+ * Keeps a {@link SecureRandom} in a singleton-bean instance field rather than a static one
+ * (CRAC-RANDOM-001). Idiomatic Spring code almost always injects a PRNG this way; the checkpoint
+ * freezes the field's state just as completely as it would a static field.
+ */
+public class InstanceRandomHolder {
+
+    private final SecureRandom random = new SecureRandom();
+
+    public int next() {
+        return random.nextInt();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/InstanceSecretHolder.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/InstanceSecretHolder.java
@@ -1,0 +1,15 @@
+package io.github.jdubois.bootui.engine.crac.fixtures;
+
+/**
+ * Captures a secret in a singleton-bean instance field rather than a static one (CRAC-SECRET-001),
+ * for example an {@code @Value}-injected credential. The checkpoint freezes the field's value just
+ * as completely as it would a static field.
+ */
+public class InstanceSecretHolder {
+
+    private String apiToken = "placeholder";
+
+    public String getApiToken() {
+        return apiToken;
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/ManagedClassWithUnrelatedLeak.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/ManagedClassWithUnrelatedLeak.java
@@ -1,0 +1,29 @@
+package io.github.jdubois.bootui.engine.crac.fixtures;
+
+import java.io.IOException;
+import java.net.Socket;
+import org.crac.Context;
+import org.crac.Resource;
+
+/**
+ * Implements {@code org.crac.Resource} but opens a socket from an unrelated method rather than from
+ * {@link #beforeCheckpoint(Context)}/{@link #afterRestore(Context)}. CRAC-NET-001's exemption is
+ * scoped to calls that originate from the managed callback methods themselves, not to the whole
+ * class, so this leak must still be flagged.
+ */
+public class ManagedClassWithUnrelatedLeak implements Resource {
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) {
+        // No resource to release here; the leak below is intentionally outside this callback.
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) {
+        // No resource to re-acquire here; the leak below is intentionally outside this callback.
+    }
+
+    public Socket connect() throws IOException {
+        return new Socket("localhost", 9090);
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/ManagedResourceLifecycle.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/ManagedResourceLifecycle.java
@@ -1,0 +1,49 @@
+package io.github.jdubois.bootui.engine.crac.fixtures;
+
+import java.io.FileInputStream;
+import java.net.ServerSocket;
+import java.net.http.HttpClient;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.crac.Context;
+import org.crac.Resource;
+
+/**
+ * Implements {@code org.crac.Resource} and re-acquires its socket, file handle, executor pool, and
+ * HTTP client inside {@link #afterRestore(Context)} - exactly the pattern that CRAC-NET-001,
+ * CRAC-FILE-001, CRAC-THREAD-001, and CRAC-POOL-002 recommend. None of these calls/fields should be
+ * flagged: the class implements {@code org.crac.Resource}, so it is a managed class for the purposes
+ * of {@code ManagedLifecycleCallSites}.
+ */
+public class ManagedResourceLifecycle implements Resource {
+
+    private ServerSocket socket;
+    private FileInputStream file;
+    private ExecutorService pool;
+    private HttpClient httpClient;
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        if (socket != null) {
+            socket.close();
+        }
+        if (file != null) {
+            file.close();
+        }
+        if (pool != null) {
+            pool.shutdown();
+        }
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        socket = new ServerSocket(8082);
+        file = new FileInputStream("data.txt");
+        pool = Executors.newFixedThreadPool(2);
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    public HttpClient getHttpClient() {
+        return httpClient;
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/NioChannelOpener.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/fixtures/NioChannelOpener.java
@@ -1,0 +1,15 @@
+package io.github.jdubois.bootui.engine.crac.fixtures;
+
+import java.io.IOException;
+import java.nio.channels.SocketChannel;
+
+/**
+ * Opens a socket channel via the NIO static {@code open()} factory method (CRAC-NET-001), the
+ * idiomatic way NIO channel types are obtained instead of a constructor.
+ */
+public class NioChannelOpener {
+
+    public SocketChannel open() throws IOException {
+        return SocketChannel.open();
+    }
+}

--- a/bootui-spring-autoconfigure/pom.xml
+++ b/bootui-spring-autoconfigure/pom.xml
@@ -167,6 +167,17 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+          Test-scope only: CracRuntimeInventoryCollectorTests constructs a real RedisCacheManager (over a
+          mocked RedisConnectionFactory, no live Redis needed) to verify the remote-backed cache manager
+          exclusion (see CracRuntimeInventoryCollector.isRedisCacheManager). Version is managed by the
+          Spring Boot BOM imported at the root pom.
+        -->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeInventoryCollector.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeInventoryCollector.java
@@ -10,13 +10,14 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.util.ClassUtils;
 
 /**
- * Collects the host application's live connection-pool and cache-manager beans into a
- * {@link CracRuntimeInventory}.
+ * Collects the host application's live connection-pool and cache-manager beans, plus whether the
+ * {@code org.crac:crac} API is on the classpath, into a {@link CracRuntimeInventory}.
  *
  * <p>The collector inspects the running {@link ApplicationContext} for the bean types that hold the
  * OS sockets CRaC cares about — JDBC {@code DataSource}s, Redis/RabbitMQ/Kafka/Mongo/Cassandra/JMS/
  * R2DBC connection factories and similar pooled clients — plus Spring {@code CacheManager} beans
- * whose contents are frozen into the checkpoint. Every type is resolved lazily and bounded to types
+ * backed by local, in-heap storage (remote-backed managers such as Redis's are excluded, since their
+ * entries are not frozen into the checkpoint). Every type is resolved lazily and bounded to types
  * that are actually on the classpath, so a missing optional dependency never fails the scan. All
  * access is read-only and never triggers a checkpoint.</p>
  */
@@ -50,6 +51,20 @@ public final class CracRuntimeInventoryCollector {
     /** A no-op cache manager holds no entries, so it is irrelevant to checkpoint/restore. */
     private static final String NO_OP_CACHE_MANAGER_TYPE_NAME = "org.springframework.cache.support.NoOpCacheManager";
 
+    /**
+     * A remote/external-store-backed cache manager does not freeze its entries into the checkpoint
+     * image: the data lives outside the JVM heap in the external store, so a restored process sees
+     * live data from that store rather than a stale in-heap snapshot. Spring Data Redis's manager is
+     * excluded here; Hazelcast and other remote caches are deliberately left in scope because Hazelcast
+     * in particular can run embedded (in-heap) as well as client-server, and there is no reliable way
+     * to tell which mode a given bean is in from its type alone.
+     */
+    private static final String REDIS_CACHE_MANAGER_TYPE_NAME =
+            "org.springframework.data.redis.cache.RedisCacheManager";
+
+    /** Fully-qualified name of the org.crac API's entry point, used only to test classpath presence. */
+    private static final String CRAC_CORE_TYPE_NAME = "org.crac.Core";
+
     private CracRuntimeInventoryCollector() {}
 
     public static CracRuntimeInventory collect(ApplicationContext applicationContext) {
@@ -61,10 +76,25 @@ public final class CracRuntimeInventoryCollector {
             List<String> cacheBeans = detectBeans(
                     applicationContext,
                     List.of(CACHE_MANAGER_TYPE_NAME),
-                    type -> NO_OP_CACHE_MANAGER_TYPE_NAME.equals(type.getName()));
-            return new CracRuntimeInventory(poolBeans, cacheBeans);
+                    type -> NO_OP_CACHE_MANAGER_TYPE_NAME.equals(type.getName()) || isRedisCacheManager(type));
+            boolean cracApiPresent =
+                    ClassUtils.isPresent(CRAC_CORE_TYPE_NAME, CracRuntimeInventoryCollector.class.getClassLoader());
+            return new CracRuntimeInventory(poolBeans, cacheBeans, cracApiPresent);
         } catch (RuntimeException ex) {
             return CracRuntimeInventory.empty();
+        }
+    }
+
+    private static boolean isRedisCacheManager(Class<?> type) {
+        ClassLoader classLoader = CracRuntimeInventoryCollector.class.getClassLoader();
+        if (!ClassUtils.isPresent(REDIS_CACHE_MANAGER_TYPE_NAME, classLoader)) {
+            return false;
+        }
+        try {
+            Class<?> redisCacheManagerType = ClassUtils.forName(REDIS_CACHE_MANAGER_TYPE_NAME, classLoader);
+            return redisCacheManagerType.isAssignableFrom(type);
+        } catch (ClassNotFoundException | LinkageError ex) {
+            return false;
         }
     }
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeStatusCollector.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeStatusCollector.java
@@ -6,6 +6,7 @@ import java.lang.management.RuntimeMXBean;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
+import org.springframework.core.SpringProperties;
 import org.springframework.core.env.Environment;
 
 /**
@@ -28,6 +29,7 @@ final class CracRuntimeStatusCollector {
     private final Supplier<List<String>> jvmArgumentsSupplier;
     private final ClassPresenceCheck classPresenceCheck;
     private final Supplier<CracRuntimeInventory> inventorySupplier;
+    private final Supplier<String> actualCheckpointPropertySupplier;
 
     CracRuntimeStatusCollector(Environment environment) {
         this(environment, CracRuntimeInventory::empty);
@@ -49,10 +51,30 @@ final class CracRuntimeStatusCollector {
             Supplier<List<String>> jvmArgumentsSupplier,
             ClassPresenceCheck classPresenceCheck,
             Supplier<CracRuntimeInventory> inventorySupplier) {
+        this(
+                environment,
+                jvmArgumentsSupplier,
+                classPresenceCheck,
+                inventorySupplier,
+                defaultActualCheckpointPropertySupplier());
+    }
+
+    /**
+     * Fullest constructor. {@code actualCheckpointPropertySupplier} reads the property that actually
+     * controls Spring Framework's automatic checkpoint-on-refresh — see {@link #checkpointOnRefresh()}
+     * for why this is deliberately not the Spring Boot {@link Environment}.
+     */
+    CracRuntimeStatusCollector(
+            Environment environment,
+            Supplier<List<String>> jvmArgumentsSupplier,
+            ClassPresenceCheck classPresenceCheck,
+            Supplier<CracRuntimeInventory> inventorySupplier,
+            Supplier<String> actualCheckpointPropertySupplier) {
         this.environment = environment;
         this.jvmArgumentsSupplier = jvmArgumentsSupplier;
         this.classPresenceCheck = classPresenceCheck;
         this.inventorySupplier = inventorySupplier;
+        this.actualCheckpointPropertySupplier = actualCheckpointPropertySupplier;
     }
 
     CracRuntimeStatusDto collect() {
@@ -92,6 +114,14 @@ final class CracRuntimeStatusCollector {
             caveats.add("Configuration is frozen into the checkpoint. Environment variables, system properties, and "
                     + "the active Spring profile are read when the checkpoint is taken, not when it is restored; "
                     + "changing them for a restore-only start has no effect until a new checkpoint is taken.");
+        } else if (environmentClaimsCheckpointOnRefresh()) {
+            caveats.add("spring.context.checkpoint=onRefresh is set in the Spring Environment (for example "
+                    + "application.yml, application.properties, or an OS environment variable), but Spring "
+                    + "Framework's DefaultLifecycleProcessor only honors this property through "
+                    + "org.springframework.core.SpringProperties: a JVM system property "
+                    + "(-Dspring.context.checkpoint=onRefresh) or a classpath spring.properties file, never the "
+                    + "Spring Boot Environment. No automatic checkpoint will actually be taken on context refresh; "
+                    + "set the property as a JVM system property or in a classpath spring.properties file instead.");
         }
         List<String> poolBeans = safeInventory().connectionPoolBeans();
         if (!poolBeans.isEmpty()) {
@@ -111,11 +141,40 @@ final class CracRuntimeStatusCollector {
         }
     }
 
+    /**
+     * Whether an automatic checkpoint is actually taken on context refresh. Spring Framework's {@code
+     * DefaultLifecycleProcessor} reads {@code spring.context.checkpoint} only through {@code
+     * org.springframework.core.SpringProperties} — a JVM system property or a classpath {@code
+     * spring.properties} file — and never through the Spring Boot {@link Environment}. Setting the
+     * property in {@code application.yml}/{@code application.properties} (or as a plain OS environment
+     * variable picked up by the Environment) has no effect on this behavior, so this method
+     * deliberately reads the same source Spring Framework itself reads, rather than the Environment,
+     * to avoid reporting an automatic checkpoint that will not actually happen. See {@link
+     * #environmentClaimsCheckpointOnRefresh()} for the check that detects that specific mismatch.
+     */
     private boolean checkpointOnRefresh() {
-        if (environment == null) {
-            return false;
+        return isOnRefresh(safeActualCheckpointProperty());
+    }
+
+    /**
+     * Whether the Spring Boot {@link Environment} reports {@code spring.context.checkpoint=onRefresh}
+     * (for example from {@code application.yml} or an OS environment variable). This does NOT mean an
+     * automatic checkpoint will actually be taken — see {@link #checkpointOnRefresh()} — it exists only
+     * to detect and warn about that common mismatch in {@link #restoreCaveats(boolean)}.
+     */
+    private boolean environmentClaimsCheckpointOnRefresh() {
+        return environment != null && isOnRefresh(environment.getProperty("spring.context.checkpoint"));
+    }
+
+    private String safeActualCheckpointProperty() {
+        try {
+            return actualCheckpointPropertySupplier == null ? null : actualCheckpointPropertySupplier.get();
+        } catch (RuntimeException ex) {
+            return null;
         }
-        String value = environment.getProperty("spring.context.checkpoint");
+    }
+
+    private static boolean isOnRefresh(String value) {
         return value != null && "onRefresh".equalsIgnoreCase(value.trim());
     }
 
@@ -168,8 +227,13 @@ final class CracRuntimeStatusCollector {
                     + "checkpoint is taken once the application context refreshes"
                     + (checkpointTo == null ? "." : " into " + checkpointTo + ".");
         }
-        return "This JVM is CRaC-capable. Trigger a checkpoint with jcmd <pid> JDK.checkpoint or by setting "
-                + "spring.context.checkpoint=onRefresh, and run the readiness checks below first.";
+        return "This JVM is CRaC-capable. Trigger a checkpoint with jcmd <pid> JDK.checkpoint, or take one "
+                + "automatically on context refresh by setting spring.context.checkpoint=onRefresh as a JVM "
+                + "system property (-Dspring.context.checkpoint=onRefresh) or in a classpath spring.properties "
+                + "file. Setting it in application.yml/application.properties alone has no effect, since Spring "
+                + "Framework's checkpoint-on-refresh support reads this property through "
+                + "org.springframework.core.SpringProperties, not the Spring Boot Environment. Run the readiness "
+                + "checks below first.";
     }
 
     private static Supplier<List<String>> defaultJvmArguments() {
@@ -179,6 +243,22 @@ final class CracRuntimeStatusCollector {
                 return runtimeMxBean == null ? List.of() : runtimeMxBean.getInputArguments();
             } catch (RuntimeException ex) {
                 return List.of();
+            }
+        };
+    }
+
+    /**
+     * Reads {@code spring.context.checkpoint} the same way Spring Framework's {@code
+     * DefaultLifecycleProcessor} does: through {@code org.springframework.core.SpringProperties}, which
+     * consults a JVM system property or a classpath {@code spring.properties} file, never the Spring
+     * Boot {@link Environment}.
+     */
+    private static Supplier<String> defaultActualCheckpointPropertySupplier() {
+        return () -> {
+            try {
+                return SpringProperties.getProperty("spring.context.checkpoint");
+            } catch (RuntimeException | LinkageError ex) {
+                return null;
             }
         };
     }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeInventoryCollectorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeInventoryCollectorTests.java
@@ -1,0 +1,136 @@
+package io.github.jdubois.bootui.autoconfigure.crac;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.github.jdubois.bootui.engine.crac.CracRuntimeInventory;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.cache.support.NoOpCacheManager;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Verifies {@link CracRuntimeInventoryCollector} against a real (lightweight) {@link
+ * org.springframework.context.ApplicationContext} rather than mocking the bean factory, so the tests
+ * exercise the same {@code getBeanNamesForType}/{@code getType} resolution the production collector
+ * relies on.
+ */
+class CracRuntimeInventoryCollectorTests {
+
+    @Test
+    void returnsEmptyInventoryWhenApplicationContextIsNull() {
+        CracRuntimeInventory inventory = CracRuntimeInventoryCollector.collect(null);
+
+        assertThat(inventory.connectionPoolBeans()).isEmpty();
+        assertThat(inventory.cacheManagerBeans()).isEmpty();
+    }
+
+    @Test
+    void collectsPoolBeans() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(PoolConfig.class)) {
+            CracRuntimeInventory inventory = CracRuntimeInventoryCollector.collect(context);
+
+            assertThat(inventory.connectionPoolBeans()).hasSize(1);
+            assertThat(inventory.connectionPoolBeans().get(0))
+                    .contains("dataSource")
+                    .contains("DataSource");
+        }
+    }
+
+    @Test
+    void excludesNoOpCacheManagerFromCacheBeans() {
+        try (AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext(NoOpCacheConfig.class)) {
+            CracRuntimeInventory inventory = CracRuntimeInventoryCollector.collect(context);
+
+            assertThat(inventory.cacheManagerBeans()).isEmpty();
+        }
+    }
+
+    @Test
+    void includesLocalInHeapCacheManagerInCacheBeans() {
+        try (AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext(LocalCacheConfig.class)) {
+            CracRuntimeInventory inventory = CracRuntimeInventoryCollector.collect(context);
+
+            assertThat(inventory.cacheManagerBeans()).hasSize(1);
+            assertThat(inventory.cacheManagerBeans().get(0)).contains("localCacheManager");
+        }
+    }
+
+    @Test
+    void excludesRedisCacheManagerFromCacheBeansBecauseItIsRemoteBacked() {
+        try (AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext(RedisCacheConfig.class)) {
+            CracRuntimeInventory inventory = CracRuntimeInventoryCollector.collect(context);
+
+            assertThat(inventory.cacheManagerBeans()).isEmpty();
+        }
+    }
+
+    @Test
+    void localAndRedisCacheManagersCoexistAndOnlyTheLocalOneIsReported() {
+        try (AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext(LocalCacheConfig.class, RedisCacheConfig.class)) {
+            CracRuntimeInventory inventory = CracRuntimeInventoryCollector.collect(context);
+
+            assertThat(inventory.cacheManagerBeans()).hasSize(1);
+            assertThat(inventory.cacheManagerBeans().get(0)).contains("localCacheManager");
+        }
+    }
+
+    @Test
+    void reportsCracApiPresentReflectingClasspath() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(EmptyConfig.class)) {
+            CracRuntimeInventory inventory = CracRuntimeInventoryCollector.collect(context);
+
+            // org.crac:crac is a test-scope dependency of bootui-engine only (needed there so CRaC
+            // readiness fixtures can implement org.crac.Resource); bootui-spring-autoconfigure never
+            // declares it, so from this module's classloader it is genuinely absent, exactly like an
+            // application that has not added the dependency yet (see CRAC-LIFECYCLE-002).
+            assertThat(inventory.cracApiPresent()).isFalse();
+        }
+    }
+
+    @Configuration
+    static class EmptyConfig {}
+
+    @Configuration
+    static class PoolConfig {
+        @Bean
+        DataSource dataSource() {
+            return mock(DataSource.class);
+        }
+    }
+
+    @Configuration
+    static class NoOpCacheConfig {
+        @Bean
+        CacheManager cacheManager() {
+            return new NoOpCacheManager();
+        }
+    }
+
+    @Configuration
+    static class LocalCacheConfig {
+        @Bean
+        CacheManager localCacheManager() {
+            return new ConcurrentMapCacheManager();
+        }
+    }
+
+    @Configuration
+    static class RedisCacheConfig {
+        @Bean
+        CacheManager redisCacheManager() {
+            RedisConnectionFactory connectionFactory = mock(RedisConnectionFactory.class);
+            return RedisCacheManager.builder(connectionFactory).build();
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeStatusCollectorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/crac/CracRuntimeStatusCollectorTests.java
@@ -13,8 +13,8 @@ class CracRuntimeStatusCollectorTests {
 
     @Test
     void reportsMissingApiWhenOrgCracIsAbsent() {
-        CracRuntimeStatusCollector collector =
-                new CracRuntimeStatusCollector(new MockEnvironment(), List::of, className -> false);
+        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
+                new MockEnvironment(), List::of, className -> false, CracRuntimeInventory::empty, () -> null);
 
         CracRuntimeStatusDto status = collector.collect();
 
@@ -27,8 +27,8 @@ class CracRuntimeStatusCollectorTests {
 
     @Test
     void detectsNoOpShimWhenOnlyApiIsPresent() {
-        CracRuntimeStatusCollector collector =
-                new CracRuntimeStatusCollector(new MockEnvironment(), List::of, "org.crac.Core"::equals);
+        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
+                new MockEnvironment(), List::of, "org.crac.Core"::equals, CracRuntimeInventory::empty, () -> null);
 
         CracRuntimeStatusDto status = collector.collect();
 
@@ -44,7 +44,9 @@ class CracRuntimeStatusCollectorTests {
         CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
                 environment,
                 () -> List.of("-XX:CRaCCheckpointTo=/tmp/cr", "-Dfoo=bar", "-XX:+UseG1GC"),
-                present::contains);
+                present::contains,
+                CracRuntimeInventory::empty,
+                () -> "onRefresh");
 
         CracRuntimeStatusDto status = collector.collect();
 
@@ -59,7 +61,11 @@ class CracRuntimeStatusCollectorTests {
     @Test
     void parsesRestoreFromArgument() {
         CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
-                new MockEnvironment(), () -> List.of("-XX:CRaCRestoreFrom=/snapshots/app"), className -> true);
+                new MockEnvironment(),
+                () -> List.of("-XX:CRaCRestoreFrom=/snapshots/app"),
+                className -> true,
+                CracRuntimeInventory::empty,
+                () -> null);
 
         CracRuntimeStatusDto status = collector.collect();
 
@@ -70,17 +76,19 @@ class CracRuntimeStatusCollectorTests {
     @Test
     void addsFrozenConfigurationCaveatWhenCheckpointOnRefresh() {
         MockEnvironment environment = new MockEnvironment().withProperty("spring.context.checkpoint", "onRefresh");
-        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(environment, CracRuntimeInventory::empty);
+        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
+                environment, List::of, className -> false, CracRuntimeInventory::empty, () -> "onRefresh");
 
         CracRuntimeStatusDto status = collector.collect();
 
+        assertThat(status.checkpointOnRefresh()).isTrue();
         assertThat(status.restoreCaveats()).anyMatch(caveat -> caveat.contains("frozen into the checkpoint"));
     }
 
     @Test
     void hasNoFrozenConfigurationCaveatWithoutCheckpointOnRefresh() {
-        CracRuntimeStatusCollector collector =
-                new CracRuntimeStatusCollector(new MockEnvironment(), CracRuntimeInventory::empty);
+        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
+                new MockEnvironment(), List::of, className -> false, CracRuntimeInventory::empty, () -> null);
 
         CracRuntimeStatusDto status = collector.collect();
 
@@ -91,11 +99,53 @@ class CracRuntimeStatusCollectorTests {
     void surfacesConnectionPoolsAsRestoreCaveat() {
         CracRuntimeInventory inventory =
                 new CracRuntimeInventory(List.of("dataSource : com.zaxxer.hikari.HikariDataSource"));
-        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(new MockEnvironment(), () -> inventory);
+        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
+                new MockEnvironment(), List::of, className -> false, () -> inventory, () -> null);
 
         CracRuntimeStatusDto status = collector.collect();
 
         assertThat(status.restoreCaveats())
                 .anyMatch(caveat -> caveat.contains("connection pool") && caveat.contains("CRAC-POOL-001"));
+    }
+
+    @Test
+    void warnsWhenEnvironmentClaimsCheckpointOnRefreshButSpringPropertyIsUnset() {
+        // Spring Boot's Environment can see spring.context.checkpoint from application.yml or an OS
+        // environment variable, but Spring Framework's DefaultLifecycleProcessor only ever honors the
+        // property through org.springframework.core.SpringProperties (a JVM system property or a
+        // classpath spring.properties file). This models the mismatch: the Environment claims onRefresh
+        // is set, but the actual SpringProperties-backed source has no value, so no automatic checkpoint
+        // will really be taken.
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.context.checkpoint", "onRefresh");
+        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
+                environment, List::of, className -> false, CracRuntimeInventory::empty, () -> null);
+
+        CracRuntimeStatusDto status = collector.collect();
+
+        assertThat(status.checkpointOnRefresh()).isFalse();
+        assertThat(status.restoreCaveats())
+                .anyMatch(caveat -> caveat.contains("SpringProperties")
+                        && caveat.contains("No automatic checkpoint will actually be taken"));
+    }
+
+    @Test
+    void hasNoMismatchCaveatWhenSpringPropertyAgreesWithEnvironment() {
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.context.checkpoint", "onRefresh");
+        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
+                environment, List::of, className -> false, CracRuntimeInventory::empty, () -> "onRefresh");
+
+        CracRuntimeStatusDto status = collector.collect();
+
+        assertThat(status.restoreCaveats()).noneMatch(caveat -> caveat.contains("SpringProperties"));
+    }
+
+    @Test
+    void hasNoMismatchCaveatWhenNeitherSourceClaimsCheckpointOnRefresh() {
+        CracRuntimeStatusCollector collector = new CracRuntimeStatusCollector(
+                new MockEnvironment(), List::of, className -> false, CracRuntimeInventory::empty, () -> null);
+
+        CracRuntimeStatusDto status = collector.collect();
+
+        assertThat(status.restoreCaveats()).noneMatch(caveat -> caveat.contains("SpringProperties"));
     }
 }

--- a/docs/CRAC-READINESS-CHECKS.md
+++ b/docs/CRAC-READINESS-CHECKS.md
@@ -5,11 +5,12 @@ readiness. It combines a live runtime-status view with a heuristic readiness adv
 ships with BootUI today, what it inspects, when it fires, and what to do about it.
 
 Each check is a small class registered in
-[`CracCheckRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracCheckRegistry.java)
+[`CracCheckRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracCheckRegistry.java)
 and implemented in
-[`CracChecks.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/crac/CracChecks.java).
-The list intentionally stays compact and reviewable; adding a new check means adding one focused class plus a registry
-entry.
+[`CracChecks.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracChecks.java).
+Both live in the framework-neutral `bootui-engine` module — CRaC readiness is a Spring-only *panel* today (see
+[QUARKUS-SUPPORT.md](QUARKUS-SUPPORT.md)), but its rule engine has no Spring dependency of its own. The list intentionally
+stays compact and reviewable; adding a new check means adding one focused class plus a registry entry.
 
 ## What BootUI does
 
@@ -18,13 +19,21 @@ The runtime-status section (always read-only) reports:
 - whether the [`org.crac`](https://crac.org/) API is on the classpath (`org.crac.Core` marker),
 - whether the running JVM is a CRaC-capable JDK (such as Azul Zulu CRaC or BellSoft Liberica), detected via the real CRaC
   implementation (`jdk.crac.Core`) rather than the no-op shim that ships with stock JDKs,
-- whether automatic checkpoint-on-refresh is enabled (`spring.context.checkpoint=onRefresh`),
+- whether automatic checkpoint-on-refresh is actually active. Spring Framework's `DefaultLifecycleProcessor` only honors
+  `spring.context.checkpoint=onRefresh` through `org.springframework.core.SpringProperties` — a JVM system property
+  (`-Dspring.context.checkpoint=onRefresh`) or a classpath `spring.properties` file — **never** the Spring Boot
+  `Environment` (so setting it in `application.yml`/`application.properties`/an OS environment variable has no effect).
+  BootUI reads the property the same way Spring Framework does, and separately checks whether the Boot `Environment` also
+  claims the property is set; if the Environment says one thing and the real property says another, a restore caveat
+  flags the mismatch,
 - any `-XX:CRaCCheckpointTo` / `-XX:CRaCRestoreFrom` JVM arguments, read from the `RuntimeMXBean` input arguments
   (the same source the JVM Tuning panel uses),
 - and any *checkpoint &amp; restore caveats* worth reviewing before a checkpoint: a reminder that CRaC freezes
   configuration (environment variables, system properties, the active Spring profile) into the image at checkpoint time
-  when `spring.context.checkpoint=onRefresh` is set, and a note when live connection pools are detected so the backing
-  service is kept reachable at both checkpoint and restore (see `CRAC-POOL-001`).
+  when checkpoint-on-refresh is actually active, a warning when the Boot `Environment` claims checkpoint-on-refresh is set
+  but the real, `SpringProperties`-backed property is not (so no automatic checkpoint will actually be taken), and a note
+  when live connection pools are detected so the backing service is kept reachable at both checkpoint and restore (see
+  `CRAC-POOL-001`).
 
 The readiness advisor detects the host application's base package(s) from the `@SpringBootApplication` configuration via
 `AutoConfigurationPackages`, imports the compiled `.class` files from those packages with
@@ -37,11 +46,14 @@ without an extra application dependency. The advisor is available only when Arch
 package is resolvable from the running application. If no classes can be imported, the panel degrades to a stable, empty
 report with an explanatory reason rather than failing.
 
-Two checks are different: `CRAC-POOL-001` and `CRAC-CACHE-001`. Connection pools and cache managers are
-contributed by Spring Boot auto-configuration and never appear in the application's own base package, so those checks
-read a small read-only inventory of live beans — pooled clients (JDBC `DataSource`s, plus R2DBC/Redis/RabbitMQ/Kafka/
-Mongo/Cassandra/JMS connection factories and similar) and Spring `CacheManager`s — from the running context instead of
-imported bytecode. They still trigger only on demand and never open, close, or checkpoint anything.
+Three checks are different: `CRAC-POOL-001`, `CRAC-CACHE-001`, and `CRAC-LIFECYCLE-002`. Connection pools, cache
+managers, and classpath dependency presence are either contributed by Spring Boot auto-configuration or are a
+runtime/dependency signal rather than something visible in the application's own base package, so those three checks
+read a small read-only runtime inventory — pooled clients (JDBC `DataSource`s, plus R2DBC/Redis/RabbitMQ/Kafka/
+Mongo/Cassandra/JMS connection factories and similar), Spring `CacheManager`s backed by local/in-heap storage, and
+whether `org.crac:crac` is on the classpath — instead of imported bytecode. They still trigger only on demand and never
+open, close, or checkpoint anything. Every other check, including `CRAC-POOL-002` (unmanaged HTTP/RPC clients), inspects
+imported application bytecode like the rest of the catalogue.
 
 ## What BootUI does not do
 
@@ -59,9 +71,11 @@ Severity reflects the worst plausible impact if the finding is real, not the lik
 - **CRITICAL** — a construct with the most severe checkpoint/restore impact if the finding is real. No active CRaC check
   currently emits this severity.
 - **HIGH** — a construct that typically blocks a clean checkpoint or leaks/duplicates state across restore (open OS
-  resources, direct network sockets, connection pools with an open connection, frozen random state, captured secrets).
-- **MEDIUM** — a construct that often misbehaves across restore unless handled (unmanaged threads/pools, captured
-  wall-clock time).
+  resources, direct network sockets, unmanaged HTTP/RPC clients, connection pools with an open connection, frozen random
+  state, captured secrets).
+- **MEDIUM** — a construct that often misbehaves across restore unless handled (unmanaged threads/pools, fixed-rate
+  scheduled tasks that may burst after restore, captured wall-clock time, captured environment/system configuration, a
+  missing `org.crac:crac` dependency).
 - **LOW** — a construct that usually needs review but rarely breaks restore on its own.
 - **INFO** — an informational prompt about checkpoint/restore lifecycle participation.
 
@@ -76,10 +90,17 @@ a handful of sample detail lines.
 ### CRAC-NET-001 — Direct network socket creation must be released at checkpoint
 
 - **Severity**: HIGH
-- **Inspects**: code that opens network sockets directly (`new Socket` / `ServerSocket` / `DatagramSocket` /
-  `MulticastSocket`, or the NIO `ServerSocketChannel` / `SocketChannel` channels).
-- **Fires when**: an application class constructs one of those sockets. Open sockets hold OS file descriptors that CRaC
-  refuses to checkpoint unless they are closed first.
+- **Inspects**: code that opens network sockets directly — constructors (`new Socket` / `ServerSocket` /
+  `DatagramSocket` / `MulticastSocket`) and the NIO static factory methods that are the conventional way to obtain a
+  channel (`SocketChannel.open(...)`, `ServerSocketChannel.open()`, `DatagramChannel.open(...)`,
+  `AsynchronousSocketChannel.open(...)`, `AsynchronousServerSocketChannel.open(...)`).
+- **Fires when**: an application class constructs or opens one of those sockets/channels outside a managed CRaC
+  lifecycle. Open sockets hold OS file descriptors that CRaC refuses to checkpoint unless they are closed first.
+- **Exempt when**: the call site is inside `beforeCheckpoint`/`afterRestore`/`start`/`stop` on a class that already
+  implements `org.crac.Resource`, `org.springframework.context.Lifecycle`, or `org.springframework.context.SmartLifecycle`
+  — i.e. exactly the pattern this check's own recommendation asks for. Without this exemption, following the
+  recommendation (re-opening the socket inside `afterRestore()`) would keep re-triggering the same finding forever. A
+  socket opened elsewhere in an otherwise-managed class (outside those callback methods) is still flagged.
 - **Recommendation**: close the socket in an `org.crac.Resource.beforeCheckpoint()` callback and re-open it in
   `afterRestore()`, or let a managed component (Spring `Lifecycle` bean, server connector) own the socket so the
   framework closes it around the checkpoint.
@@ -97,23 +118,50 @@ a handful of sample detail lines.
   that CRaC refuses to snapshot, so the checkpoint aborts with `CheckpointOpenSocketException`. The backing service must
   also be reachable both when the checkpoint is taken and when it is restored.
 - **Recommendation**: ensure no pooled connection is open at checkpoint time — let the pool drain to zero idle
-  connections (for example `spring.datasource.hikari.minimum-idle=0`) or rely on Spring closing CRaC-aware pools before
-  the checkpoint — and keep the database/cache reachable at both checkpoint and restore. Take the checkpoint after the
-  context refreshes but before traffic opens a connection. An in-memory profile (such as H2 with no network socket)
-  avoids the problem entirely.
+  connections (for example `spring.datasource.hikari.minimum-idle=0`) — and keep the database/cache reachable at both
+  checkpoint and restore. Take the checkpoint after the context refreshes but before traffic opens a connection. Do not
+  assume the pool closes itself for CRaC: check whether your specific pool/client library has adopted
+  `org.crac.Resource` natively. As of today, most common pools — including HikariCP and Lettuce, Spring Boot's default
+  JDBC pool and Redis client — do **not** ship this out of the box (a search of both projects' source for
+  `org.crac.Resource` returns no matches as of this writing), so unless you have verified otherwise for your library's
+  current version, plan to register your own `org.crac.Resource` wrapper around the `DataSource`/connection factory bean
+  to close and reopen it around the checkpoint. An in-memory profile (such as H2 with no network socket) avoids the
+  problem entirely.
+
+### CRAC-POOL-002 — HTTP/RPC clients hold sockets and threads that must be released at checkpoint
+
+- **Severity**: HIGH
+- **Inspects**: fields that hold a long-lived HTTP/RPC client with its own connection pool or event-loop threads — the
+  JDK's `java.net.http.HttpClient`, Apache HttpClient's `CloseableHttpClient` (4.x and 5.x), OkHttp's `OkHttpClient`,
+  Reactor Netty's `HttpClient`/`ConnectionProvider`, or gRPC's `ManagedChannel`.
+- **Fires when**: an application class holds one of those client types in a field outside a managed CRaC lifecycle.
+  These clients hold open OS file descriptors and background threads exactly like the raw socket/pool types
+  `CRAC-RES-001` already covers, but are easy to miss because the client is typically built once via a builder rather
+  than constructed directly.
+- **Exempt when**: the field is declared on a class that already implements `org.crac.Resource`,
+  `org.springframework.context.Lifecycle`, or `org.springframework.context.SmartLifecycle` — the same whole-class
+  exemption `CRAC-RES-001` uses, since the managed class is expected to close and rebuild the client itself around the
+  checkpoint.
+- **Recommendation**: close the client (and its underlying connection pool/event-loop) in an
+  `org.crac.Resource.beforeCheckpoint()` callback and rebuild it in `afterRestore()`, or hold it in a Spring
+  `Lifecycle`/`SmartLifecycle` bean so the framework stops it before the checkpoint.
 
 ## Caches
 
 ### CRAC-CACHE-001 — In-memory caches may hold stale entries after restore
 
 - **Severity**: LOW
-- **Inspects**: live Spring `CacheManager` beans in the running context, detected from the application's beans rather
-  than its bytecode. A no-op cache manager holds no entries and is ignored.
-- **Fires when**: at least one non-no-op `CacheManager` bean is present. Cache entries populated before the checkpoint
-  are frozen into the image and survive into every restored process, where they may be stale (for example expired tokens
-  or other time-sensitive data).
-- **Recommendation**: clear or refresh time-sensitive caches in an `org.crac.Resource.afterRestore()` callback, or use
-  restore-aware expiry, so a restored process does not serve data captured at checkpoint time.
+- **Inspects**: live Spring `CacheManager` beans backed by local, in-heap storage (for example
+  `ConcurrentMapCacheManager` or Caffeine), detected from the application's beans rather than its bytecode. A no-op
+  cache manager holds no entries and is ignored, and well-known remote/external-store-backed managers — currently
+  Spring Data Redis's `RedisCacheManager` — are excluded too, because their entries live outside the JVM heap in an
+  external store and are not frozen into the checkpoint image the way a local manager's entries are.
+- **Fires when**: at least one non-no-op, local/in-heap `CacheManager` bean is present. Cache entries populated before
+  the checkpoint are frozen into the image and survive into every restored process, where they may be stale (for
+  example expired tokens or other time-sensitive data). Cache managers backed by a remote store are a lower concern and
+  are not reported here.
+- **Recommendation**: clear or refresh time-sensitive local caches in an `org.crac.Resource.afterRestore()` callback, or
+  use restore-aware expiry, so a restored process does not serve data captured at checkpoint time.
 
 ## Resources
 
@@ -124,7 +172,12 @@ a handful of sample detail lines.
   `RandomAccessFile`, zip/jar files, NIO channels and selectors, `FileLock`, `WatchService`, `Process`, JDBC
   `Connection`) on classes that do not implement `org.crac.Resource` or a Spring `Lifecycle`.
 - **Fires when**: such a field exists on an unmanaged class. CRaC cannot snapshot live file descriptors. Auto-configured
-  pools (a HikariCP `DataSource`, a Redis client) are the common case and are covered separately by `CRAC-POOL-001`.
+  pools (a HikariCP `DataSource`, a Redis client) are the common case and are covered separately by `CRAC-POOL-001`;
+  long-lived HTTP/RPC clients (`HttpClient`, `OkHttpClient`, gRPC `ManagedChannel` and similar) are covered separately by
+  `CRAC-POOL-002`.
+- **Exempt when**: the field is declared on a class that already implements `org.crac.Resource`,
+  `org.springframework.context.Lifecycle`, or `org.springframework.context.SmartLifecycle` — the managed class is
+  expected to close and reopen the resource itself around the checkpoint.
 - **Recommendation**: implement `org.crac.Resource` and close the resource in `beforeCheckpoint()`, re-opening it in
   `afterRestore()`; or hold the resource in a Spring `Lifecycle` / `SmartLifecycle` bean so the framework stops it before
   the checkpoint. For auto-configured connection pools, see `CRAC-POOL-001`.
@@ -136,8 +189,13 @@ a handful of sample detail lines.
   `FileReader` / `FileWriter` / `ZipFile` / `JarFile`, or the `Files.newInputStream` / `newOutputStream` /
   `newByteChannel` / `newBufferedReader` / `newBufferedWriter` and `FileChannel` / `AsynchronousFileChannel.open` factory
   methods).
-- **Fires when**: an application class opens one of those file handles. An open file holds an OS file descriptor that
-  CRaC refuses to checkpoint, so the checkpoint aborts with `CheckpointOpenFileException`.
+- **Fires when**: an application class opens one of those file handles outside a managed CRaC lifecycle. An open file
+  holds an OS file descriptor that CRaC refuses to checkpoint, so the checkpoint aborts with
+  `CheckpointOpenFileException`.
+- **Exempt when**: the call site is inside `beforeCheckpoint`/`afterRestore`/`start`/`stop` on a class that already
+  implements `org.crac.Resource`, `org.springframework.context.Lifecycle`, or `org.springframework.context.SmartLifecycle`
+  — reopening the file from `afterRestore()`/`start()` on a managed class is the recommended pattern and is not flagged.
+  A file opened elsewhere in an otherwise-managed class is still flagged.
 - **Recommendation**: close the file before the checkpoint (try-with-resources for short-lived handles, or release it in
   an `org.crac.Resource.beforeCheckpoint()` callback and re-open it in `afterRestore()`), or let a managed component own
   the file so the framework closes it around the checkpoint.
@@ -149,11 +207,34 @@ a handful of sample detail lines.
 - **Severity**: MEDIUM
 - **Inspects**: threads, timers, and executor pools created directly (`new Thread` / `Timer` / `ThreadPoolExecutor`, or
   the `Executors` factory methods).
-- **Fires when**: an application class creates one of those directly. Such threads are not paused by CRaC before a
-  checkpoint and are snapshotted while running.
+- **Fires when**: an application class creates one of those directly outside a managed CRaC lifecycle. CRIU (which CRaC
+  is built on) freezes *every* OS thread in the process to take a checkpoint — no thread "keeps running through" it, and
+  none is skipped. The actual risk is in what happens just *before* that freeze: Spring stops `SmartLifecycle` beans
+  gracefully before the checkpoint is even requested, so managed background work reaches a quiescent, consistent state
+  first. A raw thread or executor has no such hook, so CRIU captures it abruptly mid-execution — in whatever state it
+  happens to be in at that instant — which risks deadlocks, stale locks, or inconsistent state on restore.
+- **Exempt when**: the call site is inside `beforeCheckpoint`/`afterRestore`/`start`/`stop` on a class that already
+  implements `org.crac.Resource`, `org.springframework.context.Lifecycle`, or `org.springframework.context.SmartLifecycle`
+  — restarting the pool from `afterRestore()`/`start()` on a managed class is the recommended pattern and is not
+  flagged. A thread/pool created elsewhere in an otherwise-managed class is still flagged.
 - **Recommendation**: drive background work through Spring (`@Async`, `TaskExecutor` / `TaskScheduler` beans,
-  `@Scheduled`) so the lifecycle stops it before checkpoint, or register an `org.crac.Resource` that quiesces the pool in
-  `beforeCheckpoint()` and restarts it in `afterRestore()`.
+  `@Scheduled`) so the lifecycle stops it gracefully before checkpoint, or register an `org.crac.Resource` that quiesces
+  the pool in `beforeCheckpoint()` and restarts it in `afterRestore()`.
+
+### CRAC-SCHED-001 — Fixed-rate scheduled tasks may run a catch-up burst after restore
+
+- **Severity**: MEDIUM
+- **Inspects**: `@Scheduled` methods that explicitly declare `fixedRate` or `fixedRateString`.
+- **Fires when**: a method is annotated this way. Fixed-rate scheduling computes each execution from a fixed wall-clock
+  point rather than the end of the previous run, so [on-demand checkpoint/restore of an already-running
+  application](https://docs.spring.io/spring-framework/reference/integration/checkpoint-restore.html#_on_demand_checkpointrestore_of_a_running_application)
+  can leave a long idle gap between the checkpoint and a later restore; every execution missed during that gap fires
+  back-to-back immediately after restore. This risk is specific to on-demand checkpoint/restore of a running
+  application — automatic checkpoint/restore at startup (`spring.context.checkpoint=onRefresh`) takes the checkpoint
+  before the scheduler starts and is not affected.
+- **Recommendation**: if a catch-up burst after restore is not the behavior you want, switch to `fixedDelay` (or a cron
+  expression), which Spring schedules relative to the end of the previous execution rather than a fixed wall-clock
+  point, so a checkpoint/restore gap does not queue up missed runs.
 
 ## Time
 
@@ -183,28 +264,38 @@ a handful of sample detail lines.
 
 ## Randomness
 
-### CRAC-RANDOM-001 — Static Random/SecureRandom state is frozen into the checkpoint
+### CRAC-RANDOM-001 — Random/SecureRandom state is frozen into the checkpoint
 
 - **Severity**: HIGH
-- **Inspects**: static fields of type `java.util.Random` or `java.security.SecureRandom`.
-- **Fires when**: such a static field exists. Its internal state is captured at checkpoint time, so every restored
-  instance replays the same sequence.
-- **Recommendation**: re-seed or recreate the generator in an `org.crac.Resource.afterRestore()` callback, or avoid a
-  static instance so a fresh generator is created per restored process.
+- **Inspects**: fields, static or instance, of type `java.util.Random` or `java.security.SecureRandom`. Idiomatic Spring
+  code rarely uses a *static* PRNG field — the dominant pattern is a singleton-bean *instance* field, such as a
+  `@Component`-injected `SecureRandom` — but a checkpoint snapshots every object reachable from GC roots, not just
+  static state, so an instance field is captured just as completely as a static one.
+- **Fires when**: such a field exists. A checkpoint freezes whatever internal state the generator holds at that moment
+  into the image, whether the field is static or an ordinary singleton-bean field. A JDK built for CRaC already
+  auto-reseeds a no-arg, never-explicitly-seeded `SecureRandom` on restore, so plain `new SecureRandom()` usage is
+  commonly safe there without any code change — but this is not guaranteed on every CRaC-capable platform, so confirm
+  your target JDK/runtime's actual behavior before relying on it. An explicitly-seeded `SecureRandom`, or a plain
+  `java.util.Random`, keeps its frozen state across restore in every case and needs its own fix.
+- **Recommendation**: for an explicitly-seeded `SecureRandom` or a plain `Random`, re-seed or recreate the generator in
+  an `org.crac.Resource.afterRestore()` callback, or avoid caching a shared instance so a fresh generator is created per
+  restored process. For a no-arg `SecureRandom`, verify your target JDK/runtime re-seeds it automatically on restore
+  before treating this as a non-issue.
 
 ## Secrets
 
-### CRAC-SECRET-001 — Secrets captured in static fields are frozen into the checkpoint
+### CRAC-SECRET-001 — Secrets captured in fields are frozen into the checkpoint
 
 - **Severity**: HIGH
-- **Inspects**: static fields that capture a secret — a field whose name looks like a secret (`token`, `password`,
-  `secret`, `api key`, `credential`, `private key`) holding a `String`, `char[]`, or `byte[]`, or a field holding
-  cryptographic key material (`javax.crypto.SecretKey`, `java.security.PrivateKey`, `KeyStore`, `KeyPair`) regardless of
-  name.
-- **Fires when**: such a static field exists. The value is captured into the checkpoint image and survives in every
-  restored process.
+- **Inspects**: fields, static or instance, that capture a secret — a field whose name looks like a secret (`token`,
+  `password`, `secret`, `api key`, `credential`, `private key`) holding a `String`, `char[]`, or `byte[]`, or a field
+  holding cryptographic key material (`javax.crypto.SecretKey`, `java.security.PrivateKey`, `KeyStore`, `KeyPair`)
+  regardless of name.
+- **Fires when**: such a field exists. A secret loaded at startup — whether into a static field or a singleton bean's
+  instance field, such as an `@Value`-injected credential — is baked into the checkpoint image and shipped with every
+  restored process, so rotation no longer takes effect and the snapshot leaks the value.
 - **Recommendation**: load secrets lazily at runtime (or refresh them in an `org.crac.Resource.afterRestore()` callback)
-  instead of caching them in a static field, so a checkpoint never freezes a credential.
+  instead of caching them in a field, so a checkpoint never freezes a credential.
 
 ## Lifecycle
 
@@ -218,3 +309,18 @@ a handful of sample detail lines.
 - **Recommendation**: if the application owns resources that Spring does not manage (custom sockets, native handles,
   caches), implement `org.crac.Resource` and register it with `Core.getGlobalContext().register(...)` so it participates
   in checkpoint/restore.
+
+### CRAC-LIFECYCLE-002 — The org.crac:crac API is not on the classpath
+
+- **Severity**: MEDIUM
+- **Inspects**: whether the `org.crac:crac` API (`org.crac.Core` / `org.crac.Resource`) is present on the application's
+  classpath, read from the live runtime inventory rather than imported bytecode — the same mechanism `CRAC-POOL-001` and
+  `CRAC-CACHE-001` use, since classpath presence is a runtime/dependency signal, not something visible in any one class's
+  bytecode.
+- **Fires when**: the dependency is absent. A Spring Boot application on a CRaC-enabled JVM does not strictly need this
+  dependency to take an automatic checkpoint, but without it no application class can implement `org.crac.Resource`, so
+  it cannot hook `beforeCheckpoint()`/`afterRestore()` to release and reacquire resources, re-seed randomness, or refresh
+  secrets around a checkpoint — the fix every other resource/random/secret finding in this rule set recommends.
+- **Recommendation**: add the `org.crac:crac` dependency (its version is managed by the Spring Boot BOM) so application
+  classes can implement `org.crac.Resource` and register with `Core.getGlobalContext().register(...)` to participate in
+  checkpoint/restore.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -671,13 +671,15 @@ CRaC or BellSoft Liberica, detected via the real CRaC implementation rather than
 `spring.context.checkpoint=onRefresh` is set, and any `-XX:CRaCCheckpointTo` / `-XX:CRaCRestoreFrom` JVM arguments (read
 from the same `RuntimeMXBean` input arguments the JVM Tuning panel uses). On demand the readiness advisor imports the
 application's own classes (bounded to the detected base package(s)) and runs a curated set of `CRaC-*` checks for
-constructs that complicate checkpoint/restore — open resources and file handles held outside Spring/CRaC lifecycle,
-network listeners, live connection pools and cache managers, unmanaged threads, captured timestamps, captured
-environment/system configuration, static random seeds, eagerly captured secrets, and missing `org.crac.Resource`
-registrations. After a scan, the concerns list can be filtered in place by severity, category, or free-text search to
-focus on a subset of findings without rerunning the scan. The checks are heuristic review aids that complement, but do
-not replace, an actual checkpoint/restore run on a CRaC-enabled JDK. See [CRAC-READINESS-CHECKS.md](CRAC-READINESS-CHECKS.md)
-for the full catalogue of checks and what each one inspects.
+constructs that complicate checkpoint/restore — open resources and file handles held outside a managed CRaC/Spring
+lifecycle, network listeners (including NIO channels), live connection pools, cache managers, and HTTP/RPC clients,
+unmanaged threads and fixed-rate scheduled tasks that may run a catch-up burst after an on-demand restore, captured
+timestamps, captured environment/system configuration, Random/SecureRandom and secret state held in static or instance
+fields, and a missing `org.crac.Resource` registration or `org.crac:crac` dependency. After a scan, the concerns list
+can be filtered in place by severity, category, or free-text search to focus on a subset of findings without rerunning
+the scan. The checks are heuristic review aids that complement, but do not replace, an actual checkpoint/restore run on
+a CRaC-enabled JDK. See [CRAC-READINESS-CHECKS.md](CRAC-READINESS-CHECKS.md) for the full catalogue of checks and what
+each one inspects.
 
 The panel also generates ready-to-use container assets for the host application: a multi-stage `Dockerfile-crac` that
 builds with a plain JDK and runs on a CRaC-enabled BellSoft Liberica JDK, plus the `checkpoint-and-run.sh` entrypoint it


### PR DESCRIPTION
## Summary

Fixes to BootUI's CRaC (Coordinated Restore at Checkpoint) Readiness Advisor, based on a synthesized audit from 5 independent AI research agents (claude-opus-4.8, gpt-5.5, gemini-3.1-pro-preview, gpt-5.3-codex, claude-sonnet-5) plus direct verification of several claims against CRIU/CRaC/Spring Framework primary sources. **Scoped Spring-only** per explicit instruction — no Quarkus changes; this pass touches only the framework-neutral `bootui-engine` rule engine and the Spring-side collectors in `bootui-spring-autoconfigure`.

## Verified fixes

1. **[Highest priority] Self-defeating logic bug fixed.** `CRAC-NET-001`/`CRAC-FILE-001`/`CRAC-THREAD-001` now exempt calls inside `beforeCheckpoint`/`afterRestore`/`start`/`stop` on a class implementing `org.crac.Resource` or Spring `Lifecycle`/`SmartLifecycle` (new shared `ManagedLifecycleCallSites` helper), matching the exemption `CRAC-RES-001` already had. Previously, doing exactly what each check's own recommendation said — reopening the resource in `afterRestore()` — would keep re-triggering the same finding forever. The exemption is scoped to the callback methods themselves (not the whole class), so a leak elsewhere in an otherwise-managed class is still flagged.
2. **`CRAC-RANDOM-001`/`CRAC-SECRET-001` now scan instance fields, not just static fields.** A checkpoint freezes every object reachable from GC roots, not just static state — the dominant Spring pattern (a `@Component`-injected `SecureRandom`, an `@Value`-injected secret) is an instance field.
3. **`CRAC-NET-001` now detects the NIO `.open(...)` static factory methods** (`SocketChannel`, `ServerSocketChannel`, `DatagramChannel`, `AsynchronousSocketChannel`, `AsynchronousServerSocketChannel`) — the idiomatic way NIO channels are obtained. The old constructor-only detection was dead code for this half of its stated coverage.
4. **`CRAC-RANDOM-001`'s description no longer claims an absolute "same sequence" fact.** A CRaC-built JDK auto-reseeds a no-arg, never-explicitly-seeded `SecureRandom` on restore; wording now reflects this while still flagging explicitly-seeded `SecureRandom`/plain `Random` as a real risk.
5. **`CRAC-POOL-001`'s recommendation no longer implies pools close themselves for CRaC.** Reworded: most common pools (HikariCP, Lettuce) do not ship native `org.crac.Resource` support today (re-verified: no `org.crac`/`Resource` references in either library's current source), so a custom wrapper is usually needed.
6. **`CRAC-CACHE-001` now excludes remote-backed `CacheManager`s** (currently Spring Data Redis's `RedisCacheManager`) via `CracRuntimeInventoryCollector`, since their entries live outside the JVM heap and aren't frozen into the checkpoint.
7. **`CRAC-THREAD-001`'s description corrected.** It no longer says unmanaged threads "keep running through" a checkpoint — CRIU freezes every OS thread to take any checkpoint. The real risk: Spring stops `SmartLifecycle` beans gracefully *before* the checkpoint is requested, while a raw thread has no such hook and is captured abruptly mid-execution. No JEP 423 reference (that JEP is G1 region pinning, unrelated to CRaC).
8. **Doc source links fixed** — `docs/CRAC-READINESS-CHECKS.md` now points to `bootui-engine` (where `CracCheckRegistry`/`CracChecks` actually live), not `bootui-spring-autoconfigure`.
9. **`CracRuntimeStatusCollector.checkpointOnRefresh()` no longer over-reports.** It now reads `org.springframework.core.SpringProperties` (a JVM system property or classpath `spring.properties` file) instead of the Spring Boot `Environment`, matching what `DefaultLifecycleProcessor` actually consults. A new caveat flags the common mismatch case: `Environment` claims `onRefresh` but the real property isn't set, so no automatic checkpoint will actually happen.

## New rules

- **`CRAC-SCHED-001` (MEDIUM)** — flags `@Scheduled(fixedRate=...)`/`fixedRateString` methods, which can fire a catch-up burst immediately after an on-demand restore following a long idle gap. `fixedDelay`/`cron` are unaffected (used as negative-control tests).
- **`CRAC-LIFECYCLE-002` (MEDIUM)** — promotes the "`org.crac:crac` not on the classpath" signal from prose-only summary text into a real, scored, inventory-based finding (`CracRuntimeInventory.cracApiPresent`), mirroring how `CRAC-POOL-001`/`CRAC-CACHE-001` already bridge runtime inventory into engine-scored findings.
- **`CRAC-POOL-002` (HIGH)** — flags fields holding long-lived HTTP/RPC clients (JDK `java.net.http.HttpClient`, Apache `CloseableHttpClient`, OkHttp `OkHttpClient`, Reactor Netty `HttpClient`/`ConnectionProvider`, gRPC `ManagedChannel`) outside a managed CRaC lifecycle. These hold sockets/event-loop threads like the raw socket/pool types `CRAC-RES-001` covers, but were previously invisible to both the bytecode scan and the Spring-side bean inventory.

## Deviations from the prompt (with reasoning)

- `RANDOM-001`/`SECRET-001` broadening applies to **all** fields, not gated to `@Component`/`@Service`/`@Repository`/`@Configuration` stereotypes — simpler, and a field on a non-stereotyped class holding a `SecureRandom`/secret is no less frozen into the checkpoint image.
- `RANDOM-001`/`SECRET-001` deliberately do **not** get the managed-class exemption `RES-001`/`POOL-002` have. A frozen `SecureRandom`/secret is a "review whether reseeding/refresh is needed" heuristic regardless of whether the class is CRaC-managed — unlike sockets/files, which have a clear "reopen it" fix that would otherwise self-trigger forever.
- `CACHE-001` excludes only Spring Data Redis's `RedisCacheManager`, not Hazelcast. Hazelcast can run embedded (in-heap) or client-server, and there's no reliable way to tell which from the bean type alone, so it stays in scope to avoid a false negative on embedded deployments.
- `CRAC-SCHED-001` covers `@Scheduled(fixedRate/fixedRateString)` only — no Quartz `Scheduler` or raw `scheduleAtFixedRate()` detection, keeping the bytecode check scoped to the annotation-driven case that had the strongest (4/5 agent) consensus.
- `CRAC-POOL-002` covers 5 client families but has runtime tests only for the JDK's `java.net.http.HttpClient` (no OkHttp/Apache HttpClient/Reactor Netty/gRPC test dependencies were added, to avoid bloating `bootui-engine`'s test classpath). The other four are detected by fully-qualified type name and will fire the same way once present on an application's classpath.
- `CRAC-LIFECYCLE-002` lives in the engine (`CracDependencyCheck`) reading the Spring-collected `CracRuntimeInventory.cracApiPresent`, reusing the existing `POOL-001`/`CACHE-001` architecture rather than inventing a new bridge mechanism.
- No discrepancies found between the prompt's factual claims and current code/library state beyond normal "line numbers drifted" — all 9 fixes and the 3 new-rule proposals matched the actual codebase after investigation.

## Testing

- **`bootui-engine`**: `CracReadinessScannerTests` grew from 7 to 16 tests, covering every fix and new rule against real ArchUnit-imported bytecode (7 new fixture classes: managed-lifecycle exemption + unrelated-leak-still-caught, instance random/secret holders, NIO channel opener, fixed-rate scheduled task, HTTP client holder).
- **`bootui-spring-autoconfigure`**: `CracRuntimeStatusCollectorTests` rewritten (10 tests) to use a 5-arg constructor with deterministic suppliers instead of relying on real JVM `SpringProperties`/system-property state; 3 new tests cover the Environment-vs-SpringProperties mismatch caveat. New `CracRuntimeInventoryCollectorTests` (7 tests) exercises the collector against a real `AnnotationConfigApplicationContext`, including a real `RedisCacheManager` (over a mocked `RedisConnectionFactory`, no live Redis needed) to verify the `CACHE-001` Redis exclusion, and confirms `cracApiPresent` reflects this module's actual classpath (genuinely absent, since `org.crac:crac` is only a test dependency of `bootui-engine`).
- **Full suite**: `./mvnw -pl bootui-core,bootui-engine,bootui-spring-autoconfigure -am test` → **932 tests, 0 failures, 0 errors**.
- **ArchUnit engine-boundary tests** (`EngineBoundaryArchitectureTests`, `SpiBoundaryArchitectureTests`) pass — `bootui-engine` remains framework-neutral despite the new test-scope `org.crac:crac` dependency.
- **`SpringApiConformanceTest`** — 5/5 passing, confirming the sample app and CRaC panel behave correctly end-to-end.
- **`./mvnw spotless:apply`** — clean, no formatting changes needed beyond what was already applied during development.

## Docs

`docs/CRAC-READINESS-CHECKS.md` rewritten (220 → 311 lines) to match every change above: corrected source links, the `SpringProperties` caveat, exemption notes on `NET-001`/`FILE-001`/`THREAD-001`, corrected `THREAD-001` CRIU framing, broadened `RANDOM-001`/`SECRET-001` wording, reworded `POOL-001`/`CACHE-001`, and three new sections for `CRAC-SCHED-001`/`CRAC-LIFECYCLE-002`/`CRAC-POOL-002`. `docs/FEATURES.md`'s CRaC panel summary updated to mention the new coverage areas.