### PR TITLE
Release workflow: fix gpg.passphrase warning, Central-publishing leak, and Javadoc links

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,10 @@ jobs:
           done
 
           if [[ "$SKIP_BUILD" != "true" ]]; then
-            ./mvnw -B -ntp -Prelease clean verify -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
+            # No -Dgpg.passphrase here: that user property is deprecated by maven-gpg-plugin
+            # ("may leak sensitive information"). The plugin already reads the passphrase from
+            # the MAVEN_GPG_PASSPHRASE env var above (its passphraseEnvName default) instead.
+            ./mvnw -B -ntp -Prelease clean verify
           fi
 
           echo "Prepared release $TAG (version $VERSION) in the working tree; deferring the commit, tag, and push until the artifacts are verified on Maven Central."
@@ -211,9 +214,11 @@ jobs:
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |
+          # No -Dgpg.passphrase here: that user property is deprecated by maven-gpg-plugin
+          # ("may leak sensitive information"). The plugin already reads the passphrase from
+          # the MAVEN_GPG_PASSPHRASE env var above (its passphraseEnvName default) instead.
           ./mvnw -B -ntp -Prelease clean deploy \
-            -Dcentral.autoPublish="${CENTRAL_AUTO_PUBLISH}" \
-            -Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"
+            -Dcentral.autoPublish="${CENTRAL_AUTO_PUBLISH}"
 
       - name: Wait for Maven Central availability
         if: env.CENTRAL_AUTO_PUBLISH == 'true'


### PR DESCRIPTION
## Problem 1: deprecated `gpg.passphrase` warning

The release workflow run at https://github.com/jdubois/boot-ui/actions/runs/29035640782/job/86179685410 logged:

```
Warning: Parameter 'passphrase' (user property 'gpg.passphrase') is deprecated: Do not use this configuration, it may leak sensitive information. Rely on gpg-agent or env variables instead.
```

**Root cause:** Both Maven invocations that sign artifacts (`clean verify` in "Prepare release version" and `clean deploy` in "Publish to Maven Central") passed `-Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"`. Setting the `gpg.passphrase` user property on the command line is exactly what `maven-gpg-plugin`'s deprecated `passphrase` parameter binds to, so Maven logs the warning during plugin parameter binding regardless of whether the value is ultimately used. Checking `AbstractGpgMojo.newSigner` confirms the passphrase resolution order: the `MAVEN_GPG_PASSPHRASE` env var (non-deprecated, checked first) always wins over the deprecated `passphrase` parameter — since both steps already export `MAVEN_GPG_PASSPHRASE`, the `-D` flag was redundant and the sole source of the warning.

**Fix:** removed `-Dgpg.passphrase="${MAVEN_GPG_PASSPHRASE}"` from both `mvn` invocations in `.github/workflows/release.yml`. No functional change, warning eliminated.

## Problem 2: sample/test artifacts silently published to Maven Central

Auditing the rest of that release log surfaced a real functional bug, not just a cosmetic warning: `central-publishing-maven-plugin` does **not** honor `maven.deploy.skip` and has no working `<skip>` parameter of its own (the pre-existing `<skip>${maven.deploy.skip}</skip>` config only produced the "unknown parameter 'skip'" warning seen ~26 times in the log — a complete no-op). The plugin auto-injects its "publish" goal onto the `deploy` phase via `<extensions>true</extensions>`, entirely independent of `maven-deploy-plugin`, so it runs regardless of `maven.deploy.skip`.

Confirmed live and publicly downloadable on Maven Central despite all declaring `maven.deploy.skip=true`:
- `bootui-spring-sample-app` (113MB fat jar)
- `bootui-spring-webflux-sample-app` (60MB fat jar)
- `bootui-conformance`
- `bootui-quarkus-sample-app`
- all 12 `bootui-quarkus-integration-tests` submodules

**Fix:** re-declare the plugin's auto-injected execution id (`injected-central-publishing`) with `<phase>none</phase>` in each of the 18 affected module poms — the documented way to disable it per-module, since the plugin has no native skip mechanism. Also removed the no-op `<skip>` config from the root pom and corrected the misleading comment above it.

**Verification:** `mvn help:effective-pom -Prelease` shows `bootui-core` (should publish) resolving to `<phase>deploy</phase>`, while all 18 patched modules resolve to `<phase>none</phase>`. `./mvnw -Prelease validate` and `compile` pass reactor-wide, including the JDK-gated `hibernate` integration-tests module (validated standalone).

## Problem 3: broken Javadoc references

The same log audit turned up Javadoc warnings during the release's `javadoc:jar` step. Running the goal directly (rather than just grepping the log) found 6 total, not the 3 initially visible:

- `QuarkusHealthGuidance`: bare `{@link #member}` refs qualified with the `HealthGuidance` class name (they're record components of the imported type, not members of this class).
- `BootUiHibernateStatementInspector`, `QuarkusKafkaConsumerCapture`, `QuarkusKafkaProducerCapture`: `io.quarkus.arc.deployment.ExcludedTypeBuildItem` is a build-time-only type never on these runtime modules' javadoc classpath, so `{@linkplain}` can never resolve it — switched to `{@code}`, matching each file's existing convention for other out-of-classpath references.
- `ReactiveOtelTraceIdProvider`: `HttpExchangeTraceRegistry` is an unimported cross-package class; switched `{@link}` to `{@code}` to match five sibling references in the same javadoc paragraph.
- `RestClientTraceGrouping`: `{@link RestClientTraceRecorder#topCalls()}` referenced a no-arg overload that doesn't exist; corrected to the actual two-arg signature with a fully-qualified `ValueExposure` (unimported here).

**Verification:** `mvn javadoc:jar` across the full reactor now reports zero warnings (previously 6).

## Checks run

- `./mvnw -B -ntp -Prelease validate` — reactor-wide, BUILD SUCCESS (JDK-gated `hibernate` module validated standalone)
- `./mvnw -B -ntp -Prelease compile` — reactor-wide, BUILD SUCCESS
- `./mvnw -B -ntp -Prelease javadoc:jar` — reactor-wide, zero warnings
- `./mvnw -B -ntp spotless:apply` / `spotless:check` — clean, no changes needed
- `mvn help:effective-pom -Prelease` diffing `bootui-core` vs. patched modules — confirms the fix resolves correctly

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>