### PR TITLE
Rename SCHEDULED_TASK Live Activity event type to SCHEDULED

### DIFF
--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ActivityEntryDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ActivityEntryDto.java
@@ -11,7 +11,7 @@ package io.github.jdubois.bootui.core.dto;
  * @param id stable identifier for the entry; for {@code REQUEST} entries this is the HTTP exchange
  *     id, which the per-request profiler endpoint accepts as {@code /activity/request/{id}}
  * @param type coarse activity type: {@code REQUEST}, {@code SQL}, {@code REST_CLIENT}, {@code EXCEPTION},
- *     {@code SECURITY}, {@code MAIL}, {@code CACHE}, {@code SCHEDULED_TASK}, or {@code MESSAGING}
+ *     {@code SECURITY}, {@code MAIL}, {@code CACHE}, {@code SCHEDULED}, or {@code MESSAGING}
  * @param timestamp epoch milliseconds when the activity occurred
  * @param severity {@code OK}, {@code SLOW}, {@code WARN}, or {@code ERROR}
  * @param summary one-line, already-masked human-readable summary
@@ -26,7 +26,7 @@ package io.github.jdubois.bootui.core.dto;
  * @param parentId id of the {@code REQUEST} entry this entry is correlated to (so the UI can nest it
  *     under that request), or {@code null} when the entry has no precise request correlation; for an
  *     {@code EXCEPTION} entry with no owning request, this may instead reference the {@code
- *     SCHEDULED_TASK} entry for the background execution that produced it
+ *     SCHEDULED} entry for the background execution that produced it
  * @param securedPrincipal for a {@code REQUEST} entry that ran as an authenticated principal — either
  *     from the request's own security context, or via a correlated audit/security event naming one —
  *     the principal it ran as; {@code null} when the request was not secured (no correlated event, or

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/scheduled/ScheduledTaskRunStore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/scheduled/ScheduledTaskRunStore.java
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Framework-neutral, in-memory, bounded ring buffer of {@code @Scheduled} task <em>executions</em>
- * (start/success/failure/duration), feeding the {@code SCHEDULED_TASK} entries in the Live Activity
+ * (start/success/failure/duration), feeding the {@code SCHEDULED} entries in the Live Activity
  * merged stream (see {@code docs/PLAN.md} §3.4). This is a companion to the existing, purely-static
  * {@link ScheduledTasksService} (which only lists task <em>definitions</em>): this store instead
  * captures what actually ran.

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/LiveActivityAssembler.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/LiveActivityAssembler.java
@@ -70,7 +70,7 @@ import java.util.Map;
  * there. The Quarkus adapter therefore always passes {@code cacheAvailable=false}, and
  * {@code cacheHitRatioPercent} renders {@code null} on that adapter, exactly as before.</p>
  *
- * <p><strong>Scheduled-task executions ({@code SCHEDULED_TASK} entries) do not correlate on trace id at
+ * <p><strong>Scheduled-task executions ({@code SCHEDULED} entries) do not correlate on trace id at
  * all</strong>, unlike every other signal above: a background {@code @Scheduled} job runs on its own thread
  * outside any HTTP request or distributed trace, so it never has a request to nest under (its own
  * {@code parentId} is always {@code null}). Instead, the relationship runs the other way — a captured
@@ -114,7 +114,7 @@ public final class LiveActivityAssembler {
     private static final String TYPE_SECURITY = "SECURITY";
     private static final String TYPE_MAIL = "MAIL";
     private static final String TYPE_CACHE = "CACHE";
-    private static final String TYPE_SCHEDULED_TASK = "SCHEDULED_TASK";
+    private static final String TYPE_SCHEDULED = "SCHEDULED";
 
     private static final String SEVERITY_OK = "OK";
     private static final String SEVERITY_SLOW = "SLOW";
@@ -587,7 +587,7 @@ public final class LiveActivityAssembler {
     }
 
     /**
-     * Build a {@code SCHEDULED_TASK} entry for a captured {@code @Scheduled} execution, mirroring Spring's
+     * Build a {@code SCHEDULED} entry for a captured {@code @Scheduled} execution, mirroring Spring's
      * {@code LiveActivityService.toScheduledTaskEntry}: there is no request to nest this entry itself under
      * (it runs on a background thread), so its own {@code parentId} is always {@code null}; a run that
      * threw is flagged {@code ERROR}, one slower than the shared request-slow threshold is flagged
@@ -608,7 +608,7 @@ public final class LiveActivityAssembler {
         String detail = run.success() ? null : run.exceptionClassName() + messageSuffix(run.message());
         return new ActivityEntryDto(
                 "sched-" + run.sequence(),
-                TYPE_SCHEDULED_TASK,
+                TYPE_SCHEDULED,
                 run.startTimestamp(),
                 severity,
                 run.runnable(),
@@ -672,7 +672,7 @@ public final class LiveActivityAssembler {
 
     /**
      * A captured {@code @Scheduled} execution reduced to what is needed to attach a correlated exception to
-     * it: its {@code SCHEDULED_TASK} entry id, its execution window, and the thread it ran on.
+     * it: its {@code SCHEDULED} entry id, its execution window, and the thread it ran on.
      */
     private record ScheduledTaskAnchor(String id, long start, long end, String thread) {
         boolean covers(long timestamp) {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/LiveActivityAssemblerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/LiveActivityAssemblerTests.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
  * entries under the owning REQUEST entry by setting their {@code parentId} (a uniquely-matched security
  * event additionally stamps {@code securedPrincipal} on that request); when no shared trace id is present
  * the feed stays flat; and an ambiguous trace id shared by more than one request never nests a child under
- * the wrong one nor stamps a principal. Also verifies the {@code SCHEDULED_TASK} fallback tier: an exception
+ * the wrong one nor stamps a principal. Also verifies the {@code SCHEDULED} fallback tier: an exception
  * with no matching request trace id nests under a captured {@code @Scheduled} execution instead, via a
  * serving-thread + time-window join, but only when the request/trace-id tier does not already claim it.
  */
@@ -894,7 +894,7 @@ class LiveActivityAssemblerTests {
                 false);
 
         ActivityEntryDto ok = entry(report, "sched-1");
-        assertThat(ok.type()).isEqualTo("SCHEDULED_TASK");
+        assertThat(ok.type()).isEqualTo("SCHEDULED");
         assertThat(ok.severity()).isEqualTo("OK");
         assertThat(ok.summary()).isEqualTo("com.example.Job#run");
         assertThat(ok.parentId()).isNull();
@@ -965,7 +965,7 @@ class LiveActivityAssemblerTests {
                 false);
 
         assertThat(report.entries()).hasSize(2);
-        assertThat(report.typeCounts()).containsEntry("REQUEST", 3).containsEntry("SCHEDULED_TASK", 1);
+        assertThat(report.typeCounts()).containsEntry("REQUEST", 3).containsEntry("SCHEDULED", 1);
     }
 
     @Test

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -1440,7 +1440,7 @@ class BootUiQuarkusProcessor {
      * {@code FailedExecution}, so it must be excluded from bean discovery when no scheduler extension is
      * present; the always-produced engine {@code ScheduledTaskRunStore} (see
      * {@link io.github.jdubois.bootui.quarkus.BootUiEngineProducer}) is neutral (no scheduler imports), so
-     * it wires unconditionally and the Live Activity panel simply renders no {@code SCHEDULED_TASK}
+     * it wires unconditionally and the Live Activity panel simply renders no {@code SCHEDULED}
      * entries when the observer is absent. Mirrors {@link #registerSecurityLogs} exactly; unlike
      * {@link #registerScheduledTasks} (the static-definitions capture, which needs no exclusion at all
      * since it imports no {@code io.quarkus.scheduler.*} type), this observer is the first runtime

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiEngineProducer.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiEngineProducer.java
@@ -202,7 +202,7 @@ public class BootUiEngineProducer {
      * §3.4). Always produced, mirroring the always-produced pattern the other optional-dependency
      * buffers use: when {@code quarkus-scheduler} is absent (or the capability-gated observer is
      * excluded), nothing ever calls {@link ScheduledTaskRunStore#record}, so the Live Activity panel
-     * simply renders no {@code SCHEDULED_TASK} entries. Capacity bounds memory
+     * simply renders no {@code SCHEDULED} entries. Capacity bounds memory
      * ({@code bootui.activity.max-scheduled-task-runs}, default 200, matching the Spring adapter's
      * {@code BootUiProperties.Activity.getMaxScheduledTaskRuns()} default) so the same config key works
      * identically on both adapters.

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -1849,7 +1849,7 @@ public class BootUiProperties {
 
         /**
          * Maximum number of recent {@code @Scheduled} task executions retained for the
-         * {@code SCHEDULED_TASK} entries in the activity stream.
+         * {@code SCHEDULED} entries in the activity stream.
          */
         private int maxScheduledTaskRuns = 200;
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityService.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/activity/LiveActivityService.java
@@ -65,7 +65,7 @@ public class LiveActivityService {
     static final String TYPE_SECURITY = "SECURITY";
     static final String TYPE_MAIL = "MAIL";
     static final String TYPE_CACHE = "CACHE";
-    static final String TYPE_SCHEDULED_TASK = "SCHEDULED_TASK";
+    static final String TYPE_SCHEDULED = "SCHEDULED";
 
     static final String SEVERITY_OK = "OK";
     static final String SEVERITY_SLOW = "SLOW";
@@ -636,7 +636,7 @@ public class LiveActivityService {
     }
 
     /**
-     * Maps a captured {@code @Scheduled} execution to a {@code SCHEDULED_TASK} entry. There is no request
+     * Maps a captured {@code @Scheduled} execution to a {@code SCHEDULED} entry. There is no request
      * to nest this entry itself under (it runs on a background thread), so its own {@code parentId} is
      * always {@code null}; a run that threw is flagged {@code ERROR}, one slower than the shared
      * request-slow threshold is flagged {@code SLOW}, otherwise {@code OK}. A failure is always summarized
@@ -657,7 +657,7 @@ public class LiveActivityService {
         String detail = run.success() ? null : run.exceptionClassName() + messageSuffix(run.message());
         return new ActivityEntryDto(
                 "sched-" + run.sequence(),
-                TYPE_SCHEDULED_TASK,
+                TYPE_SCHEDULED,
                 run.startTimestamp(),
                 severity,
                 run.runnable(),
@@ -896,7 +896,7 @@ public class LiveActivityService {
 
     /**
      * A captured {@code @Scheduled} execution reduced to what is needed to attach a correlated exception to
-     * it: its {@code SCHEDULED_TASK} entry id, its execution window, and the thread it ran on.
+     * it: its {@code SCHEDULED} entry id, its execution window, and the thread it ran on.
      */
     private record ScheduledTaskAnchor(String id, long start, long end, String thread) {}
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/scheduled/ScheduledTaskRunObservationHandler.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/scheduled/ScheduledTaskRunObservationHandler.java
@@ -24,7 +24,7 @@ import org.springframework.scheduling.support.ScheduledTaskObservationContext;
  *
  * <p>Only {@code @Scheduled} <em>method</em> tasks go through this observation; a manually registered
  * {@code Runnable}/{@code Trigger} task (via {@code SchedulingConfigurer}) is not observed and so does
- * not appear as a {@code SCHEDULED_TASK} activity entry — consistent with the static Scheduled Tasks
+ * not appear as a {@code SCHEDULED} activity entry — consistent with the static Scheduled Tasks
  * panel, which lists it as a task but with a generic runnable name.</p>
  */
 public final class ScheduledTaskRunObservationHandler implements ObservationHandler<ScheduledTaskObservationContext> {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveLiveActivityControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveLiveActivityControllerTests.java
@@ -379,7 +379,7 @@ class ReactiveLiveActivityControllerTests {
 
         assertThat(report.entries())
                 .singleElement()
-                .satisfies(entry -> assertThat(entry.type()).isEqualTo("SCHEDULED_TASK"));
+                .satisfies(entry -> assertThat(entry.type()).isEqualTo("SCHEDULED"));
         assertThat(report.sources()).contains("scheduled-tasks");
     }
 

--- a/bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -3506,7 +3506,7 @@ const activityReport = {
     },
     {
       id: 'act-sched-1',
-      type: 'SCHEDULED_TASK',
+      type: 'SCHEDULED',
       timestamp: nowMillis - 30000,
       severity: 'OK',
       summary: 'EchoScheduler.echo',
@@ -3521,7 +3521,7 @@ const activityReport = {
     },
     {
       id: 'act-sched-2',
-      type: 'SCHEDULED_TASK',
+      type: 'SCHEDULED',
       timestamp: nowMillis - 95000,
       severity: 'ERROR',
       summary: 'InventorySyncScheduler.sync',
@@ -3558,7 +3558,7 @@ const activityReport = {
     CACHE: 4,
     REST_CLIENT: 2,
     MAIL: 1,
-    SCHEDULED_TASK: 2,
+    SCHEDULED: 2,
     MESSAGING: 2
   },
   kpis: {

--- a/bootui-ui/src/main/frontend/src/utils/activityStream.js
+++ b/bootui-ui/src/main/frontend/src/utils/activityStream.js
@@ -160,7 +160,7 @@ export function deepLink(entry) {
       const needle = exceptionNeedle(entry.summary)
       return needle ? {path: '/exceptions', query: {q: needle}, label: 'Open in Exceptions'} : null
     }
-    case 'SCHEDULED_TASK': {
+    case 'SCHEDULED': {
       const needle = (entry.summary || '').trim()
       return needle ? {path: '/scheduled', query: {q: needle}, label: 'Open in Scheduled Tasks'} : null
     }

--- a/bootui-ui/src/main/frontend/src/utils/activityStream.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/activityStream.test.js
@@ -166,7 +166,7 @@ describe('deepLink', () => {
   })
 
   it('links a scheduled-task-run entry to Scheduled Tasks filtered by the runnable name', () => {
-    expect(deepLink({type: 'SCHEDULED_TASK', summary: 'com.example.jobs.NightlyJob.run'})).toEqual({
+    expect(deepLink({type: 'SCHEDULED', summary: 'com.example.jobs.NightlyJob.run'})).toEqual({
       path: '/scheduled',
       query: {q: 'com.example.jobs.NightlyJob.run'},
       label: 'Open in Scheduled Tasks'
@@ -174,8 +174,8 @@ describe('deepLink', () => {
   })
 
   it('returns null for a scheduled-task-run entry without a summary', () => {
-    expect(deepLink({type: 'SCHEDULED_TASK', summary: ''})).toBeNull()
-    expect(deepLink({type: 'SCHEDULED_TASK'})).toBeNull()
+    expect(deepLink({type: 'SCHEDULED', summary: ''})).toBeNull()
+    expect(deepLink({type: 'SCHEDULED'})).toBeNull()
   })
 
   it('links a cache entry to the Cache panel', () => {

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
@@ -161,7 +161,7 @@ describe('LiveActivity', () => {
   it('renders a scheduled-task-run entry with its own icon and links the KPI card to the Scheduled Tasks panel', async () => {
     const scheduledEntry = {
       id: 'sched-1',
-      type: 'SCHEDULED_TASK',
+      type: 'SCHEDULED',
       timestamp: 1700000000000,
       severity: 'ERROR',
       summary: 'com.example.jobs.NightlyJob.run',
@@ -194,7 +194,7 @@ describe('LiveActivity', () => {
             heapUsedBytes: 104857600,
             scheduledTaskFailureCount: 3
           },
-          typeCounts: {REQUEST: 0, SQL: 0, EXCEPTION: 0, SECURITY: 0, SCHEDULED_TASK: 1},
+          typeCounts: {REQUEST: 0, SQL: 0, EXCEPTION: 0, SECURITY: 0, SCHEDULED: 1},
           entries: [scheduledEntry]
         }),
         requestProfile()
@@ -205,7 +205,7 @@ describe('LiveActivity', () => {
     await flushPromises()
 
     const row = wrapper.get('tbody tr')
-    expect(row.text()).toContain('SCHEDULED_TASK')
+    expect(row.text()).toContain('SCHEDULED')
     expect(row.find('i.bi-clock-history').exists()).toBe(true)
 
     const scheduledLink = wrapper.findAll('router-link').find((a) => a.text().includes('Scheduled failures'))

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
@@ -23,7 +23,7 @@ import {
   nestEntries
 } from '../utils/activityStream.js'
 
-const TYPES = ['REQUEST', 'SQL', 'EXCEPTION', 'SECURITY', 'CACHE', 'SCHEDULED_TASK', 'MESSAGING', 'MAIL', 'REST_CLIENT']
+const TYPES = ['REQUEST', 'SQL', 'EXCEPTION', 'SECURITY', 'CACHE', 'SCHEDULED', 'MESSAGING', 'MAIL', 'REST_CLIENT']
 const SEVERITIES = ['OK', 'SLOW', 'WARN', 'ERROR']
 const FILTERS_STORAGE_KEY = 'bootui.activity.filters'
 const PERSISTENCE_DOCS_URL = 'https://www.julien-dubois.com/boot-ui/properties#live-activity-durable-persistence'
@@ -308,7 +308,7 @@ function typeIcon(type) {
       EXCEPTION: 'bi-exclamation-octagon',
       SECURITY: 'bi-shield-lock',
       CACHE: 'bi-lightning-charge',
-      SCHEDULED_TASK: 'bi-clock-history',
+      SCHEDULED: 'bi-clock-history',
       MESSAGING: 'bi-diagram-3',
       MAIL: 'bi-envelope'
     }[type] || 'bi-dot'

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -71,7 +71,7 @@ scheduler always fires — feeding a bounded in-memory buffer the same way the o
 producer/consumer activity, is described below.
 
 The stream merges nine signal types into one feed: requests (`REQUEST`), SQL statements (`SQL`), exceptions
-(`EXCEPTION`), security events (`SECURITY`), scheduled-task runs (`SCHEDULED_TASK`), Kafka producer/consumer activity
+(`EXCEPTION`), security events (`SECURITY`), scheduled-task runs (`SCHEDULED`), Kafka producer/consumer activity
 (`MESSAGING`), and captured emails (`MAIL`) on both adapters, plus — on the Spring servlet and WebFlux adapters only —
 outbound REST client calls (`REST_CLIENT`) and cache accesses (`CACHE`). Each row carries a timestamp, a type icon, a
 color-coded severity

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -46,7 +46,7 @@ The priorities for every item below remain unchanged:
   HTML previews sandboxed, and offers a per-message `.eml` download. Captured mail also feeds the Live Activity stream as
   a `MAIL` entry type.
 - Shipped all five §3.4 Live Activity event-type extensions, bringing the stream to nine merged entry types —
-  `REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `CACHE`, `SCHEDULED_TASK`, `MESSAGING`, `MAIL`, and `REST_CLIENT`: Cache
+  `REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `CACHE`, `SCHEDULED`, `MESSAGING`, `MAIL`, and `REST_CLIENT`: Cache
   operations, Scheduled Task runs, Kafka messaging (both adapters), Mail (backed by the Email panel above), and outbound
   `RestClient`/`RestTemplate`/`WebClient` capture (Spring only). Each keeps pass-through-by-default capture, nests under
   the originating request as a child event when a shared trace id/serving thread/time window is available, and reuses
@@ -170,7 +170,7 @@ Design constraints:
 ### 3.4 Live Activity — event types and correlation — Diagnostics ✅ Completed
 
 **Status: completed.** All five event-type extensions below have shipped. Live Activity now merges nine entry types —
-`REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `CACHE`, `SCHEDULED_TASK`, `MESSAGING`, `MAIL`, and `REST_CLIENT` — from
+`REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `CACHE`, `SCHEDULED`, `MESSAGING`, `MAIL`, and `REST_CLIENT` — from
 BootUI's existing in-memory buffers (see `docs/SPECIFICATION.md` §5.14.2). The original scope, prioritized by value
 versus new-instrumentation cost and drawn from the same comparable-dashboard benchmarks (Laravel Telescope, Symfony Web
 Profiler, .NET Aspire) already guiding this workstream, is retained below for reference.
@@ -178,7 +178,7 @@ Profiler, .NET Aspire) already guiding this workstream, is retained below for re
 Scope — new event types, roughly in priority order:
 
 - **Scheduled Task runs — implemented on both adapters.** Each `@Scheduled` method *execution* (start/success/failure,
-  duration, exception if any) is captured as a `SCHEDULED_TASK` entry, reusing the existing Scheduled Tasks panel's
+  duration, exception if any) is captured as a `SCHEDULED` entry, reusing the existing Scheduled Tasks panel's
   discovery/naming so a captured run and its static definition share the same identifier. On Spring, the framework's own
   Micrometer instrumentation (`ScheduledTaskObservationContext`, present since Spring Framework 6.1) is tapped via a
   `SchedulingConfigurer` bean that installs an `ObservationHandler` — no AOP proxying or bean wrapping needed — feeding a

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -334,7 +334,7 @@ drawer additionally lists the flagged group's call site(s) whenever `bootui.sql-
 | `bootui.activity.max-entries`                 | `200`   | Maximum number of merged stream entries returned per page after merging and sorting all sources.                 |
 | `bootui.activity.request-slow-threshold-ms`   | `1000`  | Duration in milliseconds above which a request is flagged as slow in the stream and KPI strip.                   |
 | `bootui.activity.n-plus-one-threshold`        | `5`     | Number of identical correlated `SELECT` statements above which a request is flagged with a potential N+1 pattern, both as a list-level badge and in its profile drawer. |
-| `bootui.activity.max-scheduled-task-runs`     | `200`   | Maximum number of captured `@Scheduled` method executions retained for `SCHEDULED_TASK` stream entries. Shared by both adapters: Spring feeds it from Micrometer's `ScheduledTaskObservationContext`, Quarkus from the CDI `SuccessfulExecution`/`FailedExecution` events (see `docs/PLAN.md` §3.4). |
+| `bootui.activity.max-scheduled-task-runs`     | `200`   | Maximum number of captured `@Scheduled` method executions retained for `SCHEDULED` stream entries. Shared by both adapters: Spring feeds it from Micrometer's `ScheduledTaskObservationContext`, Quarkus from the CDI `SuccessfulExecution`/`FailedExecution` events (see `docs/PLAN.md` §3.4). |
 
 #### Live Activity Kafka capture
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -722,7 +722,7 @@ Data sources:
   `FailedExecution` events the scheduler always fires after every execution (the single-instance `JobInstrumenter` SPI
   is unusable since `quarkus-opentelemetry` already claims it); the trigger's `getFireTime()` stands in for a start
   timestamp since these events only fire on completion. Only `@Scheduled` *method* tasks are observed this way, so a
-  manually registered `Runnable`/`Trigger` task does not produce a `SCHEDULED_TASK` entry, consistent with how the
+  manually registered `Runnable`/`Trigger` task does not produce a `SCHEDULED` entry, consistent with how the
   static Scheduled Tasks panel lists it with only a generic runnable name. Capped by
   `bootui.activity.max-scheduled-task-runs` (default 200, shared config key on both adapters), and self-filtered the
   same way the static task list is; on Quarkus the observer is additionally gated on the `SCHEDULER` capability (see
@@ -743,7 +743,7 @@ Data sources:
 
 Features:
 
-- Merged stream of `REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `SCHEDULED_TASK`, `MESSAGING`, `MAIL`, and (Spring
+- Merged stream of `REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `SCHEDULED`, `MESSAGING`, `MAIL`, and (Spring
   servlet/WebFlux only) `CACHE` and `REST_CLIENT` entries normalized to a common shape (timestamp, type, severity,
   one-line summary, optional duration and correlation id), sorted newest-first and capped by
   `bootui.activity.max-entries`. The `since` cursor allows incremental polling. Each entry also carries an optional
@@ -751,10 +751,10 @@ Features:
   method/path), so the client can nest correlated SQL, REST, exceptions, security events, cache accesses, and captured
   email chronologically under the request that produced them; the server list stays flat (KPIs, filters, and the
   sparkline are unaffected) and entries without a precise request correlation have a null `parentId` — a
-  `SCHEDULED_TASK` or `MESSAGING` entry always has a null `parentId` since neither has a single owning request (a
+  `SCHEDULED` or `MESSAGING` entry always has a null `parentId` since neither has a single owning request (a
   background-thread execution and an unattributed message flow, respectively). The one exception to "`parentId` always
   points at a `REQUEST`": an `EXCEPTION` entry with no owning HTTP request falls back to a serving-thread + time-window
-  join against captured `@Scheduled` executions, so a scheduled task's failure nests under its `SCHEDULED_TASK` entry
+  join against captured `@Scheduled` executions, so a scheduled task's failure nests under its `SCHEDULED` entry
   instead. A `CACHE` entry's summary is
   `"<HIT|MISS|PUT|EVICT|CLEAR> <cacheName>"`, its detail is `"key <hash>"` when a key was involved (omitted for
   whole-cache `CLEAR`), and a `MISS` is flagged `WARN` severity (all other operations `OK`). A `REQUEST` entry that was
@@ -764,7 +764,7 @@ Features:
   lock icon and a principal tag without opening the profiler. It also carries a `sqlNPlusOneSuspected` boolean, computed
   with the identical threshold/logic the per-request profiler uses below, so a request whose correlated SQL looks like
   an N+1 access pattern can be badged directly in the list without opening its profiler. The client also tints `REQUEST` rows on a graduated yellow-to-red latency heat scale (crossing
-  100, 200, 500, and 1000 ms) so slower requests stand out by how slow they are. A `SCHEDULED_TASK` entry is severity
+  100, 200, 500, and 1000 ms) so slower requests stand out by how slow they are. A `SCHEDULED` entry is severity
   `ERROR` on a thrown exception (with the exception class name and message surfaced as `detail`), `SLOW` when its
   duration meets the same slow-request threshold, otherwise `OK`, and clicking it deep-links into the Scheduled Tasks
   panel prefilled with its runnable name.
@@ -882,7 +882,7 @@ Acceptance criteria:
 - The "Use the existing datasource" switch takes effect immediately (no restart), returns a clear error when no
   `DataSource` is present or the request is unconfirmed, and is a no-op (not an error) when persistence is already
   active; it never blocks on a hung schema check indefinitely (the same bounded JDBC timeouts the startup path uses).
-- `SCHEDULED_TASK` capture is implemented on both adapters. Quarkus's scheduler
+- `SCHEDULED` capture is implemented on both adapters. Quarkus's scheduler
   (`io.quarkus.scheduler.Scheduler`) has no per-execution observability hook analogous to Spring's
   `ScheduledTaskObservationContext`; instead `QuarkusScheduledTaskRunRecorder` observes the CDI
   `SuccessfulExecution`/`FailedExecution` events the scheduler always fires, gated on the `SCHEDULER` capability


### PR DESCRIPTION
## What does this PR do?

Renames the Live Activity `SCHEDULED_TASK` event type to `SCHEDULED` across the wire contract, engine, both adapters, the frontend, and docs.

## Why is this change needed?

`SCHEDULED_TASK` was noticeably longer than every other entry type (`REQUEST`, `SQL`, `CACHE`, `MAIL`, etc.), making it stand out awkwardly in the Live Activity type column and filter dropdown. `SCHEDULED` is shorter and just as clear.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A - no visual/layout change, just a shorter label in the same spot (type filter dropdown, table column, icon map).

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [ ] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

### Notes for reviewers

- **Breaking change**: any external consumer of `/bootui/api/activity` filtering or matching on the literal string `"SCHEDULED_TASK"` (e.g. a saved filter, a script, or a custom dashboard) will need to switch to `"SCHEDULED"`. This is a local-only dev console with no external API contract, so no migration path is provided.
- Renamed the `TYPE_SCHEDULED_TASK` constants (Spring's `LiveActivityService`, engine's `LiveActivityAssembler`) to `TYPE_SCHEDULED` and updated the frontend filter list, type-icon map, and `deepLink` switch in `activityStream.js` / `LiveActivity.vue`.
- Left unchanged: internal identifiers that reference the "scheduled task" concept but aren't the wire value itself, e.g. `SCHEDULED_TASK_WINDOW_SLACK_MS`, `SCHEDULED_TASK_RUN_RECORDER_CLASS`, and the `bootui.activity.max-scheduled-task-runs` property key.