### PR TITLE
Release workflow: retry push with rebase on non-fast-forward

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,8 +349,34 @@ jobs:
             echo "Project files already declare the released version; tagging current HEAD."
           fi
 
+          # The Maven Central publish + availability wait + smoke test steps above can take
+          # tens of minutes - long enough for another PR to merge into $GITHUB_REF_NAME while
+          # this job runs, which would otherwise reject this push as a non-fast-forward. Retry
+          # by rebasing onto the latest remote tip instead of failing outright: the release
+          # commit only touches version-specific files (pom.xml, README.md, docs/SETUP.md,
+          # package.json/-lock.json), so an unrelated concurrent merge is expected to rebase
+          # cleanly. A genuine conflict (e.g. a second release racing this one) still fails loudly.
+          attempt=1
+          max_attempts=5
+          while ! git push origin "HEAD:$GITHUB_REF_NAME"; do
+            if (( attempt >= max_attempts )); then
+              echo "::error::Failed to push the release commit to $GITHUB_REF_NAME after $max_attempts attempts (another merge kept landing on $GITHUB_REF_NAME)."
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+            echo "Push rejected: $GITHUB_REF_NAME advanced during the release. Rebasing onto the latest origin/$GITHUB_REF_NAME and retrying (attempt $attempt/$max_attempts)."
+            sleep 5
+            git fetch origin "$GITHUB_REF_NAME"
+            if ! git rebase FETCH_HEAD; then
+              git rebase --abort
+              echo "::error::Rebasing the release commit onto origin/$GITHUB_REF_NAME hit a conflict; resolve manually and re-run the release."
+              exit 1
+            fi
+          done
+
+          # Tag after the push succeeds so the tag points at the commit that actually landed on
+          # $GITHUB_REF_NAME (a rebase above would have changed the release commit's SHA).
           git tag -a "$TAG" -m "Release $TAG"
-          git push origin "HEAD:$GITHUB_REF_NAME"
           git push origin "$TAG"
 
       - name: Redeploy documentation site


### PR DESCRIPTION
## Problem

The [v1.11.0 release run](https://github.com/jdubois/boot-ui/actions/runs/29035640782/job/86179685410) failed at the final **"Commit, tag, and push release"** step:

```
To https://github.com/jdubois/boot-ui
 ! [rejected]          HEAD -> main (fetch first)
error: failed to push some refs to 'https://github.com/jdubois/boot-ui'
```

Root cause: the job checked out `main` at `75206ccc`, then spent ~27 minutes running `versions:set`, the release build, the Maven Central deploy, the up-to-45-minute availability wait, and the published-artifact smoke test. During that window, two unrelated PRs (#557, #558) merged into `main`, so the final `git push origin HEAD:main` was rejected as non-fast-forward.

Net effect: **v1.11.0 was already live on Maven Central** (verified all artifacts return 200 from `repo1.maven.org`), but `main` had no release commit and no `v1.11.0` tag, and the docs site was never redeployed with it.

## Fix

`.github/workflows/release.yml`: the push now retries (up to 5 attempts) by fetching and rebasing onto the latest remote tip instead of failing outright on a non-fast-forward push. The release commit only touches version-specific files (`pom.xml`, `README.md`, `docs/SETUP.md`, `package.json`/`-lock.json`), so an unrelated concurrent merge is expected to rebase cleanly; a genuine conflict (e.g. two releases racing) still fails loudly. Tag creation moved to *after* the push succeeds so the tag always points at the commit that actually landed on the branch (a rebase changes the release commit's SHA).

## Recovery performed

Since Maven Central already had v1.11.0 published, I manually completed the missing git bookkeeping instead of re-running the whole pipeline (which would likely fail trying to redeploy an already-published version): reproduced the exact version bump (`versions:set` + doc/npm version replacements) on top of current `main`, confirmed it matched the original attempt byte-for-byte (36 files changed, 51 insertions(+), 51 deletions(-)), then committed, tagged `v1.11.0`, and pushed both. Also triggered the `pages.yml` docs redeploy, which completed successfully.

`main` is now in sync with what's live on Maven Central.