### PR TITLE
docs: remove stale Laravel Telescope references

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1194,7 +1194,7 @@ capability hint, on applications that do not use it.
 
 ### Email
 
-The Email panel is BootUI's mail-watcher equivalent of Laravel Telescope: it intercepts the application's
+The Email panel captures outgoing application mail: it intercepts the application's
 `JavaMailSender` so every outgoing `send(...)` call is recorded into a bounded ring buffer *before* delegating to the
 real sender — pass-through by default, so application behaviour is unchanged. Captured messages list newest-first with
 sender, recipients, subject, and attachment count; opening a message shows the parsed `from`/`to`/`cc`/`bcc`, an HTML
@@ -1202,7 +1202,7 @@ preview rendered in a sandboxed iframe (scripts and same-origin access are both 
 and attachment metadata (name/type/size, never contents). Each message can be downloaded as a `.eml` file, and the whole
 buffer can be cleared.
 
-Recipients, subjects, and bodies are revealed by default — like Laravel Telescope's Mail watcher, and consistent with
+Recipients, subjects, and bodies are revealed by default — consistent with
 BootUI's other data-capture panels (HTTP Exchanges, SQL Trace), email content is not treated as a config secret, so it
 is not masked by the global `bootui.expose-values` flag. Teams that route real customer PII through a shared dev
 environment can opt into masking with `bootui.email.mask-content=true`, which reuses the same name-based `SecretMasker`
@@ -1332,7 +1332,7 @@ intended for quick local diagnosis without leaving the BootUI console.
 ### Exceptions
 
 The Exceptions panel captures exceptions thrown by the running application and groups repeated failures into a single
-entry with an occurrence count, in the spirit of tools like Laravel Telescope. BootUI records exceptions from two
+entry with an occurrence count. BootUI records exceptions from two
 complementary sources while it is active: a non-intrusive Spring MVC `HandlerExceptionResolver` that observes exceptions
 escaping web request handlers (capturing the request method, path, and handler), and a logback appender that picks up
 anything logged with a throwable from scheduled tasks, async work, or `log.error("…", ex)` calls. A failure that is both

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -9,7 +9,7 @@ database migrations, services, diagnostics, project health, and developer toolin
 Threads, HTTP Exchanges, Flyway, Liquibase, Hibernate Advisor, HTTP Sessions, GitHub, Security Advisor, and Overview
 scanner dashboard panels. This plan describes the **next merged feature workstream** after the `1.0.0` release: it keeps
 the remaining roadmap items and the one capture-oriented addition chosen to close the clearest gaps against comparable
-developer dashboards (Spring Boot Admin, Quarkus Dev UI, Laravel Telescope/Pulse, Phoenix LiveDashboard, .NET Aspire,
+developer dashboards (Spring Boot Admin, Quarkus Dev UI, Laravel Pulse, Phoenix LiveDashboard, .NET Aspire,
 Symfony Web Profiler) while staying inside BootUI's read-mostly, fail-closed safety model.
 
 The priorities for every item below remain unchanged:
@@ -41,10 +41,9 @@ The priorities for every item below remain unchanged:
   panel is read-only and reuses the existing masking, value-exposure, and panel-toggle model.
 - Shipped §3.3 (E-mail Viewer) as the **Email** panel: a `JavaMailSender` `BeanPostProcessor` captures every outgoing
   message pass-through by default (with an explicitly opt-in `bootui.email.dev-trap` mode), reveals recipients/subject/body
-  by default — decoupled from the global value-exposure model, matching Laravel Telescope's Mail watcher, with an
-  explicitly opt-in `bootui.email.mask-content` flag for teams that want the old masked-by-default behavior — renders
-  HTML previews sandboxed, and offers a per-message `.eml` download. Captured mail also feeds the Live Activity stream as
-  a `MAIL` entry type.
+  by default — decoupled from the global value-exposure model, with an explicitly opt-in `bootui.email.mask-content`
+  flag for teams that want the old masked-by-default behavior — renders HTML previews sandboxed, and offers a
+  per-message `.eml` download. Captured mail also feeds the Live Activity stream as a `MAIL` entry type.
 - Shipped all five §3.4 Live Activity event-type extensions, bringing the stream to nine merged entry types —
   `REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `CACHE`, `SCHEDULED`, `MESSAGING`, `MAIL`, and `REST_CLIENT`: Cache
   operations, Scheduled Task runs, Kafka messaging (both adapters), Mail (backed by the Email panel above), and outbound
@@ -144,8 +143,7 @@ Design constraints:
 **Status: completed.** Shipped as the **Email** panel (see `docs/FEATURES.md` → *Email*). The original scope and
 design constraints below are retained for reference.
 
-Laravel Telescope's mail watcher is a beloved feature with no built-in Spring equivalent. Captured outgoing mail (HTML
-preview plus raw source) is a high-value dev-loop aid.
+Captured outgoing mail (HTML preview plus raw source) is a high-value dev-loop aid with no built-in Spring equivalent.
 
 Scope:
 
@@ -160,7 +158,7 @@ Scope:
 Design constraints:
 
 - Available only when a `JavaMailSender` bean is present (e.g. `spring-boot-starter-mail`); otherwise fail closed.
-- Recipients, subjects, and bodies are revealed by default, like Laravel Telescope's Mail watcher and BootUI's other
+- Recipients, subjects, and bodies are revealed by default, like BootUI's other
   data-capture panels (HTTP Exchanges, SQL Trace) — email content is not a config secret, so masking is decoupled from
   the global value-exposure model. An opt-in `bootui.email.mask-content` flag applies the same name-based
   `SecretMasker` heuristic for teams routing real customer PII through a shared dev environment. HTML is rendered

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -413,7 +413,7 @@ buffering/flush, merge-for-reads, re-queue-on-failure, the flush guard, and mult
 | `bootui.panels.email.read-only`   | `false` | Disable the clear action while keeping captured messages visible.                                                     |
 | `bootui.email.max-entries`        | `100`   | Maximum number of captured messages retained; the oldest is evicted once full.                                        |
 | `bootui.email.dev-trap`           | `false` | On Spring, when `true`, captured messages are recorded but never actually handed to the real mail transport. On Quarkus, sent/not-sent instead reflects `quarkus.mailer.mock` because capture happens after send. |
-| `bootui.email.mask-content`       | `false` | When `true`, mask recipients/subject/body (like Configuration's secret masking) unless `bootui.expose-values=FULL`. Email content is not a config secret, so BootUI reveals it by default (matching Laravel Telescope's Mail watcher); enable this for teams that route real customer PII through a shared dev environment. |
+| `bootui.email.mask-content`       | `false` | When `true`, mask recipients/subject/body (like Configuration's secret masking) unless `bootui.expose-values=FULL`. Email content is not a config secret, so BootUI reveals it by default; enable this for teams that route real customer PII through a shared dev environment. |
 
 ### Kafka
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -938,8 +938,8 @@ Acceptance criteria:
 
 ### 5.14.4 Email Panel
 
-Purpose: capture outgoing application email for local inspection, mirroring Laravel Telescope's mail watcher — a
-high-value dev-loop aid with no built-in Spring equivalent.
+Purpose: capture outgoing application email for local inspection — a high-value dev-loop aid with no built-in Spring
+equivalent.
 
 Data sources:
 


### PR DESCRIPTION
## What does this PR do?

Removes outdated Laravel Telescope comparisons from `docs/` where the Email/Exceptions panels were described as mimicking Telescope's behavior, while keeping the reference where it's a legitimate prior-art/inspiration mention.

## Why is this change needed?

Several docs described the Email and Exceptions panels as "equivalent to" or "in the spirit of" Laravel Telescope's watchers. This framing was stale/inaccurate for how those panels are described elsewhere, so the behavior-comparison mentions were reworded to describe what BootUI actually does, without leaning on the Telescope comparison.

Laravel Telescope (and Pulse) are kept in the two "comparable dashboards" lists (`SPECIFICATION.md`'s intro and `PLAN.md`'s workstream benchmarks) since those are legitimate prior-art references this project was inspired by / benchmarked against, not behavior claims.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

This is a docs-only change (no code, no build/test impact).

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed