### PR TITLE
Fix Quarkus Application advisor: QA-SCH-001 broken wiring, QA-WEB-003/QA-RX-001/QA-PROD-001/002 corrections, add QA-CDI-003/QA-CFG-004/QA-WEB-004/QA-DB-001 rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,33 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   MEDIUM to INFO after review showed it fired on any entity merely declaring 2+ lazy bag collections, a common and safe
   pattern — the actual failure mode (`MultipleBagFetchException`) is already covered by `HIB-QUERY-007`, which fires
   only when bags are actually join-fetched together (#511).
+- **Fixed a completely non-functional Quarkus application advisor rule (`QA-SCH-001`) and corrected five other
+  rules' severity or rationale**, following a second, independent 5-model research audit, re-verified against live
+  Quarkus 3.33 source before implementation. `QA-SCH-001` (scheduled tasks without a clustered scheduler) never
+  fired in practice because the build-time processor never emitted the `bootui.internal.app.scheduled` config key
+  its own provider reads — fixed by wiring the existing `@Scheduled` Jandex scan into the same build step. Also
+  fixed: `QA-WEB-003`'s rationale incorrectly claimed Quarkus REST clients have no default timeout (they default
+  to a 15s connect-timeout / 30s read-timeout, per `RestClientsConfig`) — the rule now only fires when a timeout
+  is explicitly disabled (`0`) or excessive (over 5 minutes), rather than merely absent; `QA-RX-001` (a reactive
+  endpoint blocking the event loop on JDBC) raised from INFO to HIGH to reflect how severe and common this
+  footgun is in production, and now treats `@Transactional` as a guard alongside `@Blocking` (Quarkus REST
+  dispatches both to a worker thread) and recognizes `CompletionStage`/`CompletableFuture`/`Publisher` return
+  types in addition to `Uni`/`Multi`; `QA-PROD-001` (a Dev Services override in `%prod`) lowered from HIGH to LOW
+  after confirming Dev Services never runs in a packaged `LaunchMode.NORMAL` build regardless of this property's
+  value; `QA-PROD-002` (a destructive Hibernate schema strategy in `%prod`) now also flags `update` (previously
+  only `drop-and-create`/`create`/`drop`), with severity split CRITICAL for the outright-destructive strategies
+  (matching the sibling Hibernate advisor's `HIB-CONFIG-002`) vs. HIGH for `update`; `QA-CDI-002` (a public
+  mutable field on a JAX-RS resource) no longer false-positives on `@RequestScoped` resources, which get a fresh
+  instance per request and carry no shared-state risk; `QA-PERF-001`/`QA-PERF-002` (virtual-thread
+  adoption/pinning) now also count class-level `@RunOnVirtualThread`, not just method-level; and `QA-PROF-001` is
+  rebased on the absence of `%prod.` override keys instead of active-profile emptiness, which rarely fires on a
+  running app. Grew the advisor from 16 to 20 rules with four new checks: `QA-CDI-003` (shared mutable state on a
+  `@Singleton` bean — the same risk `QA-CDI-001` already flags for `@ApplicationScoped`), `QA-CFG-004` (the
+  deprecated `quarkus.hibernate-orm.database.generation` property, in favour of
+  `quarkus.hibernate-orm.schema-management.strategy`), `QA-WEB-004` (graceful shutdown timeout never configured
+  at all, distinct from `QA-WEB-002`'s "explicitly zeroed" case), and `QA-DB-001` (a JDBC datasource with no
+  explicit `quarkus.datasource.jdbc.max-size`, silently relying on Agroal's default pool size of 50). See
+  [docs/QUARKUS-ADVISOR-CHECKS.md](docs/QUARKUS-ADVISOR-CHECKS.md) (#520).
 
 ## [1.9.0] - 2026-07-03
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppChecks.java
@@ -15,7 +15,7 @@ import java.util.List;
 final class QuarkusAppChecks {
 
     private static final String VIOLATION = "VIOLATION";
-    private static final int RULE_COUNT = 16;
+    private static final int RULE_COUNT = 20;
     private static final String GUIDE = "https://quarkus.io/guides/cdi-reference";
     private static final String CONFIG_GUIDE = "https://quarkus.io/guides/config-reference";
     private static final String REACTIVE_GUIDE = "https://quarkus.io/guides/getting-started-reactive";
@@ -57,10 +57,25 @@ final class QuarkusAppChecks {
                     "CDI",
                     "MEDIUM",
                     "JAX-RS resources default to @Singleton, so a public non-final field is process-wide shared"
-                            + " mutable state accessed concurrently across requests.",
+                            + " mutable state accessed concurrently across requests. (A resource explicitly"
+                            + " annotated @RequestScoped gets a fresh instance per request and is excluded.)",
                     s.publicResourceFields().size(),
                     s.publicResourceFields(),
                     "Make the field private final, inject it, or move per-request state to a @RequestScoped bean.",
+                    GUIDE));
+        }
+        if (!s.mutableSingletonFields().isEmpty()) {
+            v.add(rule(
+                    "QA-CDI-003",
+                    "Shared mutable state on a @Singleton bean",
+                    "CDI",
+                    "MEDIUM",
+                    "@Singleton beans are a single instance shared across threads, exactly like"
+                            + " @ApplicationScoped; public or non-final fields (other than injected dependencies)"
+                            + " hold unsynchronised shared state.",
+                    s.mutableSingletonFields().size(),
+                    s.mutableSingletonFields(),
+                    "Make fields private final, or move per-request state to a @RequestScoped bean.",
                     GUIDE));
         }
         if (s.beanCount() > 0 && s.configPropertyCount() == 0 && s.configMappingCount() == 0) {
@@ -81,36 +96,48 @@ final class QuarkusAppChecks {
                     "QA-RX-001",
                     "Reactive endpoints with a blocking JDBC datasource",
                     "Reactive",
-                    "INFO",
-                    "Endpoint(s) return Uni/Multi (run on the I/O event loop), lack a @Blocking guard on the"
-                            + " method or resource class, and a blocking JDBC datasource is configured; a JDBC call"
-                            + " on the event loop stalls it.",
+                    "HIGH",
+                    "Endpoint(s) return Uni/Multi/CompletionStage/CompletableFuture/Publisher (run on the I/O"
+                            + " event loop), lack a @Blocking or @Transactional guard on the method or resource"
+                            + " class, and a blocking JDBC datasource is configured; a JDBC call on the event loop"
+                            + " stalls it and can throw BlockingOperationNotAllowedException at runtime.",
                     s.reactiveEndpointsWithoutBlockingCount(),
                     List.of(s.reactiveEndpointsWithoutBlockingCount()
-                            + " reactive endpoint(s) without @Blocking, JDBC datasource present"),
-                    "Annotate blocking work with @Blocking, or use a reactive datasource client.",
+                            + " reactive endpoint(s) without @Blocking/@Transactional, JDBC datasource present"),
+                    "Annotate blocking work with @Blocking (Quarkus also treats @Transactional as blocking), or"
+                            + " use a reactive datasource client.",
                     REACTIVE_GUIDE));
         }
         if (s.prodDevServicesEnabled()) {
             v.add(rule(
                     "QA-PROD-001",
-                    "Dev Services enabled in the prod profile",
+                    "Dev Services override present in the prod profile",
                     "Profiles",
-                    "HIGH",
-                    "A %prod.*devservices.enabled=true key would start throwaway containers in production.",
+                    "LOW",
+                    "A %prod.*devservices.enabled=true key is set. This has no effect in a packaged production"
+                            + " build — Dev Services only runs during augmentation/dev/test, never in a"
+                            + " LaunchMode.NORMAL packaged JAR or native executable — but its presence usually"
+                            + " means leftover or copy-pasted config that should be cleaned up.",
                     s.prodProfileKeys().size(),
                     List.of("%prod devservices.enabled=true"),
-                    "Remove the %prod devservices override; configure a real datasource/broker for prod.",
+                    "Remove the unused %prod devservices override; it does not start containers in production"
+                            + " but can confuse readers of the config.",
                     PROFILE_GUIDE));
         }
-        if (isDestructiveSchema(s.prodSchemaGeneration())) {
+        String prodSchemaSeverity = destructiveSchemaSeverity(s.prodSchemaGeneration());
+        if (prodSchemaSeverity != null) {
             v.add(rule(
                     "QA-PROD-002",
                     "Destructive Hibernate schema strategy in the prod profile",
                     "Profiles",
-                    "HIGH",
-                    "A %prod Hibernate schema strategy of drop-and-create/create/drop rebuilds or drops the"
-                            + " production schema on every boot, destroying data.",
+                    prodSchemaSeverity,
+                    prodSchemaSeverity.equals("CRITICAL")
+                            ? "A %prod Hibernate schema strategy of drop-and-create/create/drop rebuilds or"
+                                    + " drops the production schema on every boot, destroying data."
+                            : "A %prod Hibernate schema strategy of update lets Hibernate silently alter the"
+                                    + " production schema on every boot (adding/changing columns or tables to"
+                                    + " match the entity model), which can lock tables or apply an unreviewed"
+                                    + " structural change directly to production.",
                     1,
                     List.of("%prod quarkus.hibernate-orm schema strategy=" + s.prodSchemaGeneration()),
                     "Use 'none' (or 'validate') in %prod and manage the schema with Flyway/Liquibase.",
@@ -128,6 +155,22 @@ final class QuarkusAppChecks {
                     List.of("%prod datasource db-kind="
                             + (s.prodDbKind().isBlank() ? "(in-memory jdbc url)" : s.prodDbKind())),
                     "Point %prod at a real managed database (PostgreSQL, MySQL, …).",
+                    DATASOURCE_GUIDE));
+        }
+        if (s.jdbcDatasourcePresent() && !s.datasourceMaxSizeConfigured()) {
+            v.add(rule(
+                    "QA-DB-001",
+                    "JDBC datasource without an explicit pool size",
+                    "Database",
+                    "LOW",
+                    "A JDBC datasource is configured, but quarkus.datasource.jdbc.max-size is never set (Agroal"
+                            + " defaults to a max pool size of 50). Under high concurrency — especially with"
+                            + " virtual threads increasing request parallelism — the default pool can become a"
+                            + " bottleneck or exhaust the database's own connection limit.",
+                    1,
+                    List.of("quarkus.datasource.jdbc.max-size not set (Agroal default: 50)"),
+                    "Set quarkus.datasource.jdbc.max-size (with a %prod override if it should differ from dev)"
+                            + " to a value sized for the target database and expected concurrency.",
                     DATASOURCE_GUIDE));
         }
         if (s.prodSqlLoggingEnabled()) {
@@ -156,6 +199,22 @@ final class QuarkusAppChecks {
                     "Set %prod.quarkus.log.level to INFO or WARN; use DEBUG/TRACE only in %dev.",
                     LOGGING_GUIDE));
         }
+        if (s.legacySchemaGenerationPropertyUsed()) {
+            v.add(rule(
+                    "QA-CFG-004",
+                    "Legacy Hibernate schema-generation property in use",
+                    "Config",
+                    "LOW",
+                    "quarkus.hibernate-orm.database.generation (or a %profile/named-persistence-unit variant)"
+                            + " is deprecated for removal in favour of"
+                            + " quarkus.hibernate-orm.schema-management.strategy; it still works today but may"
+                            + " be removed in a future Quarkus release.",
+                    1,
+                    List.of("quarkus.hibernate-orm.database.generation present"),
+                    "Migrate to quarkus.hibernate-orm.schema-management.strategy (it accepts the same values:"
+                            + " none/create/drop-and-create/drop/update/validate).",
+                    HIBERNATE_GUIDE));
+        }
         if (s.scheduledCount() > 0 && !s.clusteredScheduler()) {
             v.add(rule(
                     "QA-SCH-001",
@@ -170,16 +229,16 @@ final class QuarkusAppChecks {
                             + " deployment.",
                     SCHEDULER_GUIDE));
         }
-        if (s.activeProfiles().isEmpty() && s.prodProfileKeys().isEmpty()) {
+        if (s.prodProfileKeys().isEmpty()) {
             v.add(rule(
                     "QA-PROF-001",
-                    "No profile configuration",
+                    "No prod-specific configuration overrides",
                     "Profiles",
                     "INFO",
-                    "No active profile and no %prod. overrides were found. This is fine when production config"
-                            + " is externalised (env vars, Secrets/ConfigMaps); otherwise prod shares dev defaults.",
+                    "No %prod. overrides were found. This is fine when production config is externalised (env"
+                            + " vars, Secrets/ConfigMaps); otherwise prod shares dev defaults for every setting.",
                     1,
-                    List.of("no %prod./%dev. keys, no active profile"),
+                    List.of("no %prod. keys found"),
                     "Add %prod. overrides (or externalise config) so production differs from dev defaults.",
                     PROFILE_GUIDE));
         }
@@ -190,7 +249,7 @@ final class QuarkusAppChecks {
                     "Web",
                     "INFO",
                     "quarkus.http.enable-compression is not set (Quarkus's own default), so responses are not"
-                            + " gzip/brotli-compressed, increasing bandwidth and latency for text-heavy payloads.",
+                            + " gzip/deflate-compressed, increasing bandwidth and latency for text-heavy payloads.",
                     1,
                     List.of("quarkus.http.enable-compression not set"),
                     "Set quarkus.http.enable-compression=true (tune quarkus.http.compress-media-types if needed).",
@@ -211,19 +270,36 @@ final class QuarkusAppChecks {
                             + " shutdown.",
                     HTTP_GUIDE));
         }
-        if (s.restClientsRegistered() && !s.restClientTimeoutConfigured()) {
+        if (!s.shutdownTimeoutConfigured()) {
+            v.add(rule(
+                    "QA-WEB-004",
+                    "Graceful shutdown timeout never configured",
+                    "Web",
+                    "LOW",
+                    "Neither quarkus.shutdown.timeout nor quarkus.http.shutdown.timeout is set. Quarkus's"
+                            + " graceful shutdown is opt-in: with no timeout configured, the application exits"
+                            + " immediately on SIGTERM instead of draining in-flight requests.",
+                    1,
+                    List.of("no shutdown timeout configured"),
+                    "Set quarkus.shutdown.timeout to a positive duration (e.g. 10s) so in-flight requests can"
+                            + " drain before shutdown.",
+                    HTTP_GUIDE));
+        }
+        if (s.restClientsRegistered() && s.restClientTimeoutZeroOrExcessive()) {
             v.add(rule(
                     "QA-WEB-003",
-                    "REST client without a connect/read timeout",
+                    "REST client connect/read timeout disabled or excessive",
                     "Web",
                     "MEDIUM",
-                    "A @RegisterRestClient interface is declared, but no connect-timeout/read-timeout is"
-                            + " configured anywhere. Quarkus REST clients have no default timeout, so a"
-                            + " slow/hanging remote service can block a caller indefinitely.",
+                    "A connect-timeout or read-timeout for a @RegisterRestClient interface is explicitly set to"
+                            + " 0 (no timeout) or to an excessively high value (over 5 minutes). Quarkus REST"
+                            + " clients already default to a 15s connect-timeout and 30s read-timeout"
+                            + " (quarkus.rest-client.connect-timeout / read-timeout), so a slow/hanging remote"
+                            + " service is normally bounded; this override removes that safety net.",
                     1,
-                    List.of("@RegisterRestClient present, no connect-timeout/read-timeout configured"),
-                    "Set quarkus.rest-client.\"<client-key>\".connect-timeout / read-timeout, or the global"
-                            + " quarkus.rest-client.connect-timeout / read-timeout.",
+                    List.of("REST client connect-timeout/read-timeout explicitly 0 or > 5m"),
+                    "Remove the override to keep Quarkus's 15s/30s defaults, or set a specific, bounded timeout"
+                            + " appropriate for the remote service.",
                     REST_CLIENT_GUIDE));
         }
         if (s.endpointCount() > 0 && s.virtualThreadEndpointCount() == 0 && s.jdkMajorVersion() >= 21) {
@@ -260,12 +336,24 @@ final class QuarkusAppChecks {
         return v;
     }
 
-    private static boolean isDestructiveSchema(String strategy) {
+    /**
+     * Severity of a {@code %prod} Hibernate schema strategy, mirroring the sibling Hibernate advisor's
+     * {@code HIB-CONFIG-002} split: {@code drop-and-create}/{@code create}/{@code drop} rebuild or drop the
+     * schema outright (CRITICAL), while {@code update} silently alters it in place (HIGH). Returns {@code
+     * null} when the strategy is not a destructive one (e.g. {@code none}/{@code validate}/unset).
+     */
+    private static String destructiveSchemaSeverity(String strategy) {
         if (strategy == null) {
-            return false;
+            return null;
         }
         String s = strategy.trim().toLowerCase();
-        return s.equals("drop-and-create") || s.equals("create") || s.equals("drop");
+        if (s.equals("drop-and-create") || s.equals("create") || s.equals("drop")) {
+            return "CRITICAL";
+        }
+        if (s.equals("update")) {
+            return "HIGH";
+        }
+        return null;
     }
 
     private static boolean isInMemoryProdDatasource(QuarkusAppSnapshot s) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusAppSnapshot.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusAppSnapshot.java
@@ -42,10 +42,23 @@ import java.util.List;
  * @param compressionEnabled whether {@code quarkus.http.enable-compression} is on
  * @param shutdownTimeoutZeroed whether the graceful shutdown grace period was explicitly zeroed
  * @param restClientsRegistered whether any {@code @RegisterRestClient} interface is declared
- * @param restClientTimeoutConfigured whether a global or per-client REST client connect/read timeout is set
+ * @param restClientTimeoutZeroOrExcessive whether a global or per-client REST client connect/read timeout is
+ *     explicitly set to {@code 0} (disabled) or to an excessively high value — Quarkus REST clients already
+ *     default to a 15s connect-timeout/30s read-timeout, so merely leaving the timeout unset is not flagged
  * @param virtualThreadEndpointCount {@code @RunOnVirtualThread} sites (methods or classes)
  * @param virtualThreadSynchronizedCount {@code @RunOnVirtualThread} sites that are also {@code synchronized}
+ *     (a class-level {@code @RunOnVirtualThread} counts every {@code synchronized} method in that class)
  * @param jdkMajorVersion the build JDK's major version (0 if undetermined)
+ * @param mutableSingletonFields {@code @Singleton} bean fields that are public or non-final (shared mutable
+ *     state, the same risk as {@link #mutableAppScopedFields()} since a {@code @Singleton} is also one
+ *     instance shared across threads)
+ * @param legacySchemaGenerationPropertyUsed whether the deprecated {@code quarkus.hibernate-orm.database.generation}
+ *     property (or a profile/named-persistence-unit variant) is used instead of the current
+ *     {@code quarkus.hibernate-orm.schema-management.strategy}
+ * @param shutdownTimeoutConfigured whether {@code quarkus.shutdown.timeout} or
+ *     {@code quarkus.http.shutdown.timeout} is set at all (to any value, including {@code 0})
+ * @param datasourceMaxSizeConfigured whether {@code quarkus.datasource.jdbc.max-size} is explicitly set
+ *     (globally or via a {@code %prod} override)
  */
 public record QuarkusAppSnapshot(
         int applicationScopedCount,
@@ -76,10 +89,14 @@ public record QuarkusAppSnapshot(
         boolean compressionEnabled,
         boolean shutdownTimeoutZeroed,
         boolean restClientsRegistered,
-        boolean restClientTimeoutConfigured,
+        boolean restClientTimeoutZeroOrExcessive,
         int virtualThreadEndpointCount,
         int virtualThreadSynchronizedCount,
-        int jdkMajorVersion) {
+        int jdkMajorVersion,
+        List<String> mutableSingletonFields,
+        boolean legacySchemaGenerationPropertyUsed,
+        boolean shutdownTimeoutConfigured,
+        boolean datasourceMaxSizeConfigured) {
 
     public QuarkusAppSnapshot {
         mutableAppScopedFields = mutableAppScopedFields == null ? List.of() : List.copyOf(mutableAppScopedFields);
@@ -88,6 +105,7 @@ public record QuarkusAppSnapshot(
         prodSchemaGeneration = prodSchemaGeneration == null ? "" : prodSchemaGeneration;
         prodDbKind = prodDbKind == null ? "" : prodDbKind;
         publicResourceFields = publicResourceFields == null ? List.of() : List.copyOf(publicResourceFields);
+        mutableSingletonFields = mutableSingletonFields == null ? List.of() : List.copyOf(mutableSingletonFields);
     }
 
     public int beanCount() {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
@@ -18,7 +18,7 @@ class QuarkusAppScannerTest {
 
     /**
      * Mutable builder whose defaults describe a clean Quarkus app that fires zero rules, so each test can flip
-     * exactly the fields under test. Mirrors the 32-field {@link QuarkusAppSnapshot} positional record.
+     * exactly the fields under test. Mirrors the 36-field {@link QuarkusAppSnapshot} positional record.
      */
     private static final class Snap {
         // CDI / beans (beanCount = applicationScoped + singleton + requestScoped + dependentScoped = 4)
@@ -28,9 +28,11 @@ class QuarkusAppScannerTest {
         int dependentScoped = 0;
         List<String> mutableAppScopedFields = List.of();
         List<String> publicResourceFields = List.of();
+        List<String> mutableSingletonFields = List.of();
         // Config
         int configProperties = 2;
         int configMappings = 0;
+        boolean legacySchemaGenerationPropertyUsed = false;
         // Endpoints / reactive
         int endpoints = 4;
         int defaultScopeResources = 0;
@@ -51,13 +53,15 @@ class QuarkusAppScannerTest {
         String prodDbKind = "";
         boolean prodJdbcUrlInMemory = false;
         boolean prodSqlLogging = false;
+        boolean datasourceMaxSizeConfigured = true;
         // Logging
         boolean prodLogLevelVerbose = false;
         // Web
         boolean compressionEnabled = true;
         boolean shutdownTimeoutZeroed = false;
+        boolean shutdownTimeoutConfigured = true;
         boolean restClientsRegistered = false;
-        boolean restClientTimeoutConfigured = false;
+        boolean restClientTimeoutZeroOrExcessive = false;
         // Performance / virtual threads (jdkMajorVersion=21 + 1 adopting endpoint is a clean modern baseline)
         int virtualThreadEndpoints = 1;
         int virtualThreadSynchronized = 0;
@@ -93,10 +97,14 @@ class QuarkusAppScannerTest {
                     compressionEnabled,
                     shutdownTimeoutZeroed,
                     restClientsRegistered,
-                    restClientTimeoutConfigured,
+                    restClientTimeoutZeroOrExcessive,
                     virtualThreadEndpoints,
                     virtualThreadSynchronized,
-                    jdkMajorVersion);
+                    jdkMajorVersion,
+                    mutableSingletonFields,
+                    legacySchemaGenerationPropertyUsed,
+                    shutdownTimeoutConfigured,
+                    datasourceMaxSizeConfigured);
         }
     }
 
@@ -133,6 +141,17 @@ class QuarkusAppScannerTest {
     }
 
     @Test
+    void mutableSingletonFieldIsFlagged() {
+        // QA-CDI-003: a @Singleton bean shares the exact same single-shared-instance risk as
+        // @ApplicationScoped (QA-CDI-001); the @RequestScoped exclusion for QA-CDI-002 itself is enforced
+        // upstream in the Jandex scan (BootUiQuarkusProcessor), not observable at this snapshot level.
+        Snap s = new Snap();
+        s.mutableSingletonFields = List.of("CounterService.total");
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-CDI-003").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
     void noTypeSafeConfigIsFlagged() {
         Snap s = new Snap();
         s.configProperties = 0;
@@ -156,7 +175,9 @@ class QuarkusAppScannerTest {
         firing.reactiveEndpoints = 2;
         firing.reactiveEndpointsWithoutBlocking = 2;
         firing.jdbcDatasource = true;
-        assertThat(find(scan(firing), "QA-RX-001")).isNotNull();
+        // QA-RX-001 was raised from INFO to HIGH: blocking the Vert.x event loop is one of the most severe,
+        // most common Quarkus production footguns (throws BlockingOperationNotAllowedException at runtime).
+        assertThat(find(scan(firing), "QA-RX-001").severity()).isEqualTo("HIGH");
 
         Snap noJdbc = new Snap();
         noJdbc.reactiveEndpoints = 2;
@@ -169,31 +190,59 @@ class QuarkusAppScannerTest {
     void blockingGuardedReactiveEndpointsDoNotFlagRx001() {
         // Regression: the old app-wide blockingAnnotationCount==0 check false-negatived whenever ANY unrelated
         // @Blocking existed anywhere in the app; the fix correlates per-endpoint via the
-        // reactiveEndpointsWithoutBlockingCount field, computed per reactive JAX-RS method.
+        // reactiveEndpointsWithoutBlockingCount field, computed per reactive JAX-RS method. Note: whether
+        // @Transactional also counts as a guard (alongside @Blocking) is computed upstream in
+        // BootUiQuarkusProcessor's Jandex scan, before reactiveEndpointsWithoutBlockingCount reaches this
+        // snapshot, so it is covered by a build-step-level test rather than here.
         Snap s = new Snap();
         s.reactiveEndpoints = 2;
-        s.reactiveEndpointsWithoutBlocking = 0; // both reactive endpoints carry @Blocking themselves
+        s.reactiveEndpointsWithoutBlocking = 0; // both reactive endpoints carry @Blocking/@Transactional themselves
         s.blockingAnnotations = 1;
         s.jdbcDatasource = true;
         assertThat(find(scan(s), "QA-RX-001")).isNull();
     }
 
     @Test
-    void prodDevServicesIsHigh() {
+    void prodDevServicesIsLow() {
+        // QA-PROD-001 was lowered from HIGH to LOW: Dev Services is build-time/augmentation-only and never
+        // runs in a packaged LaunchMode.NORMAL production build regardless of this override, so it is a
+        // config-hygiene signal, not an active production risk.
         Snap s = new Snap();
         s.prodDevServices = true;
         s.prodProfileKeys = List.of("%prod.x.devservices.enabled");
         SpringReport r = scan(s);
-        assertThat(find(r, "QA-PROD-001").severity()).isEqualTo("HIGH");
+        assertThat(find(r, "QA-PROD-001").severity()).isEqualTo("LOW");
     }
 
     @Test
-    void prodDestructiveSchemaIsHigh() {
+    void prodDestructiveCreateSchemaIsCritical() {
+        // QA-PROD-002: drop-and-create/create/drop rebuild or drop the schema outright, aligned with the
+        // sibling Hibernate advisor's HIB-CONFIG-002 CRITICAL severity for the same condition.
         Snap s = new Snap();
         s.prodSchemaGeneration = "drop-and-create";
         s.prodDbKind = "postgresql";
         SpringReport r = scan(s);
+        assertThat(find(r, "QA-PROD-002").severity()).isEqualTo("CRITICAL");
+    }
+
+    @Test
+    void prodUpdateSchemaIsHigh() {
+        // QA-PROD-002: 'update' silently alters the schema in place rather than rebuilding it outright, so it
+        // is a step down from CRITICAL but still HIGH (was previously not flagged as destructive at all).
+        Snap s = new Snap();
+        s.prodSchemaGeneration = "update";
+        s.prodDbKind = "postgresql";
+        SpringReport r = scan(s);
         assertThat(find(r, "QA-PROD-002").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void prodValidateSchemaIsNotFlagged() {
+        Snap s = new Snap();
+        s.prodSchemaGeneration = "validate";
+        s.prodDbKind = "postgresql";
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-PROD-002")).isNull();
     }
 
     @Test
@@ -205,6 +254,33 @@ class QuarkusAppScannerTest {
         Snap byUrl = new Snap();
         byUrl.prodJdbcUrlInMemory = true;
         assertThat(find(scan(byUrl), "QA-PROD-003")).isNotNull();
+    }
+
+    @Test
+    void datasourceWithoutMaxSizeIsFlagged() {
+        Snap s = new Snap();
+        s.jdbcDatasource = true;
+        s.datasourceMaxSizeConfigured = false;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-DB-001").severity()).isEqualTo("LOW");
+    }
+
+    @Test
+    void datasourceWithMaxSizeConfiguredDoesNotFlagDb001() {
+        Snap s = new Snap();
+        s.jdbcDatasource = true;
+        s.datasourceMaxSizeConfigured = true;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-DB-001")).isNull();
+    }
+
+    @Test
+    void noDatasourceDoesNotFlagDb001() {
+        Snap s = new Snap();
+        s.jdbcDatasource = false;
+        s.datasourceMaxSizeConfigured = false;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-DB-001")).isNull();
     }
 
     @Test
@@ -224,6 +300,22 @@ class QuarkusAppScannerTest {
     }
 
     @Test
+    void legacySchemaGenerationPropertyIsFlagged() {
+        Snap s = new Snap();
+        s.legacySchemaGenerationPropertyUsed = true;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-CFG-004").severity()).isEqualTo("LOW");
+    }
+
+    @Test
+    void currentSchemaManagementPropertyDoesNotFlagCfg004() {
+        Snap s = new Snap();
+        s.legacySchemaGenerationPropertyUsed = false;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-CFG-004")).isNull();
+    }
+
+    @Test
     void scheduledWithoutClusteringIsFlagged() {
         Snap firing = new Snap();
         firing.scheduled = 1;
@@ -236,12 +328,23 @@ class QuarkusAppScannerTest {
     }
 
     @Test
-    void noProfileConfigurationIsInfo() {
+    void noProdOverridesIsFlagged() {
+        // Regression: the old condition additionally required activeProfiles().isEmpty(), but
+        // SmallRyeConfig.getProfiles() almost always returns a live profile (dev/test/prod) in a running app,
+        // making the old rule a near-dead signal. The fix drops that requirement and fires on the absence of
+        // %prod. overrides alone -- note activeProfiles is non-empty here (the Snap default, "prod"),
+        // proving the fix.
         Snap s = new Snap();
-        s.activeProfiles = List.of();
         s.prodProfileKeys = List.of();
         SpringReport r = scan(s);
         assertThat(find(r, "QA-PROF-001").severity()).isEqualTo("INFO");
+    }
+
+    @Test
+    void prodOverridesPresentDoesNotFlagProf001() {
+        Snap s = new Snap(); // default Snap already carries a non-empty prodProfileKeys
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-PROF-001")).isNull();
     }
 
     @Test
@@ -256,24 +359,49 @@ class QuarkusAppScannerTest {
     void gracefulShutdownZeroedIsFlagged() {
         Snap s = new Snap();
         s.shutdownTimeoutZeroed = true;
+        // Zeroing the timeout means it IS configured (to 0), so QA-WEB-004 ("never configured") is
+        // mutually exclusive with QA-WEB-002 ("explicitly zeroed") by construction.
+        s.shutdownTimeoutConfigured = true;
         SpringReport r = scan(s);
         assertThat(find(r, "QA-WEB-002").severity()).isEqualTo("MEDIUM");
+        assertThat(find(r, "QA-WEB-004")).isNull();
     }
 
     @Test
-    void restClientWithoutTimeoutIsFlagged() {
+    void shutdownTimeoutNeverConfiguredIsFlagged() {
+        Snap s = new Snap();
+        s.shutdownTimeoutConfigured = false;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-WEB-004").severity()).isEqualTo("LOW");
+        assertThat(find(r, "QA-WEB-002")).isNull();
+    }
+
+    @Test
+    void shutdownTimeoutConfiguredDoesNotFlagWeb004() {
+        Snap s = new Snap();
+        s.shutdownTimeoutConfigured = true;
+        SpringReport r = scan(s);
+        assertThat(find(r, "QA-WEB-004")).isNull();
+    }
+
+    @Test
+    void restClientTimeoutZeroOrExcessiveIsFlagged() {
+        // QA-WEB-003 was redesigned: it used to fire on the mere ABSENCE of a timeout override (a factually
+        // wrong premise -- Quarkus REST clients already default to a 15s connect-timeout/30s read-timeout).
+        // It now fires only on an explicit 0 (disabled) or excessive (>5m) override.
         Snap s = new Snap();
         s.restClientsRegistered = true;
-        s.restClientTimeoutConfigured = false;
+        s.restClientTimeoutZeroOrExcessive = true;
         SpringReport r = scan(s);
         assertThat(find(r, "QA-WEB-003").severity()).isEqualTo("MEDIUM");
     }
 
     @Test
-    void restClientWithTimeoutDoesNotFlagWeb003() {
+    void restClientWithoutOverrideDoesNotFlagWeb003() {
+        // The Quarkus default (15s connect / 30s read) applies when nothing is overridden -- no longer flagged.
         Snap s = new Snap();
         s.restClientsRegistered = true;
-        s.restClientTimeoutConfigured = true;
+        s.restClientTimeoutZeroOrExcessive = false;
         SpringReport r = scan(s);
         assertThat(find(r, "QA-WEB-003")).isNull();
     }
@@ -282,7 +410,7 @@ class QuarkusAppScannerTest {
     void noRestClientsDoesNotFlagWeb003() {
         Snap s = new Snap();
         s.restClientsRegistered = false;
-        s.restClientTimeoutConfigured = false;
+        s.restClientTimeoutZeroOrExcessive = false;
         SpringReport r = scan(s);
         assertThat(find(r, "QA-WEB-003")).isNull();
     }
@@ -344,7 +472,7 @@ class QuarkusAppScannerTest {
     @Test
     void rulesEvaluatedMatchesTotalRuleCount() {
         SpringReport r = scan(new Snap());
-        assertThat(r.scan().rulesEvaluated()).isEqualTo(16);
+        assertThat(r.scan().rulesEvaluated()).isEqualTo(20);
     }
 
     @Test

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -520,6 +520,13 @@ class BootUiQuarkusProcessor {
     private static final DotName RUN_ON_VIRTUAL_THREAD =
             DotName.createSimple("io.smallrye.common.annotation.RunOnVirtualThread");
 
+    /**
+     * Quarkus REST (RESTEasy Reactive) dispatches a {@code @Transactional} method to a worker thread just
+     * like {@code @Blocking} does (see the Quarkus REST execution-model docs), so QA-RX-001 treats it as an
+     * equivalent guard against blocking the event loop.
+     */
+    private static final DotName TRANSACTIONAL = DotName.createSimple("jakarta.transaction.Transactional");
+
     /** Bytecode access-flag bit for the {@code synchronized} method modifier ({@code ACC_SYNCHRONIZED}). */
     private static final int ACC_SYNCHRONIZED = 0x0020;
 
@@ -539,14 +546,21 @@ class BootUiQuarkusProcessor {
     /**
      * Captures build-time idiom counts for the Quarkus-native application advisor: CDI scope annotation counts,
      * {@code @ConfigProperty} sites, {@code @ConfigMapping} interfaces, JAX-RS resources without an explicit scope,
-     * reactive ({@code Uni}/{@code Multi}) endpoints, {@code @Blocking} sites, shared mutable fields on
-     * {@code @ApplicationScoped} beans (excluding injected fields), public mutable fields on JAX-RS resources,
-     * {@code @RegisterRestClient} interfaces (QA-WEB-003), and the JEP-491 virtual-thread-pinning correlation
-     * (QA-PERF-002): {@code @RunOnVirtualThread} sites total vs. the subset that are also declared {@code
-     * synchronized}, plus the build JDK's major version (the pinning-on-{@code synchronized} bug is fixed in
-     * JDK 24). Note the {@code synchronized}-count only sees the method-level modifier — Jandex does not index
-     * {@code synchronized(lock) { … }} blocks inside a method body, so this is a real but incomplete signal.
-     * Emitted as runtime config defaults the advisor reads. Dev/test only — skipped in {@link LaunchMode#NORMAL}.
+     * reactive ({@code Uni}/{@code Multi}/{@code CompletionStage}/{@code CompletableFuture}/{@code Publisher})
+     * endpoints without a {@code @Blocking} or {@code @Transactional} guard (Quarkus REST dispatches either
+     * annotation to a worker thread, so both count as a guard for QA-RX-001), shared mutable fields on
+     * {@code @ApplicationScoped} beans (QA-CDI-001) and on {@code @Singleton} beans (QA-CDI-003, excluding
+     * injected fields in both cases), public mutable fields on JAX-RS resources excluding those explicitly
+     * {@code @RequestScoped} (QA-CDI-002 — a fresh instance per request has no shared-state risk),
+     * {@code @RegisterRestClient} interfaces (QA-WEB-003), {@code @Scheduled} method count (QA-SCH-001, reusing
+     * {@link #scanScheduledTasks(IndexView)}), and the JEP-491 virtual-thread-pinning correlation
+     * (QA-PERF-001/QA-PERF-002): {@code @RunOnVirtualThread} sites — method or class level, per the docs; a
+     * class-level annotation makes every method in that class run on a virtual thread — total vs. the subset
+     * that are also declared {@code synchronized}, plus the build JDK's major version (the
+     * pinning-on-{@code synchronized} bug is fixed in JDK 24). Note the {@code synchronized}-count only sees the
+     * method-level modifier — Jandex does not index {@code synchronized(lock) { … }} blocks inside a method
+     * body, so this is a real but incomplete signal. Emitted as runtime config defaults the advisor reads.
+     * Dev/test only — skipped in {@link LaunchMode#NORMAL}.
      */
     @BuildStep
     void registerAppIdioms(
@@ -583,8 +597,13 @@ class BootUiQuarkusProcessor {
                     MethodInfo method = ann.target().asMethod();
                     if (isReactive(method.returnType())) {
                         reactive++;
+                        // Quarkus REST dispatches a @Transactional method to a worker thread just like
+                        // @Blocking, so either annotation (method or class level) guards the event loop
+                        // (QA-RX-001).
                         boolean guarded = method.hasAnnotation(BLOCKING)
-                                || method.declaringClass().hasAnnotation(BLOCKING);
+                                || method.declaringClass().hasAnnotation(BLOCKING)
+                                || method.hasAnnotation(TRANSACTIONAL)
+                                || method.declaringClass().hasAnnotation(TRANSACTIONAL);
                         if (!guarded) {
                             reactiveWithoutBlocking++;
                         }
@@ -609,6 +628,10 @@ class BootUiQuarkusProcessor {
                     && cls.declaredAnnotation(DEPENDENT) == null) {
                 defaultScopeResources++;
             }
+            if (cls.declaredAnnotation(REQUEST_SCOPED) != null) {
+                // A fresh instance per request carries no shared-mutable-state risk (QA-CDI-002).
+                continue;
+            }
             for (FieldInfo f : cls.fields()) {
                 boolean isPublic = (f.flags() & 0x0001) != 0;
                 boolean isFinal = (f.flags() & 0x0010) != 0;
@@ -618,8 +641,83 @@ class BootUiQuarkusProcessor {
                 }
             }
         }
-        List<String> mutableFields = new ArrayList<>();
-        for (AnnotationInstance ann : app.getAnnotations(APPLICATION_SCOPED)) {
+        List<String> mutableFields = mutableFieldsOf(app, APPLICATION_SCOPED);
+        List<String> mutableSingletonFields = mutableFieldsOf(app, SINGLETON);
+        emit(runtimeDefaults, "bootui.internal.app.default-scope-resources", defaultScopeResources);
+        if (!mutableFields.isEmpty()) {
+            runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                    "bootui.internal.app.mutable-fields", String.join(",", mutableFields)));
+        }
+        if (!mutableSingletonFields.isEmpty()) {
+            runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                    "bootui.internal.app.mutable-singleton-fields", String.join(",", mutableSingletonFields)));
+        }
+        if (!publicResourceFields.isEmpty()) {
+            runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                    "bootui.internal.app.public-resource-fields", String.join(",", publicResourceFields)));
+        }
+
+        emit(runtimeDefaults, "bootui.internal.app.rest-clients", classAnnotations(app, REGISTER_REST_CLIENT));
+        emit(
+                runtimeDefaults,
+                "bootui.internal.app.scheduled",
+                scanScheduledTasks(beans).size());
+
+        VirtualThreadCounts virtualThreadCounts = virtualThreadSitesOf(app);
+        emit(runtimeDefaults, "bootui.internal.app.virtual-thread-endpoints", virtualThreadCounts.sites());
+        emit(
+                runtimeDefaults,
+                "bootui.internal.app.virtual-thread-synchronized",
+                virtualThreadCounts.synchronizedSites());
+        emit(
+                runtimeDefaults,
+                "bootui.internal.app.jdk-major-version",
+                Runtime.version().feature());
+    }
+
+    /**
+     * Number of {@code @RunOnVirtualThread} sites — method or class level — and, of those, how many
+     * synchronized methods run on a virtual thread as a result. A class-level annotation counts as a single
+     * site (matching {@code virtualThreadEndpointCount}'s "sites (methods or classes)" contract) but scans
+     * every method it covers for the {@code synchronized} modifier, since the annotation makes all of them
+     * run on a virtual thread (QA-PERF-001/QA-PERF-002).
+     */
+    static VirtualThreadCounts virtualThreadSitesOf(IndexView app) {
+        int sites = 0;
+        int synchronizedSites = 0;
+        for (AnnotationInstance ann : app.getAnnotations(RUN_ON_VIRTUAL_THREAD)) {
+            if (ann.target() == null) {
+                continue;
+            }
+            if (ann.target().kind() == AnnotationTarget.Kind.METHOD) {
+                sites++;
+                MethodInfo method = ann.target().asMethod();
+                if ((method.flags() & ACC_SYNCHRONIZED) != 0) {
+                    synchronizedSites++;
+                }
+            } else if (ann.target().kind() == AnnotationTarget.Kind.CLASS) {
+                sites++;
+                for (MethodInfo method : ann.target().asClass().methods()) {
+                    if ((method.flags() & ACC_SYNCHRONIZED) != 0) {
+                        synchronizedSites++;
+                    }
+                }
+            }
+        }
+        return new VirtualThreadCounts(sites, synchronizedSites);
+    }
+
+    /** Result of {@link #virtualThreadSitesOf(IndexView)}. */
+    record VirtualThreadCounts(int sites, int synchronizedSites) {}
+
+    /**
+     * Public-or-non-final, non-static, non-injected fields on every class annotated {@code scopeAnnotation}.
+     * Shared by QA-CDI-001 ({@code @ApplicationScoped}) and QA-CDI-003 ({@code @Singleton}) — both scopes are
+     * a single instance shared across threads, so a mutable field on either is unsynchronised shared state.
+     */
+    static List<String> mutableFieldsOf(IndexView app, DotName scopeAnnotation) {
+        List<String> result = new ArrayList<>();
+        for (AnnotationInstance ann : app.getAnnotations(scopeAnnotation)) {
             if (ann.target() == null || ann.target().kind() != AnnotationTarget.Kind.CLASS) {
                 continue;
             }
@@ -631,43 +729,14 @@ class BootUiQuarkusProcessor {
                 boolean injected =
                         f.hasAnnotation(INJECT) || f.hasAnnotation(CONFIG_PROPERTY) || f.hasAnnotation(REST_CLIENT);
                 if (!isStatic && !injected && (isPublic || !isFinal)) {
-                    mutableFields.add(cls.simpleName() + "." + f.name());
+                    result.add(cls.simpleName() + "." + f.name());
                 }
             }
         }
-        emit(runtimeDefaults, "bootui.internal.app.default-scope-resources", defaultScopeResources);
-        if (!mutableFields.isEmpty()) {
-            runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
-                    "bootui.internal.app.mutable-fields", String.join(",", mutableFields)));
-        }
-        if (!publicResourceFields.isEmpty()) {
-            runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
-                    "bootui.internal.app.public-resource-fields", String.join(",", publicResourceFields)));
-        }
-
-        emit(runtimeDefaults, "bootui.internal.app.rest-clients", classAnnotations(app, REGISTER_REST_CLIENT));
-
-        int virtualThreadSites = 0;
-        int virtualThreadSynchronizedSites = 0;
-        for (AnnotationInstance ann : app.getAnnotations(RUN_ON_VIRTUAL_THREAD)) {
-            if (ann.target() == null || ann.target().kind() != AnnotationTarget.Kind.METHOD) {
-                continue;
-            }
-            virtualThreadSites++;
-            MethodInfo method = ann.target().asMethod();
-            if ((method.flags() & ACC_SYNCHRONIZED) != 0) {
-                virtualThreadSynchronizedSites++;
-            }
-        }
-        emit(runtimeDefaults, "bootui.internal.app.virtual-thread-endpoints", virtualThreadSites);
-        emit(runtimeDefaults, "bootui.internal.app.virtual-thread-synchronized", virtualThreadSynchronizedSites);
-        emit(
-                runtimeDefaults,
-                "bootui.internal.app.jdk-major-version",
-                Runtime.version().feature());
+        return result;
     }
 
-    private static int classAnnotations(IndexView index, DotName annotation) {
+    static int classAnnotations(IndexView index, DotName annotation) {
         int n = 0;
         for (AnnotationInstance ann : index.getAnnotations(annotation)) {
             if (ann.target() != null && ann.target().kind() == AnnotationTarget.Kind.CLASS) {
@@ -677,12 +746,16 @@ class BootUiQuarkusProcessor {
         return n;
     }
 
-    private static boolean isReactive(Type returnType) {
+    static boolean isReactive(Type returnType) {
         if (returnType == null) {
             return false;
         }
         String name = returnType.name().toString();
-        return name.equals("io.smallrye.mutiny.Uni") || name.equals("io.smallrye.mutiny.Multi");
+        return name.equals("io.smallrye.mutiny.Uni")
+                || name.equals("io.smallrye.mutiny.Multi")
+                || name.equals("java.util.concurrent.CompletionStage")
+                || name.equals("java.util.concurrent.CompletableFuture")
+                || name.equals("org.reactivestreams.Publisher");
     }
 
     /**

--- a/bootui-quarkus-deployment/src/test/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessorAppIdiomsTest.java
+++ b/bootui-quarkus-deployment/src/test/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessorAppIdiomsTest.java
@@ -1,0 +1,197 @@
+package io.github.jdubois.bootui.quarkus.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+/**
+ * Unit tests for the pure Jandex-index-processing helpers behind the Quarkus application advisor's
+ * build-time idiom counts: {@link BootUiQuarkusProcessor#isReactive(Type)} (QA-RX-001),
+ * {@link BootUiQuarkusProcessor#mutableFieldsOf(org.jboss.jandex.IndexView, DotName)} (QA-CDI-001/QA-CDI-003),
+ * {@link BootUiQuarkusProcessor#classAnnotations(org.jboss.jandex.IndexView, DotName)}, and
+ * {@link BootUiQuarkusProcessor#virtualThreadSitesOf(org.jboss.jandex.IndexView)} (QA-PERF-001/QA-PERF-002).
+ *
+ * <p>These build a real Jandex index from the small fixture classes below (compiled by Maven, indexed via
+ * {@link Indexer#indexClass(Class)}) so the assertions exercise the exact bytecode-level annotation/flag
+ * signals {@code registerAppIdioms} reads, rather than hand-rolled Jandex objects. The end-to-end wiring
+ * (build step → runtime config → engine snapshot) is covered by
+ * {@code BootUiQuarkusSpringResourceTest} in {@code bootui-quarkus-integration-tests}.
+ */
+class BootUiQuarkusProcessorAppIdiomsTest {
+
+    private static final DotName APPLICATION_SCOPED =
+            DotName.createSimple("jakarta.enterprise.context.ApplicationScoped");
+    private static final DotName SINGLETON = DotName.createSimple("jakarta.inject.Singleton");
+    private static final DotName RUN_ON_VIRTUAL_THREAD =
+            DotName.createSimple("io.smallrye.common.annotation.RunOnVirtualThread");
+
+    private static Index indexOf(Class<?>... classes) throws IOException {
+        Indexer indexer = new Indexer();
+        for (Class<?> c : classes) {
+            indexer.indexClass(c);
+        }
+        return indexer.complete();
+    }
+
+    // ---- isReactive (QA-RX-001) ----
+
+    @Test
+    void isReactiveRecognizesMutinyTypes() {
+        assertThat(BootUiQuarkusProcessor.isReactive(classType("io.smallrye.mutiny.Uni")))
+                .isTrue();
+        assertThat(BootUiQuarkusProcessor.isReactive(classType("io.smallrye.mutiny.Multi")))
+                .isTrue();
+    }
+
+    @Test
+    void isReactiveRecognizesJdkAndReactiveStreamsTypes() {
+        assertThat(BootUiQuarkusProcessor.isReactive(classType(CompletionStage.class.getName())))
+                .as("CompletionStage return types are reactive dispatch too")
+                .isTrue();
+        assertThat(BootUiQuarkusProcessor.isReactive(classType(CompletableFuture.class.getName())))
+                .isTrue();
+        assertThat(BootUiQuarkusProcessor.isReactive(classType(Publisher.class.getName())))
+                .isTrue();
+    }
+
+    @Test
+    void isReactiveRejectsNonReactiveTypesAndNull() {
+        assertThat(BootUiQuarkusProcessor.isReactive(classType("java.lang.String")))
+                .isFalse();
+        assertThat(BootUiQuarkusProcessor.isReactive(null)).isFalse();
+    }
+
+    private static Type classType(String fqcn) {
+        return Type.create(DotName.createSimple(fqcn), Type.Kind.CLASS);
+    }
+
+    // ---- mutableFieldsOf (QA-CDI-001 / QA-CDI-003) ----
+
+    @Test
+    void mutableFieldsOfFlagsPublicAndPrivateMutableFieldsButExcludesStaticAndInjected() throws IOException {
+        Index index = indexOf(MutableAppScopedBean.class);
+
+        assertThat(BootUiQuarkusProcessor.mutableFieldsOf(index, APPLICATION_SCOPED))
+                .containsExactlyInAnyOrder(
+                        "MutableAppScopedBean.publicMutableField",
+                        "MutableAppScopedBean.publicFinalField",
+                        "MutableAppScopedBean.privateMutableField")
+                .as("static fields, @Inject fields, and @ConfigProperty fields are never a shared-state risk")
+                .doesNotContain(
+                        "MutableAppScopedBean.staticField",
+                        "MutableAppScopedBean.injectedField",
+                        "MutableAppScopedBean.configPropertyField");
+    }
+
+    @Test
+    void mutableFieldsOfCoversSingletonScopeForQaCdi003() throws IOException {
+        Index index = indexOf(MutableSingletonBean.class);
+
+        assertThat(BootUiQuarkusProcessor.mutableFieldsOf(index, SINGLETON))
+                .containsExactly("MutableSingletonBean.publicMutableField");
+    }
+
+    @Test
+    void mutableFieldsOfIgnoresClassesWithoutTheRequestedScopeAnnotation() throws IOException {
+        Index index = indexOf(PlainBean.class);
+
+        assertThat(BootUiQuarkusProcessor.mutableFieldsOf(index, APPLICATION_SCOPED))
+                .isEmpty();
+        assertThat(BootUiQuarkusProcessor.mutableFieldsOf(index, SINGLETON)).isEmpty();
+    }
+
+    // ---- classAnnotations / virtualThreadSitesOf (QA-PERF-001 / QA-PERF-002) ----
+
+    @Test
+    void classAnnotationsCountsOnlyClassLevelTargetsNotMethodLevel() throws IOException {
+        Index index = indexOf(ClassLevelVirtualThreadBean.class, MethodLevelVirtualThreadBean.class);
+
+        assertThat(BootUiQuarkusProcessor.classAnnotations(index, RUN_ON_VIRTUAL_THREAD))
+                .as("the two method-level @RunOnVirtualThread sites on MethodLevelVirtualThreadBean must not count")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void virtualThreadSitesOfCountsClassLevelAsOneSiteButScansAllItsMethodsForSynchronized() throws IOException {
+        Index index = indexOf(ClassLevelVirtualThreadBean.class);
+
+        BootUiQuarkusProcessor.VirtualThreadCounts counts = BootUiQuarkusProcessor.virtualThreadSitesOf(index);
+
+        assertThat(counts.sites()).isEqualTo(1);
+        assertThat(counts.synchronizedSites())
+                .as("the class-level annotation makes synchronizedMethod run on a virtual thread too")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void virtualThreadSitesOfCountsEachMethodLevelSiteIndividually() throws IOException {
+        Index index = indexOf(MethodLevelVirtualThreadBean.class);
+
+        BootUiQuarkusProcessor.VirtualThreadCounts counts = BootUiQuarkusProcessor.virtualThreadSitesOf(index);
+
+        assertThat(counts.sites()).isEqualTo(2);
+        assertThat(counts.synchronizedSites()).isEqualTo(1);
+    }
+
+    @Test
+    void virtualThreadSitesOfCombinesClassAndMethodLevelSites() throws IOException {
+        Index index = indexOf(ClassLevelVirtualThreadBean.class, MethodLevelVirtualThreadBean.class);
+
+        BootUiQuarkusProcessor.VirtualThreadCounts counts = BootUiQuarkusProcessor.virtualThreadSitesOf(index);
+
+        assertThat(counts.sites()).isEqualTo(3);
+        assertThat(counts.synchronizedSites()).isEqualTo(2);
+    }
+
+    // ---- Fixtures ----
+
+    @ApplicationScoped
+    static class MutableAppScopedBean {
+        public int publicMutableField;
+        public final int publicFinalField = 1;
+        private int privateMutableField;
+        private static int staticField;
+
+        @Inject
+        public String injectedField;
+
+        @ConfigProperty(name = "some.prop")
+        String configPropertyField;
+    }
+
+    @Singleton
+    static class MutableSingletonBean {
+        public String publicMutableField;
+    }
+
+    static class PlainBean {
+        public String publicMutableField;
+    }
+
+    @io.smallrye.common.annotation.RunOnVirtualThread
+    static class ClassLevelVirtualThreadBean {
+        void plainMethod() {}
+
+        synchronized void synchronizedMethod() {}
+    }
+
+    static class MethodLevelVirtualThreadBean {
+        @io.smallrye.common.annotation.RunOnVirtualThread
+        void annotatedMethod() {}
+
+        @io.smallrye.common.annotation.RunOnVirtualThread
+        synchronized void annotatedSynchronizedMethod() {}
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/quarkusapp/QuarkusAppSnapshotProviderImpl.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/quarkusapp/QuarkusAppSnapshotProviderImpl.java
@@ -22,6 +22,7 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
     static final String REQUEST_SCOPED_KEY = "bootui.internal.app.request-scoped";
     static final String DEPENDENT_KEY = "bootui.internal.app.dependent";
     static final String MUTABLE_FIELDS_KEY = "bootui.internal.app.mutable-fields";
+    static final String MUTABLE_SINGLETON_FIELDS_KEY = "bootui.internal.app.mutable-singleton-fields";
     static final String CONFIG_PROPERTY_KEY = "bootui.internal.app.config-property";
     static final String ENDPOINTS_KEY = "bootui.internal.app.endpoints";
     static final String DEFAULT_SCOPE_RESOURCES_KEY = "bootui.internal.app.default-scope-resources";
@@ -36,6 +37,13 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
     static final String VIRTUAL_THREAD_ENDPOINTS_KEY = "bootui.internal.app.virtual-thread-endpoints";
     static final String VIRTUAL_THREAD_SYNCHRONIZED_KEY = "bootui.internal.app.virtual-thread-synchronized";
     static final String JDK_MAJOR_VERSION_KEY = "bootui.internal.app.jdk-major-version";
+
+    /**
+     * A REST client connect/read timeout at or above this bound (5 minutes) is treated as "excessive" for
+     * QA-WEB-003 — long enough that it provides essentially no protection against a hanging remote call,
+     * even though it is technically a finite value rather than the more obviously dangerous {@code 0}.
+     */
+    private static final long EXCESSIVE_REST_CLIENT_TIMEOUT_MS = 300_000L;
 
     private final Config config;
 
@@ -84,10 +92,14 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
                 bool("quarkus.http.enable-compression"),
                 shutdownTimeoutZeroed(),
                 count(REST_CLIENTS_KEY) > 0,
-                restClientTimeoutConfigured(),
+                restClientTimeoutZeroOrExcessive(),
                 count(VIRTUAL_THREAD_ENDPOINTS_KEY),
                 count(VIRTUAL_THREAD_SYNCHRONIZED_KEY),
-                count(JDK_MAJOR_VERSION_KEY));
+                count(JDK_MAJOR_VERSION_KEY),
+                strList(MUTABLE_SINGLETON_FIELDS_KEY),
+                legacySchemaGenerationPropertyUsed(),
+                shutdownTimeoutConfigured(),
+                datasourceMaxSizeConfigured());
     }
 
     private boolean prodLogLevelVerbose() {
@@ -99,15 +111,28 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
         return isZero("quarkus.shutdown.timeout") || isZero("quarkus.http.shutdown.timeout");
     }
 
+    private boolean shutdownTimeoutConfigured() {
+        return has("quarkus.shutdown.timeout") || has("quarkus.http.shutdown.timeout");
+    }
+
     private boolean isZero(String key) {
         return config.getOptionalValue(key, Duration.class).map(d -> d.isZero()).orElse(false);
     }
 
-    private boolean restClientTimeoutConfigured() {
+    /**
+     * QA-WEB-003: unlike the presence-only check this replaces, this only fires on an <em>explicit</em>
+     * footgun — a connect/read timeout set to {@code 0} (disabled) or an excessively high value. Quarkus REST
+     * clients already default to a 15s connect-timeout / 30s read-timeout ({@code RestClientsConfig}), so
+     * merely leaving the property unset is safe and intentionally not flagged.
+     */
+    private boolean restClientTimeoutZeroOrExcessive() {
         for (String name : config.getPropertyNames()) {
             if (name.startsWith("quarkus.rest-client")
                     && (name.endsWith("connect-timeout") || name.endsWith("read-timeout"))) {
-                return true;
+                Long ms = config.getOptionalValue(name, Long.class).orElse(null);
+                if (ms != null && (ms == 0L || ms > EXCESSIVE_REST_CLIENT_TIMEOUT_MS)) {
+                    return true;
+                }
             }
         }
         return false;
@@ -135,6 +160,26 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
                 || url.contains("h2:mem")
                 || url.contains("hsqldb:mem")
                 || url.contains("derby:memory");
+    }
+
+    /**
+     * QA-CFG-004: {@code quarkus.hibernate-orm.database.generation} is {@code @Deprecated(forRemoval = true)}
+     * as of Quarkus 3.22, in favour of {@code quarkus.hibernate-orm.schema-management.strategy}. Matches any
+     * profile (bare, {@code %prod.}/{@code %dev.}/…) or named-persistence-unit variant, since the property
+     * name — not just its {@code %prod} use — is what is being flagged as legacy.
+     */
+    private boolean legacySchemaGenerationPropertyUsed() {
+        for (String name : config.getPropertyNames()) {
+            if (name.endsWith("database.generation")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** QA-DB-001: the default (unnamed) datasource's own max pool size, checked bare or under {@code %prod}. */
+    private boolean datasourceMaxSizeConfigured() {
+        return has("quarkus.datasource.jdbc.max-size") || has("%prod.quarkus.datasource.jdbc.max-size");
     }
 
     private List<String> activeProfiles() {

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -345,7 +345,7 @@ contract, and the same report shape. The [Quarkus](#quarkus) section below cover
 On the Quarkus adapter the framework-application advisor above is relabelled **Quarkus** and runs a Quarkus-native idiom
 ruleset in place of the Spring rules. It takes the same explicit, read-only approach — evaluating a curated set of checks
 against the running application and its MicroProfile `Config` — but the rules target Quarkus idioms: CDI/Arc scopes and
-shared mutable state on `@ApplicationScoped` beans, build-time type-safe configuration (`@ConfigProperty` vs
+shared mutable state on `@ApplicationScoped`/`@Singleton` beans, build-time type-safe configuration (`@ConfigProperty` vs
 `@ConfigMapping`), reactive-versus-blocking endpoints, `@Scheduled` clustering, and production-profile hygiene
 (destructive Hibernate schema strategies, SQL logging). It is the **same panel and menu slot** as the Spring advisor —
 the same `/spring` route, `/bootui/api/spring` endpoint, and report contract — so the shared UI simply renders the

--- a/docs/QUARKUS-ADVISOR-CHECKS.md
+++ b/docs/QUARKUS-ADVISOR-CHECKS.md
@@ -3,13 +3,15 @@
 The Spring advisor panel, on Quarkus, runs a fixed, on-demand ruleset against the host application's
 **Quarkus idioms** — not the Spring application context. It reads build-time counts of CDI scope
 annotations, `@ConfigProperty` injection sites, `@ConfigMapping` interfaces, JAX-RS endpoints, reactive
-(`Uni`/`Multi`) signatures, `@Blocking` sites, `@Scheduled` methods, `@RegisterRestClient` interfaces,
-`@RunOnVirtualThread`/`synchronized` combinations, the build JDK version, public mutable fields on JAX-RS
-resources, and shared mutable fields on `@ApplicationScoped` beans, plus active/`%prod.` profile keys
-(Hibernate schema strategy, datasource kind/URL, SQL logging, log level, Dev Services, clustered scheduler)
-and HTTP settings (response compression, graceful-shutdown timeout, REST client timeouts) from MicroProfile
-config. It never intercepts live traffic, exposes config values, or modifies the application. Findings are
-heuristic review prompts; the right remediation depends on the application.
+(`Uni`/`Multi`/`CompletionStage`/`CompletableFuture`/`Publisher`) signatures, `@Blocking`/`@Transactional`
+sites, `@Scheduled` methods, `@RegisterRestClient` interfaces, `@RunOnVirtualThread` (method- or class-level)
+/`synchronized` combinations, the build JDK version, public mutable fields on JAX-RS resources (excluding
+`@RequestScoped` ones), and shared mutable fields on `@ApplicationScoped` and `@Singleton` beans, plus
+active/`%prod.` profile keys (Hibernate schema strategy, the legacy `database.generation` property, datasource
+kind/URL/pool size, SQL logging, log level, Dev Services, clustered scheduler) and HTTP settings (response
+compression, graceful-shutdown timeout presence/value, REST client timeouts) from MicroProfile config. It
+never intercepts live traffic, exposes config values, or modifies the application. Findings are heuristic
+review prompts; the right remediation depends on the application.
 
 This is the Quarkus replacement for the Spring ruleset in [SPRING-CHECKS.md](SPRING-CHECKS.md): the panel
 and DTO are shared, but the rules are framework-specific (CDI/Arc, MicroProfile Config vs Spring beans), so
@@ -24,6 +26,7 @@ in dev/test only (skipped in `NORMAL`/production); profile keys are read live. M
 
 ## Severity scale
 
+- **CRITICAL** - active data-loss or destructive-in-production risk; fix immediately.
 - **HIGH** - likely to cause production trouble; fix before shipping.
 - **MEDIUM** - common concurrency or hygiene risk.
 - **LOW** - hygiene/maintainability prompt.
@@ -39,9 +42,15 @@ bean.
 
 ### QA-CDI-002 - Public mutable field on a JAX-RS resource (MEDIUM)
 JAX-RS resources default to `@Singleton`, so a public non-final (non-static) field is process-wide shared
-mutable state accessed concurrently across requests. Make the field `private final`, inject it, or move
-per-request state to a `@RequestScoped` bean. (Private fields set in `@PostConstruct`, e.g. injected
-Micrometer meters, are not flagged.)
+mutable state accessed concurrently across requests. A resource explicitly annotated `@RequestScoped` gets a
+fresh instance per request and carries no shared-state risk, so it is excluded from this scan. Make the field
+`private final`, inject it, or move per-request state to a `@RequestScoped` bean. (Private fields set in
+`@PostConstruct`, e.g. injected Micrometer meters, are not flagged.)
+
+### QA-CDI-003 - Shared mutable state on a @Singleton bean (MEDIUM)
+`@Singleton` beans are a single instance shared across threads, exactly like `@ApplicationScoped` — the same
+unsynchronised-shared-state risk applies to public or non-final fields (other than injected dependencies).
+Make fields `private final`, or move per-request state to a `@RequestScoped` bean.
 
 ## Config
 
@@ -59,15 +68,25 @@ risking sensitive data in logs. Disable SQL logging in `%prod`; enable it only i
 hurts performance and risks leaking sensitive data into logs. Set `%prod.quarkus.log.level` to `INFO` or
 `WARN`; use `DEBUG`/`TRACE` only in `%dev`.
 
+### QA-CFG-004 - Legacy Hibernate schema-generation property in use (LOW)
+`quarkus.hibernate-orm.database.generation` (or a `%profile`/named-persistence-unit variant) is deprecated
+for removal in favour of `quarkus.hibernate-orm.schema-management.strategy`; it still works today but may be
+removed in a future Quarkus release. Migrate to `quarkus.hibernate-orm.schema-management.strategy` (it
+accepts the same values: `none`/`create`/`drop-and-create`/`drop`/`update`/`validate`).
+
 ## Reactive
 
-### QA-RX-001 - Reactive endpoints with a blocking JDBC datasource (INFO)
-One or more endpoints return `Uni`/`Multi` (run on the I/O event loop), and neither the method nor its
-declaring resource class carries a `@Blocking` guard, while a blocking JDBC datasource is configured; a
-JDBC call on the event loop stalls it. Annotate blocking work with `@Blocking`, or use a reactive datasource
-client. (Only raised when a JDBC datasource is present, so fully-reactive apps are not flagged. The check is
-correlated per endpoint — an unrelated `@Blocking` method elsewhere in the app does not suppress a finding on
-a genuinely unguarded reactive endpoint.)
+### QA-RX-001 - Reactive endpoints with a blocking JDBC datasource (HIGH)
+One or more endpoints return `Uni`/`Multi`/`CompletionStage`/`CompletableFuture`/`Publisher` (run on the I/O
+event loop), and neither the method nor its declaring resource class carries a `@Blocking` or `@Transactional`
+guard (Quarkus REST dispatches a `@Transactional` method to a worker thread just like `@Blocking` — see the
+[REST execution-model docs](https://quarkus.io/version/3.33/guides/rest#execution-model-blocking-non-blocking)),
+while a blocking JDBC datasource is configured; a JDBC call on the event loop stalls it and throws
+`BlockingOperationNotAllowedException` at runtime. This is one of the most common and severe Quarkus
+production footguns, hence HIGH rather than an informational note. Annotate blocking work with `@Blocking`
+(or make the method `@Transactional`), or use a reactive datasource client. (Only raised when a JDBC
+datasource is present, so fully-reactive apps are not flagged. The check is correlated per endpoint — an
+unrelated guard elsewhere in the app does not suppress a finding on a genuinely unguarded reactive endpoint.)
 
 ## Scheduling
 
@@ -78,29 +97,49 @@ causing duplicate work in a scaled-out deployment. Use the Quartz extension with
 
 ## Profiles
 
-### QA-PROD-001 - Dev Services enabled in the prod profile (HIGH)
-A `%prod.*devservices.enabled=true` key would start throwaway containers in production. Remove the `%prod`
-Dev Services override; configure a real datasource/broker for prod.
+### QA-PROD-001 - Dev Services override present in the prod profile (LOW)
+A `%prod.*devservices.enabled=true` key is set. Dev Services is a build-time/augmentation-only mechanism —
+per the [Dev Services guide](https://quarkus.io/guides/dev-services), it starts containers during
+`quarkus:dev`/`quarkus:test`/augmentation only, and never runs in a `LaunchMode.NORMAL` packaged JAR or
+native executable regardless of this property's value. So the override has no effect in production; its
+presence is a config-hygiene signal (leftover or copy-pasted config) rather than an active production risk,
+hence LOW rather than HIGH. Remove the unused `%prod` Dev Services override to avoid confusing readers of the
+config.
 
-### QA-PROD-002 - Destructive Hibernate schema strategy in the prod profile (HIGH)
+### QA-PROD-002 - Destructive Hibernate schema strategy in the prod profile (CRITICAL or HIGH)
 A `%prod` Hibernate schema strategy of `drop-and-create`/`create`/`drop` rebuilds or drops the production
-schema on every boot, destroying data. Use `none` (or `validate`) in `%prod` and manage the schema with
-Flyway/Liquibase.
+schema on every boot, destroying data — **CRITICAL**, matching the sibling Hibernate advisor's
+[`HIB-CONFIG-002`](HIBERNATE-CHECKS.md). A strategy of `update` is a distinct, slightly lower risk: Hibernate
+silently alters the schema in place (adding/changing columns or tables to match the entity model) instead of
+destroying data outright, which can still lock tables or apply an unreviewed structural change directly to
+production — **HIGH**. Use `none` (or `validate`) in `%prod` and manage the schema with Flyway/Liquibase.
 
 ### QA-PROD-003 - In-memory/dev datasource in the prod profile (MEDIUM)
 The `%prod` datasource targets an in-memory/embedded database (H2/HSQLDB/Derby) — by `db-kind` or a
 `jdbc:*:mem:`/`:memory:` URL — so production data is lost on restart and never shared across instances.
 Point `%prod` at a real managed database (PostgreSQL, MySQL, …).
 
-### QA-PROF-001 - No profile configuration (INFO)
-No active profile and no `%prod.` overrides were found. This is fine when production config is externalised
-(env vars, Secrets/ConfigMaps); otherwise prod shares dev defaults. Add `%prod.` overrides (or externalise
-config) so production differs from dev defaults.
+### QA-PROF-001 - No prod-specific configuration overrides (INFO)
+No `%prod.` overrides were found anywhere in config. (Rebased from active-profile emptiness: Quarkus's
+`SmallRyeConfig.getProfiles()` almost always resolves to a live profile — dev/test/prod — when read from a
+running app, so an "active profile is empty" condition rarely fires in practice; absence of any `%prod.`
+override key is the signal this rule actually intends to catch.) This is fine when production config is
+externalised (env vars, Secrets/ConfigMaps); otherwise prod shares dev defaults for every setting. Add
+`%prod.` overrides (or externalise config) so production differs from dev defaults.
+
+## Database
+
+### QA-DB-001 - JDBC datasource without an explicit pool size (LOW)
+A JDBC datasource is configured, but `quarkus.datasource.jdbc.max-size` is never set. Agroal (Quarkus's
+connection pool) defaults to a max pool size of 50. Under high concurrency — especially with virtual threads
+increasing request parallelism — the default pool can become a bottleneck or exhaust the database's own
+connection limit. Set `quarkus.datasource.jdbc.max-size` (with a `%prod` override if it should differ from
+dev) to a value sized for the target database and expected concurrency.
 
 ## Web
 
 ### QA-WEB-001 - HTTP response compression disabled (INFO)
-`quarkus.http.enable-compression` is not set (Quarkus's own default), so responses are not gzip/brotli
+`quarkus.http.enable-compression` is not set (Quarkus's own default), so responses are not gzip/deflate
 -compressed, increasing bandwidth and latency for text-heavy payloads. Set
 `quarkus.http.enable-compression=true` (tune `quarkus.http.compress-media-types` if needed).
 
@@ -109,22 +148,36 @@ config) so production differs from dev defaults.
 graceful-shutdown grace period; in-flight requests are dropped instead of being allowed to complete on
 `SIGTERM`. Remove the override (or set a positive duration) so in-flight requests can drain before shutdown.
 
-### QA-WEB-003 - REST client without a connect/read timeout (MEDIUM)
-A `@RegisterRestClient` interface is declared, but no connect-timeout/read-timeout is configured anywhere.
-Unlike many HTTP client libraries, Quarkus REST clients have no default timeout, so a slow/hanging remote
-service can block a caller indefinitely. Set `quarkus.rest-client."<client-key>".connect-timeout` /
-`read-timeout`, or the global `quarkus.rest-client.connect-timeout` / `read-timeout`.
+### QA-WEB-003 - REST client connect/read timeout disabled or excessive (MEDIUM)
+A connect-timeout or read-timeout for a `@RegisterRestClient` interface is explicitly set to `0` (no timeout)
+or to an excessively high value (over 5 minutes). Quarkus REST clients already default to a 15s
+connect-timeout and 30s read-timeout (`quarkus.rest-client.connect-timeout` / `read-timeout` — see
+[`RestClientsConfig`](https://github.com/quarkusio/quarkus/blob/main/extensions/resteasy-classic/rest-client-config/runtime/src/main/java/io/quarkus/restclient/config/RestClientsConfig.java)),
+so a slow/hanging remote service is normally bounded; this override removes that safety net. Remove the
+override to keep Quarkus's 15s/30s defaults, or set a specific, bounded timeout appropriate for the remote
+service.
+
+### QA-WEB-004 - Graceful shutdown timeout never configured (LOW)
+Neither `quarkus.shutdown.timeout` nor `quarkus.http.shutdown.timeout` is set anywhere. Quarkus's graceful
+shutdown is opt-in — with no timeout configured at all, the application exits immediately on `SIGTERM`
+instead of draining in-flight requests. This is a distinct, lower-severity case from QA-WEB-002 (which fires
+only when the timeout is explicitly disabled via `=0`); the two are mutually exclusive; see the
+[lifecycle guide](https://quarkus.io/guides/lifecycle#graceful-shutdown). Set `quarkus.shutdown.timeout` to a
+positive duration (e.g. `10s`) so in-flight requests can drain before shutdown.
 
 ## Performance
 
 ### QA-PERF-001 - No virtual-thread adoption (INFO)
-The app declares JAX-RS endpoint(s) but none use `@RunOnVirtualThread` (checked only from JDK 21, when
-virtual threads became stable/mainstream). If any endpoint performs blocking I/O (JDBC, file access,
-blocking REST calls), running it on a virtual thread can improve throughput without sizing a worker thread
-pool. Annotate blocking I/O-bound endpoint methods (or the resource class) with `@RunOnVirtualThread`.
+The app declares JAX-RS endpoint(s) but none use `@RunOnVirtualThread` at the method or class level (checked
+only from JDK 21, when virtual threads became stable/mainstream). If any endpoint performs blocking I/O
+(JDBC, file access, blocking REST calls), running it on a virtual thread can improve throughput without
+sizing a worker thread pool. Annotate blocking I/O-bound endpoint methods (or the resource class) with
+`@RunOnVirtualThread`.
 
 ### QA-PERF-002 - Virtual-thread pinning via synchronized (HIGH)
-**Quarkus/JDK-specific — no Spring equivalent.** One or more `@RunOnVirtualThread` methods are also declared
+**Quarkus/JDK-specific — no Spring equivalent.** One or more methods that run on a virtual thread — via a
+method-level `@RunOnVirtualThread`, or because their declaring class carries a class-level
+`@RunOnVirtualThread` (which makes every method in that class run on a virtual thread) — are also declared
 `synchronized`. On JDK 21-23, entering a `synchronized` method or block pins the carrier thread instead of
 yielding it, defeating the scalability benefit of virtual threads under load; [JEP
 491](https://openjdk.org/jeps/491) removes this pinning starting in JDK 24. Replace `synchronized` with a


### PR DESCRIPTION
## Summary

Fixes and additions to the Quarkus Application Advisor (`QA-*` rules), based on a 5-model research synthesis (claude-opus-4.8, gpt-5.5, gemini-3.1-pro-preview, gpt-5.3-codex, claude-sonnet-5). **Every finding was independently re-verified against live Quarkus 3.33 source** before implementation — not just taken on the research agents' word.

### 🔴 Headline fix: `QA-SCH-001` was 100% non-functional

The engine rule reads `scheduledCount()` from the `bootui.internal.app.scheduled` config key — but the build-time processor's `registerAppIdioms` build step **never emitted that key anywhere**. Every other `bootui.internal.app.*` key was wired (application-scoped, singleton, request-scoped, blocking, endpoints, virtual-thread counts, etc.) except this one, so the rule always evaluated `scheduledCount() == 0` and could never fire, no matter how many `@Scheduled` methods existed. Fixed by reusing the existing `@Scheduled` Jandex scan (`scanScheduledTasks`, already used by the Scheduled Tasks panel) to populate the count in the same build step.

### Other corrections

| Rule | Change |
|---|---|
| `QA-WEB-003` | Rationale was **factually wrong** — claimed Quarkus REST clients have no default timeout. Verified against `RestClientsConfig` source: they default to a **15s connect-timeout / 30s read-timeout**. Rule now only fires when a timeout is explicitly disabled (`0`) or excessive (>5m), not merely absent. Also fixed detection granularity issues from the presence-only check. |
| `QA-RX-001` | Severity raised **INFO → HIGH** (blocking the Vert.x event loop is one of the most common/severe Quarkus production footguns — throws `BlockingOperationNotAllowedException`). Now treats `@Transactional` as a guard alongside `@Blocking` (Quarkus REST dispatches both to a worker thread per the [execution-model docs](https://quarkus.io/version/3.33/guides/rest#execution-model-blocking-non-blocking)), and recognizes `CompletionStage`/`CompletableFuture`/`Publisher` return types in addition to `Uni`/`Multi`. |
| `QA-PROD-001` | Rationale was misleading — claimed an explicit `%prod` Dev Services override "would start throwaway containers in production." Dev Services is build-time/augmentation-only and **never runs in a packaged `LaunchMode.NORMAL` build**, regardless of this property. Corrected the text and lowered **HIGH → LOW** (config-hygiene signal, not an active risk). |
| `QA-PROD-002` | Now also flags `update` as a destructive schema strategy (previously only `drop-and-create`/`create`/`drop`). Severity split: **CRITICAL** for the outright-destructive strategies (aligned with the sibling Hibernate advisor's `HIB-CONFIG-002`), **HIGH** for `update` (silent in-place alteration). |
| `QA-CDI-002` | No longer false-positives on `@RequestScoped` JAX-RS resources — a fresh instance per request carries no shared-state risk. |
| `QA-PERF-001`/`002` | Now count **class-level** `@RunOnVirtualThread` in addition to method-level (docs already claimed "method or class" but the scan only checked methods); `QA-PERF-002`'s synchronized-pinning check now also scans every method of a class-level-annotated class. |
| `QA-PROF-001` | Rebased on absence of `%prod.` override keys instead of active-profile emptiness — `SmallRyeConfig.getProfiles()` almost always returns a live profile on a running app, making the old condition a near-dead signal in practice. |
| `QA-WEB-001` | Doc wording fixed: "gzip/brotli" → "gzip/deflate" (Quarkus/Vert.x's actual default compressors; Brotli isn't a built-in). |

### New rules (16 → 20 total)

- **`QA-CDI-003`** (MEDIUM) — shared mutable state on a `@Singleton` bean, the same risk `QA-CDI-001` already flags for `@ApplicationScoped`.
- **`QA-CFG-004`** (LOW) — the deprecated `quarkus.hibernate-orm.database.generation` property in use instead of `quarkus.hibernate-orm.schema-management.strategy`.
- **`QA-WEB-004`** (LOW) — graceful shutdown timeout never configured at all (distinct from `QA-WEB-002`'s "explicitly zeroed" case; Quarkus's graceful shutdown is opt-in).
- **`QA-DB-001`** (LOW) — a JDBC datasource with no explicit `quarkus.datasource.jdbc.max-size`, silently relying on Agroal's default pool size.
  - ⚠️ **Correction to the research input**: one of the 5 models claimed Agroal's default max pool size is 20. I verified this against Quarkus 3.33 source/docs myself and found the actual default is **50** — the doc and rule text use the correct value.

### Explicitly skipped

- **`QA-TX-001`** (`@Transactional` on a `private`/`static` method) — proposed by 1 of 5 models with sound rationale, but on inspection it **duplicates the existing `ARCH-SPRING-010` rule** in the Architecture advisor, which already covers this exact CDI-interceptor limitation (interceptor bindings don't apply to private/static/final methods). Not implemented to avoid a redundant finding across two panels.
- Lower-priority items from the research list not addressed in this pass (documented as known limitations, not regressions): `QA-CDI-001`'s constructor/`@PostConstruct`-write carve-out, and broadening `QA-CFG-002`/`QA-PROD-002`/`QA-PROD-003` to named datasources/persistence-units beyond the default one.
- Not implemented per the task's explicit "don't add" list: CORS rules, actuator/management endpoint exposure, Panache pagination/N+1, GraalVM reflection registration — all intentionally owned by sibling advisors or out of scope for this snapshot's architecture.

## Testing

- `./mvnw -Dmaven.repo.local=.m2 -B -ntp -pl bootui-core,bootui-engine,bootui-quarkus,bootui-quarkus-deployment,bootui-quarkus-integration-tests/base -am install` — **BUILD SUCCESS**, all reactor modules pass, including the `@QuarkusTest` conformance suite for the Quarkus app advisor (167 tests in `bootui-quarkus-integration-tests/base`, including `BootUiQuarkusSpringResourceTest` which boots the app and scans the advisor end-to-end).
- Added `BootUiQuarkusProcessorAppIdiomsTest` — a new build-step-level unit test (10 tests) exercising the Jandex-scan helper methods (`isReactive`, `mutableFieldsOf`, `classAnnotations`, `virtualThreadSitesOf`) directly against real compiled fixture classes via Jandex's `Indexer`, since no prior test in this codebase covered `@BuildStep` Jandex logic in isolation. Established this as a reusable pattern (extract pure `IndexView`-consuming logic to package-private static helpers + widen visibility for testability).
- Extended `QuarkusAppScannerTest` with positive/negative/edge-case coverage for every changed and new rule; `rulesEvaluatedMatchesTotalRuleCount()` now asserts 20.
- `./mvnw -B -ntp spotless:apply` — clean, no changes needed.
- `docs/QUARKUS-ADVISOR-CHECKS.md` fully rewritten to match final code/severities; `docs/FEATURES.md` and `CHANGELOG.md` updated.

## Process note

Per the task instructions: every specific factual claim above (timeout defaults, Agroal pool size, Dev Services execution model, deprecated property names, `@Transactional` dispatch behavior) was independently checked against Quarkus 3.33.2.1 source/docs before being implemented, not just trusted from the research synthesis. The one correction found during verification (Agroal default pool size) is called out above.