### PR TITLE
Fix Architecture advisor proxy checks

### DIFF
--- a/bootui-engine/pom.xml
+++ b/bootui-engine/pom.xml
@@ -109,6 +109,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-aop</artifactId>
             <scope>test</scope>
         </dependency>
@@ -135,6 +140,18 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.transaction</groupId>
+            <artifactId>javax.transaction-api</artifactId>
+            <version>1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistry.java
@@ -44,7 +44,9 @@ final class ArchitectureRuleRegistry {
             new LiteModeBeanMethodsShouldNotCallSiblingBeanMethodsRule(),
             new LifecycleCallbacksShouldNotBeProxyDrivenRule(),
             new AsyncAndTransactionalShouldNotBeCombinedRule(),
+            new AsyncEventListenersShouldReturnVoidRule(),
             new BeanPostProcessorFactoryMethodsShouldBeStaticRule(),
+            new LegacyJavaxTransactionalShouldBeMigratedRule(),
             new InternalPackagesShouldNotBeAccessedExternallyRule(),
             new NoDirectThreadInstantiationRule(),
             new AssertionsShouldHaveDetailMessageRule());

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
@@ -95,9 +95,14 @@ final class SpringStereotypes {
 
     static final String TRANSACTIONAL = "org.springframework.transaction.annotation.Transactional";
     static final String JAKARTA_TRANSACTIONAL = "jakarta.transaction.Transactional";
+    static final String JAVAX_TRANSACTIONAL = "javax.transaction.Transactional";
     static final String ASYNC = "org.springframework.scheduling.annotation.Async";
     static final String CACHEABLE = "org.springframework.cache.annotation.Cacheable";
+    static final String CACHE_EVICT = "org.springframework.cache.annotation.CacheEvict";
+    static final String CACHE_PUT = "org.springframework.cache.annotation.CachePut";
+    static final String CACHING = "org.springframework.cache.annotation.Caching";
     static final String SCHEDULED = "org.springframework.scheduling.annotation.Scheduled";
+    static final String EVENT_LISTENER = "org.springframework.context.event.EventListener";
     static final String CONFIGURATION_PROPERTIES =
             "org.springframework.boot.context.properties.ConfigurationProperties";
     static final String BEAN = "org.springframework.context.annotation.Bean";
@@ -140,6 +145,12 @@ final class SpringStereotypes {
     static final DescribedPredicate<CanBeAnnotated> ASYNC_ANNOTATED =
             annotatedWith(ASYNC).as("annotated with @Async");
 
+    static final DescribedPredicate<CanBeAnnotated> CACHE_OPERATION_ANNOTATED = annotatedWith(CACHEABLE)
+            .or(annotatedWith(CACHE_EVICT))
+            .or(annotatedWith(CACHE_PUT))
+            .or(annotatedWith(CACHING))
+            .as("annotated with a Spring cache operation");
+
     static final DescribedPredicate<CanBeAnnotated> SCHEDULED_ANNOTATED =
             annotatedWith(SCHEDULED).as("annotated with @Scheduled");
 
@@ -155,14 +166,15 @@ final class SpringStereotypes {
 
     static final DescribedPredicate<CanBeAnnotated> PROXIED_METHOD_ANNOTATED = TRANSACTIONAL_ANNOTATED
             .or(annotatedWith(ASYNC))
-            .or(annotatedWith(CACHEABLE))
-            .as("annotated with @Transactional, @Async, or @Cacheable");
+            .or(CACHE_OPERATION_ANNOTATED)
+            .as("annotated with @Transactional, @Async, or a Spring cache operation");
 
-    // Class-level @Async / @Cacheable make every method proxied, so self-invocation always loses the
-    // behaviour. Class-level @Transactional is deliberately excluded here: a self-call to another method
-    // of the same class simply joins the existing class-level transaction, so flagging it is noise.
-    static final DescribedPredicate<CanBeAnnotated> CLASS_LEVEL_PROXY_ANNOTATED =
-            annotatedWith(ASYNC).or(annotatedWith(CACHEABLE)).as("a class annotated with @Async or @Cacheable");
+    // Class-level @Async / cache operations make every method proxied, so self-invocation always loses
+    // the behaviour. Class-level @Transactional is deliberately excluded here: a self-call to another
+    // method of the same class simply joins the existing class-level transaction, so flagging it is noise.
+    static final DescribedPredicate<CanBeAnnotated> CLASS_LEVEL_PROXY_ANNOTATED = annotatedWith(ASYNC)
+            .or(CACHE_OPERATION_ANNOTATED)
+            .as("a class annotated with @Async or a Spring cache operation");
 
     private SpringStereotypes() {}
 }
@@ -419,7 +431,16 @@ final class NoSystemExitRule extends AbstractArchitectureRule {
     }
 
     private static boolean isStaticMainMethod(JavaCodeUnit origin) {
-        return origin.getName().equals("main") && origin.getModifiers().contains(JavaModifier.STATIC);
+        if (!(origin instanceof JavaMethod method)) {
+            return false;
+        }
+        List<JavaClass> parameters = method.getRawParameterTypes();
+        return method.getName().equals("main")
+                && method.getModifiers().contains(JavaModifier.PUBLIC)
+                && method.getModifiers().contains(JavaModifier.STATIC)
+                && method.getRawReturnType().isEquivalentTo(void.class)
+                && parameters.size() == 1
+                && parameters.get(0).isEquivalentTo(String[].class);
     }
 }
 
@@ -786,7 +807,8 @@ final class LoggersShouldBePrivateStaticFinalRule extends AbstractArchitectureRu
                 "LOW",
                 "Detects logger fields (SLF4J, Log4j2, Commons Logging, JBoss Logging, java.util.logging, or"
                         + " Logback) that are not private, static, and final. Exempts container-managed injection"
-                        + " points (@Inject/@Autowired/@Resource, e.g. Quarkus's `@Inject Logger log;`) and a"
+                        + " points (@Inject/@Autowired/jakarta.annotation.Resource, e.g. Quarkus's"
+                        + " `@Inject Logger log;`) and a"
                         + " protected, non-static, final logger declared in an abstract base class and initialized"
                         + " via LoggerFactory.getLogger(getClass()) so each subclass logs under its own name.",
                 "Make logger fields private, static, and final. For a logger shared with subclasses, declare it"
@@ -927,17 +949,18 @@ final class RepositoriesShouldNotDependOnServicesRule extends AbstractArchitectu
 }
 
 /**
- * Flags service and repository beans that depend on servlet request/response infrastructure.
+ * Flags service and repository beans that depend on servlet or reactive web request/response
+ * infrastructure.
  */
 final class ServicesAndRepositoriesShouldNotDependOnServletTypesRule extends AbstractArchitectureRule {
 
     ServicesAndRepositoriesShouldNotDependOnServletTypesRule() {
         super(new ArchitectureRuleDefinition(
                 "ARCH-SPRING-008",
-                "Services and repositories should not depend on servlet types",
+                "Services and repositories should not depend on web request types",
                 ArchitectureCategory.SPRING_STEREOTYPES,
                 "MEDIUM",
-                "Detects @Service or @Repository beans that depend on servlet or Spring web request types.",
+                "Detects @Service or @Repository beans that depend on servlet or reactive Spring web request types.",
                 "Extract request data in the web layer and pass plain application values into services and repositories.",
                 "https://www.archunit.org/userguide/html/000_Index.html#_layer_checks"));
     }
@@ -949,7 +972,12 @@ final class ServicesAndRepositoriesShouldNotDependOnServletTypesRule extends Abs
                 .should()
                 .dependOnClassesThat()
                 .resideInAnyPackage(
-                        "jakarta.servlet..", "javax.servlet..", "org.springframework.web.context.request..");
+                        "jakarta.servlet..",
+                        "javax.servlet..",
+                        "org.springframework.web.context.request..",
+                        "org.springframework.web.reactive.function.server..",
+                        "org.springframework.web.server..",
+                        "org.springframework.http.server.reactive..");
     }
 }
 
@@ -1008,8 +1036,8 @@ final class TransactionalAnnotationsShouldNotBeDeclaredOnInterfacesRule extends 
  * Flags methods annotated with proxy-driven annotations that the runtime's proxy mechanism cannot
  * actually intercept.
  *
- * <p>Spring's own proxy-driven annotations ({@code @Async}, {@code @Cacheable}, and Spring's own
- * {@code @Transactional}) require a public, non-static, non-final method: interface-based JDK
+ * <p>Spring's own proxy-driven annotations ({@code @Async}, Spring cache annotations, and Spring's
+ * own {@code @Transactional}) require a public, non-static, non-final method: interface-based JDK
  * proxies and the default CGLIB subclass proxy only ever intercept public instance methods (Spring's
  * transaction-management reference documents this restriction explicitly, and {@code CglibAopProxy}
  * logs a warning and silently calls the original, un-intercepted method for a {@code final} method).
@@ -1035,7 +1063,7 @@ final class ProxiedMethodsShouldNotBePrivateOrStaticRule extends AbstractArchite
                 "Proxy-driven methods should be publicly overridable",
                 ArchitectureCategory.SPRING_STEREOTYPES,
                 "MEDIUM",
-                "Detects @Async, @Cacheable, or Spring's own @Transactional on a non-public, static, or final method, and jakarta.transaction.Transactional on a private, static, or final method. Interface-based and CGLIB proxies can only intercept public, overridable instance methods, while a CDI client proxy can also intercept protected and package-private ones, so the proxy behaviour can be silently skipped.",
+                "Detects @Async, Spring cache annotations, or Spring's own @Transactional on a non-public, static, or final method, and jakarta.transaction.Transactional on a private, static, or final method. Interface-based and CGLIB proxies can only intercept public, overridable instance methods, while a CDI client proxy can also intercept protected and package-private ones, so the proxy behaviour can be silently skipped.",
                 "Make the annotated method public, non-static, and non-final so it can be intercepted by a Spring proxy (or at least package-visible, non-static, and non-final for the portable jakarta.transaction.Transactional annotation, which a CDI client proxy can also intercept), or move the annotation to a method that can be.",
                 "https://docs.spring.io/spring-framework/reference/core/aop/proxying.html"));
     }
@@ -1068,7 +1096,7 @@ final class ProxiedMethodsShouldNotBePrivateOrStaticRule extends AbstractArchite
     private static Optional<String> proxyabilityProblem(JavaMethod method) {
         boolean springAnnotated = method.isAnnotatedWith(SpringStereotypes.TRANSACTIONAL)
                 || method.isAnnotatedWith(SpringStereotypes.ASYNC)
-                || method.isAnnotatedWith(SpringStereotypes.CACHEABLE);
+                || SpringStereotypes.CACHE_OPERATION_ANNOTATED.test(method);
         if (springAnnotated) {
             return visibilityProblem(method, JavaModifier.PUBLIC);
         }
@@ -1473,8 +1501,9 @@ final class ConfigurationPropertiesShouldBeImmutableRule extends AbstractArchite
 /**
  * Flags direct calls between {@code @Bean} methods declared in the same class when that class is not
  * a full {@code @Configuration(proxyBeanMethods=true)}. In lite mode such a call is a plain method
- * invocation, so the Spring container does not intercept it and a second, unmanaged instance is
- * created instead of returning the shared singleton.
+ * invocation, so the Spring container does not intercept it. Calling a sibling factory method creates
+ * a new instance rather than resolving the container-managed bean; whether that is a duplicate singleton
+ * or another unmanaged object depends on the factory method's scope and implementation.
  */
 final class LiteModeBeanMethodsShouldNotCallSiblingBeanMethodsRule extends AbstractArchitectureRule {
 
@@ -1485,7 +1514,7 @@ final class LiteModeBeanMethodsShouldNotCallSiblingBeanMethodsRule extends Abstr
                         "Lite-mode @Bean methods should not call sibling @Bean methods",
                         ArchitectureCategory.SPRING_STEREOTYPES,
                         "HIGH",
-                        "Detects direct calls between @Bean methods declared in the same class when that class is not a full @Configuration(proxyBeanMethods=true). In lite mode the call bypasses the Spring container, creating a second unmanaged instance instead of the shared singleton.",
+                        "Detects direct calls between @Bean methods declared in the same class when that class is not a full @Configuration(proxyBeanMethods=true). In lite mode the call is a plain Java invocation that bypasses the container, so it creates whatever the factory method returns instead of resolving the managed bean.",
                         "Declare the class as @Configuration (the default proxyBeanMethods=true), or pass the dependency as a @Bean method parameter instead of calling the sibling @Bean method directly.",
                         "https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Bean.html"));
     }
@@ -1554,7 +1583,8 @@ final class LiteModeBeanMethodsShouldNotCallSiblingBeanMethodsRule extends Abstr
 
 /**
  * Flags {@code @PostConstruct} / {@code @PreDestroy} lifecycle callbacks that are also annotated with
- * a proxy-driven annotation ({@code @Transactional}, {@code @Async}, or {@code @Cacheable}). Spring
+ * a proxy-driven annotation ({@code @Transactional}, {@code @Async}, or a Spring cache operation).
+ * Spring
  * invokes lifecycle callbacks before the bean is wrapped in its proxy (and after it is unwrapped at
  * destruction), so the proxy behaviour never applies.
  */
@@ -1566,7 +1596,7 @@ final class LifecycleCallbacksShouldNotBeProxyDrivenRule extends AbstractArchite
                 "Lifecycle callbacks should not be proxy-driven",
                 ArchitectureCategory.SPRING_STEREOTYPES,
                 "HIGH",
-                "Detects @PostConstruct or @PreDestroy methods that are also annotated with @Transactional, @Async, or @Cacheable. The proxy is not active during bean initialization or destruction, so the transactional, asynchronous, or caching behaviour is silently lost.",
+                "Detects @PostConstruct or @PreDestroy methods that are also annotated with @Transactional, @Async, @Cacheable, @CachePut, @CacheEvict, or @Caching. The proxy is not active during bean initialization or destruction, so the transactional, asynchronous, or caching behaviour is silently lost.",
                 "Move the transactional, asynchronous, or cached work to a separate proxied bean method and invoke it after initialization rather than annotating the lifecycle callback itself.",
                 "https://docs.spring.io/spring-framework/reference/core/aop/proxying.html"));
     }
@@ -1584,7 +1614,7 @@ final class LifecycleCallbacksShouldNotBeProxyDrivenRule extends AbstractArchite
                                         SimpleConditionEvent.violated(
                                                 method,
                                                 "Lifecycle callback " + method.getFullName()
-                                                        + " is annotated with a proxy-driven annotation (@Transactional, @Async, or @Cacheable), which does not apply during initialization or destruction"));
+                                                        + " is annotated with a proxy-driven annotation (@Transactional, @Async, or a Spring cache operation), which does not apply during initialization or destruction"));
                             }
                         }
                     }
@@ -1632,6 +1662,96 @@ final class AsyncAndTransactionalShouldNotBeCombinedRule extends AbstractArchite
                     }
                 })
                 .as("Async and transactional semantics on one method should be reviewed");
+    }
+}
+
+/**
+ * Flags asynchronous event listeners that declare a return value. Spring explicitly supports
+ * {@code @Async} on {@code @EventListener}, but its contract states that an asynchronous listener
+ * cannot publish a follow-up event by returning a value.
+ */
+final class AsyncEventListenersShouldReturnVoidRule extends AbstractArchitectureRule {
+
+    AsyncEventListenersShouldReturnVoidRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-020",
+                        "Async event listeners should return void",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "MEDIUM",
+                        "Detects @EventListener methods that run through @Async (on the method or declaring class) and return a value. Spring cannot publish that value as a follow-up event for an asynchronous listener.",
+                        "Return void from the asynchronous listener. To publish a follow-up event, inject ApplicationEventPublisher and publish it explicitly.",
+                        "https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/event/EventListener.html"));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return classes()
+                .should(new ArchCondition<JavaClass>("declare void-returning asynchronous event listeners") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        boolean classLevelAsync = SpringStereotypes.ASYNC_ANNOTATED.test(javaClass);
+                        for (JavaMethod method : javaClass.getMethods()) {
+                            if (method.isAnnotatedWith(SpringStereotypes.EVENT_LISTENER)
+                                    && (classLevelAsync || SpringStereotypes.ASYNC_ANNOTATED.test(method))
+                                    && !method.getRawReturnType().isEquivalentTo(void.class)) {
+                                events.add(SimpleConditionEvent.violated(
+                                        method,
+                                        "Asynchronous event listener " + method.getFullName()
+                                                + " returns "
+                                                + method.getRawReturnType().getName()
+                                                + "; Spring cannot publish return values from asynchronous listeners"));
+                            }
+                        }
+                    }
+                })
+                .as("Async event listeners should return void");
+    }
+}
+
+/**
+ * Flags the legacy Java EE transaction annotation, which is ignored on the Spring Framework 7 /
+ * Jakarta EE 11 baseline used by Spring Boot 4.
+ */
+final class LegacyJavaxTransactionalShouldBeMigratedRule extends AbstractArchitectureRule {
+
+    LegacyJavaxTransactionalShouldBeMigratedRule() {
+        super(
+                new ArchitectureRuleDefinition(
+                        "ARCH-SPRING-022",
+                        "Legacy javax.transaction.Transactional should be migrated",
+                        ArchitectureCategory.SPRING_STEREOTYPES,
+                        "HIGH",
+                        "Detects javax.transaction.Transactional on classes or methods. Spring Framework 7 no longer supports legacy javax annotations, so the intended transaction boundary is ignored.",
+                        "Replace javax.transaction.Transactional with org.springframework.transaction.annotation.Transactional or jakarta.transaction.Transactional and use the corresponding Jakarta-era dependency.",
+                        "https://github.com/spring-projects/spring-framework/blob/v7.0.8/spring-tx/src/main/java/org/springframework/transaction/annotation/AnnotationTransactionAttributeSource.java"));
+    }
+
+    @Override
+    ArchRule rule(ArchitectureContext context) {
+        return classes()
+                .should(new ArchCondition<JavaClass>("not use legacy javax.transaction.Transactional") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        if (javaClass.isAnnotatedWith(SpringStereotypes.JAVAX_TRANSACTIONAL)) {
+                            events.add(
+                                    SimpleConditionEvent.violated(
+                                            javaClass,
+                                            "Class " + javaClass.getName()
+                                                    + " uses legacy javax.transaction.Transactional, which Spring Framework 7 ignores"));
+                        }
+                        for (JavaMethod method : javaClass.getMethods()) {
+                            if (method.isAnnotatedWith(SpringStereotypes.JAVAX_TRANSACTIONAL)) {
+                                events.add(
+                                        SimpleConditionEvent.violated(
+                                                method,
+                                                "Method " + method.getFullName()
+                                                        + " uses legacy javax.transaction.Transactional, which Spring Framework 7 ignores"));
+                            }
+                        }
+                    }
+                })
+                .as("Legacy javax.transaction.Transactional should be migrated");
     }
 }
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistryTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistryTests.java
@@ -11,7 +11,7 @@ class ArchitectureRuleRegistryTests {
     void everyRuleHasACompleteAndUniqueDefinition() {
         List<ArchitectureRule> rules = ArchitectureRuleRegistry.activeRules();
 
-        assertThat(rules).isNotEmpty();
+        assertThat(rules).hasSize(41);
         assertThat(rules).extracting(rule -> rule.definition().id()).doesNotHaveDuplicates();
         assertThat(rules).allSatisfy(rule -> {
             ArchitectureRuleDefinition definition = rule.definition();
@@ -53,7 +53,9 @@ class ArchitectureRuleRegistryTests {
                         "ARCH-SPRING-017",
                         "ARCH-SPRING-018",
                         "ARCH-SPRING-019",
+                        "ARCH-SPRING-020",
                         "ARCH-SPRING-021",
+                        "ARCH-SPRING-022",
                         "ARCH-CODE-017",
                         "ARCH-CODE-018",
                         "ARCH-MOD-001");

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import io.github.jdubois.bootui.core.dto.ArchitectureRuleResultDto;
+import io.github.jdubois.bootui.engine.architecture.cyclefixtures.alpha.AlphaComponent;
+import io.github.jdubois.bootui.engine.architecture.cyclefixtures.beta.BetaComponent;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Resource;
 import jakarta.inject.Inject;
@@ -22,9 +24,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -32,8 +38,24 @@ import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebSession;
 
 class ArchitectureRulesTests {
+
+    @Test
+    void packageCyclesCountEachDetectedCycleOnceRatherThanEachDependencyEdge() {
+        JavaClasses importedClasses = new ClassFileImporter().importClasses(AlphaComponent.class, BetaComponent.class);
+        ArchitectureRuleResultDto result = new FreeOfPackageCyclesRule()
+                .evaluate(new ArchitectureContext(
+                        importedClasses, List.of("io.github.jdubois.bootui.engine.architecture.cyclefixtures")));
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-PKG-001");
+        assertThat(result.violationCount()).isEqualTo(1);
+        assertThat(result.sampleViolations()).singleElement().asString().contains("Cycle detected");
+    }
 
     @Test
     void servicesShouldNotDependOnControllersFlagsWebLayerDependencies() {
@@ -237,6 +259,20 @@ class ArchitectureRulesTests {
     }
 
     @Test
+    void servicesAndRepositoriesShouldNotDependOnWebTypesFlagsReactiveRequestDependencies() {
+        ArchitectureRuleResultDto result = evaluate(
+                new ServicesAndRepositoriesShouldNotDependOnServletTypesRule(), ServiceUsingReactiveWebTypes.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-008");
+        assertThat(result.violationCount()).isGreaterThanOrEqualTo(3);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("ServerRequest"))
+                .anySatisfy(sample -> assertThat(sample).contains("ServerWebExchange"))
+                .anySatisfy(sample -> assertThat(sample).contains("WebSession"));
+    }
+
+    @Test
     void transactionalAnnotationsShouldNotBeDeclaredOnInterfacesFlagsInterfaceAnnotations() {
         ArchitectureRuleResultDto result = evaluate(
                 new TransactionalAnnotationsShouldNotBeDeclaredOnInterfacesRule(),
@@ -259,9 +295,11 @@ class ArchitectureRulesTests {
 
         assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
         assertThat(result.id()).isEqualTo("ARCH-SPRING-010");
-        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.violationCount()).isEqualTo(5);
         assertThat(result.sampleViolations())
                 .anySatisfy(sample -> assertThat(sample).contains("private"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("protected"));
         assertThat(result.sampleViolations())
                 .anySatisfy(sample -> assertThat(sample).contains("static"));
     }
@@ -448,6 +486,15 @@ class ArchitectureRulesTests {
     }
 
     @Test
+    void noSystemExitStillFlagsSystemExitFromStaticMainOverload() {
+        ArchitectureRuleResultDto result = evaluate(new NoSystemExitRule(), MainOverloadSystemExitCaller.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-006");
+        assertThat(result.violationCount()).isEqualTo(1);
+    }
+
+    @Test
     void noJdkInternalApiDoesNotFlagExportedComSunApi() {
         ArchitectureRuleResultDto result = evaluate(new NoJdkInternalApiRule(), ExportedComSunUser.class);
 
@@ -483,6 +530,16 @@ class ArchitectureRulesTests {
 
         assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
         assertThat(result.id()).isEqualTo("ARCH-SPRING-004");
+    }
+
+    @Test
+    void noSelfInvocationFlagsAllSpringCacheOperationAnnotations() {
+        ArchitectureRuleResultDto result =
+                evaluate(new NoSelfInvocationOfProxiedMethodsRule(), SelfInvokingCacheOperationsBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-004");
+        assertThat(result.violationCount()).isEqualTo(3);
     }
 
     @Test
@@ -533,6 +590,16 @@ class ArchitectureRulesTests {
     }
 
     @Test
+    void lifecycleCallbacksShouldNotBeProxyDrivenFlagsAllSpringCacheOperations() {
+        ArchitectureRuleResultDto result =
+                evaluate(new LifecycleCallbacksShouldNotBeProxyDrivenRule(), CachedLifecycleBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-018");
+        assertThat(result.violationCount()).isEqualTo(3);
+    }
+
+    @Test
     void lifecycleCallbacksShouldNotBeProxyDrivenPassesForPlainLifecycleMethods() {
         ArchitectureRuleResultDto result =
                 evaluate(new LifecycleCallbacksShouldNotBeProxyDrivenRule(), CleanLifecycleBean.class);
@@ -557,6 +624,53 @@ class ArchitectureRulesTests {
                 evaluate(new AsyncAndTransactionalShouldNotBeCombinedRule(), AsyncOnlyBean.class);
 
         assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void asyncEventListenersShouldReturnVoidFlagsIgnoredReturnValues() {
+        ArchitectureRuleResultDto result = evaluate(
+                new AsyncEventListenersShouldReturnVoidRule(),
+                AsyncEventListenerBean.class,
+                ClassLevelAsyncEventListenerBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-020");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("methodLevel"))
+                .anySatisfy(sample -> assertThat(sample).contains("classLevel"));
+    }
+
+    @Test
+    void asyncEventListenersShouldReturnVoidAllowsSynchronousReturnValuesAndAsyncVoidListeners() {
+        ArchitectureRuleResultDto result =
+                evaluate(new AsyncEventListenersShouldReturnVoidRule(), ValidEventListenerBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void legacyJavaxTransactionalShouldBeMigratedFlagsClassAndMethodUsage() {
+        ArchitectureRuleResultDto result = evaluate(
+                new LegacyJavaxTransactionalShouldBeMigratedRule(),
+                LegacyTransactionalBean.class,
+                LegacyTransactionalMethodBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-022");
+        assertThat(result.violationCount()).isEqualTo(2);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("LegacyTransactionalBean"))
+                .anySatisfy(sample -> assertThat(sample).contains("legacyTransaction"));
+    }
+
+    @Test
+    void loggersShouldNotTreatLegacyJavaxResourceAsContainerManagedOnSpringSeven() {
+        ArchitectureRuleResultDto result =
+                evaluate(new LoggersShouldBePrivateStaticFinalRule(), LegacyResourceLoggerComponent.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-CODE-012");
     }
 
     @Test
@@ -892,6 +1006,22 @@ class ArchitectureRulesTests {
         }
     }
 
+    @Service
+    private static class ServiceUsingReactiveWebTypes {
+
+        String requestPath(ServerRequest request) {
+            return request.path();
+        }
+
+        String exchangePath(ServerWebExchange exchange) {
+            return exchange.getRequest().getPath().value();
+        }
+
+        String sessionId(WebSession session) {
+            return session.getId();
+        }
+    }
+
     @Transactional
     private interface TransactionalInterface {}
 
@@ -908,6 +1038,39 @@ class ArchitectureRulesTests {
 
         @Async
         static void staticAsync() {}
+
+        @CachePut("items")
+        private String privateCachePut() {
+            return "item";
+        }
+
+        @CacheEvict("items")
+        protected void protectedCacheEvict() {}
+
+        @Caching(evict = @CacheEvict("items"))
+        static void staticCaching() {}
+    }
+
+    private static class SelfInvokingCacheOperationsBean {
+
+        void refreshAll() {
+            put();
+            evict();
+            combined();
+        }
+
+        @CachePut("items")
+        public String put() {
+            return "item";
+        }
+
+        @CacheEvict("items")
+        public void evict() {}
+
+        @Caching(put = @CachePut("items"), evict = @CacheEvict("other"))
+        public String combined() {
+            return "item";
+        }
     }
 
     private static class BadAsyncComponent {
@@ -1059,6 +1222,13 @@ class ArchitectureRulesTests {
         }
     }
 
+    private static class MainOverloadSystemExitCaller {
+
+        public static void main() {
+            System.exit(1);
+        }
+    }
+
     private static class ExportedComSunUser {
 
         String osName(com.sun.management.OperatingSystemMXBean osBean) {
@@ -1153,6 +1323,21 @@ class ArchitectureRulesTests {
         void init() {}
     }
 
+    private static class CachedLifecycleBean {
+
+        @PostConstruct
+        @CachePut("items")
+        void put() {}
+
+        @PostConstruct
+        @CacheEvict("items")
+        void evict() {}
+
+        @PostConstruct
+        @Caching(evict = @CacheEvict("items"))
+        void combined() {}
+    }
+
     private static class CleanLifecycleBean {
 
         @PostConstruct
@@ -1170,6 +1355,56 @@ class ArchitectureRulesTests {
 
         @Async
         void doWork() {}
+    }
+
+    private static class AsyncEventListenerBean {
+
+        @Async
+        @EventListener
+        String methodLevel(String event) {
+            return event;
+        }
+
+        @EventListener
+        String synchronous(String event) {
+            return event;
+        }
+    }
+
+    @Async
+    private static class ClassLevelAsyncEventListenerBean {
+
+        @EventListener
+        String classLevel(String event) {
+            return event;
+        }
+    }
+
+    private static class ValidEventListenerBean {
+
+        @Async
+        @EventListener
+        void asynchronous(String event) {}
+
+        @EventListener
+        String synchronous(String event) {
+            return event;
+        }
+    }
+
+    @javax.transaction.Transactional
+    private static class LegacyTransactionalBean {}
+
+    private static class LegacyTransactionalMethodBean {
+
+        @javax.transaction.Transactional
+        void legacyTransaction() {}
+    }
+
+    private static class LegacyResourceLoggerComponent {
+
+        @javax.annotation.Resource
+        Logger logger;
     }
 
     @Configuration

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/cyclefixtures/alpha/AlphaComponent.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/cyclefixtures/alpha/AlphaComponent.java
@@ -1,0 +1,16 @@
+package io.github.jdubois.bootui.engine.architecture.cyclefixtures.alpha;
+
+import io.github.jdubois.bootui.engine.architecture.cyclefixtures.beta.BetaComponent;
+
+public final class AlphaComponent {
+
+    private final BetaComponent beta;
+
+    public AlphaComponent(BetaComponent beta) {
+        this.beta = beta;
+    }
+
+    public BetaComponent beta() {
+        return beta;
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/cyclefixtures/beta/BetaComponent.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/cyclefixtures/beta/BetaComponent.java
@@ -1,0 +1,16 @@
+package io.github.jdubois.bootui.engine.architecture.cyclefixtures.beta;
+
+import io.github.jdubois.bootui.engine.architecture.cyclefixtures.alpha.AlphaComponent;
+
+public final class BetaComponent {
+
+    private final AlphaComponent alpha;
+
+    public BetaComponent(AlphaComponent alpha) {
+        this.alpha = alpha;
+    }
+
+    public AlphaComponent alpha() {
+        return alpha;
+    }
+}

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -80,7 +80,8 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Inspects**: cyclic dependencies between the top-level package slices under the application base package
   (`<basePackage>.(*)..`).
 - **Fires when**: two or more slices depend on each other directly or transitively, forming a cycle. Evaluated per
-  detected base package and aggregated.
+  detected base package and aggregated. The violation count is the number of cycles ArchUnit reports, not the number of
+  dependency edges shown inside those cycle reports.
 - **Why it matters**: package cycles make code hard to understand, test, and modularize, and they block clean extraction
   of modules.
 - **Recommendation**: break the dependency cycle by extracting shared types or inverting one of the dependencies so
@@ -146,7 +147,8 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Severity**: HIGH
 - **Inspects**: calls to `System.exit(int)`, `Runtime.exit(int)`, or `Runtime.halt(int)`.
 - **Fires when**: a class abruptly terminates the JVM instead of letting the framework manage shutdown.
-  `System.exit(int)` is exempt when called directly from a static `main` method: this is Spring Boot's own officially
+  `System.exit(int)` is exempt when called directly from a canonical `public static void main(String[])` entry point:
+  this is Spring Boot's own officially
   documented pattern for propagating an `ExitCodeGenerator` result from CLI/batch applications,
   `System.exit(SpringApplication.exit(context, ...))` — see the Spring Boot reference docs,
   ["Application Exit"](https://docs.spring.io/spring-boot/reference/features/spring-application.html#features.spring-application.application-exit).
@@ -201,9 +203,12 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Inspects**: logger fields whose raw type is SLF4J, Log4j2, Commons Logging, JBoss Logging, `java.util.logging`, or
   Logback.
 - **Fires when**: a logger field is not `private`, `static`, and `final` — with two recognized alternate patterns.
-  Container-managed injection points (`@Inject`/`@Autowired`/`@Resource`, e.g. Quarkus's idiomatic `@Inject Logger
-  log;`) are exempt entirely, since a field wired by the container is non-static by construction — see the
+  Container-managed injection points (`@Inject`, `@Autowired`, or `jakarta.annotation.Resource`, e.g. Quarkus's idiomatic
+  `@Inject Logger log;`) are exempt entirely, since a field wired by the container is non-static by construction — see the
   [Quarkus Logging guide's "logging with injection" section](https://quarkus.io/guides/logging#logging-with-injection).
+  Legacy `javax.annotation.Resource` is deliberately not exempt: Spring Framework 7 removed support for
+  `javax.annotation` annotations, and Quarkus 3 uses the Jakarta namespace, so it is not a container-managed injection
+  point on either supported baseline.
   A `protected`, non-static, `final` logger declared in an abstract base class and initialized via
   `LoggerFactory.getLogger(getClass())` is also accepted: subclasses inherit the field and each logs under its own
   runtime class name, which requires the field to be an instance member; the SLF4J FAQ explicitly declines to
@@ -339,8 +344,8 @@ include up to a handful of sample detail lines from ArchUnit.
 
 - **Severity**: HIGH
 - **Inspects**: direct self-invocation (`this.method()`) of methods proxied through `@Transactional` (Spring's own or the
-  portable `jakarta.transaction.Transactional`), `@Async`, or `@Cacheable` on the method, or `@Async` / `@Cacheable` on
-  the declaring class.
+  portable `jakarta.transaction.Transactional`), `@Async`, or any Spring cache operation (`@Cacheable`, `@CachePut`,
+  `@CacheEvict`, or `@Caching`) on the method, or `@Async` / a cache operation on the declaring class.
 - **Fires when**: a bean calls one of its own proxied methods directly, bypassing the Spring proxy.
 - **Why it matters**: the transaction, async execution, or caching behaviour is silently lost because the call never
   passes through the proxy — a real correctness bug, not just a style issue.
@@ -360,12 +365,14 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Recommendation**: move Spring stereotype beans into a named package so component scanning and proxying work as
   expected.
 
-### ARCH-SPRING-008 — Services and repositories should not depend on servlet types
+### ARCH-SPRING-008 — Services and repositories should not depend on web request types
 
 - **Severity**: MEDIUM
 - **Inspects**: `@Service` and `@Repository` beans that depend on `jakarta.servlet`, `javax.servlet`, or Spring web
-  request types.
-- **Fires when**: business or persistence code accepts, stores, or otherwise references servlet request/response
+  request types, including WebFlux functional request/response types (`ServerRequest` / `ServerResponse`), reactive
+  server exchange/session types (`ServerWebExchange`, `WebSession`, and their families), and low-level reactive HTTP
+  server types.
+- **Fires when**: business or persistence code accepts, stores, or otherwise references servlet or reactive web
   infrastructure.
 - **Why it matters**: service and repository code should be transport-agnostic so it can be reused from HTTP
   controllers, CLI runners, scheduled jobs, tests, and message consumers.
@@ -385,10 +392,11 @@ include up to a handful of sample detail lines from ArchUnit.
 
 - **Severity**: MEDIUM
 - **Inspects**: methods annotated with `@Transactional` (Spring's own or the portable
-  `jakarta.transaction.Transactional`), `@Async`, or `@Cacheable`.
-- **Fires when**: `@Async`, `@Cacheable`, or Spring's own `@Transactional` is applied to a method that is private,
-  protected, package-private, static, or final; or the portable `jakarta.transaction.Transactional` is applied to a
-  method that is private, static, or final.
+  `jakarta.transaction.Transactional`), `@Async`, or a Spring cache operation (`@Cacheable`, `@CachePut`, `@CacheEvict`,
+  or `@Caching`).
+- **Fires when**: `@Async`, a Spring cache operation, or Spring's own `@Transactional` is applied to a method that is
+  private, protected, package-private, static, or final; or the portable `jakarta.transaction.Transactional` is applied
+  to a method that is private, static, or final.
 - **Why it matters**: interface-based JDK proxies and the default CGLIB subclass proxy only intercept public, overridable
   instance methods — CGLIB additionally warns and silently calls the original, un-intercepted method when a `final`
   method carries the annotation — so the proxy behaviour can be silently skipped.
@@ -474,10 +482,11 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Severity**: HIGH
 - **Inspects**: direct calls between `@Bean` methods declared in the same class when that class is not a full
   `@Configuration(proxyBeanMethods=true)`.
-- **Fires when**: a `@Bean` method directly calls a different sibling `@Bean` method in lite mode, bypassing the Spring
-  container.
-- **Why it matters**: in lite mode the call is a plain method invocation, so Spring does not return the shared singleton
-  and a second, unmanaged instance can be created.
+- **Fires when**: a `@Bean` method directly calls a different sibling `@Bean` method in lite mode, where Spring treats
+  each factory method with ordinary Java semantics rather than intercepting inter-bean calls.
+- **Why it matters**: the call bypasses container resolution and directly creates whatever the sibling factory method
+  returns. For the common singleton case this is a duplicate unmanaged instance, but the exact consequence depends on
+  the factory method's scope and implementation.
 - **Recommendation**: declare the class as `@Configuration` (the default `proxyBeanMethods=true`), or pass the dependency
   as a `@Bean` method parameter instead of calling the sibling `@Bean` method directly.
 
@@ -485,7 +494,8 @@ include up to a handful of sample detail lines from ArchUnit.
 
 - **Severity**: HIGH
 - **Inspects**: `@PostConstruct` or `@PreDestroy` methods that are also annotated with `@Transactional` (Spring's own or
-  the portable `jakarta.transaction.Transactional`), `@Async`, or `@Cacheable`.
+  the portable `jakarta.transaction.Transactional`), `@Async`, or a Spring cache operation (`@Cacheable`, `@CachePut`,
+  `@CacheEvict`, or `@Caching`).
 - **Fires when**: a lifecycle callback is annotated with a proxy-driven annotation.
 - **Why it matters**: Spring invokes lifecycle callbacks before the bean is wrapped in its proxy, and after it is unwrapped
   at destruction, so the proxy behaviour never applies.
@@ -507,6 +517,18 @@ include up to a handful of sample detail lines from ArchUnit.
 - **Recommendation**: review the design; usually the transactional work belongs in a separate bean method that the
   `@Async` method calls, so the transaction is scoped correctly on the async thread.
 
+### ARCH-SPRING-020 — Async event listeners should return void
+
+- **Severity**: MEDIUM
+- **Inspects**: `@EventListener` methods that run asynchronously because `@Async` is declared on the method or its class.
+- **Fires when**: an asynchronous event listener declares a non-`void` return type.
+- **Why it matters**: Spring supports return values from synchronous event listeners by publishing them as follow-up
+  events, but its
+  [`@EventListener` contract](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/event/EventListener.html)
+  explicitly states that asynchronous listeners cannot publish a subsequent event through their return value.
+- **Recommendation**: return `void`; when a follow-up event is needed, inject `ApplicationEventPublisher` and publish it
+  explicitly from the listener.
+
 ### ARCH-SPRING-021 — BeanPostProcessor and BeanFactoryPostProcessor @Bean methods should be static
 
 - **Severity**: MEDIUM
@@ -516,3 +538,16 @@ include up to a handful of sample detail lines from ArchUnit.
   bean post-processing is fully set up, which can disable post-processing of other beans.
 - **Recommendation**: declare these `@Bean` methods `static` so the post-processor can be created without instantiating
   the surrounding configuration class.
+
+### ARCH-SPRING-022 — Legacy javax.transaction.Transactional should be migrated
+
+- **Severity**: HIGH
+- **Inspects**: `javax.transaction.Transactional` on classes and methods.
+- **Fires when**: application bytecode still uses the legacy Java EE transaction annotation.
+- **Why it matters**: Spring Framework 7 uses a Jakarta EE 11 baseline. Its
+  [`AnnotationTransactionAttributeSource`](https://github.com/spring-projects/spring-framework/blob/v7.0.8/spring-tx/src/main/java/org/springframework/transaction/annotation/AnnotationTransactionAttributeSource.java)
+  registers parsers for Spring's own annotation and `jakarta.transaction.Transactional`, not the old
+  `javax.transaction.Transactional`. On BootUI's Spring Boot 4 baseline, the legacy annotation therefore does not create
+  the intended transaction boundary.
+- **Recommendation**: replace it with Spring's `org.springframework.transaction.annotation.Transactional` or
+  `jakarta.transaction.Transactional`, and replace the legacy Java EE API dependency with its Jakarta equivalent.


### PR DESCRIPTION
## Summary

- cover `@CachePut`, `@CacheEvict`, and `@Caching` in Architecture advisor self-invocation, proxyability, and lifecycle checks
- restrict the `System.exit` launcher exemption to the canonical `public static void main(String[])` signature
- detect legacy `javax.transaction.Transactional` on classes and methods, and clarify `javax.annotation.Resource` handling on the Spring 7 / Quarkus 3 baselines
- extend ARCH-SPRING-008 to WebFlux request, exchange, session, and reactive HTTP server types
- add ARCH-SPRING-020 for non-void `@Async` event listeners, whose return values Spring cannot republish
- clarify lite `@Bean` semantics and pin package-cycle counts to one violation per reported cycle

## Authoritative references

- Spring Framework AOP proxy semantics: https://docs.spring.io/spring-framework/reference/core/aop/proxying.html
- Spring cache annotations: https://docs.spring.io/spring-framework/reference/integration/cache/annotations.html
- `@EventListener` asynchronous listener contract: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/event/EventListener.html
- Spring Framework 7 transaction annotation parsers: https://github.com/spring-projects/spring-framework/blob/v7.0.8/spring-tx/src/main/java/org/springframework/transaction/annotation/AnnotationTransactionAttributeSource.java
- Spring Framework 7 legacy annotation removal: https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-7.0-Release-Notes
- Spring WebFlux functional endpoints and server API: https://docs.spring.io/spring-framework/reference/web/webflux-functional.html

## Tests

- `./mvnw -B -ntp spotless:check`
- `./mvnw -B -ntp -pl bootui-engine test`
- Spring: `ArchitectureScanWiringTest`, `SpringApiConformanceTest`
- Quarkus: `BootUiQuarkusArchitectureResourceTest`, `BootUiQuarkusApiConformanceTest`

## Manual validation

1. Start the Spring sample app with the `dev` profile.
2. Open `/bootui/`, run the Architecture scan, and confirm newly detected findings show the updated descriptions and recommendations.
3. Repeat against the Quarkus sample app to confirm the shared ruleset remains CDI-safe.