### PR TITLE
Add Spring Security rule for inline One-Time-Token success handlers (SEC-AUTH-010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   subdomain — the unmodified default `JSESSIONID` is not flagged, LOW). The Security advisor now has 59 rules, up
   from 57 (#522).
 
+- **One new Spring Security advisor rule**, `SEC-AUTH-010`, closing the one area the audit above did not cover:
+  one-time-token ("magic link") login. It flags a chain running `GenerateOneTimeTokenFilter` (installed by
+  `oneTimeTokenLogin()`, Spring Security 6.2+) whose configured `OneTimeTokenGenerationSuccessHandler` is an inline
+  lambda, anonymous, or local class rather than a dedicated, named component (HIGH). Note on scope: Spring Security
+  has no framework-default handler for one-time-token login — `oneTimeTokenLogin()` throws `IllegalStateException`
+  at startup unless a handler bean is supplied explicitly — so this rule does not claim a "logs to console by
+  default" finding. It instead targets the real, common risk: a *mandatory* handler wired up as a throwaway
+  tutorial/demo lambda that prints the raw magic-link token, leaking a valid authentication credential into
+  application logs. The Security advisor now has 60 rules, up from 59.
+
 - **Three new Hibernate advisor rules**, from a second, deeper audit pass dedicated to the Hibernate advisor alone:
   `HIB-ID-007` (composite identifier classes — `@EmbeddedId`/`@IdClass` — must be `Serializable`, expose a public no-arg
   constructor, and override both `equals` and `hashCode`, HIGH), `HIB-CONFIG-018` (bind-parameter logging should not be

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
@@ -39,6 +39,13 @@ final class SecurityModel {
      *     {@code RememberMeAuthenticationFilter} is present and its key could be read, {@code null}
      *     otherwise. Only the length is retained -- never the key itself -- so a short/predictable
      *     key can be flagged without the key value ever leaving this process.
+     * @param oneTimeTokenSuccessHandlerInline {@code TRUE} when a {@code GenerateOneTimeTokenFilter}
+     *     (one-time-token / "magic link" login, {@code oneTimeTokenLogin()}) is present and its
+     *     configured {@code OneTimeTokenGenerationSuccessHandler} is an inline lambda, anonymous, or
+     *     local class rather than a dedicated named component, {@code FALSE} when the handler is a
+     *     dedicated class, {@code null} when no such filter is present or its handler could not be
+     *     read. Only the handler's {@code Class} shape is retained -- never the generated token
+     *     itself.
      */
     record FilterChainModel(
             int index,
@@ -51,7 +58,8 @@ final class SecurityModel {
             Boolean hstsIncludeSubdomains,
             String cspPolicyDirectives,
             Boolean authorizationRuleShadowed,
-            Integer rememberMeKeyLength) {
+            Integer rememberMeKeyLength,
+            Boolean oneTimeTokenSuccessHandlerInline) {
 
         private static final long HSTS_MIN_MAX_AGE_SECONDS = 31536000L; // HstsHeaderWriter's own 1-year default
 
@@ -91,12 +99,13 @@ final class SecurityModel {
                     null,
                     null,
                     null,
+                    null,
                     null);
         }
 
         /**
          * Convenience constructor for callers that need the HSTS/CSP policy details but predate the
-         * authorization-shadowing and remember-me-key fields.
+         * authorization-shadowing, remember-me-key, and one-time-token-handler fields.
          */
         FilterChainModel(
                 int index,
@@ -119,6 +128,38 @@ final class SecurityModel {
                     hstsIncludeSubdomains,
                     cspPolicyDirectives,
                     null,
+                    null,
+                    null);
+        }
+
+        /**
+         * Convenience constructor for callers that need the authorization-shadowing and
+         * remember-me-key fields but predate the one-time-token-handler field.
+         */
+        FilterChainModel(
+                int index,
+                String matcher,
+                List<String> filterNames,
+                Boolean permitsAllAnonymous,
+                Boolean sessionFixationDisabled,
+                List<String> headerWriterNames,
+                Long hstsMaxAgeSeconds,
+                Boolean hstsIncludeSubdomains,
+                String cspPolicyDirectives,
+                Boolean authorizationRuleShadowed,
+                Integer rememberMeKeyLength) {
+            this(
+                    index,
+                    matcher,
+                    filterNames,
+                    permitsAllAnonymous,
+                    sessionFixationDisabled,
+                    headerWriterNames,
+                    hstsMaxAgeSeconds,
+                    hstsIncludeSubdomains,
+                    cspPolicyDirectives,
+                    authorizationRuleShadowed,
+                    rememberMeKeyLength,
                     null);
         }
 
@@ -224,6 +265,19 @@ final class SecurityModel {
                 return trimmed.substring(directive.length()).trim();
             }
             return null;
+        }
+
+        /**
+         * {@code true} when this chain's one-time-token ("magic link") login is wired to a
+         * {@code OneTimeTokenGenerationSuccessHandler} whose concrete type is an inline lambda,
+         * anonymous, or local class rather than a dedicated, named component. Spring Security has no
+         * framework default for this handler -- {@code oneTimeTokenLogin()} fails to start unless one
+         * is supplied explicitly -- so an inline implementation is a strong signal that a
+         * tutorial/demo snippet (which commonly just logs or prints the generated magic-link token)
+         * was left in place rather than a considered, out-of-band delivery mechanism.
+         */
+        boolean hasInlineOneTimeTokenSuccessHandler() {
+            return Boolean.TRUE.equals(oneTimeTokenSuccessHandlerInline);
         }
 
         /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuleRegistry.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuleRegistry.java
@@ -15,6 +15,7 @@ final class SecurityRuleRegistry {
             new BasicAuthWithoutTlsRule(),
             new UsernameEnumerationRiskRule(),
             new GeneratedUserInProductionRule(),
+            new InlineOneTimeTokenSuccessHandlerRule(),
             // Authorization
             new MissingAuthorizationFilterRule(),
             new PermitAllCatchAllRule(),

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
@@ -316,6 +316,43 @@ final class GeneratedUserInProductionRule extends AbstractSecurityRule {
     }
 }
 
+final class InlineOneTimeTokenSuccessHandlerRule extends AbstractSecurityRule {
+
+    InlineOneTimeTokenSuccessHandlerRule() {
+        super(
+                new SecurityRuleDefinition(
+                        "SEC-AUTH-010",
+                        "One-Time-Token login should use a dedicated success handler, not an inline lambda",
+                        SecurityCategory.AUTHENTICATION,
+                        "HIGH",
+                        "Detects a one-time-token login chain (GenerateOneTimeTokenFilter, installed by oneTimeTokenLogin())"
+                                + " whose configured OneTimeTokenGenerationSuccessHandler is an inline lambda, anonymous, or"
+                                + " local class rather than a dedicated, named component. Spring Security has no framework"
+                                + " default for this handler -- oneTimeTokenLogin() fails to start unless one is supplied"
+                                + " explicitly -- so an inline implementation is a strong signal that a tutorial/demo snippet"
+                                + " (which commonly just logs or prints the generated magic-link token) was left in place,"
+                                + " risking a valid authentication credential leaking into application logs.",
+                        "Implement the handler as a dedicated, reviewed component -- following Spring Security's own"
+                                + " MagicLinkOneTimeTokenGenerationSuccessHandler example -- that delivers the token only"
+                                + " through a trusted out-of-band channel such as email or SMS, and never logs or renders the"
+                                + " raw token value.",
+                        "https://docs.spring.io/spring-security/reference/servlet/authentication/onetimetoken.html#sending-token-to-user"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        List<String> details = new ArrayList<>();
+        for (FilterChainModel chain : context.chains()) {
+            if (chain.hasInlineOneTimeTokenSuccessHandler()) {
+                details.add(chain.describe()
+                        + " wires one-time-token login (oneTimeTokenLogin()) to an inline lambda/anonymous success"
+                        + " handler instead of a dedicated, reviewable component.");
+            }
+        }
+        return violation(details);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Authorization
 // ---------------------------------------------------------------------------

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -301,6 +301,7 @@ final class SecurityScanner {
         HeaderWriterInfo headerWriters = detectHeaderWriters(filters);
         Boolean authorizationRuleShadowed = detectAuthorizationRuleShadowed(authorizationManager);
         Integer rememberMeKeyLength = detectRememberMeKeyLength(filters);
+        Boolean oneTimeTokenSuccessHandlerInline = detectInlineOneTimeTokenSuccessHandler(filters);
         return new FilterChainModel(
                 index,
                 matcher,
@@ -312,7 +313,8 @@ final class SecurityScanner {
                 headerWriters.hstsIncludeSubdomains(),
                 headerWriters.cspPolicyDirectives(),
                 authorizationRuleShadowed,
-                rememberMeKeyLength);
+                rememberMeKeyLength,
+                oneTimeTokenSuccessHandlerInline);
     }
 
     private static String matcherDescription(SecurityFilterChain chain) {
@@ -424,6 +426,34 @@ final class SecurityScanner {
                 }
                 return null;
             }
+        }
+        return null;
+    }
+
+    /**
+     * {@code true} when this chain's {@code GenerateOneTimeTokenFilter} (one-time-token /
+     * "magic link" login, {@code oneTimeTokenLogin()}) is wired to a
+     * {@code OneTimeTokenGenerationSuccessHandler} whose concrete type is an inline lambda,
+     * anonymous, or local class, {@code false} when it is a dedicated (named) class, and
+     * {@code null} when no {@code GenerateOneTimeTokenFilter} is present on this chain or its
+     * handler field could not be read. Spring Security has no framework default for this handler --
+     * {@code oneTimeTokenLogin()} fails to start unless one is supplied explicitly -- so an inline
+     * implementation is a strong signal that a tutorial/demo snippet (which commonly just logs or
+     * prints the generated magic-link token) was left in place rather than a considered, out-of-band
+     * delivery mechanism. Only the handler's {@code Class} shape is inspected here -- never the
+     * generated token itself.
+     */
+    private static Boolean detectInlineOneTimeTokenSuccessHandler(List<Filter> filters) {
+        for (Filter filter : filters) {
+            if (!"GenerateOneTimeTokenFilter".equals(filter.getClass().getSimpleName())) {
+                continue;
+            }
+            Object handler = readField(filter, "tokenGenerationSuccessHandler");
+            if (handler == null) {
+                return null;
+            }
+            Class<?> handlerType = handler.getClass();
+            return handlerType.isSynthetic() || handlerType.isAnonymousClass() || handlerType.isLocalClass();
         }
         return null;
     }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
@@ -892,6 +892,61 @@ class SecurityRulesTests {
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
 
+    // --- SEC-AUTH-010: one-time-token login success handler should not be an inline lambda --
+
+    @Test
+    void inlineOneTimeTokenSuccessHandlerFiresWhenHandlerIsInline() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("GenerateOneTimeTokenFilter"),
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.TRUE);
+
+        SecurityRuleResultDto result = new InlineOneTimeTokenSuccessHandlerRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("HIGH");
+        assertThat(result.sampleViolations()).anyMatch(detail -> detail.contains("oneTimeTokenLogin()"));
+    }
+
+    @Test
+    void inlineOneTimeTokenSuccessHandlerPassesWhenHandlerIsADedicatedClass() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("GenerateOneTimeTokenFilter"),
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.FALSE);
+
+        SecurityRuleResultDto result = new InlineOneTimeTokenSuccessHandlerRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void inlineOneTimeTokenSuccessHandlerPassesWhenNoOneTimeTokenFilterIsPresent() {
+        FilterChainModel chain = chain("any request", List.of("SecurityContextHolderFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new InlineOneTimeTokenSuccessHandlerRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
     // --- SEC-CONFIG-008: StrictHttpFirewall weakening ---------------------------------------
 
     @Test

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -23,7 +23,7 @@ import org.springframework.security.web.FilterChainProxy;
 
 class SecurityScannerTests {
 
-    private static final int RULE_COUNT = 59;
+    private static final int RULE_COUNT = 60;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 
     @Test
@@ -402,6 +402,48 @@ class SecurityScannerTests {
         SecurityReport report = new SecurityScanner(contextWith(chain, new MockEnvironment()), CLOCK).scan();
 
         assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-SESSION-007");
+    }
+
+    @Test
+    void flagsOneTimeTokenLoginWithAnInlineSuccessHandler() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("SecurityContextHolderFilter", "GenerateOneTimeTokenFilter", "AuthorizationFilter"),
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.TRUE);
+
+        SecurityReport report = new SecurityScanner(contextWith(chain, new MockEnvironment()), CLOCK).scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-AUTH-010");
+    }
+
+    @Test
+    void doesNotFlagOneTimeTokenLoginWithADedicatedSuccessHandler() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("SecurityContextHolderFilter", "GenerateOneTimeTokenFilter", "AuthorizationFilter"),
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.FALSE);
+
+        SecurityReport report = new SecurityScanner(contextWith(chain, new MockEnvironment()), CLOCK).scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-AUTH-010");
     }
 
     @Test

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -99,6 +99,13 @@ includes up to a handful of sample details plus a remediation link.
 - **Recommendation**: Register a real UserDetailsService, AuthenticationProvider, or external identity provider before running in production; do not rely on the console-logged generated password.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/spring-security.html>
 
+### SEC-AUTH-010 - One-Time-Token login should use a dedicated success handler, not an inline lambda
+
+- **Severity**: HIGH
+- **Detects**: Detects a one-time-token login chain (GenerateOneTimeTokenFilter, installed by oneTimeTokenLogin()) whose configured OneTimeTokenGenerationSuccessHandler is an inline lambda, anonymous, or local class rather than a dedicated, named component. Spring Security has no framework default for this handler -- oneTimeTokenLogin() fails to start unless one is supplied explicitly -- so an inline implementation is a strong signal that a tutorial/demo snippet (which commonly just logs or prints the generated magic-link token) was left in place, risking a valid authentication credential leaking into application logs.
+- **Recommendation**: Implement the handler as a dedicated, reviewed component -- following Spring Security's own MagicLinkOneTimeTokenGenerationSuccessHandler example -- that delivers the token only through a trusted out-of-band channel such as email or SMS, and never logs or renders the raw token value.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authentication/onetimetoken.html#sending-token-to-user>
+
 ## Authorization
 
 ### SEC-AUTHZ-001 - Every filter chain should enforce authorization


### PR DESCRIPTION
## Summary

Adds one new rule to the Spring Security advisor, `SEC-AUTH-010`, closing the one area the prior Security advisor audit (#519, #522) did not cover: one-time-token ("magic link") login (`oneTimeTokenLogin()`, Spring Security 6.2+).

## Important: the original premise was corrected

The task that prompted this PR assumed `oneTimeTokenLogin()` **defaults to a handler that logs the generated token to the console** when no custom handler is configured. I verified this against the project's actual pinned dependency (decompiled `spring-security-web-7.1.0.jar` / `spring-security-config-7.1.0.jar`, plus their `-sources.jar`s from the local Maven repo) and Spring's own reference docs:

> "It is not possible for Spring Security to reasonably determine the way the token should be delivered to your users... a custom `OneTimeTokenGenerationSuccessHandler` must be provided."
> — https://docs.spring.io/spring-security/reference/servlet/authentication/onetimetoken.html#sending-token-to-user

`OneTimeTokenLoginConfigurer.getOneTimeTokenGenerationSuccessHandler()` throws `IllegalStateException` at startup if no handler bean/customizer is supplied — there is **no default console-logging behavior** to detect.

Rather than ship a rule based on a false premise, I reframed it around a real, verifiable risk instead: since a handler is *mandatory*, a common tutorial/demo shortcut is to wire it up as an **inline lambda/anonymous/local class** that just prints the raw magic-link token — a genuine credential-leak pattern that's straightforward to detect via reflection on the handler's `Class` shape (never inspecting the token value itself). All code, docs, and changelog text are careful to state this corrected premise explicitly rather than imply a false default.

## What's in this PR

- **`SEC-AUTH-010`** (AUTHENTICATION, HIGH): flags a chain running `GenerateOneTimeTokenFilter` whose configured `OneTimeTokenGenerationSuccessHandler` is an inline lambda, anonymous, or local class rather than a dedicated, named component.
- `SecurityModel.FilterChainModel`: new `oneTimeTokenSuccessHandlerInline` tri-state `Boolean` field, a backward-compatible constructor overload preserving all existing 11-arg call sites, and a `hasInlineOneTimeTokenSuccessHandler()` accessor.
- `SecurityScanner`: `detectInlineOneTimeTokenSuccessHandler` reads `GenerateOneTimeTokenFilter`'s private `tokenGenerationSuccessHandler` field via the existing `readField` reflection helper (no public getter exists — confirmed via `javap -p` on the real jar) and checks `isSynthetic() || isAnonymousClass() || isLocalClass()`.
- `SecurityRules` / `SecurityRuleRegistry`: new `InlineOneTimeTokenSuccessHandlerRule`, registered alongside the other authentication rules.
- Tests: positive/negative cases in `SecurityRulesTests` (handler is inline → fires; handler is a dedicated class → passes; no OTT filter present → passes) and full-scan cases in `SecurityScannerTests` (`RULE_COUNT` bumped 59 → 60).
- `docs/SECURITY-CHECKS.md`: new `SEC-AUTH-010` entry, text matching the Java rule definition exactly.
- `CHANGELOG.md`: `[Unreleased]` entry explaining the corrected premise and the real risk targeted.

## Validation

- [x] `./mvnw -B -ntp spotless:apply` — clean, only the intended 8 files changed.
- [x] `./mvnw -B -ntp spotless:check` — passes.
- [x] `./mvnw -pl bootui-core,bootui-engine,bootui-spring-autoconfigure -am test` — **1019 tests, 0 failures, 0 errors**.
- [x] `SpringApiConformanceTest` black-box suite — **5 tests, 0 failures**.
- [x] Rule IDs/titles/severities cross-checked between `SecurityRules.java` and `docs/SECURITY-CHECKS.md` — exact match for all `SEC-AUTH-*` entries.

## Scope

Single, focused rule addition — no other ruleset changes. Detection is confined to inspecting the handler's `Class` shape via reflection; the generated token value is never read or logged by the scanner itself.