### PR TITLE
Fix Quarkus Security advisor: remove 2 dead-property rules, repurpose QS-AUTH-006, fix CORS wildcard/credentials logic, close quarkus.* secret-scan gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,32 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   explicit `quarkus.datasource.jdbc.max-size`, silently relying on Agroal's default pool size of 50). See
   [docs/QUARKUS-ADVISOR-CHECKS.md](docs/QUARKUS-ADVISOR-CHECKS.md) (#520).
 
+### Fixed
+
+- **Quarkus Security advisor: removed two dead-property rules, repurposed a third, and fixed several logic bugs**,
+  found via a 5-model research synthesis independently re-verified against live Quarkus/SmallRye 3.33 source (grew from
+  43 to 45 rules). `QS-AUTH-011` (JDBC bcrypt work-factor) and `QS-CORS-004` (unanchored CORS regex) were retired
+  outright: both checked config properties/behaviors that don't exist in current Quarkus (`BcryptPasswordKeyMapperConfig`
+  has no work-factor field at all, and the CORS regex full-match bypass from quarkus/quarkus#34718 was fixed in Quarkus
+  3.3.0). `QS-AUTH-006` was repurposed from a dead `allow-unsigned-tokens` check (that property never existed) into a
+  real finding for an unpinned JWT signature algorithm on a remote JWKS. `QS-GRAPHQL-001` was fixed to check the real
+  `quarkus.smallrye-graphql.field-visibility=no-introspection` mechanism instead of a non-existent
+  `introspection-enabled` property. `QS-CORS-001`/`002` no longer treat unset origins as equivalent to a wildcard
+  (Quarkus's `CORSFilter` actually restricts unset origins to same-origin-only, the opposite of the old wording) — the
+  unset case now gets its own correctly-worded `QS-CORS-005` (INFO). `QS-CORS-003`'s credentials-default modeling now
+  mirrors Quarkus's real `.orElse(originMatches)` behavior instead of assuming credentials are off when unset.
+  `QS-CFG-001` no longer blanket-excludes the entire `quarkus.*` namespace from secret scanning (it could never flag
+  `quarkus.datasource.password`, `quarkus.oidc.credentials.secret`, etc.). `QS-TLS-002`/`003` now also scan named TLS
+  registry buckets (`quarkus.tls.<name>.*`), not just the default bucket. `QS-MGMT-001` switched from resolved-value to
+  raw-key inspection for `quarkus.management.host`, since BootUI's Quarkus advisor only ever runs under dev/test
+  `LaunchMode`, where the resolved value could never observe Quarkus's real non-loopback prod default. `QS-AUTHZ-002`/
+  `004` now factor in HTTP-method-scoped permission policies (`quarkus.http.auth.permission.*.methods`) instead of
+  treating every policy as applying to all methods. `QS-MSG-001` now evaluates each messaging channel independently so
+  one channel's secure protocol can't mask another's insecure one. `QS-SESSION-003`'s wording now matches its `>= 8h`
+  trigger. Three new rules were added: `QS-OIDC-003` (public OIDC client without PKCE), `QS-DEV-003` (SmallRye Health UI
+  always-include), and `QS-MGMT-003` (management interface with no explicit prod-scoped host binding, complementing
+  `QS-MGMT-001`). See [docs/QUARKUS-CHECKS.md](docs/QUARKUS-CHECKS.md) for full details on every rule.
+
 ## [1.9.0] - 2026-07-03
 
 Feature release headlined by **optional durable JDBC persistence for Live Activity** on both adapters — the feed can

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityChecks.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 final class QuarkusSecurityChecks {
 
     private static final String VIOLATION = "VIOLATION";
-    private static final int RULE_COUNT = 43;
+    private static final int RULE_COUNT = 45;
     private static final String GUIDE = "https://quarkus.io/guides/security-overview";
     private static final Pattern MAX_AGE = Pattern.compile("max-age\\s*=\\s*(\\d+)");
     private static final long HSTS_MIN_MAX_AGE = 31536000L;
@@ -90,18 +90,20 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.auth.proactive=false"),
                     "Confirm this is intentional; enable quarkus.security.jaxrs.deny-unannotated-endpoints."));
         }
-        if (s.jwtAllowUnsignedTokens()) {
+        if (s.jwtAlgorithmUnpinnedForRemoteJwks()) {
             v.add(rule(
                     "QS-AUTH-006",
-                    "JWT unsigned tokens allowed",
+                    "JWT signature algorithm not pinned for a remote JWKS",
                     "Authentication",
-                    "CRITICAL",
-                    "quarkus.smallrye-jwt.allow-unsigned-tokens=true accepts JWTs with alg=none, meaning anyone"
-                            + " can forge a token with an arbitrary payload and no signature at all.",
+                    "MEDIUM",
+                    "mp.jwt.verify.publickey.location points at a remote (http/https) JWKS endpoint but"
+                            + " mp.jwt.verify.publickey.algorithm is left unset, relying on SmallRye JWT's"
+                            + " implicit RS256-only default instead of explicitly pinning the expected"
+                            + " algorithm(s) for a key source that can rotate/change independently of this"
+                            + " application.",
                     1,
-                    List.of("quarkus.smallrye-jwt.allow-unsigned-tokens=true"),
-                    "Remove the override; only allow unsigned tokens in a throwaway local dev profile, never"
-                            + " in any deployed environment."));
+                    List.of("mp.jwt.verify.publickey.location=http(s)://…, mp.jwt.verify.publickey.algorithm absent"),
+                    "Set mp.jwt.verify.publickey.algorithm explicitly to the algorithm(s) this application expects."));
         }
         if (s.embeddedUsersEnabled()) {
             v.add(rule(
@@ -152,18 +154,6 @@ final class QuarkusSecurityChecks {
                     List.of("principal-query *.clear-password-mapper.enabled=true"),
                     "Switch to bcrypt-password-mapper (or another hashing mapper) and re-hash stored passwords."));
         }
-        if (s.jdbcBcryptWorkFactorLow()) {
-            v.add(rule(
-                    "QS-AUTH-011",
-                    "JDBC identity store bcrypt work-factor too low",
-                    "Authentication",
-                    "MEDIUM",
-                    "A quarkus-elytron-security-jdbc principal-query's bcrypt-password-mapper work-factor is set"
-                            + " below the default (10), weakening resistance to offline brute-force attacks.",
-                    1,
-                    List.of("principal-query *.bcrypt-password-mapper.work-factor < 10"),
-                    "Remove the override, or raise it to at least the default of 10."));
-        }
         if (s.permissions().isEmpty() && s.annotationCount() == 0 && s.anyAuthMechanism()) {
             v.add(rule(
                     "QS-AUTHZ-001",
@@ -177,7 +167,7 @@ final class QuarkusSecurityChecks {
         }
         List<String> permitAll = new ArrayList<>();
         for (QuarkusSecurityPermission p : s.permissions()) {
-            if ("permit".equalsIgnoreCase(p.policy()) && isBroadPath(p.paths())) {
+            if ("permit".equalsIgnoreCase(p.policy()) && isBroadPath(p.paths()) && appliesToAllMethods(p.methods())) {
                 permitAll.add(p.name() + " (" + (p.paths() == null ? "/*" : p.paths()) + ")");
             }
         }
@@ -253,15 +243,17 @@ final class QuarkusSecurityChecks {
                     "Outbound TLS certificate validation disabled",
                     "Transport",
                     "HIGH",
-                    "quarkus.tls.trust-all=true disables certificate validation for all outbound TLS (REST clients,"
-                            + " OIDC, datasources), enabling man-in-the-middle attacks.",
+                    "trust-all=true is set on the default TLS registry bucket or a named bucket"
+                            + " (quarkus.tls.<name>.trust-all), disabling certificate validation for outbound"
+                            + " TLS (REST clients, OIDC, datasources, gRPC), enabling man-in-the-middle attacks.",
                     1,
-                    List.of("quarkus.tls.trust-all=true"),
+                    List.of("quarkus.tls.trust-all=true (default or a named bucket)"),
                     "Remove trust-all; import the peer's CA into a trust-store instead."));
         }
-        boolean wildcardCors =
-                s.corsEnabled() && (s.corsOrigins() == null || s.corsOrigins().contains("*"));
-        if (wildcardCors && s.corsCredentials()) {
+        boolean explicitWildcardCors = s.corsEnabled() && isExplicitWildcardOrigin(s.corsOrigins());
+        boolean unsetOriginsCors =
+                s.corsEnabled() && (s.corsOrigins() == null || s.corsOrigins().isBlank());
+        if (explicitWildcardCors && s.corsCredentials()) {
             v.add(rule(
                     "QS-CORS-002",
                     "CORS wildcard origin with credentials",
@@ -269,22 +261,39 @@ final class QuarkusSecurityChecks {
                     "CRITICAL",
                     "Credentialed cross-origin requests are allowed from any origin.",
                     1,
-                    List.of("quarkus.http.cors.origins=* with allow-credentials=true"),
+                    List.of("quarkus.http.cors.origins=" + s.corsOrigins() + " with allow-credentials=true"),
                     "Pin explicit origins; never combine wildcard with credentials."));
-        } else if (wildcardCors) {
+        } else if (explicitWildcardCors) {
             v.add(rule(
                     "QS-CORS-001",
                     "CORS allows any origin",
                     "CORS",
                     "MEDIUM",
-                    "CORS is enabled without pinned origins, allowing any site to call the API.",
+                    "CORS is enabled with an explicit wildcard origin (* or /.*/), allowing any site to call"
+                            + " the API.",
                     1,
-                    List.of("quarkus.http.cors.origins unset or *"),
+                    List.of("quarkus.http.cors.origins=" + s.corsOrigins()),
                     "Set quarkus.http.cors.origins to explicit origins."));
+        }
+        if (unsetOriginsCors) {
+            v.add(rule(
+                    "QS-CORS-005",
+                    "CORS enabled with no origins configured",
+                    "CORS",
+                    "INFO",
+                    "quarkus.http.cors is enabled but quarkus.http.cors.origins is unset. Quarkus's CORSFilter"
+                            + " then only permits same-origin requests (the most restrictive possible outcome),"
+                            + " so the filter is effectively inert until origins are configured.",
+                    1,
+                    List.of("quarkus.http.cors=true, quarkus.http.cors.origins unset"),
+                    "If cross-origin access is intended, configure quarkus.http.cors.origins explicitly;"
+                            + " otherwise this has no practical effect."));
         }
         if (s.corsEnabled()
                 && s.corsCredentials()
-                && !wildcardCors
+                && s.corsOrigins() != null
+                && !s.corsOrigins().isBlank()
+                && !explicitWildcardCors
                 && (wildcard(s.corsMethods()) || wildcard(s.corsHeaders()))) {
             v.add(rule(
                     "QS-CORS-003",
@@ -296,20 +305,6 @@ final class QuarkusSecurityChecks {
                     1,
                     List.of("cors.access-control-allow-credentials=true with cors.methods/headers=*"),
                     "List the exact methods and headers the client needs instead of *."));
-        }
-        List<String> unanchoredCorsRegexes = unanchoredCorsRegexOrigins(s);
-        if (!unanchoredCorsRegexes.isEmpty()) {
-            v.add(rule(
-                    "QS-CORS-004",
-                    "CORS regex origin pattern not anchored",
-                    "CORS",
-                    "MEDIUM",
-                    "A quarkus.http.cors.origins entry uses the /regex/ syntax without ^/$ anchors. Quarkus"
-                            + " matches the pattern anywhere in the origin string, so e.g. /example\\.com/ also"
-                            + " matches \"evil-example.com.attacker.net\" (quarkusio/quarkus#34718).",
-                    unanchoredCorsRegexes.size(),
-                    unanchoredCorsRegexes,
-                    "Anchor the pattern with ^ and $, e.g. /^https:\\/\\/(?:[a-z0-9-]+\\.)*example\\.com$/."));
         }
         if (s.hstsHeader() && isWeakHsts(s.hstsHeaderValue())) {
             v.add(rule(
@@ -447,6 +442,20 @@ final class QuarkusSecurityChecks {
                     alwaysIncluded,
                     "Restrict to dev, or remove always-include."));
         }
+        if (s.healthUiAlwaysInclude()) {
+            v.add(rule(
+                    "QS-DEV-003",
+                    "SmallRye Health UI always included",
+                    "Dev exposure",
+                    "LOW",
+                    "quarkus.smallrye-health.ui.always-include=true exposes the Health UI in every profile,"
+                            + " including production, revealing the app's health-check topology to anyone who"
+                            + " can reach it.",
+                    1,
+                    List.of("quarkus.smallrye-health.ui.always-include=true"),
+                    "Remove the override so the Health UI is only available outside production, or protect it"
+                            + " via the management interface / a permission policy."));
+        }
         if (s.oidcConfigured() && !s.oidcAudienceConfigured()) {
             v.add(rule(
                     "QS-OIDC-001",
@@ -472,6 +481,20 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.oidc.application-type=" + s.oidcApplicationType()
                             + ", cookie-force-secure=false, no TLS"),
                     "Set quarkus.oidc.authentication.cookie-force-secure=true (required behind a TLS proxy)."));
+        }
+        if (oidcWebApp && !s.oidcHasClientSecret() && !s.oidcPkceRequired()) {
+            v.add(rule(
+                    "QS-OIDC-003",
+                    "Public OIDC client without PKCE",
+                    "OIDC",
+                    "MEDIUM",
+                    "An OIDC web-app/hybrid client has no client secret configured (a public client, e.g. an SPA"
+                            + " or mobile app) and quarkus.oidc.authentication.pkce-required is not enabled,"
+                            + " leaving the authorization-code flow vulnerable to interception.",
+                    1,
+                    List.of("quarkus.oidc.application-type=" + s.oidcApplicationType()
+                            + ", no client secret, pkce-required=false"),
+                    "Set quarkus.oidc.authentication.pkce-required=true for public clients."));
         }
         if (s.managementEnabled() && s.managementHostNonLoopback()) {
             v.add(rule(
@@ -500,6 +523,21 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.non-application-root-path=/"),
                     "Leave non-application-root-path at its default (/q), or use the separate management"
                             + " interface (quarkus.management.enabled=true) instead."));
+        }
+        if (s.managementEnabled() && s.managementHostUnpinnedForProd()) {
+            v.add(rule(
+                    "QS-MGMT-003",
+                    "Management interface has no explicit prod-scoped host binding",
+                    "Management",
+                    "INFO",
+                    "The separate management interface is enabled but neither quarkus.management.host nor a"
+                            + " %prod-scoped override is configured, so Quarkus's own built-in profile-dependent"
+                            + " default silently applies: localhost in dev/test, but 0.0.0.0 (all interfaces) in"
+                            + " a real production deployment.",
+                    1,
+                    List.of("quarkus.management.enabled=true, quarkus.management.host /"
+                            + " %prod.quarkus.management.host absent"),
+                    "Explicitly pin %prod.quarkus.management.host to 127.0.0.1, or to the intended bind address."));
         }
         if (!s.suspectedSecretKeys().isEmpty()) {
             v.add(rule(
@@ -542,10 +580,10 @@ final class QuarkusSecurityChecks {
                     "Excessive form-auth session timeout",
                     "Session",
                     "LOW",
-                    "quarkus.http.auth.form.timeout is set above 8 hours, keeping an authenticated session alive"
-                            + " long after a user has stepped away.",
+                    "quarkus.http.auth.form.timeout is set to 8 hours or more, keeping an authenticated session"
+                            + " alive long after a user has stepped away.",
                     1,
-                    List.of("quarkus.http.auth.form.timeout > 8h"),
+                    List.of("quarkus.http.auth.form.timeout >= 8h"),
                     "Lower the timeout (the Quarkus default is 30 minutes) and pair it with new-cookie-interval."));
         }
         if (s.grpcReflectionEnabledInProd()) {
@@ -568,28 +606,32 @@ final class QuarkusSecurityChecks {
                     "GraphQL schema introspection enabled",
                     "GraphQL",
                     "LOW",
-                    "quarkus.smallrye-graphql.introspection-enabled defaults to true in every profile, including"
+                    "GraphQL schema introspection is enabled (the Quarkus default) in every profile, including"
                             + " production, letting any client enumerate the full schema (types, fields,"
                             + " mutations). Often intentional for public APIs, but worth a deliberate decision."
                             + " No Spring equivalent — Spring has no first-party GraphQL server support.",
                     1,
-                    List.of("quarkus.smallrye-graphql.introspection-enabled=true (the Quarkus default)"),
-                    "Set quarkus.smallrye-graphql.introspection-enabled=false in %prod unless the schema is"
-                            + " meant to be publicly discoverable."));
+                    List.of("quarkus.smallrye-graphql.field-visibility does not include no-introspection (the"
+                            + " Quarkus default)"),
+                    "Add no-introspection to quarkus.smallrye-graphql.field-visibility in %prod unless the"
+                            + " schema is meant to be publicly discoverable."));
         }
-        if (s.messagingCredentialsWithoutTls()) {
+        if (!s.insecureMessagingChannels().isEmpty()) {
             v.add(rule(
                     "QS-MSG-001",
                     "Messaging credentials configured without an encrypted protocol",
                     "Messaging",
                     "HIGH",
                     "A Kafka/SmallRye Reactive Messaging channel configures SASL credentials (username/password"
-                            + " or JAAS config) without a corresponding SASL_SSL/SSL security.protocol, sending"
-                            + " broker credentials in clear text over the wire. No Spring equivalent in the same"
-                            + " idiomatic reactive-messaging form.",
-                    1,
-                    List.of("*.sasl.password/*.sasl.jaas.config set, *.security.protocol not SASL_SSL/SSL"),
-                    "Set security.protocol=SASL_SSL (or SSL) alongside the SASL credentials."));
+                            + " or JAAS config) without a corresponding SASL_SSL/SSL security.protocol (its own,"
+                            + " or a global fallback), sending broker credentials in clear text over the wire."
+                            + " Each channel is evaluated independently so one channel's secure protocol can't"
+                            + " mask another channel's insecure one. No Spring equivalent in the same idiomatic"
+                            + " reactive-messaging form.",
+                    s.insecureMessagingChannels().size(),
+                    s.insecureMessagingChannels(),
+                    "Set security.protocol=SASL_SSL (or SSL) for each affected channel (or globally via"
+                            + " kafka.security.protocol)."));
         }
         return v;
     }
@@ -609,11 +651,16 @@ final class QuarkusSecurityChecks {
 
     private static boolean hasBroadProtectivePolicy(List<QuarkusSecurityPermission> perms) {
         for (QuarkusSecurityPermission p : perms) {
-            if (!"permit".equalsIgnoreCase(p.policy()) && isBroadPath(p.paths())) {
+            if (!"permit".equalsIgnoreCase(p.policy()) && isBroadPath(p.paths()) && appliesToAllMethods(p.methods())) {
                 return true;
             }
         }
         return false;
+    }
+
+    /** A permission with no {@code methods} restriction applies to every HTTP method (Quarkus semantics). */
+    private static boolean appliesToAllMethods(String methods) {
+        return methods == null || methods.isBlank();
     }
 
     private static boolean wildcard(String csv) {
@@ -621,26 +668,21 @@ final class QuarkusSecurityChecks {
     }
 
     /**
-     * Finds {@code /regex/}-syntax CORS origin entries that are not anchored with {@code ^}/{@code $}. Quarkus
-     * matches such a pattern anywhere in the origin string rather than against the whole string, so e.g.
-     * {@code /example\.com/} also matches {@code https://evil-example.com.attacker.net}
-     * (quarkusio/quarkus#34718).
+     * Mirrors Quarkus's real {@code CORSFilter.isOriginConfiguredWithWildcard}: only a single configured origin
+     * entry equal to exactly {@code *} or the bare regex wildcard {@code /} + {@code .*} + {@code /} counts as
+     * an explicit wildcard. A multi-entry list such as {@code "*,https://foo.com"} is NOT treated as a wildcard
+     * by real Quarkus.
      */
-    private static List<String> unanchoredCorsRegexOrigins(QuarkusSecuritySnapshot s) {
-        List<String> found = new ArrayList<>();
-        if (!s.corsEnabled() || s.corsOrigins() == null) {
-            return found;
+    private static boolean isExplicitWildcardOrigin(String corsOrigins) {
+        if (corsOrigins == null || corsOrigins.isBlank()) {
+            return false;
         }
-        for (String origin : s.corsOrigins().split(",")) {
-            String o = origin.trim();
-            if (o.length() > 2 && o.startsWith("/") && o.endsWith("/")) {
-                String pattern = o.substring(1, o.length() - 1);
-                if (!pattern.startsWith("^") || !pattern.endsWith("$")) {
-                    found.add(o);
-                }
-            }
+        String[] parts = corsOrigins.split(",");
+        if (parts.length != 1) {
+            return false;
         }
-        return found;
+        String only = parts[0].trim();
+        return only.equals("*") || only.equals("/.*/");
     }
 
     private static boolean isWeakHsts(String value) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusSecurityPermission.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusSecurityPermission.java
@@ -1,8 +1,16 @@
 package io.github.jdubois.bootui.spi;
 
 /**
- * One {@code quarkus.http.auth.permission.<name>} block: the paths it matches and the policy applied
- * ({@code permit}, {@code authenticated}, {@code deny}, or a named roles policy). Neutral carrier with
- * no framework dependency; the Quarkus adapter populates it from MicroProfile config.
+ * One {@code quarkus.http.auth.permission.<name>} block: the paths it matches, the policy applied
+ * ({@code permit}, {@code authenticated}, {@code deny}, or a named roles policy), and the HTTP methods it
+ * is scoped to. Neutral carrier with no framework dependency; the Quarkus adapter populates it from
+ * MicroProfile config.
+ *
+ * @param name the permission block name (the {@code <name>} segment of the config key)
+ * @param paths the comma-separated paths the policy matches
+ * @param policy the policy applied ({@code permit}, {@code authenticated}, {@code deny}, or a roles policy name)
+ * @param methods the comma-separated HTTP methods the policy is scoped to via
+ *     {@code quarkus.http.auth.permission.<name>.methods}, or {@code null}/blank when unset — meaning the
+ *     policy applies to every method, not just some
  */
-public record QuarkusSecurityPermission(String name, String paths, String policy) {}
+public record QuarkusSecurityPermission(String name, String paths, String policy, String methods) {}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusSecuritySnapshot.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusSecuritySnapshot.java
@@ -50,10 +50,20 @@ import java.util.List;
  * @param xContentTypeOptionsHeader whether an X-Content-Type-Options response header is configured
  * @param denyUnannotatedEndpoints whether {@code quarkus.security.jaxrs.deny-unannotated-endpoints=true}
  * @param managementEnabled whether the separate management interface is enabled
- * @param managementHostNonLoopback whether the management interface binds a non-loopback host
- * @param jwtAllowUnsignedTokens whether {@code quarkus.smallrye-jwt.allow-unsigned-tokens=true}
+ * @param managementHostNonLoopback whether a literal (unresolved) {@code quarkus.management.host} or
+ *     {@code %prod.quarkus.management.host} key pins a non-loopback host; read as a raw config key rather
+ *     than the profile-resolved value because Quarkus's own built-in default for {@code host} is
+ *     profile-dependent ({@code localhost} in dev/test, {@code 0.0.0.0} in prod) and BootUI's Quarkus
+ *     advisor only ever runs in dev/test {@code LaunchMode}, so a resolved read would never observe the
+ *     prod default it is trying to catch
+ * @param managementHostUnpinnedForProd whether the management interface is enabled but neither a literal
+ *     {@code quarkus.management.host} nor {@code %prod.quarkus.management.host} key exists at all, meaning
+ *     a real prod deployment would silently fall back to Quarkus's own {@code 0.0.0.0} prod default
+ * @param jwtAlgorithmUnpinnedForRemoteJwks whether {@code mp.jwt.verify.publickey.location} points at a
+ *     remote ({@code http}/{@code https}) JWKS endpoint while {@code mp.jwt.verify.publickey.algorithm} is
+ *     left unset, relying on SmallRye JWT's implicit default (RS256-only) instead of explicitly pinning the
+ *     expected algorithm(s) for a key source that can rotate/change independently of this application
  * @param jdbcClearPasswordMapperEnabled whether a JDBC principal-query uses the clear-password mapper
- * @param jdbcBcryptWorkFactorLow whether a JDBC principal-query's bcrypt work-factor is set below the default (10)
  * @param embeddedUsersEnabled whether {@code quarkus.security.users.embedded.enabled=true}
  * @param jwtAudiencesConfigured whether {@code mp.jwt.verify.audiences} is configured
  * @param jwtInlinePublicKey whether {@code mp.jwt.verify.publickey} holds a static inline key (never rotates)
@@ -68,13 +78,19 @@ import java.util.List;
  * @param graphqlIntrospectionEnabled whether GraphQL schema introspection is enabled (Quarkus-specific;
  *     Spring has no first-party GraphQL equivalent)
  * @param graphqlUiAlwaysInclude whether the GraphQL UI is always included, even outside dev/test
- * @param messagingCredentialsWithoutTls whether a Kafka/Reactive-Messaging channel configures SASL
- *     credentials without an encrypted (SASL_SSL/SSL) security protocol (Quarkus-specific; Spring has no
- *     first-party reactive-messaging equivalent)
+ * @param insecureMessagingChannels the specific Kafka/Reactive-Messaging channel key prefixes that configure
+ *     SASL credentials without an encrypted (SASL_SSL/SSL) security protocol, evaluated independently per
+ *     channel so one channel's secure protocol can't mask another channel's insecure one (Quarkus-specific;
+ *     Spring has no first-party reactive-messaging equivalent); empty when none are insecure
  * @param formCookieHttpOnly whether the form-auth cookie has {@code http-only-cookie} set (Quarkus defaults
  *     this to {@code false}, unlike most frameworks)
  * @param formCookieSameSiteNone whether the form-auth cookie's {@code cookie-same-site} was weakened to {@code none}
  * @param formSessionTimeoutExcessive whether the form-auth session {@code timeout} exceeds a sane bound (8h)
+ * @param oidcHasClientSecret whether an OIDC client secret is configured ({@code quarkus.oidc.credentials.secret}
+ *     or {@code quarkus.oidc.credentials.client-secret.value}), i.e. this is a confidential rather than a
+ *     public client
+ * @param oidcPkceRequired whether {@code quarkus.oidc.authentication.pkce-required=true}
+ * @param healthUiAlwaysInclude whether {@code quarkus.smallrye-health.ui.always-include=true}
  */
 public record QuarkusSecuritySnapshot(
         boolean oidcConfigured,
@@ -117,9 +133,9 @@ public record QuarkusSecuritySnapshot(
         boolean denyUnannotatedEndpoints,
         boolean managementEnabled,
         boolean managementHostNonLoopback,
-        boolean jwtAllowUnsignedTokens,
+        boolean managementHostUnpinnedForProd,
+        boolean jwtAlgorithmUnpinnedForRemoteJwks,
         boolean jdbcClearPasswordMapperEnabled,
-        boolean jdbcBcryptWorkFactorLow,
         boolean embeddedUsersEnabled,
         boolean jwtAudiencesConfigured,
         boolean jwtInlinePublicKey,
@@ -130,10 +146,13 @@ public record QuarkusSecuritySnapshot(
         boolean graphqlPresent,
         boolean graphqlIntrospectionEnabled,
         boolean graphqlUiAlwaysInclude,
-        boolean messagingCredentialsWithoutTls,
+        List<String> insecureMessagingChannels,
         boolean formCookieHttpOnly,
         boolean formCookieSameSiteNone,
-        boolean formSessionTimeoutExcessive) {
+        boolean formSessionTimeoutExcessive,
+        boolean oidcHasClientSecret,
+        boolean oidcPkceRequired,
+        boolean healthUiAlwaysInclude) {
 
     public QuarkusSecuritySnapshot {
         permissions = permissions == null ? List.of() : List.copyOf(permissions);
@@ -141,6 +160,8 @@ public record QuarkusSecuritySnapshot(
         oidcApplicationType = oidcApplicationType == null ? "" : oidcApplicationType;
         nonApplicationRootPath =
                 nonApplicationRootPath == null || nonApplicationRootPath.isBlank() ? "/q" : nonApplicationRootPath;
+        insecureMessagingChannels =
+                insecureMessagingChannels == null ? List.of() : List.copyOf(insecureMessagingChannels);
     }
 
     public boolean anyAuthMechanism() {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScannerTest.java
@@ -19,7 +19,7 @@ class QuarkusSecurityScannerTest {
 
     /**
      * Mutable builder whose defaults describe a hardened Quarkus app that fires zero rules, so each test can
-     * flip exactly the fields under test. Mirrors the 58-field {@link QuarkusSecuritySnapshot} positional record.
+     * flip exactly the fields under test. Mirrors the 60-field {@link QuarkusSecuritySnapshot} positional record.
      */
     private static final class Snap {
         // Auth mechanisms — basic auth on, over redirected HTTP, is a clean baseline.
@@ -69,12 +69,12 @@ class QuarkusSecurityScannerTest {
         // Management
         boolean mgmtEnabled = false;
         boolean mgmtNonLoopback = false;
+        boolean mgmtHostUnpinnedForProd = false;
         // Config hygiene
         List<String> secrets = List.of();
         // Auth hardening
-        boolean jwtAllowUnsigned = false;
+        boolean jwtAlgUnpinnedForRemoteJwks = false;
         boolean jdbcClearPasswordMapper = false;
-        boolean jdbcBcryptWorkFactorLow = false;
         boolean embeddedUsers = false;
         boolean jwtAudiences = true;
         boolean jwtInlineKey = false;
@@ -87,11 +87,15 @@ class QuarkusSecurityScannerTest {
         boolean graphqlPresent = false;
         boolean graphqlIntrospection = true;
         boolean graphqlUi = false;
-        boolean messagingCredsNoTls = false;
+        List<String> insecureMessagingChannels = List.of();
         // Session (form-auth cookies)
         boolean formHttpOnly = true;
         boolean formSameSiteNone = false;
         boolean formTimeoutExcessive = false;
+        // OIDC PKCE / Health UI
+        boolean oidcHasClientSecret = true;
+        boolean oidcPkceRequired = true;
+        boolean healthUiAlwaysInclude = false;
 
         QuarkusSecuritySnapshot build() {
             return new QuarkusSecuritySnapshot(
@@ -135,9 +139,9 @@ class QuarkusSecurityScannerTest {
                     denyUnannotated,
                     mgmtEnabled,
                     mgmtNonLoopback,
-                    jwtAllowUnsigned,
+                    mgmtHostUnpinnedForProd,
+                    jwtAlgUnpinnedForRemoteJwks,
                     jdbcClearPasswordMapper,
-                    jdbcBcryptWorkFactorLow,
                     embeddedUsers,
                     jwtAudiences,
                     jwtInlineKey,
@@ -148,10 +152,13 @@ class QuarkusSecurityScannerTest {
                     graphqlPresent,
                     graphqlIntrospection,
                     graphqlUi,
-                    messagingCredsNoTls,
+                    insecureMessagingChannels,
                     formHttpOnly,
                     formSameSiteNone,
-                    formTimeoutExcessive);
+                    formTimeoutExcessive,
+                    oidcHasClientSecret,
+                    oidcPkceRequired,
+                    healthUiAlwaysInclude);
         }
     }
 
@@ -166,7 +173,7 @@ class QuarkusSecurityScannerTest {
     @Test
     void hardenedBaselineHasNoFindings() {
         Snap s = new Snap();
-        s.permissions = List.of(new QuarkusSecurityPermission("api", "/api/*", "authenticated"));
+        s.permissions = List.of(new QuarkusSecurityPermission("api", "/api/*", "authenticated", null));
         SecurityReport r = scan(s);
         assertThat(r.violationsFound()).isZero();
         assertThat(r.filterChainsAnalyzed()).isEqualTo(1);
@@ -256,7 +263,7 @@ class QuarkusSecurityScannerTest {
     @Test
     void permitAllOnRootPathFlagsAuthz002() {
         Snap s = new Snap();
-        s.permissions = List.of(new QuarkusSecurityPermission("open", "/*", "permit"));
+        s.permissions = List.of(new QuarkusSecurityPermission("open", "/*", "permit", null));
         SecurityReport r = scan(s);
         assertThat(find(r, "QS-AUTHZ-002").severity()).isEqualTo("HIGH");
     }
@@ -265,7 +272,7 @@ class QuarkusSecurityScannerTest {
     void permitAllOnScopedPathDoesNotFlagAuthz002() {
         // Regression: the old substring check matched "/public/*" against "/*".
         Snap s = new Snap();
-        s.permissions = List.of(new QuarkusSecurityPermission("public", "/public/*", "permit"));
+        s.permissions = List.of(new QuarkusSecurityPermission("public", "/public/*", "permit", null));
         SecurityReport r = scan(s);
         assertThat(find(r, "QS-AUTHZ-002")).isNull();
     }
@@ -307,7 +314,7 @@ class QuarkusSecurityScannerTest {
         s.endpoints = 4;
         s.secured = 2;
         s.denyUnannotated = false;
-        s.permissions = List.of(new QuarkusSecurityPermission("all", "/*", "authenticated"));
+        s.permissions = List.of(new QuarkusSecurityPermission("all", "/*", "authenticated", null));
         SecurityReport r = scan(s);
         assertThat(find(r, "QS-AUTHZ-004")).isNull();
     }
@@ -521,11 +528,11 @@ class QuarkusSecurityScannerTest {
     }
 
     @Test
-    void unsignedJwtTokensAllowedFlagsAuth006() {
+    void jwtAlgorithmUnpinnedForRemoteJwksFlagsAuth006() {
         Snap s = new Snap();
-        s.jwtAllowUnsigned = true;
+        s.jwtAlgUnpinnedForRemoteJwks = true;
         SecurityReport r = scan(s);
-        assertThat(find(r, "QS-AUTH-006").severity()).isEqualTo("CRITICAL");
+        assertThat(find(r, "QS-AUTH-006").severity()).isEqualTo("MEDIUM");
     }
 
     @Test
@@ -578,41 +585,6 @@ class QuarkusSecurityScannerTest {
         s.jdbcClearPasswordMapper = true;
         SecurityReport r = scan(s);
         assertThat(find(r, "QS-AUTH-010").severity()).isEqualTo("HIGH");
-    }
-
-    @Test
-    void jdbcLowBcryptWorkFactorFlagsAuth011() {
-        Snap s = new Snap();
-        s.jdbcBcryptWorkFactorLow = true;
-        SecurityReport r = scan(s);
-        assertThat(find(r, "QS-AUTH-011").severity()).isEqualTo("MEDIUM");
-    }
-
-    @Test
-    void unanchoredCorsRegexOriginFlagsCors004() {
-        Snap s = new Snap();
-        s.cors = true;
-        s.corsOrigins = "/example\\.com/";
-        SecurityReport r = scan(s);
-        assertThat(find(r, "QS-CORS-004").severity()).isEqualTo("MEDIUM");
-    }
-
-    @Test
-    void anchoredCorsRegexOriginDoesNotFlagCors004() {
-        Snap s = new Snap();
-        s.cors = true;
-        s.corsOrigins = "/^https:\\/\\/example\\.com$/";
-        SecurityReport r = scan(s);
-        assertThat(find(r, "QS-CORS-004")).isNull();
-    }
-
-    @Test
-    void plainStringCorsOriginDoesNotFlagCors004() {
-        Snap s = new Snap();
-        s.cors = true;
-        s.corsOrigins = "https://app.example";
-        SecurityReport r = scan(s);
-        assertThat(find(r, "QS-CORS-004")).isNull();
     }
 
     @Test
@@ -737,9 +709,201 @@ class QuarkusSecurityScannerTest {
     @Test
     void messagingCredentialsWithoutTlsFlagsMsg001() {
         Snap s = new Snap();
-        s.messagingCredsNoTls = true;
+        s.insecureMessagingChannels = List.of("kafka (global default)");
         SecurityReport r = scan(s);
         assertThat(find(r, "QS-MSG-001").severity()).isEqualTo("HIGH");
+        assertThat(find(r, "QS-MSG-001").sampleViolations()).containsExactly("kafka (global default)");
+    }
+
+    @Test
+    void noInsecureMessagingChannelsDoesNotFlagMsg001() {
+        Snap s = new Snap();
+        s.insecureMessagingChannels = List.of();
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-MSG-001")).isNull();
+    }
+
+    @Test
+    void singleInsecureChannelNameAppearsAsMsg001Sample() {
+        // The engine trusts insecureMessagingChannels() as already-resolved per-channel names; the provider
+        // (QuarkusSecuritySnapshotProviderImpl) owns evaluating each channel prefix independently so one
+        // channel's secure protocol can't mask another's insecure one.
+        Snap s = new Snap();
+        s.insecureMessagingChannels = List.of("orders-out");
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-MSG-001").violationCount()).isEqualTo(1);
+        assertThat(find(r, "QS-MSG-001").sampleViolations()).containsExactly("orders-out");
+    }
+
+    @Test
+    void publicOidcClientWithoutPkceFlagsOidc003() {
+        Snap s = new Snap();
+        s.oidc = true;
+        s.oidcAppType = "web-app";
+        s.oidcHasClientSecret = false;
+        s.oidcPkceRequired = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-OIDC-003").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void confidentialOidcClientDoesNotFlagOidc003() {
+        Snap s = new Snap();
+        s.oidc = true;
+        s.oidcAppType = "web-app";
+        s.oidcHasClientSecret = true;
+        s.oidcPkceRequired = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-OIDC-003")).isNull();
+    }
+
+    @Test
+    void publicOidcClientWithPkceDoesNotFlagOidc003() {
+        Snap s = new Snap();
+        s.oidc = true;
+        s.oidcAppType = "web-app";
+        s.oidcHasClientSecret = false;
+        s.oidcPkceRequired = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-OIDC-003")).isNull();
+    }
+
+    @Test
+    void serviceApplicationTypeDoesNotFlagOidc003() {
+        Snap s = new Snap();
+        s.oidc = true;
+        s.oidcAppType = "service";
+        s.oidcHasClientSecret = false;
+        s.oidcPkceRequired = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-OIDC-003")).isNull();
+    }
+
+    @Test
+    void healthUiAlwaysIncludeFlagsDev003() {
+        Snap s = new Snap();
+        s.healthUiAlwaysInclude = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-DEV-003").severity()).isEqualTo("LOW");
+    }
+
+    @Test
+    void healthUiNotAlwaysIncludeDoesNotFlagDev003() {
+        Snap s = new Snap();
+        s.healthUiAlwaysInclude = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-DEV-003")).isNull();
+    }
+
+    @Test
+    void managementHostUnpinnedForProdFlagsMgmt003() {
+        Snap s = new Snap();
+        s.mgmtEnabled = true;
+        s.mgmtHostUnpinnedForProd = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-MGMT-003").severity()).isEqualTo("INFO");
+    }
+
+    @Test
+    void managementHostPinnedForProdDoesNotFlagMgmt003() {
+        Snap s = new Snap();
+        s.mgmtEnabled = true;
+        s.mgmtHostUnpinnedForProd = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-MGMT-003")).isNull();
+    }
+
+    @Test
+    void managementDisabledDoesNotFlagMgmt003() {
+        Snap s = new Snap();
+        s.mgmtEnabled = false;
+        s.mgmtHostUnpinnedForProd = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-MGMT-003")).isNull();
+    }
+
+    @Test
+    void unsetCorsOriginsFlagsCors005AsInfoNotWildcard() {
+        Snap s = new Snap();
+        s.cors = true;
+        s.corsOrigins = null;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-CORS-005").severity()).isEqualTo("INFO");
+        assertThat(find(r, "QS-CORS-001")).isNull();
+        assertThat(find(r, "QS-CORS-002")).isNull();
+    }
+
+    @Test
+    void blankCorsOriginsFlagsCors005() {
+        Snap s = new Snap();
+        s.cors = true;
+        s.corsOrigins = "  ";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-CORS-005").severity()).isEqualTo("INFO");
+    }
+
+    @Test
+    void pinnedCorsOriginsDoesNotFlagCors005() {
+        Snap s = new Snap();
+        s.cors = true;
+        s.corsOrigins = "https://app.example";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-CORS-005")).isNull();
+    }
+
+    @Test
+    void multiEntryOriginsWithWildcardIsNotExplicitWildcard() {
+        // Regression: real Quarkus's isOriginConfiguredWithWildcard only treats a SINGLE "*" entry as a
+        // wildcard; a multi-entry list containing "*" alongside another origin is not a wildcard match.
+        Snap s = new Snap();
+        s.cors = true;
+        s.corsOrigins = "*,https://app.example";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-CORS-001")).isNull();
+        assertThat(find(r, "QS-CORS-002")).isNull();
+        assertThat(find(r, "QS-CORS-005")).isNull();
+    }
+
+    @Test
+    void methodScopedPermitAllDoesNotFlagAuthz002() {
+        // Regression: a permit policy scoped to a single HTTP method on a root path is not equivalent to an
+        // unrestricted permit — it should not be over-flagged as "permits all paths".
+        Snap s = new Snap();
+        s.permissions = List.of(new QuarkusSecurityPermission("cors-preflight", "/*", "permit", "OPTIONS"));
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTHZ-002")).isNull();
+    }
+
+    @Test
+    void unrestrictedPermitAllOnRootPathStillFlagsAuthz002() {
+        Snap s = new Snap();
+        s.permissions = List.of(new QuarkusSecurityPermission("open", "/*", "permit", null));
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTHZ-002").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void methodScopedProtectivePolicyDoesNotSuppressAuthz004() {
+        // Regression: a protective policy scoped to only one HTTP method (e.g. GET) does not actually cover
+        // every unannotated endpoint, so it must not suppress the "no deny-by-default" finding.
+        Snap s = new Snap();
+        s.endpoints = 4;
+        s.secured = 2;
+        s.denyUnannotated = false;
+        s.permissions = List.of(new QuarkusSecurityPermission("get-only", "/*", "authenticated", "GET"));
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTHZ-004").severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void unrestrictedProtectivePolicyStillSuppressesAuthz004() {
+        Snap s = new Snap();
+        s.endpoints = 4;
+        s.secured = 2;
+        s.denyUnannotated = false;
+        s.permissions = List.of(new QuarkusSecurityPermission("all", "/*", "authenticated", null));
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTHZ-004")).isNull();
     }
 
     @Test
@@ -775,6 +939,6 @@ class QuarkusSecurityScannerTest {
         s.secured = 0;
         SecurityReport r = scan(s);
         assertThat(r.results()).allSatisfy(x -> assertThat(x.id()).startsWith("QS-"));
-        assertThat(r.scan().rulesEvaluated()).isEqualTo(43);
+        assertThat(r.scan().rulesEvaluated()).isEqualTo(45);
     }
 }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/security/QuarkusSecuritySnapshotProviderImpl.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/security/QuarkusSecuritySnapshotProviderImpl.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.Config;
 
@@ -33,6 +34,11 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
             Pattern.compile("^quarkus\\.http\\.auth\\.permission\\.([^.]+)\\.policy$");
     private static final Pattern SECRET_NAME = Pattern.compile(
             ".*(password|passwd|secret|token|api-?key|client-secret|private-key).*", Pattern.CASE_INSENSITIVE);
+    private static final Pattern NAMED_TLS_KEY_STORE = Pattern.compile("^quarkus\\.tls\\.[^.]+\\.key-store\\..+$");
+    private static final Pattern NAMED_TLS_TRUST_ALL = Pattern.compile("^quarkus\\.tls\\.[^.]+\\.trust-all$");
+    private static final Pattern SASL_CREDENTIAL = Pattern.compile("(?i)^(.*)\\.sasl\\.(?:password|jaas\\.config)$");
+    private static final Pattern SECURITY_PROTOCOL = Pattern.compile("(?i)^(.*)\\.security\\.protocol$");
+    private static final Set<String> SECURE_KAFKA_PROTOCOLS = Set.of("SASL_SSL", "SSL");
 
     private final Config config;
 
@@ -54,10 +60,11 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 || has("quarkus.http.ssl.certificate.files")
                 || has("quarkus.http.ssl.certificate.key-files")
                 || has("quarkus.tls.key-store.p12.path")
-                || has("quarkus.tls.key-store.pem.0.cert");
+                || has("quarkus.tls.key-store.pem.0.cert")
+                || namedTlsBucketHasKeyStore();
         boolean cors = bool("quarkus.http.cors", false) || bool("quarkus.http.cors.enabled", false);
         String corsOrigins = str("quarkus.http.cors.origins", null);
-        boolean corsCreds = bool("quarkus.http.cors.access-control-allow-credentials", false);
+        boolean corsCreds = corsCredentials(corsOrigins);
         boolean hsts = has("quarkus.http.header.\"Strict-Transport-Security\".value");
         boolean csp = has("quarkus.http.header.\"Content-Security-Policy\".value");
         boolean oidcVerifyNone = "none".equalsIgnoreCase(str("quarkus.oidc.tls.verification", ""));
@@ -74,7 +81,7 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
         boolean oidcAudience = has("quarkus.oidc.token.audience");
         String oidcAppType = str("quarkus.oidc.application-type", "").toLowerCase();
         boolean oidcCookieForceSecure = bool("quarkus.oidc.authentication.cookie-force-secure", false);
-        boolean tlsTrustAll = bool("quarkus.tls.trust-all", false);
+        boolean tlsTrustAll = bool("quarkus.tls.trust-all", false) || namedTlsBucketTrustAll();
         String corsMethods = str("quarkus.http.cors.methods", null);
         String corsHeaders = str("quarkus.http.cors.headers", null);
         String hstsValue = str("quarkus.http.header.\"Strict-Transport-Security\".value", null);
@@ -83,12 +90,17 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
         boolean xContentType = has("quarkus.http.header.\"X-Content-Type-Options\".value");
         boolean denyUnannotated = bool("quarkus.security.jaxrs.deny-unannotated-endpoints", false);
         boolean managementEnabled = bool("quarkus.management.enabled", false);
+        String managementHostPin = managementHostPinnedForProd();
         boolean managementHostNonLoopback =
-                managementEnabled && !isLoopbackHost(str("quarkus.management.host", "0.0.0.0"));
+                managementEnabled && managementHostPin != null && !isLoopbackHost(managementHostPin);
+        boolean managementHostUnpinnedForProd = managementEnabled && managementHostPin == null;
 
-        boolean jwtAllowUnsigned = bool("quarkus.smallrye-jwt.allow-unsigned-tokens", false);
+        String jwksLocation = str("mp.jwt.verify.publickey.location", null);
+        boolean jwksLocationRemote = jwksLocation != null
+                && (jwksLocation.toLowerCase().startsWith("http://")
+                        || jwksLocation.toLowerCase().startsWith("https://"));
+        boolean jwtAlgorithmUnpinnedForRemoteJwks = jwksLocationRemote && !has("mp.jwt.verify.publickey.algorithm");
         boolean jdbcClearPasswordMapper = jdbcClearPasswordMapperEnabled();
-        boolean jdbcBcryptWorkFactorLow = jdbcBcryptWorkFactorLow();
         boolean embeddedUsers = bool("quarkus.security.users.embedded.enabled", false);
         boolean jwtAudiences = has("mp.jwt.verify.audiences");
         boolean jwtInlineKey = has("mp.jwt.verify.publickey");
@@ -98,13 +110,17 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
         boolean grpcPresent = bool(GRPC_PRESENT_KEY, false);
         boolean grpcReflectionProd = grpcPresent && grpcReflectionEnabledInProdProfile();
         boolean graphqlPresent = bool(GRAPHQL_PRESENT_KEY, false);
-        boolean graphqlIntrospection = bool("quarkus.smallrye-graphql.introspection-enabled", true);
+        boolean graphqlIntrospection = graphqlIntrospectionEnabled();
         boolean graphqlUiAlwaysInclude = bool("quarkus.smallrye-graphql.ui.always-include", false);
-        boolean messagingCredsWithoutTls = messagingCredentialsWithoutTls();
+        List<String> insecureMessagingChannels = messagingChannelsWithCredentialsWithoutTls();
         boolean formCookieHttpOnly = bool("quarkus.http.auth.form.http-only-cookie", false);
         boolean formCookieSameSiteNone =
                 "none".equalsIgnoreCase(str("quarkus.http.auth.form.cookie-same-site", "strict"));
         boolean formSessionTimeoutExcessive = formSessionTimeoutExcessive();
+        boolean oidcHasClientSecret =
+                has("quarkus.oidc.credentials.secret") || has("quarkus.oidc.credentials.client-secret.value");
+        boolean oidcPkceRequired = bool("quarkus.oidc.authentication.pkce-required", false);
+        boolean healthUiAlwaysInclude = bool("quarkus.smallrye-health.ui.always-include", false);
 
         return new QuarkusSecuritySnapshot(
                 oidc,
@@ -147,9 +163,9 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 denyUnannotated,
                 managementEnabled,
                 managementHostNonLoopback,
-                jwtAllowUnsigned,
+                managementHostUnpinnedForProd,
+                jwtAlgorithmUnpinnedForRemoteJwks,
                 jdbcClearPasswordMapper,
-                jdbcBcryptWorkFactorLow,
                 embeddedUsers,
                 jwtAudiences,
                 jwtInlineKey,
@@ -160,10 +176,13 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 graphqlPresent,
                 graphqlIntrospection,
                 graphqlUiAlwaysInclude,
-                messagingCredsWithoutTls,
+                insecureMessagingChannels,
                 formCookieHttpOnly,
                 formCookieSameSiteNone,
-                formSessionTimeoutExcessive);
+                formSessionTimeoutExcessive,
+                oidcHasClientSecret,
+                oidcPkceRequired,
+                healthUiAlwaysInclude);
     }
 
     private static boolean isLoopbackHost(String host) {
@@ -178,25 +197,84 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 || h.equals("0:0:0:0:0:0:0:1");
     }
 
-    private boolean jdbcClearPasswordMapperEnabled() {
+    /** Raw-scans for any named TLS registry bucket ({@code quarkus.tls.<name>.key-store.*}) configuring a keystore,
+     * so a keystore pinned to a non-default bucket (e.g. for a REST client or gRPC) still counts as "TLS configured". */
+    private boolean namedTlsBucketHasKeyStore() {
         for (String name : config.getPropertyNames()) {
-            if (name.contains("principal-query")
-                    && name.endsWith("clear-password-mapper.enabled")
-                    && bool(name, false)) {
+            if (NAMED_TLS_KEY_STORE.matcher(name).matches()) {
                 return true;
             }
         }
         return false;
     }
 
-    private boolean jdbcBcryptWorkFactorLow() {
+    /** Raw-scans for any named TLS registry bucket ({@code quarkus.tls.<name>.trust-all}) set to {@code true}. */
+    private boolean namedTlsBucketTrustAll() {
         for (String name : config.getPropertyNames()) {
-            if (name.contains("principal-query") && name.endsWith("bcrypt-password-mapper.work-factor")) {
-                Integer workFactor =
-                        config.getOptionalValue(name, Integer.class).orElse(null);
-                if (workFactor != null && workFactor < 10) {
-                    return true;
-                }
+            if (NAMED_TLS_TRUST_ALL.matcher(name).matches() && bool(name, false)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Mirrors Quarkus's real {@code CORSFilter} default: {@code accessControlAllowCredentials().orElse(originMatches)}.
+     * If the property is explicitly set, that value wins; otherwise credentials are implicitly allowed whenever
+     * origins are configured as one or more precisely-pinned literal values (not a wildcard, not a {@code /regex/}),
+     * since that is the only case where Quarkus's real request-time {@code originMatches} check can be statically
+     * approximated as always-true from config alone.
+     */
+    private boolean corsCredentials(String corsOrigins) {
+        if (has("quarkus.http.cors.access-control-allow-credentials")) {
+            return bool("quarkus.http.cors.access-control-allow-credentials", false);
+        }
+        return originsArePreciselyPinned(corsOrigins);
+    }
+
+    private static boolean originsArePreciselyPinned(String corsOrigins) {
+        if (corsOrigins == null || corsOrigins.isBlank()) {
+            return false;
+        }
+        for (String entry : corsOrigins.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty() || trimmed.equals("*") || (trimmed.startsWith("/") && trimmed.endsWith("/"))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks only the literal {@code quarkus.management.host} or {@code %prod.quarkus.management.host} keys (not
+     * the profile-resolved value), mirroring {@link #grpcReflectionEnabledInProdProfile()}. Quarkus's own built-in
+     * default for {@code host} is profile-dependent ({@code localhost} in dev/test, {@code 0.0.0.0} in prod), and
+     * BootUI's Quarkus advisor only ever runs in dev/test {@code LaunchMode}, so a resolved read would never
+     * observe the prod default it is trying to catch. Returns {@code null} when neither literal key is present.
+     */
+    private String managementHostPinnedForProd() {
+        String prodScoped = literalPropertyValue("%prod.quarkus.management.host");
+        if (prodScoped != null) {
+            return prodScoped;
+        }
+        return literalPropertyValue("quarkus.management.host");
+    }
+
+    private String literalPropertyValue(String literalKey) {
+        for (String name : config.getPropertyNames()) {
+            if (name.equals(literalKey)) {
+                return str(literalKey, null);
+            }
+        }
+        return null;
+    }
+
+    private boolean jdbcClearPasswordMapperEnabled() {
+        for (String name : config.getPropertyNames()) {
+            if (name.contains("principal-query")
+                    && name.endsWith("clear-password-mapper.enabled")
+                    && bool(name, false)) {
+                return true;
             }
         }
         return false;
@@ -218,22 +296,55 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
         return false;
     }
 
-    private boolean messagingCredentialsWithoutTls() {
-        boolean saslCredentialsConfigured = false;
-        boolean encryptedProtocolConfigured = false;
-        for (String name : config.getPropertyNames()) {
-            String lower = name.toLowerCase();
-            if ((lower.endsWith(".sasl.password") || lower.endsWith(".sasl.jaas.config"))
-                    && !str(name, "").isBlank()) {
-                saslCredentialsConfigured = true;
-            } else if (lower.endsWith(".security.protocol")) {
-                String protocol = str(name, "").toUpperCase();
-                if (protocol.equals("SASL_SSL") || protocol.equals("SSL")) {
-                    encryptedProtocolConfigured = true;
-                }
+    /**
+     * Real Quarkus has no {@code quarkus.smallrye-graphql.introspection-enabled} property; introspection is
+     * disabled via the {@code no-introspection} token in the comma-separated
+     * {@code quarkus.smallrye-graphql.field-visibility} list (see {@code SmallRyeGraphQLRuntimeConfig}).
+     */
+    private boolean graphqlIntrospectionEnabled() {
+        String fieldVisibility = str("quarkus.smallrye-graphql.field-visibility", "default");
+        for (String token : fieldVisibility.split(",")) {
+            if ("no-introspection".equalsIgnoreCase(token.trim())) {
+                return false;
             }
         }
-        return saslCredentialsConfigured && !encryptedProtocolConfigured;
+        return true;
+    }
+
+    /**
+     * Evaluates each Kafka/Reactive-Messaging channel prefix (e.g. {@code mp.messaging.incoming.orders}, or the
+     * bare {@code kafka} global-default bucket) independently, so one channel's secure protocol can't mask
+     * another channel's insecure one. A channel with its own {@code security.protocol} uses that value; a
+     * channel without one falls back to the global {@code kafka.security.protocol} (mirroring Kafka client
+     * config inheritance), and the global bucket itself is checked as a channel too when it directly configures
+     * credentials.
+     */
+    private List<String> messagingChannelsWithCredentialsWithoutTls() {
+        Map<String, Boolean> credentialsByPrefix = new LinkedHashMap<>();
+        Map<String, String> protocolByPrefix = new LinkedHashMap<>();
+        for (String name : config.getPropertyNames()) {
+            var credMatch = SASL_CREDENTIAL.matcher(name);
+            if (credMatch.matches()) {
+                if (!str(name, "").isBlank()) {
+                    credentialsByPrefix.put(credMatch.group(1), Boolean.TRUE);
+                }
+                continue;
+            }
+            var protoMatch = SECURITY_PROTOCOL.matcher(name);
+            if (protoMatch.matches()) {
+                protocolByPrefix.put(protoMatch.group(1), str(name, "").toUpperCase());
+            }
+        }
+        String globalProtocol = protocolByPrefix.get("kafka");
+        List<String> insecureChannels = new ArrayList<>();
+        for (String prefix : credentialsByPrefix.keySet()) {
+            String effectiveProtocol =
+                    protocolByPrefix.getOrDefault(prefix, "kafka".equals(prefix) ? null : globalProtocol);
+            if (effectiveProtocol == null || !SECURE_KAFKA_PROTOCOLS.contains(effectiveProtocol)) {
+                insecureChannels.add("kafka".equals(prefix) ? "kafka (global default)" : prefix);
+            }
+        }
+        return insecureChannels;
     }
 
     private boolean formSessionTimeoutExcessive() {
@@ -250,7 +361,8 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 String key = m.group(1);
                 String policy = str(name, "permit");
                 String paths = str("quarkus.http.auth.permission." + key + ".paths", "/*");
-                byName.put(key, new QuarkusSecurityPermission(key, paths, policy));
+                String methods = str("quarkus.http.auth.permission." + key + ".methods", null);
+                byName.put(key, new QuarkusSecurityPermission(key, paths, policy, methods));
             }
         }
         return new ArrayList<>(byName.values());
@@ -259,9 +371,7 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
     private List<String> suspectedSecrets() {
         List<String> out = new ArrayList<>();
         for (String name : config.getPropertyNames()) {
-            if (!name.startsWith("quarkus.")
-                    && !name.startsWith("bootui.")
-                    && SECRET_NAME.matcher(name).matches()) {
+            if (!name.startsWith("bootui.") && SECRET_NAME.matcher(name).matches()) {
                 String value = str(name, "");
                 if (!value.isBlank() && !value.contains("${")) {
                     out.add(name);

--- a/docs/QUARKUS-CHECKS.md
+++ b/docs/QUARKUS-CHECKS.md
@@ -67,10 +67,11 @@ with a trusted key are accepted. Set `mp.jwt.verify.issuer` to the expected toke
 pattern, but unannotated endpoints then run anonymously unless explicitly secured — pair it with
 deny-by-default (`quarkus.security.jaxrs.deny-unannotated-endpoints=true`).
 
-### QS-AUTH-006 - JWT unsigned tokens allowed (CRITICAL)
-`quarkus.smallrye-jwt.allow-unsigned-tokens=true` accepts JWTs with `alg=none`, meaning anyone can forge a
-token with an arbitrary payload and no signature at all. Remove the override; only allow unsigned tokens in
-a throwaway local dev profile, never in any deployed environment.
+### QS-AUTH-006 - JWT signature algorithm not pinned for a remote JWKS (MEDIUM)
+`mp.jwt.verify.publickey.location` points at a remote (`http`/`https`) JWKS endpoint but
+`mp.jwt.verify.publickey.algorithm` is left unset, relying on SmallRye JWT's implicit RS256-only default instead
+of explicitly pinning the expected algorithm(s) for a key source that can rotate/change independently of this
+application. Set `mp.jwt.verify.publickey.algorithm` explicitly to the algorithm(s) this application expects.
 
 ### QS-AUTH-007 - Embedded properties-file users enabled (MEDIUM)
 `quarkus.security.users.embedded.enabled=true` authenticates against a static in-memory/properties-file
@@ -92,10 +93,13 @@ A `quarkus-elytron-security-jdbc` `principal-query` uses the `clear-password-map
 compared/stored in plain text rather than hashed. Switch to `bcrypt-password-mapper` (or another hashing
 mapper) and re-hash stored passwords.
 
-### QS-AUTH-011 - JDBC identity store bcrypt work-factor too low (MEDIUM)
-A `quarkus-elytron-security-jdbc` `principal-query`'s `bcrypt-password-mapper` work-factor is set below the
-default (10), weakening resistance to offline brute-force attacks. Remove the override, or raise it to at
-least the default of 10.
+> **Retired: QS-AUTH-011** (JDBC identity store bcrypt work-factor too low) was removed. The rule checked
+> `principal-query.*.bcrypt-password-mapper.work-factor`, a property that does not exist:
+> `BcryptPasswordKeyMapperConfig` (quarkus-elytron-security-jdbc) has no work-factor/cost-factor field at all
+> (only `enabled`, `password-index`, `hash-encoding`, `salt-index`, `salt-encoding`, `iteration-count-index` — a
+> column index, not a cost factor). Bcrypt's cost factor is embedded in the stored MCF-format hash string
+> itself, not externally configurable via this extension, so the rule could never fire and its remediation
+> ("raise the work factor") was nonsensical. The rule id is retired and will not be reused.
 
 ## Authorization
 
@@ -105,9 +109,12 @@ restrict any endpoint. Add `@RolesAllowed`/`@Authenticated` or path permissions 
 `policy=authenticated`/roles.
 
 ### QS-AUTHZ-002 - Permission policy permits all paths (HIGH)
-A permission policy applies `policy=permit` to a root path (`/` or `/*`), disabling authentication across
-the whole application. Scope the path, or use `policy=authenticated`/roles instead of `permit`. (Paths are
-parsed as a comma-separated list and matched exactly, so a scoped path like `/public/*` is not flagged.)
+A permission policy applies `policy=permit` to a root path (`/` or `/*`) **with no method restriction**,
+disabling authentication across the whole application. Scope the path, or use `policy=authenticated`/roles
+instead of `permit`. (Paths are parsed as a comma-separated list and matched exactly, so a scoped path like
+`/public/*` is not flagged. A permission carrying `quarkus.http.auth.permission.<name>.methods`, e.g. a
+CORS-preflight `OPTIONS`-only permit, is scoped to that method and is not flagged either — only a permit with
+no `methods` restriction applies to every HTTP method.)
 
 ### QS-AUTHZ-003 - Mostly unsecured endpoints (LOW)
 Fewer than half of discovered endpoints carry an authorization annotation. Confirm the open endpoints are
@@ -116,8 +123,10 @@ intentionally public; add `@Authenticated`/`@RolesAllowed` otherwise.
 ### QS-AUTHZ-004 - No deny-by-default for unannotated endpoints (MEDIUM)
 Authentication is configured but endpoints without an authorization annotation are reachable anonymously:
 `quarkus.security.jaxrs.deny-unannotated-endpoints` is off and no broad permission policy covers them. Set
-`deny-unannotated-endpoints=true` and mark public endpoints `@PermitAll`. (Suppressed when a broad
-non-permit permission policy on `/` or `/*` already protects everything.)
+`deny-unannotated-endpoints=true` and mark public endpoints `@PermitAll`. (Suppressed only when a broad
+non-permit permission policy on `/` or `/*` with **no method restriction** already protects everything; a
+policy scoped to a single HTTP method, e.g. `methods=GET`, does not actually cover every unannotated endpoint
+and so does not suppress this finding.)
 
 ## Transport
 
@@ -127,35 +136,59 @@ TLS-terminating proxy; risky if exposed directly. Prefer `redirect` once TLS is 
 terminating proxy. (Suppressed when the app is configured behind a proxy.)
 
 ### QS-TLS-002 - No TLS configured (INFO)
-No HTTPS keystore/TLS registry (`quarkus.http.ssl.*` / `quarkus.tls.*`) is configured. Acceptable behind a
-terminating proxy. (Suppressed when the app is configured behind a proxy.)
+No HTTPS keystore/TLS registry is configured — checked against `quarkus.http.ssl.*`, the default
+`quarkus.tls.*` bucket, **and any named TLS registry bucket** (`quarkus.tls.<name>.key-store.*`, commonly used
+to pin TLS independently for a REST client, gRPC, or OIDC connection). Acceptable behind a terminating proxy.
+(Suppressed when the app is configured behind a proxy.)
 
 ### QS-TLS-003 - Outbound TLS certificate validation disabled (HIGH)
-`quarkus.tls.trust-all=true` disables certificate validation for all outbound TLS (REST clients, OIDC,
-datasources), enabling man-in-the-middle attacks. Remove `trust-all`; import the peer's CA into a
-trust-store instead.
+`trust-all=true` is set on the default TLS registry bucket (`quarkus.tls.trust-all`) **or any named bucket**
+(`quarkus.tls.<name>.trust-all`), disabling certificate validation for outbound TLS (REST clients, OIDC,
+datasources, gRPC) on that bucket, enabling man-in-the-middle attacks. Remove `trust-all`; import the peer's
+CA into a trust-store instead.
 
 ## CORS
 
 ### QS-CORS-001 - CORS allows any origin (MEDIUM)
-CORS is enabled without pinned origins (`quarkus.http.cors.origins` unset or `*`), allowing any site to
-call the API. Set explicit origins.
+CORS is enabled with an **explicit** wildcard origin — `quarkus.http.cors.origins` is exactly `*` or the
+bare regex `/.*/ ` — allowing any site to call the API. Set explicit origins. (Unset/absent origins are
+**not** treated as a wildcard — see QS-CORS-005 below; Quarkus's own `CORSFilter.isOriginConfiguredWithWildcard`
+only matches when the configured origin list has exactly one entry equal to `*`/`/.*/ `, so e.g.
+`*,https://app.example` is a literal two-entry list, not a wildcard, and is not flagged here either.)
 
 ### QS-CORS-002 - CORS wildcard origin with credentials (CRITICAL)
-`quarkus.http.cors.access-control-allow-credentials=true` combined with a wildcard origin allows
-credentialed cross-origin requests from any origin. Pin explicit origins; never combine wildcard with
-credentials.
+`quarkus.http.cors.access-control-allow-credentials=true` combined with an **explicit** wildcard origin (as
+defined above) allows credentialed cross-origin requests from any origin. Pin explicit origins; never
+combine wildcard with credentials.
 
 ### QS-CORS-003 - Credentialed CORS with wildcard methods or headers (MEDIUM)
-CORS allows credentials with a pinned origin but a wildcard `quarkus.http.cors.methods`/`headers` list,
-widening the cross-origin surface. List the exact methods and headers the client needs instead of `*`.
+CORS allows credentials with a pinned (non-wildcard) origin but a wildcard `quarkus.http.cors.methods`/`headers`
+list, widening the cross-origin surface. List the exact methods and headers the client needs instead of `*`.
+Credentials are considered "allowed" here either when `access-control-allow-credentials=true` is set
+explicitly, **or** when it is left unset and `origins` is configured as one or more precisely-pinned literal
+values (no `*`, no `/regex/`) — mirroring Quarkus's real `CORSFilter` default,
+`corsConfig.accessControlAllowCredentials().orElse(originMatches)`: when the property isn't set, Quarkus itself
+allows credentials whenever the request's `Origin` matches a configured (non-wildcard) origin. An earlier
+version of this rule modeled the unset case as "credentials disabled," missing this common
+pinned-single-origin configuration.
 
-### QS-CORS-004 - CORS regex origin pattern not anchored (MEDIUM)
-A `quarkus.http.cors.origins` entry uses the `/regex/` syntax without `^`/`$` anchors. Quarkus matches the
-pattern anywhere in the origin string rather than against the whole string, so e.g. `/example\.com/` also
-matches `https://evil-example.com.attacker.net`
-([quarkusio/quarkus#34718](https://github.com/quarkusio/quarkus/issues/34718)). Anchor the pattern with `^`
-and `$`, e.g. `/^https:\/\/(?:[a-z0-9-]+\.)*example\.com$/`.
+### QS-CORS-005 - CORS enabled with no origins configured (INFO)
+`quarkus.http.cors` is enabled but `quarkus.http.cors.origins` is unset. Quarkus's `CORSFilter` then only
+permits same-origin requests — the most restrictive possible outcome, not "any origin" — so the filter is
+effectively inert until origins are configured. If cross-origin access is intended, configure
+`quarkus.http.cors.origins` explicitly; otherwise this has no practical effect.
+
+> **Retired: QS-CORS-004** (CORS regex origin pattern not anchored) was removed. The rule claimed Quarkus's
+> `CORSFilter` matched an unanchored `/regex/` origin pattern anywhere in the string (`.find()` semantics)
+> rather than against the whole string, citing
+> [quarkusio/quarkus#34718](https://github.com/quarkusio/quarkus/issues/34718). Direct inspection of the
+> current `CORSFilter.isOriginAllowedByRegex` shows `pattern.matcher(origin).matches()` — Java's `.matches()`
+> requires a full match of the entire input string, not `.find()` — and issue #34718 was fixed in Quarkus
+> 3.3.0, long before this project's Quarkus 3.33 target. The bypass the rule warned about no longer applies
+> to any Quarkus version this project supports, so the rule was removed rather than re-worded; preferring
+> literal origins over regex (and anchoring any regex you do use) remains sound general advice, just not
+> something this advisor asserts a specific exploitable mechanism for. The rule id is retired and will not be
+> reused.
 
 ## Headers
 
@@ -207,6 +240,12 @@ local dev provider, but must never reach production.
 `quarkus.smallrye-graphql.ui.always-include=true` exposes API docs and/or the GraphQL UI in all profiles,
 including production. Restrict to dev, or remove `always-include`.
 
+### QS-DEV-003 - SmallRye Health UI always included (LOW)
+`quarkus.smallrye-health.ui.always-include=true` exposes the Health UI in every profile, including
+production, revealing the app's health-check topology to anyone who can reach it. Same pattern as
+QS-DEV-002, for the Health UI specifically. Remove the override so the Health UI is only available outside
+production, or protect it via the management interface / a permission policy.
+
 ## OIDC
 
 ### QS-OIDC-001 - OIDC without token audience validation (MEDIUM)
@@ -218,12 +257,25 @@ An OIDC `web-app`/`hybrid` app stores the session in a cookie but `cookie-force-
 does not terminate TLS, so the session cookie can travel over plain HTTP. Set
 `quarkus.oidc.authentication.cookie-force-secure=true` (required behind a TLS proxy).
 
+### QS-OIDC-003 - Public OIDC client without PKCE (MEDIUM)
+An OIDC `web-app`/`hybrid` client has no client secret configured (`quarkus.oidc.credentials.secret` /
+`quarkus.oidc.credentials.client-secret.value` both absent — a public client, e.g. an SPA or mobile app) and
+`quarkus.oidc.authentication.pkce-required` is not enabled (the Quarkus default is `false`), leaving the
+authorization-code flow vulnerable to interception. Set `quarkus.oidc.authentication.pkce-required=true` for
+public clients.
+
 ## Management
 
 ### QS-MGMT-001 - Management interface on a non-loopback host (LOW)
-The separate management interface (`quarkus.management.enabled=true`, health/metrics) binds a non-loopback
-host, exposing it beyond the local machine. Bind `quarkus.management.host` to `127.0.0.1`, or protect the
-management endpoints.
+The separate management interface (`quarkus.management.enabled=true`, health/metrics) has a **literal**
+`quarkus.management.host` (or `%prod.quarkus.management.host`) key pinned to a non-loopback value, exposing
+it beyond the local machine. Bind the host to `127.0.0.1`, or protect the management endpoints. (Checked by
+scanning for the literal, unresolved config key — not the profile-resolved value — via the same raw-key
+technique QS-GRPC-001 uses for `%prod`-scoped reflection: Quarkus's own built-in default for
+`quarkus.management.host` is profile-dependent, `localhost` in dev/test but `0.0.0.0` in prod, and this
+advisor only ever runs under a dev/test `LaunchMode`, so a resolved-value read would always observe the safe
+dev/test default and could never catch a real prod-facing `0.0.0.0`. See QS-MGMT-003 for the complementary
+case where neither key is pinned at all.)
 
 ### QS-MGMT-002 - Non-application endpoints merged into the main application path (MEDIUM)
 **Quarkus-specific — no Spring equivalent.** `quarkus.http.non-application-root-path=/` collapses
@@ -233,11 +285,24 @@ separate `/q` root, widening the app's exposed surface and risking accidental pa
 `non-application-root-path` at its default (`/q`), or use the separate management interface
 (`quarkus.management.enabled=true`) instead.
 
+### QS-MGMT-003 - Management interface has no explicit prod-scoped host binding (INFO)
+The separate management interface is enabled but **neither** a literal `quarkus.management.host` nor a
+`%prod.quarkus.management.host` key is present at all, so Quarkus's own built-in profile-dependent default
+silently applies: `localhost` in dev/test, but `0.0.0.0` (all interfaces) in a real production deployment.
+This complements QS-MGMT-001 — MGMT-001 fires when a non-loopback host is pinned explicitly; MGMT-003 fires
+when nothing is pinned and Quarkus's prod-mode default would take over unnoticed. Explicitly pin
+`%prod.quarkus.management.host` to `127.0.0.1`, or to the intended bind address.
+
 ## Config hygiene
 
 ### QS-CFG-001 - Possible secret in configuration (CRITICAL)
-A config key looks like a password/secret/token set to a literal. Move to a vault/env var; never commit
-literals.
+A config key looks like a password/secret/token set to a literal value (not an externalized `${...}`
+reference). Scans **all** configuration keys, including the `quarkus.*` namespace — e.g.
+`quarkus.datasource.password`, `quarkus.oidc.credentials.secret`, `quarkus.mail.password` are all in scope,
+alongside application-owned keys. Only BootUI's own internal `bootui.*` keys are excluded. Move secrets to a
+vault/env var; never commit literals. (An earlier version of this rule excluded the entire `quarkus.*`
+namespace from scanning, meaning the most common real-world Quarkus secret-bearing properties could never be
+flagged regardless of their literal value; that blanket exclusion has been removed.)
 
 ## Session
 
@@ -252,8 +317,8 @@ the session cookie be sent on cross-site requests (CSRF exposure). Remove the ov
 or use `lax` only if cross-site GET flows require it.
 
 ### QS-SESSION-003 - Excessive form-auth session timeout (LOW)
-`quarkus.http.auth.form.timeout` is set above 8 hours, keeping an authenticated session alive long after a
-user has stepped away. Lower the timeout (the Quarkus default is 30 minutes) and pair it with
+`quarkus.http.auth.form.timeout` is set to 8 hours or more, keeping an authenticated session alive long
+after a user has stepped away. Lower the timeout (the Quarkus default is 30 minutes) and pair it with
 `new-cookie-interval`.
 
 ## gRPC
@@ -268,15 +333,24 @@ override re-exposes it. Remove the `%prod` override; keep reflection enabled onl
 
 ### QS-GRAPHQL-001 - GraphQL schema introspection enabled (LOW)
 **Quarkus-specific — no Spring equivalent** (Spring has no first-party GraphQL server support).
-`quarkus.smallrye-graphql.introspection-enabled` defaults to `true` in every profile, including production,
-letting any client enumerate the full schema (types, fields, mutations). Often intentional for public APIs,
-but worth a deliberate decision. Set `quarkus.smallrye-graphql.introspection-enabled=false` in `%prod`
-unless the schema is meant to be publicly discoverable.
+`quarkus.smallrye-graphql.field-visibility` does not include the `no-introspection` token (the Quarkus
+default), so schema introspection is enabled in every profile, including production, letting any client
+enumerate the full schema (types, fields, mutations). Often intentional for public APIs, but worth a
+deliberate decision. Add `no-introspection` to `quarkus.smallrye-graphql.field-visibility` in `%prod` unless
+the schema is meant to be publicly discoverable. (There is no
+`quarkus.smallrye-graphql.introspection-enabled` property in real Quarkus — an earlier version of this rule
+checked that non-existent key and could never fire; the real, current mechanism is the
+`no-introspection` value in the comma-separated `field-visibility` list, confirmed against
+`SmallRyeGraphQLRuntimeConfig` and Quarkus's own `FieldVisibilityNoIntrospectionTest`.)
 
 ## Messaging
 
 ### QS-MSG-001 - Messaging credentials configured without an encrypted protocol (HIGH)
 **Quarkus-specific** (no Spring equivalent in the same idiomatic reactive-messaging form). A Kafka/SmallRye
 Reactive Messaging channel configures SASL credentials (username/password or JAAS config) without a
-corresponding `SASL_SSL`/`SSL` `security.protocol`, sending broker credentials in clear text over the wire.
-Set `security.protocol=SASL_SSL` (or `SSL`) alongside the SASL credentials.
+corresponding `SASL_SSL`/`SSL` `security.protocol` (its own, or a global fallback), sending broker
+credentials in clear text over the wire. Each channel prefix (e.g. `mp.messaging.incoming.orders`, or the
+bare `kafka` global-default bucket) is evaluated **independently**, so one channel's secure protocol cannot
+mask another channel's insecure one; the finding lists the specific violating channel name(s), not a single
+aggregate boolean. Set `security.protocol=SASL_SSL` (or `SSL`) for each affected channel (or globally via
+`kafka.security.protocol`).


### PR DESCRIPTION
## Summary

Implements fixes to BootUI's Quarkus Security Advisor (`QS-*` rules) based on a 5-model research
synthesis (claude-opus-4.8, gpt-5.5, gemini-3.1-pro-preview, gpt-5.3-codex, claude-sonnet-5), with
**every finding independently re-verified against live Quarkus/SmallRye 3.33 source code** before
being implemented — not just documentation or agent claims. The ruleset grows from **43 to 45 rules**.

See [docs/QUARKUS-CHECKS.md](../blob/jdubois-quarkus-security-advisor-fixes/docs/QUARKUS-CHECKS.md) for
the full, updated rule catalogue, and the new `[Unreleased]` entry in `CHANGELOG.md` for a condensed summary.

## Headline fix: three dead/non-existent-property rules

These were confirmed via **direct GitHub source-code search**, not just documentation reading — this
matters because some research agents (and an AI web search performed during research) gave confidently
wrong answers about whether these properties exist.

- **`QS-AUTH-011`** (JDBC bcrypt work-factor too low) — **removed entirely**. Direct read of
  `BcryptPasswordKeyMapperConfig.java` (quarkus-elytron-security-jdbc) confirms it has **no**
  work-factor/cost-factor property at all (only `enabled`, `password-index`, `hash-encoding`,
  `salt-index`, `salt-encoding`, `iteration-count-index` — the last a column index, not a cost factor).
  Bcrypt's cost factor is embedded in the stored MCF-format hash string itself. The rule could never
  fire and its remediation was nonsensical. No sensible repurposing exists (a real bcrypt-strength check
  would require inspecting stored hash values at runtime, out of scope for a static-config advisor).
- **`QS-CORS-004`** (CORS regex origin not anchored) — **removed entirely**. Direct inspection of the
  current `CORSFilter.isOriginAllowedByRegex` shows `pattern.matcher(origin).matches()` — Java's
  `.matches()` requires a full match of the entire string, not "matches anywhere". The bypass this rule
  described (quarkusio/quarkus#34718) was fixed in Quarkus **3.3.0**, long before this project's 3.33.x
  target. The rule id is retired rather than reused.
- **`QS-AUTH-006`** (JWT unsigned tokens allowed) — **repurposed**, not removed.
  `quarkus.smallrye-jwt.allow-unsigned-tokens` never existed (`SmallRyeJwtConfig` has exactly three
  properties: `blockingAuthentication`, `silent`, `priority`); a GitHub issue requesting exactly this
  feature was rejected by SmallRye JWT maintainers as insecure. Repurposed into a real, checkable finding:
  **JWT signature algorithm not pinned for a remote JWKS** (`mp.jwt.verify.publickey.location` is a remote
  `http(s)` endpoint but `mp.jwt.verify.publickey.algorithm` is unset, relying on SmallRye JWT's implicit
  RS256-only default).
- **`QS-GRAPHQL-001`** (GraphQL introspection) — property fixed, rule kept. A GitHub code search of
  `quarkusio/quarkus` confirms `quarkus.smallrye-graphql.introspection-enabled` doesn't exist anywhere in
  the repo. The real mechanism is `quarkus.smallrye-graphql.field-visibility=no-introspection`, confirmed
  against `SmallRyeGraphQLRuntimeConfig` and Quarkus's own `FieldVisibilityNoIntrospectionTest`.

## CORS logic corrections (verified against `CORSFilter.java`/`CORSConfig.java`)

The old CORS logic was **backwards** in a meaningful way:

- **`QS-CORS-001`/`002`**: previously treated *unset* origins as equivalent to a wildcard (`*`), warning
  "allows any site to call the API." This is factually wrong — `CORSFilter.isOriginConfiguredWithWildcard`
  only matches when the origin list has **exactly one entry** equal to `*`/`/.*/ `, and when origins are
  unset, Quarkus's request-handling path (`isSameOrigin(request, origin)`) makes the filter **same-origin
  only** — the *most restrictive* possible outcome, the exact opposite of the old wording. Fixed: these
  rules now only fire on an **explicit** wildcard; the unset case gets its own new, correctly-worded
  `QS-CORS-005` (INFO: "CORS enabled with no origins configured... only permits same-origin requests").
- **`QS-CORS-003`**: previously modeled the credentials default as always `false` when unset. Real Quarkus:
  `corsConfig.accessControlAllowCredentials().orElse(originMatches)` — i.e. when unset, Quarkus allows
  credentials whenever the origin precisely matches a configured (non-wildcard) origin. This was a real
  false-negative for the common "single pinned SPA origin, no explicit credentials setting" case. Fixed to
  infer `true` when origins are one or more precisely-pinned literal values.
- **`QS-CORS-004`** investigated per the prompt's own flagged lower-confidence item — see removal above;
  resolved by checking Quarkus's current source rather than trusting the original issue description.

## Other verified bugs fixed

- **`QS-CFG-001`**: removed a blanket `quarkus.*` exclusion from secret scanning that meant
  `quarkus.datasource.password`, `quarkus.oidc.credentials.secret`, `quarkus.mail.password`, etc. — the
  most common real-world Quarkus secret-bearing properties — could **never** be flagged. Only `bootui.*`
  (BootUI's own internal keys) is excluded now.
- **`QS-TLS-002`/`003`**: now also raw-scan named TLS registry buckets (`quarkus.tls.<name>.key-store.*`,
  `quarkus.tls.<name>.trust-all`), not just the default bucket — closing a blind spot for apps that TLS-pin
  a REST client/gRPC/OIDC connection independently of the default HTTP server bucket.
- **`QS-MGMT-001`**: switched from resolved-value to **raw-key** inspection for `quarkus.management.host` /
  `%prod.quarkus.management.host`, mirroring the existing `QS-GRPC-001` pattern. Quarkus's built-in default
  is profile-dependent (`localhost` dev/test, `0.0.0.0` prod), and BootUI's Quarkus advisor only ever runs
  under dev/test `LaunchMode` — so the old resolved-value check could **never** observe the prod default it
  was trying to catch. New `QS-MGMT-003` (INFO) complements it for the "nothing pinned at all" case.
- **`QS-AUTHZ-002`/`004`**: `QuarkusSecurityPermission` gained a `methods` field
  (`quarkus.http.auth.permission.<name>.methods`), so a permission scoped to one HTTP method is no longer
  treated identically to an unrestricted one in the "is this policy broad" determination both rules share.
- **`QS-MSG-001`**: now evaluates each Kafka/Reactive-Messaging channel prefix **independently** (with a
  security-protocol inheritance fallback to the global `kafka.*` bucket, mirroring real Kafka client
  config), so one channel's secure protocol can no longer mask another channel's insecure one. The finding
  now lists the specific violating channel name(s).
- **`QS-SESSION-003`**: wording ("above 8 hours") now matches the actual `>= 8h` trigger condition.

## New rules added

- **`QS-OIDC-003`** (MEDIUM) — Public OIDC client (`web-app`/`hybrid`, no client secret configured) without
  `quarkus.oidc.authentication.pkce-required=true`, leaving the authorization-code flow vulnerable to
  interception.
- **`QS-DEV-003`** (LOW) — `quarkus.smallrye-health.ui.always-include=true`, same pattern as the existing
  `QS-DEV-002` (Swagger/OpenAPI/GraphQL UI) but for the Health UI.
- **`QS-MGMT-003`** (INFO) — Management interface enabled with no explicit prod-scoped host binding at all,
  complementing `QS-MGMT-001`.

**Skipped**: `QS-MGMT-003`'s original "no permission policy covers health/metrics" framing (closest
analogue to the Spring sibling's actuator-exposure check) — reused the simpler, higher-confidence
"no explicit prod-scoped host" framing instead, since reliably resolving the *effective* health/metrics
root path against arbitrary `quarkus.http.auth.permission.*` policies turned out to be a bigger, lower-confidence
undertaking than the time budget for this pass warranted. Also skipped the lower-consensus proposals the
research explicitly flagged as skippable (`QS-CSRF-002`, `QS-AUTH-012`, `QS-OIDC-004`, `QS-MSG-002`).

## Testing

- `QuarkusSecurityScannerTest.java` rewritten: obsolete tests removed (QS-AUTH-011, QS-CORS-004), ~15 new
  tests added (QS-OIDC-003, QS-DEV-003, QS-MGMT-003, QS-CORS-005, multi-entry-wildcard regression,
  AUTHZ-002/004 method-specificity regressions), all existing tests updated for renamed/changed fields.
  **All 79 tests in this file pass.**
- Full `bootui-engine` module test suite (including ArchUnit boundary tests): **1013 tests, 0 failures**.
- Full isolated-repo reactor build/test:
  `./mvnw -Dmaven.repo.local=.m2 -B -ntp -pl bootui-core,bootui-engine,bootui-quarkus,bootui-quarkus-deployment,bootui-quarkus-integration-tests -am install`
  → **BUILD SUCCESS**, including the `bootui-quarkus-integration-tests/base` and `/security`
  `@QuarkusTest` conformance submodules (167 + 5 tests, 0 failures).
- `./mvnw spotless:apply` / `spotless:check` — clean, no formatting changes needed.

## Known limitation (deliberately out of scope)

No dedicated provider-level unit test file (e.g. `QuarkusSecuritySnapshotProviderImplTest`) was created for
`QuarkusSecuritySnapshotProviderImpl`'s new parsing logic (CORS credentials inference, per-channel messaging
independence, TLS named-bucket scans, management raw-key scan). None existed before this change either, and
the task scoped test coverage to the engine-level `QuarkusSecurityScannerTest`. Provider logic is exercised
indirectly through the `@QuarkusTest` conformance suite, but a focused unit-test file for the provider would
be a reasonable follow-up.

## Where this diverges from the original research prompt

- The research prompt suggested `QS-MGMT-003` should ideally be closer to the Spring sibling's
  actuator-exposure-without-auth check; I implemented the simpler, already-planned "no explicit prod host
  pin" framing instead (see "Skipped" above) rather than the more speculative permission-coverage version,
  since the prompt itself flagged that framing as lower-confidence.
- Everything else in the original prompt's 12 must-fix items was verified against current code/Quarkus
  source as described and implemented as specified; no other claims turned out to be wrong on
  re-verification.