### PR TITLE
Add Live Activity deep link to Email detail drawer

### DIFF
--- a/bootui-ui/src/main/frontend/src/utils/activityStream.js
+++ b/bootui-ui/src/main/frontend/src/utils/activityStream.js
@@ -134,8 +134,10 @@ export function bucketEntries(entries, bucketCount = 24) {
 
 /**
  * Build a deep link from a merged stream entry to the dedicated panel that owns that signal, so the
- * Live Activity view is a launchpad rather than a dead end. The link prefills the target panel's
- * free-text filter (read from {@code ?q=}) to surface the originating record.
+ * Live Activity view is a launchpad rather than a dead end. Most link types prefill the target panel's
+ * free-text filter (read from {@code ?q=}) to surface the originating record; {@code MAIL} instead links
+ * by {@code ?id=} since a captured email's entry id is the same stable id the Email panel uses to open
+ * that exact message's detail drawer.
  *
  * Returns {@code null} for entry types without a dedicated drill-down (for example SECURITY) or when
  * there is no useful needle to filter by.
@@ -164,6 +166,8 @@ export function deepLink(entry) {
     }
     case 'CACHE':
       return {path: '/cache', label: 'Open in Cache'}
+    case 'MAIL':
+      return entry.id ? {path: '/email', query: {id: entry.id}, label: 'Open in Email'} : null
     default:
       return null
   }

--- a/bootui-ui/src/main/frontend/src/utils/activityStream.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/activityStream.test.js
@@ -185,6 +185,18 @@ describe('deepLink', () => {
     })
   })
 
+  it('links a mail entry to the Email panel by its id, opening that message directly', () => {
+    expect(deepLink({type: 'MAIL', id: 'msg-1', summary: 'Order shipped'})).toEqual({
+      path: '/email',
+      query: {id: 'msg-1'},
+      label: 'Open in Email'
+    })
+  })
+
+  it('returns null for a mail entry without an id', () => {
+    expect(deepLink({type: 'MAIL', summary: 'Order shipped'})).toBeNull()
+  })
+
   it('returns null for security entries and unknown types', () => {
     expect(deepLink({type: 'SECURITY', summary: 'AUTHENTICATION_FAILURE'})).toBeNull()
     expect(deepLink(null)).toBeNull()

--- a/bootui-ui/src/main/frontend/src/views/Email.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Email.test.js
@@ -2,6 +2,10 @@ import {flushPromises, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it, vi} from 'vitest'
 import {ref} from 'vue'
 
+const routeQuery = {}
+
+vi.mock('vue-router', () => ({useRoute: () => ({query: routeQuery})}))
+
 import Email from './Email.vue'
 
 function jsonResponse(body, ok = true, status = 200) {
@@ -67,6 +71,7 @@ describe('Email panel', () => {
     wrapper?.unmount()
     wrapper = null
     vi.unstubAllGlobals()
+    routeQuery.id = undefined
   })
 
   it('shows an unavailable notice when no JavaMailSender bean is present', async () => {
@@ -106,6 +111,29 @@ describe('Email panel', () => {
     expect(frame.attributes('srcdoc')).toContain('Your order is on the way')
     expect(frame.attributes('sandbox')).toBe('')
     expect(wrapper.text()).toContain('invoice.pdf')
+  })
+
+  it('opens the matching message detail drawer directly from a Live Activity ?id= deep link', async () => {
+    routeQuery.id = 'msg-1'
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(reportWithMessages())))
+    wrapper = mount(Email)
+    await flushPromises()
+
+    const frame = wrapper.find('iframe.email-html-frame')
+    expect(frame.exists()).toBe(true)
+    expect(frame.attributes('srcdoc')).toContain('Your order is on the way')
+
+    const viewButton = wrapper.findAll('button').find((b) => b.text() === 'Close')
+    expect(viewButton).toBeTruthy()
+  })
+
+  it('ignores an ?id= deep link that does not match any captured message', async () => {
+    routeQuery.id = 'no-such-id'
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(reportWithMessages())))
+    wrapper = mount(Email)
+    await flushPromises()
+
+    expect(wrapper.find('iframe.email-html-frame').exists()).toBe(false)
   })
 
   it('filters messages by sender, recipient, or subject', async () => {

--- a/bootui-ui/src/main/frontend/src/views/Email.vue
+++ b/bootui-ui/src/main/frontend/src/views/Email.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {apiFetch, getJson} from '../api.js'
-import {computed, inject, ref} from 'vue'
+import {computed, inject, onMounted, ref} from 'vue'
+import {useRoute} from 'vue-router'
 import {formatBytes} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
@@ -53,6 +54,17 @@ const filteredMessages = computed(() => {
 })
 
 const selected = computed(() => messages.value.find((m) => m.id === selectedId.value) || null)
+
+// Deep-linked from Live Activity (see `deepLink` in utils/activityStream.js): a MAIL entry there
+// shares its id with the captured message here, so `?id=` opens that message's detail drawer directly
+// instead of only prefilling a filter like the other panels' `?q=` deep links do.
+const route = useRoute()
+onMounted(() => {
+  const targetId = route?.query?.id
+  if (typeof targetId === 'string' && targetId) {
+    selectedId.value = targetId
+  }
+})
 
 function toggle(id) {
   selectedId.value = id === selectedId.value ? null : id

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
@@ -213,6 +213,47 @@ describe('LiveActivity', () => {
     expect(scheduledLink.text()).toContain('3')
   })
 
+  it('renders a mail entry with a deep link to its message in the Email panel', async () => {
+    const mailEntry = {
+      id: 'msg-1',
+      type: 'MAIL',
+      timestamp: 1700000000000,
+      severity: 'OK',
+      summary: 'Order shipped',
+      detail: 'to customer@example.com',
+      durationMs: null,
+      correlationId: null,
+      method: null,
+      path: null,
+      status: null,
+      thread: 'mail-1',
+      profileable: false,
+      parentId: null,
+      securedPrincipal: null,
+      sqlNPlusOneSuspected: false
+    }
+    vi.stubGlobal(
+      'fetch',
+      stubFetch(
+        activityReport({
+          typeCounts: {REQUEST: 0, SQL: 0, EXCEPTION: 0, SECURITY: 0, MAIL: 1},
+          entries: [mailEntry]
+        }),
+        requestProfile()
+      )
+    )
+
+    wrapper = mount(LiveActivity)
+    await flushPromises()
+
+    const row = wrapper.get('tbody tr')
+    expect(row.text()).toContain('MAIL')
+    expect(row.find('i.bi-envelope').exists()).toBe(true)
+
+    const mailLink = row.find('[title="Open in Email"]')
+    expect(mailLink.exists()).toBe(true)
+  })
+
   it('shows call sites for a flagged SQL group in the request profile drawer', async () => {
     vi.stubGlobal(
       'fetch',

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -115,7 +115,9 @@ signal.
 Every row is also a launchpad: clicking anywhere on a request row opens its profiler, and each row carries a deep link
 that jumps to the dedicated panel with the originating record pre-filtered — requests open in **HTTP Exchanges**, SQL in
 **SQL Trace**, REST client calls in **REST Client**, exceptions in **Exceptions**, cache accesses in **Cache**,
-and scheduled-task runs in **Scheduled Tasks**. REST client calls nest under their correlated request in the stream
+scheduled-task runs in **Scheduled Tasks**, and captured emails open the very same message's detail drawer in **Email**
+(the `MAIL` entry's id is the captured message's own id, so the link opens that exact email rather than only a
+filtered list). REST client calls nest under their correlated request in the stream
 using the same trace-id-first, serving-thread-second join described below for SQL, exactly like cache accesses and
 emails — but, unlike SQL, exceptions, and security events, none of REST client calls, cache accesses, or scheduled-task
 runs are yet part of the per-request profiler drawer's correlated timeline or **Copy profile** export; that


### PR DESCRIPTION
## Summary

When an email arrives in the **Live Activity** panel, its row now links directly to that message's detail drawer in the **Email** panel — matching the "Open in X" pattern already used for REQUEST, SQL, REST_CLIENT, EXCEPTION, SCHEDULED_TASK, and CACHE entries.

Other entry types deep-link via `?q=` to prefill a free-text filter in the target panel. `MAIL` entries instead deep-link via `?id=`, since a captured email's Live Activity entry id already matches the Email panel's message id (true for both the Spring and Quarkus adapters — confirmed in `LiveActivityService.java` and `LiveActivityAssembler.java`). This lets the Email panel open the *exact* message directly rather than just filtering the list, which would be ambiguous for messages sharing a subject.

No backend changes were required.

## Changes

- `activityStream.js`: added a `MAIL` case to `deepLink()` returning `{path: '/email', query: {id: entry.id}, label: 'Open in Email'}`, and updated the function's JSDoc to document the `?id=` convention.
- `Email.vue`: reads `route.query.id` in `onMounted` and pre-selects that message id, so arriving via the deep link opens its detail drawer immediately.
- Added unit tests in `activityStream.test.js`, `Email.test.js`, and `LiveActivity.test.js`.
- Updated `docs/FEATURES.md`'s Live Activity deep-link description.

## Testing

- `npm test` — full frontend suite passes (68 files / 391 tests).
- `npm run format:check` — clean.
- `npm run build` — production Vite build succeeds with no errors/warnings.