### PR TITLE
Seed only the welcome email at sample app startup

### DIFF
--- a/bootui-quarkus-sample-app/src/main/java/io/github/jdubois/bootui/sample/mail/SampleMailSender.java
+++ b/bootui-quarkus-sample-app/src/main/java/io/github/jdubois/bootui/sample/mail/SampleMailSender.java
@@ -18,7 +18,7 @@ import org.jboss.logging.Logger;
  * transport, so no mail server is required and no real email is ever sent — the panel labels these messages
  * "mock".
  *
- * <p>A couple of messages are seeded once at startup, and {@link #sendSampleEmail()} lets callers (e.g. the
+ * <p>One message is seeded once at startup, and {@link #sendSampleEmail()} lets callers (e.g. the
  * sample {@code /api/sample/send-email} endpoint) generate one more on demand.</p>
  */
 @ApplicationScoped
@@ -31,9 +31,8 @@ public class SampleMailSender {
 
     private final AtomicInteger counter = new AtomicInteger();
 
-    /** Seeds a couple of sample emails once the application starts, so the panel is not empty. */
+    /** Seeds a single sample email once the application starts, so the panel is not empty. */
     void seedSampleEmails(@Observes StartupEvent event) {
-        sendOrderShipped();
         sendWelcome();
     }
 

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/mail/SampleMailSender.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/mail/SampleMailSender.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
  * {@code bootui.email.dev-trap=true}, BootUI captures each message for the panel but never hands it to a
  * real SMTP transport, so no mail server is required and no real email is ever sent.
  *
- * <p>A couple of messages are seeded once at startup, and {@link #sendSampleEmail()} lets callers (e.g.
+ * <p>One message is seeded once at startup, and {@link #sendSampleEmail()} lets callers (e.g.
  * the sample "Send email" endpoint and the Playwright e2e suite) generate one more on demand.</p>
  */
 @Component
@@ -34,10 +34,9 @@ public class SampleMailSender {
         this.mailSender = mailSender;
     }
 
-    /** Seeds a couple of sample emails once the application is ready, so the panel is not empty. */
+    /** Seeds a single sample email once the application is ready, so the panel is not empty. */
     @EventListener(ApplicationReadyEvent.class)
     public void seedSampleEmails() {
-        sendOrderShipped();
         sendWelcome();
     }
 

--- a/bootui-spring-webflux-sample-app/src/main/java/io/github/jdubois/bootui/webfluxsample/mail/WebfluxSampleMailSender.java
+++ b/bootui-spring-webflux-sample-app/src/main/java/io/github/jdubois/bootui/webfluxsample/mail/WebfluxSampleMailSender.java
@@ -38,10 +38,9 @@ public class WebfluxSampleMailSender {
         this.mailSender = mailSender;
     }
 
-    /** Seeds a couple of sample emails once the application is ready, so the panel is not empty. */
+    /** Seeds a single sample email once the application is ready, so the panel is not empty. */
     @EventListener(ApplicationReadyEvent.class)
     public void seedSampleEmails() {
-        sendOrderShipped();
         sendWelcome();
     }
 


### PR DESCRIPTION
## What does this PR do?

Stops the sample apps from sending a second, unnecessary "Your order has shipped" email at startup, seeding only the "Welcome to BootUI Sample" message instead.

## Why is this change needed?

All three sample apps (Spring servlet, Spring WebFlux, Quarkus) sent two emails on boot purely to keep the Email panel non-empty. Only one is actually needed for that purpose, so the extra send was removed from startup seeding in all three `SampleMailSender`/`WebfluxSampleMailSender` classes.

`sendOrderShipped()` itself was kept (not deleted): it's still used by `sendSampleEmail()`, which backs the on-demand `/api/sample/send-email` endpoint and the Playwright e2e suite (`email.spec.js` calls that endpoint repeatedly to exercise the attachment/PDF capture path), so it's not dead code.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Scoped verification actually performed:
- Compiled `bootui-spring-sample-app`, `bootui-spring-webflux-sample-app`, and `bootui-quarkus-sample-app` (with their shared modules via `-am`) successfully.
- Ran `spotless:apply` / confirmed no further formatting changes were needed.
- Reviewed `email.spec.js` and the docs screenshot script to confirm neither depends on two emails being seeded at startup (the e2e test seeds its own "order shipped" email on demand via the existing endpoint).
- Did not run a full `./mvnw clean install` or start the sample app end-to-end in this environment, since port 8080 was already occupied by an existing local dev instance.

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed