### PR TITLE
Prep v1.11.0 release: fix stale Quarkus panel counts, add REST Client Trace spec, write CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-09
+
+Feature release headlined by two new dev-loop panels — **Email** and **REST Client Trace** — and **Live Activity
+growing from 4 to 9 merged signal types**. Also ships a ~2.4x faster Maven build.
+
+### Added
+
+- **Email panel** — captures outgoing application email (recipients, subject, HTML/text body, attachments) for local
+  inspection, mirroring Laravel Telescope's mail watcher. Ships on both Spring and Quarkus; content is revealed by
+  default, with an opt-in `bootui.email.mask-content` flag for teams routing real PII through a shared dev
+  environment (#538).
+- **REST Client Trace panel** — captures outbound `RestClient`/`RestTemplate`/`WebClient` calls (method, host, path,
+  status, duration), with slow-call and "chatty" (repeated-call) detection. Spring servlet adapter only for now
+  (#544).
+- **Live Activity grows from 4 to 9 merged signal types**, adding cache accesses, scheduled-task runs, Kafka
+  producer/consumer activity, outbound REST client calls, and captured email to the existing request/SQL/exception/
+  security feed — each nested under its correlated request. Kafka and scheduled-task capture are also new on
+  Quarkus, and cache capture is also new on Spring WebFlux (#538, #541, #542, #543, #544).
+
+### Changed
+
+- **Email and REST Client Trace moved into the Services group** in the sidebar, alongside Scheduled Tasks and Cache.
+- **~2.4x faster full Maven build** (5:09 → ~2:10 min on a 10-core machine) by enabling reactor (`-T 1C`) and
+  Surefire test parallelism, after fixing two latent Quarkus concurrency races that made parallel builds flaky
+  (#545).
+
+### Fixed
+
+- **Hardened Kafka and Scheduled Tasks activity capture to fail open on errors**, so a capture-side bug can no
+  longer disrupt a real Kafka send/consume or scheduled-task run.
+
 ## [1.10.0] - 2026-07-07
 
 Feature release headlined by **Spring WebFlux support**, a third first-class BootUI adapter alongside Spring MVC and

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -184,7 +184,7 @@ lookup, a thin Jackson-2 `QuarkusMcpEnvelope` codec + `QuarkusMcpTools` catalog 
 `LocalhostGuard` write floor) · `Dev Services` (**Implemented** — a Quarkus-native concept; build-time
 `DevServicesResultBuildItem` snapshot captured via recorder + synthetic bean, masked config, logs/restart unavailable).
 
-### 5.2 Ported by swapping the data source (10)
+### 5.2 Ported by swapping the data source (11)
 
 Same DTO and UX; the Quarkus adapter implements the relevant SPI against a Quarkus API.
 
@@ -198,8 +198,9 @@ discovered via `LiquibaseFactoryUtil.getActiveLiquibaseFactories()`, the shared 
 action behind the same DTO contract) · `Scheduled Tasks`
 (→ `quarkus-scheduler`) · `Architecture` advisor (ArchUnit engine + rules run unmodified; Spring-stereotype rules
 simply match no classes and degrade to a no-op pass, while a few rules are already dual-framework via the shared
-`jakarta.*` annotations) · `Overview` (panel available; the scoring dashboard aggregates the advisor endpoints client-side, and
-`GET /bootui/api/overview` reports the Quarkus version + shell chrome).
+`jakarta.*` annotations) · `Beans` (**Implemented** — → Arc/CDI `BeanManager.getBeans(...)`, build-time-retained beans
+only, so a few fields are reduced fidelity — see §5 appendix) · `Overview` (panel available; the scoring dashboard
+aggregates the advisor endpoints client-side, and `GET /bootui/api/overview` reports the Quarkus version + shell chrome).
 
 ### 5.3 Kept, with a rebuilt capture layer or reduced fidelity (9)
 
@@ -284,12 +285,13 @@ store swapped and capturing on success — all behind the shared `LocalhostGuard
 true, "tableName": "bootui_activity"}`) the Vue UI reads to render the "Currently saving N events in memory" tip and
 the **Use a database** button/confirmation flow, so the panel behaves and looks identical on both adapters.
 
-### 5.4 Replaced with a Quarkus-native panel (2)
+### 5.4 Replaced with a Quarkus-native panel (3)
 
-| Spring panel     | Quarkus replacement                                                                                    |
-| ---------------- | ------------------------------------------------------------------------------------------------------ |
-| `Spring` advisor | **Implemented** — **`Quarkus` advisor**: new Quarkus-native ruleset over the shared scanning engine (CDI/Arc scopes, build-time config, reactive idioms, profiles) under the same panel id `spring` + `/bootui/api/spring` + `SpringReport`. See [QUARKUS-ADVISOR-CHECKS.md](QUARKUS-ADVISOR-CHECKS.md) |
-| `Cache`          | **Implemented** — served over `quarkus-cache` (Caffeine) under the shared id `cache`; cache names + Micrometer metrics + clear, with an empty operations list (caching annotations are build-time woven) |
+| Spring panel        | Quarkus replacement                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
+| `Spring` advisor    | **Implemented** — **`Quarkus` advisor**: new Quarkus-native ruleset over the shared scanning engine (CDI/Arc scopes, build-time config, reactive idioms, profiles) under the same panel id `spring` + `/bootui/api/spring` + `SpringReport`. See [QUARKUS-ADVISOR-CHECKS.md](QUARKUS-ADVISOR-CHECKS.md) |
+| `Cache`             | **Implemented** — served over `quarkus-cache` (Caffeine) under the shared id `cache`; cache names + Micrometer metrics + clear, with an empty operations list (caching annotations are build-time woven) |
+| `Security` advisor  | **Implemented** — a Quarkus-native ruleset (Elytron/OIDC, `quarkus.http.auth.permission.*`, TLS, CORS, `@RolesAllowed`) under the same panel id `security`, replacing the Spring-Security-coupled checks. See [QUARKUS-CHECKS.md](QUARKUS-CHECKS.md) |
 
 ### 5.5 Dropped on Quarkus (8)
 
@@ -305,12 +307,12 @@ No equivalent, low value, or superseded by Quarkus's own tooling:
   it niche), `DevTools` (**Implemented as `NOT_APPLICABLE`** — Quarkus has built-in dev-mode live reload, so there is no
   Spring-style DevTools restart/LiveReload to expose; the panel reports *not applicable* rather than *not yet*).
 
-**Result:** 39 of the ~47 panels ship on Quarkus (17 ported as-is, 10 source-swapped, 8 capture-rebuilt, 2 replaced,
-plus the advisors and the runtime panels lit up through the shared engine), and 8 are dropped as *not applicable*
-(GraalVM, CRaC, Conditions, Startup Timeline, HTTP Sessions, Spring Data, Spring Security, DevTools). No panels
-remain merely *not yet* ported: the Overview dashboard panel is now available (its scoring dashboard renders
-client-side from the advisor endpoints, and the shell-chrome `GET /bootui/api/overview` endpoint is served on both
-adapters).
+**Result:** 40 of the 49 panels ship on Quarkus (17 ported as-is, 11 source-swapped, 9 capture-rebuilt, 3 replaced
+with a Quarkus-native panel), and 9 are dropped: 8 as *not applicable* (GraalVM, CRaC, Conditions, Startup
+Timeline, HTTP Sessions, Spring Data, Spring Security, DevTools) and 1 (REST Client Trace) as Spring-servlet-only
+for now — no comparable runtime interception seam yet for the Quarkus-native REST client. The Overview dashboard
+panel is available (its scoring dashboard renders client-side from the advisor endpoints, and the shell-chrome
+`GET /bootui/api/overview` endpoint is served on both adapters).
 
 ## 6. Activation & safety on Quarkus
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -961,6 +961,38 @@ Acceptance criteria:
   each message can be downloaded as a `.eml` file.
 - Clearing the buffer is gated by `bootui.panels.email.read-only`, consistent with every other clearable capture panel.
 
+### 5.14.5 REST Client Panel
+
+Purpose: show outbound HTTP calls the application makes through its own REST clients, so a slow or failing downstream
+dependency is visible without a third-party HTTP proxy library.
+
+Data sources:
+
+- A shared `ClientHttpRequestInterceptor` customizes every auto-configured `RestClient` and `RestTemplate`; a shared
+  `ExchangeFilterFunction` customizes every auto-configured `WebClient`. Each call is recorded with its method, host,
+  path, query string, response status, wall-clock duration, success/failure, client type, trace id (when active),
+  executing thread, and call site.
+
+Acceptance criteria:
+
+- A capture failure never disrupts the outbound call itself: both instrumentation points always let the request
+  through and only best-effort record around it.
+- The URI and query parameters are always captured and masked **by name** (the same `SecretMasker` rules Config and
+  HTTP Exchanges use); request headers are withheld by default and only captured, subject to the same masking, when
+  `bootui.rest-client-trace.capture-headers=true`.
+- Calls are grouped by method, host, and normalized path (numeric/UUID segments collapsed to `{id}`) and a group at or
+  above `bootui.rest-client-trace.chatty-call-threshold` is flagged as a **chatty** (repeated-call) pattern, for calls
+  of any HTTP method.
+- Pause/Resume and Clear are gated by `bootui.panels.rest-client-trace.read-only`; recording state, buffer size, and
+  the slow/chatty thresholds are configurable under `bootui.rest-client-trace.*`.
+- Recent calls surface in Live Activity as `REST_CLIENT` entries, nested under their correlated request using the
+  same trace-id-first, serving-thread-second join SQL statements use.
+- The dedicated panel is available on the Spring MVC (servlet) adapter only, since its push-updating `/stream`
+  endpoint relies on the servlet-specific `SseEmitter`. The underlying `WebClient` call capture is shared with Spring
+  WebFlux and feeds Live Activity there with trace-id-only correlation, but WebFlux has no dedicated panel yet.
+  Quarkus has no outbound REST client capture pipeline at all yet, so both the dedicated panel and the Live Activity
+  `REST_CLIENT` entries are unavailable there (see `docs/WEBFLUX-SUPPORT.md` and `docs/QUARKUS-SUPPORT.md`).
+
 ### 5.15 Profile Diff Panel
 
 Purpose: show which properties are contributed by active profile-specific property sources.


### PR DESCRIPTION
## Summary

Prepares the v1.11.0 release. Version bumping itself is handled by the automated `Release` workflow (per precedent from #527) — this PR only covers documentation sync and the CHANGELOG entry.

## Documentation audit

Reconstructed everything that shipped since v1.10.0 from the actual commit diffs (17 commits / 7 merged PRs), then checked every doc that touches the changed surface: `docs/PLAN.md`, `docs/FEATURES.md`, `docs/WEBFLUX-SUPPORT.md`, `docs/PROPERTIES.md`, `README.md`, `.github/copilot-instructions.md`, the conformance golden fixtures, and the e2e panel list. All of those were already accurate. Two issues found and fixed:

- **`docs/QUARKUS-SUPPORT.md`** — the panel-count summary was stale (still said "39 of ~47 panels" and claimed "no panels remain not yet ported"), which became actively wrong once Email (ships on Quarkus) and REST Client Trace (Spring-servlet-only) landed. Corrected the arithmetic throughout (49 total panels, 40 ship, 9 dropped) and, since I was already in that section, reconciled two pre-existing internal count mismatches (§5.2 said "(10)" vs. 11 rows — missing `Beans`; §5.4 said "(2)" vs. 3 rows — missing the `Security` advisor). Those two predate this release but were one-line fixes in the same paragraphs.
- **`docs/SPECIFICATION.md`** — REST Client Trace (a brand-new dedicated panel) had no spec section at all, unlike every other panel. Added §5.14.5 following the established Purpose/Data sources/Acceptance criteria template.

## CHANGELOG

Added the `[1.11.0]` entry, kept intentionally concise per usual practice: intro paragraph + Added/Changed/Fixed bullets, citing PR numbers only for headline items (matching the existing citation convention in this file, e.g. the `[1.6.0]` entry).

## Verification

- `./mvnw spotless:check` passes (docs-only change; no Java/JS touched).
- Both edited docs re-read end-to-end after editing to confirm correct rendering and no dangling arithmetic.

## Not in this PR

- Version bumps (pom.xml, npm `package.json` ×4, README/SETUP.md install snippets) — handled by the `Release` workflow.
- Social announcement copy (LinkedIn/X) — provided separately in-session, not part of the repo.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>