### PR TITLE
Add Kafka support to the Spring sample app's docker profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Activity's `MESSAGING` entries: direction, topic, partition, offset, key hash, duration, and success/failure, with
   the message value/payload never captured. Ships in the Services group just under Email, on both Spring and
   Quarkus, reusing the existing `bootui.kafka.*` capture properties and adding `bootui.panels.kafka.*` panel toggles.
+- **Kafka support in the Spring sample app's `docker` profile** — a single-node KRaft `compose.yaml` service
+  (`apache/kafka`) plus a `spring-boot-starter-kafka` dependency, a seeded `orders.created` producer/listener pair,
+  and a **Send Kafka message** demo button, so the new Kafka panel has real produce/consume activity to show. The
+  `dev` profile stays Docker-free by excluding Kafka autoconfiguration.
 
 ## [1.11.0] - 2026-07-09
 

--- a/bootui-spring-sample-app/README.md
+++ b/bootui-spring-sample-app/README.md
@@ -10,9 +10,9 @@ the Playwright suite under `e2e/` exercises.
 - BootUI auto-activating in local development (the `dev`/`docker` profiles, or via `spring-boot-devtools`).
 - A relational Spring Data repository so the Spring Data panel has data to show
   (in-memory H2 by default, PostgreSQL with the `docker` profile).
-- Optional PostgreSQL, Redis, and Ollama Docker Compose services (`compose.yaml`, enabled by the `docker` profile) so the
-  Spring Data, Database Connection Pools, Cache, AI Usage, and Dev Services panels have realistic infrastructure
-  to show.
+- Optional PostgreSQL, Redis, Kafka, and Ollama Docker Compose services (`compose.yaml`, enabled by the `docker`
+  profile) so the Spring Data, Database Connection Pools, Cache, Kafka, AI Usage, and Dev Services panels have
+  realistic infrastructure to show.
 - Flyway migrations (the `catalog_*` tables) and Liquibase change sets (the separate
   `inventory_*` tables) with two pending updates each so the Flyway and Liquibase actions can be exercised manually.
 - Spring Security, scheduled tasks, custom metrics, and a small static welcome
@@ -46,15 +46,15 @@ runs this same Docker-free `dev` profile.
 
 ## Run it with Docker
 
-For the full experience — Postgres, Redis, Ollama, and every panel populated — activate the `docker` profile from the
-repository root:
+For the full experience — Postgres, Redis, Kafka, Ollama, and every panel populated — activate the `docker` profile
+from the repository root:
 
 ```bash
 ./mvnw -pl bootui-spring-sample-app spring-boot:run -Dspring-boot.run.profiles=docker
 ```
 
-Spring Boot will start Docker Compose, wait for Postgres, Redis, and Ollama, pull the small `qwen2.5:0.5b` chat model
-when missing, and then bind the sample app to `http://localhost:8080`.
+Spring Boot will start Docker Compose, wait for Postgres, Redis, Kafka, and Ollama, pull the small `qwen2.5:0.5b` chat
+model when missing, and then bind the sample app to `http://localhost:8080`.
 
 ## Visit BootUI
 
@@ -105,19 +105,22 @@ and AI Usage steps note where the `docker` profile adds Postgres/Redis/Ollama-ba
 12. **Cache** — verify the in-memory (`ConcurrentHashMap`) `sample-products`
     and `sample-greetings` caches are listed (Redis-backed with the `docker`
     profile), inspect cache annotations, and clear a cache after confirming the action.
-13. **Dev Services** — in the default Docker-free mode no containers are listed;
+13. **Kafka** — unavailable in the default Docker-free mode (no `KafkaTemplate` bean); with the `docker` profile,
+    click **Send Kafka message** on the welcome page and watch the produce/consume pair for the `orders.created`
+    topic appear in the panel.
+14. **Dev Services** — in the default Docker-free mode no containers are listed;
     with the `docker` profile the Postgres and Redis Docker Compose entries appear
     and their service-connection metadata matches the actual mapped ports.
-14. **Spring Security and Security Logs** — inspect filter chains, endpoint rule explanations, and recent masked audit
+15. **Spring Security and Security Logs** — inspect filter chains, endpoint rule explanations, and recent masked audit
     events.
-15. **Traces, Log Tail, HTTP Exchanges, Architecture, Pentesting, Vulnerabilities** — inspect local telemetry, logs,
+16. **Traces, Log Tail, HTTP Exchanges, Architecture, Pentesting, Vulnerabilities** — inspect local telemetry, logs,
     inbound requests, and run explicit local scans as development hygiene prompts.
-16. **HTTP Probe** — send a request to `/api/echo`, then try to send one to an
+17. **HTTP Probe** — send a request to `/api/echo`, then try to send one to an
     external host and confirm it is rejected as non-loopback.
-17. **AI Usage** — the Chat and AI Usage panels report AI is unavailable in the
+18. **AI Usage** — the Chat and AI Usage panels report AI is unavailable in the
     default mode; with the `docker` profile, exercise the sample AI endpoints and
     local AI helper paths, then inspect the retained in-memory spans and token summaries.
-18. **DevTools, Dev Services, Copilot, Claude Code** — confirm the developer-tool panels show local status, bounded service
+19. **DevTools, Dev Services, Copilot, Claude Code** — confirm the developer-tool panels show local status, bounded service
     metadata/logs, and sanitized local agent activity.
 
 ## Stop it

--- a/bootui-spring-sample-app/compose.yaml
+++ b/bootui-spring-sample-app/compose.yaml
@@ -13,6 +13,39 @@ services:
     # Spring Boot's docker-compose support discovers the mapped port.
     ports:
       - "6379"
+  kafka:
+    image: apache/kafka:4.3.1
+    # Single-node KRaft broker (no ZooKeeper), adapted from Apache Kafka's own example compose file.
+    # Pinned to 9092: unlike Postgres/Redis, spring-boot-kafka (4.1.0) ships no docker-compose
+    # connection-details factory (only Testcontainers factories), so the app resolves Kafka only via
+    # the static spring.kafka.bootstrap-servers (localhost:9092) and a dynamic host port would be
+    # unreachable.
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_LISTENERS: CONTROLLER://:29093,PLAINTEXT_HOST://:9092,PLAINTEXT://:19092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT_HOST://localhost:9092,PLAINTEXT://kafka:19092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:29093
+      CLUSTER_ID: 4L6g3nShT-eMCtK--X86sw
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR: 1
+      KAFKA_LOG_DIRS: /tmp/kraft-combined-logs
+    ports:
+      - "9092:9092"
+    healthcheck:
+      test: [ "CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1 || exit 1" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+    labels:
+      org.springframework.boot.service-connection: kafka
   ollama:
     image: ollama/ollama:latest
     # Pinned to 11434: unlike Postgres/Redis, spring-ai-starter-model-ollama

--- a/bootui-spring-sample-app/e2e/tests/docker-smoke.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/docker-smoke.spec.js
@@ -3,9 +3,10 @@ import {expect, test} from '@playwright/test'
 
 // These checks only run when the sample app was booted with the full Docker stack (the `docker`
 // Spring profile, set via BOOTUI_SAMPLE_PROFILES=docker by the weekly "Docker configuration"
-// workflow). They assert the runtime genuinely uses PostgreSQL, Redis, and Ollama instead of the
-// Docker-free `dev` defaults (H2, an in-memory cache, disabled Spring AI), so a green run actually
-// proves the Docker-based configuration works rather than passing in a broadly compatible mode.
+// workflow). They assert the runtime genuinely uses PostgreSQL, Redis, Kafka, and Ollama instead of
+// the Docker-free `dev` defaults (H2, an in-memory cache, no KafkaTemplate, disabled Spring AI), so a
+// green run actually proves the Docker-based configuration works rather than passing in a broadly
+// compatible mode.
 const dockerProfileActive = (process.env.BOOTUI_SAMPLE_PROFILES || '')
   .split(',')
   .map((profile) => profile.trim())
@@ -53,5 +54,20 @@ test.describe('Docker profile smoke checks', () => {
     const body = await response.json()
     expect(typeof body.reply).toBe('string')
     expect(body.reply.length).toBeGreaterThan(0)
+  })
+
+  test('captures a real Kafka produce/consume round trip', async ({request}) => {
+    const sendResponse = await request.get('/api/sample/send-kafka-message')
+    expect(sendResponse.ok()).toBeTruthy()
+
+    const response = await request.get('/bootui/api/kafka')
+    expect(response.ok()).toBeTruthy()
+    const kafka = await response.json()
+    expect(kafka.available).toBeTruthy()
+    const topics = (kafka.messages || []).map((message) => message.topic)
+    expect(topics).toContain('orders.created')
+    const directions = (kafka.messages || []).map((message) => message.direction)
+    expect(directions).toContain('PRODUCE')
+    expect(directions).toContain('CONSUME')
   })
 })

--- a/bootui-spring-sample-app/pom.xml
+++ b/bootui-spring-sample-app/pom.xml
@@ -77,6 +77,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-kafka</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/kafka/SampleKafkaConfiguration.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/kafka/SampleKafkaConfiguration.java
@@ -1,0 +1,27 @@
+package io.github.jdubois.bootui.sample.kafka;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+/**
+ * Declares the sample "orders.created" topic used by {@link SampleKafkaProducer} and
+ * {@link SampleOrderEventListener}.
+ *
+ * <p>A {@link NewTopic} bean is safe to declare unconditionally: it is a plain descriptor with no
+ * dependencies, so in the Docker-free "dev" profile (where {@code KafkaAutoConfiguration} — and
+ * therefore the {@code KafkaAdmin} that would apply this descriptor — is excluded) it simply sits
+ * unused in the context.
+ */
+@Configuration
+public class SampleKafkaConfiguration {
+
+    /** Topic shared by the sample producer, listener, and controller. */
+    public static final String ORDERS_TOPIC = "orders.created";
+
+    @Bean
+    public NewTopic ordersCreatedTopic() {
+        return TopicBuilder.name(ORDERS_TOPIC).partitions(1).replicas(1).build();
+    }
+}

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/kafka/SampleKafkaController.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/kafka/SampleKafkaController.java
@@ -1,0 +1,26 @@
+package io.github.jdubois.bootui.sample.kafka;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Triggers one more sample "order created" Kafka event on demand so the BootUI Kafka panel can be
+ * exercised interactively (and by the Playwright e2e suite). Only produces data when the "docker"
+ * profile is active (see {@link SampleKafkaProducer}).
+ */
+@RestController
+@RequestMapping("/api/sample")
+public class SampleKafkaController {
+
+    private final SampleKafkaProducer kafkaProducer;
+
+    public SampleKafkaController(SampleKafkaProducer kafkaProducer) {
+        this.kafkaProducer = kafkaProducer;
+    }
+
+    @GetMapping("/send-kafka-message")
+    public String sendKafkaMessage() {
+        return kafkaProducer.sendSampleOrderEvent();
+    }
+}

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/kafka/SampleKafkaProducer.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/kafka/SampleKafkaProducer.java
@@ -1,0 +1,66 @@
+package io.github.jdubois.bootui.sample.kafka;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Publishes sample "order created" events to Kafka so the BootUI Kafka panel (and Live Activity's
+ * Kafka signal) have producer data to display.
+ *
+ * <p>Kafka auto-configuration is excluded in the Docker-free "dev" profile, so no
+ * {@link KafkaTemplate} bean exists there. The template is injected through an
+ * {@link ObjectProvider} and every send is null-checked, mirroring {@code ChatController}'s
+ * graceful degradation for the (also Docker-only) Spring AI {@code ChatClient}.
+ *
+ * <p>One event is seeded once at startup, and {@link #sendSampleOrderEvent()} lets callers (e.g.
+ * the sample "Send Kafka message" endpoint) publish one more on demand.
+ */
+@Component
+public class SampleKafkaProducer {
+
+    private static final Logger log = LoggerFactory.getLogger(SampleKafkaProducer.class);
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final AtomicInteger orderSequence = new AtomicInteger(1000);
+
+    public SampleKafkaProducer(ObjectProvider<KafkaTemplate<String, String>> kafkaTemplateProvider) {
+        this.kafkaTemplate = kafkaTemplateProvider.getIfAvailable();
+    }
+
+    /** Seeds a single sample order event once the application is ready, so the panel is not empty. */
+    @EventListener(ApplicationReadyEvent.class)
+    public void seedSampleOrderEvent() {
+        if (kafkaTemplate != null) {
+            sendSampleOrderEvent();
+        }
+    }
+
+    /**
+     * Publishes one more sample "order created" event on demand and returns a short human-readable
+     * summary, or a clear "not configured" message when Kafka is unavailable (e.g. the "dev"
+     * profile).
+     */
+    public String sendSampleOrderEvent() {
+        if (kafkaTemplate == null) {
+            return "Kafka is not configured. Activate the \"docker\" profile to start a broker "
+                    + "(-Dspring-boot.run.profiles=docker).";
+        }
+        int orderId = orderSequence.incrementAndGet();
+        String key = "order-" + orderId;
+        String value = "{\"orderId\":%d,\"status\":\"CREATED\",\"createdAt\":\"%s\"}".formatted(orderId, Instant.now());
+        try {
+            kafkaTemplate.send(SampleKafkaConfiguration.ORDERS_TOPIC, key, value);
+            return "Published order #" + orderId + " to \"" + SampleKafkaConfiguration.ORDERS_TOPIC + "\"";
+        } catch (Exception ex) {
+            log.warn("Sample app could not publish the demo Kafka event", ex);
+            return "Could not publish the demo Kafka event: " + ex.getMessage();
+        }
+    }
+}

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/kafka/SampleOrderEventListener.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/kafka/SampleOrderEventListener.java
@@ -1,0 +1,33 @@
+package io.github.jdubois.bootui.sample.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Consumes {@link SampleKafkaConfiguration#ORDERS_TOPIC} so the BootUI Kafka panel (and Live
+ * Activity's Kafka signal) have matching consumer data alongside {@link SampleKafkaProducer}'s
+ * producer records.
+ *
+ * <p>No defensive coding is needed here for the Docker-free "dev" profile: excluding
+ * {@code KafkaAutoConfiguration} also excludes {@code @EnableKafka} processing, so this listener
+ * simply becomes inert (never registered) rather than failing to start.
+ */
+@Component
+public class SampleOrderEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(SampleOrderEventListener.class);
+
+    @KafkaListener(topics = SampleKafkaConfiguration.ORDERS_TOPIC)
+    public void onOrderCreated(ConsumerRecord<String, String> record) {
+        log.info(
+                "Consumed order event from {}-{}@{}: key={} value={}",
+                record.topic(),
+                record.partition(),
+                record.offset(),
+                record.key(),
+                record.value());
+    }
+}

--- a/bootui-spring-sample-app/src/main/resources/application-dev.properties
+++ b/bootui-spring-sample-app/src/main/resources/application-dev.properties
@@ -1,10 +1,11 @@
 # Docker-free defaults for the sample app. "dev" is the DEFAULT profile
 # (spring.profiles.default=dev in application.properties), so it applies to a bare `spring-boot:run`,
 # the "try me" scripts, and the Playwright e2e suite. It swaps the Docker Compose PostgreSQL, Redis,
-# and Ollama services for an in-memory H2 database, a simple in-memory cache, and disabled Spring AI.
-# (Docker Compose is already disabled by the base config; the "docker" profile re-enables it.)
-# The Database, Spring Data, Flyway, Liquibase, and Cache panels still work; the Chat / AI Usage
-# panels report AI as unavailable. Use the "docker" profile for the full Docker experience:
+# Kafka, and Ollama services for an in-memory H2 database, a simple in-memory cache, disabled Kafka,
+# and disabled Spring AI. (Docker Compose is already disabled by the base config; the "docker"
+# profile re-enables it.) The Database, Spring Data, Flyway, Liquibase, and Cache panels still work;
+# the Kafka and Chat / AI Usage panels report as unavailable. Use the "docker" profile for the full
+# Docker experience:
 #   ./mvnw -pl bootui-spring-sample-app spring-boot:run -Dspring-boot.run.profiles=docker
 
 # In-memory H2 database in place of the Dockerized PostgreSQL service (the H2 driver is auto-detected
@@ -16,15 +17,17 @@ spring.datasource.password=
 # Simple in-memory cache in place of the Dockerized Redis service.
 spring.cache.type=simple
 
-# Disable the Redis and Spring AI / Ollama auto-configuration so the app starts
-# without those Docker services. ChatController then returns a clear "AI
-# unavailable" response instead of attempting a network call.
+# Disable the Redis, Kafka, and Spring AI / Ollama auto-configuration so the app starts without
+# those Docker services. ChatController then returns a clear "AI unavailable" response instead of
+# attempting a network call, and SampleKafkaProducer degrades gracefully with no KafkaTemplate bean.
 spring.autoconfigure.exclude=\
   org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration,\
   org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration,\
   org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration,\
   org.springframework.boot.data.redis.autoconfigure.health.DataRedisHealthContributorAutoConfiguration,\
   org.springframework.boot.data.redis.autoconfigure.health.DataRedisReactiveHealthContributorAutoConfiguration,\
+  org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration,\
+  org.springframework.boot.kafka.autoconfigure.metrics.KafkaMetricsAutoConfiguration,\
   org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration,\
   org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration,\
   org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration

--- a/bootui-spring-sample-app/src/main/resources/application-docker.properties
+++ b/bootui-spring-sample-app/src/main/resources/application-docker.properties
@@ -1,14 +1,14 @@
 # Full Docker experience for the sample app. Activate with -Dspring-boot.run.profiles=docker
 # (the default is the Docker-free "dev" profile). Spring Boot's docker-compose support starts the
-# PostgreSQL, Redis, and Ollama services from compose.yaml; the first startup also pulls the small
-# qwen2.5:0.5b chat model. Postgres backs JPA / Flyway / Liquibase, Redis backs Cache, and
-# Ollama powers the Chat / AI Usage panels.
+# PostgreSQL, Redis, Kafka, and Ollama services from compose.yaml; the first startup also pulls the
+# small qwen2.5:0.5b chat model. Postgres backs JPA / Flyway / Liquibase, Redis backs Cache, Kafka
+# backs the Kafka panel, and Ollama powers the Chat / AI Usage panels.
 
 # Start Docker Compose (compose.yaml) and wait for the services to be ready.
 spring.docker.compose.enabled=true
 
-# Clear the Docker-free profile's auto-configuration excludes so Redis, Ollama, and the ChatClient
-# auto-configuration run (also keeps -Dspring-boot.run.profiles=dev,docker working).
+# Clear the Docker-free profile's auto-configuration excludes so Redis, Kafka, Ollama, and the
+# ChatClient auto-configuration run (also keeps -Dspring-boot.run.profiles=dev,docker working).
 spring.autoconfigure.exclude=
 
 # PostgreSQL connection details are provided by the docker-compose "postgres" service.
@@ -17,6 +17,16 @@ spring.autoconfigure.exclude=
 spring.cache.type=redis
 spring.cache.redis.time-to-live=10m
 spring.data.redis.repositories.enabled=false
+
+# Kafka (the pinned "kafka" docker-compose service on port 9092). Like Ollama, spring-boot-kafka
+# ships no docker-compose connection-details factory, so the bootstrap address is static.
+spring.kafka.bootstrap-servers=localhost:9092
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.consumer.group-id=order-processing
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.auto-offset-reset=earliest
 
 # Spring AI / Ollama (the pinned "ollama" docker-compose service on port 11434).
 spring.ai.ollama.base-url=http://localhost:11434

--- a/bootui-spring-sample-app/src/main/resources/static/index.html
+++ b/bootui-spring-sample-app/src/main/resources/static/index.html
@@ -330,6 +330,11 @@
           <small>Inspect: Email</small>
         </article>
         <article class="test-action">
+          <button class="button" id="send-kafka-button" type="button">Send Kafka message</button>
+          <p>Calls <code>GET /api/sample/send-kafka-message</code> to publish a demo "order created" event.</p>
+          <small>Inspect: Kafka (requires the "docker" profile)</small>
+        </article>
+        <article class="test-action">
           <button class="button" id="quarkus-cross-service-button" type="button">Call the Quarkus sample app</button>
           <p>
             Calls <code>GET /api/sample/quarkus-secure-products</code>, which this Spring Boot app uses to call the
@@ -394,6 +399,7 @@
   const quarkusCrossServiceButton = document.getElementById('quarkus-cross-service-button')
   const authFailButton = document.getElementById('auth-fail-button')
   const sendEmailButton = document.getElementById('send-email-button')
+  const sendKafkaButton = document.getElementById('send-kafka-button')
   const sessionDataButton = document.getElementById('session-data-button')
   const sessionDataStatus = document.getElementById('session-data-status')
   const sampleActionStatus = document.getElementById('sample-action-status')
@@ -686,6 +692,17 @@
         throw new Error(text)
       }
       showSampleResult('Test email sent', `${text}\n\nOpen BootUI Email to inspect the captured message.`)
+    })
+  )
+
+  sendKafkaButton.addEventListener('click', () =>
+    runSampleAction(sendKafkaButton, 'Publishing Kafka message...', async () => {
+      const response = await fetch('/api/sample/send-kafka-message')
+      const text = await readTextResponse(response)
+      if (!response.ok) {
+        throw new Error(text)
+      }
+      showSampleResult('Kafka message published', `${text}\n\nOpen BootUI Kafka to inspect the captured event.`)
     })
   )
 

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -55,6 +55,8 @@ import org.springframework.web.client.RestClient;
                     + "org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration,"
                     + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisHealthContributorAutoConfiguration,"
                     + "org.springframework.boot.data.redis.autoconfigure.health.DataRedisReactiveHealthContributorAutoConfiguration,"
+                    + "org.springframework.boot.kafka.autoconfigure.KafkaAutoConfiguration,"
+                    + "org.springframework.boot.kafka.autoconfigure.metrics.KafkaMetricsAutoConfiguration,"
                     + "org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration,"
                     + "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration,"
                     + "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration",


### PR DESCRIPTION
## Why

The BootUI Kafka panel had no way to be exercised in the Spring sample app — `compose.yaml` only started Postgres/Redis/Ollama, and the sample app had no Kafka dependency at all, so the panel's documented behavior was based on mocked fixtures only.

## What

- **`compose.yaml`** — single-node KRaft Kafka broker (`apache/kafka:4.3.1`), pinned to port `9092`. `spring-boot-kafka` ships no Docker Compose connection-details factory (only Testcontainers factories), so the bootstrap address must be static — mirrors the existing Ollama precedent in this file.
- **`pom.xml`** — added `spring-boot-starter-kafka`.
- **`application-docker.properties`** — static `bootstrap-servers=localhost:9092`, producer/consumer (de)serializers, consumer group id.
- **`application-dev.properties`** — excludes Kafka autoconfiguration so the Docker-free default profile stays broker-free.
- **New `sample.kafka` package** (mirrors the existing `mail`/`chat` sample packages):
  - `SampleKafkaConfiguration` — declares the `orders.created` topic.
  - `SampleKafkaProducer` — graceful `ObjectProvider`-based producer; seeds one event at startup, exposes an on-demand send.
  - `SampleOrderEventListener` — `@KafkaListener` consumer for the same topic.
  - `SampleKafkaController` — `GET /api/sample/send-kafka-message`.
- **`index.html`** — "Send Kafka message" demo button, mirroring "Send test email".
- **Test fix** — `BootUiSampleApplicationIntegrationTests` hardcodes its own `spring.autoconfigure.exclude` list (inline `@SpringBootTest` properties override the properties file rather than merge with it); added the same two Kafka excludes there to fix 34 cascading `@KafkaListener` startup failures.
- **`docker-smoke.spec.js`** — new test asserting a genuine produce/consume round trip through the Docker Kafka broker.
- **`README.md`** / **`CHANGELOG.md`** — updated to mention Kafka alongside Postgres/Redis/Ollama.

## Verification

- Compiled and ran the full reactor test suite (2640+ tests, 0 failures/errors).
- `spotless:apply` / `spotless:check` clean; e2e `format:check` clean.
- Live-tested the exact KRaft compose config in isolation (pulled the image, confirmed a genuine host→container produce/consume round trip) before adding it to the repo.
- Ran the actual sample app under `-Dspring-boot.run.profiles=docker`: all four containers (Postgres/Redis/Kafka/Ollama) started healthy, the seeded producer/listener exchanged a real message, and:
  - `GET /bootui/api/kafka` reported `available: true` with the captured PRODUCE/CONSUME pair.
  - `GET /api/sample/send-kafka-message` published a second message end-to-end and the panel updated to 4 entries.
  - `GET /bootui/api/panels` reports the `kafka` panel as `available: true`.
- Confirmed the `dev` profile (and existing conformance/e2e suites, which boot under `dev`) is unaffected — Kafka stays excluded/unavailable there.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>