### PR TITLE
Enforce GitHub Actions reference policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,7 +66,10 @@ updates:
           - '@playwright/*'
           - 'prettier'
 
+  # Trusted major tags receive compatible updates automatically; Dependabot
+  # proposes new majors and new release SHAs for immutable references.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/scripts/check-action-references.sh
+++ b/.github/scripts/check-action-references.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly WORKFLOW_DIRECTORY=".github/workflows"
+readonly ACTION_DIRECTORY=".github/actions"
+
+is_trusted_action() {
+  case "$1" in
+    actions/checkout | \
+      actions/configure-pages | \
+      actions/deploy-pages | \
+      actions/download-artifact | \
+      actions/setup-java | \
+      actions/setup-node | \
+      actions/upload-artifact | \
+      actions/upload-pages-artifact | \
+      docker/build-push-action | \
+      docker/login-action | \
+      docker/metadata-action | \
+      docker/setup-buildx-action | \
+      github/codeql-action)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+files=()
+
+add_file() {
+  local file="$1"
+  if [[ ! -r "$file" ]]; then
+    printf 'Cannot read action-reference policy input: %s\n' "$file" >&2
+    exit 2
+  fi
+  files[${#files[@]}]="$file"
+}
+
+discover_files() {
+  local directory="$1"
+  shift
+
+  [[ -d "$directory" ]] || return 0
+
+  while IFS= read -r file; do
+    add_file "$file"
+  done < <(find "$directory" -type f "$@" -print | LC_ALL=C sort)
+}
+
+if [[ $# -gt 0 ]]; then
+  for file in "$@"; do
+    add_file "$file"
+  done
+else
+  discover_files "$WORKFLOW_DIRECTORY" \( -name '*.yml' -o -name '*.yaml' \)
+  discover_files "$ACTION_DIRECTORY" \( -name 'action.yml' -o -name 'action.yaml' \)
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  printf 'No workflow or composite-action files found.\n' >&2
+  exit 2
+fi
+
+errors=0
+reference_count=0
+
+report_error() {
+  local file="$1"
+  local line_number="$2"
+  local message="$3"
+
+  printf '%s:%s: %s\n' "$file" "$line_number" "$message" >&2
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    printf '::error file=%s,line=%s::%s\n' "$file" "$line_number" "$message" >&2
+  fi
+  errors=$((errors + 1))
+}
+
+for file in "${files[@]}"; do
+  line_number=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+
+    if [[ ! "$line" =~ ^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*(.*)$ ]]; then
+      continue
+    fi
+
+    reference_count=$((reference_count + 1))
+    raw_reference="${BASH_REMATCH[2]}"
+    version_comment=""
+
+    if [[ "$raw_reference" == *"#"* ]]; then
+      version_comment="${raw_reference#*#}"
+      raw_reference="${raw_reference%%#*}"
+    fi
+
+    reference="$(trim "$raw_reference")"
+    version_comment="$(trim "$version_comment")"
+
+    case "$reference" in
+      \"*\")
+        reference="${reference:1:${#reference}-2}"
+        ;;
+      \'*\')
+        reference="${reference:1:${#reference}-2}"
+        ;;
+    esac
+
+    if [[ "$reference" == ./* ]]; then
+      continue
+    fi
+
+    if [[ "$reference" != *@* ]]; then
+      report_error "$file" "$line_number" "Remote action reference '$reference' must include an @ref."
+      continue
+    fi
+
+    action_path="${reference%@*}"
+    action_ref="${reference##*@}"
+
+    if [[ "$action_path" != */* || -z "$action_ref" ]]; then
+      report_error "$file" "$line_number" "Remote action reference '$reference' is malformed."
+      continue
+    fi
+
+    action_owner="${action_path%%/*}"
+    action_remainder="${action_path#*/}"
+    action_repository="${action_remainder%%/*}"
+
+    if [[ -z "$action_owner" || -z "$action_repository" ]]; then
+      report_error "$file" "$line_number" "Remote action reference '$reference' is malformed."
+      continue
+    fi
+
+    action_name="$action_owner/$action_repository"
+
+    if is_trusted_action "$action_name"; then
+      if [[ ! "$action_ref" =~ ^v[0-9]+$ ]]; then
+        report_error "$file" "$line_number" \
+          "Trusted action '$action_name' must use a major-version tag such as @v4; found @$action_ref."
+      fi
+      continue
+    fi
+
+    if [[ ! "$action_ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+      report_error "$file" "$line_number" \
+        "Non-allowlisted action '$action_name' must use a full 40-character commit SHA."
+      continue
+    fi
+
+    if [[ ! "$version_comment" =~ ^v[0-9]+([.][0-9]+){0,2}([.-][0-9A-Za-z]+)*$ ]]; then
+      report_error "$file" "$line_number" \
+        "SHA-pinned action '$action_name' must have an inline release comment such as '# v1.2.3'."
+    fi
+  done < "$file"
+done
+
+if [[ $errors -gt 0 ]]; then
+  printf 'GitHub Action reference policy failed with %s error(s).\n' "$errors" >&2
+  exit 1
+fi
+
+printf 'GitHub Action reference policy passed for %s reference(s) across %s file(s).\n' \
+  "$reference_count" "${#files[@]}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: Check GitHub Action references
+        run: bash .github/scripts/check-action-references.sh
+
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
@@ -82,7 +85,7 @@ jobs:
 
       - name: Publish Java test report
         if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: Java tests (Surefire)
           path: '**/target/surefire-reports/TEST-*.xml'
@@ -92,7 +95,7 @@ jobs:
 
       - name: Publish frontend unit test report
         if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: Frontend unit tests (Vitest)
           path: bootui-ui/src/main/frontend/test-results/vitest-junit.xml
@@ -102,7 +105,7 @@ jobs:
 
       - name: Publish end-to-end test report
         if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: End-to-end tests (Playwright)
           path: bootui-spring-sample-app/e2e/test-results/junit/results.xml
@@ -112,7 +115,7 @@ jobs:
 
       - name: Publish WebFlux end-to-end test report
         if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: WebFlux end-to-end tests (Playwright)
           path: bootui-spring-sample-app/e2e/test-results-webflux/junit/results.xml
@@ -222,7 +225,7 @@ jobs:
 
       - name: Publish Quarkus end-to-end test report
         if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
           name: Quarkus end-to-end tests (Playwright)
           path: bootui-quarkus-sample-app/e2e/test-results/junit/results.xml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,32 @@ Use Prettier for the Vue app and Playwright tests:
 (cd bootui-spring-sample-app/e2e && npm run format)
 ```
 
+## GitHub Actions dependencies
+
+Remote GitHub Actions default to a full 40-character commit SHA with an inline release comment:
+
+```yaml
+uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+```
+
+The following explicitly trusted actions may instead use a mutable major-version tag:
+
+- GitHub: `actions/checkout`, `actions/configure-pages`, `actions/deploy-pages`, `actions/download-artifact`,
+  `actions/setup-java`, `actions/setup-node`, `actions/upload-artifact`, `actions/upload-pages-artifact`, and
+  `github/codeql-action`
+- Docker: `docker/build-push-action`, `docker/login-action`, `docker/metadata-action`, and
+  `docker/setup-buildx-action`
+
+New remote actions remain SHA-pinned unless this allowlist is deliberately extended. Local actions continue to use
+relative paths. Dependabot checks action references weekly: major tags receive compatible updates automatically,
+Dependabot proposes new major tags, and SHA-pinned actions receive pull requests for newer release SHAs.
+
+Run the policy check locally with:
+
+```bash
+bash .github/scripts/check-action-references.sh
+```
+
 ## Run the sample app
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Enforces an explicit trust-based policy for GitHub Action references: approved GitHub and Docker actions use mutable major tags, while all other remote actions require a full commit SHA and release comment.

It adds an early CI policy check for workflows and composite actions, records the trusted allowlist in `CONTRIBUTING.md`, keeps `dorny/test-reporter` pinned to the v3.0.0 release SHA, and clarifies weekly Dependabot maintenance.

## Why is this change needed?

The previous references were intentionally mixed but the policy was implicit. Making the trusted set explicit preserves automatic compatible updates for official actions while preventing mutable references from unreviewed publishers.

Closes #570

## How was it tested?

- [ ] `./mvnw clean install` passes locally (not run; this change only affects workflow policy and documentation)
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (not applicable; no runtime or UI changes)
- [x] Added or updated tests where applicable

The policy checker passes all 46 current references, accepts trusted major tags, local actions, composite actions, and versioned SHA pins, and rejects mutable third-party refs, missing version comments, and non-major trusted tags. Repository, frontend, and both e2e formatting checks pass.

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes (not applicable; the contributor policy is documented in `CONTRIBUTING.md`)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed