### PR TITLE
Trim javadoc boilerplate to reduce Maven Central release size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,16 @@
                         <doclint>none</doclint>
                         <failOnError>false</failOnError>
                         <quiet>true</quiet>
+                        <!--
+                            Trim static doclet boilerplate that scales with class count instead of actual
+                            documentation content, to help stay under Maven Central's new monthly publishing
+                            quota (see https://central.sonatype.org/publish/maven-central-publishing-limits/):
+                            noindex/notree/nohelp drop the master index, class-hierarchy tree, and per-page
+                            help link. No loss of per-class Javadoc content, just the generated index chrome.
+                        -->
+                        <noindex>true</noindex>
+                        <notree>true</notree>
+                        <nohelp>true</nohelp>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## What does this PR do?

Adds `noindex`/`notree`/`nohelp` to the shared `maven-javadoc-plugin` config so generated javadoc jars drop static doclet chrome (master index, class-hierarchy tree, per-page help link) that scales with class count rather than actual documentation content.

## Why is this change needed?

Maven Central now enforces per-organization monthly quotas on file count, release size, and release count (see [Maven Central publishing limits](https://central.sonatype.org/publish/maven-central-publishing-limits/)), and the usage dashboard has flagged this org for exceeding them. Auditing the release footprint showed javadoc jars are the single biggest content driver (~56% of total release bytes across `bootui-core`, `bootui-engine`, `bootui-spring-autoconfigure`, and `bootui-quarkus`). These three flags are a safe, no-content-loss way to shrink them; there is no public javadoc option to trim the JS search-index assets further without switching to placeholder javadoc, which was out of scope here.

Note: release *frequency* is actually the dominant factor in the quota complaint (this org tags far more releases per month than Sonatype's free-tier threshold), not per-release size. This PR only addresses the release-size dimension; it does not change release cadence.

Closes #

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

Also verified directly: rebuilt the four largest javadoc jars (core, engine, spring-autoconfigure, quarkus) with `-Prelease` before/after this change. Combined javadoc jar size dropped from ~6.26MB to ~5.08MB (~1.2MB / ~10.5% smaller), with no change in per-release file count and no loss of per-class documentation content (only generated index/tree/help pages removed).

## Screenshots (UI changes)

N/A - build/release config only, no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes - N/A, this is internal build config with no documented public behavior change
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed