### PR TITLE
Refactor: dedupe shared code across engine, adapters, and UI

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/activity/ActivityQuery.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/activity/ActivityQuery.java
@@ -1,5 +1,7 @@
 package io.github.jdubois.bootui.engine.activity;
 
+import io.github.jdubois.bootui.engine.support.BlankStrings;
+
 /**
  * A query against an {@link ActivityStore}: an optional filter set plus a "load more" pagination
  * cursor. All filters are optional (blank/{@code null} means "no filter on this field") and are applied
@@ -50,18 +52,14 @@ public record ActivityQuery(
     }
 
     String normalizedType() {
-        return blankToNull(type);
+        return BlankStrings.blankToNull(type);
     }
 
     String normalizedSeverity() {
-        return blankToNull(severity);
+        return BlankStrings.blankToNull(severity);
     }
 
     String normalizedText() {
-        return blankToNull(text);
-    }
-
-    private static String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value;
+        return BlankStrings.blankToNull(text);
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleSupport.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.engine.architecture;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 import io.github.jdubois.bootui.core.dto.ArchitectureRuleResultDto;
+import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,7 +22,6 @@ final class ArchitectureRuleSupport {
     static final String ERROR = "ERROR";
 
     private static final int MAX_SAMPLE_VIOLATIONS = 10;
-    private static final int MAX_DETAIL_CHARS = 240;
 
     private ArchitectureRuleSupport() {}
 
@@ -74,16 +74,6 @@ final class ArchitectureRuleSupport {
     }
 
     static String detail(String value) {
-        if (value == null) {
-            return "No additional detail.";
-        }
-        String sanitized = value.replaceAll("[\\r\\n\\t]+", " ").trim();
-        if (sanitized.isBlank()) {
-            return "No additional detail.";
-        }
-        if (sanitized.length() <= MAX_DETAIL_CHARS) {
-            return sanitized;
-        }
-        return sanitized.substring(0, MAX_DETAIL_CHARS - 3) + "...";
+        return DetailText.sanitize(value);
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureScanner.java
@@ -5,9 +5,9 @@ import io.github.jdubois.bootui.core.dto.ArchitectureReport;
 import io.github.jdubois.bootui.core.dto.ArchitectureRuleResultDto;
 import io.github.jdubois.bootui.core.dto.ArchitectureScanStatusDto;
 import io.github.jdubois.bootui.core.dto.ArchitectureSeverityCountDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,9 +27,8 @@ public final class ArchitectureScanner {
             "Heuristic, project-agnostic architecture rules run against the host application's own classes only. "
                     + "These checks complement, but do not replace, a project-specific ArchUnit test suite or an "
                     + "architecture review.";
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
     private static final Comparator<ArchitectureRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(
-                    (ArchitectureRuleResultDto result) -> severityRank(result.severity()))
+                    (ArchitectureRuleResultDto result) -> SeverityOrder.rank(result.severity()))
             .thenComparing(Comparator.comparingInt(ArchitectureRuleResultDto::violationCount)
                     .reversed())
             .thenComparing(ArchitectureRuleResultDto::id);
@@ -197,15 +196,8 @@ public final class ArchitectureScanner {
     }
 
     private List<ArchitectureSeverityCountDto> severityCounts(List<ArchitectureRuleResultDto> results) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String severity : SEVERITIES) {
-            counts.put(severity, 0);
-        }
-        for (ArchitectureRuleResultDto result : results) {
-            if (isViolation(result)) {
-                counts.computeIfPresent(result.severity(), (ignored, count) -> count + 1);
-            }
-        }
+        Map<String, Integer> counts =
+                SeverityOrder.counts(results, ArchitectureScanner::isViolation, ArchitectureRuleResultDto::severity);
         return counts.entrySet().stream()
                 .map(entry -> new ArchitectureSeverityCountDto(entry.getKey(), entry.getValue()))
                 .toList();
@@ -216,11 +208,6 @@ public final class ArchitectureScanner {
                 .filter(ArchitectureScanner::isViolation)
                 .sorted(IMPORTANCE_ORDER)
                 .toList();
-    }
-
-    private static int severityRank(String severity) {
-        int index = SEVERITIES.indexOf(severity);
-        return index >= 0 ? index : SEVERITIES.size();
     }
 
     private static boolean isViolation(ArchitectureRuleResultDto result) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracCheckSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracCheckSupport.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.engine.crac;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 import io.github.jdubois.bootui.core.dto.CracFindingDto;
+import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +23,6 @@ final class CracCheckSupport {
     static final String ERROR = "ERROR";
 
     private static final int MAX_SAMPLE_OCCURRENCES = 10;
-    private static final int MAX_DETAIL_CHARS = 240;
 
     private CracCheckSupport() {}
 
@@ -78,17 +78,7 @@ final class CracCheckSupport {
     }
 
     static String detail(String value) {
-        if (value == null) {
-            return "No additional detail.";
-        }
-        String sanitized = value.replaceAll("[\\r\\n\\t]+", " ").trim();
-        if (sanitized.isBlank()) {
-            return "No additional detail.";
-        }
-        if (sanitized.length() <= MAX_DETAIL_CHARS) {
-            return sanitized;
-        }
-        return sanitized.substring(0, MAX_DETAIL_CHARS - 3) + "...";
+        return DetailText.sanitize(value);
     }
 
     static int maxSampleOccurrences() {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracReadinessScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/crac/CracReadinessScanner.java
@@ -6,9 +6,9 @@ import io.github.jdubois.bootui.core.dto.CracReadinessReport;
 import io.github.jdubois.bootui.core.dto.CracRuntimeStatusDto;
 import io.github.jdubois.bootui.core.dto.CracScanStatusDto;
 import io.github.jdubois.bootui.core.dto.CracSeverityCountDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -29,9 +29,8 @@ public final class CracReadinessScanner {
                     + "commonly needs attention before a checkpoint, but they complement, and do not replace, an actual "
                     + "checkpoint/restore run on a CRaC-enabled JDK.";
 
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
     private static final Comparator<CracFindingDto> IMPORTANCE_ORDER = Comparator.comparingInt(
-                    (CracFindingDto finding) -> severityRank(finding.severity()))
+                    (CracFindingDto finding) -> SeverityOrder.rank(finding.severity()))
             .thenComparing(
                     Comparator.comparingInt(CracFindingDto::occurrenceCount).reversed())
             .thenComparing(CracFindingDto::id);
@@ -199,13 +198,7 @@ public final class CracReadinessScanner {
     }
 
     private List<CracSeverityCountDto> severityCounts(List<CracFindingDto> findings) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String severity : SEVERITIES) {
-            counts.put(severity, 0);
-        }
-        for (CracFindingDto finding : findings) {
-            counts.computeIfPresent(finding.severity(), (ignored, count) -> count + 1);
-        }
+        Map<String, Integer> counts = SeverityOrder.counts(findings, CracFindingDto::severity);
         return counts.entrySet().stream()
                 .map(entry -> new CracSeverityCountDto(entry.getKey(), entry.getValue()))
                 .toList();
@@ -217,11 +210,6 @@ public final class CracReadinessScanner {
                         || CracCheckSupport.ERROR.equals(result.status()))
                 .sorted(IMPORTANCE_ORDER)
                 .toList();
-    }
-
-    private static int severityRank(String severity) {
-        int index = SEVERITIES.indexOf(severity);
-        return index >= 0 ? index : SEVERITIES.size();
     }
 
     /** Scan-specific portion of a CRaC readiness run, cached by the controller between requests. */

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmCheckSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmCheckSupport.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.engine.graalvm;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.lang.EvaluationResult;
 import io.github.jdubois.bootui.core.dto.GraalVmFindingDto;
+import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -22,7 +23,6 @@ final class GraalVmCheckSupport {
     static final String ERROR = "ERROR";
 
     private static final int MAX_SAMPLE_OCCURRENCES = 10;
-    private static final int MAX_DETAIL_CHARS = 240;
 
     private GraalVmCheckSupport() {}
 
@@ -78,17 +78,7 @@ final class GraalVmCheckSupport {
     }
 
     static String detail(String value) {
-        if (value == null) {
-            return "No additional detail.";
-        }
-        String sanitized = value.replaceAll("[\\r\\n\\t]+", " ").trim();
-        if (sanitized.isBlank()) {
-            return "No additional detail.";
-        }
-        if (sanitized.length() <= MAX_DETAIL_CHARS) {
-            return sanitized;
-        }
-        return sanitized.substring(0, MAX_DETAIL_CHARS - 3) + "...";
+        return DetailText.sanitize(value);
     }
 
     static int maxSampleOccurrences() {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmReadinessScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/graalvm/GraalVmReadinessScanner.java
@@ -8,9 +8,9 @@ import io.github.jdubois.bootui.core.dto.GraalVmReadinessReport;
 import io.github.jdubois.bootui.core.dto.GraalVmScanProgressDto;
 import io.github.jdubois.bootui.core.dto.GraalVmScanStatusDto;
 import io.github.jdubois.bootui.core.dto.GraalVmSeverityCountDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -32,9 +32,8 @@ public final class GraalVmReadinessScanner {
                     + "dependencies ship reachability metadata. They complement, but do not replace, the GraalVM "
                     + "tracing agent and an actual native-image build.";
 
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
     private static final Comparator<GraalVmFindingDto> IMPORTANCE_ORDER = Comparator.comparingInt(
-                    (GraalVmFindingDto finding) -> severityRank(finding.severity()))
+                    (GraalVmFindingDto finding) -> SeverityOrder.rank(finding.severity()))
             .thenComparing(
                     Comparator.comparingInt(GraalVmFindingDto::occurrenceCount).reversed())
             .thenComparing(GraalVmFindingDto::id);
@@ -310,13 +309,7 @@ public final class GraalVmReadinessScanner {
     }
 
     private List<GraalVmSeverityCountDto> severityCounts(List<GraalVmFindingDto> findings) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String severity : SEVERITIES) {
-            counts.put(severity, 0);
-        }
-        for (GraalVmFindingDto finding : findings) {
-            counts.computeIfPresent(finding.severity(), (ignored, count) -> count + 1);
-        }
+        Map<String, Integer> counts = SeverityOrder.counts(findings, GraalVmFindingDto::severity);
         return counts.entrySet().stream()
                 .map(entry -> new GraalVmSeverityCountDto(entry.getKey(), entry.getValue()))
                 .toList();
@@ -328,11 +321,6 @@ public final class GraalVmReadinessScanner {
                         || GraalVmCheckSupport.ERROR.equals(result.status()))
                 .sorted(IMPORTANCE_ORDER)
                 .toList();
-    }
-
-    private static int severityRank(String severity) {
-        int index = SEVERITIES.indexOf(severity);
-        return index >= 0 ? index : SEVERITIES.size();
     }
 
     /** Result of one scan: the report served to the panel plus the metadata scaffold candidates. */

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleSupport.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.hibernate;
 
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
+import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,7 +21,6 @@ final class HibernateRuleSupport {
     private static final java.util.Set<String> KNOWN_SEVERITIES = java.util.Set.of(CRITICAL, HIGH, MEDIUM, LOW, INFO);
 
     private static final int MAX_SAMPLE_VIOLATIONS = 10;
-    private static final int MAX_DETAIL_CHARS = 240;
 
     private HibernateRuleSupport() {}
 
@@ -78,17 +78,7 @@ final class HibernateRuleSupport {
     }
 
     static String detail(String value) {
-        if (value == null) {
-            return "No additional detail.";
-        }
-        String sanitized = value.replaceAll("[\\r\\n\\t]+", " ").trim();
-        if (sanitized.isBlank()) {
-            return "No additional detail.";
-        }
-        if (sanitized.length() <= MAX_DETAIL_CHARS) {
-            return sanitized;
-        }
-        return sanitized.substring(0, MAX_DETAIL_CHARS - 3) + "...";
+        return DetailText.sanitize(value);
     }
 
     private static List<String> samples(List<String> details) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateScanner.java
@@ -4,9 +4,9 @@ import io.github.jdubois.bootui.core.dto.HibernateReport;
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
 import io.github.jdubois.bootui.core.dto.HibernateScanStatusDto;
 import io.github.jdubois.bootui.core.dto.HibernateSeverityCountDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,9 +26,8 @@ public final class HibernateScanner {
             "Heuristic Hibernate/JPA mapping rules run against the host application's mapped entities only. "
                     + "These checks are review prompts, not verdicts, and should be validated against the "
                     + "application's data access patterns.";
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
     private static final Comparator<HibernateRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(
-                    (HibernateRuleResultDto result) -> severityRank(result.severity()))
+                    (HibernateRuleResultDto result) -> SeverityOrder.rank(result.severity()))
             .thenComparing(Comparator.comparingInt(HibernateRuleResultDto::violationCount)
                     .reversed())
             .thenComparing(HibernateRuleResultDto::id);
@@ -221,15 +220,8 @@ public final class HibernateScanner {
     }
 
     private List<HibernateSeverityCountDto> severityCounts(List<HibernateRuleResultDto> results) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String severity : SEVERITIES) {
-            counts.put(severity, 0);
-        }
-        for (HibernateRuleResultDto result : results) {
-            if (isViolation(result)) {
-                counts.computeIfPresent(result.severity(), (ignored, count) -> count + 1);
-            }
-        }
+        Map<String, Integer> counts =
+                SeverityOrder.counts(results, HibernateScanner::isViolation, HibernateRuleResultDto::severity);
         return counts.entrySet().stream()
                 .map(entry -> new HibernateSeverityCountDto(entry.getKey(), entry.getValue()))
                 .toList();
@@ -249,11 +241,6 @@ public final class HibernateScanner {
                 .distinct()
                 .sorted()
                 .toList();
-    }
-
-    private static int severityRank(String severity) {
-        int index = SEVERITIES.indexOf(severity);
-        return index >= 0 ? index : SEVERITIES.size();
     }
 
     private static boolean isViolation(HibernateRuleResultDto result) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRuleSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRuleSupport.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.memory;
 
 import io.github.jdubois.bootui.core.dto.MemoryRuleResultDto;
+import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,7 +21,6 @@ final class MemoryRuleSupport {
     private static final java.util.Set<String> KNOWN_SEVERITIES = java.util.Set.of(CRITICAL, HIGH, MEDIUM, LOW, INFO);
 
     private static final int MAX_SAMPLE_VIOLATIONS = 10;
-    private static final int MAX_DETAIL_CHARS = 240;
 
     private MemoryRuleSupport() {}
 
@@ -78,17 +78,7 @@ final class MemoryRuleSupport {
     }
 
     static String detail(String value) {
-        if (value == null) {
-            return "No additional detail.";
-        }
-        String sanitized = value.replaceAll("[\\r\\n\\t]+", " ").trim();
-        if (sanitized.isBlank()) {
-            return "No additional detail.";
-        }
-        if (sanitized.length() <= MAX_DETAIL_CHARS) {
-            return sanitized;
-        }
-        return sanitized.substring(0, MAX_DETAIL_CHARS - 3) + "...";
+        return DetailText.sanitize(value);
     }
 
     private static List<String> samples(List<String> details) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryScanner.java
@@ -5,6 +5,7 @@ import io.github.jdubois.bootui.core.dto.MemoryRuleResultDto;
 import io.github.jdubois.bootui.core.dto.MemoryScanStatusDto;
 import io.github.jdubois.bootui.core.dto.MemorySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.MemorySummaryDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import io.github.jdubois.bootui.engine.threads.ThreadDumpService;
 import java.time.Clock;
 import java.util.Comparator;
@@ -36,10 +37,8 @@ public final class MemoryScanner {
             "Heuristic JVM memory and thread health rules run against this process's live management beans only. "
                     + "These findings are review prompts, not verdicts, and should be validated against the "
                     + "application's workload and a profiler before acting.";
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
-
     private static final Comparator<MemoryRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(
-                    (MemoryRuleResultDto result) -> severityRank(result.severity()))
+                    (MemoryRuleResultDto result) -> SeverityOrder.rank(result.severity()))
             .thenComparing(
                     Comparator.comparingInt(MemoryRuleResultDto::violationCount).reversed())
             .thenComparing(MemoryRuleResultDto::id);
@@ -278,21 +277,10 @@ public final class MemoryScanner {
     }
 
     private List<MemorySeverityCountDto> severityCounts(List<MemoryRuleResultDto> violations) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String severity : SEVERITIES) {
-            counts.put(severity, 0);
-        }
-        for (MemoryRuleResultDto result : violations) {
-            counts.computeIfPresent(result.severity(), (ignored, count) -> count + 1);
-        }
+        Map<String, Integer> counts = SeverityOrder.counts(violations, MemoryRuleResultDto::severity);
         return counts.entrySet().stream()
                 .map(entry -> new MemorySeverityCountDto(entry.getKey(), entry.getValue()))
                 .toList();
-    }
-
-    private static int severityRank(String severity) {
-        int index = SEVERITIES.indexOf(severity);
-        return index >= 0 ? index : SEVERITIES.size();
     }
 
     private static boolean isViolation(MemoryRuleResultDto result) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingScanner.java
@@ -5,10 +5,10 @@ import io.github.jdubois.bootui.core.dto.PentestingFindingDto;
 import io.github.jdubois.bootui.core.dto.PentestingReport;
 import io.github.jdubois.bootui.core.dto.PentestingScanStatusDto;
 import io.github.jdubois.bootui.core.dto.PentestingSeverityCountDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.net.URI;
 import java.time.Clock;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -34,7 +34,6 @@ public final class PentestingScanner {
             "Heuristic local checks only against the host application; BootUI /bootui paths are excluded. "
                     + "This panel does not replace a manual security review or a full pentesting.";
     private static final String SYNTHETIC_PATH = "/__bootui_pentesting__/missing-resource";
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
 
     private final Supplier<PentestingObservation> observationSupplier;
     private final PentestingLocalHttpClient httpClient;
@@ -134,7 +133,8 @@ public final class PentestingScanner {
             List<PentestingCoverageDto> coverage,
             List<PentestingFindingDto> findings) {
         List<PentestingFindingDto> sortedFindings = findings.stream()
-                .sorted(Comparator.comparingInt((PentestingFindingDto finding) -> severityRank(finding.severity()))
+                .sorted(Comparator.comparingInt(
+                                (PentestingFindingDto finding) -> SeverityOrder.rank(finding.severity()))
                         .thenComparing(PentestingFindingDto::id))
                 .toList();
         PentestingScanStatusDto scan =
@@ -151,20 +151,9 @@ public final class PentestingScanner {
     }
 
     private List<PentestingSeverityCountDto> severityCounts(List<PentestingFindingDto> findings) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String severity : SEVERITIES) {
-            counts.put(severity, 0);
-        }
-        for (PentestingFindingDto finding : findings) {
-            counts.computeIfPresent(finding.severity(), (ignored, count) -> count + 1);
-        }
+        Map<String, Integer> counts = SeverityOrder.counts(findings, PentestingFindingDto::severity);
         return counts.entrySet().stream()
                 .map(entry -> new PentestingSeverityCountDto(entry.getKey(), entry.getValue()))
                 .toList();
-    }
-
-    private int severityRank(String severity) {
-        int rank = SEVERITIES.indexOf(severity);
-        return rank < 0 ? SEVERITIES.size() : rank;
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScanner.java
@@ -4,11 +4,11 @@ import io.github.jdubois.bootui.core.dto.SpringReport;
 import io.github.jdubois.bootui.core.dto.SpringRuleResultDto;
 import io.github.jdubois.bootui.core.dto.SpringScanStatusDto;
 import io.github.jdubois.bootui.core.dto.SpringSeverityCountDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import io.github.jdubois.bootui.spi.QuarkusAppSnapshot;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,9 +27,8 @@ public final class QuarkusAppScanner {
     private static final String DISCLAIMER =
             "Heuristic local checks against the Quarkus application idioms (CDI scopes, MicroProfile config, "
                     + "reactive vs blocking, profiles). Review prompts only; not a substitute for a manual review.";
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
     private static final Comparator<SpringRuleResultDto> IMPORTANCE = Comparator.comparingInt(
-                    (SpringRuleResultDto r) -> SEVERITIES.indexOf(r.severity()))
+                    (SpringRuleResultDto r) -> SeverityOrder.rank(r.severity()))
             .thenComparing(r -> -r.violationCount())
             .thenComparing(SpringRuleResultDto::id);
 
@@ -146,15 +145,9 @@ public final class QuarkusAppScanner {
     }
 
     private List<SpringSeverityCountDto> severityCounts(List<SpringRuleResultDto> results) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String s : SEVERITIES) {
-            counts.put(s, 0);
-        }
-        for (SpringRuleResultDto r : results) {
-            counts.computeIfPresent(r.severity(), (k, c) -> c + 1);
-        }
-        List<SpringSeverityCountDto> out = new ArrayList<>();
-        counts.forEach((sev, c) -> out.add(new SpringSeverityCountDto(sev, c)));
-        return out;
+        Map<String, Integer> counts = SeverityOrder.counts(results, SpringRuleResultDto::severity);
+        return counts.entrySet().stream()
+                .map(entry -> new SpringSeverityCountDto(entry.getKey(), entry.getValue()))
+                .toList();
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScanner.java
@@ -4,12 +4,11 @@ import io.github.jdubois.bootui.core.dto.SecurityReport;
 import io.github.jdubois.bootui.core.dto.SecurityRuleResultDto;
 import io.github.jdubois.bootui.core.dto.SecurityScanStatusDto;
 import io.github.jdubois.bootui.core.dto.SecuritySeverityCountDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import io.github.jdubois.bootui.spi.QuarkusSecurityPermission;
 import io.github.jdubois.bootui.spi.QuarkusSecuritySnapshot;
 import java.time.Clock;
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,9 +27,8 @@ public final class QuarkusSecurityScanner {
     private static final String DISCLAIMER =
             "Heuristic local checks against the Quarkus security configuration (HTTP auth, OIDC/JWT, TLS, CORS, "
                     + "headers) and authorization annotations. Review prompts only; not a substitute for a manual review.";
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
     private static final Comparator<SecurityRuleResultDto> IMPORTANCE = Comparator.comparingInt(
-                    (SecurityRuleResultDto r) -> SEVERITIES.indexOf(r.severity()))
+                    (SecurityRuleResultDto r) -> SeverityOrder.rank(r.severity()))
             .thenComparing(r -> -r.violationCount())
             .thenComparing(SecurityRuleResultDto::id);
 
@@ -130,15 +128,9 @@ public final class QuarkusSecurityScanner {
     }
 
     private List<SecuritySeverityCountDto> severityCounts(List<SecurityRuleResultDto> results) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String s : SEVERITIES) {
-            counts.put(s, 0);
-        }
-        for (SecurityRuleResultDto r : results) {
-            counts.computeIfPresent(r.severity(), (k, c) -> c + 1);
-        }
-        List<SecuritySeverityCountDto> out = new ArrayList<>();
-        counts.forEach((sev, c) -> out.add(new SecuritySeverityCountDto(sev, c)));
-        return out;
+        Map<String, Integer> counts = SeverityOrder.counts(results, SecurityRuleResultDto::severity);
+        return counts.entrySet().stream()
+                .map(entry -> new SecuritySeverityCountDto(entry.getKey(), entry.getValue()))
+                .toList();
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleSupport.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.restapi;
 
 import io.github.jdubois.bootui.core.dto.RestApiRuleResultDto;
+import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,7 +20,6 @@ final class RestApiRuleSupport {
     static final String ERROR = "ERROR";
 
     private static final int MAX_SAMPLE_VIOLATIONS = 10;
-    private static final int MAX_DETAIL_CHARS = 240;
 
     private RestApiRuleSupport() {}
 
@@ -69,16 +69,6 @@ final class RestApiRuleSupport {
     }
 
     static String detail(String value) {
-        if (value == null) {
-            return "No additional detail.";
-        }
-        String sanitized = value.replaceAll("[\\r\\n\\t]+", " ").trim();
-        if (sanitized.isBlank()) {
-            return "No additional detail.";
-        }
-        if (sanitized.length() <= MAX_DETAIL_CHARS) {
-            return sanitized;
-        }
-        return sanitized.substring(0, MAX_DETAIL_CHARS - 3) + "...";
+        return DetailText.sanitize(value);
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiScanner.java
@@ -5,9 +5,9 @@ import io.github.jdubois.bootui.core.dto.RestApiReport;
 import io.github.jdubois.bootui.core.dto.RestApiRuleResultDto;
 import io.github.jdubois.bootui.core.dto.RestApiScanStatusDto;
 import io.github.jdubois.bootui.core.dto.RestApiSeverityCountDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,13 +30,11 @@ public final class RestApiScanner {
             "Heuristic, project-agnostic REST API design rules run against the host application's own controllers "
                     + "only. These checks complement, but do not replace, an API design review or contract testing. "
                     + "Security concerns (CORS, authentication, authorization) are covered by the Security Advisor.";
-    private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
-
     /** Rules tied to Spring-only types (RFC 9457 ProblemDetail) with no JAX-RS equivalent; skipped on JAX-RS. */
     private static final Set<String> SPRING_ONLY_RULE_IDS = Set.of("RAPI-ERR-003", "RAPI-ERR-006");
 
     private static final Comparator<RestApiRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(
-                    (RestApiRuleResultDto result) -> severityRank(result.severity()))
+                    (RestApiRuleResultDto result) -> SeverityOrder.rank(result.severity()))
             .thenComparing(Comparator.comparingInt(RestApiRuleResultDto::violationCount)
                     .reversed())
             .thenComparing(RestApiRuleResultDto::id);
@@ -261,15 +259,8 @@ public final class RestApiScanner {
     }
 
     private List<RestApiSeverityCountDto> severityCounts(List<RestApiRuleResultDto> results) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        for (String severity : SEVERITIES) {
-            counts.put(severity, 0);
-        }
-        for (RestApiRuleResultDto result : results) {
-            if (isViolation(result)) {
-                counts.computeIfPresent(result.severity(), (ignored, count) -> count + 1);
-            }
-        }
+        Map<String, Integer> counts =
+                SeverityOrder.counts(results, RestApiScanner::isViolation, RestApiRuleResultDto::severity);
         return counts.entrySet().stream()
                 .map(entry -> new RestApiSeverityCountDto(entry.getKey(), entry.getValue()))
                 .toList();
@@ -280,11 +271,6 @@ public final class RestApiScanner {
                 .filter(RestApiScanner::isViolation)
                 .sorted(IMPORTANCE_ORDER)
                 .toList();
-    }
-
-    private static int severityRank(String severity) {
-        int index = SEVERITIES.indexOf(severity);
-        return index >= 0 ? index : SEVERITIES.size();
     }
 
     private static boolean isViolation(RestApiRuleResultDto result) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/BlankStrings.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/BlankStrings.java
@@ -1,0 +1,40 @@
+package io.github.jdubois.bootui.engine.support;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+
+/**
+ * Shared blank-string normalization reused across the engine and both adapters wherever an optional
+ * {@code String} value (a request query parameter, a captured event field, an annotation attribute) needs
+ * null-if-blank handling instead of an empty/whitespace string.
+ *
+ * <p>Two flavors, matching the two call-site shapes found across the codebase: {@link #blankToNull(String)}
+ * preserves the original value's surrounding whitespace (for values that are never user-typed, e.g. a
+ * captured trace id or an annotation attribute), while {@link #blankToNullTrimmed(String)} additionally
+ * trims (for values that come straight off an HTTP query parameter, which can carry incidental leading/
+ * trailing whitespace).
+ */
+public final class BlankStrings {
+
+    private BlankStrings() {}
+
+    /** {@code null} if {@code value} is null/blank, else {@code value} unchanged. */
+    public static String blankToNull(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    /** {@code null} if {@code value} is null/blank, else {@code value} trimmed. */
+    public static String blankToNullTrimmed(String value) {
+        return value == null || value.isBlank() ? null : value.trim();
+    }
+
+    /**
+     * Parses an optional ISO-8601 instant query parameter: {@code null} if blank, else {@link
+     * Instant#parse}. Lets {@link DateTimeException} (which {@link java.time.format.DateTimeParseException}
+     * extends) propagate so each adapter can translate a malformed value into its own 400 response.
+     */
+    public static Instant parseInstant(String value) {
+        String normalized = blankToNullTrimmed(value);
+        return normalized == null ? null : Instant.parse(normalized);
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/DetailText.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/DetailText.java
@@ -1,0 +1,41 @@
+package io.github.jdubois.bootui.engine.support;
+
+/**
+ * Shared sanitization for the free-form "detail" strings advisor rules attach to a finding (an ArchUnit
+ * failure message, an exception message, a config value, ...). Every advisor's rule-support class
+ * (Architecture, Hibernate, Memory, REST API, CRaC, GraalVM) flattened and truncated these the same way
+ * so the browser panel never renders raw newlines/tabs or unbounded text; this class is the single copy
+ * of that logic.
+ */
+public final class DetailText {
+
+    /** Every advisor's prior hardcoded limit; kept as the default so behavior is unchanged. */
+    public static final int DEFAULT_MAX_CHARS = 240;
+
+    private static final String NO_DETAIL = "No additional detail.";
+
+    private DetailText() {}
+
+    /** {@link #sanitize(String, int)} using {@link #DEFAULT_MAX_CHARS}. */
+    public static String sanitize(String value) {
+        return sanitize(value, DEFAULT_MAX_CHARS);
+    }
+
+    /**
+     * Flattens newlines/tabs to single spaces, trims, and truncates to {@code maxChars} (appending
+     * {@code "..."} when truncated). Returns {@value #NO_DETAIL} for a {@code null} or blank input.
+     */
+    public static String sanitize(String value, int maxChars) {
+        if (value == null) {
+            return NO_DETAIL;
+        }
+        String sanitized = value.replaceAll("[\\r\\n\\t]+", " ").trim();
+        if (sanitized.isBlank()) {
+            return NO_DETAIL;
+        }
+        if (sanitized.length() <= maxChars) {
+            return sanitized;
+        }
+        return sanitized.substring(0, maxChars - 3) + "...";
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/SeverityOrder.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/SeverityOrder.java
@@ -1,0 +1,76 @@
+package io.github.jdubois.bootui.engine.support;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * Shared severity-ranking and severity-tally helpers reused by every advisor scanner (Architecture,
+ * Hibernate, Memory, REST API, Pentesting, CRaC, GraalVM, the Quarkus app advisor, and the Quarkus
+ * Security advisor). Every scanner sorts and groups its findings by the same fixed, most-severe-first
+ * vocabulary; this class is the single source of truth for that ordering so each scanner only supplies
+ * its own DTO's severity/countable accessors and severity-count DTO constructor.
+ *
+ * <p>{@link io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports} intentionally keeps its
+ * own severity vocabulary (it also ranks {@code UNKNOWN}/{@code NONE}), but can still reuse {@link
+ * #rank(List, String)} with its own order.
+ */
+public final class SeverityOrder {
+
+    /** The severity vocabulary shared by every advisor scanner, most severe first. */
+    public static final List<String> DEFAULT = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
+
+    private SeverityOrder() {}
+
+    /**
+     * Ranks {@code severity} within {@code order} (lower is more severe); a value not found in
+     * {@code order} sorts after every known severity.
+     */
+    public static int rank(List<String> order, String severity) {
+        int index = order.indexOf(severity);
+        return index >= 0 ? index : order.size();
+    }
+
+    /** {@link #rank(List, String)} using the {@link #DEFAULT} vocabulary. */
+    public static int rank(String severity) {
+        return rank(DEFAULT, severity);
+    }
+
+    /**
+     * Builds a zero-initialized, insertion-ordered tally of {@code results} by severity: every severity in
+     * {@code order} is present (even with a zero count), and each element of {@code results} for which
+     * {@code countable} holds increments its {@code severityOf} bucket. An element whose severity isn't in
+     * {@code order} is silently skipped, matching every scanner's prior behavior.
+     */
+    public static <T> Map<String, Integer> counts(
+            List<String> order, List<T> results, Predicate<T> countable, Function<T, String> severityOf) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        for (String severity : order) {
+            counts.put(severity, 0);
+        }
+        for (T result : results) {
+            if (countable.test(result)) {
+                counts.computeIfPresent(severityOf.apply(result), (ignored, count) -> count + 1);
+            }
+        }
+        return counts;
+    }
+
+    /** {@link #counts(List, List, Predicate, Function)} using the {@link #DEFAULT} vocabulary. */
+    public static <T> Map<String, Integer> counts(
+            List<T> results, Predicate<T> countable, Function<T, String> severityOf) {
+        return counts(DEFAULT, results, countable, severityOf);
+    }
+
+    /** {@link #counts(List, List, Predicate, Function)} for a list that is already fully countable. */
+    public static <T> Map<String, Integer> counts(List<String> order, List<T> results, Function<T, String> severityOf) {
+        return counts(order, results, ignored -> true, severityOf);
+    }
+
+    /** {@link #counts(List, List, Function)} using the {@link #DEFAULT} vocabulary. */
+    public static <T> Map<String, Integer> counts(List<T> results, Function<T, String> severityOf) {
+        return counts(DEFAULT, results, severityOf);
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/telemetry/BootUiIdentitySpanProcessor.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/telemetry/BootUiIdentitySpanProcessor.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.engine.telemetry;
 
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
 import io.opentelemetry.sdk.trace.ReadableSpan;
@@ -26,8 +27,8 @@ public final class BootUiIdentitySpanProcessor implements SpanProcessor {
 
     public BootUiIdentitySpanProcessor(TelemetrySettings settings, String serviceName, String instanceId) {
         this.settings = settings;
-        this.serviceName = blankToNull(serviceName);
-        this.instanceId = blankToNull(instanceId);
+        this.serviceName = BlankStrings.blankToNull(serviceName);
+        this.instanceId = BlankStrings.blankToNull(instanceId);
     }
 
     @Override
@@ -61,9 +62,5 @@ public final class BootUiIdentitySpanProcessor implements SpanProcessor {
     @Override
     public boolean isEndRequired() {
         return false;
-    }
-
-    private static String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value;
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/LiveActivityAssembler.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/LiveActivityAssembler.java
@@ -16,6 +16,7 @@ import io.github.jdubois.bootui.engine.kafka.KafkaActivityEntries;
 import io.github.jdubois.bootui.engine.kafka.KafkaActivityRecorder.CapturedMessage;
 import io.github.jdubois.bootui.engine.scheduled.ScheduledTaskRunStore;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceGrouping;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
 import java.time.Instant;
@@ -214,7 +215,7 @@ public final class LiveActivityAssembler {
         Map<String, String> securedPrincipalByRequestId = new HashMap<>();
         for (SecurityLogEventDto event : security) {
             String requestId = traceIndex.parentRequestId(event.traceId());
-            String principal = blankToNull(event.principal());
+            String principal = BlankStrings.blankToNull(event.principal());
             if (requestId != null && principal != null) {
                 securedPrincipalByRequestId.putIfAbsent(requestId, principal);
             }
@@ -538,7 +539,7 @@ public final class LiveActivityAssembler {
         String type = event.type() == null ? "" : event.type();
         String upperType = type.toUpperCase(Locale.ROOT);
         String severity = upperType.contains("FAILURE") || upperType.contains("DENIED") ? SEVERITY_WARN : SEVERITY_OK;
-        String principal = blankToNull(event.principal());
+        String principal = BlankStrings.blankToNull(event.principal());
         String summary = (type + (principal == null ? "" : " · " + principal)).trim();
         return new ActivityEntryDto(
                 SecurityActivityIds.stableId(event),
@@ -678,10 +679,6 @@ public final class LiveActivityAssembler {
             return timestamp >= start - SCHEDULED_TASK_WINDOW_SLACK_MS
                     && timestamp <= end + SCHEDULED_TASK_WINDOW_SLACK_MS;
         }
-    }
-
-    private static String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value;
     }
 
     /** Parse an ISO-8601 instant to epoch millis, returning {@code 0} for null/blank/unparseable input. */

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/RequestProfileAssembler.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/RequestProfileAssembler.java
@@ -13,6 +13,7 @@ import io.github.jdubois.bootui.core.dto.SqlTraceEntryDto;
 import io.github.jdubois.bootui.core.dto.SqlTraceGroupDto;
 import io.github.jdubois.bootui.core.dto.TraceDetailDto;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceGrouping;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -75,7 +76,7 @@ public final class RequestProfileAssembler {
         if (request == null) {
             return RequestProfileDto.unavailable("Request " + requestId + " is no longer in the buffer");
         }
-        String traceId = blankToNull(request.traceId());
+        String traceId = BlankStrings.blankToNull(request.traceId());
         if (traceId == null) {
             return RequestProfileDto.unavailable("No distributed trace id was captured for this request; "
                     + "per-request profiling requires a resolvable trace id, for example from an active "
@@ -211,11 +212,6 @@ public final class RequestProfileAssembler {
     private static List<SqlTraceGroupDto> groupSql(List<SqlTraceEntryDto> sql) {
         return SqlTraceGrouping.group(sql, SqlTraceGrouping.DEFAULT_N_PLUS_ONE_THRESHOLD);
     }
-
-    private static String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value;
-    }
-
     /** Parse an ISO-8601 instant to epoch millis, returning {@code 0} for null/blank/unparseable input. */
     private static long parseEpochMillis(String timestamp) {
         if (timestamp == null || timestamp.isBlank()) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/TraceCorrelationIndex.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/TraceCorrelationIndex.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.web;
 
 import io.github.jdubois.bootui.core.dto.HttpExchangeDto;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -37,7 +38,7 @@ final class TraceCorrelationIndex {
         Map<String, String> requestIdByTrace = new HashMap<>();
         Set<String> ambiguousTraces = new HashSet<>();
         for (HttpExchangeDto e : exchanges) {
-            String trace = blankToNull(e.traceId());
+            String trace = BlankStrings.blankToNull(e.traceId());
             if (trace != null && requestIdByTrace.putIfAbsent(trace, e.id()) != null) {
                 ambiguousTraces.add(trace);
             }
@@ -51,14 +52,10 @@ final class TraceCorrelationIndex {
      * more than one request carries it (an ambiguous, likely reused, inbound {@code traceparent}).
      */
     String parentRequestId(String childTraceId) {
-        String trace = blankToNull(childTraceId);
+        String trace = BlankStrings.blankToNull(childTraceId);
         if (trace == null || ambiguousTraces.contains(trace)) {
             return null;
         }
         return requestIdByTrace.get(trace);
-    }
-
-    private static String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value;
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureScannerTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.tngtech.archunit.lang.ArchRule;
 import io.github.jdubois.bootui.core.dto.ArchitectureReport;
 import io.github.jdubois.bootui.core.dto.ArchitectureRuleResultDto;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -52,7 +53,7 @@ class ArchitectureScannerTests {
         assertThat(report.results().stream()
                         .map(ArchitectureRuleResultDto::severity)
                         .toList())
-                .isSortedAccordingTo(Comparator.comparingInt(ArchitectureScannerTests::severityRank));
+                .isSortedAccordingTo(Comparator.comparingInt(SeverityOrder::rank));
 
         ArchitectureRuleResultDto standardStreams = report.results().stream()
                 .filter(result -> result.id().equals("ARCH-CODE-001"))
@@ -190,9 +191,5 @@ class ArchitectureScannerTests {
                 List.of("detail"),
                 "recommendation",
                 "https://example.com");
-    }
-
-    private static int severityRank(String severity) {
-        return List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO").indexOf(severity);
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/CracReadinessScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/crac/CracReadinessScannerTests.java
@@ -6,6 +6,7 @@ import io.github.jdubois.bootui.core.dto.CracFindingDto;
 import io.github.jdubois.bootui.core.dto.CracReadinessReport;
 import io.github.jdubois.bootui.core.dto.CracRuntimeStatusDto;
 import io.github.jdubois.bootui.engine.crac.CracReadinessScanner.CracScanResult;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -74,7 +75,7 @@ class CracReadinessScannerTests {
                         "CRAC-SCHED-001",
                         "CRAC-POOL-002");
         assertThat(report.findings().stream().map(CracFindingDto::severity).toList())
-                .isSortedAccordingTo(Comparator.comparingInt(CracReadinessScannerTests::severityRank));
+                .isSortedAccordingTo(Comparator.comparingInt(SeverityOrder::rank));
         assertThat(report.severityCounts())
                 .extracting("severity")
                 .containsExactly("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
@@ -265,10 +266,6 @@ class CracReadinessScannerTests {
         assertThat(cache.status()).isEqualTo("REVIEW");
         assertThat(cache.occurrenceCount()).isEqualTo(1);
         assertThat(cache.sampleOccurrences()).anyMatch(sample -> sample.contains("ConcurrentMapCacheManager"));
-    }
-
-    private static int severityRank(String severity) {
-        return List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO").indexOf(severity);
     }
 
     private static List<String> findingSamples(CracReadinessReport report, String id) {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/GraalVmReadinessScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/graalvm/GraalVmReadinessScannerTests.java
@@ -6,6 +6,7 @@ import com.tngtech.archunit.lang.ArchRule;
 import io.github.jdubois.bootui.core.dto.GraalVmFindingDto;
 import io.github.jdubois.bootui.core.dto.GraalVmReadinessReport;
 import io.github.jdubois.bootui.engine.graalvm.GraalVmReadinessScanner.GraalVmScanResult;
+import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -74,7 +75,7 @@ class GraalVmReadinessScannerTests {
                         "GRAAL-NATIVE-001",
                         "GRAAL-NATIVE-002");
         assertThat(report.findings().stream().map(GraalVmFindingDto::severity).toList())
-                .isSortedAccordingTo(Comparator.comparingInt(GraalVmReadinessScannerTests::severityRank));
+                .isSortedAccordingTo(Comparator.comparingInt(SeverityOrder::rank));
         assertThat(report.severityCounts())
                 .extracting("severity")
                 .containsExactly("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
@@ -258,9 +259,5 @@ class GraalVmReadinessScannerTests {
         ArchRule rule(GraalVmContext context) {
             return null;
         }
-    }
-
-    private static int severityRank(String severity) {
-        return List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO").indexOf(severity);
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/BlankStringsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/BlankStringsTests.java
@@ -1,0 +1,58 @@
+package io.github.jdubois.bootui.engine.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the shared blank-string and ISO-instant query-parameter helpers reused across the engine and
+ * both adapters (notably the Security Logs, Live Activity, and Cache panels).
+ */
+class BlankStringsTests {
+
+    @Test
+    void blankToNullReturnsNullForNullAndBlank() {
+        assertThat(BlankStrings.blankToNull(null)).isNull();
+        assertThat(BlankStrings.blankToNull("")).isNull();
+        assertThat(BlankStrings.blankToNull("   ")).isNull();
+    }
+
+    @Test
+    void blankToNullPreservesSurroundingWhitespaceOnNonBlankValues() {
+        assertThat(BlankStrings.blankToNull("  value  ")).isEqualTo("  value  ");
+    }
+
+    @Test
+    void blankToNullTrimmedReturnsNullForNullAndBlank() {
+        assertThat(BlankStrings.blankToNullTrimmed(null)).isNull();
+        assertThat(BlankStrings.blankToNullTrimmed("")).isNull();
+        assertThat(BlankStrings.blankToNullTrimmed("   ")).isNull();
+    }
+
+    @Test
+    void blankToNullTrimmedTrimsNonBlankValues() {
+        assertThat(BlankStrings.blankToNullTrimmed("  value  ")).isEqualTo("value");
+    }
+
+    @Test
+    void parseInstantReturnsNullForNullAndBlank() {
+        assertThat(BlankStrings.parseInstant(null)).isNull();
+        assertThat(BlankStrings.parseInstant("")).isNull();
+        assertThat(BlankStrings.parseInstant("   ")).isNull();
+    }
+
+    @Test
+    void parseInstantParsesATrimmedIsoInstant() {
+        assertThat(BlankStrings.parseInstant("  2024-01-15T10:30:00Z  "))
+                .isEqualTo(Instant.parse("2024-01-15T10:30:00Z"));
+    }
+
+    @Test
+    void parseInstantPropagatesDateTimeParseExceptionForMalformedInput() {
+        assertThatThrownBy(() -> BlankStrings.parseInstant("not-an-instant"))
+                .isInstanceOf(DateTimeParseException.class);
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/DetailTextTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/DetailTextTests.java
@@ -1,0 +1,51 @@
+package io.github.jdubois.bootui.engine.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the shared "detail" sanitizer every advisor's rule-support class (Architecture, Hibernate,
+ * Memory, REST API, CRaC, GraalVM) relies on to flatten and bound a free-form finding detail before it
+ * reaches the browser panel.
+ */
+class DetailTextTests {
+
+    @Test
+    void returnsPlaceholderForNull() {
+        assertThat(DetailText.sanitize(null)).isEqualTo("No additional detail.");
+    }
+
+    @Test
+    void returnsPlaceholderForBlank() {
+        assertThat(DetailText.sanitize("   ")).isEqualTo("No additional detail.");
+        assertThat(DetailText.sanitize("")).isEqualTo("No additional detail.");
+    }
+
+    @Test
+    void flattensNewlinesTabsAndTrims() {
+        assertThat(DetailText.sanitize("  line one\nline two\tcol  ")).isEqualTo("line one line two col");
+    }
+
+    @Test
+    void leavesShortValuesUnchanged() {
+        assertThat(DetailText.sanitize("a short detail")).isEqualTo("a short detail");
+    }
+
+    @Test
+    void truncatesValuesLongerThanTheDefaultLimitWithEllipsis() {
+        String longValue = "x".repeat(DetailText.DEFAULT_MAX_CHARS + 50);
+
+        String result = DetailText.sanitize(longValue);
+
+        assertThat(result).hasSize(DetailText.DEFAULT_MAX_CHARS);
+        assertThat(result).endsWith("...");
+    }
+
+    @Test
+    void honorsACustomMaxCharsLimit() {
+        String result = DetailText.sanitize("abcdefghij", 5);
+
+        assertThat(result).isEqualTo("ab...");
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/SeverityOrderTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/SeverityOrderTests.java
@@ -1,0 +1,93 @@
+package io.github.jdubois.bootui.engine.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the shared severity-ranking and severity-tally helpers every advisor scanner (Architecture,
+ * Hibernate, Memory, REST API, Pentesting, CRaC, GraalVM, the Quarkus app advisor, and the Quarkus
+ * Security advisor) relies on to sort and group findings by severity.
+ */
+class SeverityOrderTests {
+
+    @Test
+    void ranksKnownSeveritiesMostSevereFirst() {
+        assertThat(SeverityOrder.rank("CRITICAL")).isZero();
+        assertThat(SeverityOrder.rank("HIGH")).isEqualTo(1);
+        assertThat(SeverityOrder.rank("MEDIUM")).isEqualTo(2);
+        assertThat(SeverityOrder.rank("LOW")).isEqualTo(3);
+        assertThat(SeverityOrder.rank("INFO")).isEqualTo(4);
+    }
+
+    @Test
+    void unknownSeveritySortsAfterEveryKnownSeverity() {
+        assertThat(SeverityOrder.rank("NOT_A_SEVERITY")).isEqualTo(SeverityOrder.DEFAULT.size());
+    }
+
+    @Test
+    void ranksWithinACustomOrder() {
+        List<String> order = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN");
+
+        assertThat(SeverityOrder.rank(order, "UNKNOWN")).isEqualTo(4);
+        assertThat(SeverityOrder.rank(order, "NONE")).isEqualTo(order.size());
+    }
+
+    @Test
+    void countsZeroInitializesEverySeverityAndTalliesCountableResults() {
+        List<String> severities = List.of("HIGH", "HIGH", "LOW", "INFO");
+
+        Map<String, Integer> counts = SeverityOrder.counts(severities, ignored -> true, s -> s);
+
+        assertThat(counts)
+                .containsExactly(
+                        Map.entry("CRITICAL", 0),
+                        Map.entry("HIGH", 2),
+                        Map.entry("MEDIUM", 0),
+                        Map.entry("LOW", 1),
+                        Map.entry("INFO", 1));
+    }
+
+    @Test
+    void countsSkipsResultsThatAreNotCountable() {
+        List<String> severities = List.of("HIGH", "HIGH", "LOW");
+
+        Map<String, Integer> counts = SeverityOrder.counts(severities, "HIGH"::equals, s -> s);
+
+        assertThat(counts.get("HIGH")).isEqualTo(2);
+        assertThat(counts.get("LOW")).isZero();
+    }
+
+    @Test
+    void countsSkipsSeveritiesNotInOrder() {
+        List<String> severities = List.of("HIGH", "UNMAPPED");
+
+        Map<String, Integer> counts = SeverityOrder.counts(severities, ignored -> true, s -> s);
+
+        assertThat(counts).doesNotContainKey("UNMAPPED");
+        assertThat(counts.get("HIGH")).isEqualTo(1);
+    }
+
+    @Test
+    void countsWithoutPredicateCountsEveryResult() {
+        List<String> severities = List.of("CRITICAL", "CRITICAL", "INFO");
+
+        Map<String, Integer> counts = SeverityOrder.counts(severities, s -> s);
+
+        assertThat(counts.get("CRITICAL")).isEqualTo(2);
+        assertThat(counts.get("INFO")).isEqualTo(1);
+        assertThat(counts.get("HIGH")).isZero();
+    }
+
+    @Test
+    void countsWithCustomOrderUsesThatOrdersVocabulary() {
+        List<String> order = List.of("CRITICAL", "UNKNOWN");
+        List<String> severities = List.of("CRITICAL", "UNKNOWN", "UNKNOWN");
+
+        Map<String, Integer> counts = SeverityOrder.counts(order, severities, s -> s);
+
+        assertThat(counts).containsExactly(Map.entry("CRITICAL", 1), Map.entry("UNKNOWN", 2));
+    }
+}

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -856,17 +856,10 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes) {
         boolean enableCapture = launchMode.getLaunchMode() != LaunchMode.NORMAL
                 && capabilities.isPresent(Capability.OPENTELEMETRY_TRACER);
-        if (enableCapture) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(OTEL_PRODUCER_CLASS)
-                    .setUnremovable()
-                    .build());
-        } else {
-            // No OpenTelemetry tracing (or production): keep the OTel-importing producer out of bean
-            // discovery so Arc never tries to resolve its SpanProcessor return type. Traces/AI still wire
-            // via BootUiTelemetryProducer and render empty.
-            excludedTypes.produce(new ExcludedTypeBuildItem(OTEL_PRODUCER_CLASS));
-        }
+        // No OpenTelemetry tracing (or production): keep the OTel-importing producer out of bean
+        // discovery so Arc never tries to resolve its SpanProcessor return type. Traces/AI still wire
+        // via BootUiTelemetryProducer and render empty.
+        registerCapabilityGatedBeans(enableCapture, additionalBeans, excludedTypes, OTEL_PRODUCER_CLASS);
     }
 
     /**
@@ -896,17 +889,10 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes) {
         boolean enableCorrelation = launchMode.getLaunchMode() != LaunchMode.NORMAL
                 && capabilities.isPresent(Capability.OPENTELEMETRY_TRACER);
-        if (enableCorrelation) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(OTEL_TRACE_ID_PROVIDER_CLASS)
-                    .setUnremovable()
-                    .build());
-        } else {
-            // No OpenTelemetry tracing (or production): keep the OTel-importing provider out of bean discovery
-            // so Arc never tries to resolve the Span it references. The capture points then resolve no
-            // TraceIdProvider and stamp null, so Live Activity stays flat (the honest status quo).
-            excludedTypes.produce(new ExcludedTypeBuildItem(OTEL_TRACE_ID_PROVIDER_CLASS));
-        }
+        // No OpenTelemetry tracing (or production): keep the OTel-importing provider out of bean discovery
+        // so Arc never tries to resolve the Span it references. The capture points then resolve no
+        // TraceIdProvider and stamp null, so Live Activity stays flat (the honest status quo).
+        registerCapabilityGatedBeans(enableCorrelation, additionalBeans, excludedTypes, OTEL_TRACE_ID_PROVIDER_CLASS);
     }
 
     /**
@@ -936,16 +922,59 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes) {
         boolean enableCapture =
                 launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.SMALLRYE_HEALTH);
-        if (enableCapture) {
+        // No SmallRye Health (or production): keep the SmallRye-importing producer out of bean discovery so
+        // Arc never tries to resolve its SmallRyeHealthReporter parameter. The Health panel still wires via
+        // the always-produced HealthService and renders setup guidance.
+        registerCapabilityGatedBeans(enableCapture, additionalBeans, excludedTypes, HEALTH_PRODUCER_CLASS);
+    }
+
+    /**
+     * Shared implementation of the R2 capability/class-presence-gated bean registration pattern repeated
+     * throughout this processor (e.g. {@link #registerOpenTelemetryCapture}, {@link #registerHibernateAdvisor},
+     * {@link #registerCacheAdvisor}, {@link #registerFlyway}, {@link #registerLiquibase},
+     * {@link #registerConnectionPools}, {@link #registerSecurityLogs}, {@link #registerKafkaCapture},
+     * {@link #registerEmail}): when {@code present} — a non-production launch with the gating capability or
+     * class on the application classpath — the optional-dependency-importing bean class(es) are registered
+     * (pinned unremovable, since each is reached only through a CDI {@code Instance}/event lookup that Arc's
+     * static usage analysis cannot see); otherwise each bean class is actively {@linkplain ExcludedTypeBuildItem
+     * excluded} from discovery instead of merely left unannotated. A missing CDI scope alone is not enough: the
+     * extension runtime jar is Jandex-indexed, so Arc would discover an annotated producer/observer/interceptor
+     * <em>unconditionally</em> regardless of whether its optional dependency is on the classpath (R2) — the
+     * exclusion is what keeps that dependency's types unlinked.
+     */
+    private static void registerCapabilityGatedBeans(
+            boolean present,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            BuildProducer<ExcludedTypeBuildItem> excludedTypes,
+            String... beanClasses) {
+        if (present) {
             additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(HEALTH_PRODUCER_CLASS)
+                    .addBeanClasses(beanClasses)
                     .setUnremovable()
                     .build());
         } else {
-            // No SmallRye Health (or production): keep the SmallRye-importing producer out of bean discovery so
-            // Arc never tries to resolve its SmallRyeHealthReporter parameter. The Health panel still wires via
-            // the always-produced HealthService and renders setup guidance.
-            excludedTypes.produce(new ExcludedTypeBuildItem(HEALTH_PRODUCER_CLASS));
+            for (String beanClass : beanClasses) {
+                excludedTypes.produce(new ExcludedTypeBuildItem(beanClass));
+            }
+        }
+    }
+
+    /**
+     * Variant of {@link #registerCapabilityGatedBeans(boolean, BuildProducer, BuildProducer, String...)} for
+     * build steps that also publish a {@code bootui.internal.*-present=true} runtime-config default when
+     * present, so a dynamically-available panel lights up in the {@code /bootui/api/panels} manifest (see
+     * {@link QuarkusPanelAvailability}).
+     */
+    private static void registerCapabilityGatedBeans(
+            boolean present,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            BuildProducer<ExcludedTypeBuildItem> excludedTypes,
+            BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults,
+            String presentKey,
+            String... beanClasses) {
+        registerCapabilityGatedBeans(present, additionalBeans, excludedTypes, beanClasses);
+        if (present) {
+            runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(presentKey, "true"));
         }
     }
 
@@ -978,20 +1007,17 @@ class BootUiQuarkusProcessor {
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present =
                 launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.HIBERNATE_ORM);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(HIBERNATE_PRODUCER_CLASS)
-                    .setUnremovable()
-                    .build());
-            runtimeDefaults.produce(
-                    new RunTimeConfigurationDefaultBuildItem(QuarkusPanelAvailability.HIBERNATE_PRESENT_KEY, "true"));
-        } else {
-            // No Hibernate ORM (or production): keep the jakarta.persistence-importing producer out of bean
-            // discovery so Arc never tries to resolve its EntityManagerFactory parameter. The Hibernate scanner
-            // still wires via the always-produced HibernateScanner and renders a not-configured report; the panel
-            // is reported unavailable in the manifest (HIBERNATE_PRESENT_KEY defaults to false).
-            excludedTypes.produce(new ExcludedTypeBuildItem(HIBERNATE_PRODUCER_CLASS));
-        }
+        // No Hibernate ORM (or production): keep the jakarta.persistence-importing producer out of bean
+        // discovery so Arc never tries to resolve its EntityManagerFactory parameter. The Hibernate scanner
+        // still wires via the always-produced HibernateScanner and renders a not-configured report; the panel
+        // is reported unavailable in the manifest (HIBERNATE_PRESENT_KEY defaults to false).
+        registerCapabilityGatedBeans(
+                present,
+                additionalBeans,
+                excludedTypes,
+                runtimeDefaults,
+                QuarkusPanelAvailability.HIBERNATE_PRESENT_KEY,
+                HIBERNATE_PRODUCER_CLASS);
     }
 
     /**
@@ -1020,14 +1046,7 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes) {
         boolean present =
                 launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.HIBERNATE_ORM);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(SQL_TRACE_INSPECTOR_CLASS)
-                    .setUnremovable()
-                    .build());
-        } else {
-            excludedTypes.produce(new ExcludedTypeBuildItem(SQL_TRACE_INSPECTOR_CLASS));
-        }
+        registerCapabilityGatedBeans(present, additionalBeans, excludedTypes, SQL_TRACE_INSPECTOR_CLASS);
     }
 
     /**
@@ -1328,20 +1347,17 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present = launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.CACHE);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(CACHE_PRODUCER_CLASS)
-                    .setUnremovable()
-                    .build());
-            runtimeDefaults.produce(
-                    new RunTimeConfigurationDefaultBuildItem(QuarkusPanelAvailability.CACHE_PRESENT_KEY, "true"));
-        } else {
-            // No quarkus-cache (or production): keep the io.quarkus.cache-importing producer out of bean
-            // discovery so Arc never tries to resolve its CacheManager parameter. The cache service still wires
-            // via the always-produced CacheService and renders the panel unavailable; the panel is reported
-            // unavailable in the manifest (CACHE_PRESENT_KEY defaults to false).
-            excludedTypes.produce(new ExcludedTypeBuildItem(CACHE_PRODUCER_CLASS));
-        }
+        // No quarkus-cache (or production): keep the io.quarkus.cache-importing producer out of bean
+        // discovery so Arc never tries to resolve its CacheManager parameter. The cache service still wires
+        // via the always-produced CacheService and renders the panel unavailable; the panel is reported
+        // unavailable in the manifest (CACHE_PRESENT_KEY defaults to false).
+        registerCapabilityGatedBeans(
+                present,
+                additionalBeans,
+                excludedTypes,
+                runtimeDefaults,
+                QuarkusPanelAvailability.CACHE_PRESENT_KEY,
+                CACHE_PRODUCER_CLASS);
     }
 
     /**
@@ -1377,22 +1393,18 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present = launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.KAFKA);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(KAFKA_PRODUCER_CAPTURE_CLASS)
-                    .addBeanClass(KAFKA_CONSUMER_CAPTURE_CLASS)
-                    .setUnremovable()
-                    .build());
-            runtimeDefaults.produce(
-                    new RunTimeConfigurationDefaultBuildItem(QuarkusPanelAvailability.KAFKA_PRESENT_KEY, "true"));
-        } else {
-            // No quarkus-messaging-kafka (or production): keep the SmallRye-messaging-importing interceptors out
-            // of bean discovery so Arc never loads them and links the messaging API. The recorder still wires via
-            // the always-produced KafkaActivityRecorder and stays empty, so Live Activity renders no MESSAGING
-            // entries and the Kafka panel reports itself unavailable (KAFKA_PRESENT_KEY defaults to false).
-            excludedTypes.produce(new ExcludedTypeBuildItem(KAFKA_PRODUCER_CAPTURE_CLASS));
-            excludedTypes.produce(new ExcludedTypeBuildItem(KAFKA_CONSUMER_CAPTURE_CLASS));
-        }
+        // No quarkus-messaging-kafka (or production): keep the SmallRye-messaging-importing interceptors out
+        // of bean discovery so Arc never loads them and links the messaging API. The recorder still wires via
+        // the always-produced KafkaActivityRecorder and stays empty, so Live Activity renders no MESSAGING
+        // entries and the Kafka panel reports itself unavailable (KAFKA_PRESENT_KEY defaults to false).
+        registerCapabilityGatedBeans(
+                present,
+                additionalBeans,
+                excludedTypes,
+                runtimeDefaults,
+                QuarkusPanelAvailability.KAFKA_PRESENT_KEY,
+                KAFKA_PRODUCER_CAPTURE_CLASS,
+                KAFKA_CONSUMER_CAPTURE_CLASS);
     }
 
     /**
@@ -1413,16 +1425,13 @@ class BootUiQuarkusProcessor {
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present =
                 launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.SECURITY);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(SECURITY_CAPTURE_CLASS)
-                    .setUnremovable()
-                    .build());
-            runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
-                    QuarkusPanelAvailability.SECURITY_LOGS_PRESENT_KEY, "true"));
-        } else {
-            excludedTypes.produce(new ExcludedTypeBuildItem(SECURITY_CAPTURE_CLASS));
-        }
+        registerCapabilityGatedBeans(
+                present,
+                additionalBeans,
+                excludedTypes,
+                runtimeDefaults,
+                QuarkusPanelAvailability.SECURITY_LOGS_PRESENT_KEY,
+                SECURITY_CAPTURE_CLASS);
     }
 
     /**
@@ -1445,14 +1454,7 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes) {
         boolean present =
                 launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.SCHEDULER);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(SCHEDULED_TASK_RUN_RECORDER_CLASS)
-                    .setUnremovable()
-                    .build());
-        } else {
-            excludedTypes.produce(new ExcludedTypeBuildItem(SCHEDULED_TASK_RUN_RECORDER_CLASS));
-        }
+        registerCapabilityGatedBeans(present, additionalBeans, excludedTypes, SCHEDULED_TASK_RUN_RECORDER_CLASS);
     }
 
     /**
@@ -1476,16 +1478,13 @@ class BootUiQuarkusProcessor {
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present = launchMode.getLaunchMode() != LaunchMode.NORMAL
                 && QuarkusClassLoader.isClassPresentAtRuntime(REACTIVE_MAILER_CLASS);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(EMAIL_CAPTURE_CLASS)
-                    .setUnremovable()
-                    .build());
-            runtimeDefaults.produce(
-                    new RunTimeConfigurationDefaultBuildItem(QuarkusPanelAvailability.EMAIL_PRESENT_KEY, "true"));
-        } else {
-            excludedTypes.produce(new ExcludedTypeBuildItem(EMAIL_CAPTURE_CLASS));
-        }
+        registerCapabilityGatedBeans(
+                present,
+                additionalBeans,
+                excludedTypes,
+                runtimeDefaults,
+                QuarkusPanelAvailability.EMAIL_PRESENT_KEY,
+                EMAIL_CAPTURE_CLASS);
     }
 
     /**
@@ -1514,20 +1513,17 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present = launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.FLYWAY);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(FLYWAY_PRODUCER_CLASS)
-                    .setUnremovable()
-                    .build());
-            runtimeDefaults.produce(
-                    new RunTimeConfigurationDefaultBuildItem(QuarkusPanelAvailability.FLYWAY_PRESENT_KEY, "true"));
-        } else {
-            // No quarkus-flyway (or production): keep the Flyway-importing producer out of bean discovery so Arc
-            // never loads QuarkusFlywayProvider and links the Flyway API. The Flyway service still wires via the
-            // always-produced FlywayService and renders the panel unavailable; the panel is reported unavailable
-            // in the manifest (FLYWAY_PRESENT_KEY defaults to false).
-            excludedTypes.produce(new ExcludedTypeBuildItem(FLYWAY_PRODUCER_CLASS));
-        }
+        // No quarkus-flyway (or production): keep the Flyway-importing producer out of bean discovery so Arc
+        // never loads QuarkusFlywayProvider and links the Flyway API. The Flyway service still wires via the
+        // always-produced FlywayService and renders the panel unavailable; the panel is reported unavailable
+        // in the manifest (FLYWAY_PRESENT_KEY defaults to false).
+        registerCapabilityGatedBeans(
+                present,
+                additionalBeans,
+                excludedTypes,
+                runtimeDefaults,
+                QuarkusPanelAvailability.FLYWAY_PRESENT_KEY,
+                FLYWAY_PRODUCER_CLASS);
     }
 
     /**
@@ -1558,20 +1554,17 @@ class BootUiQuarkusProcessor {
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present =
                 launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.LIQUIBASE);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(LIQUIBASE_PRODUCER_CLASS)
-                    .setUnremovable()
-                    .build());
-            runtimeDefaults.produce(
-                    new RunTimeConfigurationDefaultBuildItem(QuarkusPanelAvailability.LIQUIBASE_PRESENT_KEY, "true"));
-        } else {
-            // No quarkus-liquibase (or production): keep the io.quarkus.liquibase-importing producer out of bean
-            // discovery so Arc never instantiates QuarkusLiquibaseProvider. The liquibase service still wires via
-            // the always-produced LiquibaseService and renders the panel unavailable; the panel is reported
-            // unavailable in the manifest (LIQUIBASE_PRESENT_KEY defaults to false).
-            excludedTypes.produce(new ExcludedTypeBuildItem(LIQUIBASE_PRODUCER_CLASS));
-        }
+        // No quarkus-liquibase (or production): keep the io.quarkus.liquibase-importing producer out of bean
+        // discovery so Arc never instantiates QuarkusLiquibaseProvider. The liquibase service still wires via
+        // the always-produced LiquibaseService and renders the panel unavailable; the panel is reported
+        // unavailable in the manifest (LIQUIBASE_PRESENT_KEY defaults to false).
+        registerCapabilityGatedBeans(
+                present,
+                additionalBeans,
+                excludedTypes,
+                runtimeDefaults,
+                QuarkusPanelAvailability.LIQUIBASE_PRESENT_KEY,
+                LIQUIBASE_PRODUCER_CLASS);
     }
 
     /**
@@ -1607,22 +1600,18 @@ class BootUiQuarkusProcessor {
             BuildProducer<ExcludedTypeBuildItem> excludedTypes,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present = launchMode.getLaunchMode() != LaunchMode.NORMAL && capabilities.isPresent(Capability.AGROAL);
-        if (present) {
-            additionalBeans.produce(AdditionalBeanBuildItem.builder()
-                    .addBeanClass(AGROAL_PRODUCER_CLASS)
-                    .addBeanClass(SQL_TRACE_PRODUCER_CLASS)
-                    .setUnremovable()
-                    .build());
-            runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
-                    QuarkusPanelAvailability.CONNECTION_POOLS_PRESENT_KEY, "true"));
-        } else {
-            // No JDBC datasource extension (or production): keep the io.agroal-importing producer out of bean
-            // discovery so Arc never links the Agroal API. The connection-pool service still wires via the
-            // always-produced ConnectionPoolService and renders the panel unavailable; the panel is reported
-            // unavailable in the manifest (CONNECTION_POOLS_PRESENT_KEY defaults to false).
-            excludedTypes.produce(new ExcludedTypeBuildItem(AGROAL_PRODUCER_CLASS));
-            excludedTypes.produce(new ExcludedTypeBuildItem(SQL_TRACE_PRODUCER_CLASS));
-        }
+        // No JDBC datasource extension (or production): keep the io.agroal-importing producer out of bean
+        // discovery so Arc never links the Agroal API. The connection-pool service still wires via the
+        // always-produced ConnectionPoolService and renders the panel unavailable; the panel is reported
+        // unavailable in the manifest (CONNECTION_POOLS_PRESENT_KEY defaults to false).
+        registerCapabilityGatedBeans(
+                present,
+                additionalBeans,
+                excludedTypes,
+                runtimeDefaults,
+                QuarkusPanelAvailability.CONNECTION_POOLS_PRESENT_KEY,
+                AGROAL_PRODUCER_CLASS,
+                SQL_TRACE_PRODUCER_CLASS);
     }
 
     /**

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAvailability.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAvailability.java
@@ -279,6 +279,29 @@ public class QuarkusPanelAvailability {
             "Not available: this application does not use Kafka messaging. Add the quarkus-messaging-kafka"
                     + " extension (with an @Incoming/@Outgoing channel) to enable the Kafka panel.";
 
+    private static final String SQL_TRACE_ABSENT =
+            "Not available: no JDBC datasource is on the classpath. Add a Quarkus JDBC datasource"
+                    + " (e.g. quarkus-jdbc-h2) so SQL executions can be traced.";
+
+    private static final String PROFILE_DIFF_ABSENT =
+            "Not available: no profiles are active. Run with a profile (e.g. quarkus.profile=dev) to"
+                    + " compare profile-specific configuration.";
+
+    private static final String REST_API_ABSENT =
+            "Not available: no JAX-RS resources were found under the application base packages. Add a"
+                    + " @Path resource so the REST API advisor has controllers to analyse.";
+
+    private static final String SECURITY_LOGS_ABSENT =
+            "Not available: Quarkus security events are disabled. Set quarkus.security.events.enabled=true"
+                    + " (with a security extension) to capture authentication/authorization events.";
+
+    private static final String COPILOT_ABSENT = "Not available: no Copilot CLI session-state directory found (default"
+            + " ~/.copilot/session-state). Run the Copilot CLI locally so it has sessions to show.";
+
+    private static final String CLAUDE_CODE_ABSENT =
+            "Not available: no Claude Code project directory found (default ~/.claude/projects)."
+                    + " Run Claude Code locally so it has sessions to show.";
+
     /**
      * Panels that are deliberately and permanently unavailable on Quarkus because they have no meaningful
      * Quarkus equivalent — as opposed to the generic {@link #NOT_YET_AVAILABLE} panels that simply have not
@@ -319,6 +342,31 @@ public class QuarkusPanelAvailability {
             "Not applicable on Quarkus: Spring Boot DevTools restart/LiveReload has no runtime analogue. Quarkus"
                     + " dev mode owns live reload through build-time augmentation, with no stable runtime API to"
                     + " read or trigger it, so this panel is not used here.");
+
+    /**
+     * Reasons shown for panels that are unavailable only because the corresponding Quarkus
+     * extension/capability is missing from the application — as opposed to {@link #NOT_APPLICABLE},
+     * which is permanent regardless of what the application adds. Keyed by panel id; consulted by
+     * {@link #unavailableReason} once the dynamic GitHub case (the only reason computed fresh per
+     * call) has been ruled out. Mirrors the {@code dynamicAvailability} map {@link #isPanelAvailable}
+     * consults, so every dynamically-available panel has a matching absent-reason entry here.
+     */
+    private static final Map<String, String> CAPABILITY_ABSENT = Map.ofEntries(
+            Map.entry(BootUiPanels.HIBERNATE, HIBERNATE_ABSENT),
+            Map.entry(BootUiPanels.SCHEDULED, SCHEDULED_ABSENT),
+            Map.entry(BootUiPanels.CACHE, CACHE_ABSENT),
+            Map.entry(BootUiPanels.FLYWAY, FLYWAY_ABSENT),
+            Map.entry(BootUiPanels.LIQUIBASE, LIQUIBASE_ABSENT),
+            Map.entry(BootUiPanels.DATABASE_CONNECTION_POOLS, CONNECTION_POOLS_ABSENT),
+            Map.entry(BootUiPanels.DEV_SERVICES, DEV_SERVICES_ABSENT),
+            Map.entry(BootUiPanels.EMAIL, EMAIL_ABSENT),
+            Map.entry(BootUiPanels.KAFKA, KAFKA_ABSENT),
+            Map.entry(BootUiPanels.SQL_TRACE, SQL_TRACE_ABSENT),
+            Map.entry(BootUiPanels.PROFILE_DIFF, PROFILE_DIFF_ABSENT),
+            Map.entry(BootUiPanels.REST_API, REST_API_ABSENT),
+            Map.entry(BootUiPanels.SECURITY_LOGS, SECURITY_LOGS_ABSENT),
+            Map.entry(BootUiPanels.COPILOT, COPILOT_ABSENT),
+            Map.entry(BootUiPanels.CLAUDE_CODE, CLAUDE_CODE_ABSENT));
 
     private static final Set<String> AVAILABLE_PANELS = Set.of(
             BootUiPanels.OVERVIEW,
@@ -378,6 +426,15 @@ public class QuarkusPanelAvailability {
     private final boolean claudeCodePanelAvailable;
     private final QuarkusPanelAccessConfig accessConfig;
 
+    /**
+     * Panel id → live availability for every panel gated by a build-time capability flag or a
+     * dynamic detector (everything {@link #isPanelAvailable} checks besides the static
+     * {@link #AVAILABLE_PANELS} set and the GitHub special case). Built once here, right after the
+     * individual flags above are computed, so {@link #isPanelAvailable} reduces to a single map
+     * lookup instead of a 14-way OR-chain.
+     */
+    private final Map<String, Boolean> dynamicAvailability;
+
     @Inject
     public QuarkusPanelAvailability(Config config) {
         this.hibernatePresent =
@@ -412,6 +469,22 @@ public class QuarkusPanelAvailability {
         this.copilotPanelAvailable = agentDirectoryPresent(copilot);
         this.claudeCodePanelAvailable = agentDirectoryPresent(claude);
         this.accessConfig = new QuarkusPanelAccessConfig(config);
+        this.dynamicAvailability = Map.ofEntries(
+                Map.entry(BootUiPanels.HIBERNATE, hibernatePresent),
+                Map.entry(BootUiPanels.SCHEDULED, schedulingPresent),
+                Map.entry(BootUiPanels.CACHE, cachePresent),
+                Map.entry(BootUiPanels.FLYWAY, flywayPresent),
+                Map.entry(BootUiPanels.LIQUIBASE, liquibasePresent),
+                Map.entry(BootUiPanels.DATABASE_CONNECTION_POOLS, connectionPoolsPresent),
+                Map.entry(BootUiPanels.DEV_SERVICES, devServicesPresent),
+                Map.entry(BootUiPanels.EMAIL, emailPresent),
+                Map.entry(BootUiPanels.KAFKA, kafkaPresent),
+                Map.entry(BootUiPanels.SECURITY_LOGS, securityLogsAvailable),
+                Map.entry(BootUiPanels.SQL_TRACE, connectionPoolsPresent),
+                Map.entry(BootUiPanels.PROFILE_DIFF, profilesActive),
+                Map.entry(BootUiPanels.REST_API, restApiPresent),
+                Map.entry(BootUiPanels.COPILOT, copilotPanelAvailable),
+                Map.entry(BootUiPanels.CLAUDE_CODE, claudeCodePanelAvailable));
     }
 
     private static boolean agentDirectoryPresent(io.github.jdubois.bootui.spi.agent.AgentSessionProperties settings) {
@@ -462,86 +535,29 @@ public class QuarkusPanelAvailability {
      * <p>This is the single source of truth for panel availability — the manifest ({@link #toDto})
      * and the MCP tool catalog ({@code QuarkusMcpTools}) both consult it so a tool is advertised iff
      * its backing panel is live. It combines the static {@link #AVAILABLE_PANELS} set with the
-     * build-time capability flags (Hibernate ORM, Scheduler, Cache, Flyway, Liquibase, Agroal pools,
-     * Dev Services, REST API), the dynamic detectors (GitHub repository, active profiles, agent
-     * directories), and the security-events gate.
+     * precomputed {@link #dynamicAvailability} map (build-time capability flags — Hibernate ORM,
+     * Scheduler, Cache, Flyway, Liquibase, Agroal pools, Dev Services, REST API — plus the
+     * active-profiles and agent-directory detectors and the security-events gate) and the GitHub
+     * special case, which is deliberately <em>not</em> memoized: it reads the working directory and
+     * git config fresh on every call.
      */
     public boolean isPanelAvailable(String panelId) {
         return AVAILABLE_PANELS.contains(panelId)
-                || (BootUiPanels.HIBERNATE.equals(panelId) && hibernatePresent)
-                || (BootUiPanels.SCHEDULED.equals(panelId) && schedulingPresent)
-                || (BootUiPanels.CACHE.equals(panelId) && cachePresent)
-                || (BootUiPanels.FLYWAY.equals(panelId) && flywayPresent)
-                || (BootUiPanels.LIQUIBASE.equals(panelId) && liquibasePresent)
-                || (BootUiPanels.DATABASE_CONNECTION_POOLS.equals(panelId) && connectionPoolsPresent)
-                || (BootUiPanels.DEV_SERVICES.equals(panelId) && devServicesPresent)
-                || (BootUiPanels.EMAIL.equals(panelId) && emailPresent)
-                || (BootUiPanels.KAFKA.equals(panelId) && kafkaPresent)
-                || (BootUiPanels.SECURITY_LOGS.equals(panelId) && securityLogsAvailable)
-                || (BootUiPanels.SQL_TRACE.equals(panelId) && connectionPoolsPresent)
-                || (BootUiPanels.PROFILE_DIFF.equals(panelId) && profilesActive)
-                || (BootUiPanels.REST_API.equals(panelId) && restApiPresent)
-                || (BootUiPanels.COPILOT.equals(panelId) && copilotPanelAvailable)
-                || (BootUiPanels.CLAUDE_CODE.equals(panelId) && claudeCodePanelAvailable)
+                || dynamicAvailability.getOrDefault(panelId, Boolean.FALSE)
                 || (BootUiPanels.GITHUB.equals(panelId) && githubAvailable());
     }
 
+    /**
+     * Reason a not-currently-available panel is unavailable: the dynamic GitHub case first (computed
+     * fresh, mirroring {@link #isPanelAvailable}), then the capability-gated panels via
+     * {@link #CAPABILITY_ABSENT}, then the permanently-inapplicable panels via {@link #NOT_APPLICABLE},
+     * and finally the generic {@link #NOT_YET_AVAILABLE} fallback for panels not yet ported at all.
+     */
     private String unavailableReason(String panelId) {
-        if (BootUiPanels.HIBERNATE.equals(panelId)) {
-            return HIBERNATE_ABSENT;
-        }
-        if (BootUiPanels.SCHEDULED.equals(panelId)) {
-            return SCHEDULED_ABSENT;
-        }
-        if (BootUiPanels.CACHE.equals(panelId)) {
-            return CACHE_ABSENT;
-        }
-        if (BootUiPanels.FLYWAY.equals(panelId)) {
-            return FLYWAY_ABSENT;
-        }
-        if (BootUiPanels.LIQUIBASE.equals(panelId)) {
-            return LIQUIBASE_ABSENT;
-        }
-        if (BootUiPanels.DATABASE_CONNECTION_POOLS.equals(panelId)) {
-            return CONNECTION_POOLS_ABSENT;
-        }
-        if (BootUiPanels.DEV_SERVICES.equals(panelId)) {
-            return DEV_SERVICES_ABSENT;
-        }
-        if (BootUiPanels.EMAIL.equals(panelId)) {
-            return EMAIL_ABSENT;
-        }
-        if (BootUiPanels.KAFKA.equals(panelId)) {
-            return KAFKA_ABSENT;
-        }
-        if (BootUiPanels.SQL_TRACE.equals(panelId)) {
-            return "Not available: no JDBC datasource is on the classpath. Add a Quarkus JDBC datasource"
-                    + " (e.g. quarkus-jdbc-h2) so SQL executions can be traced.";
-        }
-        if (BootUiPanels.PROFILE_DIFF.equals(panelId)) {
-            return "Not available: no profiles are active. Run with a profile (e.g. quarkus.profile=dev) to"
-                    + " compare profile-specific configuration.";
-        }
         if (BootUiPanels.GITHUB.equals(panelId)) {
             return githubUnavailableReason();
         }
-        if (BootUiPanels.REST_API.equals(panelId)) {
-            return "Not available: no JAX-RS resources were found under the application base packages. Add a"
-                    + " @Path resource so the REST API advisor has controllers to analyse.";
-        }
-        if (BootUiPanels.SECURITY_LOGS.equals(panelId)) {
-            return "Not available: Quarkus security events are disabled. Set quarkus.security.events.enabled=true"
-                    + " (with a security extension) to capture authentication/authorization events.";
-        }
-        if (BootUiPanels.COPILOT.equals(panelId)) {
-            return "Not available: no Copilot CLI session-state directory found (default"
-                    + " ~/.copilot/session-state). Run the Copilot CLI locally so it has sessions to show.";
-        }
-        if (BootUiPanels.CLAUDE_CODE.equals(panelId)) {
-            return "Not available: no Claude Code project directory found (default ~/.claude/projects)."
-                    + " Run Claude Code locally so it has sessions to show.";
-        }
-        return NOT_APPLICABLE.getOrDefault(panelId, NOT_YET_AVAILABLE);
+        return CAPABILITY_ABSENT.getOrDefault(panelId, NOT_APPLICABLE.getOrDefault(panelId, NOT_YET_AVAILABLE));
     }
 
     /**

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/HttpExchangesResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/HttpExchangesResource.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.quarkus.web;
 
 import io.github.jdubois.bootui.core.dto.HttpExchangesReport;
+import io.github.jdubois.bootui.engine.telemetry.SelfTelemetryClassifier;
 import io.github.jdubois.bootui.engine.web.HttpExchangeBuffer;
 import io.github.jdubois.bootui.engine.web.HttpExchangesService;
 import io.github.jdubois.bootui.quarkus.QuarkusExposurePolicy;
@@ -17,6 +18,10 @@ import jakarta.ws.rs.core.MediaType;
  * shared engine {@link HttpExchangesService}, which owns masking, trace-id extraction, self-exclusion
  * and paging. The capture source is the Quarkus-only {@link HttpExchangeBuffer} fed by
  * {@link QuarkusHttpExchangeCaptureFilter} (Spring keeps Actuator's repository), so the wire is identical.
+ * The self-exclusion predicate reuses the adapter-wide {@link SelfTelemetryClassifier} singleton (see its
+ * class javadoc) rather than a locally hardcoded path check, so this panel can never disagree with
+ * Metrics/Cache/Traces about which requests are BootUI's own, and correctly honors
+ * {@code bootui.monitoring.exclude-self}.
  *
  * <p>Read-only — no state-changing endpoints, hence no write gate.</p>
  */
@@ -25,12 +30,15 @@ public class HttpExchangesResource {
 
     private final HttpExchangeBuffer buffer;
     private final QuarkusExposurePolicy exposure;
+    private final SelfTelemetryClassifier selfClassifier;
     private final HttpExchangesService service = new HttpExchangesService();
 
     @Inject
-    public HttpExchangesResource(HttpExchangeBuffer buffer, QuarkusExposurePolicy exposure) {
+    public HttpExchangesResource(
+            HttpExchangeBuffer buffer, QuarkusExposurePolicy exposure, SelfTelemetryClassifier selfClassifier) {
         this.buffer = buffer;
         this.exposure = exposure;
+        this.selfClassifier = selfClassifier;
     }
 
     @GET
@@ -43,7 +51,7 @@ public class HttpExchangesResource {
             @QueryParam("limit") Integer limit) {
         return service.report(
                 buffer.snapshot(),
-                uri -> uri != null && (uri.contains("/bootui/") || uri.endsWith("/bootui")),
+                uri -> !selfClassifier.shouldInclude(selfClassifier.isBootUiPath(uri)),
                 exposure.maskSecrets(),
                 exposure.valueExposure(),
                 query,

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/LiveActivityResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/LiveActivityResource.java
@@ -33,6 +33,7 @@ import io.github.jdubois.bootui.engine.scheduled.ScheduledTaskRunStore;
 import io.github.jdubois.bootui.engine.security.SecurityEventBuffer;
 import io.github.jdubois.bootui.engine.security.SecurityLogsService;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
+import io.github.jdubois.bootui.engine.telemetry.SelfTelemetryClassifier;
 import io.github.jdubois.bootui.engine.telemetry.TracesService;
 import io.github.jdubois.bootui.engine.web.HttpExchangeBuffer;
 import io.github.jdubois.bootui.engine.web.HttpExchangesService;
@@ -73,7 +74,9 @@ import javax.sql.DataSource;
  * captured email (via the shared {@link EmailCaptureService}) — plus JVM heap into the neutral
  * {@link LiveActivityReport}. Cache activity and outbound REST-client calls have no capture seam on
  * Quarkus yet (see {@link LiveActivityAssembler}'s class Javadoc), so both slots are always
- * empty/unavailable here. SQL trace
+ * empty/unavailable here. The HTTP-exchange source hides BootUI's own traffic via the adapter-wide
+ * {@link SelfTelemetryClassifier} singleton (see its class javadoc), the same instance Metrics/Cache/Traces
+ * inject, rather than a locally hardcoded path check. SQL trace
  * contributes only when a datasource is configured (the recorder is gated on Agroal); security events
  * contribute only when Quarkus's security capability is present and
  * {@code quarkus.security.events.enabled=true} (the same gate {@code SecurityLogsResource} uses, reused here
@@ -142,6 +145,7 @@ public class LiveActivityResource {
     private final ActivityPersistenceSettings persistenceSettings;
     private final Instance<DataSource> dataSources;
     private final KafkaActivityRecorder kafkaRecorder;
+    private final SelfTelemetryClassifier selfClassifier;
     private final HttpExchangesService exchanges = new HttpExchangesService();
     private final LiveActivityAssembler assembler = new LiveActivityAssembler();
     private final RequestProfileAssembler profileAssembler = new RequestProfileAssembler();
@@ -164,7 +168,8 @@ public class LiveActivityResource {
             SwitchableActivityStore activityStore,
             ActivityPersistenceSettings persistenceSettings,
             Instance<DataSource> dataSources,
-            KafkaActivityRecorder kafkaRecorder) {
+            KafkaActivityRecorder kafkaRecorder,
+            SelfTelemetryClassifier selfClassifier) {
         this.buffer = buffer;
         this.exposure = exposure;
         this.sqlRecorder = sqlRecorder;
@@ -179,6 +184,7 @@ public class LiveActivityResource {
         this.persistenceSettings = persistenceSettings;
         this.dataSources = dataSources;
         this.kafkaRecorder = kafkaRecorder;
+        this.selfClassifier = selfClassifier;
     }
 
     /**
@@ -399,7 +405,7 @@ public class LiveActivityResource {
     private HttpExchangesReport requestsReport() {
         return exchanges.report(
                 buffer.snapshot(),
-                uri -> uri != null && (uri.contains("/bootui/") || uri.endsWith("/bootui")),
+                uri -> !selfClassifier.shouldInclude(selfClassifier.isBootUiPath(uri)),
                 exposure.maskSecrets(),
                 exposure.valueExposure(),
                 null,

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/SecurityLogsResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/SecurityLogsResource.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.quarkus.web;
 import io.github.jdubois.bootui.core.dto.SecurityLogsReport;
 import io.github.jdubois.bootui.engine.security.SecurityEventBuffer;
 import io.github.jdubois.bootui.engine.security.SecurityLogsService;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import io.github.jdubois.bootui.quarkus.QuarkusExposurePolicy;
 import io.smallrye.mutiny.Multi;
 import jakarta.inject.Inject;
@@ -76,8 +77,8 @@ public class SecurityLogsResource {
                 maxLogs,
                 exposure.maskSecrets(),
                 exposure.valueExposure(),
-                blankToNull(principal),
-                blankToNull(type),
+                BlankStrings.blankToNullTrimmed(principal),
+                BlankStrings.blankToNullTrimmed(type),
                 parseAfter(after),
                 offset,
                 limit);
@@ -96,12 +97,8 @@ public class SecurityLogsResource {
     }
 
     private static Instant parseAfter(String after) {
-        String value = blankToNull(after);
-        if (value == null) {
-            return null;
-        }
         try {
-            return Instant.parse(value);
+            return BlankStrings.parseInstant(after);
         } catch (DateTimeException e) {
             // Mirror the Spring controller's @ExceptionHandler: a malformed `after` is a 400, not a 500.
             String message = e.getMessage() == null ? "Invalid request" : e.getMessage();
@@ -110,12 +107,5 @@ public class SecurityLogsResource {
                     .entity(Map.of("error", message))
                     .build());
         }
-    }
-
-    private static String blankToNull(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return value.trim();
     }
 }

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/activity/QuarkusActivityCaptureTests.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/activity/QuarkusActivityCaptureTests.java
@@ -11,6 +11,7 @@ import io.github.jdubois.bootui.engine.exceptions.ExceptionsService;
 import io.github.jdubois.bootui.engine.kafka.KafkaActivityRecorder;
 import io.github.jdubois.bootui.engine.scheduled.ScheduledTaskRunStore;
 import io.github.jdubois.bootui.engine.security.SecurityEventBuffer;
+import io.github.jdubois.bootui.engine.telemetry.SelfTelemetryClassifier;
 import io.github.jdubois.bootui.engine.web.HttpExchangeBuffer;
 import io.github.jdubois.bootui.quarkus.QuarkusExposurePolicy;
 import io.github.jdubois.bootui.quarkus.QuarkusPanelAvailability;
@@ -109,7 +110,8 @@ class QuarkusActivityCaptureTests {
                 new SwitchableActivityStore(new InMemoryActivityStore(10)),
                 disabledSettings(),
                 new UnsatisfiedInstance<>(),
-                new KafkaActivityRecorder(true, true, 200, 200));
+                new KafkaActivityRecorder(true, true, 200, 200),
+                new SelfTelemetryClassifier(true, "/bootui", "/bootui/api"));
     }
 
     private static Thread awaitThreadNamed(String name) throws InterruptedException {

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/LiveActivityResourceTests.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/LiveActivityResourceTests.java
@@ -25,6 +25,7 @@ import io.github.jdubois.bootui.engine.kafka.KafkaActivityRecorder;
 import io.github.jdubois.bootui.engine.scheduled.ScheduledTaskRunStore;
 import io.github.jdubois.bootui.engine.security.SecurityEventBuffer;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
+import io.github.jdubois.bootui.engine.telemetry.SelfTelemetryClassifier;
 import io.github.jdubois.bootui.engine.web.CapturedHttpExchange;
 import io.github.jdubois.bootui.engine.web.HttpExchangeBuffer;
 import io.github.jdubois.bootui.quarkus.QuarkusExposurePolicy;
@@ -511,7 +512,18 @@ class LiveActivityResourceTests {
                 activityStore,
                 settings,
                 dataSources,
-                kafkaRecorder);
+                kafkaRecorder,
+                selfTelemetryClassifier(config));
+    }
+
+    /** Mirrors {@code BootUiTelemetryProducer.selfTelemetryClassifier} so tests wire the same classifier. */
+    private static SelfTelemetryClassifier selfTelemetryClassifier(SmallRyeConfig config) {
+        boolean excludeSelf = config.getOptionalValue("bootui.monitoring.exclude-self", Boolean.class)
+                .orElse(Boolean.TRUE);
+        String path = config.getOptionalValue("bootui.path", String.class).orElse("/bootui");
+        String apiPath =
+                config.getOptionalValue("bootui.api-path", String.class).orElse("/bootui/api");
+        return new SelfTelemetryClassifier(excludeSelf, path, apiPath);
     }
 
     private static SmallRyeConfig config(Map<String, String> properties) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityService.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityService.java
@@ -33,6 +33,7 @@ import io.github.jdubois.bootui.engine.kafka.KafkaActivityRecorder.CapturedMessa
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.github.jdubois.bootui.engine.scheduled.ScheduledTaskRunStore;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceGrouping;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import io.github.jdubois.bootui.engine.web.SecurityActivityIds;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
@@ -236,8 +237,8 @@ public class LiveActivityService {
             typeCounts.merge(entry.type(), 1, Integer::sum);
         }
 
-        String normalizedType = blankToNull(typeFilter);
-        String normalizedSeverity = blankToNull(severityFilter);
+        String normalizedType = BlankStrings.blankToNullTrimmed(typeFilter);
+        String normalizedSeverity = BlankStrings.blankToNullTrimmed(severityFilter);
         List<ActivityEntryDto> visible = new ArrayList<>();
         for (ActivityEntryDto entry : all) {
             if (entry.timestamp() <= since) {
@@ -1077,9 +1078,5 @@ public class LiveActivityService {
             return value;
         }
         return value.substring(0, SQL_SUMMARY_LENGTH) + "…";
-    }
-
-    private static String blankToNull(String value) {
-        return value == null || value.isBlank() ? null : value.trim();
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/cache/SpringCacheProvider.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/cache/SpringCacheProvider.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.autoconfigure.cache;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.monitoring.BootUiSelfDataFilter;
 import io.github.jdubois.bootui.core.dto.CacheOperationDto;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import io.github.jdubois.bootui.spi.CacheManagerSnapshot;
 import io.github.jdubois.bootui.spi.CacheOperationDiscovery;
 import io.github.jdubois.bootui.spi.CacheProvider;
@@ -301,9 +302,9 @@ public class SpringCacheProvider implements CacheProvider {
         boolean allEntries = false;
         boolean beforeInvocation = false;
         if (operation instanceof CacheableOperation cacheable) {
-            unless = blankToNull(cacheable.getUnless());
+            unless = BlankStrings.blankToNull(cacheable.getUnless());
         } else if (operation instanceof CachePutOperation cachePut) {
-            unless = blankToNull(cachePut.getUnless());
+            unless = BlankStrings.blankToNull(cachePut.getUnless());
         } else if (operation instanceof CacheEvictOperation cacheEvict) {
             allEntries = cacheEvict.isCacheWide();
             beforeInvocation = cacheEvict.isBeforeInvocation();
@@ -315,8 +316,8 @@ public class SpringCacheProvider implements CacheProvider {
                 signatureOf(method),
                 operationName(operation),
                 operation.getCacheNames().stream().sorted().toList(),
-                blankToNull(operation.getKey()),
-                blankToNull(operation.getCondition()),
+                BlankStrings.blankToNull(operation.getKey()),
+                BlankStrings.blankToNull(operation.getCondition()),
                 unless,
                 allEntries,
                 beforeInvocation);
@@ -341,14 +342,6 @@ public class SpringCacheProvider implements CacheProvider {
                 .reduce((left, right) -> left + ", " + right)
                 .orElse("");
         return method.getReturnType().getSimpleName() + " " + method.getName() + "(" + params + ")";
-    }
-
-    private boolean isBlank(String value) {
-        return value == null || value.isBlank();
-    }
-
-    private String blankToNull(String value) {
-        return isBlank(value) ? null : value;
     }
 
     private record CacheManagerEntry(String name, CacheManager manager) {}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/ExceptionsController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/ExceptionsController.java
@@ -26,7 +26,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 /**
@@ -36,6 +35,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
  * {@code METADATA_ONLY}, scrubbed of obvious secret-like assignments for the default {@code MASKED}
  * mode, and shown verbatim only for {@code FULL}. Stack frames carry only class/method/file/line
  * information.</p>
+ *
+ * <p>The read/clear/triage business logic lives in {@link ExceptionsControllerSupport}, shared with
+ * the WebFlux sibling {@code ReactiveExceptionsController} since none of it touches a servlet or
+ * reactive request/response type. This class keeps only the {@code @RestController} wiring, the
+ * SSE {@code /stream} endpoint, and the store-listener lifecycle.</p>
  */
 @RestController
 @RequestMapping("/bootui/api/exceptions")
@@ -89,53 +93,29 @@ public class ExceptionsController {
 
     @GetMapping
     public ExceptionsReport list() {
-        ExceptionStore store = storeProvider.getIfAvailable();
-        if (store == null) {
-            return ExceptionsReport.unavailable(
-                    "Exception capture is disabled", properties.getExceptions().getMaxGroups());
-        }
-        return service.report(store);
+        return ExceptionsControllerSupport.list(storeProvider, properties, service);
     }
 
     @GetMapping("/{id}")
     public ExceptionDetailDto detail(@PathVariable String id) {
-        ExceptionStore store = storeProvider.getIfAvailable();
-        ExceptionStore.GroupDetail detail = store == null ? null : store.find(id);
-        if (detail == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "exception " + id + " not found");
-        }
-        return service.detail(detail);
+        return ExceptionsControllerSupport.detail(storeProvider, service, id);
     }
 
     @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void clear() {
-        ExceptionStore store = storeProvider.getIfAvailable();
-        if (store != null) {
-            store.clear();
-        }
+        ExceptionsControllerSupport.clear(storeProvider);
     }
 
-    /**
-     * Changes the triage status of one exception group ({@code OPEN}/{@code ACKNOWLEDGED}/
-     * {@code RESOLVED}). See {@link ExceptionsService#updateStatus} for validation and regression
-     * semantics.
-     */
     @PostMapping("/{id}/status")
     public ExceptionGroupDto updateStatus(
             @PathVariable String id, @RequestBody(required = false) ExceptionStatusUpdateRequest request) {
-        ExceptionStore store = storeProvider.getIfAvailable();
-        ExceptionGroupDto updated = service.updateStatus(store, id, request == null ? null : request.status());
-        if (updated == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "exception " + id + " not found");
-        }
-        return updated;
+        return ExceptionsControllerSupport.updateStatus(storeProvider, service, id, request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()));
+        return ExceptionsControllerSupport.handleBadRequest(ex);
     }
 
     /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/ExceptionsControllerSupport.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/exceptions/ExceptionsControllerSupport.java
@@ -1,0 +1,78 @@
+package io.github.jdubois.bootui.autoconfigure.exceptions;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.core.dto.ExceptionDetailDto;
+import io.github.jdubois.bootui.core.dto.ExceptionGroupDto;
+import io.github.jdubois.bootui.core.dto.ExceptionStatusUpdateRequest;
+import io.github.jdubois.bootui.core.dto.ExceptionsReport;
+import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
+import io.github.jdubois.bootui.engine.exceptions.ExceptionsService;
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Shared read/clear/triage business logic for the BootUI Exceptions panel, used by both the servlet
+ * {@code ExceptionsController} and the WebFlux {@code ReactiveExceptionsController}. Both bindings
+ * expose the identical REST contract over the same framework-neutral {@link ExceptionStore} /
+ * {@link ExceptionsService}, and none of this logic touches a servlet or reactive request/response
+ * type, so it is extracted once here rather than duplicated per transport. The transport-specific
+ * pieces (the {@code @RestController} wiring itself, the SSE {@code /stream} endpoint, and
+ * constructor/shutdown lifecycle) stay in each controller.
+ */
+public final class ExceptionsControllerSupport {
+
+    private ExceptionsControllerSupport() {}
+
+    public static ExceptionsReport list(
+            ObjectProvider<ExceptionStore> storeProvider, BootUiProperties properties, ExceptionsService service) {
+        ExceptionStore store = storeProvider.getIfAvailable();
+        if (store == null) {
+            return ExceptionsReport.unavailable(
+                    "Exception capture is disabled", properties.getExceptions().getMaxGroups());
+        }
+        return service.report(store);
+    }
+
+    public static ExceptionDetailDto detail(
+            ObjectProvider<ExceptionStore> storeProvider, ExceptionsService service, String id) {
+        ExceptionStore store = storeProvider.getIfAvailable();
+        ExceptionStore.GroupDetail detail = store == null ? null : store.find(id);
+        if (detail == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "exception " + id + " not found");
+        }
+        return service.detail(detail);
+    }
+
+    public static void clear(ObjectProvider<ExceptionStore> storeProvider) {
+        ExceptionStore store = storeProvider.getIfAvailable();
+        if (store != null) {
+            store.clear();
+        }
+    }
+
+    /**
+     * Changes the triage status of one exception group ({@code OPEN}/{@code ACKNOWLEDGED}/
+     * {@code RESOLVED}). See {@link ExceptionsService#updateStatus} for validation and regression
+     * semantics.
+     */
+    public static ExceptionGroupDto updateStatus(
+            ObjectProvider<ExceptionStore> storeProvider,
+            ExceptionsService service,
+            String id,
+            ExceptionStatusUpdateRequest request) {
+        ExceptionStore store = storeProvider.getIfAvailable();
+        ExceptionGroupDto updated = service.updateStatus(store, id, request == null ? null : request.status());
+        if (updated == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "exception " + id + " not found");
+        }
+        return updated;
+    }
+
+    public static ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()));
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveExceptionsController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveExceptionsController.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.reactive;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
+import io.github.jdubois.bootui.autoconfigure.exceptions.ExceptionsControllerSupport;
 import io.github.jdubois.bootui.core.dto.ExceptionDetailDto;
 import io.github.jdubois.bootui.core.dto.ExceptionGroupDto;
 import io.github.jdubois.bootui.core.dto.ExceptionStatusUpdateRequest;
@@ -26,7 +27,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Flux;
 
 /**
@@ -82,53 +82,29 @@ public class ReactiveExceptionsController {
 
     @GetMapping
     public ExceptionsReport list() {
-        ExceptionStore store = storeProvider.getIfAvailable();
-        if (store == null) {
-            return ExceptionsReport.unavailable(
-                    "Exception capture is disabled", properties.getExceptions().getMaxGroups());
-        }
-        return service.report(store);
+        return ExceptionsControllerSupport.list(storeProvider, properties, service);
     }
 
     @GetMapping("/{id}")
     public ExceptionDetailDto detail(@PathVariable String id) {
-        ExceptionStore store = storeProvider.getIfAvailable();
-        ExceptionStore.GroupDetail detail = store == null ? null : store.find(id);
-        if (detail == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "exception " + id + " not found");
-        }
-        return service.detail(detail);
+        return ExceptionsControllerSupport.detail(storeProvider, service, id);
     }
 
     @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void clear() {
-        ExceptionStore store = storeProvider.getIfAvailable();
-        if (store != null) {
-            store.clear();
-        }
+        ExceptionsControllerSupport.clear(storeProvider);
     }
 
-    /**
-     * Changes the triage status of one exception group ({@code OPEN}/{@code ACKNOWLEDGED}/
-     * {@code RESOLVED}). See {@link ExceptionsService#updateStatus} for validation and regression
-     * semantics.
-     */
     @PostMapping("/{id}/status")
     public ExceptionGroupDto updateStatus(
             @PathVariable String id, @RequestBody(required = false) ExceptionStatusUpdateRequest request) {
-        ExceptionStore store = storeProvider.getIfAvailable();
-        ExceptionGroupDto updated = service.updateStatus(store, id, request == null ? null : request.status());
-        if (updated == null) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "exception " + id + " not found");
-        }
-        return updated;
+        return ExceptionsControllerSupport.updateStatus(storeProvider, service, id, request);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()));
+        return ExceptionsControllerSupport.handleBadRequest(ex);
     }
 
     /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveLocalhostOnlyFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveLocalhostOnlyFilter.java
@@ -1,23 +1,15 @@
 package io.github.jdubois.bootui.autoconfigure.reactive;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
-import io.github.jdubois.bootui.autoconfigure.BootUiProperties.Mode;
-import io.github.jdubois.bootui.engine.safety.CidrRange;
+import io.github.jdubois.bootui.autoconfigure.safety.LocalhostGuardConfigSupport;
 import io.github.jdubois.bootui.engine.safety.ContainerGatewayDetector;
-import io.github.jdubois.bootui.engine.safety.GatewayTrust;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuard;
-import io.github.jdubois.bootui.engine.safety.LocalhostGuardConfig;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuardDecision;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuardDecision.Allow;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuardDecision.Reject;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuardRequest;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
@@ -35,26 +27,19 @@ import reactor.core.publisher.Mono;
  * their order, and the canonical 403 message) &mdash; that policy is unchanged here, it lives entirely
  * in the engine {@link LocalhostGuard}.
  *
- * <p>This class intentionally duplicates the servlet filter's caching / lazy-gateway-resolution /
- * logging rather than sharing a common servlet+reactive base class, mirroring how the Quarkus Vert.x
- * binding is its own independent translation layer over the same guard.</p>
+ * <p>The guard-config translation (caching / lazy gateway resolution) is shared with the servlet
+ * filter via {@link LocalhostGuardConfigSupport}, since none of it touches a servlet or reactive
+ * request type. Only the request/response glue that genuinely differs by transport &mdash; reading the
+ * {@link ServerHttpRequest}, and per-reason rejection logging &mdash; stays local to this class,
+ * mirroring how the Quarkus Vert.x binding remains its own independent translation layer over the same
+ * guard.</p>
  */
 public class ReactiveLocalhostOnlyFilter extends AbstractReactiveBootUiFilter implements Ordered {
 
     private static final Logger log = LoggerFactory.getLogger(ReactiveLocalhostOnlyFilter.class);
 
     private final LocalhostGuard guard = new LocalhostGuard();
-
-    private volatile String[] parsedFrom;
-    private volatile List<CidrRange> trustedRanges = List.of();
-
-    private final ContainerGatewayDetector gatewayDetector;
-
-    private final Object gatewayLock = new Object();
-    private volatile boolean gatewayResolved = false;
-    private volatile boolean inContainer = false;
-    private volatile Set<InetAddress> containerGateways = Set.of();
-    private volatile boolean loggedTrustedGateway = false;
+    private final LocalhostGuardConfigSupport configSupport;
 
     public ReactiveLocalhostOnlyFilter(BootUiProperties properties) {
         this(properties, new ContainerGatewayDetector());
@@ -62,7 +47,7 @@ public class ReactiveLocalhostOnlyFilter extends AbstractReactiveBootUiFilter im
 
     ReactiveLocalhostOnlyFilter(BootUiProperties properties, ContainerGatewayDetector gatewayDetector) {
         super(properties);
-        this.gatewayDetector = gatewayDetector;
+        this.configSupport = new LocalhostGuardConfigSupport(properties, gatewayDetector);
     }
 
     /**
@@ -89,7 +74,7 @@ public class ReactiveLocalhostOnlyFilter extends AbstractReactiveBootUiFilter im
                 request.getHeaders().getFirst("Origin"),
                 request.getHeaders().getFirst("Sec-Fetch-Site"));
 
-        LocalhostGuardDecision decision = guard.decide(guardRequest, buildConfig());
+        LocalhostGuardDecision decision = guard.decide(guardRequest, configSupport.buildConfig(log));
 
         if (decision instanceof Reject reject) {
             logRejection(reject, request);
@@ -99,7 +84,7 @@ public class ReactiveLocalhostOnlyFilter extends AbstractReactiveBootUiFilter im
         }
 
         if (decision instanceof Allow allow && allow.trustedViaGateway()) {
-            warnTrustedGatewayOnce(allow.trustedGateway());
+            configSupport.warnTrustedGatewayOnce(log, allow.trustedGateway());
         }
         return chain.filter(exchange);
     }
@@ -116,59 +101,6 @@ public class ReactiveLocalhostOnlyFilter extends AbstractReactiveBootUiFilter im
         }
         InetAddress address = remote.getAddress();
         return address != null ? address.getHostAddress() : null;
-    }
-
-    /**
-     * Builds the per-request guard configuration. The container-gateway snapshot is resolved (and
-     * cached) lazily on the first request only when {@code bootui.trust-container-gateway} is not
-     * {@code OFF}, so an {@code OFF} deployment never touches {@code /proc} or DNS.
-     */
-    private LocalhostGuardConfig buildConfig() {
-        GatewayTrust gatewayTrust = toGatewayTrust(properties.getTrustContainerGateway());
-        boolean container;
-        Set<InetAddress> gateways;
-        if (gatewayTrust == GatewayTrust.OFF) {
-            container = false;
-            gateways = Set.of();
-        } else {
-            resolveGatewayOnce();
-            container = this.inContainer;
-            gateways = this.containerGateways;
-        }
-        String[] allowedHosts = properties.getAllowedHosts();
-        return new LocalhostGuardConfig(
-                properties.isAllowNonLocalhost(),
-                allowedHosts == null ? List.of() : Arrays.asList(allowedHosts),
-                trustedRanges(),
-                gatewayTrust,
-                container,
-                gateways);
-    }
-
-    private static GatewayTrust toGatewayTrust(Mode mode) {
-        if (mode == null) {
-            return GatewayTrust.OFF;
-        }
-        return switch (mode) {
-            case AUTO -> GatewayTrust.AUTO;
-            case ON -> GatewayTrust.ON;
-            case OFF -> GatewayTrust.OFF;
-        };
-    }
-
-    /**
-     * Emits the once-only operator warning that a container gateway is being trusted as
-     * loopback-equivalent. Fires when a request is actually allowed via the gateway; invisible to
-     * behavior since no response status or body depends on it.
-     */
-    private void warnTrustedGatewayOnce(InetAddress gateway) {
-        if (loggedTrustedGateway) {
-            return;
-        }
-        loggedTrustedGateway = true;
-        log.warn(
-                "BootUI trusting auto-detected container gateway {} (/32) for loopback-equivalent access.",
-                gateway != null ? gateway.getHostAddress() : null);
     }
 
     private void logRejection(Reject reject, ServerHttpRequest request) {
@@ -189,54 +121,5 @@ public class ReactiveLocalhostOnlyFilter extends AbstractReactiveBootUiFilter im
                         request.getMethod(),
                         request.getPath().value());
         }
-    }
-
-    /**
-     * Resolves and caches the container detection result and trusted gateways exactly once. Mirrors
-     * the lazy, double-checked caching used by {@link #trustedRanges()} so the lookups happen on the
-     * first relevant request rather than per request. The trusted set is the union of the route-table
-     * default gateway and any Docker Desktop gateway resolved from {@code gateway.docker.internal}.
-     */
-    private void resolveGatewayOnce() {
-        if (gatewayResolved) {
-            return;
-        }
-        synchronized (gatewayLock) {
-            if (gatewayResolved) {
-                return;
-            }
-            inContainer = gatewayDetector.isInContainer();
-            Set<InetAddress> gateways = new LinkedHashSet<>();
-            gatewayDetector.defaultGateway().ifPresent(gateways::add);
-            gateways.addAll(gatewayDetector.dockerDesktopGateways());
-            containerGateways = Set.copyOf(gateways);
-            gatewayResolved = true;
-        }
-    }
-
-    /**
-     * Returns the configured {@code bootui.trusted-proxies} ranges, parsing (and caching) them only
-     * when the configured array changes. Malformed entries are logged once and skipped.
-     */
-    private List<CidrRange> trustedRanges() {
-        String[] configured = properties.getTrustedProxies();
-        if (configured == parsedFrom) {
-            return trustedRanges;
-        }
-        List<CidrRange> parsed = new ArrayList<>();
-        if (configured != null) {
-            for (String entry : configured) {
-                CidrRange range = CidrRange.parse(entry);
-                if (range != null) {
-                    parsed.add(range);
-                } else if (entry != null && !entry.isBlank()) {
-                    log.warn("BootUI ignoring malformed bootui.trusted-proxies entry '{}'", entry);
-                }
-            }
-        }
-        List<CidrRange> immutable = List.copyOf(parsed);
-        trustedRanges = immutable;
-        parsedFrom = configured;
-        return immutable;
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityLogsController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityLogsController.java
@@ -5,8 +5,8 @@ import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
 import io.github.jdubois.bootui.core.dto.SecurityLogsReport;
 import io.github.jdubois.bootui.engine.security.CapturedSecurityEvent;
 import io.github.jdubois.bootui.engine.security.SecurityLogsService;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import io.github.jdubois.bootui.spi.TraceIdProvider;
-import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
@@ -105,18 +105,22 @@ public class ReactiveSecurityLogsController implements ApplicationListener<Audit
             return SecurityLogsReport.unavailable("No AuditEventRepository bean is available", maxLogs);
         }
 
-        List<CapturedSecurityEvent> events =
-                repository.find(blankToNull(principal), parseAfter(after), blankToNull(type)).stream()
-                        .map(this::toCaptured)
-                        .toList();
+        List<CapturedSecurityEvent> events = repository
+                .find(
+                        BlankStrings.blankToNullTrimmed(principal),
+                        BlankStrings.parseInstant(after),
+                        BlankStrings.blankToNullTrimmed(type))
+                .stream()
+                .map(this::toCaptured)
+                .toList();
         return securityLogsService.report(
                 events,
                 maxLogs,
                 exposure.maskSecrets(),
                 exposure.valueExposure(),
-                blankToNull(principal),
-                blankToNull(type),
-                parseAfter(after),
+                BlankStrings.blankToNullTrimmed(principal),
+                BlankStrings.blankToNullTrimmed(type),
+                BlankStrings.parseInstant(after),
                 offset,
                 limit);
     }
@@ -196,17 +200,5 @@ public class ReactiveSecurityLogsController implements ApplicationListener<Audit
 
     private int maxLogs() {
         return securityLogsService.maxLogs(properties.getSecurityLogs().getMaxLogs());
-    }
-
-    private Instant parseAfter(String after) {
-        String value = blankToNull(after);
-        return value == null ? null : Instant.parse(value);
-    }
-
-    private String blankToNull(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return value.trim();
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSqlTraceController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSqlTraceController.java
@@ -1,7 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.reactive;
 
 import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
-import io.github.jdubois.bootui.core.ValueExposure;
+import io.github.jdubois.bootui.autoconfigure.sqltrace.SqlTraceControllerSupport;
 import io.github.jdubois.bootui.core.dto.SqlTraceRecordingRequest;
 import io.github.jdubois.bootui.core.dto.SqlTraceReport;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
@@ -27,8 +27,6 @@ import reactor.core.publisher.Flux;
 @RestController
 @RequestMapping("/bootui/api/sql-trace")
 public class ReactiveSqlTraceController {
-
-    private static final String NOT_CONFIGURED = "SQL tracing is not configured";
 
     private final ObjectProvider<SqlTraceRecorder> recorderProvider;
     private final ObjectProvider<DataSource> dataSourceProvider;
@@ -66,32 +64,17 @@ public class ReactiveSqlTraceController {
 
     @GetMapping
     public SqlTraceReport trace() {
-        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
-        if (recorder == null) {
-            return SqlTraceReport.unavailable(NOT_CONFIGURED);
-        }
-        return report(recorder);
+        return SqlTraceControllerSupport.trace(recorderProvider, exposure, dataSourceProvider);
     }
 
     @PostMapping("/clear")
     public SqlTraceReport clear() {
-        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
-        if (recorder == null) {
-            return SqlTraceReport.unavailable(NOT_CONFIGURED);
-        }
-        recorder.clear();
-        return report(recorder);
+        return SqlTraceControllerSupport.clear(recorderProvider, exposure, dataSourceProvider);
     }
 
     @PostMapping("/recording")
     public SqlTraceReport recording(@RequestBody(required = false) SqlTraceRecordingRequest request) {
-        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
-        if (recorder == null) {
-            return SqlTraceReport.unavailable(NOT_CONFIGURED);
-        }
-        boolean enabled = (request == null || request.enabled() == null) ? !recorder.isRecording() : request.enabled();
-        recorder.setRecording(enabled);
-        return report(recorder);
+        return SqlTraceControllerSupport.recording(recorderProvider, exposure, dataSourceProvider, request);
     }
 
     /**
@@ -101,24 +84,5 @@ public class ReactiveSqlTraceController {
     @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<Map<String, Object>>> stream() {
         return changeStream.open();
-    }
-
-    private SqlTraceReport report(SqlTraceRecorder recorder) {
-        if (!recorder.hasWrappedDataSource()) {
-            return SqlTraceReport.unavailable(unavailableReason(recorder));
-        }
-        boolean exposeParameters =
-                recorder.isCaptureParameters() && exposure.valueExposure() != ValueExposure.METADATA_ONLY;
-        return recorder.report(exposeParameters);
-    }
-
-    private String unavailableReason(SqlTraceRecorder recorder) {
-        if (!recorder.isEnabled()) {
-            return "SQL tracing is disabled (set bootui.sql-trace.enabled=true in a trusted local profile).";
-        }
-        if (dataSourceProvider.getIfAvailable() == null) {
-            return "No DataSource bean is available";
-        }
-        return "No DataSource has been wrapped for tracing yet.";
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostGuardConfigSupport.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostGuardConfigSupport.java
@@ -1,0 +1,152 @@
+package io.github.jdubois.bootui.autoconfigure.safety;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties.Mode;
+import io.github.jdubois.bootui.engine.safety.CidrRange;
+import io.github.jdubois.bootui.engine.safety.ContainerGatewayDetector;
+import io.github.jdubois.bootui.engine.safety.GatewayTrust;
+import io.github.jdubois.bootui.engine.safety.LocalhostGuardConfig;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+
+/**
+ * Shared {@link LocalhostGuardConfig} construction for the servlet {@code LocalhostOnlyFilter} and the
+ * WebFlux {@code ReactiveLocalhostOnlyFilter}. Both bindings need the exact same lazy, cached
+ * translation of {@link BootUiProperties} (plus the auto-detected container gateway) into a guard
+ * config, and none of that translation touches a servlet or reactive request/response type, so it is
+ * extracted once here rather than duplicated per transport.
+ *
+ * <p>Owns the per-instance caches the engine guard intentionally does not: the
+ * {@code bootui.trusted-proxies} parse cache and the resolve-once container-gateway snapshot. Each
+ * filter constructs and keeps its own instance (no shared mutable state across the two transports).
+ * Logging call sites accept the caller's own {@link Logger} so log lines keep attributing to the
+ * concrete filter class exactly as they did before this extraction.</p>
+ */
+public final class LocalhostGuardConfigSupport {
+
+    private final BootUiProperties properties;
+    private final ContainerGatewayDetector gatewayDetector;
+
+    private volatile String[] parsedFrom;
+    private volatile List<CidrRange> trustedRanges = List.of();
+
+    private final Object gatewayLock = new Object();
+    private volatile boolean gatewayResolved = false;
+    private volatile boolean inContainer = false;
+    private volatile Set<InetAddress> containerGateways = Set.of();
+    private volatile boolean loggedTrustedGateway = false;
+
+    public LocalhostGuardConfigSupport(BootUiProperties properties, ContainerGatewayDetector gatewayDetector) {
+        this.properties = properties;
+        this.gatewayDetector = gatewayDetector;
+    }
+
+    /**
+     * Builds the per-request guard configuration. The container-gateway snapshot is resolved (and
+     * cached) lazily on the first request only when {@code bootui.trust-container-gateway} is not
+     * {@code OFF}, so an {@code OFF} deployment never touches {@code /proc} or DNS.
+     */
+    public LocalhostGuardConfig buildConfig(Logger log) {
+        GatewayTrust gatewayTrust = toGatewayTrust(properties.getTrustContainerGateway());
+        boolean container;
+        Set<InetAddress> gateways;
+        if (gatewayTrust == GatewayTrust.OFF) {
+            container = false;
+            gateways = Set.of();
+        } else {
+            resolveGatewayOnce();
+            container = this.inContainer;
+            gateways = this.containerGateways;
+        }
+        String[] allowedHosts = properties.getAllowedHosts();
+        return new LocalhostGuardConfig(
+                properties.isAllowNonLocalhost(),
+                allowedHosts == null ? List.of() : Arrays.asList(allowedHosts),
+                trustedRanges(log),
+                gatewayTrust,
+                container,
+                gateways);
+    }
+
+    private static GatewayTrust toGatewayTrust(Mode mode) {
+        if (mode == null) {
+            return GatewayTrust.OFF;
+        }
+        return switch (mode) {
+            case AUTO -> GatewayTrust.AUTO;
+            case ON -> GatewayTrust.ON;
+            case OFF -> GatewayTrust.OFF;
+        };
+    }
+
+    /**
+     * Emits the once-only operator warning that a container gateway is being trusted as
+     * loopback-equivalent, logged through the caller's own {@link Logger} so the line still attributes
+     * to the concrete filter class. Fires when a request is actually allowed via the gateway; invisible
+     * to behavior since no response status or body depends on it.
+     */
+    public void warnTrustedGatewayOnce(Logger log, InetAddress gateway) {
+        if (loggedTrustedGateway) {
+            return;
+        }
+        loggedTrustedGateway = true;
+        log.warn(
+                "BootUI trusting auto-detected container gateway {} (/32) for loopback-equivalent access.",
+                gateway != null ? gateway.getHostAddress() : null);
+    }
+
+    /**
+     * Resolves and caches the container detection result and trusted gateways exactly once. Mirrors
+     * the lazy, double-checked caching used by {@link #trustedRanges} so the lookups happen on the
+     * first relevant request rather than per request. The trusted set is the union of the route-table
+     * default gateway and any Docker Desktop gateway resolved from {@code gateway.docker.internal}.
+     */
+    private void resolveGatewayOnce() {
+        if (gatewayResolved) {
+            return;
+        }
+        synchronized (gatewayLock) {
+            if (gatewayResolved) {
+                return;
+            }
+            inContainer = gatewayDetector.isInContainer();
+            Set<InetAddress> gateways = new LinkedHashSet<>();
+            gatewayDetector.defaultGateway().ifPresent(gateways::add);
+            gateways.addAll(gatewayDetector.dockerDesktopGateways());
+            containerGateways = Set.copyOf(gateways);
+            gatewayResolved = true;
+        }
+    }
+
+    /**
+     * Returns the configured {@code bootui.trusted-proxies} ranges, parsing (and caching) them only
+     * when the configured array changes. Malformed entries are logged once (through the caller's own
+     * {@link Logger}) and skipped.
+     */
+    private List<CidrRange> trustedRanges(Logger log) {
+        String[] configured = properties.getTrustedProxies();
+        if (configured == parsedFrom) {
+            return trustedRanges;
+        }
+        List<CidrRange> parsed = new ArrayList<>();
+        if (configured != null) {
+            for (String entry : configured) {
+                CidrRange range = CidrRange.parse(entry);
+                if (range != null) {
+                    parsed.add(range);
+                } else if (entry != null && !entry.isBlank()) {
+                    log.warn("BootUI ignoring malformed bootui.trusted-proxies entry '{}'", entry);
+                }
+            }
+        }
+        List<CidrRange> immutable = List.copyOf(parsed);
+        trustedRanges = immutable;
+        parsedFrom = configured;
+        return immutable;
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LocalhostOnlyFilter.java
@@ -1,13 +1,9 @@
 package io.github.jdubois.bootui.autoconfigure.safety;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
-import io.github.jdubois.bootui.autoconfigure.BootUiProperties.Mode;
 import io.github.jdubois.bootui.autoconfigure.web.AbstractBootUiFilter;
-import io.github.jdubois.bootui.engine.safety.CidrRange;
 import io.github.jdubois.bootui.engine.safety.ContainerGatewayDetector;
-import io.github.jdubois.bootui.engine.safety.GatewayTrust;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuard;
-import io.github.jdubois.bootui.engine.safety.LocalhostGuardConfig;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuardDecision;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuardDecision.Allow;
 import io.github.jdubois.bootui.engine.safety.LocalhostGuardDecision.Reject;
@@ -17,12 +13,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,10 +21,11 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This Spring servlet filter is a thin binding over the framework-neutral
  * {@link LocalhostGuard}: it translates the {@link HttpServletRequest} and the BootUI configuration
- * into a {@link LocalhostGuardRequest} / {@link LocalhostGuardConfig}, asks the guard to
- * {@link LocalhostGuard#decide decide}, and renders the {@link LocalhostGuardDecision}. The access
- * policy itself (trusted-source / Host allow-list / cross-site-write defenses, their evaluation
- * order, and the canonical 403 messages) lives in the engine so the Quarkus adapter shares it.</p>
+ * into a {@link LocalhostGuardRequest} / {@link io.github.jdubois.bootui.engine.safety.LocalhostGuardConfig},
+ * asks the guard to {@link LocalhostGuard#decide decide}, and renders the {@link LocalhostGuardDecision}.
+ * The access policy itself (trusted-source / Host allow-list / cross-site-write defenses, their
+ * evaluation order, and the canonical 403 messages) lives in the engine so the Quarkus adapter shares
+ * it.</p>
  *
  * <p>The three defenses are bypassed entirely only when {@code bootui.allow-non-localhost=true}:</p>
  * <ol>
@@ -48,10 +39,12 @@ import org.slf4j.LoggerFactory;
  *       rejected on {@code Sec-Fetch-Site: cross-site} or an {@code Origin} host mismatch.</li>
  * </ol>
  *
- * <p>This binding owns the per-instance caches and side effects the guard intentionally does not:
- * the {@code bootui.trusted-proxies} parse cache, the resolve-once container-gateway snapshot, the
- * once-only "trusting container gateway" warning (emitted when a request is ultimately allowed via a
- * gateway), and the per-reason rejection logging.</p>
+ * <p>The per-instance caches and side effects the guard intentionally does not own (the
+ * {@code bootui.trusted-proxies} parse cache, the resolve-once container-gateway snapshot, and the
+ * once-only "trusting container gateway" warning) live in {@link LocalhostGuardConfigSupport}, shared
+ * with the WebFlux sibling {@code ReactiveLocalhostOnlyFilter} since none of that translation touches a
+ * servlet or reactive request type. This class keeps only the per-reason rejection logging, which does
+ * read the servlet request.</p>
  *
  * <p>BootUI is a developer tool, not a production endpoint, so we fail closed by default.</p>
  */
@@ -60,17 +53,7 @@ public class LocalhostOnlyFilter extends AbstractBootUiFilter {
     private static final Logger log = LoggerFactory.getLogger(LocalhostOnlyFilter.class);
 
     private final LocalhostGuard guard = new LocalhostGuard();
-
-    private volatile String[] parsedFrom;
-    private volatile List<CidrRange> trustedRanges = List.of();
-
-    private final ContainerGatewayDetector gatewayDetector;
-
-    private final Object gatewayLock = new Object();
-    private volatile boolean gatewayResolved = false;
-    private volatile boolean inContainer = false;
-    private volatile Set<InetAddress> containerGateways = Set.of();
-    private volatile boolean loggedTrustedGateway = false;
+    private final LocalhostGuardConfigSupport configSupport;
 
     public LocalhostOnlyFilter(BootUiProperties properties) {
         this(properties, new ContainerGatewayDetector());
@@ -78,7 +61,7 @@ public class LocalhostOnlyFilter extends AbstractBootUiFilter {
 
     LocalhostOnlyFilter(BootUiProperties properties, ContainerGatewayDetector gatewayDetector) {
         super(properties);
-        this.gatewayDetector = gatewayDetector;
+        this.configSupport = new LocalhostGuardConfigSupport(properties, gatewayDetector);
     }
 
     @Override
@@ -97,7 +80,7 @@ public class LocalhostOnlyFilter extends AbstractBootUiFilter {
                 request.getHeader("Origin"),
                 request.getHeader("Sec-Fetch-Site"));
 
-        LocalhostGuardDecision decision = guard.decide(guardRequest, buildConfig());
+        LocalhostGuardDecision decision = guard.decide(guardRequest, configSupport.buildConfig(log));
 
         if (decision instanceof Reject reject) {
             logRejection(reject, request);
@@ -106,63 +89,9 @@ public class LocalhostOnlyFilter extends AbstractBootUiFilter {
         }
 
         if (decision instanceof Allow allow && allow.trustedViaGateway()) {
-            warnTrustedGatewayOnce(allow.trustedGateway());
+            configSupport.warnTrustedGatewayOnce(log, allow.trustedGateway());
         }
         chain.doFilter(request, response);
-    }
-
-    /**
-     * Builds the per-request guard configuration. The container-gateway snapshot is resolved (and
-     * cached) lazily on the first request only when {@code bootui.trust-container-gateway} is not
-     * {@code OFF}, so an {@code OFF} deployment never touches {@code /proc} or DNS.
-     */
-    private LocalhostGuardConfig buildConfig() {
-        GatewayTrust gatewayTrust = toGatewayTrust(properties.getTrustContainerGateway());
-        boolean container;
-        Set<InetAddress> gateways;
-        if (gatewayTrust == GatewayTrust.OFF) {
-            container = false;
-            gateways = Set.of();
-        } else {
-            resolveGatewayOnce();
-            container = this.inContainer;
-            gateways = this.containerGateways;
-        }
-        String[] allowedHosts = properties.getAllowedHosts();
-        return new LocalhostGuardConfig(
-                properties.isAllowNonLocalhost(),
-                allowedHosts == null ? List.of() : Arrays.asList(allowedHosts),
-                trustedRanges(),
-                gatewayTrust,
-                container,
-                gateways);
-    }
-
-    private static GatewayTrust toGatewayTrust(Mode mode) {
-        if (mode == null) {
-            return GatewayTrust.OFF;
-        }
-        return switch (mode) {
-            case AUTO -> GatewayTrust.AUTO;
-            case ON -> GatewayTrust.ON;
-            case OFF -> GatewayTrust.OFF;
-        };
-    }
-
-    /**
-     * Emits the once-only operator warning that a container gateway is being trusted as
-     * loopback-equivalent. Mirrors the legacy message; it now fires when a request is actually
-     * allowed via the gateway (rather than the instant source trust is granted), which is invisible
-     * to behavior — no response status or body depends on it.
-     */
-    private void warnTrustedGatewayOnce(InetAddress gateway) {
-        if (loggedTrustedGateway) {
-            return;
-        }
-        loggedTrustedGateway = true;
-        log.warn(
-                "BootUI trusting auto-detected container gateway {} (/32) for loopback-equivalent access.",
-                gateway != null ? gateway.getHostAddress() : null);
     }
 
     private void logRejection(Reject reject, HttpServletRequest request) {
@@ -180,55 +109,6 @@ public class LocalhostOnlyFilter extends AbstractBootUiFilter {
             case CROSS_SITE_WRITE ->
                 log.warn("BootUI rejected cross-site {} request to {}", request.getMethod(), request.getRequestURI());
         }
-    }
-
-    /**
-     * Resolves and caches the container detection result and trusted gateways exactly once. Mirrors
-     * the lazy, double-checked caching used by {@link #trustedRanges()} so the lookups happen on the
-     * first relevant request rather than per request. The trusted set is the union of the route-table
-     * default gateway and any Docker Desktop gateway resolved from {@code gateway.docker.internal}.
-     */
-    private void resolveGatewayOnce() {
-        if (gatewayResolved) {
-            return;
-        }
-        synchronized (gatewayLock) {
-            if (gatewayResolved) {
-                return;
-            }
-            inContainer = gatewayDetector.isInContainer();
-            Set<InetAddress> gateways = new LinkedHashSet<>();
-            gatewayDetector.defaultGateway().ifPresent(gateways::add);
-            gateways.addAll(gatewayDetector.dockerDesktopGateways());
-            containerGateways = Set.copyOf(gateways);
-            gatewayResolved = true;
-        }
-    }
-
-    /**
-     * Returns the configured {@code bootui.trusted-proxies} ranges, parsing (and caching) them only
-     * when the configured array changes. Malformed entries are logged once and skipped.
-     */
-    private List<CidrRange> trustedRanges() {
-        String[] configured = properties.getTrustedProxies();
-        if (configured == parsedFrom) {
-            return trustedRanges;
-        }
-        List<CidrRange> parsed = new ArrayList<>();
-        if (configured != null) {
-            for (String entry : configured) {
-                CidrRange range = CidrRange.parse(entry);
-                if (range != null) {
-                    parsed.add(range);
-                } else if (entry != null && !entry.isBlank()) {
-                    log.warn("BootUI ignoring malformed bootui.trusted-proxies entry '{}'", entry);
-                }
-            }
-        }
-        List<CidrRange> immutable = List.copyOf(parsed);
-        trustedRanges = immutable;
-        parsedFrom = configured;
-        return immutable;
     }
 
     private void reject(HttpServletResponse response, String message) throws IOException {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceController.java
@@ -2,7 +2,6 @@ package io.github.jdubois.bootui.autoconfigure.sqltrace;
 
 import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
 import io.github.jdubois.bootui.autoconfigure.stream.BootUiChangeStream;
-import io.github.jdubois.bootui.core.ValueExposure;
 import io.github.jdubois.bootui.core.dto.SqlTraceRecordingRequest;
 import io.github.jdubois.bootui.core.dto.SqlTraceReport;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
@@ -26,12 +25,15 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
  * actions (gated by the panel access filter when the panel is read-only).
  * Parameter bindings are only surfaced when capture is enabled and value
  * exposure is not metadata-only.</p>
+ *
+ * <p>The trace/clear/recording business logic lives in {@link SqlTraceControllerSupport}, shared
+ * with the WebFlux sibling {@code ReactiveSqlTraceController} since none of it touches a servlet or
+ * reactive request/response type. This class keeps only the {@code @RestController} wiring, the SSE
+ * {@code /stream} endpoint, and the recorder-listener lifecycle.</p>
  */
 @RestController
 @RequestMapping("/bootui/api/sql-trace")
 public class SqlTraceController {
-
-    private static final String NOT_CONFIGURED = "SQL tracing is not configured";
 
     private final ObjectProvider<SqlTraceRecorder> recorderProvider;
     private final ObjectProvider<DataSource> dataSourceProvider;
@@ -74,32 +76,17 @@ public class SqlTraceController {
 
     @GetMapping
     public SqlTraceReport trace() {
-        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
-        if (recorder == null) {
-            return SqlTraceReport.unavailable(NOT_CONFIGURED);
-        }
-        return report(recorder);
+        return SqlTraceControllerSupport.trace(recorderProvider, exposure, dataSourceProvider);
     }
 
     @PostMapping("/clear")
     public SqlTraceReport clear() {
-        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
-        if (recorder == null) {
-            return SqlTraceReport.unavailable(NOT_CONFIGURED);
-        }
-        recorder.clear();
-        return report(recorder);
+        return SqlTraceControllerSupport.clear(recorderProvider, exposure, dataSourceProvider);
     }
 
     @PostMapping("/recording")
     public SqlTraceReport recording(@RequestBody(required = false) SqlTraceRecordingRequest request) {
-        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
-        if (recorder == null) {
-            return SqlTraceReport.unavailable(NOT_CONFIGURED);
-        }
-        boolean enabled = (request == null || request.enabled() == null) ? !recorder.isRecording() : request.enabled();
-        recorder.setRecording(enabled);
-        return report(recorder);
+        return SqlTraceControllerSupport.recording(recorderProvider, exposure, dataSourceProvider, request);
     }
 
     /**
@@ -109,24 +96,5 @@ public class SqlTraceController {
     @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter stream() {
         return changeStream.open();
-    }
-
-    private SqlTraceReport report(SqlTraceRecorder recorder) {
-        if (!recorder.hasWrappedDataSource()) {
-            return SqlTraceReport.unavailable(unavailableReason(recorder));
-        }
-        boolean exposeParameters =
-                recorder.isCaptureParameters() && exposure.valueExposure() != ValueExposure.METADATA_ONLY;
-        return recorder.report(exposeParameters);
-    }
-
-    private String unavailableReason(SqlTraceRecorder recorder) {
-        if (!recorder.isEnabled()) {
-            return "SQL tracing is disabled (set bootui.sql-trace.enabled=true in a trusted local profile).";
-        }
-        if (dataSourceProvider.getIfAvailable() == null) {
-            return "No DataSource bean is available";
-        }
-        return "No DataSource has been wrapped for tracing yet.";
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceControllerSupport.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceControllerSupport.java
@@ -1,0 +1,82 @@
+package io.github.jdubois.bootui.autoconfigure.sqltrace;
+
+import io.github.jdubois.bootui.autoconfigure.config.BootUiExposure;
+import io.github.jdubois.bootui.core.ValueExposure;
+import io.github.jdubois.bootui.core.dto.SqlTraceRecordingRequest;
+import io.github.jdubois.bootui.core.dto.SqlTraceReport;
+import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Shared read/clear/recording business logic for the BootUI SQL Trace panel, used by both the
+ * servlet {@code SqlTraceController} and the WebFlux {@code ReactiveSqlTraceController}. Both
+ * bindings expose the identical REST contract over the same framework-neutral
+ * {@link SqlTraceRecorder}, and none of this logic touches a servlet or reactive request/response
+ * type, so it is extracted once here rather than duplicated per transport. The transport-specific
+ * pieces (the {@code @RestController} wiring itself and the SSE {@code /stream} endpoint) stay in
+ * each controller.
+ */
+public final class SqlTraceControllerSupport {
+
+    private static final String NOT_CONFIGURED = "SQL tracing is not configured";
+
+    private SqlTraceControllerSupport() {}
+
+    public static SqlTraceReport trace(
+            ObjectProvider<SqlTraceRecorder> recorderProvider,
+            BootUiExposure exposure,
+            ObjectProvider<DataSource> dataSourceProvider) {
+        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
+        if (recorder == null) {
+            return SqlTraceReport.unavailable(NOT_CONFIGURED);
+        }
+        return report(recorder, exposure, dataSourceProvider);
+    }
+
+    public static SqlTraceReport clear(
+            ObjectProvider<SqlTraceRecorder> recorderProvider,
+            BootUiExposure exposure,
+            ObjectProvider<DataSource> dataSourceProvider) {
+        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
+        if (recorder == null) {
+            return SqlTraceReport.unavailable(NOT_CONFIGURED);
+        }
+        recorder.clear();
+        return report(recorder, exposure, dataSourceProvider);
+    }
+
+    public static SqlTraceReport recording(
+            ObjectProvider<SqlTraceRecorder> recorderProvider,
+            BootUiExposure exposure,
+            ObjectProvider<DataSource> dataSourceProvider,
+            SqlTraceRecordingRequest request) {
+        SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
+        if (recorder == null) {
+            return SqlTraceReport.unavailable(NOT_CONFIGURED);
+        }
+        boolean enabled = (request == null || request.enabled() == null) ? !recorder.isRecording() : request.enabled();
+        recorder.setRecording(enabled);
+        return report(recorder, exposure, dataSourceProvider);
+    }
+
+    private static SqlTraceReport report(
+            SqlTraceRecorder recorder, BootUiExposure exposure, ObjectProvider<DataSource> dataSourceProvider) {
+        if (!recorder.hasWrappedDataSource()) {
+            return SqlTraceReport.unavailable(unavailableReason(recorder, dataSourceProvider));
+        }
+        boolean exposeParameters =
+                recorder.isCaptureParameters() && exposure.valueExposure() != ValueExposure.METADATA_ONLY;
+        return recorder.report(exposeParameters);
+    }
+
+    private static String unavailableReason(SqlTraceRecorder recorder, ObjectProvider<DataSource> dataSourceProvider) {
+        if (!recorder.isEnabled()) {
+            return "SQL tracing is disabled (set bootui.sql-trace.enabled=true in a trusted local profile).";
+        }
+        if (dataSourceProvider.getIfAvailable() == null) {
+            return "No DataSource bean is available";
+        }
+        return "No DataSource has been wrapped for tracing yet.";
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyProvider;
 import java.io.File;
 import java.io.IOException;
@@ -57,9 +58,9 @@ final class DependencyCatalog implements DependencyProvider {
         } catch (IOException ex) {
             throw new IllegalStateException("Could not read Maven metadata from " + resource.getDescription(), ex);
         }
-        String groupId = blankToNull(properties.getProperty("groupId"));
-        String artifactId = blankToNull(properties.getProperty("artifactId"));
-        String version = blankToNull(properties.getProperty("version"));
+        String groupId = BlankStrings.blankToNullTrimmed(properties.getProperty("groupId"));
+        String artifactId = BlankStrings.blankToNullTrimmed(properties.getProperty("artifactId"));
+        String version = BlankStrings.blankToNullTrimmed(properties.getProperty("version"));
         if (groupId == null || artifactId == null || version == null) {
             return null;
         }
@@ -121,12 +122,5 @@ final class DependencyCatalog implements DependencyProvider {
             groupId.append(groupPath.getName(i));
         }
         return groupId.toString();
-    }
-
-    private String blankToNull(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return value.trim();
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityLogsController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/SecurityLogsController.java
@@ -6,7 +6,7 @@ import io.github.jdubois.bootui.autoconfigure.stream.BootUiChangeStream;
 import io.github.jdubois.bootui.core.dto.SecurityLogsReport;
 import io.github.jdubois.bootui.engine.security.CapturedSecurityEvent;
 import io.github.jdubois.bootui.engine.security.SecurityLogsService;
-import java.time.Instant;
+import io.github.jdubois.bootui.engine.support.BlankStrings;
 import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Map;
@@ -72,18 +72,22 @@ public class SecurityLogsController implements ApplicationListener<AuditApplicat
             return SecurityLogsReport.unavailable("No AuditEventRepository bean is available", maxLogs);
         }
 
-        List<CapturedSecurityEvent> events =
-                repository.find(blankToNull(principal), parseAfter(after), blankToNull(type)).stream()
-                        .map(SecurityLogsController::toCaptured)
-                        .toList();
+        List<CapturedSecurityEvent> events = repository
+                .find(
+                        BlankStrings.blankToNullTrimmed(principal),
+                        BlankStrings.parseInstant(after),
+                        BlankStrings.blankToNullTrimmed(type))
+                .stream()
+                .map(SecurityLogsController::toCaptured)
+                .toList();
         return securityLogsService.report(
                 events,
                 maxLogs,
                 exposure.maskSecrets(),
                 exposure.valueExposure(),
-                blankToNull(principal),
-                blankToNull(type),
-                parseAfter(after),
+                BlankStrings.blankToNullTrimmed(principal),
+                BlankStrings.blankToNullTrimmed(type),
+                BlankStrings.parseInstant(after),
                 offset,
                 limit);
     }
@@ -133,17 +137,5 @@ public class SecurityLogsController implements ApplicationListener<AuditApplicat
 
     private int maxLogs() {
         return securityLogsService.maxLogs(properties.getSecurityLogs().getMaxLogs());
-    }
-
-    private Instant parseAfter(String after) {
-        String value = blankToNull(after);
-        return value == null ? null : Instant.parse(value);
-    }
-
-    private String blankToNull(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return value.trim();
     }
 }

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -2,7 +2,9 @@
 import {apiFetch} from '../api.js'
 import {onMounted, ref, watch} from 'vue'
 import {panelProps, usePanelState} from '../utils/panelState.js'
+import {useFlashMessage} from '../utils/useFlashMessage.js'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
+import FlashBanner from './components/FlashBanner.vue'
 import ServerListFooter from './components/ServerListFooter.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
@@ -10,8 +12,7 @@ import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
 const filter = ref('')
-const message = ref(null)
-const messageType = ref('success')
+const {message, flash, clear} = useFlashMessage(3000)
 
 const {
   data,
@@ -37,7 +38,7 @@ const {
 
 async function changeLevel(logger, level) {
   if (readOnly.value) {
-    showMessage(readOnlyReason.value, 'warning')
+    flash(readOnlyReason.value, 'warning')
     return
   }
   const body = level ? {level} : {}
@@ -50,16 +51,8 @@ async function changeLevel(logger, level) {
     const updated = await res.json()
     const i = data.value.loggers.findIndex((l) => l.name === logger.name)
     if (i >= 0) data.value.loggers[i] = updated
-    showMessage(`Level updated for ${logger.name}`)
+    flash(`Level updated for ${logger.name}`)
   }
-}
-
-function showMessage(text, type = 'success') {
-  message.value = text
-  messageType.value = type
-  setTimeout(() => {
-    message.value = null
-  }, 3000)
 }
 
 const levelClass = (l) =>
@@ -81,7 +74,7 @@ watch(filter, scheduleReload)
   <div>
     <PanelHeader icon="bi-journal-text" title="Loggers" :error="error" />
     <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Logger levels are read-only.</ReadOnlyNotice>
-    <div v-if="message" :class="'alert-' + messageType" class="alert">{{ message }}</div>
+    <FlashBanner :message="message" @dismiss="clear" />
     <input v-model="filter" class="form-control mb-3" placeholder="Filter loggers by name…" />
     <p v-if="data" class="small text-muted">{{ matchedCount }} of {{ totalCount }} loggers matched</p>
     <div class="table-responsive">

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -51,7 +51,7 @@ async function changeLevel(logger, level) {
     const updated = await res.json()
     const i = data.value.loggers.findIndex((l) => l.name === logger.name)
     if (i >= 0) data.value.loggers[i] = updated
-    flash(`Level updated for ${logger.name}`)
+    flash(`Level updated for ${logger.name}`, 'success')
   }
 }
 

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -13,15 +13,7 @@ const panel = useAdvisorPanel(props, {
   scanErrorMessage: 'Unable to run memory checks',
   emptyScanPrompt: 'Run memory checks to see advisor findings',
   emptyNoFindings: 'No Memory Advisor findings',
-  countNoun: 'observation',
-  severityClasses: {
-    CRITICAL: 'text-bg-danger',
-    HIGH: 'text-bg-danger',
-    MEDIUM: 'text-bg-warning',
-    LOW: 'text-bg-info',
-    INFO: 'text-bg-secondary'
-  },
-  severityOrder: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO']
+  countNoun: 'observation'
 })
 
 const summary = computed(() => panel.report?.summary || null)


### PR DESCRIPTION
## What does this PR do?

Consolidates duplicated logic that had accumulated across the engine, both framework adapters (Spring MVC/Reactive, Quarkus), and the frontend into shared helpers. Pure refactoring, no behavior changes.

## Why is this change needed?

BootUI's dual-framework architecture (Spring + Quarkus adapters over one shared engine) grew panel-by-panel, and several near-identical blocks of logic had been copy-pasted along the way instead of shared:

- 9 advisor scanners each re-implemented severity ranking and detail-sanitizing inline (one had a latent bug: no fallback rank for unknown severities).
- Two Quarkus `Resource` classes had naive self-exclusion lambdas that silently ignored `bootui.monitoring.exclude-self`.
- `blankToNull`/`parseInstant`-style parsing was reimplemented across 11 files.
- Spring's MVC and Reactive adapters kept several controller/filter pairs as near-identical hand-maintained duplicates (localhost guard config, Exceptions, SQL Trace).
- `QuarkusPanelAvailability` had grown into a 14-branch if/else chain for panel availability + reasons, duplicated as two parallel chains.
- `BootUiQuarkusProcessor` had 13 `@BuildStep` methods sharing an identical capability-gating shape.
- A couple of frontend views predated composables (`useFlashMessage`, shared severity classes) that are now used by over a dozen other views.

None of this changes observable behavior, but every duplicate is a place a future fix could land in only one copy and quietly drift from the others. This PR was produced by a full-codebase audit for exactly this kind of opportunity, followed by the "quick wins plus medium" tranche of fixes.

Rebased onto the latest `main` (which had drifted with an unrelated Kafka panel addition); the rewritten `QuarkusPanelAvailability`/`BootUiQuarkusProcessor` conflicts were resolved by folding Kafka's new capability gate into the table-driven structure rather than reverting to if/else branches.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally (all 26 modules, both adapters, full conformance suite)
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (full Playwright e2e suite: 117 passed, 5 skipped Docker-profile tests)
- [x] Added or updated tests where applicable (new `BlankStrings` unit tests; existing suites continued to cover the relocated logic; caught and fixed a real bug via e2e where a migrated flash-message call defaulted to the wrong banner color)

## Screenshots (UI changes)

N/A - no visual or behavioral UI changes. `Loggers.vue`/`Memory.vue` now reuse existing shared composables (flash banner, severity classes) with identical rendered output.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes - N/A, no behavior changes
- [x] Public API kept backward compatible - no DTO, route, or config-key changes
- [x] No secrets, tokens, or local paths committed