### PR TITLE
Fix Kafka panel showing a raw 404 when unavailable

### DIFF
--- a/bootui-ui/src/main/frontend/src/views/Kafka.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Kafka.test.js
@@ -3,6 +3,7 @@ import {afterEach, describe, expect, it, vi} from 'vitest'
 import {useRoute} from 'vue-router'
 
 import Kafka from './Kafka.vue'
+import PanelHeader from './components/PanelHeader.vue'
 
 vi.mock('../utils/useConfirm.js', () => ({
   useConfirm: () => ({confirm: () => Promise.resolve(true)})
@@ -99,6 +100,40 @@ describe('Kafka panel', () => {
 
     expect(wrapper.text()).toContain('Kafka capture is unavailable')
     expect(wrapper.text()).toContain('No KafkaTemplate bean is present')
+  })
+
+  it('shows an unavailable notice without calling the API when the panel manifest reports Kafka unavailable', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    wrapper = mount(Kafka, {
+      props: {
+        panel: {
+          id: 'kafka',
+          enabled: true,
+          available: false,
+          unavailableReason: 'No KafkaTemplate bean is available'
+        }
+      }
+    })
+    await flushPromises()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Kafka capture is unavailable')
+    expect(wrapper.text()).toContain('No KafkaTemplate bean is available')
+    expect(wrapper.findComponent(PanelHeader).props('refreshable')).toBe(false)
+  })
+
+  it('shows a disabled explanation without calling the API when the panel is disabled via config', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    wrapper = mount(Kafka, {props: {panel: {id: 'kafka', enabled: false}}})
+    await flushPromises()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Kafka capture is unavailable')
+    expect(wrapper.text()).toContain('Panel is disabled via bootui.panels.kafka.enabled=false')
   })
 
   it('shows an empty state when no Kafka activity has been captured yet', async () => {

--- a/bootui-ui/src/main/frontend/src/views/Kafka.vue
+++ b/bootui-ui/src/main/frontend/src/views/Kafka.vue
@@ -15,7 +15,7 @@ import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
-const {readOnly, readOnlyReason} = usePanelState(props)
+const {readOnly, readOnlyReason, manifestAvailable, manifestUnavailableReason} = usePanelState(props)
 const {confirm} = useConfirm()
 const report = ref(null)
 const error = ref(null)
@@ -43,7 +43,10 @@ onMounted(() => {
   }
 })
 
-const {autoRefresh, loading, load} = useAutoRefresh(fetchKafka)
+const {autoRefresh, loading, initialLoading, load} = useAutoRefresh(fetchKafka, {
+  enabled: manifestAvailable,
+  initialLoading: false
+})
 
 const messages = computed(() => report.value?.messages ?? [])
 
@@ -57,8 +60,18 @@ const filteredMessages = computed(() => {
   })
 })
 
+// Whether the panel manifest already knows Kafka can't be used (no KafkaTemplate bean, or explicitly
+// disabled): the backing endpoint may not even be wired in that case (see KafkaController's
+// @ConditionalOnClass), so fetchKafka() is gated on manifestAvailable via useAutoRefresh and never runs —
+// avoiding a 404 in favor of this manifest-driven explanation.
+const available = computed(() => manifestAvailable.value && report.value?.available !== false)
+const unavailableReason = computed(() => {
+  if (!manifestAvailable.value) return manifestUnavailableReason.value
+  return report.value?.unavailableReason || 'Kafka capture is unavailable.'
+})
+
 const subtitle = computed(() => {
-  if (!report.value || !report.value.available) return null
+  if (!available.value || !report.value) return null
   const parts = [
     `${formatNumber(report.value.total)} retained`,
     `${formatNumber(report.value.totalCaptured)} captured since startup`
@@ -122,6 +135,8 @@ async function clearAll() {
       :loading="loading"
       :error="error"
       :last-fetched="lastFetched"
+      :refreshable="manifestAvailable"
+      :auto-refreshable="manifestAvailable"
       v-model:auto-refresh="autoRefresh"
       @refresh="load"
     >
@@ -139,12 +154,12 @@ async function clearAll() {
 
     <FlashBanner :message="banner" @dismiss="clear" />
 
-    <PanelSkeleton v-if="loading && !report" />
+    <PanelSkeleton v-if="initialLoading && manifestAvailable" />
 
-    <template v-else-if="report">
-      <div v-if="!report.available" class="alert alert-warning">
+    <template v-else-if="!manifestAvailable || report">
+      <div v-if="!available" class="alert alert-warning">
         <strong>Kafka capture is unavailable.</strong>
-        <span class="d-block small">{{ report.unavailableReason }}</span>
+        <span class="d-block small">{{ unavailableReason }}</span>
       </div>
 
       <template v-else>


### PR DESCRIPTION
## What does this PR do?

Stops the Kafka panel from firing a doomed API request (and showing a raw 404) when Kafka capture is unavailable, so it shows a clean explanation like every other gated panel.

## Why is this change needed?

`Kafka.vue` always called `GET /bootui/api/kafka` on mount, regardless of what the panel manifest already knew. `KafkaController` is `@ConditionalOnClass(KafkaTemplate)`, so when `spring-kafka` isn't on the classpath (true for `bootui-spring-sample-app` today), the controller never registers and the request 404s. That produced an ugly load-failed banner stacked on top of the app's own "Panel unavailable" explanation, instead of the clean single message users see on other unavailable panels.

The fix gates the fetch on `usePanelState`'s `manifestAvailable`/`manifestUnavailableReason`, the same pattern already used by `HttpSessions.vue` and `DatabaseConnectionPools.vue` for panels whose backing endpoint may not be wired at all. No backend changes were needed: `PanelsController.kafkaAvailable()` already reports availability correctly for `/bootui/api/panels`.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally (ran targeted Kafka/Panels controller tests plus reactor build)
- [x] Frontend unit tests: `npm test -- --run` (405/405 tests pass, including 2 new Kafka tests for the manifest-unavailable and config-disabled cases)
- [x] `npm run format:check` and `npm run build` pass
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end

## Screenshots (UI changes)

N/A (behavior-only fix; the panel body already showed the same warning styling, this just removes the redundant 404 banner above it)

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (not needed, no documented behavior changed, this is a bug fix)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed