### PR TITLE
Fix WebFlux Live Activity trace correlation gap

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfiguration.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfiguration.java
@@ -20,10 +20,13 @@ import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiStaticResou
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveClaudeCodeController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveCopilotController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveExceptionsController;
+import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveHttpExchangeTraceFilter;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveLiveActivityController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveLocalhostOnlyFilter;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveLogTailController;
+import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveOtelTraceIdProvider;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactivePanelAccessFilter;
+import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveSecurityEventTraceRegistry;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveSecurityLogsController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveSqlTraceController;
 import io.github.jdubois.bootui.autoconfigure.restapi.RestApiController;
@@ -35,6 +38,7 @@ import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
 import io.github.jdubois.bootui.engine.telemetry.TelemetryStore;
+import io.github.jdubois.bootui.spi.TraceIdProvider;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
@@ -42,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.aot.AotDetector;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -219,7 +224,8 @@ import org.springframework.web.util.DisconnectedClientHelper;
     ReactiveClaudeCodeController.class,
     ReactiveBootUiIndexController.class,
     BootUiEngineConfiguration.class,
-    BootUiOpenTelemetryConfiguration.class
+    BootUiOpenTelemetryConfiguration.class,
+    BootUiReactiveAutoConfiguration.ReactiveOpenTelemetryCorrelationConfiguration.class
 })
 public class BootUiReactiveAutoConfiguration {
 
@@ -639,6 +645,84 @@ public class BootUiReactiveAutoConfiguration {
                 HttpExchangeRepository repository, HttpExchangesProperties properties) {
             return new HttpExchangesWebFilter(
                     repository, properties.getRecording().getInclude());
+        }
+    }
+
+    /**
+     * Reactive sibling of the trace-id correlation Quarkus's adapter supplies natively (see
+     * {@code QuarkusOtelTraceIdProvider}): installs an OpenTelemetry-backed {@link TraceIdProvider} onto
+     * the SQL Trace recorder, the reactive exception handler, the {@link HttpExchangesController} (via the
+     * side-buffer {@link HttpExchangeTraceRegistry}), and the {@link ReactiveSecurityLogsController} (via
+     * {@link ReactiveSecurityEventTraceRegistry}), so {@link ReactiveLiveActivityController} - which
+     * already feeds all four signal sources to the shared engine {@code LiveActivityAssembler} - can
+     * actually nest a request's SQL/exception/security signals under it.
+     *
+     * <p>WebFlux has no thread-per-request invariant for {@code SqlTraceRecorder}'s default MDC-based
+     * {@link TraceIdProvider} to rely on (Reactor Netty's event-loop / {@code boundedElastic} scheduler
+     * hops break thread-local propagation), so it must instead read the active OpenTelemetry span, whose
+     * context survives those hops - exactly like the Quarkus adapter, and for the same reason. Gated on
+     * the OpenTelemetry SDK being present, exactly like {@link BootUiOpenTelemetryConfiguration} and
+     * Quarkus's own {@code Capability.OPENTELEMETRY_TRACER} gate - deliberately <em>not</em> also gated on
+     * {@code bootui.telemetry.enabled} (that property governs BootUI's own span capture for the
+     * Traces/AI Usage panels, a separate concern from reading the id of a span the application's own
+     * tracing already started). When OpenTelemetry is absent, every capture point keeps its existing
+     * behavior unchanged (MDC-based for SQL, header-derived for HTTP exchanges, none for
+     * exceptions/security events).</p>
+     */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(name = "io.opentelemetry.sdk.trace.export.SpanExporter")
+    static class ReactiveOpenTelemetryCorrelationConfiguration {
+
+        @Bean
+        ReactiveOtelTraceIdProvider bootUiReactiveOtelTraceIdProvider() {
+            return new ReactiveOtelTraceIdProvider();
+        }
+
+        @Bean
+        HttpExchangeTraceRegistry bootUiHttpExchangeTraceRegistry(BootUiProperties properties) {
+            return new HttpExchangeTraceRegistry(properties.getHttpExchanges().getMaxExchanges());
+        }
+
+        @Bean
+        ReactiveSecurityEventTraceRegistry bootUiReactiveSecurityEventTraceRegistry(BootUiProperties properties) {
+            return new ReactiveSecurityEventTraceRegistry(
+                    properties.getSecurityLogs().getMaxLogs());
+        }
+
+        @Bean
+        ReactiveHttpExchangeTraceFilter bootUiReactiveHttpExchangeTraceFilter(
+                BootUiProperties properties,
+                HttpExchangeTraceRegistry registry,
+                ReactiveOtelTraceIdProvider traceIdProvider) {
+            return new ReactiveHttpExchangeTraceFilter(properties, registry, traceIdProvider);
+        }
+
+        /**
+         * Installs the OpenTelemetry-backed provider/registries onto the already-constructed capture
+         * points once all singletons exist, mirroring
+         * {@link BootUiOpenTelemetryConfiguration#bootUiSpanEnricherInstaller}. Each target bean is
+         * optional (its owning panel may be disabled), so every installation step is a no-op
+         * {@link ObjectProvider#ifAvailable} rather than a hard dependency.
+         */
+        @Bean
+        SmartInitializingSingleton bootUiReactiveTraceCorrelationInstaller(
+                ReactiveOtelTraceIdProvider traceIdProvider,
+                HttpExchangeTraceRegistry httpExchangeTraceRegistry,
+                ReactiveSecurityEventTraceRegistry securityEventTraceRegistry,
+                ObjectProvider<SqlTraceRecorder> sqlTraceRecorders,
+                ObjectProvider<HttpExchangesController> httpExchangesControllers,
+                ObjectProvider<ReactiveBootUiExceptionHandler> exceptionHandlers,
+                ObjectProvider<ReactiveSecurityLogsController> securityLogsControllers) {
+            return () -> {
+                sqlTraceRecorders.ifAvailable(recorder -> recorder.setTraceIdProvider(traceIdProvider));
+                httpExchangesControllers.ifAvailable(
+                        controller -> controller.setTraceRegistry(httpExchangeTraceRegistry));
+                exceptionHandlers.ifAvailable(handler -> handler.setTraceIdProvider(traceIdProvider));
+                securityLogsControllers.ifAvailable(controller -> {
+                    controller.setTraceIdProvider(traceIdProvider);
+                    controller.setTraceRegistry(securityEventTraceRegistry);
+                });
+            };
         }
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessor.java
@@ -5,10 +5,12 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MutablePropertySources;
+import org.springframework.util.ClassUtils;
 
 /**
  * Contributes the Actuator endpoint exposure defaults BootUI needs for its
@@ -48,6 +50,18 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
             "logging.level.io.opentelemetry", TRACING_LOG_LEVEL,
             "logging.level.io.micrometer.tracing", TRACING_LOG_LEVEL);
 
+    public static final String REACTOR_CONTEXT_PROPAGATION_PROPERTY = "spring.reactor.context-propagation";
+
+    public static final String REACTOR_CONTEXT_PROPAGATION_VALUE = "auto";
+
+    /**
+     * The OpenTelemetry SDK class {@code ReactiveOpenTelemetryCorrelationConfiguration} itself gates on,
+     * checked by name here too (rather than importing it, which would pull an optional dependency into
+     * this always-loaded {@code EnvironmentPostProcessor}) so this default is contributed exactly when
+     * that WebFlux-only trace-id wiring will actually be active.
+     */
+    private static final String OTEL_SPAN_EXPORTER_CLASS = "io.opentelemetry.sdk.trace.export.SpanExporter";
+
     private static final Map<String, Object> ACTUATOR_DEFAULTS = Map.of(
             "management.endpoints.web.exposure.include",
             REQUIRED_ENDPOINTS,
@@ -70,6 +84,9 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
         if (telemetryEnabled(environment) && tracesPanelEnabled(environment)) {
             defaults.put(TRACING_SAMPLING_PROBABILITY_PROPERTY, TRACING_SAMPLING_PROBABILITY);
             defaults.putAll(TRACING_LOG_LEVEL_DEFAULTS);
+        }
+        if (reactiveOpenTelemetryCorrelationActive(application)) {
+            defaults.put(REACTOR_CONTEXT_PROPAGATION_PROPERTY, REACTOR_CONTEXT_PROPAGATION_VALUE);
         }
 
         // Only contribute defaults the host has not already configured through any property source,
@@ -94,6 +111,24 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
         return environment.getProperty("bootui.panels.traces.enabled", Boolean.class, true);
     }
 
+    /**
+     * WebFlux has no thread-per-request invariant: a single reactive chain hops between the Netty
+     * event loop, {@code boundedElastic} (blocking JDBC calls), and {@code parallel} schedulers.
+     * BootUI's reactive Live Activity/SQL-trace/exception/security-log correlation stamps each capture
+     * point with {@code Span.current()}'s trace id (see {@code ReactiveOtelTraceIdProvider}), which only
+     * resolves correctly across those thread hops when Reactor's automatic context propagation is on
+     * ({@code Hooks.enableAutomaticContextPropagation()}). Spring Boot 4.1 only enables that when
+     * {@value #REACTOR_CONTEXT_PROPAGATION_PROPERTY} is {@code auto}; its own default is {@code limited},
+     * which leaves the OpenTelemetry trace context ThreadLocal empty on every thread but the one the
+     * request happened to start on. Scoped to reactive applications with the OpenTelemetry SDK on the
+     * classpath, since that is exactly when {@code ReactiveOpenTelemetryCorrelationConfiguration} wires
+     * the trace-id-stamping beans this default exists to support.
+     */
+    private boolean reactiveOpenTelemetryCorrelationActive(SpringApplication application) {
+        return application.getWebApplicationType() == WebApplicationType.REACTIVE
+                && ClassUtils.isPresent(OTEL_SPAN_EXPORTER_CLASS, application.getClassLoader());
+    }
+
     public static boolean isBootUiActuatorDefault(String key, String value) {
         if (key == null || value == null) {
             return false;
@@ -105,6 +140,7 @@ public class BootUiActuatorDefaultsEnvironmentPostProcessor implements Environme
             case TRACING_SAMPLING_PROBABILITY_PROPERTY -> TRACING_SAMPLING_PROBABILITY.equals(normalized);
             case "logging.level.io.opentelemetry", "logging.level.io.micrometer.tracing" ->
                 TRACING_LOG_LEVEL.equalsIgnoreCase(normalized);
+            case REACTOR_CONTEXT_PROPAGATION_PROPERTY -> REACTOR_CONTEXT_PROPAGATION_VALUE.equalsIgnoreCase(normalized);
             default -> false;
         };
     }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiExceptionHandler.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.reactive;
 
 import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
+import io.github.jdubois.bootui.spi.TraceIdProvider;
 import org.springframework.core.Ordered;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.reactive.HandlerMapping;
@@ -37,8 +38,20 @@ public class ReactiveBootUiExceptionHandler implements WebExceptionHandler, Orde
 
     private final ExceptionStore store;
 
+    private TraceIdProvider traceIdProvider;
+
     public ReactiveBootUiExceptionHandler(ExceptionStore store) {
         this.store = store;
+    }
+
+    /**
+     * Installed only by {@code BootUiReactiveAutoConfiguration} once OpenTelemetry is present, so the
+     * exception is nested under its owning request in the Live Activity feed exactly like the Quarkus
+     * adapter; left {@code null} otherwise, in which case {@link #currentTraceId()} returns {@code null}
+     * and {@code store.record} falls back to its existing six-argument, no-trace-id overload.
+     */
+    public void setTraceIdProvider(TraceIdProvider traceIdProvider) {
+        this.traceIdProvider = traceIdProvider;
     }
 
     @Override
@@ -52,11 +65,28 @@ public class ReactiveBootUiExceptionHandler implements WebExceptionHandler, Orde
                             : null,
                     exchange.getRequest().getURI().getRawPath(),
                     describeHandler(exchange.getAttribute(HandlerMapping.BEST_MATCHING_HANDLER_ATTRIBUTE)),
-                    "web");
+                    "web",
+                    currentTraceId());
         } catch (RuntimeException ignored) {
             // Diagnostics capture must never interfere with the application's error handling.
         }
         return Mono.error(ex);
+    }
+
+    /**
+     * The trace id active for the request currently unwinding this exception, or {@code null} when no
+     * provider is installed or it fails to resolve one - fully guarded so a misbehaving tracer never
+     * disrupts the application's own error handling.
+     */
+    private String currentTraceId() {
+        if (traceIdProvider == null) {
+            return null;
+        }
+        try {
+            return traceIdProvider.currentTraceId();
+        } catch (RuntimeException ex) {
+            return null;
+        }
     }
 
     private static String describeHandler(Object handler) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveHttpExchangeTraceFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveHttpExchangeTraceFilter.java
@@ -1,0 +1,80 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.web.HttpExchangeTraceRegistry;
+import io.github.jdubois.bootui.autoconfigure.web.HttpExchangeTraceRegistry.HttpExchangeTrace;
+import io.github.jdubois.bootui.spi.TraceIdProvider;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive (WebFlux) sibling of {@code RequestCorrelationFilter}: instead of the serving thread - which
+ * WebFlux has no per-request invariant for - it captures the distributed-trace id active when the
+ * request completes, via {@link TraceIdProvider}, feeding {@link HttpExchangeTraceRegistry} so
+ * {@code HttpExchangesController} can stamp it onto the exchange it separately captures through Spring
+ * Boot's own {@code HttpExchangesWebFilter}.
+ *
+ * <p>Reads {@link TraceIdProvider#currentTraceId()} from {@code doFinally}, the same relative point in
+ * request processing that {@code SqlTraceRecorder}/{@code ExceptionStore} already read it from for
+ * SQL/exception capture, so this has the same reliability characteristics (dependent on the
+ * application's OpenTelemetry/Reactor context propagation setup), not a new or weaker guarantee.</p>
+ *
+ * <p><strong>Ordered last</strong> ({@link Ordered#LOWEST_PRECEDENCE}), exactly like {@code
+ * ReactiveActivitySignalFilter}: WebFlux's filter chain unwinds completion signals from the innermost
+ * filter outward, so a filter registered here - closest to the actual handler - has its {@code
+ * doFinally} fire before any more-outer filter's own completion hook (in practice, the tracing
+ * instrumentation that ends the active span). Registering any earlier would risk reading {@code
+ * Span.current()} after that span has already been closed.</p>
+ *
+ * <p>Records the request's raw {@link java.net.URI} path (not {@link ServerHttpRequest#getPath()}'s
+ * context-relative form) to stay consistent with how {@code HttpExchangesController} reads the path
+ * back from Actuator's captured {@code HttpExchange.Request#getUri()} - both sides must compute the same
+ * key for {@link HttpExchangeTraceRegistry#match} to find its entry. The inherited {@link
+ * #isBootUiRequest} check (used only to decide whether to skip capture) uses the context-relative path
+ * as usual, exactly like the other BootUI filters.</p>
+ */
+public final class ReactiveHttpExchangeTraceFilter extends AbstractReactiveBootUiFilter implements Ordered {
+
+    private final HttpExchangeTraceRegistry registry;
+    private final TraceIdProvider traceIdProvider;
+
+    public ReactiveHttpExchangeTraceFilter(
+            BootUiProperties properties, HttpExchangeTraceRegistry registry, TraceIdProvider traceIdProvider) {
+        super(properties);
+        this.registry = registry;
+        this.traceIdProvider = traceIdProvider;
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(ServerWebExchange exchange) {
+        return isBootUiRequest(exchange.getRequest());
+    }
+
+    @Override
+    protected Mono<Void> doFilterInternal(ServerWebExchange exchange, WebFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+        long start = System.currentTimeMillis();
+        String method = request.getMethod() == null ? null : request.getMethod().name();
+        String path = request.getURI() == null ? null : request.getURI().getPath();
+        return chain.filter(exchange).doFinally(signal -> {
+            String traceId = safeCurrentTraceId();
+            registry.record(new HttpExchangeTrace(start, System.currentTimeMillis(), method, path, traceId));
+        });
+    }
+
+    private String safeCurrentTraceId() {
+        try {
+            return traceIdProvider.currentTraceId();
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveOtelTraceIdProvider.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveOtelTraceIdProvider.java
@@ -1,0 +1,34 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import io.github.jdubois.bootui.spi.TraceIdProvider;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+
+/**
+ * OpenTelemetry-backed {@link TraceIdProvider} for the Spring WebFlux adapter: the reactive-correct seam
+ * the Live Activity correlation needs. It reads the trace id of the active server span via
+ * {@link Span#current()}, whose OpenTelemetry context propagates across Reactor Netty's event-loop and
+ * {@code boundedElastic} scheduler hops - the same hopping that defeats the servlet adapter's
+ * thread-identity correlation ({@code RequestCorrelationRegistry}, {@code SecurityEventCorrelationRegistry}).
+ *
+ * <p>This mirrors {@code QuarkusOtelTraceIdProvider} exactly, and is installed onto the same capture
+ * points (SQL, exceptions, security events, and - unlike Quarkus, which stamps its {@code HttpExchange}
+ * DTO directly - the HTTP exchange itself via the side-buffer {@link HttpExchangeTraceRegistry}, since
+ * Spring's Actuator {@code HttpExchange} model has no trace-id field to populate). Only wired by {@link
+ * io.github.jdubois.bootui.autoconfigure.BootUiReactiveAutoConfiguration}, gated on the OpenTelemetry SDK
+ * being present, exactly like {@code BootUiOpenTelemetryConfiguration}; the servlet adapter never
+ * registers a bean of this type, so it keeps reading Micrometer's SLF4J MDC {@code traceId} key via
+ * {@code SqlTraceRecorder}'s default.</p>
+ */
+public final class ReactiveOtelTraceIdProvider implements TraceIdProvider {
+
+    @Override
+    public String currentTraceId() {
+        try {
+            SpanContext context = Span.current().getSpanContext();
+            return context.isValid() ? context.getTraceId() : null;
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityEventTraceRegistry.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityEventTraceRegistry.java
@@ -1,0 +1,96 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Bounded, in-memory record of the distributed-trace id active when each recent Spring Security audit
+ * event was published on the reactive (WebFlux) adapter, captured by
+ * {@link ReactiveSecurityLogsController#onApplicationEvent} while it observes the synchronously-published
+ * {@code AuditApplicationEvent}.
+ *
+ * <p>Reactive sibling of {@code SecurityEventCorrelationRegistry}: Spring Security audit events carry no
+ * thread, request path, or trace id, so on WebFlux - which has no serving-thread invariant to fall back
+ * on - the only correlation signal available is the trace id read from {@link
+ * io.github.jdubois.bootui.spi.TraceIdProvider} at the moment of publication, the same signal {@code
+ * ReactiveHttpExchangeTraceFilter} and {@code SqlTraceRecorder} capture from. Matched by type + principal
+ * + timestamp window, mirroring {@code SecurityEventCorrelationRegistry}'s matching rule (captures and
+ * the displayed event originate from the very same {@code AuditEvent}, so the timestamps are effectively
+ * equal) but requiring a <em>unique</em> candidate, exactly like {@code RequestCorrelationRegistry}.</p>
+ *
+ * <p>The buffer is capped and evicts oldest-first so it never grows unbounded.</p>
+ */
+public final class ReactiveSecurityEventTraceRegistry {
+
+    /** One published audit event: its epoch-millisecond timestamp, type, principal, and captured trace id. */
+    public record SecurityEventTrace(long millis, String type, String principal, String traceId) {}
+
+    private final int maxEntries;
+    private final Deque<SecurityEventTrace> buffer = new ArrayDeque<>();
+    private final Object lock = new Object();
+
+    public ReactiveSecurityEventTraceRegistry(int maxEntries) {
+        this.maxEntries = Math.max(1, maxEntries);
+    }
+
+    /**
+     * Records one published audit event's captured trace id, evicting the oldest entry when the buffer
+     * is full. A blank/missing trace id is not recorded at all - there is nothing useful to correlate
+     * later.
+     */
+    public void record(SecurityEventTrace trace) {
+        if (trace == null || trace.traceId() == null || trace.traceId().isBlank()) {
+            return;
+        }
+        synchronized (lock) {
+            buffer.addLast(trace);
+            while (buffer.size() > maxEntries) {
+                buffer.removeFirst();
+            }
+        }
+    }
+
+    /**
+     * Returns the trace id captured for the single audit event matching {@code type}/{@code principal}
+     * within {@code slack} milliseconds of {@code timestamp}, or {@code null} when there is no match or
+     * more than one candidate.
+     */
+    public String match(String type, String principal, long timestamp) {
+        if (type == null) {
+            return null;
+        }
+        long slack = 50L;
+        SecurityEventTrace found = null;
+        synchronized (lock) {
+            for (SecurityEventTrace candidate : buffer) {
+                if (!type.equalsIgnoreCase(candidate.type()) || !principalMatches(principal, candidate.principal())) {
+                    continue;
+                }
+                if (Math.abs(candidate.millis() - timestamp) > slack) {
+                    continue;
+                }
+                if (found != null) {
+                    return null;
+                }
+                found = candidate;
+            }
+        }
+        return found == null ? null : found.traceId();
+    }
+
+    private boolean principalMatches(String left, String right) {
+        if (left == null && right == null) {
+            return true;
+        }
+        return left != null && left.equalsIgnoreCase(right);
+    }
+
+    /** Test-only snapshot of the retained records, oldest first. */
+    List<SecurityEventTrace> snapshot() {
+        synchronized (lock) {
+            return new ArrayList<>(buffer);
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityLogsController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityLogsController.java
@@ -5,6 +5,7 @@ import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
 import io.github.jdubois.bootui.core.dto.SecurityLogsReport;
 import io.github.jdubois.bootui.engine.security.CapturedSecurityEvent;
 import io.github.jdubois.bootui.engine.security.SecurityLogsService;
+import io.github.jdubois.bootui.spi.TraceIdProvider;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
@@ -55,6 +56,10 @@ public class ReactiveSecurityLogsController implements ApplicationListener<Audit
 
     private final ReactiveBootUiChangeStream changeStream = new ReactiveBootUiChangeStream("security-logs");
 
+    private TraceIdProvider traceIdProvider;
+
+    private ReactiveSecurityEventTraceRegistry traceRegistry;
+
     @Autowired
     public ReactiveSecurityLogsController(
             ObjectProvider<AuditEventRepository> auditEventRepositoryProvider,
@@ -68,6 +73,23 @@ public class ReactiveSecurityLogsController implements ApplicationListener<Audit
     ReactiveSecurityLogsController(
             ObjectProvider<AuditEventRepository> auditEventRepositoryProvider, BootUiProperties properties) {
         this(auditEventRepositoryProvider, properties, new BootUiExposure(properties));
+    }
+
+    /**
+     * Installed only by {@code BootUiReactiveAutoConfiguration} once OpenTelemetry is present, so
+     * {@link #onApplicationEvent} can capture the trace id active when Spring Security publishes each
+     * audit event; left {@code null} otherwise, in which case {@link #recordTraceId} no-ops.
+     */
+    public void setTraceIdProvider(TraceIdProvider traceIdProvider) {
+        this.traceIdProvider = traceIdProvider;
+    }
+
+    /**
+     * Installed alongside {@link #setTraceIdProvider}; left {@code null} otherwise, in which case
+     * {@link #toCaptured} always renders a {@code null} trace id, exactly like today.
+     */
+    public void setTraceRegistry(ReactiveSecurityEventTraceRegistry traceRegistry) {
+        this.traceRegistry = traceRegistry;
     }
 
     @GetMapping
@@ -85,7 +107,7 @@ public class ReactiveSecurityLogsController implements ApplicationListener<Audit
 
         List<CapturedSecurityEvent> events =
                 repository.find(blankToNull(principal), parseAfter(after), blankToNull(type)).stream()
-                        .map(ReactiveSecurityLogsController::toCaptured)
+                        .map(this::toCaptured)
                         .toList();
         return securityLogsService.report(
                 events,
@@ -99,11 +121,22 @@ public class ReactiveSecurityLogsController implements ApplicationListener<Audit
                 limit);
     }
 
-    private static CapturedSecurityEvent toCaptured(AuditEvent event) {
-        // Spring's Live Activity correlation is thread-based (see LiveActivityService), not trace-id-based,
-        // so there is no trace id to stamp here; only the Quarkus adapter populates it.
+    private CapturedSecurityEvent toCaptured(AuditEvent event) {
         return new CapturedSecurityEvent(
-                event.getTimestamp(), event.getPrincipal(), event.getType(), event.getData(), null);
+                event.getTimestamp(), event.getPrincipal(), event.getType(), event.getData(), capturedTraceId(event));
+    }
+
+    /**
+     * Looks up the trace id {@link ReactiveSecurityEventTraceRegistry} captured for this event (type +
+     * principal + timestamp window, see {@link ReactiveSecurityEventTraceRegistry#match}); returns
+     * {@code null} when no registry is installed, exactly like before this correlation existed.
+     */
+    private String capturedTraceId(AuditEvent event) {
+        if (traceRegistry == null) {
+            return null;
+        }
+        return traceRegistry.match(
+                event.getType(), event.getPrincipal(), event.getTimestamp().toEpochMilli());
     }
 
     /**
@@ -118,7 +151,31 @@ public class ReactiveSecurityLogsController implements ApplicationListener<Audit
 
     @Override
     public void onApplicationEvent(AuditApplicationEvent event) {
+        recordTraceId(event.getAuditEvent());
         changeStream.signal();
+    }
+
+    /**
+     * Captures the trace id active when Spring Security published this audit event, keyed by
+     * type/principal/timestamp so {@link #toCaptured} can look it up later - the same
+     * {@link TraceIdProvider} signal {@code ReactiveHttpExchangeTraceFilter}/{@code SqlTraceRecorder}
+     * capture from. Fully guarded so a missing registry/provider, or a misbehaving tracer, never disrupts
+     * Spring Security's own event publication.
+     */
+    private void recordTraceId(AuditEvent event) {
+        if (traceIdProvider == null || traceRegistry == null || event == null || event.getTimestamp() == null) {
+            return;
+        }
+        try {
+            String traceId = traceIdProvider.currentTraceId();
+            if (traceId == null || traceId.isBlank()) {
+                return;
+            }
+            traceRegistry.record(new ReactiveSecurityEventTraceRegistry.SecurityEventTrace(
+                    event.getTimestamp().toEpochMilli(), event.getType(), event.getPrincipal(), traceId));
+        } catch (RuntimeException ignored) {
+            // Diagnostics capture must never interfere with Spring Security's own event publication.
+        }
     }
 
     /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangeTraceRegistry.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangeTraceRegistry.java
@@ -1,0 +1,88 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+
+/**
+ * Bounded, in-memory record of the distributed-trace id active when each recent HTTP request completed on
+ * the reactive (WebFlux) adapter, captured by {@code ReactiveHttpExchangeTraceFilter}.
+ *
+ * <p>Spring Boot's Actuator {@code HttpExchange} model has no trace-id field (see
+ * {@code CapturedHttpExchange}'s javadoc), so {@link HttpExchangesController} cannot read one back from
+ * the exchange it maps for either stack. This side-buffer supplies it for WebFlux, where
+ * {@code Span.current()} - not thread identity - is the only signal that survives the Reactor Netty
+ * event-loop / {@code boundedElastic} hop a request may take (see {@code ReactiveOtelTraceIdProvider}).
+ * The servlet adapter never registers a bean of this type, so {@link HttpExchangesController#toCaptured}
+ * simply finds none and keeps its existing header-derived behavior unchanged.</p>
+ *
+ * <p>Matched by method + path + overlapping time window, exactly like
+ * {@code RequestCorrelationRegistry} - including requiring a <em>unique</em> candidate, so two genuinely
+ * concurrent identical requests safely correlate neither rather than risk cross-attribution. The buffer
+ * is capped and evicts oldest-first so it never grows unbounded.</p>
+ */
+public final class HttpExchangeTraceRegistry {
+
+    /** One completed request: its wall-clock window, method + path, and the trace id captured at completion. */
+    public record HttpExchangeTrace(long startMillis, long endMillis, String method, String path, String traceId) {}
+
+    private final int maxEntries;
+    private final Deque<HttpExchangeTrace> buffer = new ArrayDeque<>();
+    private final Object lock = new Object();
+
+    public HttpExchangeTraceRegistry(int maxEntries) {
+        this.maxEntries = Math.max(1, maxEntries);
+    }
+
+    /**
+     * Records one completed request's captured trace id, evicting the oldest entry when the buffer is
+     * full. A blank/missing trace id is not recorded at all - there is nothing useful to correlate later.
+     */
+    public void record(HttpExchangeTrace trace) {
+        if (trace == null || trace.traceId() == null || trace.traceId().isBlank()) {
+            return;
+        }
+        synchronized (lock) {
+            buffer.addLast(trace);
+            while (buffer.size() > maxEntries) {
+                buffer.removeFirst();
+            }
+        }
+    }
+
+    /**
+     * Returns the trace id captured for the single request whose handling window overlaps
+     * {@code [start, end]} for the given method and path, or {@code null} when there is no match or more
+     * than one candidate (see {@code RequestCorrelationRegistry#match} for why uniqueness is required).
+     */
+    public String match(String method, String path, long start, long end) {
+        if (method == null || path == null) {
+            return null;
+        }
+        long slack = 50L;
+        HttpExchangeTrace found = null;
+        synchronized (lock) {
+            for (HttpExchangeTrace candidate : buffer) {
+                if (!method.equalsIgnoreCase(candidate.method()) || !path.equals(candidate.path())) {
+                    continue;
+                }
+                if (candidate.startMillis() > end + slack || candidate.endMillis() < start - slack) {
+                    continue;
+                }
+                if (found != null) {
+                    return null;
+                }
+                found = candidate;
+            }
+        }
+        return found == null ? null : found.traceId();
+    }
+
+    /** Test-only snapshot of the retained records, oldest first. */
+    List<HttpExchangeTrace> snapshot() {
+        synchronized (lock) {
+            return new ArrayList<>(buffer);
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangesController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangesController.java
@@ -38,6 +38,8 @@ public class HttpExchangesController {
 
     private final HttpExchangesService service = new HttpExchangesService();
 
+    private HttpExchangeTraceRegistry traceRegistry;
+
     public HttpExchangesController(ObjectProvider<HttpExchangeRepository> repository, BootUiProperties properties) {
         this(repository, properties, BootUiSelfDataFilter.defaults(), new BootUiExposure(properties));
     }
@@ -52,6 +54,17 @@ public class HttpExchangesController {
         this.properties = properties;
         this.selfDataFilter = selfDataFilter;
         this.exposure = exposure;
+    }
+
+    /**
+     * Installed only by {@code BootUiReactiveAutoConfiguration} once OpenTelemetry is present, so the
+     * reactive adapter can stamp a real trace id despite Actuator's {@link HttpExchange} model carrying
+     * none natively; left {@code null} on the servlet adapter, where {@link #capturedTraceId} simply
+     * returns {@code null} and {@link HttpExchangesService#resolveTraceId} falls back to its existing
+     * header-derived extraction unchanged. See {@link HttpExchangeTraceRegistry}.
+     */
+    public void setTraceRegistry(HttpExchangeTraceRegistry traceRegistry) {
+        this.traceRegistry = traceRegistry;
     }
 
     @GetMapping
@@ -82,17 +95,34 @@ public class HttpExchangesController {
     private CapturedHttpExchange toCaptured(HttpExchange exchange) {
         HttpExchange.Request request = exchange.getRequest();
         HttpExchange.Response response = exchange.getResponse();
+        Long durationMs =
+                exchange.getTimeTaken() == null ? null : exchange.getTimeTaken().toMillis();
         return new CapturedHttpExchange(
                 exchange.getTimestamp(),
                 request == null ? null : request.getMethod(),
                 request == null ? null : request.getUri(),
                 response == null ? 0 : response.getStatus(),
-                exchange.getTimeTaken() == null ? null : exchange.getTimeTaken().toMillis(),
+                durationMs,
                 request == null ? null : request.getRemoteAddress(),
                 exchange.getPrincipal() == null ? null : exchange.getPrincipal().getName(),
                 exchange.getSession() == null ? null : exchange.getSession().getId(),
                 request == null ? null : request.getHeaders(),
                 response == null ? null : response.getHeaders(),
-                null);
+                capturedTraceId(exchange, request, durationMs));
+    }
+
+    /**
+     * Looks up the trace id {@link HttpExchangeTraceRegistry} captured for this exchange (method + path +
+     * overlapping time window, see {@link HttpExchangeTraceRegistry#match}); returns {@code null} when no
+     * registry is installed (the servlet adapter, or OpenTelemetry absent on the reactive one) so callers
+     * fall back to header-derived extraction unchanged.
+     */
+    private String capturedTraceId(HttpExchange exchange, HttpExchange.Request request, Long durationMs) {
+        if (traceRegistry == null || request == null || exchange.getTimestamp() == null) {
+            return null;
+        }
+        long start = exchange.getTimestamp().toEpochMilli();
+        long end = durationMs == null ? start : start + durationMs;
+        return traceRegistry.match(request.getMethod(), request.getUri().getPath(), start, end);
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiActuatorDefaultsEnvironmentPostProcessorTests.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.core.Ordered;
 import org.springframework.core.env.MapPropertySource;
@@ -173,5 +174,54 @@ class BootUiActuatorDefaultsEnvironmentPostProcessorTests {
         DefaultPropertiesPropertySource.moveToEnd(env);
 
         assertThat(env.getProperty("management.endpoints.web.exposure.include")).isEqualTo("*");
+    }
+
+    @Test
+    void contributesReactorContextPropagationForReactiveAppsWithOpenTelemetry() {
+        MockEnvironment env = new MockEnvironment().withProperty("bootui.enabled", "ON");
+
+        processor.postProcessEnvironment(env, applicationWithWebType(WebApplicationType.REACTIVE));
+
+        assertThat(env.getProperty(BootUiActuatorDefaultsEnvironmentPostProcessor.REACTOR_CONTEXT_PROPAGATION_PROPERTY))
+                .isEqualTo(BootUiActuatorDefaultsEnvironmentPostProcessor.REACTOR_CONTEXT_PROPAGATION_VALUE);
+    }
+
+    @Test
+    void doesNotContributeReactorContextPropagationForServletApps() {
+        MockEnvironment env = new MockEnvironment().withProperty("bootui.enabled", "ON");
+
+        processor.postProcessEnvironment(env, applicationWithWebType(WebApplicationType.SERVLET));
+
+        assertThat(env.getProperty(BootUiActuatorDefaultsEnvironmentPostProcessor.REACTOR_CONTEXT_PROPAGATION_PROPERTY))
+                .isNull();
+    }
+
+    @Test
+    void keepsHostConfiguredReactorContextPropagation() {
+        MockEnvironment env = new MockEnvironment()
+                .withProperty("bootui.enabled", "ON")
+                .withProperty(
+                        BootUiActuatorDefaultsEnvironmentPostProcessor.REACTOR_CONTEXT_PROPAGATION_PROPERTY, "limited");
+
+        processor.postProcessEnvironment(env, applicationWithWebType(WebApplicationType.REACTIVE));
+
+        assertThat(env.getProperty(BootUiActuatorDefaultsEnvironmentPostProcessor.REACTOR_CONTEXT_PROPAGATION_PROPERTY))
+                .isEqualTo("limited");
+    }
+
+    @Test
+    void isBootUiActuatorDefaultRecognizesReactorContextPropagation() {
+        assertThat(BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(
+                        BootUiActuatorDefaultsEnvironmentPostProcessor.REACTOR_CONTEXT_PROPAGATION_PROPERTY, "auto"))
+                .isTrue();
+        assertThat(BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(
+                        BootUiActuatorDefaultsEnvironmentPostProcessor.REACTOR_CONTEXT_PROPAGATION_PROPERTY, "limited"))
+                .isFalse();
+    }
+
+    private static SpringApplication applicationWithWebType(WebApplicationType type) {
+        SpringApplication application = new SpringApplication();
+        application.setWebApplicationType(type);
+        return application;
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiExceptionHandlerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiExceptionHandlerTests.java
@@ -56,4 +56,56 @@ class ReactiveBootUiExceptionHandlerTests {
         ReactiveBootUiExceptionHandler handler = new ReactiveBootUiExceptionHandler(new ExceptionStore(1, 1, 1));
         assertThat(handler.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
     }
+
+    @Test
+    void stampsTraceIdFromProviderWhenInstalled() {
+        ExceptionStore store = new ExceptionStore(100, 25, 50);
+        ReactiveBootUiExceptionHandler handler = new ReactiveBootUiExceptionHandler(store);
+        handler.setTraceIdProvider(() -> "trace-abc-123");
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/bootui/api/beans"));
+
+        StepVerifier.create(handler.handle(exchange, new RuntimeException("boom")))
+                .expectError(RuntimeException.class)
+                .verify();
+
+        ExceptionStore.GroupDetail detail = store.find(store.groups().get(0).fingerprint());
+        ExceptionStore.Occurrence occurrence =
+                detail.occurrences().get(detail.occurrences().size() - 1);
+        assertThat(occurrence.traceId()).isEqualTo("trace-abc-123");
+    }
+
+    @Test
+    void leavesTraceIdNullWhenNoProviderIsInstalled() {
+        ExceptionStore store = new ExceptionStore(100, 25, 50);
+        ReactiveBootUiExceptionHandler handler = new ReactiveBootUiExceptionHandler(store);
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/bootui/api/beans"));
+
+        StepVerifier.create(handler.handle(exchange, new RuntimeException("boom")))
+                .expectError(RuntimeException.class)
+                .verify();
+
+        ExceptionStore.GroupDetail detail = store.find(store.groups().get(0).fingerprint());
+        ExceptionStore.Occurrence occurrence =
+                detail.occurrences().get(detail.occurrences().size() - 1);
+        assertThat(occurrence.traceId()).isNull();
+    }
+
+    @Test
+    void leavesTraceIdNullWhenProviderThrows() {
+        ExceptionStore store = new ExceptionStore(100, 25, 50);
+        ReactiveBootUiExceptionHandler handler = new ReactiveBootUiExceptionHandler(store);
+        handler.setTraceIdProvider(() -> {
+            throw new IllegalStateException("no active span");
+        });
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/bootui/api/beans"));
+
+        StepVerifier.create(handler.handle(exchange, new RuntimeException("boom")))
+                .expectError(RuntimeException.class)
+                .verify();
+
+        ExceptionStore.GroupDetail detail = store.find(store.groups().get(0).fingerprint());
+        ExceptionStore.Occurrence occurrence =
+                detail.occurrences().get(detail.occurrences().size() - 1);
+        assertThat(occurrence.traceId()).isNull();
+    }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveHttpExchangeTraceFilterTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveHttpExchangeTraceFilterTests.java
@@ -1,0 +1,98 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.web.HttpExchangeTraceRegistry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Scope;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Tests for {@link ReactiveHttpExchangeTraceFilter}: proves it feeds {@link HttpExchangeTraceRegistry}
+ * with the trace id active when a non-BootUI request completes, and skips BootUI's own traffic exactly
+ * like its sibling filters.
+ */
+class ReactiveHttpExchangeTraceFilterTests {
+
+    private static final String TRACE_ID = "0123456789abcdef0123456789abcdef";
+    private static final String SPAN_ID = "0123456789abcdef";
+
+    private static final WebFilterChain OK_CHAIN = exchange -> {
+        exchange.getResponse().setStatusCode(HttpStatus.OK);
+        return Mono.empty();
+    };
+
+    private BootUiProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new BootUiProperties();
+    }
+
+    @Test
+    void recordsTheActiveTraceIdWhenTheRequestCompletes() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        ReactiveHttpExchangeTraceFilter filter =
+                new ReactiveHttpExchangeTraceFilter(properties, registry, new ReactiveOtelTraceIdProvider());
+        SpanContext context = SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+
+        MockServerWebExchange exchange = exchange("GET", "/api/sample/products");
+        long before = System.currentTimeMillis();
+        try (Scope ignored = Span.wrap(context).makeCurrent()) {
+            filter.filter(exchange, OK_CHAIN).block(Duration.ofSeconds(5));
+        }
+        long after = System.currentTimeMillis();
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(registry.match("GET", "/api/sample/products", before, after)).isEqualTo(TRACE_ID);
+    }
+
+    @Test
+    void doesNotRecordWhenNoSpanIsActive() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        ReactiveHttpExchangeTraceFilter filter =
+                new ReactiveHttpExchangeTraceFilter(properties, registry, new ReactiveOtelTraceIdProvider());
+
+        long before = System.currentTimeMillis();
+        filter.filter(exchange("GET", "/api/sample/products"), OK_CHAIN).block(Duration.ofSeconds(5));
+        long after = System.currentTimeMillis();
+
+        assertThat(registry.match("GET", "/api/sample/products", before, after)).isNull();
+    }
+
+    @Test
+    void skipsBootUiOwnTraffic() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        ReactiveHttpExchangeTraceFilter filter =
+                new ReactiveHttpExchangeTraceFilter(properties, registry, new ReactiveOtelTraceIdProvider());
+        SpanContext context = SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+
+        long before = System.currentTimeMillis();
+        try (Scope ignored = Span.wrap(context).makeCurrent()) {
+            filter.filter(exchange("GET", "/bootui/api/http-exchanges"), OK_CHAIN)
+                    .block(Duration.ofSeconds(5));
+            filter.filter(exchange("GET", "/bootui"), OK_CHAIN).block(Duration.ofSeconds(5));
+        }
+        long after = System.currentTimeMillis();
+
+        assertThat(registry.match("GET", "/bootui/api/http-exchanges", before, after))
+                .isNull();
+        assertThat(registry.match("GET", "/bootui", before, after)).isNull();
+    }
+
+    private static MockServerWebExchange exchange(String method, String uri) {
+        return MockServerWebExchange.from(MockServerHttpRequest.method(HttpMethod.valueOf(method), uri));
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveOtelTraceIdProviderTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveOtelTraceIdProviderTests.java
@@ -1,0 +1,47 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
+import io.opentelemetry.context.Scope;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link ReactiveOtelTraceIdProvider}'s span-reading logic - the seam that lets the Live
+ * Activity timeline correlate SQL/exceptions/security events/HTTP exchanges on WebFlux. Mirrors {@code
+ * QuarkusOtelTraceIdProviderTest} exactly: uses only the OpenTelemetry API (no SDK), making a span wrapped
+ * around a synthetic {@link SpanContext} current, exactly as Spring Boot's own reactive OpenTelemetry
+ * instrumentation would in a real request context.
+ */
+class ReactiveOtelTraceIdProviderTests {
+
+    private static final String TRACE_ID = "0123456789abcdef0123456789abcdef";
+    private static final String SPAN_ID = "0123456789abcdef";
+
+    @Test
+    void returnsTraceIdOfActiveSpan() {
+        ReactiveOtelTraceIdProvider provider = new ReactiveOtelTraceIdProvider();
+        SpanContext context = SpanContext.create(TRACE_ID, SPAN_ID, TraceFlags.getSampled(), TraceState.getDefault());
+
+        try (Scope ignored = Span.wrap(context).makeCurrent()) {
+            assertThat(provider.currentTraceId()).isEqualTo(TRACE_ID);
+        }
+    }
+
+    @Test
+    void returnsNullWhenNoSpanIsActive() {
+        assertThat(new ReactiveOtelTraceIdProvider().currentTraceId()).isNull();
+    }
+
+    @Test
+    void returnsNullForAnInvalidSpanContext() {
+        ReactiveOtelTraceIdProvider provider = new ReactiveOtelTraceIdProvider();
+
+        try (Scope ignored = Span.wrap(SpanContext.getInvalid()).makeCurrent()) {
+            assertThat(provider.currentTraceId()).isNull();
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityEventTraceRegistryTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityEventTraceRegistryTests.java
@@ -1,0 +1,79 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveSecurityEventTraceRegistry.SecurityEventTrace;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ReactiveSecurityEventTraceRegistry}: the reactive adapter's side-buffer that lets
+ * {@link ReactiveSecurityLogsController} stamp a captured OpenTelemetry trace id onto a Spring Security
+ * {@code AuditEvent}, which carries no trace id of its own. Mirrors {@code
+ * SecurityEventCorrelationRegistryTests}' matching conventions, simplified to a direct trace-id-or-null
+ * return (WebFlux has no serving thread to classify against).
+ */
+class ReactiveSecurityEventTraceRegistryTests {
+
+    @Test
+    void matchesUniqueEventByTypePrincipalAndTimestamp() {
+        ReactiveSecurityEventTraceRegistry registry = new ReactiveSecurityEventTraceRegistry(10);
+        registry.record(new SecurityEventTrace(1_000L, "AUTHORIZATION_FAILURE", "admin", "trace-1"));
+
+        assertThat(registry.match("authorization_failure", "admin", 1_010L)).isEqualTo("trace-1");
+    }
+
+    @Test
+    void returnsNullWhenTypeOrPrincipalDiffer() {
+        ReactiveSecurityEventTraceRegistry registry = new ReactiveSecurityEventTraceRegistry(10);
+        registry.record(new SecurityEventTrace(1_000L, "AUTHORIZATION_FAILURE", "admin", "trace-1"));
+
+        assertThat(registry.match("AUTHENTICATION_SUCCESS", "admin", 1_000L)).isNull();
+        assertThat(registry.match("AUTHORIZATION_FAILURE", "guest", 1_000L)).isNull();
+    }
+
+    @Test
+    void returnsNullOutsideTheSlackWindow() {
+        ReactiveSecurityEventTraceRegistry registry = new ReactiveSecurityEventTraceRegistry(10);
+        registry.record(new SecurityEventTrace(1_000L, "AUTHORIZATION_FAILURE", "admin", "trace-1"));
+
+        assertThat(registry.match("AUTHORIZATION_FAILURE", "admin", 5_000L)).isNull();
+    }
+
+    @Test
+    void returnsNullWhenMultipleCandidatesMatch() {
+        ReactiveSecurityEventTraceRegistry registry = new ReactiveSecurityEventTraceRegistry(10);
+        registry.record(new SecurityEventTrace(1_000L, "AUTHORIZATION_FAILURE", "admin", "trace-1"));
+        registry.record(new SecurityEventTrace(1_010L, "AUTHORIZATION_FAILURE", "admin", "trace-2"));
+
+        assertThat(registry.match("AUTHORIZATION_FAILURE", "admin", 1_000L)).isNull();
+    }
+
+    @Test
+    void matchesNullPrincipalToNullPrincipalOnly() {
+        ReactiveSecurityEventTraceRegistry registry = new ReactiveSecurityEventTraceRegistry(10);
+        registry.record(new SecurityEventTrace(1_000L, "SYSTEM_EVENT", null, "trace-1"));
+
+        assertThat(registry.match("SYSTEM_EVENT", null, 1_000L)).isEqualTo("trace-1");
+        assertThat(registry.match("SYSTEM_EVENT", "admin", 1_000L)).isNull();
+    }
+
+    @Test
+    void evictsOldestBeyondCapacity() {
+        ReactiveSecurityEventTraceRegistry registry = new ReactiveSecurityEventTraceRegistry(2);
+        registry.record(new SecurityEventTrace(1L, "T", "a", "trace-1"));
+        registry.record(new SecurityEventTrace(2L, "T", "b", "trace-2"));
+        registry.record(new SecurityEventTrace(3L, "T", "c", "trace-3"));
+
+        assertThat(registry.snapshot()).extracting(SecurityEventTrace::traceId).containsExactly("trace-2", "trace-3");
+    }
+
+    @Test
+    void ignoresRecordsWithNoUsableTraceId() {
+        ReactiveSecurityEventTraceRegistry registry = new ReactiveSecurityEventTraceRegistry(10);
+        registry.record(new SecurityEventTrace(1L, "T", "a", null));
+        registry.record(new SecurityEventTrace(1L, "T", "b", ""));
+        registry.record(null);
+
+        assertThat(registry.snapshot()).isEmpty();
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityLogsControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityLogsControllerTests.java
@@ -1,0 +1,149 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.dto.SecurityLogsReport;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.audit.AuditEvent;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
+import org.springframework.boot.actuate.audit.InMemoryAuditEventRepository;
+import org.springframework.boot.actuate.audit.listener.AuditApplicationEvent;
+
+/**
+ * Tests for {@link ReactiveSecurityLogsController}: baseline parity with the servlet {@code
+ * SecurityLogsController} over the same {@link AuditEventRepository} (there was previously no dedicated
+ * test file for the reactive controller), plus the reactive-only OpenTelemetry trace-id correlation this
+ * controller adds - capturing the trace id active when Spring Security publishes each {@link
+ * AuditApplicationEvent} into {@link ReactiveSecurityEventTraceRegistry}, then reading it back onto the
+ * matching event {@link #logs} returns.
+ */
+class ReactiveSecurityLogsControllerTests {
+
+    @Test
+    void absentAuditRepositoryReturnsUnavailableReport() {
+        ReactiveSecurityLogsController controller =
+                new ReactiveSecurityLogsController(emptyProvider(), new BootUiProperties());
+
+        SecurityLogsReport report = controller.logs(null, null, null, null, null);
+
+        assertThat(report.auditEventsPresent()).isFalse();
+        assertThat(report.unavailableReason()).isEqualTo("No AuditEventRepository bean is available");
+    }
+
+    @Test
+    void eventsAreNewestFirst() {
+        InMemoryAuditEventRepository repository = new InMemoryAuditEventRepository();
+        repository.add(event("alice", "AUTHENTICATION_SUCCESS", "2026-06-03T08:00:00Z"));
+        repository.add(event("bob", "AUTHORIZATION_DENIED", "2026-06-03T08:01:00Z"));
+        ReactiveSecurityLogsController controller =
+                new ReactiveSecurityLogsController(providerOf(repository), new BootUiProperties());
+
+        SecurityLogsReport report = controller.logs(null, null, null, null, null);
+
+        assertThat(report.events()).hasSize(2);
+        assertThat(report.events().get(0).principal()).isEqualTo("bob");
+        assertThat(report.events().get(1).principal()).isEqualTo("alice");
+    }
+
+    @Test
+    void filtersByPrincipalTypeAndAfter() {
+        InMemoryAuditEventRepository repository = new InMemoryAuditEventRepository();
+        repository.add(event("developer", "AUTHENTICATION_SUCCESS", "2026-06-03T08:00:00Z"));
+        repository.add(event("developer", "AUTHENTICATION_FAILURE", "2026-06-03T08:05:00Z"));
+        repository.add(event("admin", "AUTHENTICATION_FAILURE", "2026-06-03T08:10:00Z"));
+        ReactiveSecurityLogsController controller =
+                new ReactiveSecurityLogsController(providerOf(repository), new BootUiProperties());
+
+        SecurityLogsReport report =
+                controller.logs("developer", "AUTHENTICATION_FAILURE", "2026-06-03T08:01:00Z", null, null);
+
+        assertThat(report.events()).hasSize(1);
+        assertThat(report.events().get(0).principal()).isEqualTo("developer");
+        assertThat(report.events().get(0).type()).isEqualTo("AUTHENTICATION_FAILURE");
+    }
+
+    @Test
+    void leavesTraceIdNullWhenNoRegistryIsInstalled() {
+        InMemoryAuditEventRepository repository = new InMemoryAuditEventRepository();
+        repository.add(event("alice", "AUTHENTICATION_SUCCESS", "2026-06-03T08:00:00Z"));
+        ReactiveSecurityLogsController controller =
+                new ReactiveSecurityLogsController(providerOf(repository), new BootUiProperties());
+
+        SecurityLogsReport report = controller.logs(null, null, null, null, null);
+
+        assertThat(report.events().get(0).traceId()).isNull();
+    }
+
+    @Test
+    void onApplicationEventCapturesTheActiveTraceIdForLaterCorrelation() {
+        InMemoryAuditEventRepository repository = new InMemoryAuditEventRepository();
+        AuditEvent event = event("alice", "AUTHENTICATION_SUCCESS", "2026-06-03T08:00:00Z");
+        repository.add(event);
+        ReactiveSecurityLogsController controller =
+                new ReactiveSecurityLogsController(providerOf(repository), new BootUiProperties());
+        controller.setTraceIdProvider(() -> "trace-xyz");
+        controller.setTraceRegistry(new ReactiveSecurityEventTraceRegistry(10));
+
+        controller.onApplicationEvent(new AuditApplicationEvent(event));
+        SecurityLogsReport report = controller.logs(null, null, null, null, null);
+
+        assertThat(report.events().get(0).traceId()).isEqualTo("trace-xyz");
+    }
+
+    @Test
+    void onApplicationEventNoOpsWhenNoProviderIsInstalled() {
+        InMemoryAuditEventRepository repository = new InMemoryAuditEventRepository();
+        AuditEvent event = event("alice", "AUTHENTICATION_SUCCESS", "2026-06-03T08:00:00Z");
+        repository.add(event);
+        ReactiveSecurityLogsController controller =
+                new ReactiveSecurityLogsController(providerOf(repository), new BootUiProperties());
+        controller.setTraceRegistry(new ReactiveSecurityEventTraceRegistry(10));
+
+        controller.onApplicationEvent(new AuditApplicationEvent(event));
+        SecurityLogsReport report = controller.logs(null, null, null, null, null);
+
+        assertThat(report.events().get(0).traceId()).isNull();
+    }
+
+    @Test
+    void onApplicationEventNeverThrowsWhenTheProviderFails() {
+        InMemoryAuditEventRepository repository = new InMemoryAuditEventRepository();
+        AuditEvent event = event("alice", "AUTHENTICATION_SUCCESS", "2026-06-03T08:00:00Z");
+        repository.add(event);
+        ReactiveSecurityLogsController controller =
+                new ReactiveSecurityLogsController(providerOf(repository), new BootUiProperties());
+        controller.setTraceIdProvider(() -> {
+            throw new IllegalStateException("no context propagated");
+        });
+        controller.setTraceRegistry(new ReactiveSecurityEventTraceRegistry(10));
+
+        controller.onApplicationEvent(new AuditApplicationEvent(event));
+
+        assertThat(controller.logs(null, null, null, null, null).events().get(0).traceId())
+                .isNull();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<AuditEventRepository> providerOf(AuditEventRepository repository) {
+        ObjectProvider<AuditEventRepository> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(repository);
+        return provider;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ObjectProvider<AuditEventRepository> emptyProvider() {
+        ObjectProvider<AuditEventRepository> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(null);
+        return provider;
+    }
+
+    private static AuditEvent event(String principal, String type, String timestamp) {
+        return new AuditEvent(Instant.parse(timestamp), principal, type, Map.of("path", "/api/secure"));
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangeTraceRegistryTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangeTraceRegistryTests.java
@@ -1,0 +1,72 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.web.HttpExchangeTraceRegistry.HttpExchangeTrace;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link HttpExchangeTraceRegistry}: the reactive adapter's side-buffer that lets {@link
+ * HttpExchangesController} stamp a captured OpenTelemetry trace id onto an Actuator {@code HttpExchange}
+ * it has no trace-id field of its own to carry one in. Mirrors {@code RequestCorrelationRegistryTests}'
+ * matching conventions (method + path + overlapping time window, unique-candidate-only).
+ */
+class HttpExchangeTraceRegistryTests {
+
+    @Test
+    void matchesUniqueRequestByWindowOverlap() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        registry.record(new HttpExchangeTrace(1000, 1100, "GET", "/a", "trace-1"));
+        registry.record(new HttpExchangeTrace(2000, 2100, "GET", "/a", "trace-2"));
+
+        assertThat(registry.match("get", "/a", 1010, 1090)).isEqualTo("trace-1");
+    }
+
+    @Test
+    void returnsNullWhenMethodOrPathDiffer() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        registry.record(new HttpExchangeTrace(1000, 1100, "GET", "/a", "trace-1"));
+
+        assertThat(registry.match("POST", "/a", 1000, 1100)).isNull();
+        assertThat(registry.match("GET", "/b", 1000, 1100)).isNull();
+    }
+
+    @Test
+    void returnsNullWhenMultipleCandidatesOverlap() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        registry.record(new HttpExchangeTrace(1000, 1100, "GET", "/a", "trace-1"));
+        registry.record(new HttpExchangeTrace(1050, 1150, "GET", "/a", "trace-2"));
+
+        assertThat(registry.match("GET", "/a", 1000, 1100)).isNull();
+    }
+
+    @Test
+    void doesNotMatchWhenWindowsDoNotOverlap() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        registry.record(new HttpExchangeTrace(1000, 1100, "GET", "/a", "trace-1"));
+
+        assertThat(registry.match("GET", "/a", 5000, 5100)).isNull();
+    }
+
+    @Test
+    void evictsOldestBeyondCapacity() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(2);
+        registry.record(new HttpExchangeTrace(1000, 1100, "GET", "/a", "trace-1"));
+        registry.record(new HttpExchangeTrace(2000, 2100, "GET", "/b", "trace-2"));
+        registry.record(new HttpExchangeTrace(3000, 3100, "GET", "/c", "trace-3"));
+
+        assertThat(registry.snapshot()).hasSize(2);
+        assertThat(registry.match("GET", "/a", 1000, 1100)).isNull();
+        assertThat(registry.match("GET", "/c", 3000, 3100)).isEqualTo("trace-3");
+    }
+
+    @Test
+    void ignoresRecordsWithNoUsableTraceId() {
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        registry.record(new HttpExchangeTrace(1000, 1100, "GET", "/a", null));
+        registry.record(new HttpExchangeTrace(1000, 1100, "GET", "/b", ""));
+        registry.record(null);
+
+        assertThat(registry.snapshot()).isEmpty();
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangesControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpExchangesControllerTests.java
@@ -176,6 +176,63 @@ class HttpExchangesControllerTests {
         assertHeader(dto.requestHeaders(), "Authorization", true);
     }
 
+    @Test
+    void stampsTraceIdFromRegistryWhenInstalled() {
+        HttpExchange appExchange = exchange("GET", "http://localhost/api/notes", 200);
+        HttpExchangesController controller =
+                new HttpExchangesController(providerOf(repositoryWith(appExchange)), new BootUiProperties());
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        long start = START.toEpochMilli();
+        registry.record(new HttpExchangeTraceRegistry.HttpExchangeTrace(
+                start, start + 37, "GET", "/api/notes", "trace-registry-abc"));
+        controller.setTraceRegistry(registry);
+
+        HttpExchangeDto dto =
+                controller.exchanges(null, null, null, null, null).exchanges().get(0);
+
+        assertThat(dto.traceId()).isEqualTo("trace-registry-abc");
+    }
+
+    @Test
+    void registryTraceIdTakesPrecedenceOverHeaderDerivedTraceId() {
+        HttpExchange appExchange = exchange(
+                "GET",
+                "http://localhost/api/notes",
+                200,
+                Map.of("traceparent", List.of("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00")),
+                Map.of());
+        HttpExchangesController controller =
+                new HttpExchangesController(providerOf(repositoryWith(appExchange)), new BootUiProperties());
+        HttpExchangeTraceRegistry registry = new HttpExchangeTraceRegistry(10);
+        long start = START.toEpochMilli();
+        registry.record(new HttpExchangeTraceRegistry.HttpExchangeTrace(
+                start, start + 37, "GET", "/api/notes", "trace-registry-wins"));
+        controller.setTraceRegistry(registry);
+
+        HttpExchangeDto dto =
+                controller.exchanges(null, null, null, null, null).exchanges().get(0);
+
+        assertThat(dto.traceId()).isEqualTo("trace-registry-wins");
+    }
+
+    @Test
+    void fallsBackToHeaderDerivedTraceIdWhenRegistryHasNoMatch() {
+        HttpExchange appExchange = exchange(
+                "GET",
+                "http://localhost/api/notes",
+                200,
+                Map.of("traceparent", List.of("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00")),
+                Map.of());
+        HttpExchangesController controller =
+                new HttpExchangesController(providerOf(repositoryWith(appExchange)), new BootUiProperties());
+        controller.setTraceRegistry(new HttpExchangeTraceRegistry(10));
+
+        HttpExchangeDto dto =
+                controller.exchanges(null, null, null, null, null).exchanges().get(0);
+
+        assertThat(dto.traceId()).isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
+    }
+
     private static void assertHeader(List<HttpHeaderDto> headers, String name, boolean masked, String... values) {
         HttpHeaderDto header = headers.stream()
                 .filter(candidate -> candidate.name().equals(name))

--- a/docs/WEBFLUX-SUPPORT.md
+++ b/docs/WEBFLUX-SUPPORT.md
@@ -156,20 +156,41 @@ constructor dependency would force-eager the controller and defeat its place in
 because `ReactiveBootUiChangeStream.signal()` is already a no-op with no subscribers, and the first `/stream`
 request naturally resolves (and thus creates) the controller bean once the panel is actually opened.
 
-**Known fidelity gap, accepted and honestly labeled (matching the Quarkus adapter's own framing):** correlation is
-trace-id-primary only — a request is only linked to "its" SQL statements/exceptions/security events when a shared
-distributed trace id is present on both sides. Reaching that state is narrower here than on Quarkus, though: the
-shared `HttpExchangesController` (identical on servlet and reactive) never stamps the active span's trace id at
-capture time — unlike Quarkus, which reads `Span.current()` unconditionally at each capture point — so a request
-only carries a trace id when the *inbound* call itself propagates one (a `traceparent`, B3, or `X-Amzn-Trace-Id`
-header), not merely because `micrometer-tracing`/OTLP is configured server-side. SQL, exception, and security
-trace ids come from the existing SLF4J MDC default in `SqlTraceRecorder`/the exception and security capture paths
-— the same source the servlet adapter already relies on — and on Reactor, MDC propagation across the event
-loop→worker-thread hop for blocking calls (for example JDBC on `boundedElastic`) depends on Reactor context
-propagation and is not guaranteed to be consistent under concurrent load, so even a request that does carry a
-trace id may not always show every one of its signals nested under it. Without a trace id, the feed still shows
-every signal, just uncorrelated/flat rather than nested per-request. The servlet adapter's thread-based
-correlation (`LiveActivityCorrelator`) is not ported — it has no reactive equivalent.
+**Trace-id correlation, now stamped identically to Quarkus:** a reactive-only `ReactiveOtelTraceIdProvider` reads
+`Span.current()` unconditionally at every capture point — HTTP exchange (via a new `ReactiveHttpExchangeTraceFilter`
+feeding a side-buffer `HttpExchangeTraceRegistry`, since Actuator's `HttpExchange` model has no trace-id field to
+populate directly), SQL (`SqlTraceRecorder.setTraceIdProvider`), exceptions (`ReactiveBootUiExceptionHandler
+.setTraceIdProvider`), and security events (`ReactiveSecurityLogsController.setTraceIdProvider` +
+`ReactiveSecurityEventTraceRegistry`) — replacing the earlier inbound-header/SLF4J-MDC-only reliance. All four are
+wired by `BootUiReactiveAutoConfiguration.ReactiveOpenTelemetryCorrelationConfiguration`, gated only on the
+OpenTelemetry SDK being present (matching Quarkus's own `Capability.OPENTELEMETRY_TRACER` gate) — deliberately
+*not* also gated on `bootui.telemetry.enabled`, which governs BootUI's own span export for the Traces/AI Usage
+panels, a separate concern from reading the id of a span the application's own tracing already started.
+
+**This alone is not sufficient — a second, non-obvious requirement makes it actually work.** WebFlux has no
+thread-per-request invariant: a single request's reactive chain hops between the Netty event loop, `boundedElastic`
+(blocking JDBC), and `parallel` schedulers. `Span.current()` only resolves correctly across those hops when
+Reactor's *automatic context propagation* is enabled (`Hooks.enableAutomaticContextPropagation()`); Spring Boot 4.1
+only calls that when `spring.reactor.context-propagation=auto`, and its own default is `limited`. Without `auto`,
+the trace-stamping code above is wired correctly but reads an empty/invalid span everywhere except by coincidence
+on the exact thread the request started on. `BootUiActuatorDefaultsEnvironmentPostProcessor` now contributes
+`spring.reactor.context-propagation=auto` as an overridable default (the same "library default, host always wins"
+pattern already used for `management.tracing.sampling.probability`) whenever the application is reactive and the
+OpenTelemetry SDK is present — see §7 for how this was found.
+
+**Known, accepted residual limitations:**
+
+- Correlation is still trace-id-primary, exactly like Quarkus: a request with no active tracing span at all (for
+  example, OpenTelemetry entirely absent from the classpath) still shows every signal flat/uncorrelated rather than
+  nested, since there is no id to key on. This is not a WebFlux-specific gap — the same is true of the Quarkus
+  adapter today.
+- `HttpExchangeTraceRegistry#match` (and its servlet-side sibling `RequestCorrelationRegistry`) deliberately requires
+  a *unique* method+path+time-window candidate: two genuinely concurrent identical requests (for example, the same
+  endpoint hit twice within roughly the same tens of milliseconds, with no other distinguishing signal available)
+  correlate to *neither* rather than risk attributing one request's trace id to the other. Both requests still show
+  up in the feed; they simply render without a nested SQL/exception child until a less ambiguous signal is added.
+- The servlet adapter's thread-based correlation (`LiveActivityCorrelator`) is not ported — it has no reactive
+  equivalent.
 
 ### 6.5 Not yet ported (2 panels)
 
@@ -218,6 +239,22 @@ Both were caught by `WebFluxApiConformanceTest`'s inherited `availablePanelsAnsw
 §8) — direct evidence for why the conformance suite runs against a real, minimal, single-stack sample app rather than
 relying on unit tests against a shared multi-stack test classpath alone.
 
+A third gap surfaced only through genuine end-to-end testing against the running sample app — unit tests call
+capture points directly on a single thread, so they never exercise a real Reactor scheduler hop and could not have
+caught this. Stamping `Span.current()` at each capture point (§6.4) is necessary but not sufficient: Spring Boot
+4.1's `spring-boot-reactor` module only calls `Hooks.enableAutomaticContextPropagation()` when
+`spring.reactor.context-propagation=auto`, and its own default is `limited`. Under the default, Reactor does not
+restore OpenTelemetry's ThreadLocal-based span context across the scheduler hops a WebFlux request constantly
+makes (Netty event loop → `boundedElastic`/`loomBoundedElastic` for blocking JDBC → `parallel`), so `Span.current()`
+returned a valid span only by coincidence, on whichever thread a request happened to still be on — every new
+trace-stamping capture point read `null`/an invalid span in practice despite being wired correctly. Fixed by having
+`BootUiActuatorDefaultsEnvironmentPostProcessor` contribute `spring.reactor.context-propagation=auto` as an
+overridable default whenever the application is reactive and the OpenTelemetry SDK is present. Confirmed by hitting
+the running sample app directly (`/api/notes`, `/api/sample/boom`) and checking `/bootui/api/http-exchanges`,
+`/bootui/api/sql-trace`, `/bootui/api/exceptions`, and `/bootui/api/activity` for populated, correctly-nested
+(`parentId`) trace ids — none of which a unit test asserts, since they all call the affected classes' methods
+directly rather than through a real multi-scheduler Reactor pipeline.
+
 ## 8. Sample app & end-to-end testing
 
 - **`bootui-spring-webflux-sample-app`** is a minimal WebFlux app (Netty, `spring-boot-starter-webflux`, deliberately
@@ -259,9 +296,6 @@ sample app — but is easy to trip over when smoke-testing a freshly built react
 - A reactive Security advisor ruleset (`ServerHttpSecurity`/`SecurityWebFilterChain`), closing the
   `security`/`spring-security` gap in §6.5.
 - A reactive-aware `BootUiMcpTools` catalog so the MCP Server panel and JSON-RPC bridge work on WebFlux.
-- Deeper Live Activity correlation for requests without a trace id (today: trace-id-primary only, matching the
-  Quarkus adapter — see §6.4).
-- A more reliable trace id source for the reactive Live Activity/profiler correlation: stamping the active
-  tracing span's id directly at each capture point (HTTP exchange, SQL, exception, security), mirroring how the
-  Quarkus adapter reads `Span.current()` unconditionally instead of relying on inbound propagation headers and
-  SLF4J MDC propagation across the Reactor event-loop→worker-thread hop (see §6.4).
+- Deeper Live Activity correlation for requests with no active tracing span at all (today: trace-id-primary only,
+  now matching the Quarkus adapter exactly since `Span.current()` is stamped unconditionally at every capture
+  point — see §6.4).


### PR DESCRIPTION
## Summary

- Fixes WebFlux's Live Activity panel correlation gap where HTTP requests could not be correlated with SQL, exception, and security events, unlike Spring MVC and Quarkus.
- Root cause 1: the reactive adapter never stamped a trace id from the active OTel span at any capture point. Fixed with a new `ReactiveOtelTraceIdProvider` that reads `Span.current()`, wired into `SqlTraceRecorder`, a new `HttpExchangeTraceRegistry` + `ReactiveHttpExchangeTraceFilter`, `ReactiveBootUiExceptionHandler`, and `ReactiveSecurityLogsController` (+ `ReactiveSecurityEventTraceRegistry`) — mirroring the Quarkus adapter's proven approach.
- Root cause 2: even with correct stamping, Spring Boot 4.1 defaults `spring.reactor.context-propagation` to `limited`, not `auto`, so Reactor never restored the OTel span across WebFlux scheduler hops (Netty event loop -> boundedElastic -> parallel). Fixed by having `BootUiActuatorDefaultsEnvironmentPostProcessor` contribute `spring.reactor.context-propagation=auto` as an overridable default when reactive + OpenTelemetry SDK are both present.
- Updated `docs/WEBFLUX-SUPPORT.md` accordingly.

## Verification

- 1162 unit tests passing.
- End-to-end verified against the running WebFlux sample app: HTTP exchanges, SQL trace, and exceptions all show correct, distinct, correctly nested trace ids in Live Activity.
- `WebFluxApiConformanceTest` passing.
- Spotless clean.
- Security log correlation uses the identical mechanism and is unit-tested, but was not directly end-to-end tested because the sample app has no Spring Security configured.
