### PR TITLE
Remove unreferenced dead code (core, engine, conformance, Spring adapter)

### DIFF
--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/BootUiHttpProbe.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/BootUiHttpProbe.java
@@ -12,7 +12,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -124,14 +123,6 @@ public final class BootUiHttpProbe {
             } catch (IOException ex) {
                 throw new IllegalStateException("Response body is not valid JSON: " + preview(), ex);
             }
-        }
-
-        /** Parse the body as a JSON object into an insertion-ordered map of top-level fields. */
-        public Map<String, JsonNode> jsonFields() {
-            JsonNode node = json();
-            Map<String, JsonNode> fields = new LinkedHashMap<>();
-            node.fieldNames().forEachRemaining(name -> fields.put(name, node.get(name)));
-            return fields;
         }
 
         private String preview() {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiInfo.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/BootUiInfo.java
@@ -8,13 +8,7 @@ import java.util.Properties;
  */
 public final class BootUiInfo {
 
-    public static final String NAME = "BootUI";
-
     public static final String VERSION = readVersion();
-
-    public static final String DEFAULT_PATH = "/bootui";
-
-    public static final String DEFAULT_API_PATH = "/bootui/api";
 
     private BootUiInfo() {}
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/agent/AgentSessionStore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/agent/AgentSessionStore.java
@@ -28,7 +28,6 @@ import java.nio.file.WatchService;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2059,11 +2058,6 @@ public abstract class AgentSessionStore {
 
     public boolean isRawRevealAllowed() {
         return properties.isAllowRawReveal();
-    }
-
-    /** Visible for testing - returns an unmodifiable snapshot of cached session ids. */
-    java.util.Set<String> cachedSessionIds() {
-        return Collections.unmodifiableSet(sessions.keySet());
     }
 
     // ── internal types ────────────────────────────────────────────────────────

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracRuntimeInventory.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracRuntimeInventory.java
@@ -44,12 +44,4 @@ public record CracRuntimeInventory(
     public static CracRuntimeInventory empty() {
         return new CracRuntimeInventory(List.of(), List.of(), true);
     }
-
-    boolean hasConnectionPools() {
-        return !connectionPoolBeans.isEmpty();
-    }
-
-    boolean hasCacheManagers() {
-        return !cacheManagerBeans.isEmpty();
-    }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateEntityModel.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateEntityModel.java
@@ -14,7 +14,6 @@ public record HibernateEntityModel(String name, Class<?> javaType, List<Hibernat
     private static final String BATCH_SIZE = "org.hibernate.annotations.BatchSize";
     private static final String CACHE = "org.hibernate.annotations.Cache";
     private static final String CACHEABLE = "jakarta.persistence.Cacheable";
-    private static final String VERSION = "jakarta.persistence.Version";
 
     public HibernateEntityModel {
         attributes = List.copyOf(attributes);

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restclienttrace/RestClientTraceGrouping.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restclienttrace/RestClientTraceGrouping.java
@@ -31,9 +31,6 @@ import java.util.regex.Pattern;
  */
 public final class RestClientTraceGrouping {
 
-    /** Default chatty-call threshold used where no configured value is supplied. */
-    public static final int DEFAULT_CHATTY_THRESHOLD = 5;
-
     /** Maximum distinct call sites retained per group, most-recently-seen first. */
     public static final int MAX_CALL_SITES_PER_GROUP = 5;
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/PagedList.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/PagedList.java
@@ -15,8 +15,6 @@ import java.util.function.Predicate;
  */
 public final class PagedList {
 
-    static final int DEFAULT_LIMIT = 200;
-
     static final int MAX_LIMIT = 1000;
 
     private PagedList() {}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
@@ -61,16 +61,6 @@ record SecurityContext(
         return chains.stream().anyMatch(FilterChainModel::isStateful);
     }
 
-    boolean isResourceServerConfigured() {
-        return chains.stream().anyMatch(chain -> chain.hasFilterContaining("BearerTokenAuthenticationFilter"))
-                || firstProperty(
-                                "spring.security.oauth2.resourceserver.jwt.issuer-uri",
-                                "spring.security.oauth2.resourceserver.jwt.jwk-set-uri",
-                                "spring.security.oauth2.resourceserver.jwt.public-key-location")
-                        != null
-                || !jwtDecoderTypes.isEmpty();
-    }
-
     /**
      * {@code true} when the application configures (or is expected to run behind) TLS: server-side
      * SSL is configured, a forwarded-headers strategy indicates TLS is terminated upstream, or a


### PR DESCRIPTION
## What does this PR do?

Removes 8 pieces of dead code (unused constants and methods) confirmed to have zero references anywhere in the repository, including tests.

## Why is this change needed?

A systematic dead-code sweep was requested to keep the codebase clean. Because BootUI relies heavily on framework auto-discovery (Spring config binding, CDI, JPA reflection), naive "unreferenced identifier" checks produce many false positives, so every candidate below was individually verified via corpus-wide grep before removal to rule out framework-invoked usage.

Closes #

## What was removed

- `BootUiInfo.NAME`, `DEFAULT_PATH`, `DEFAULT_API_PATH` (`bootui-core`) - only `VERSION` is ever read by either adapter.
- `HibernateEntityModel.VERSION` (`bootui-engine`) - a duplicate of the constant actually used in `HibernateAttributeModel`.
- `PagedList.DEFAULT_LIMIT` (`bootui-engine`) - unused fallback constant; `MAX_LIMIT` is the one actually referenced.
- `RestClientTraceGrouping.DEFAULT_CHATTY_THRESHOLD` (`bootui-engine`) - `BootUiProperties` hardcodes the same literal separately.
- `CracRuntimeInventory.hasConnectionPools()` / `hasCacheManagers()` (`bootui-engine`) - `CracChecks` re-derives emptiness directly from the list accessors instead.
- `AgentSessionStore.cachedSessionIds()` (`bootui-engine`) - marked "visible for testing" but never used by any test.
- `SecurityContext.isResourceServerConfigured()` (`bootui-spring-autoconfigure`) - `SecurityRules` reimplements the same check inline for `SEC-OAUTH-001`.
- `BootUiHttpProbe.Response.jsonFields()` (`bootui-conformance`) - unused helper on the conformance HTTP probe; this module is not published to Maven Central.

No behavior changes: every removed item had zero call sites, so this is purely subtractive.

## How was it tested?

- [x] `./mvnw clean install` passes locally (full 26-module reactor: both adapters, all 12 Quarkus `@QuarkusTest` integration-test submodules, the shared conformance suite, and the frontend Vitest suite - all green, zero test changes needed)
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (not applicable - no user-visible behavior changed)
- [x] Added or updated tests where applicable (not applicable - removed code had no dedicated tests to update)

Also ran `spotless:apply` per repo convention.

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A - no public/documented behavior changed)
- [x] Public API kept backward compatible, or a migration note added to the PR description (the removed `bootui-core` constants had zero usages anywhere and no doc/README references, so they were not part of any documented public API contract)
- [x] No secrets, tokens, or local paths committed