### PR TITLE
Fix Dependabot alerts on direct dependencies (jackson-databind, opentelemetry-api)

### DIFF
--- a/bootui-conformance/pom.xml
+++ b/bootui-conformance/pom.xml
@@ -35,9 +35,13 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
         </dependency>
+        <!-- The Spring Boot BOM manages this at 2.21.4, vulnerable to GHSA-5jmj-h7xm-6q6v (case-insensitive
+             deserialization bypasses per-property @JsonIgnoreProperties, fixed upstream in 2.21.5). Pin it
+             explicitly until the BOM catches up. -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>2.21.5</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/bootui-quarkus/pom.xml
+++ b/bootui-quarkus/pom.xml
@@ -75,14 +75,20 @@
              never gets the OTel SDK on its classpath, and the capability-gated build step never registers the
              producer that would reference it (R2/BF2). When an app DOES add quarkus-opentelemetry, the SDK is
              supplied (at the same quarkus-bom-managed version) by that extension. -->
+        <!-- quarkus-bom 3.37.1 manages these at 1.60.1, vulnerable to GHSA-rcgg-9c38-7xpx (unbounded memory
+             allocation in W3C baggage propagation, fixed upstream in opentelemetry-api 1.62.0). Pin both
+             OTel artifacts to 1.62.0 explicitly so they stay at the same version as each other (per the
+             comment above) instead of drifting apart. -->
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-sdk-trace</artifactId>
+            <version>1.62.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
+            <version>1.62.0</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
## Summary

Addresses a subset of the open Dependabot alerts, scoped strictly to dependencies this repo declares **directly** (per request — no transitive-only overrides).

| Alert(s) | Package | Module | Change |
|---|---|---|---|
| #53 (+ transitively fixes #149, #158) | `com.fasterxml.jackson.core:jackson-databind` | `bootui-conformance` | 2.21.4 → 2.21.5 |
| #141 | `io.opentelemetry:opentelemetry-api` / `opentelemetry-sdk-trace` | `bootui-quarkus` | 1.60.1 → 1.62.0 |

Both packages are declared as explicit `<dependency>` entries in these poms (version previously left to BOM management), so bumping them is a direct-dependency fix, not a transitive override. `bootui-spring-sample-app` and `bootui-spring-webflux-sample-app` pick up jackson-databind from `bootui-conformance` in test scope, so alerts #149/#158 are resolved as a side effect of the same fix.

## Alerts intentionally left untouched (transitive, or no fix available yet)

- **jackson-databind 2.22.0** in `bootui-quarkus`, `bootui-quarkus-deployment`, and all `bootui-quarkus-integration-tests/*` modules (GHSA-5jmj-h7xm-6q6v, 13 alerts) — no patched 2.22.x release exists upstream yet (`first_patched_version` is null).
- **jackson-databind** in `bootui-quarkus-sample-app` (7 alerts) — pulled transitively via `org.flywaydb:flyway-core`, itself resolved through the sample app's own older, independently-pinned `quarkus.platform.version` (3.33.2.1). Fixing this cleanly would mean bumping the whole Quarkus platform version for that app — a much bigger, riskier change than a single-dependency patch.
- **opentelemetry-api** in `bootui-quarkus-sample-app` and the `otel`/`security`/`scheduler` integration-test modules (4 alerts) — pulled in transitively via `quarkus-opentelemetry` or `quarkus-scheduler`, not declared directly by those modules.
- **js-yaml** (npm, #52) — transitive via `gray-matter` (a `vuepress` dependency), not a direct `package.json` dependency.

Happy to open follow-up work for the Quarkus platform bump or to track the unfixed jackson CVE until upstream ships a patch.

## Verification

```
./mvnw -B -ntp -pl bootui-quarkus,bootui-conformance -am -amd install   # 21 modules, all green
./mvnw -B -ntp -pl bootui-quarkus,bootui-conformance spotless:check    # clean
```