### PR TITLE
Speed up Maven builds with reactor and Surefire parallelism

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,14 @@ jobs:
       - name: Check Maven formatting
         run: ./mvnw -B -ntp spotless:check
 
+      # -T 1C: one reactor thread per available CPU core. Safe because every module that triggers Quarkus
+      # build-time augmentation declares an explicit provided-scope dependency on bootui-quarkus-deployment
+      # (so the reactor always orders it first) and every @QuarkusTest-bearing module pins Surefire's
+      # forkCount to a value that does not race Quarkus's own test-bootstrap classloading (see the
+      # maven-surefire-plugin comment in the root pom and the forkCount comment in
+      # bootui-quarkus-integration-tests/base/pom.xml).
       - name: Build all modules
-        run: ./mvnw -B -ntp clean install
+        run: ./mvnw -T 1C -B -ntp clean install
 
       - name: Check frontend formatting
         working-directory: bootui-ui/src/main/frontend
@@ -158,11 +164,16 @@ jobs:
       # Build and install the BootUI Quarkus extension + the sample app into the local Maven
       # repository so Playwright's `quarkus:dev` web server can resolve them. BootUI activates
       # automatically under `quarkus:dev` (dev mode); it stays dark in a packaged prod run.
-      # bootui-quarkus-deployment is listed explicitly so it joins the reactor: the sample only depends
-      # on the runtime extension, and Quarkus pulls the -deployment counterpart in at augmentation time,
-      # not as a Maven dependency, so -am alone would leave it out and the build would fail.
+      # bootui-quarkus-sample-app (and every Quarkus consumer module) declares an explicit provided-scope
+      # dependency on bootui-quarkus-deployment, so plain -am now resolves it into the reactor; Quarkus
+      # would otherwise only pull the -deployment counterpart in at augmentation time (not via Maven's
+      # dependency graph), which is invisible to -am and, under a parallel (-T) build, is also an
+      # unordered race with the deployment module's own build.
+      # -T 1C is safe here even without the Surefire forkCount guards above: -DskipTests means no
+      # @QuarkusTest classloading race is possible, and -am's ordering relies only on the same explicit
+      # provided-scope bootui-quarkus-deployment dependency called out above.
       - name: Build BootUI Quarkus extension and sample app
-        run: ./mvnw -B -ntp -pl bootui-quarkus-deployment,bootui-quarkus-sample-app -am -DskipTests install
+        run: ./mvnw -T 1C -B -ntp -pl bootui-quarkus-sample-app -am -DskipTests install
 
       - name: Install Playwright dependencies
         working-directory: bootui-quarkus-sample-app/e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,22 @@ This downloads Node + npm, runs `npm install`, runs the Vue unit tests with Vite
 builds the Vue UI with Vite, and packages every module. A full clean build takes
 about a minute on a warm cache.
 
+For a faster local build, add `-T 1C` (one reactor thread per CPU core) to build modules in parallel:
+
+```bash
+./mvnw -T 1C clean install
+```
+
+This is safe: every module that triggers Quarkus build-time augmentation declares an explicit
+`provided`-scope dependency on `bootui-quarkus-deployment` so the reactor always orders it first, and every
+`@QuarkusTest`-bearing module pins its own Surefire `forkCount` so parallel forks never race Quarkus's shared
+test-bootstrap cache (see the `maven-surefire-plugin` comments in the root `pom.xml` and in
+`bootui-quarkus-integration-tests/base/pom.xml`). `-T` is a personal preference, not a project default, so it
+is not baked into `.mvn/maven.config` — add it to your own shell alias or a personal, git-ignored
+`.mvn/maven.config` if you want it every time (that file is also used for personal, per-worktree overrides such
+as `-Dmaven.repo.local`; see "Isolating parallel worktrees" in `.github/copilot-instructions.md`). CI always
+builds with `-T 1C`.
+
 To rebuild only the backend (useful while iterating on Java code):
 
 ```bash

--- a/bootui-quarkus-integration-tests/base/pom.xml
+++ b/bootui-quarkus-integration-tests/base/pom.xml
@@ -47,6 +47,27 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--
+            Explicit, provided-scope dependency on the deployment half of the extension under test. Without a
+            real Maven <dependency> edge here, this module's link to bootui-quarkus-deployment exists only as a
+            GAV string baked into bootui-quarkus's packaged extension descriptor (META-INF/quarkus-extension.
+            properties), read by Quarkus's own Aether-based bootstrap resolver at plugin-execution time — the
+            Maven reactor graph, and therefore its -T parallel-build scheduler, has no visibility into that
+            string. Without this dependency, a parallel reactor build can legally schedule this module's
+            quarkus:generate-code/build goals concurrently with (or before) bootui-quarkus-deployment finishes
+            installing, intermittently failing augmentation with an artifact-resolution error. This dependency
+            gives the reactor a real edge so bootui-quarkus-deployment always finishes first; provided scope
+            keeps it off this module's runtime/test classpath (Quarkus resolves the deployment artifact
+            independently for augmentation, exactly as it would for any consumer of a published extension).
+            Every sibling module under bootui-quarkus-integration-tests, plus bootui-quarkus-sample-app, needs
+            the same dependency for the same reason.
+        -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- The shared, framework-neutral HTTP conformance contract + JDK-HttpClient probe. -->
         <dependency>
@@ -99,11 +120,31 @@
               LogManager, and QuarkusLoggerProvider only reports itself available when that manager is
               installed. Setting it here makes the Loggers IT (and the shared write-path conformance test)
               exercise the real backend deterministically instead of depending on JVM-global init order.
+
+              forkCount is pinned to 1 here too, overriding the root pom's pluginManagement default (see the
+              maven-surefire-plugin comment there for the general port-safety rationale of forked test
+              parallelism elsewhere in the reactor). This needs a real <build><plugins> override, not a
+              <properties> entry: forkCount is a Surefire "user property", but the root pom already binds it
+              to a literal value in pluginManagement, and a literal <configuration> value always wins over a
+              same-named property once one is present anywhere in the merged POM. This module has 49 test
+              classes and is the one where the incompatibility was first observed: @QuarkusTest builds a
+              "curated application" classloader keyed on shared derived artifacts under the module's own
+              target/test-classes directory (notably a test-classes.idx index file); running two Surefire
+              forks concurrently against the SAME module races writing/reading that shared cache, and one
+              fork failed test discovery with a NoSuchFileException. This is a genuine Quarkus test-bootstrap
+              incompatibility with forkCount > 1 within a single module, not a timing flake, and it
+              reproduced here (both with forkCount=1C and forkCount=2). Reactor-level parallelism (-T, see
+              .github/workflows/build.yml and CONTRIBUTING.md) is unaffected and still gives real speedup:
+              this module builds concurrently
+              with its Quarkus IT siblings. Every @QuarkusTest-bearing module in the reactor (bootui-quarkus
+              itself and every other bootui-quarkus-integration-tests/* submodule) pins the same override;
+              see there for the short cross-reference.
             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <forkCount>1</forkCount>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemPropertyVariables>

--- a/bootui-quarkus-integration-tests/base/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/base/src/test/resources/application.properties
@@ -1,3 +1,10 @@
+# Bind the test HTTP server to a random free port instead of Quarkus's fixed default test port (8081). This
+# lets this module's @QuarkusTest run concurrently with the other bootui-quarkus-integration-tests siblings
+# under a parallel Maven build (-T) without a bind-port collision. @TestHTTPResource-injected URLs already
+# resolve to whichever port Quarkus actually binds (it rewrites this property after binding), so no test code
+# needs to change. Every sibling module below sets the same property for the same reason.
+quarkus.http.test-port=0
+
 # Deterministic fixtures for the Configuration / Profile Diff panel ITs. A plain value (visible),
 # a secret-looking key (must be masked before serialization), and a %test-profiled key (must surface
 # as a Profile Diff source while the test profile is active).

--- a/bootui-quarkus-integration-tests/cache/pom.xml
+++ b/bootui-quarkus-integration-tests/cache/pom.xml
@@ -51,6 +51,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds the Quarkus Cache extension. Its presence makes the CACHE capability available, so the
              deployment build step wires BootUiCacheProducer and the cache panel is reported available;
@@ -103,6 +111,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/cache/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/cache/src/test/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 quarkus.application.name=bootui-quarkus-cache-it
 # Enable Micrometer metrics for the Caffeine cache used by the test, so the engine CacheService overlays real
 # cache.gets/puts/size meters onto the report (the cache-metrics half of the panel). The JVM/system base meter

--- a/bootui-quarkus-integration-tests/datasource/pom.xml
+++ b/bootui-quarkus-integration-tests/datasource/pom.xml
@@ -50,6 +50,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds an in-memory H2 JDBC datasource, backed by Agroal. Its presence makes the AGROAL capability
              available, so the deployment build step wires BootUiAgroalProducer and the Database Connection Pools
@@ -103,6 +111,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/datasource/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/datasource/src/test/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 quarkus.application.name=bootui-quarkus-datasource-it
 # An in-memory H2 datasource backed by Agroal. Enabling JDBC metrics lets the QuarkusAgroalConnectionPoolProvider
 # read the live AgroalDataSourceMetrics (active/available/awaiting counts) and map them into the snapshot; without

--- a/bootui-quarkus-integration-tests/flyway/pom.xml
+++ b/bootui-quarkus-integration-tests/flyway/pom.xml
@@ -49,6 +49,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds the Quarkus Flyway extension. Its presence makes the FLYWAY capability available, so the
              deployment build step wires BootUiFlywayProducer and the flyway panel is reported available; the
@@ -99,6 +107,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/flyway/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/flyway/src/test/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 quarkus.application.name=bootui-quarkus-flyway-it
 # In-memory H2 datasource for Flyway to manage; keeps the @QuarkusTest Docker-free.
 quarkus.datasource.db-kind=h2

--- a/bootui-quarkus-integration-tests/health/pom.xml
+++ b/bootui-quarkus-integration-tests/health/pom.xml
@@ -49,6 +49,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds SmallRye Health. Its presence flips the BootUI extension's SMALLRYE_HEALTH capability gate on,
              so the deployment processor registers the in-process BootUiHealthProducer and the aggregated health
@@ -94,6 +102,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/health/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/health/src/test/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 quarkus.application.name=bootui-quarkus-health-it
 # Expose the SmallRye Health endpoints at their default /q/health root; BootUI reads the same aggregated
 # report in-process via SmallRyeHealthReporter, so no HTTP round trip is involved in the assertions.

--- a/bootui-quarkus-integration-tests/hibernate/pom.xml
+++ b/bootui-quarkus-integration-tests/hibernate/pom.xml
@@ -55,6 +55,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds Hibernate ORM. Its presence flips the BootUI extension's HIBERNATE_ORM capability gate on, so the
              deployment processor registers the in-process BootUiHibernateProducer (the jakarta.persistence-reading
@@ -106,6 +114,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/hibernate/src/main/resources/application.properties
+++ b/bootui-quarkus-integration-tests/hibernate/src/main/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 # Docker-free in-memory H2 datasource so Hibernate ORM has a real database to build its metamodel against.
 quarkus.datasource.db-kind=h2
 quarkus.datasource.username=sa

--- a/bootui-quarkus-integration-tests/liquibase/pom.xml
+++ b/bootui-quarkus-integration-tests/liquibase/pom.xml
@@ -50,6 +50,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds the Quarkus Liquibase extension. Its presence makes the LIQUIBASE capability available, so the
              deployment build step wires BootUiLiquibaseProducer and the liquibase panel is reported available;
@@ -100,6 +108,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/liquibase/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/liquibase/src/test/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 quarkus.application.name=bootui-quarkus-liquibase-it
 
 # In-memory H2 datasource, so the @QuarkusTest boots without Docker.

--- a/bootui-quarkus-integration-tests/micrometer/pom.xml
+++ b/bootui-quarkus-integration-tests/micrometer/pom.xml
@@ -50,6 +50,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds a real Micrometer registry. Its presence makes a MeterRegistry bean available, so the engine
              MetricsReportProvider resolves the live composite registry and the Metrics panel reports real meters
@@ -95,6 +103,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/micrometer/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/micrometer/src/test/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 quarkus.application.name=bootui-quarkus-micrometer-it
 # Disable the JVM/system/uptime base meter binders so the Metrics report is dominated by the meters this
 # test registers (and the HTTP server binding), keeping the assertions focused and fast.

--- a/bootui-quarkus-integration-tests/otel/pom.xml
+++ b/bootui-quarkus-integration-tests/otel/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds the OpenTelemetry SDK + tracer. Its presence flips the BootUI extension's OPENTELEMETRY_TRACER
              capability gate on, so the deployment processor registers the in-process SpanProcessor producer and
@@ -106,6 +114,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/otel/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/otel/src/test/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 # Keep the OpenTelemetry SDK active (so the BootUI in-process SpanProcessor receives spans) but export
 # nowhere: this is an in-process capture test, not an OTLP-export test, so no collector/network is needed.
 quarkus.otel.traces.exporter=none

--- a/bootui-quarkus-integration-tests/prod-shell-guard/pom.xml
+++ b/bootui-quarkus-integration-tests/prod-shell-guard/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- The shared, framework-neutral HTTP probe used to assert the production process's responses. -->
         <dependency>
@@ -95,11 +103,18 @@
               QuarkusProdModeTest's own static initializer requires this (it casts the root
               java.util.logging.Logger to org.jboss.logmanager.Logger), so this is not optional here the way
               it might be for a plain @QuarkusTest module.
+
+              forkCount=1: same override as every other bootui-quarkus-integration-tests/* submodule (and
+              bootui-quarkus itself); see bootui-quarkus-integration-tests/base/pom.xml for the full
+              rationale (a Quarkus test-bootstrap classloading race between concurrent Surefire forks in the
+              same module). This module has a single test class today, but pins the override anyway for
+              consistency and to stay safe if a second one is ever added.
             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <forkCount>1</forkCount>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                     </systemPropertyVariables>

--- a/bootui-quarkus-integration-tests/scheduler/pom.xml
+++ b/bootui-quarkus-integration-tests/scheduler/pom.xml
@@ -51,6 +51,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds the Quarkus scheduler. Its presence flips the SCHEDULER capability, so the deployment
              processor's registerScheduledTasks build step captures the app's @Scheduled methods and lights up
@@ -96,6 +104,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/scheduler/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/scheduler/src/test/resources/application.properties
@@ -1,1 +1,5 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 quarkus.application.name=bootui-quarkus-scheduler-it

--- a/bootui-quarkus-integration-tests/security/pom.xml
+++ b/bootui-quarkus-integration-tests/security/pom.xml
@@ -46,6 +46,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Adds Quarkus security with embedded users. Its presence flips the SECURITY capability, so the
              deployment processor's registerSecurityLogs build step registers the capture observer and lights up
@@ -103,6 +111,16 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- forkCount=1: avoids a Quarkus @QuarkusTest classloading race between concurrent Surefire
+                 forks in the same module (test-classes.idx); see
+                 bootui-quarkus-integration-tests/base/pom.xml for the full rationale. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-quarkus-integration-tests/security/src/main/resources/application.properties
+++ b/bootui-quarkus-integration-tests/security/src/main/resources/application.properties
@@ -1,3 +1,7 @@
+# Random test port to avoid parallel-build collisions — see
+# bootui-quarkus-integration-tests/base/src/test/resources/application.properties for why.
+quarkus.http.test-port=0
+
 quarkus.application.name=bootui-quarkus-security-it
 
 # Embedded basic-auth users so authentication/authorization can succeed and fail.

--- a/bootui-quarkus-sample-app/README.md
+++ b/bootui-quarkus-sample-app/README.md
@@ -42,7 +42,7 @@ Quarkus Dev Services starts a throwaway PostgreSQL container, so **Docker (or Po
 Install the extension (and its dependencies) once, then launch the sample in dev mode:
 
 ```bash
-./mvnw -pl bootui-quarkus-deployment,bootui-quarkus-sample-app -am -DskipTests install
+./mvnw -pl bootui-quarkus-sample-app -am -DskipTests install
 ./mvnw -f bootui-quarkus-sample-app/pom.xml quarkus:dev
 ```
 

--- a/bootui-quarkus-sample-app/pom.xml
+++ b/bootui-quarkus-sample-app/pom.xml
@@ -75,6 +75,14 @@
             <artifactId>bootui-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Explicit, provided-scope dependency on the deployment artifact — required for -T parallel-build
+             safety, not just an optional courtesy. See bootui-quarkus-integration-tests/base/pom.xml for why. -->
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- REST layer: drives the REST API advisor, Mappings, and the demo endpoints. -->
         <dependency>

--- a/bootui-quarkus/pom.xml
+++ b/bootui-quarkus/pom.xml
@@ -271,6 +271,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Force sequential (single-fork) Surefire execution for this module's own tests, overriding
+                 the root pom's pluginManagement forkCount default (see the maven-surefire-plugin comment
+                 there for the general port-safety rationale of forked test parallelism elsewhere in the
+                 reactor). This needs a real <build><plugins> override, not a <properties> entry: forkCount
+                 is a Surefire "user property", but the root pom already binds it to a literal value in
+                 pluginManagement, and a literal <configuration> value always wins over a same-named
+                 property once one is present anywhere in the merged POM. @QuarkusTest builds a "curated
+                 application" classloader keyed on shared derived artifacts under this module's own
+                 target/test-classes directory (notably a test-classes.idx index file); running two Surefire
+                 forks concurrently against the SAME module — this one has ~19 test classes, several
+                 @QuarkusTest-based (QuarkusServerPortSupplierTest, LiveActivityResourceTests,
+                 QuarkusResourceHandlersTest, QuarkusMappingProviderTest) — races writing/reading that shared
+                 cache, and one fork can fail test discovery with a NoSuchFileException. This is a genuine
+                 Quarkus test-bootstrap incompatibility with forkCount > 1 within a single module, not a
+                 timing flake, and it reproduced here (both with forkCount=1C and forkCount=2). Reactor-level
+                 parallelism (-T, see .github/workflows/build.yml and CONTRIBUTING.md) is unaffected and
+                 still gives real speedup: this
+                 module builds concurrently with its Spring siblings. Every @QuarkusTest-bearing module in
+                 the reactor (this one and every bootui-quarkus-integration-tests/* submodule) pins the same
+                 override; see there for the short cross-reference. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,33 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.6</version>
+                    <configuration>
+                        <!-- A modest, fixed number of test-class forks, reused across classes assigned to
+                             each one (JVM start-up is amortized instead of paid per class). This is
+                             process-level parallelism only — different forks are separate JVMs, so it
+                             needs no in-JVM thread-safety from test code, and every test in this reactor
+                             that binds a real socket already binds to port 0 (ephemeral) rather than a
+                             fixed port (embedded HttpServer fixtures in bootui-engine/
+                             bootui-spring-autoconfigure/bootui-quarkus, @SpringBootTest's
+                             WebEnvironment.RANDOM_PORT everywhere, and quarkus.http.test-port=0 in every
+                             bootui-quarkus-integration-tests/* submodule); the only fixed-port literals
+                             elsewhere are inert (ArchUnit bytecode-scan fixtures that are never actually
+                             instantiated, or plain ints/strings in mocks and DTOs).
+
+                             Deliberately NOT scaled to core count (e.g. 1C): CI (.github/workflows/build.yml)
+                             and CONTRIBUTING.md's recommended local command both build with -T 1C, so
+                             several sibling modules' own Surefire runs can already be executing concurrently
+                             (e.g. bootui-spring-autoconfigure and bootui-quarkus depend only on
+                             bootui-engine, so they are reactor-parallel with each other). forkCount scaling
+                             to the core count in each of those concurrent executions compounds with
+                             reactor-level parallelism and oversubscribes CPU enough to trip real timeouts
+                             (observed: a WebTestClient read exceeding its default 5s budget under that
+                             combined load). A small fixed count still gives every large test module
+                             (bootui-engine, bootui-spring-autoconfigure) real intra-module parallelism
+                             without multiplying out of control. -->
+                        <forkCount>2</forkCount>
+                        <reuseForks>true</reuseForks>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What does this PR do?

Enables safe Maven reactor parallelism (`-T 1C`) and process-level Surefire test parallelism, after fixing two latent concurrency bugs that would otherwise make parallel builds flaky.

## Why is this change needed?

A full `./mvnw clean install` took over 5 minutes sequentially. Reactor and test parallelism can cut that significantly, but two hidden races needed fixing first:

1. **Deployment-dependency race.** Quarkus links a runtime extension to its `-deployment` counterpart only through `META-INF/quarkus-extension.properties`, resolved by Quarkus's own bootstrap resolver at plugin-execution time - invisible to Maven's `-T` reactor scheduler. Without a real Maven edge, a parallel build can start building a consumer before `bootui-quarkus-deployment` is installed. Fixed by adding an explicit `provided`-scope dependency on `bootui-quarkus-deployment` to every consumer (the sample app and all 12 `bootui-quarkus-integration-tests/*` submodules).
2. **Quarkus test-bootstrap classloading race.** `@QuarkusTest` builds a "curated application" classloader keyed on a shared cache file (`test-classes.idx`) under the module's own `target/test-classes`. Running 2+ Surefire forks (separate JVMs) concurrently against the *same* module races that shared cache and can fail test discovery with a `NoSuchFileException`. This reproduced consistently (not a timing flake) once Surefire parallelism was turned on. Fixed by pinning `forkCount=1` on all 13 `@QuarkusTest`-bearing modules while leaving other modules free to fork.

Also assigns each `@QuarkusTest` module a random test port (`quarkus.http.test-port=0`) so IT modules can build concurrently without port collisions.

Net effect: ~2.4x faster full build (5:09 -> ~2:10 min wall clock on a 10-core machine), verified across four consecutive full clean builds with zero test failures.

**Non-obvious note:** `-T 1C` is wired into CI (`.github/workflows/build.yml`, both jobs) and documented in `CONTRIBUTING.md` for local use, rather than added to `.mvn/maven.config` - that file is reserved (and git-ignored) for personal per-worktree overrides like `-Dmaven.repo.local`, so anything placed there would never reach CI or other developers.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally (ran 4 full clean-repo builds, including a final run with `-T 1C` passed explicitly on the command line to match CI exactly)
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (not applicable - build/CI tooling change only, no UI or runtime behavior touched; the sample app's own test suite runs as part of every validated build)
- [x] Added or updated tests where applicable (no new tests needed; existing Surefire/`@QuarkusTest` suites across the full reactor validate the fix)

Also ran `./mvnw spotless:check` and the frontend `npm run format:check`, both clean.

## Screenshots (UI changes)

N/A - build/CI configuration only, no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (`CONTRIBUTING.md` documents the new `-T 1C` recommendation)
- [x] Public API kept backward compatible, or a migration note added to the PR description (build-only change, no public API impact)
- [x] No secrets, tokens, or local paths committed