### PR TITLE
Fold Kafka panel into v1.11.0 release notes; fix panel-count drift

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -367,7 +367,7 @@ hide newer ones. Keep API, UI,
 - **Configuration**: Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings
 - **Database**: Database Connection Pools, SQL Trace, Spring Data, Flyway, Liquibase
 - **Security**: Spring Security, Security Logs
-- **Services**: Scheduled Tasks, REST Client, Cache, Email, AI Usage
+- **Services**: Scheduled Tasks, REST Client, Cache, Email, Kafka, AI Usage
 - **Diagnostics**: Traces, Log Tail, Exceptions, HTTP Exchanges, HTTP Probe
 - **Developer Tools**: MCP Server, DevTools, Dev Services, Copilot, Claude Code
 
@@ -396,13 +396,15 @@ hide newer ones. Keep API, UI,
   capability or detector is present:** Hibernate (Hibernate ORM), Scheduled Tasks (`quarkus-scheduler`), Cache
   (`quarkus-cache`), Flyway, Liquibase, Database Connection Pools (an Agroal datasource), Dev Services, Security Logs
   (`quarkus-security` + `quarkus.security.events.enabled`), SQL Trace (a datasource), REST API (app-owned JAX-RS
-  resources), Profile Diff (active profiles), GitHub (a detected repository), and Copilot / Claude Code (a detected
+  resources), Profile Diff (active profiles), GitHub (a detected repository), Email (`quarkus-mailer`), Kafka
+  (`quarkus-messaging-kafka` with a configured channel), and Copilot / Claude Code (a detected
   agent session directory). **Action-capable panels behave identically to Spring**, all behind the shared
   `LocalhostGuard` write floor: the advisor scans (Architecture, the Quarkus app advisor, Pentesting, Hibernate,
   Security, Memory, REST API, and Vulnerabilities/OSV), Heap Dump (capture/analyze/delete/download), Threads (download),
-  Loggers (set level), HTTP Probe, Cache (clear), Flyway (migrate/clean), Liquibase (update), Traces (clear), and the
-  MCP Server toggle. Only GraalVM, CRaC, Conditions, Startup Timeline, HTTP Sessions, Spring Data, Spring Security, and
-  DevTools stay deliberately unavailable, each with a panel-specific not-applicable reason. The
+  Loggers (set level), HTTP Probe, Cache (clear), Kafka (clear), Email (clear), Flyway (migrate/clean), Liquibase
+  (update), Traces (clear), and the MCP Server toggle. Only GraalVM, CRaC, Conditions, Startup Timeline, HTTP
+  Sessions, Spring Data, Spring Security, DevTools, and the standalone REST Client panel (Spring MVC only for now)
+  stay unavailable, most with a panel-specific not-applicable reason. The
   **Memory** advisor is the cleanest port: every scanner/rule/context class was already framework-neutral (JMX +
   `java.lang.management` only), so it relocated wholesale into the engine `MemoryScanner` (built via
   `MemoryScanner.create(ThreadDumpService, Clock)`) with the Spring `MemoryController` reduced to thin wiring and a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Added
-
-- **Kafka panel** — a dedicated, filterable view over the same producer/consumer capture that already feeds Live
-  Activity's `MESSAGING` entries: direction, topic, partition, offset, key hash, duration, and success/failure, with
-  the message value/payload never captured. Ships in the Services group just under Email, on both Spring and
-  Quarkus, reusing the existing `bootui.kafka.*` capture properties and adding `bootui.panels.kafka.*` panel toggles.
-- **Kafka support in the Spring sample app's `docker` profile** — a single-node KRaft `compose.yaml` service
-  (`apache/kafka`) plus a `spring-boot-starter-kafka` dependency, a seeded `orders.created` producer/listener pair,
-  and a **Send Kafka message** demo button, so the new Kafka panel has real produce/consume activity to show. The
-  `dev` profile stays Docker-free by excluding Kafka autoconfiguration.
-
 ## [1.11.0] - 2026-07-09
 
-Feature release headlined by two new dev-loop panels — **Email** and **REST Client Trace** — and **Live Activity
-growing from 4 to 9 merged signal types**. Also ships a ~2.4x faster Maven build.
+Feature release headlined by three new dev-loop panels — **Email**, **REST Client Trace**, and **Kafka** — and
+**Live Activity growing from 4 to 9 merged signal types**. Also ships a ~2.4x faster Maven build.
 
 ### Added
 
@@ -32,6 +21,9 @@ growing from 4 to 9 merged signal types**. Also ships a ~2.4x faster Maven build
 - **REST Client Trace panel** — captures outbound `RestClient`/`RestTemplate`/`WebClient` calls (method, host, path,
   status, duration), with slow-call and "chatty" (repeated-call) detection. Spring servlet adapter only for now
   (#544).
+- **Kafka panel** — a dedicated, filterable view over producer/consumer activity: direction, topic, partition,
+  offset, key hash, duration, and success/failure, with the message value/payload never captured. Ships on both
+  Spring and Quarkus (#550).
 - **Live Activity grows from 4 to 9 merged signal types**, adding cache accesses, scheduled-task runs, Kafka
   producer/consumer activity, outbound REST client calls, and captured email to the existing request/SQL/exception/
   security feed — each nested under its correlated request. Kafka and scheduled-task capture are also new on

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -167,9 +167,10 @@ extension of the mechanism `App.vue` already uses, so the same UI build renders 
 > behind the shared `LocalhostGuard` write floor: Heap Dump (capture/analyze/delete/download), Threads (download), the
 > advisor scans, Loggers (set level), HTTP Probe, Cache (clear), Flyway (migrate/clean), Liquibase (update), Traces
 > (clear), Email (clear), Kafka (clear), and the MCP Server toggle. Only **GraalVM**, **CRaC**, **Conditions**, **Startup Timeline**, **HTTP
-> Sessions**, **Spring Data**, **Spring Security**, and **DevTools** stay deliberately unavailable, each with a
-> panel-specific not-applicable reason. The per-panel `**Implemented**` markers below and `docs/FEATURES.md` carry the
-> authoritative, current per-platform detail.
+> Sessions**, **Spring Data**, **Spring Security**, and **DevTools** stay unavailable with a panel-specific
+> not-applicable reason (§5.5), plus **REST Client Trace**, which is Spring MVC only for now (see the Result note
+> below §5.5). The per-panel `**Implemented**` markers below and `docs/FEATURES.md` carry the authoritative, current
+> per-platform detail.
 
 ### 5.1 Ported as-is — framework-agnostic or same library (17)
 
@@ -308,7 +309,7 @@ No equivalent, low value, or superseded by Quarkus's own tooling:
   it niche), `DevTools` (**Implemented as `NOT_APPLICABLE`** — Quarkus has built-in dev-mode live reload, so there is no
   Spring-style DevTools restart/LiveReload to expose; the panel reports *not applicable* rather than *not yet*).
 
-**Result:** 40 of the 49 panels ship on Quarkus (17 ported as-is, 11 source-swapped, 9 capture-rebuilt, 3 replaced
+**Result:** 41 of the 50 panels ship on Quarkus (17 ported as-is, 11 source-swapped, 10 capture-rebuilt, 3 replaced
 with a Quarkus-native panel), and 9 are dropped: 8 as *not applicable* (GraalVM, CRaC, Conditions, Startup
 Timeline, HTTP Sessions, Spring Data, Spring Security, DevTools) and 1 (REST Client Trace) as Spring-servlet-only
 for now — no comparable runtime interception seam yet for the Quarkus-native REST client. The Overview dashboard

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -993,6 +993,39 @@ Acceptance criteria:
   Quarkus has no outbound REST client capture pipeline at all yet, so both the dedicated panel and the Live Activity
   `REST_CLIENT` entries are unavailable there (see `docs/WEBFLUX-SUPPORT.md` and `docs/QUARKUS-SUPPORT.md`).
 
+### 5.14.6 Kafka Panel
+
+Purpose: show producer/consumer activity over `KafkaTemplate`/`@KafkaListener` (Spring) or SmallRye Reactive
+Messaging Kafka channels (Quarkus) as its own dedicated, filterable view, over the same capture that already feeds
+Live Activity's `MESSAGING` entries.
+
+Data sources:
+
+- On Spring, `KafkaProducerCaptureBeanPostProcessor` and `KafkaConsumerCaptureBeanPostProcessor` wrap every
+  application-owned `KafkaTemplate` bean and `@KafkaListener` container factory, pass-through by default. On
+  Quarkus, `QuarkusKafkaProducerCapture`/`QuarkusKafkaConsumerCapture` implement SmallRye Reactive Messaging's
+  `OutgoingInterceptor`/`IncomingInterceptor` SPI. Both feed the same framework-neutral `KafkaActivityRecorder`
+  (bounded ring buffer in `bootui-engine`) that already backs Live Activity's `MESSAGING` entries — there is only
+  ever one buffer, so the dedicated panel and Live Activity are always in sync and clearing one clears both.
+
+Acceptance criteria:
+
+- Available whenever a `KafkaTemplate` bean is present on Spring, or the Quarkus `KAFKA` capability is present in a
+  non-production launch; otherwise the panel reports a clear unavailable reason instead of an empty list.
+- Only metadata is ever captured — direction (`PRODUCE`/`CONSUME`), topic, partition, offset, duration,
+  success/failure, consumer group id, and listener/channel id. The message value/payload is never captured at all,
+  regardless of configuration, since it is an arbitrary, potentially large application payload with no generic
+  masking strategy (unlike a SQL statement or a config value).
+- The message key is never retained verbatim: when `bootui.kafka.capture-key=true` (the default), a SHA-256 hash of
+  the key is captured and truncated to `bootui.kafka.max-key-length` hex characters; when disabled, the key is
+  `null`.
+- Messages are listed newest-first from a bounded ring buffer sized by `bootui.kafka.max-entries` (default 200,
+  oldest evicted first).
+- Clearing the buffer is gated by `bootui.panels.kafka.read-only`, consistent with every other clearable capture
+  panel; disabling capture entirely (`bootui.kafka.enabled=false`) stops both the panel and Live Activity's
+  `MESSAGING` entries, not just the dedicated view.
+- Ships on both Spring (servlet and WebFlux — the controller has no reactive-specific code) and Quarkus.
+
 ### 5.15 Profile Diff Panel
 
 Purpose: show which properties are contributed by active profile-specific property sources.

--- a/docs/WEBFLUX-SUPPORT.md
+++ b/docs/WEBFLUX-SUPPORT.md
@@ -9,7 +9,7 @@ reactive analog genuinely exists, and an honest "not yet ported" / "not applicab
 
 ## 2. Current status
 
-The WebFlux adapter serves the large majority of the panel surface — the same 49-panel manifest the servlet adapter
+The WebFlux adapter serves the large majority of the panel surface — the same 50-panel manifest the servlet adapter
 reports, minus the five panels that stay unavailable for stack reasons described below. **Every action-capable panel
 that is available behaves identically to the servlet adapter**, behind the same shared `LocalhostGuard` write floor:
 Loggers (set level), HTTP Probe, Cache (clear), Flyway (migrate/clean), Liquibase (update), Heap Dump
@@ -87,7 +87,7 @@ reactive binding (e.g. a `WebFilter` capturing into the same engine store) · `R
 capture layer replacing a servlet-only primitive · `Not yet ported` = deliberately deferred, no reactive
 implementation wired yet · `Not applicable` = no faithful reactive analog exists for this panel's concept.
 
-### 6.1 Ported as-is (36 panels)
+### 6.1 Ported as-is (37 panels)
 
 Bulk-imported from the servlet adapter's `@RestController`s with no code changes at all — confirming these
 controllers were already framework-neutral in practice, not just in the engine underneath them:
@@ -95,7 +95,10 @@ controllers were already framework-neutral in practice, not just in the engine u
 Overview · GitHub · Beans · Conditions · Configuration · Mappings · Health · Loggers · Startup Timeline · Spring Data ·
 Hibernate · Flyway · Liquibase · Database Connection Pools · Cache · Dev Services · Vulnerabilities · Scheduled Tasks ·
 HTTP Probe · Pentesting · Heap Dump · Architecture · REST API advisor · Profile Diff · Spring advisor[^spring-advisor-reactive] ·
-Live Memory · JVM Tuning · Metrics · DevTools · Traces · AI Usage · GraalVM · CRaC · Threads · Memory · Email.
+Live Memory · JVM Tuning · Metrics · DevTools · Traces · AI Usage · GraalVM · CRaC · Threads · Memory · Email · Kafka.
+`KafkaController` and its `KafkaTemplate`/`@KafkaListener` `BeanPostProcessor` capture pair have no
+`ConditionalOnWebApplication`/reactive-specific code at all, so the panel and its Live Activity `MESSAGING` capture
+work identically to the servlet adapter with zero adapter changes, the same as Email.
 
 [^spring-advisor-reactive]: The `SpringController` wiring itself needed no adapter change, but the ruleset it runs
     (`SpringScanner`/`SpringRules`) is reactive-aware internally: it detects a WebFlux `ReactiveWebApplicationContext`
@@ -203,23 +206,14 @@ OpenTelemetry SDK is present — see §7 for how this was found.
 - The servlet adapter's thread-based correlation (`LiveActivityCorrelator`) is not ported — it has no reactive
   equivalent.
 
-### 6.5 Not yet ported (3 panels)
+### 6.5 Not yet ported (4 panels)
 
 | Panel          | Reason                                                                                                                                                                                        |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Spring Security (raw panel, `spring-security`) | *"Not yet ported for Spring WebFlux: this advisor analyzes the servlet SecurityFilterChain/HttpSecurity configuration model, which has no reactive equivalent wired here yet (a ServerHttpSecurity/SecurityWebFilterChain ruleset is planned)."* `springSecurityAvailable()` now requires `!isReactive()` in addition to the pre-existing classpath/bean checks. |
+| Security advisor (`security`, grouped under Advisors — distinct from the raw Spring Security panel above, grouped under Security) | Also stays unavailable on WebFlux, but needed no dedicated reactive-aware string: `securityAvailable()` checks for a `FilterChainProxy` bean (the servlet security filter, `extends GenericFilterBean`), while a reactive Spring Security setup only ever registers a `WebFilterChainProxy` bean (`implements WebFilter`, package `org.springframework.security.web.server`) — two unrelated types in the same `spring-security-web` jar. The existing check already resolves `false` on WebFlux by construction, so the panel falls through to its pre-existing generic reasons ("Spring Security not on the classpath" / "No Spring Security filter chains are available") rather than a WebFlux-specific one. A reactive ruleset for this advisor is a genuinely new advisor (comparable in scope to the from-scratch Quarkus Security ruleset), deliberately deferred to a follow-up. |
 | MCP Server              | *"Not yet ported for Spring WebFlux: the MCP tool catalog is hard-wired to the servlet panel controllers, so it cannot yet resolve the reactive panel surface."* The JSON-RPC bridge itself (`McpDispatcher`) is already framework-neutral; only `BootUiMcpTools`' tool catalog needs a reactive-aware rewrite. |
 | REST Client       | *"REST Client is only available on the Spring MVC (servlet) adapter."* — the panel's availability check in `PanelsController` requires `!isReactive()` alongside the pre-existing `RestClientTraceRecorder` bean-presence check, so the dedicated full-detail panel (with its own filtering/paging over every captured call) is not wired into `BootUiReactiveAutoConfiguration`. **Capture itself is not stack-gated**, though: `BootUiEngineConfiguration`'s `WebClientCustomizer` attaches `RestClientTraceExchangeFilter` to every auto-configured `WebClient.Builder` regardless of web application type, so REST/WebClient calls are still captured into the shared `RestClientTraceRecorder` and still appear as `REST_CLIENT` entries in the Live Activity merge (§6.4) on WebFlux — only the standalone panel is unavailable. |
-
-Note: **the Security advisor** (`security`, grouped under Advisors — distinct from the raw **Spring Security**
-configuration panel above, grouped under Security) also stays unavailable on WebFlux, but needed no dedicated
-reactive-aware string: `securityAvailable()` checks for a `FilterChainProxy` bean (the servlet security filter,
-`extends GenericFilterBean`), while a reactive Spring Security setup only ever registers a `WebFilterChainProxy` bean
-(`implements WebFilter`, package `org.springframework.security.web.server`) — two unrelated types in the same
-`spring-security-web` jar. So the existing check already resolves `false` on WebFlux by construction, and the panel
-falls through to its pre-existing generic reasons ("Spring Security not on the classpath" / "No Spring Security
-filter chains are available") rather than a WebFlux-specific one. A reactive ruleset for this advisor is a genuinely
-new advisor (comparable in scope to the from-scratch Quarkus Security ruleset), deliberately deferred to a follow-up.
 
 ### 6.6 Not applicable (1 panel)
 


### PR DESCRIPTION
## Context

PR #546 prepared the v1.11.0 release notes (Email panel, REST Client Trace panel, Live Activity growing to 9 signal types, ~2.4x faster build). The Kafka panel (#550) merged shortly after and added its own `CHANGELOG.md` bullet under `## [Unreleased]` instead of the pending `## [1.11.0]` section, since no release had been cut yet.

This PR reconciles the release notes for Kafka and fixes panel-count drift discovered while re-auditing the docs.

## Changes

- **`CHANGELOG.md`** — moves the Kafka panel into `[1.11.0]`'s `### Added` section as a third headline panel alongside Email and REST Client Trace (50 panels total now). Drops the sample-app-only Kafka docker-profile bullet, consistent with how other demo-only changes were excluded from this release's changelog.
- **`docs/SPECIFICATION.md`** — adds the missing §5.14.6 "Kafka Panel" spec section (Purpose/Data sources/Acceptance criteria), matching the Email and REST Client Trace precedent that was already established.
- **`docs/QUARKUS-SUPPORT.md`** — fixes stale "40 of the 49 panels" arithmetic to "41 of the 50 panels" (the Kafka PR had already bumped the §5.3 header but not this summary line), and clarifies that REST Client Trace sits alongside the other Quarkus-unavailable panels in the status summary.
- **`docs/WEBFLUX-SUPPORT.md`** — adds the missing Kafka panel to the panel disposition breakdown (still said "49-panel manifest"), and fixes a **pre-existing** gap (unrelated to Kafka, found while re-tallying) where the Security advisor's WebFlux-unavailability was explained in prose but never counted in the section total (3 → 4 panels).
- **`.github/copilot-instructions.md`** — adds Kafka, and the previously-missing Email/REST Client Trace, to the Quarkus availability and action-capable panel lists.

## Validation

- `./mvnw -B -ntp spotless:check` — clean (docs-only change).
- Verified panel-count arithmetic against the conformance fixtures (`expected-panels-{spring,quarkus,webflux}.json`), which already show 50 panels including `kafka`.
- Verified via `grep`/code inspection that Kafka ships on Spring MVC, Spring WebFlux, and Quarkus with no reactive-specific gating (same "ported as-is" pattern as Email).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>