### PR TITLE
Fix Spring Security advisor: OAuth2 opaque-token and Actuator health-details false positives, add 2 new rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Two new Spring Security advisor rules**, from the same follow-up audit described under Changed below:
+  `SEC-AUTH-009` (Spring Boot's auto-generated default user/password must not be relied on in production — the
+  fully-default case where no `UserDetailsService`/`AuthenticationProvider` bean and no `spring.security.user.*`
+  property exist at all, distinct from `SEC-AUTH-004`'s explicitly-configured static user, HIGH) and
+  `SEC-SESSION-009` (a custom `server.servlet.session.cookie.name` should use the `__Host-`/`__Secure-` cookie-name
+  prefix so the browser enforces Secure/no-Domain/Path=/, hardening against cookie-tossing from a sibling or
+  subdomain — the unmodified default `JSESSIONID` is not flagged, LOW). The Security advisor now has 59 rules, up
+  from 57 (#522).
+
 - **Three new Hibernate advisor rules**, from a second, deeper audit pass dedicated to the Hibernate advisor alone:
   `HIB-ID-007` (composite identifier classes — `@EmbeddedId`/`@IdClass` — must be `Serializable`, expose a public no-arg
   constructor, and override both `equals` and `hashCode`, HIGH), `HIB-CONFIG-018` (bind-parameter logging should not be
@@ -18,6 +27,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rules, up from 66 (#511).
 
 ### Changed
+
+- **Follow-up Spring Security advisor audit pass**, cross-validated by 5 independent AI models (Claude Opus 4.8,
+  GPT-5.5, Gemini 3.1 Pro, GPT-5.3-Codex, Claude Sonnet 5) re-auditing the ruleset shortly after #519, catching two
+  remaining false-positive/stale-doc gaps that audit had not covered: `SEC-OAUTH-001` fired a false HIGH violation
+  on legitimate opaque-token resource servers (`.oauth2ResourceServer(oauth2 -> oauth2.opaqueToken(...))`) because
+  `BearerTokenAuthenticationFilter` is installed identically for both JWT and opaque-token resource servers, but the
+  rule only ever checked JWT-specific config — it now also accepts
+  `spring.security.oauth2.resourceserver.opaquetoken.introspection-uri` or a custom `OpaqueTokenIntrospector` bean
+  as valid proof the resource server validates tokens; and `SEC-ACT-004`'s description/recommendation claimed
+  Spring Boot's `management.endpoint.health.show-details` default is `when-authorized`, which was true before
+  Spring Boot 3.0 but the real current default is `never` — corrected the text and also added detection for
+  `management.endpoint.health.show-components=always`, which leaks the same infrastructure/component names as
+  `show-details=always` but was previously unchecked (#522).
 
 - **Second Hibernate advisor audit pass**, cross-validated by 5 independent AI models (Claude Opus 4.8, GPT-5.5,
   Gemini 3.1 Pro, GPT-5.3-Codex, Claude Sonnet 5) auditing the ruleset against official Hibernate ORM/Quarkus/Spring

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
@@ -36,6 +36,8 @@ record SecurityContext(
         List<String> oauth2TokenValidatorTypes,
         boolean strictHttpFirewallWeakened,
         boolean hideUserNotFoundExceptionsDisabled,
+        List<String> opaqueTokenIntrospectorTypes,
+        boolean generatedUserDetailsManagerPresent,
         Environment environment) {
     SecurityContext {
         chains = List.copyOf(chains);
@@ -43,6 +45,7 @@ record SecurityContext(
         corsConfigs = List.copyOf(corsConfigs);
         jwtDecoderTypes = List.copyOf(jwtDecoderTypes);
         oauth2TokenValidatorTypes = List.copyOf(oauth2TokenValidatorTypes);
+        opaqueTokenIntrospectorTypes = List.copyOf(opaqueTokenIntrospectorTypes);
     }
 
     /** The fully-qualified type names of the discovered {@code PasswordEncoder} beans. */

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuleRegistry.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuleRegistry.java
@@ -14,6 +14,7 @@ final class SecurityRuleRegistry {
             new DefaultLoginPageProductionRule(),
             new BasicAuthWithoutTlsRule(),
             new UsernameEnumerationRiskRule(),
+            new GeneratedUserInProductionRule(),
             // Authorization
             new MissingAuthorizationFilterRule(),
             new PermitAllCatchAllRule(),
@@ -32,6 +33,7 @@ final class SecurityRuleRegistry {
             new BearerTokenStatefulRule(),
             new ConcurrentSessionControlRule(),
             new WeakRememberMeKeyRule(),
+            new SessionCookieNamePrefixRule(),
             // Transport & security headers
             new HstsHeaderRule(),
             new FrameOptionsRule(),

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
@@ -280,6 +280,42 @@ final class UsernameEnumerationRiskRule extends AbstractSecurityRule {
     }
 }
 
+final class GeneratedUserInProductionRule extends AbstractSecurityRule {
+
+    GeneratedUserInProductionRule() {
+        super(new SecurityRuleDefinition(
+                "SEC-AUTH-009",
+                "Do not run production on Spring Boot's auto-generated default user",
+                SecurityCategory.AUTHENTICATION,
+                "HIGH",
+                "Detects Spring Boot's auto-configured InMemoryUserDetailsManager (created only when no"
+                        + " UserDetailsService/AuthenticationManager/AuthenticationProvider bean and no"
+                        + " spring.security.user.* property are present) while a production profile is active. Unlike"
+                        + " SEC-AUTH-004 (an explicitly-configured static user), this is the fully-default case: Spring"
+                        + " Boot generates a random password for a single 'user' account and logs it to the console at"
+                        + " startup, which Spring Boot's own documentation warns is for development use only.",
+                "Register a real UserDetailsService, AuthenticationProvider, or external identity provider before"
+                        + " running in production; do not rely on the console-logged generated password.",
+                "https://docs.spring.io/spring-boot/reference/web/spring-security.html"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        if (!context.generatedUserDetailsManagerPresent() || !context.isProductionProfileActive()) {
+            return pass();
+        }
+        if (context.firstProperty("spring.security.user.name", "spring.security.user.password") != null) {
+            // spring.security.user.* is set, so SEC-AUTH-004 already covers this (explicit, non-generated
+            // credentials); avoid double-reporting the same static-account risk under two rule ids.
+            return pass();
+        }
+        return violation(List.of(
+                "Spring Boot's auto-generated default user/password (InMemoryUserDetailsManager) is active while a"
+                        + " production profile is running, with no custom UserDetailsService/AuthenticationProvider"
+                        + " and no spring.security.user.* configured."));
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Authorization
 // ---------------------------------------------------------------------------
@@ -706,6 +742,36 @@ final class WeakRememberMeKeyRule extends AbstractSecurityRule {
             }
         }
         return violation(details);
+    }
+}
+
+final class SessionCookieNamePrefixRule extends AbstractSecurityRule {
+
+    SessionCookieNamePrefixRule() {
+        super(
+                new SecurityRuleDefinition(
+                        "SEC-SESSION-009",
+                        "Custom session cookie names should use a __Host-/__Secure- prefix",
+                        SecurityCategory.SESSION,
+                        "LOW",
+                        "Detects server.servlet.session.cookie.name configured to a custom value that does not start with the"
+                                + " __Host- or __Secure- cookie-name prefix (exact case -- browsers only honor these prefixes"
+                                + " verbatim). The unmodified default name, JSESSIONID, is not flagged; this rule only fires"
+                                + " once an application has already chosen to customize the cookie name.",
+                        "Name the session cookie __Host-<name> (requires Secure, no Domain attribute, and Path=/) or, at"
+                                + " minimum, __Secure-<name>, so the browser rejects the cookie unless it was set over HTTPS --"
+                                + " hardening against cookie-tossing from a sibling or subdomain.",
+                        "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#cookie-name-prefixes"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        String name = context.firstProperty("server.servlet.session.cookie.name");
+        if (name == null || name.startsWith("__Host-") || name.startsWith("__Secure-")) {
+            return pass();
+        }
+        return violation(List.of("server.servlet.session.cookie.name is set to '" + name
+                + "', which does not use the __Host- or __Secure- cookie-name prefix."));
     }
 }
 
@@ -1290,21 +1356,29 @@ final class HealthDetailsExposureRule extends AbstractSecurityRule {
         super(
                 new SecurityRuleDefinition(
                         "SEC-ACT-004",
-                        "Actuator health details should not be exposed unconditionally",
+                        "Actuator health details/components should not be exposed unconditionally",
                         SecurityCategory.ACTUATOR,
                         "HIGH",
-                        "Detects management.endpoint.health.show-details=always, which leaks infrastructure details to anonymous callers.",
-                        "Change management.endpoint.health.show-details to 'when-authorized' (the default) or ensure the /health endpoint is strictly authenticated.",
+                        "Detects management.endpoint.health.show-details=always or show-components=always, either of"
+                                + " which leaks infrastructure/component details (disk space, database, custom health"
+                                + " indicators, dependency versions) to anonymous callers. Spring Boot's own default"
+                                + " for both properties is 'never' (not 'when-authorized', which was the default"
+                                + " prior to Spring Boot 3.0).",
+                        "Leave show-details/show-components at 'never' (the default), or set them to 'when-authorized'"
+                                + " and require authentication for the health endpoint.",
                         "https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.health.show-details"));
     }
 
     @Override
     SecurityRuleResultDto evaluateRule(SecurityContext context) {
-        String showDetails = context.firstHostProperty("management.endpoint.health.show-details");
-        if ("always".equalsIgnoreCase(showDetails)) {
-            return violation(List.of("management.endpoint.health.show-details is set to 'always'."));
+        List<String> details = new ArrayList<>();
+        if ("always".equalsIgnoreCase(context.firstHostProperty("management.endpoint.health.show-details"))) {
+            details.add("management.endpoint.health.show-details is set to 'always'.");
         }
-        return pass();
+        if ("always".equalsIgnoreCase(context.firstHostProperty("management.endpoint.health.show-components"))) {
+            details.add("management.endpoint.health.show-components is set to 'always'.");
+        }
+        return violation(details);
     }
 }
 
@@ -1398,12 +1472,20 @@ final class ResourceServerValidationRule extends AbstractSecurityRule {
     ResourceServerValidationRule() {
         super(new SecurityRuleDefinition(
                 "SEC-OAUTH-001",
-                "JWT resource server must validate tokens via issuer or JWK set",
+                "Resource server must validate tokens via JWT issuer/JWK or opaque-token introspection",
                 SecurityCategory.OAUTH2,
                 "HIGH",
-                "Detects a bearer-token resource server with no issuer-uri, jwk-set-uri, public key, or JwtDecoder bean configured.",
-                "Configure spring.security.oauth2.resourceserver.jwt.issuer-uri (or jwk-set-uri / a JwtDecoder bean) so signatures and the issuer are verified.",
-                "https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html"));
+                "Detects a bearer-token resource server with neither JWT validation (issuer-uri, jwk-set-uri,"
+                        + " public key, or a JwtDecoder bean) nor opaque-token validation (introspection-uri or an"
+                        + " OpaqueTokenIntrospector bean) configured. BearerTokenAuthenticationFilter is installed"
+                        + " identically for oauth2ResourceServer().jwt(...) and .opaqueToken(...), so both"
+                        + " validation styles are accepted.",
+                "Configure spring.security.oauth2.resourceserver.jwt.issuer-uri (or jwk-set-uri / a JwtDecoder bean)"
+                        + " for JWT resource servers, or"
+                        + " spring.security.oauth2.resourceserver.opaquetoken.introspection-uri (or a custom"
+                        + " OpaqueTokenIntrospector bean) for opaque-token resource servers, so incoming bearer"
+                        + " tokens are actually verified.",
+                "https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/index.html"));
     }
 
     @Override
@@ -1413,17 +1495,20 @@ final class ResourceServerValidationRule extends AbstractSecurityRule {
         if (!bearerChain) {
             return pass();
         }
-        boolean configured = context.firstProperty(
+        boolean jwtConfigured = context.firstProperty(
                                 "spring.security.oauth2.resourceserver.jwt.issuer-uri",
                                 "spring.security.oauth2.resourceserver.jwt.jwk-set-uri",
                                 "spring.security.oauth2.resourceserver.jwt.public-key-location")
                         != null
                 || !context.jwtDecoderTypes().isEmpty();
-        if (configured) {
+        boolean opaqueTokenConfigured =
+                context.firstProperty("spring.security.oauth2.resourceserver.opaquetoken.introspection-uri") != null
+                        || !context.opaqueTokenIntrospectorTypes().isEmpty();
+        if (jwtConfigured || opaqueTokenConfigured) {
             return pass();
         }
-        return violation(List.of(
-                "A bearer-token resource server is active but no issuer/JWK/JwtDecoder validation is configured."));
+        return violation(List.of("A bearer-token resource server is active but no issuer/JWK/JwtDecoder (JWT) or"
+                + " introspection-uri/OpaqueTokenIntrospector (opaque token) validation is configured."));
     }
 }
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
@@ -758,8 +758,9 @@ final class SessionCookieNamePrefixRule extends AbstractSecurityRule {
                                 + " __Host- or __Secure- cookie-name prefix (exact case -- browsers only honor these prefixes"
                                 + " verbatim). The unmodified default name, JSESSIONID, is not flagged; this rule only fires"
                                 + " once an application has already chosen to customize the cookie name.",
-                        "Name the session cookie __Host-<name> (requires Secure, no Domain attribute, and Path=/) or, at"
-                                + " minimum, __Secure-<name>, so the browser rejects the cookie unless it was set over HTTPS --"
+                        "Name the session cookie with the __Host- prefix, e.g. __Host-SESSION (requires Secure, no"
+                                + " Domain attribute, and Path=/) or, at minimum, the __Secure- prefix, e.g."
+                                + " __Secure-SESSION, so the browser rejects the cookie unless it was set over HTTPS --"
                                 + " hardening against cookie-tossing from a sibling or subdomain.",
                         "https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#cookie-name-prefixes"));
     }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -266,6 +266,10 @@ final class SecurityScanner {
         boolean methodSecurityAnnotations = discoverMethodSecurityAnnotations(beanFactory);
         boolean strictHttpFirewallWeakened = discoverStrictHttpFirewallWeakened(beanFactory);
         boolean hideUserNotFoundExceptionsDisabled = discoverHideUserNotFoundExceptionsDisabled(beanFactory);
+        List<String> opaqueTokenIntrospectorTypes = beanTypeNames(
+                beanFactory,
+                "org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector");
+        boolean generatedUserDetailsManagerPresent = discoverGeneratedUserDetailsManagerPresent(beanFactory);
 
         SecurityContext context = new SecurityContext(
                 chains,
@@ -280,6 +284,8 @@ final class SecurityScanner {
                 oauth2TokenValidatorTypes,
                 strictHttpFirewallWeakened,
                 hideUserNotFoundExceptionsDisabled,
+                opaqueTokenIntrospectorTypes,
+                generatedUserDetailsManagerPresent,
                 environment);
         return new SecurityDiscovery(context, errors);
     }
@@ -693,6 +699,26 @@ final class SecurityScanner {
             }
         }
         return false;
+    }
+
+    /**
+     * {@code true} when Spring Boot's own auto-configured {@code InMemoryUserDetailsManager} bean is
+     * present -- the single generated-password "user" account {@code
+     * UserDetailsServiceAutoConfiguration} creates only when no other {@code UserDetailsService},
+     * {@code AuthenticationManager}, or {@code AuthenticationProvider} bean exists. Matched by the
+     * exact bean name Spring Boot's auto-configuration registers it under ({@code
+     * inMemoryUserDetailsManager}), since the bean's type alone would also match a host application's
+     * own, deliberately-configured {@code InMemoryUserDetailsManager}.
+     */
+    private static boolean discoverGeneratedUserDetailsManagerPresent(ListableBeanFactory beanFactory) {
+        if (beanFactory == null) {
+            return false;
+        }
+        try {
+            return beanFactory.containsBean("inMemoryUserDetailsManager");
+        } catch (RuntimeException | LinkageError ex) {
+            return false;
+        }
     }
 
     // ── Reflection / proxy helpers ───────────────────────────────────────────────

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
@@ -242,6 +242,136 @@ class SecurityRulesTests {
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
 
+    // --- SEC-ACT-004: health show-details/show-components should not be unconditional ------
+
+    @Test
+    void healthDetailsExposureFiresForShowDetailsAlways() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("management.endpoint.health.show-details", "always");
+
+        SecurityRuleResultDto result = new HealthDetailsExposureRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations()).anyMatch(detail -> detail.contains("show-details"));
+    }
+
+    @Test
+    void healthDetailsExposureFiresForShowComponentsAlways() {
+        // Spring Boot's show-components=always leaks the same infrastructure/component names as
+        // show-details=always, so it must be caught independently.
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("management.endpoint.health.show-components", "always");
+
+        SecurityRuleResultDto result = new HealthDetailsExposureRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations()).anyMatch(detail -> detail.contains("show-components"));
+    }
+
+    @Test
+    void healthDetailsExposureReportsBothWhenShowDetailsAndShowComponentsAreBothAlways() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("management.endpoint.health.show-details", "always")
+                .withProperty("management.endpoint.health.show-components", "always");
+
+        SecurityRuleResultDto result = new HealthDetailsExposureRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.violationCount()).isEqualTo(2);
+    }
+
+    @Test
+    void healthDetailsExposurePassesWhenNeitherPropertyIsSet() {
+        // Spring Boot's actual default for both properties is 'never' (not 'when-authorized', which
+        // was the pre-3.0 default) -- confirm the rule does not flag the unconfigured/default case.
+        SecurityRuleResultDto result = new HealthDetailsExposureRule().evaluate(context(new MockEnvironment()));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void healthDetailsExposurePassesWhenAuthorizedOnly() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("management.endpoint.health.show-details", "when-authorized")
+                .withProperty("management.endpoint.health.show-components", "when-authorized");
+
+        SecurityRuleResultDto result = new HealthDetailsExposureRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-OAUTH-001: JWT and opaque-token resource servers must validate tokens ----------
+
+    @Test
+    void resourceServerValidationPassesWhenNoBearerChainIsPresent() {
+        FilterChainModel chain = chain(
+                "any request",
+                List.of("SecurityContextHolderFilter", "UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new ResourceServerValidationRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void resourceServerValidationFiresWhenBearerChainHasNoJwtOrOpaqueTokenConfig() {
+        FilterChainModel chain = chain(
+                "any request",
+                List.of("SecurityContextHolderFilter", "BearerTokenAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result =
+                new ResourceServerValidationRule().evaluate(context(List.of(chain), new MockEnvironment()));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void resourceServerValidationPassesWithJwtIssuerUriConfigured() {
+        FilterChainModel chain = chain(
+                "any request",
+                List.of("SecurityContextHolderFilter", "BearerTokenAuthenticationFilter", "AuthorizationFilter"));
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com");
+
+        SecurityRuleResultDto result =
+                new ResourceServerValidationRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void resourceServerValidationPassesWithOpaqueTokenIntrospectionUriConfigured() {
+        // Verified false-positive fix: BearerTokenAuthenticationFilter is installed identically for
+        // .oauth2ResourceServer(oauth2 -> oauth2.jwt(...)) and .opaqueToken(...), so an opaque-token
+        // resource server configured only via the introspection-uri property must also pass.
+        FilterChainModel chain = chain(
+                "any request",
+                List.of("SecurityContextHolderFilter", "BearerTokenAuthenticationFilter", "AuthorizationFilter"));
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty(
+                        "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri",
+                        "https://issuer.example.com/introspect");
+
+        SecurityRuleResultDto result =
+                new ResourceServerValidationRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void resourceServerValidationPassesWithOpaqueTokenIntrospectorBeanPresent() {
+        FilterChainModel chain = chain(
+                "any request",
+                List.of("SecurityContextHolderFilter", "BearerTokenAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new ResourceServerValidationRule()
+                .evaluate(contextWithOpaqueTokenIntrospector(
+                        List.of(chain), List.of("com.example.CustomOpaqueTokenIntrospector"), new MockEnvironment()));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
     // --- SEC-OAUTH-002: custom decoder is advisory ------------------------------------------
 
     @Test
@@ -284,8 +414,13 @@ class SecurityRulesTests {
     void jwtAudienceWithCustomTokenValidatorIsInfoAdvisory() {
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com");
-        SecurityContext context =
-                context(environment, List.of("com.example.AudienceValidatingOAuth2TokenValidator"), false, false);
+        SecurityContext context = context(
+                environment,
+                List.of("com.example.AudienceValidatingOAuth2TokenValidator"),
+                false,
+                false,
+                List.of(),
+                false);
 
         SecurityRuleResultDto result = new JwtAudienceValidationRule().evaluate(context);
 
@@ -382,6 +517,8 @@ class SecurityRulesTests {
                         true,
                         List.of(),
                         false,
+                        false,
+                        List.of(),
                         false,
                         new MockEnvironment()));
 
@@ -611,6 +748,48 @@ class SecurityRulesTests {
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
 
+    // --- SEC-SESSION-009: session cookie name should use a __Host-/__Secure- prefix ---------
+
+    @Test
+    void sessionCookieNamePrefixFiresForACustomNameWithoutAPrefix() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("server.servlet.session.cookie.name", "MYSESSIONID");
+
+        SecurityRuleResultDto result = new SessionCookieNamePrefixRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("LOW");
+        assertThat(result.sampleViolations()).anyMatch(detail -> detail.contains("MYSESSIONID"));
+    }
+
+    @Test
+    void sessionCookieNamePrefixPassesWhenNoCustomNameIsConfigured() {
+        // The unmodified default cookie name, JSESSIONID, is not flagged.
+        SecurityRuleResultDto result = new SessionCookieNamePrefixRule().evaluate(context(new MockEnvironment()));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void sessionCookieNamePrefixPassesForAHostPrefixedName() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("server.servlet.session.cookie.name", "__Host-SESSION");
+
+        SecurityRuleResultDto result = new SessionCookieNamePrefixRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void sessionCookieNamePrefixPassesForASecurePrefixedName() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("server.servlet.session.cookie.name", "__Secure-SESSION");
+
+        SecurityRuleResultDto result = new SessionCookieNamePrefixRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
     // --- SEC-AUTH-007: HTTP Basic requires TLS in production -------------------------------
 
     @Test
@@ -649,7 +828,7 @@ class SecurityRulesTests {
 
     @Test
     void usernameEnumerationRiskFiresWhenHideUserNotFoundExceptionsIsDisabled() {
-        SecurityContext context = context(new MockEnvironment(), List.of(), false, true);
+        SecurityContext context = context(new MockEnvironment(), List.of(), false, true, List.of(), false);
 
         SecurityRuleResultDto result = new UsernameEnumerationRiskRule().evaluate(context);
 
@@ -659,9 +838,56 @@ class SecurityRulesTests {
 
     @Test
     void usernameEnumerationRiskPassesWhenHideUserNotFoundExceptionsIsNotDisabled() {
-        SecurityContext context = context(new MockEnvironment(), List.of(), false, false);
+        SecurityContext context = context(new MockEnvironment(), List.of(), false, false, List.of(), false);
 
         SecurityRuleResultDto result = new UsernameEnumerationRiskRule().evaluate(context);
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-AUTH-009: Spring Boot's auto-generated default user should not run in production
+
+    @Test
+    void generatedUserInProductionFiresWhenNoCustomUserDetailsServiceIsConfigured() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+        SecurityContext context = context(environment, List.of(), false, false, List.of(), true);
+
+        SecurityRuleResultDto result = new GeneratedUserInProductionRule().evaluate(context);
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void generatedUserInProductionPassesOutsideProduction() {
+        SecurityContext context = context(new MockEnvironment(), List.of(), false, false, List.of(), true);
+
+        SecurityRuleResultDto result = new GeneratedUserInProductionRule().evaluate(context);
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void generatedUserInProductionPassesWhenNoGeneratedUserDetailsManagerIsPresent() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+        SecurityContext context = context(environment, List.of(), false, false, List.of(), false);
+
+        SecurityRuleResultDto result = new GeneratedUserInProductionRule().evaluate(context);
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void generatedUserInProductionPassesWhenSpringSecurityUserPropertiesAreExplicitlyConfigured() {
+        // SEC-AUTH-004 (DefaultInMemoryUserRule) already covers an explicitly-configured static user;
+        // this rule only targets the fully-default, no-configuration-at-all case.
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.security.user.name", "admin");
+        environment.setActiveProfiles("prod");
+        SecurityContext context = context(environment, List.of(), false, false, List.of(), true);
+
+        SecurityRuleResultDto result = new GeneratedUserInProductionRule().evaluate(context);
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
@@ -670,7 +896,7 @@ class SecurityRulesTests {
 
     @Test
     void strictHttpFirewallWeakenedFiresWhenADefaultProtectionWasReAllowed() {
-        SecurityContext context = context(new MockEnvironment(), List.of(), true, false);
+        SecurityContext context = context(new MockEnvironment(), List.of(), true, false, List.of(), false);
 
         SecurityRuleResultDto result = new StrictHttpFirewallWeakenedRule().evaluate(context);
 
@@ -680,7 +906,7 @@ class SecurityRulesTests {
 
     @Test
     void strictHttpFirewallWeakenedPassesWhenDefaultsAreUnchanged() {
-        SecurityContext context = context(new MockEnvironment(), List.of(), false, false);
+        SecurityContext context = context(new MockEnvironment(), List.of(), false, false, List.of(), false);
 
         SecurityRuleResultDto result = new StrictHttpFirewallWeakenedRule().evaluate(context);
 
@@ -1124,6 +1350,8 @@ class SecurityRulesTests {
                 List.of(),
                 false,
                 false,
+                List.of(),
+                false,
                 new MockEnvironment());
     }
 
@@ -1154,19 +1382,24 @@ class SecurityRulesTests {
                 List.of(),
                 false,
                 false,
+                List.of(),
+                false,
                 environment);
     }
 
     /**
      * Full-control overload for tests that need to set the {@code oauth2TokenValidatorTypes},
-     * {@code strictHttpFirewallWeakened}, or {@code hideUserNotFoundExceptionsDisabled} fields
+     * {@code strictHttpFirewallWeakened}, {@code hideUserNotFoundExceptionsDisabled},
+     * {@code opaqueTokenIntrospectorTypes}, or {@code generatedUserDetailsManagerPresent} fields
      * directly, without any filter chains, encoders, or CORS configs.
      */
     private static SecurityContext context(
             Environment environment,
             List<String> oauth2TokenValidatorTypes,
             boolean strictHttpFirewallWeakened,
-            boolean hideUserNotFoundExceptionsDisabled) {
+            boolean hideUserNotFoundExceptionsDisabled,
+            List<String> opaqueTokenIntrospectorTypes,
+            boolean generatedUserDetailsManagerPresent) {
         return new SecurityContext(
                 List.of(),
                 List.of(),
@@ -1180,6 +1413,33 @@ class SecurityRulesTests {
                 oauth2TokenValidatorTypes,
                 strictHttpFirewallWeakened,
                 hideUserNotFoundExceptionsDisabled,
+                opaqueTokenIntrospectorTypes,
+                generatedUserDetailsManagerPresent,
+                environment);
+    }
+
+    /**
+     * Combines custom filter chains with a set of discovered {@code OpaqueTokenIntrospector} bean
+     * types -- used only to test SEC-OAUTH-001's opaque-token-bean detection path, which neither of
+     * the overloads above can express together.
+     */
+    private static SecurityContext contextWithOpaqueTokenIntrospector(
+            List<FilterChainModel> chains, List<String> opaqueTokenIntrospectorTypes, Environment environment) {
+        return new SecurityContext(
+                chains,
+                List.of(),
+                List.of(),
+                false,
+                List.of(),
+                false,
+                false,
+                false,
+                false,
+                List.of(),
+                false,
+                false,
+                opaqueTokenIntrospectorTypes,
+                false,
                 environment);
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -23,7 +23,7 @@ import org.springframework.security.web.FilterChainProxy;
 
 class SecurityScannerTests {
 
-    private static final int RULE_COUNT = 57;
+    private static final int RULE_COUNT = 59;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 
     @Test
@@ -57,6 +57,8 @@ class SecurityScannerTests {
                 false,
                 List.of(),
                 false,
+                false,
+                List.of(),
                 false,
                 environment);
         SecurityScanner scanner = new SecurityScanner(context, CLOCK);
@@ -134,6 +136,8 @@ class SecurityScannerTests {
                 List.of(),
                 false,
                 false,
+                List.of(),
+                false,
                 environment);
         SecurityScanner scanner = new SecurityScanner(context, CLOCK);
 
@@ -184,6 +188,8 @@ class SecurityScannerTests {
                 false,
                 List.of(),
                 false,
+                false,
+                List.of(),
                 false,
                 environment);
         SecurityScanner scanner = new SecurityScanner(context, CLOCK);
@@ -237,6 +243,8 @@ class SecurityScannerTests {
                 false,
                 List.of(),
                 false,
+                false,
+                List.of(),
                 false,
                 environment);
         SecurityScanner scanner = new SecurityScanner(context, CLOCK);
@@ -314,6 +322,8 @@ class SecurityScannerTests {
                 false,
                 List.of(),
                 false,
+                false,
+                List.of(),
                 false,
                 new MockEnvironment());
         SecurityScanner scanner = new SecurityScanner(context, CLOCK);
@@ -462,6 +472,8 @@ class SecurityScannerTests {
                 List.of(),
                 false,
                 false,
+                List.of(),
+                false,
                 environment);
     }
 
@@ -478,6 +490,8 @@ class SecurityScannerTests {
                 false,
                 List.of(),
                 false,
+                false,
+                List.of(),
                 false,
                 environment);
     }
@@ -531,6 +545,8 @@ class SecurityScannerTests {
                 false,
                 List.of(),
                 false,
+                false,
+                List.of(),
                 false,
                 new MockEnvironment());
     }

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -92,6 +92,13 @@ includes up to a handful of sample details plus a remediation link.
 - **Recommendation**: Leave hideUserNotFoundExceptions at its default (true) so a failed login always reports the same generic BadCredentialsException regardless of whether the username exists.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/dao-authentication-provider.html>
 
+### SEC-AUTH-009 - Do not run production on Spring Boot's auto-generated default user
+
+- **Severity**: HIGH
+- **Detects**: Detects Spring Boot's auto-configured InMemoryUserDetailsManager (created only when no UserDetailsService/AuthenticationManager/AuthenticationProvider bean and no spring.security.user.* property are present) while a production profile is active. Unlike SEC-AUTH-004 (an explicitly-configured static user), this is the fully-default case: Spring Boot generates a random password for a single 'user' account and logs it to the console at startup, which Spring Boot's own documentation warns is for development use only.
+- **Recommendation**: Register a real UserDetailsService, AuthenticationProvider, or external identity provider before running in production; do not rely on the console-logged generated password.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/web/spring-security.html>
+
 ## Authorization
 
 ### SEC-AUTHZ-001 - Every filter chain should enforce authorization
@@ -202,6 +209,13 @@ includes up to a handful of sample details plus a remediation link.
 - **Detects**: Detects a RememberMeAuthenticationFilter whose signing key is shorter than 16 characters, which makes the remember-me token's HMAC signature easier to brute-force and forge. Only the key's length is inspected -- the key value itself is never read into a finding.
 - **Recommendation**: Configure a long, random remember-me key (16+ characters, generated from a secure source) via rememberMe().key(...), ideally sourced from an externalized secret rather than a literal in configuration.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authentication/rememberme.html>
+
+### SEC-SESSION-009 - Custom session cookie names should use a __Host-/__Secure- prefix
+
+- **Severity**: LOW
+- **Detects**: Detects server.servlet.session.cookie.name configured to a custom value that does not start with the __Host- or __Secure- cookie-name prefix (exact case -- browsers only honor these prefixes verbatim). The unmodified default name, JSESSIONID, is not flagged; this rule only fires once an application has already chosen to customize the cookie name.
+- **Recommendation**: Name the session cookie __Host-<name> (requires Secure, no Domain attribute, and Path=/) or, at minimum, __Secure-<name>, so the browser rejects the cookie unless it was set over HTTPS -- hardening against cookie-tossing from a sibling or subdomain.
+- **Learn more**: <https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#cookie-name-prefixes>
 
 ## Transport & security headers
 
@@ -356,11 +370,11 @@ custom source is never misreported as verified-safe.
 - **Recommendation**: Add a SecurityFilterChain with a securityMatcher for the actuator base path that requires authentication/authorization.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.security>
 
-### SEC-ACT-004 - Actuator health details should not be exposed unconditionally
+### SEC-ACT-004 - Actuator health details/components should not be exposed unconditionally
 
 - **Severity**: HIGH
-- **Detects**: Detects management.endpoint.health.show-details=always, which leaks infrastructure details to anonymous callers.
-- **Recommendation**: Change management.endpoint.health.show-details to 'when-authorized' (the default) or ensure the /health endpoint is strictly authenticated.
+- **Detects**: Detects management.endpoint.health.show-details=always or show-components=always, either of which leaks infrastructure/component details (disk space, database, custom health indicators, dependency versions) to anonymous callers. Spring Boot's own default for both properties is 'never' (not 'when-authorized', which was the default prior to Spring Boot 3.0).
+- **Recommendation**: Leave show-details/show-components at 'never' (the default), or set them to 'when-authorized' and require authentication for the health endpoint.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.health.show-details>
 
 ### SEC-ACT-005 - The actuator shutdown endpoint should not be enabled
@@ -386,12 +400,12 @@ custom source is never misreported as verified-safe.
 
 ## OAuth2 / JWT resource server
 
-### SEC-OAUTH-001 - JWT resource server must validate tokens via issuer or JWK set
+### SEC-OAUTH-001 - Resource server must validate tokens via JWT issuer/JWK or opaque-token introspection
 
 - **Severity**: HIGH
-- **Detects**: Detects a bearer-token resource server with no issuer-uri, jwk-set-uri, public key, or JwtDecoder bean configured.
-- **Recommendation**: Configure spring.security.oauth2.resourceserver.jwt.issuer-uri (or jwk-set-uri / a JwtDecoder bean) so signatures and the issuer are verified.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html>
+- **Detects**: Detects a bearer-token resource server with neither JWT validation (issuer-uri, jwk-set-uri, public key, or a JwtDecoder bean) nor opaque-token validation (introspection-uri or an OpaqueTokenIntrospector bean) configured. BearerTokenAuthenticationFilter is installed identically for oauth2ResourceServer().jwt(...) and .opaqueToken(...), so both validation styles are accepted.
+- **Recommendation**: Configure spring.security.oauth2.resourceserver.jwt.issuer-uri (or jwk-set-uri / a JwtDecoder bean) for JWT resource servers, or spring.security.oauth2.resourceserver.opaquetoken.introspection-uri (or a custom OpaqueTokenIntrospector bean) for opaque-token resource servers, so incoming bearer tokens are actually verified.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/index.html>
 
 ### SEC-OAUTH-002 - Validate the JWT audience claim
 

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -214,7 +214,7 @@ includes up to a handful of sample details plus a remediation link.
 
 - **Severity**: LOW
 - **Detects**: Detects server.servlet.session.cookie.name configured to a custom value that does not start with the __Host- or __Secure- cookie-name prefix (exact case -- browsers only honor these prefixes verbatim). The unmodified default name, JSESSIONID, is not flagged; this rule only fires once an application has already chosen to customize the cookie name.
-- **Recommendation**: Name the session cookie __Host-<name> (requires Secure, no Domain attribute, and Path=/) or, at minimum, __Secure-<name>, so the browser rejects the cookie unless it was set over HTTPS -- hardening against cookie-tossing from a sibling or subdomain.
+- **Recommendation**: Name the session cookie with the __Host- prefix, e.g. __Host-SESSION (requires Secure, no Domain attribute, and Path=/) or, at minimum, the __Secure- prefix, e.g. __Secure-SESSION, so the browser rejects the cookie unless it was set over HTTPS -- hardening against cookie-tossing from a sibling or subdomain.
 - **Learn more**: <https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html#cookie-name-prefixes>
 
 ## Transport & security headers


### PR DESCRIPTION
## Summary

Follow-up audit of the Security advisor's ruleset, based on a synthesized review from 5 independent AI research
agents (claude-opus-4.8, gpt-5.5, gemini-3.1-pro-preview, gpt-5.3-codex, claude-sonnet-5) plus direct
source-code/decompiled-jar verification against Spring Security 7.1.0 / Spring Boot 4.1.0 (the only versions this
project targets).

**Important context on scope**: this PR was originally scoped much more broadly (13 findings from the audit
prompt), but **PR #519 merged concurrently** while this work was in progress and already implemented the large
majority of the same findings — including retiring `SEC-CONFIG-003`, the actuator include/exclude fix, the
CSP/hardcoded-secret/catch-all-ordering fixes, and 6 new rules (`SEC-AUTHZ-005`, `SEC-CONFIG-008`,
`SEC-CONFIG-009`, `SEC-AUTH-008`, `SEC-SESSION-008`, `SEC-HEAD-010`). Rather than duplicate that work or fight
rule-id collisions, I reset onto current `main` (post-#519) and re-verified the remaining audit findings against
the already-updated code. **This PR now contains only the genuine, non-duplicated delta.**

## Fixed

- **`SEC-OAUTH-001` false positive for opaque-token resource servers.** `BearerTokenAuthenticationFilter` is
  installed identically for `.oauth2ResourceServer(oauth2 -> oauth2.jwt(...))` and `.opaqueToken(...)`, but the
  rule only ever checked JWT-specific configuration (`issuer-uri`/`jwk-set-uri`/`public-key-location`/`JwtDecoder`
  bean) to decide "configured" — so a fully legitimate opaque-token resource server tripped a false HIGH
  violation. Now also accepts `spring.security.oauth2.resourceserver.opaquetoken.introspection-uri` (property key
  double-checked against Spring Security's reference docs and confirmed via web search of
  `OAuth2ResourceServerProperties`) or a custom `OpaqueTokenIntrospector` bean as valid proof the resource server
  validates tokens.
- **`SEC-ACT-004` stale documentation.** The rule's description/recommendation claimed Spring Boot's
  `management.endpoint.health.show-details` default is `when-authorized`. I decompiled the real
  `spring-boot-security-4.1.0.jar` (`UserDetailsServiceAutoConfiguration` et al. — Spring Boot 4 split security
  autoconfiguration into its own `spring-boot-security` module) and confirmed via `HealthEndpointProperties`
  wiring that the actual current default is `never` (`when-authorized` was the default prior to Spring Boot 3.0).
  Corrected the text, and also added detection for `management.endpoint.health.show-components=always`, which
  leaks the same infrastructure/component names as `show-details=always` but was previously unchecked.

## Added (2 new rules)

- **`SEC-AUTH-009`** (HIGH) — Spring Boot's auto-generated default user left active in a production profile. I
  decompiled `UserDetailsServiceAutoConfiguration` to confirm the exact bean name (`inMemoryUserDetailsManager`)
  and its real activation conditions (`@ConditionalOnMissingBean` for `AuthenticationManager`/
  `AuthenticationProvider`/`UserDetailsService`/`AuthenticationManagerResolver`/`JwtDecoder`, plus an
  `AnyNestedCondition` satisfied when either no OAuth2/SAML classes are on the classpath, or
  `spring.security.user.name`/`.password` is explicitly set). The rule checks for the bean's presence and
  explicitly **defers to the existing `SEC-AUTH-004`** (explicitly-configured static user) when
  `spring.security.user.*` is set, so it only fires on the fully-default, silent, auto-generated-random-password
  case — confirmed via bytecode inspection this distinction is exactly correct.
- **`SEC-SESSION-009`** (LOW) — a custom `server.servlet.session.cookie.name` that doesn't use the
  `__Host-`/`__Secure-` cookie-name prefix (exact case), per OWASP's cookie-prefix guidance. The unmodified
  default `JSESSIONID` is not flagged.

(Rule IDs use `009` instead of `008` to avoid colliding with #519's `SEC-AUTH-008`/`SEC-SESSION-008`, which cover
different concepts under the same category.)

## Investigated and deliberately not changed (already covered by #519)

Everything else in the original 13-finding audit prompt — `SEC-CONFIG-003` retirement, `SEC-METHOD-002`,
actuator `include`/`exclude`, `SEC-HEAD-009` CSP directive coverage, `SEC-CONFIG-007` hardcoded-secret false
positives, `SEC-AUTHZ-004` severity, the `StrictHttpFirewall`-weakening rule, and the
`spring.security.debug`/logging-level rule — was already implemented by #519 with equivalent or near-equivalent
fixes before this PR was opened. I compared #519's diff against the original audit findings and confirmed the
substance matches; re-implementing them here would just be redundant churn against the same files.

## Testing

- 18 new tests across `SecurityRulesTests.java` (98 tests total, up from 80), covering positive and negative
  cases for all 4 changes above (5 for SEC-OAUTH-001, 5 for SEC-ACT-004, 4 for SEC-SESSION-009, 4 for
  SEC-AUTH-009).
- Full reactor test run — `./mvnw -pl bootui-core,bootui-engine,bootui-spring-autoconfigure -am test`: **1014
  tests, 0 failures, 0 errors**.
- `SpringApiConformanceTest` (black-box HTTP contract suite): **5/5 passing**.
- `./mvnw -B -ntp spotless:apply` / `spotless:check`: clean, no formatting changes needed.
- Cross-checked all 59 rule ids, titles, and severities between `SecurityRules.java` and
  `docs/SECURITY-CHECKS.md` programmatically — exact match.
- Rebased onto latest `main` (through #521, an unrelated concurrent Quarkus Security advisor PR) and re-ran the
  full suite to confirm no regressions.

## Docs

- `docs/SECURITY-CHECKS.md` updated: `SEC-OAUTH-001` and `SEC-ACT-004` entries corrected to match the fixed rule
  text; `SEC-AUTH-009` and `SEC-SESSION-009` entries added in their category-appropriate positions.
- `CHANGELOG.md` — added `[Unreleased]` entries (Added + Changed) summarizing this follow-up pass and explicitly
  noting it's additive to #519.


## CI fix (follow-up commit)

The first push here failed the "Build documentation site" check: the VuePress/Vue markdown compiler misparsed a
bare `__Host-<name>`/`__Secure-<name>` placeholder in the `SEC-SESSION-009` recommendation text (added in this
PR) as an unclosed HTML tag. Reworded to use concrete examples (`__Host-SESSION`/`__Secure-SESSION`) in both the
Java rule text and `docs/SECURITY-CHECKS.md` instead of angle-bracket placeholders, matching the existing
codebase convention of avoiding bare `<...>` tokens in prose. Verified with `npm run docs:build` locally (23
pages render successfully) and confirmed green in CI afterward.

## CI status (final)

All checks passing: `Build (Java 17)`, `Quarkus end-to-end (Java 17)`, `Build documentation site`, `CodeQL`
(java-kotlin, javascript-typescript), `submit-maven`.
