### PR TITLE
Fix flaky heap-usage assertion in LiveActivityControllerTests

### DIFF
--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityControllerTests.java
@@ -139,7 +139,15 @@ class LiveActivityControllerTests {
             // historical page is being browsed.
             assertThat(result.available()).isEqualTo(expectedLive.available());
             assertThat(result.typeCounts()).isEqualTo(expectedLive.typeCounts());
-            assertThat(result.kpis()).isEqualTo(expectedLive.kpis());
+            // heapUsedBytes is sampled live at call time via ManagementFactory, so it can drift by a few
+            // bytes between the two independent report() invocations (this one and referenceLiveReport's)
+            // even a few instructions apart - compare everything else exactly and only sanity-check heap.
+            assertThat(result.kpis())
+                    .usingRecursiveComparison()
+                    .ignoringFields("heapUsedBytes", "heapMaxBytes")
+                    .isEqualTo(expectedLive.kpis());
+            assertThat(result.kpis().heapUsedBytes()).isNotNull().isPositive();
+            assertThat(result.kpis().heapMaxBytes()).isNotNull().isPositive();
             assertThat(result.sources()).isEqualTo(expectedLive.sources());
             assertThat(result.warnings()).isEqualTo(expectedLive.warnings());
 


### PR DESCRIPTION
## What does this PR do?

Fixes a flaky test assertion in `LiveActivityControllerTests` that was failing the Windows job of the cross-platform build.

## Why is this change needed?

The [cross-platform build](https://github.com/jdubois/boot-ui/actions/workflows/cross-platform.yml) failed on `windows-latest` (the `ubuntu-latest` and `macos-latest` jobs both passed) with:

```
LiveActivityControllerTests.activityDelegatesEntriesAndPageInfoToStoreWhenPersistenceEnabled
expected: heapUsedBytes=210763776 ... but was: heapUsedBytes=212860928
```

`activityDelegatesEntriesAndPageInfoToStoreWhenPersistenceEnabled` builds two independent `LiveActivityReport` snapshots (one via a `referenceLiveReport` helper, one via the actual controller call) and asserted the `kpis()` records were byte-for-byte equal. But `heapUsedBytes`/`heapMaxBytes` are sampled *live* from `ManagementFactory.getMemoryMXBean()` at call time (`LiveActivityAssembler.heapUsed()`/`heapMax()`), so JVM allocations happening between the two snapshots (Mockito proxying, `ArgumentCaptor`, etc.) can shift heap usage by a few bytes - this is what tripped on the Windows runner. It's test flakiness, not a product regression; no production code changed.

The fix compares the KPI DTOs with a recursive comparison that ignores the two live heap fields, and separately asserts they are populated (non-null, positive) instead of requiring byte-exact values.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Ran the full `bootui-spring-autoconfigure` suite: 1126 tests, 0 failures, 0 errors
- [x] Re-ran the previously-flaky test 5x in a row to confirm it's now stable
- [x] `./mvnw spotless:check` passes
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (N/A - test-only change)

## Screenshots (UI changes)

N/A - test-only change, no UI impact.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes - N/A, no behavior change
- [x] Public API kept backward compatible, or a migration note added to the PR description - N/A, test-only
- [x] No secrets, tokens, or local paths committed

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>