### PR TITLE
Fix REST API advisor guidance and heuristics

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/ExceptionHandlersDoNotReturnRawStringsRule.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/ExceptionHandlersDoNotReturnRawStringsRule.java
@@ -1,0 +1,38 @@
+package io.github.jdubois.bootui.engine.restapi;
+
+import io.github.jdubois.bootui.core.dto.RestApiRuleResultDto;
+import io.github.jdubois.bootui.engine.restapi.RestApiModel.ExceptionHandlerModel;
+import java.util.ArrayList;
+import java.util.List;
+
+final class ExceptionHandlersDoNotReturnRawStringsRule extends AbstractRestApiRule {
+
+    ExceptionHandlersDoNotReturnRawStringsRule() {
+        super(new RestApiRuleDefinition(
+                "RAPI-ERR-008",
+                "Exception handlers return structured errors",
+                RestApiCategory.ERROR_HANDLING,
+                "LOW",
+                "An exception handler that returns a raw String exposes an unstructured error contract with no stable"
+                        + " fields for type, status, detail, or correlation metadata.",
+                "Return a typed error DTO or an RFC 9457 problem-details representation instead of a raw String.",
+                RestApiRuleHelp.PROBLEM_DETAIL_DOCS));
+    }
+
+    @Override
+    RestApiRuleResultDto doEvaluate(RestApiContext context) {
+        List<String> violations = new ArrayList<>();
+        for (ExceptionHandlerModel handler : context.exceptionHandlers()) {
+            if ("java.lang.String".equals(handler.bodyTypeName()) && handler.rendersBody()) {
+                violations.add(simpleName(handler.declaringClassName()) + "#" + handler.methodName()
+                        + " returns a raw String error body");
+            }
+        }
+        return RestApiRuleSupport.fromViolations(definition(), violations);
+    }
+
+    private static String simpleName(String fullName) {
+        int lastDot = fullName.lastIndexOf('.');
+        return lastDot >= 0 ? fullName.substring(lastDot + 1) : fullName;
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/HeadHandlersDoNotReturnBodiesRule.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/HeadHandlersDoNotReturnBodiesRule.java
@@ -1,0 +1,38 @@
+package io.github.jdubois.bootui.engine.restapi;
+
+import io.github.jdubois.bootui.core.dto.RestApiRuleResultDto;
+
+final class HeadHandlersDoNotReturnBodiesRule extends AbstractRestApiRule {
+
+    HeadHandlersDoNotReturnBodiesRule() {
+        super(new RestApiRuleDefinition(
+                "RAPI-RESP-009",
+                "HEAD handlers do not return response bodies",
+                RestApiCategory.RESPONSES,
+                "LOW",
+                "RFC 9110 requires HEAD responses to omit message content. A dedicated HEAD handler that returns a"
+                        + " body declares work and a representation that the server must discard.",
+                "Return void or a headers-only response from dedicated HEAD handlers; let the framework derive HEAD"
+                        + " from GET when no distinct metadata calculation is needed.",
+                RestApiRuleHelp.REST_GUIDELINES));
+    }
+
+    @Override
+    RestApiRuleResultDto doEvaluate(RestApiContext context) {
+        return handlersMatching(
+                context,
+                handler -> handler.httpMethods().contains("HEAD")
+                        && handler.serializesBody()
+                        && hasStaticallyProvableBody(handler.bodyTypeName()),
+                "HEAD handler declares a response body that cannot be sent");
+    }
+
+    private static boolean hasStaticallyProvableBody(String bodyTypeName) {
+        return !"void".equals(bodyTypeName)
+                && !"java.lang.Void".equals(bodyTypeName)
+                && !RestApiModel.Types.RESPONSE_ENTITY.equals(bodyTypeName)
+                && !RestApiModel.Types.HTTP_ENTITY.equals(bodyTypeName)
+                && !RestApiModel.Types.JAXRS_RESPONSE.equals(bodyTypeName)
+                && !RestApiModel.Types.QUARKUS_REST_RESPONSE.equals(bodyTypeName);
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiHandlerModelBuilder.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiHandlerModelBuilder.java
@@ -92,6 +92,7 @@ final class RestApiHandlerModelBuilder {
             "post",
             "register",
             "edit");
+    private static final Set<String> NON_MUTATING_METHOD_PREFIXES = Set.of("postprocess", "putaside", "patchversion");
 
     private static final List<String> MAPPING_ANNOTATIONS = List.of(
             Types.GET_MAPPING,
@@ -123,7 +124,7 @@ final class RestApiHandlerModelBuilder {
     private static final Set<String> OFFSET_LIMIT_PARAM_NAMES = Set.of("offset", "limit");
     private static final Set<String> CURSOR_PARAM_NAMES = Set.of("cursor", "after", "before");
 
-    /** Header name (case-insensitive) recognised by the IETF HTTPAPI Idempotency-Key draft. */
+    /** Header name (case-insensitive) recognised by the expired IETF HTTPAPI Idempotency-Key draft. */
     private static final String IDEMPOTENCY_KEY_HEADER_NAME = "idempotency-key";
 
     private static final List<String> JAXRS_METHOD_ANNOTATIONS = List.of(
@@ -444,7 +445,7 @@ final class RestApiHandlerModelBuilder {
             }
         }
 
-        boolean stateChanging = startsWithWord(method.getName(), STATE_CHANGING_PREFIXES);
+        boolean stateChanging = nameLooksStateChanging(method.getName());
         String lowerName = method.getName().toLowerCase(Locale.ROOT);
         boolean findAll = lowerName.startsWith("findall")
                 || lowerName.startsWith("getall")
@@ -614,9 +615,9 @@ final class RestApiHandlerModelBuilder {
         boolean returnsVoid = "void".equals(returnTypeName) || "java.lang.Void".equals(returnTypeName);
         boolean hasResponseParam =
                 methodOpt.map(RestApiHandlerModelBuilder::hasResponseParameter).orElse(false);
-        // No JAX-RS equivalent of Spring's ProblemDetail/@ResponseStatus exists, so those two fields are
-        // always false/empty here; RAPI-ERR-003/RAPI-ERR-006 are Spring-only rules (see SPRING_ONLY_RULE_IDS
-        // in RestApiScanner) and never evaluate JAX-RS-derived exception handlers.
+        // Spring's ProblemDetail/@ResponseStatus types do not exist on JAX-RS, so those two fields are
+        // always false/empty here. RFC 9457 itself is framework-neutral, but the bounded model cannot
+        // reliably prove that an arbitrary JAX-RS payload implements the problem-details schema.
         boolean catchesExceptionOrThrowable =
                 "java.lang.Exception".equals(exceptionType) || "java.lang.Throwable".equals(exceptionType);
         exceptionHandlers.add(new ExceptionHandlerModel(
@@ -849,7 +850,7 @@ final class RestApiHandlerModelBuilder {
         String responseStatusValue = responseStatusValue(method, type);
         boolean declaresBroadThrows = declaresBroadThrows(method);
         boolean hasOperation = hasOperationAnnotation(method);
-        boolean stateChanging = startsWithWord(method.getName(), STATE_CHANGING_PREFIXES);
+        boolean stateChanging = nameLooksStateChanging(method.getName());
         String lowerName = method.getName().toLowerCase(Locale.ROOT);
         boolean findAll = lowerName.startsWith("findall")
                 || lowerName.startsWith("getall")
@@ -1170,6 +1171,14 @@ final class RestApiHandlerModelBuilder {
         }
         String name = type.getName();
         return SIMPLE_BODY_TYPES.contains(name) || SCALAR_TYPES.contains(name) || UNTYPED_TYPES.contains(name);
+    }
+
+    private static boolean nameLooksStateChanging(String methodName) {
+        String lower = methodName.toLowerCase(Locale.ROOT);
+        if (NON_MUTATING_METHOD_PREFIXES.stream().anyMatch(lower::startsWith)) {
+            return false;
+        }
+        return startsWithWord(methodName, STATE_CHANGING_PREFIXES);
     }
 
     /**

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleRegistry.java
@@ -35,6 +35,7 @@ final class RestApiRuleRegistry {
             new NoContentResponsesHaveNoBodyRule(),
             new ResponseStatusIgnoredWithResponseEntityRule(),
             new CreatedResponsesExposeLocationRule(),
+            new HeadHandlersDoNotReturnBodiesRule(),
             // Input validation & binding
             new RequestBodyIsValidatedRule(),
             new NoMassAssignmentViaEntitiesRule(),
@@ -65,6 +66,7 @@ final class RestApiRuleRegistry {
             new BroadExceptionHandlerRule(),
             new ResponseStatusOnExceptionRule(),
             new RetryAfterOnThrottlingResponsesRule(),
+            new ExceptionHandlersDoNotReturnRawStringsRule(),
             new EndpointsAreDocumentedRule(),
             new ControllersAreTaggedRule(),
             new DeprecatedEndpointsSignalDeprecationRule());

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRules.java
@@ -78,7 +78,7 @@ final class RestApiRuleHelp {
             "https://docs.spring.io/spring-framework/reference/web/webmvc-versioning.html";
     static final String IDEMPOTENCY_KEY_DOCS =
             "https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/";
-    static final String DEPRECATION_DOCS = "https://www.rfc-editor.org/rfc/rfc8594.html";
+    static final String DEPRECATION_DOCS = "https://www.rfc-editor.org/rfc/rfc9745.html";
     static final String RETRY_AFTER_DOCS = "https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3";
 
     private static final Pattern VERSION_SEGMENT = Pattern.compile("v\\d+", Pattern.CASE_INSENSITIVE);
@@ -511,8 +511,9 @@ final class StateChangingHandlersNotOnGetRule extends AbstractRestApiRule {
                 "State-changing handlers are not mapped to GET",
                 RestApiCategory.ROUTING,
                 "HIGH",
-                "GET must be safe and idempotent. A create/update/delete-style handler mapped to GET can be triggered"
-                        + " by crawlers, prefetching, or caching.",
+                "GET must be safe and idempotent. A create/update/delete/save-style handler mapped to GET can be"
+                        + " triggered by crawlers, prefetching, or caching. Ambiguous HTTP-verb prefixes such as"
+                        + " postProcess, putAside, and patchVersion are deliberately not treated as mutations.",
                 "Map state-changing operations to POST/PUT/PATCH/DELETE instead of GET.",
                 RestApiRuleHelp.REST_GUIDELINES));
     }
@@ -1220,9 +1221,11 @@ final class ReturnPagedTypeRule extends AbstractRestApiRule {
                 "Pageable handlers return a paged type",
                 RestApiCategory.PAGINATION,
                 "LOW",
-                "A handler that accepts a Pageable but returns a raw List/array discards the paging metadata (total"
-                        + " elements, total pages) that Page or Slice would carry.",
-                "Return Page or Slice when the handler accepts a Pageable, so paging metadata reaches the client.",
+                "A Spring handler that accepts Spring Data Pageable but returns a raw List/array discards the paging"
+                        + " metadata (total elements, total pages) that Page or Slice would carry. This Spring-specific"
+                        + " type relationship has no reliably detectable JAX-RS equivalent in the current model.",
+                "On Spring, return Page or Slice when the handler accepts Pageable, so paging metadata reaches the"
+                        + " client. On JAX-RS, document and return an explicit pagination envelope.",
                 RestApiRuleHelp.PAGINATION_DOCS));
     }
 
@@ -1970,11 +1973,11 @@ final class BroadExceptionHandlerRule extends AbstractRestApiRule {
                 "Broad @ExceptionHandler should not collapse all errors to one status",
                 RestApiCategory.ERROR_HANDLING,
                 "LOW",
-                "@ExceptionHandler(Exception.class) or Throwable is the only exception handler present (so every"
-                        + " error — validation, not-found, server fault — collapses to one status), or it maps to a"
-                        + " fixed non-5xx status. A broad catch-all mapped to a 5xx status (RFC 9110 §15.6.1) that"
-                        + " coexists with specific handlers for other exception types is a deliberate, correct"
-                        + " last-resort fallback and is not flagged.",
+                "@ExceptionHandler(Exception.class) or Throwable is the only exception handler declared by its class"
+                        + " (so that advice/mapper collapses every error it handles to one status), or it maps to a"
+                        + " fixed non-5xx status. The comparison is per declaring class, not application-wide. A broad"
+                        + " catch-all mapped to a 5xx status (RFC 9110 §15.6.1) that coexists in the same class with"
+                        + " specific handlers is a deliberate last-resort fallback and is not flagged.",
                 "Catch specific exception types and map each to its appropriate status (e.g. 400, 404, 409), and"
                         + " keep any Exception/Throwable catch-all as a last-resort fallback mapped to a 5xx status.",
                 RestApiRuleHelp.PROBLEM_DETAIL_DOCS));
@@ -2002,8 +2005,9 @@ final class BroadExceptionHandlerRule extends AbstractRestApiRule {
                     && !RestApiRuleHelp.SERVER_ERROR_STATUS_NAMES.contains(handler.responseStatusValue());
             if (isSoleHandlerInClass) {
                 violations.add(simpleName(handler.declaringClassName()) + "#" + handler.methodName()
-                        + " catches Exception/Throwable and is the only exception handler present, so all errors"
-                        + " collapse to one status");
+                        + " catches Exception/Throwable and is the only exception handler declared by "
+                        + simpleName(handler.declaringClassName()) + ", so that mapper collapses all handled errors"
+                        + " to one status");
             } else if (mapsToNonServerErrorStatus) {
                 violations.add(simpleName(handler.declaringClassName()) + "#" + handler.methodName()
                         + " catches Exception/Throwable and maps it to a fixed non-5xx status ("
@@ -2112,9 +2116,9 @@ final class IdempotencyKeyOnCreationEndpointsRule extends AbstractRestApiRule {
                 RestApiCategory.VALIDATION,
                 "INFO",
                 "A POST creation endpoint has no client-supplied Idempotency-Key header, so a client cannot safely"
-                        + " retry the request after a network failure without risking a duplicate resource. The"
-                        + " Idempotency-Key HTTP header is still an IETF HTTPAPI working-group Internet-Draft, but it"
-                        + " formalises a pattern already used by Stripe, PayPal, and Azure.",
+                        + " retry the request after a network failure without risking a duplicate resource."
+                        + " draft-ietf-httpapi-idempotency-key-header expired in April 2026 without becoming an RFC,"
+                        + " but the header remains a useful de-facto convention implemented by major payment APIs.",
                 "Worth a design review: accept an Idempotency-Key header (@RequestHeader/@HeaderParam) and"
                         + " de-duplicate retried requests by that key for non-idempotent creation endpoints.",
                 RestApiRuleHelp.IDEMPOTENCY_KEY_DOCS));
@@ -2140,11 +2144,11 @@ final class DeprecatedEndpointsSignalDeprecationRule extends AbstractRestApiRule
                 "INFO",
                 "A handler (or its declaring class) is annotated @Deprecated but has no accompanying"
                         + " @Operation(deprecated = true). @Deprecated only communicates to compile-time Java"
-                        + " consumers; HTTP clients calling the endpoint directly need an out-of-band signal (RFC"
-                        + " 8594 Sunset header, or the still-draft Deprecation header).",
+                        + " consumers; HTTP clients need an OpenAPI deprecation marker and can also receive the"
+                        + " standardized Deprecation response header defined by RFC 9745.",
                 "Add @Operation(deprecated = true) alongside @Deprecated so the generated OpenAPI document signals"
-                        + " deprecation to HTTP clients, and consider RFC 8594's Sunset header for a concrete"
-                        + " retirement date.",
+                        + " deprecation, and consider RFC 9745's Deprecation header plus RFC 8594's Sunset header for"
+                        + " runtime notice and a concrete retirement date.",
                 RestApiRuleHelp.DEPRECATION_DOCS));
     }
 
@@ -2174,7 +2178,8 @@ final class RetryAfterOnThrottlingResponsesRule extends AbstractRestApiRule {
                         + " retry. This is a weak, advisory signal: an imperatively-set header cannot be detected by"
                         + " static analysis, so treat this as a reminder rather than a confirmed defect.",
                 "Set a Retry-After header (RFC 9110 §10.2.3) alongside 429 (RFC 6585 §4) or 503 responses so"
-                        + " clients know when to retry.",
+                        + " clients know when to retry. For quota visibility, RateLimit and RateLimit-Policy are"
+                        + " complementary fields from an active IETF HTTPAPI Internet-Draft, not an RFC.",
                 RestApiRuleHelp.RETRY_AFTER_DOCS));
     }
 
@@ -2187,12 +2192,14 @@ final class RetryAfterOnThrottlingResponsesRule extends AbstractRestApiRule {
                         + " with no statically-visible Retry-After header");
             }
         }
+
         for (ExceptionHandlerModel handler : context.exceptionHandlers()) {
             if (THROTTLING_STATUS_NAMES.contains(handler.responseStatusValue())) {
                 violations.add(simpleName(handler.declaringClassName()) + "#" + handler.methodName() + " maps to "
                         + handler.responseStatusValue() + " with no statically-visible Retry-After header");
             }
         }
+
         return RestApiRuleSupport.fromViolations(definition(), violations);
     }
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiScanner.java
@@ -30,8 +30,10 @@ public final class RestApiScanner {
             "Heuristic, project-agnostic REST API design rules run against the host application's own controllers "
                     + "only. These checks complement, but do not replace, an API design review or contract testing. "
                     + "Security concerns (CORS, authentication, authorization) are covered by the Security Advisor.";
-    /** Rules tied to Spring-only types (RFC 9457 ProblemDetail) with no JAX-RS equivalent; skipped on JAX-RS. */
-    private static final Set<String> SPRING_ONLY_RULE_IDS = Set.of("RAPI-ERR-003", "RAPI-ERR-006");
+    /** Rules tied to Spring's RFC 9457 convenience types; skipped when the model contains only JAX-RS resources. */
+    private static final Set<String> SPRING_PROBLEM_DETAIL_RULE_IDS = Set.of("RAPI-ERR-003", "RAPI-ERR-006");
+
+    private static final Set<String> SPRING_DATA_PAGINATION_RULE_IDS = Set.of("RAPI-PAGE-002");
 
     private static final Comparator<RestApiRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(
                     (RestApiRuleResultDto result) -> SeverityOrder.rank(result.severity()))
@@ -166,11 +168,20 @@ public final class RestApiScanner {
                 results);
     }
 
-    private static RestApiRuleResultDto evaluate(RestApiRule rule, RestApiContext context) {
+    static RestApiRuleResultDto evaluate(RestApiRule rule, RestApiContext context) {
         RestApiRuleDefinition definition = rule.definition();
-        if (context.jaxRs() && SPRING_ONLY_RULE_IDS.contains(definition.id())) {
+        if (context.jaxRs() && SPRING_PROBLEM_DETAIL_RULE_IDS.contains(definition.id())) {
             return RestApiRuleSupport.skipped(
-                    definition, "Not applicable on JAX-RS: Spring ProblemDetail (RFC 9457) types are not available.");
+                    definition,
+                    "Not applicable on JAX-RS: RFC 9457 is framework-neutral, but this rule specifically detects"
+                            + " Spring ProblemDetail/ErrorResponse return types; the current model cannot reliably"
+                            + " identify equivalent JAX-RS problem-details payloads.");
+        }
+        if (context.jaxRs() && SPRING_DATA_PAGINATION_RULE_IDS.contains(definition.id())) {
+            return RestApiRuleSupport.skipped(
+                    definition,
+                    "Not applicable on JAX-RS: this rule specifically compares Spring Data Pageable inputs with"
+                            + " Page/Slice outputs.");
         }
         return rule.evaluate(context);
     }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/JaxRsRestApiModelTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/JaxRsRestApiModelTests.java
@@ -72,9 +72,13 @@ class JaxRsRestApiModelTests {
 
     @Test
     void stateChangingGetRuleFiresOnJaxRs() {
-        String status =
-                new StateChangingHandlersNotOnGetRule().evaluate(context(BAD)).status();
-        assertThat(status).isEqualTo(RestApiRuleSupport.VIOLATION);
+        RestApiRuleResultDto result = new StateChangingHandlersNotOnGetRule().evaluate(context(BAD));
+        assertThat(result.status()).isEqualTo(RestApiRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations()).anyMatch(violation -> violation.contains("createGadget"));
+        assertThat(result.sampleViolations())
+                .noneMatch(violation -> violation.contains("postProcess")
+                        || violation.contains("putAside")
+                        || violation.contains("patchVersion"));
     }
 
     @Test
@@ -255,5 +259,22 @@ class JaxRsRestApiModelTests {
         assertThat(result.status()).isEqualTo(RestApiRuleSupport.VIOLATION);
         assertThat(result.sampleViolations()).anyMatch(violation -> violation.contains("CatchAllRegexResource"));
         assertThat(result.sampleViolations()).noneMatch(violation -> violation.contains("ConstrainedIdResource"));
+    }
+
+    @Test
+    void springSpecificRulesExplainTheirActualJaxRsLimitation() {
+        RestApiContext context = context(GOOD);
+
+        RestApiRuleResultDto problemDetail = RestApiScanner.evaluate(new PreferProblemDetailRule(), context);
+        assertThat(problemDetail.status()).isEqualTo(RestApiRuleSupport.SKIPPED);
+        assertThat(problemDetail.sampleViolations().get(0))
+                .contains("RFC 9457 is framework-neutral")
+                .contains("current model cannot reliably identify");
+
+        RestApiRuleResultDto pagination = RestApiScanner.evaluate(new ReturnPagedTypeRule(), context);
+        assertThat(pagination.status()).isEqualTo(RestApiRuleSupport.SKIPPED);
+        assertThat(pagination.sampleViolations().get(0))
+                .contains("Spring Data Pageable")
+                .contains("Page/Slice");
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleRegistryTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleRegistryTests.java
@@ -9,10 +9,10 @@ import org.junit.jupiter.api.Test;
 class RestApiRuleRegistryTests {
 
     @Test
-    void registersFiftyOneRulesWithUniqueIds() {
+    void registersFiftyThreeRulesWithUniqueIds() {
         List<RestApiRule> rules = RestApiRuleRegistry.activeRules();
 
-        assertThat(rules).hasSize(51);
+        assertThat(rules).hasSize(53);
 
         List<String> ids = rules.stream().map(rule -> rule.definition().id()).toList();
         assertThat(ids).doesNotHaveDuplicates();
@@ -24,11 +24,13 @@ class RestApiRuleRegistryTests {
                         "RAPI-MAP-010",
                         "RAPI-MAP-011",
                         "RAPI-RESP-008",
+                        "RAPI-RESP-009",
                         "RAPI-VER-005",
                         "RAPI-VER-006",
                         "RAPI-ERR-005",
                         "RAPI-ERR-006",
                         "RAPI-ERR-007",
+                        "RAPI-ERR-008",
                         "RAPI-VALID-004",
                         "RAPI-VALID-005",
                         "RAPI-DTO-005",

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiRulesTests.java
@@ -24,6 +24,8 @@ class RestApiRulesTests {
     private static final String NEWRULES_RETRY_AFTER = "io.github.jdubois.bootui.engine.restapi.newrules.retryafter";
     private static final String NEWRULES_PAGINATION = "io.github.jdubois.bootui.engine.restapi.newrules.pagination";
     private static final String NEWRULES_PAGINATION_PAGESIZE = NEWRULES_PAGINATION + ".pagesize";
+    private static final String RESPONSE_CONTRACTS =
+            "io.github.jdubois.bootui.engine.restapi.newrules.responsecontracts";
 
     private RestApiContext context(boolean openApiAnnotationsPresent, String... packages) {
         JavaClasses classes = new ClassFileImporter().importPackages(packages);
@@ -405,6 +407,35 @@ class RestApiRulesTests {
         // A clean package with no throttling status codes must PASS.
         assertThat(status(new RetryAfterOnThrottlingResponsesRule(), context(false, GOOD)))
                 .isEqualTo("PASS");
+    }
+
+    @Test
+    void headBodyAndRawStringExceptionRulesFireOnSpringAndJaxRs() {
+        for (String frameworkPackage : List.of(RESPONSE_CONTRACTS + ".spring", RESPONSE_CONTRACTS + ".jaxrs")) {
+            RestApiContext context = context(false, frameworkPackage);
+
+            RestApiRuleResultDto headResult = new HeadHandlersDoNotReturnBodiesRule().evaluate(context);
+            assertThat(headResult.status()).isEqualTo("VIOLATION");
+            assertThat(headResult.sampleViolations()).anyMatch(violation -> violation.contains("#head"));
+            assertThat(headResult.sampleViolations()).noneMatch(violation -> violation.contains("#headersOnly"));
+
+            RestApiRuleResultDto exceptionResult = new ExceptionHandlersDoNotReturnRawStringsRule().evaluate(context);
+            assertThat(exceptionResult.status()).isEqualTo("VIOLATION");
+            assertThat(exceptionResult.sampleViolations()).anyMatch(violation -> violation.contains("#handle"));
+        }
+    }
+
+    @Test
+    void stateChangingNameMatchingAvoidsAmbiguousHttpVerbPrefixesOnSpring() {
+        RestApiRuleResultDto result =
+                new StateChangingHandlersNotOnGetRule().evaluate(context(false, RESPONSE_CONTRACTS + ".spring"));
+
+        assertThat(result.status()).isEqualTo("VIOLATION");
+        assertThat(result.sampleViolations()).anyMatch(violation -> violation.contains("updateWidget"));
+        assertThat(result.sampleViolations())
+                .noneMatch(violation -> violation.contains("postProcess")
+                        || violation.contains("putAside")
+                        || violation.contains("patchVersion"));
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/fixtures/bad/BadOrderController.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/fixtures/bad/BadOrderController.java
@@ -12,8 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class BadOrderController {
 
-    // RAPI-NAME-001 (verb), RAPI-DTO-001 (entity), RAPI-DTO-003 (raw collection),
-    // RAPI-PAGE-001 (unpaginated collection GET)
+    // RAPI-NAME-001 (verb), RAPI-DTO-001 (entity), RAPI-PAGE-001 (unpaginated collection GET)
     @GetMapping("/getOrders")
     public List<OrderEntity> getOrders() {
         return List.of();

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/jaxrs/bad/BadGadgetResource.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/jaxrs/bad/BadGadgetResource.java
@@ -13,4 +13,22 @@ public class BadGadgetResource {
     public WidgetDto createGadget() {
         return new WidgetDto("1", "g");
     }
+
+    @GET
+    @Path("/post-process")
+    public WidgetDto postProcess() {
+        return new WidgetDto("2", "processed");
+    }
+
+    @GET
+    @Path("/put-aside")
+    public WidgetDto putAside() {
+        return new WidgetDto("3", "aside");
+    }
+
+    @GET
+    @Path("/patch-version")
+    public WidgetDto patchVersion() {
+        return new WidgetDto("4", "versioned");
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/newrules/responsecontracts/jaxrs/JaxRsHeadResource.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/newrules/responsecontracts/jaxrs/JaxRsHeadResource.java
@@ -1,0 +1,20 @@
+package io.github.jdubois.bootui.engine.restapi.newrules.responsecontracts.jaxrs;
+
+import jakarta.ws.rs.HEAD;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Response;
+
+@Path("/widgets")
+public class JaxRsHeadResource {
+
+    @HEAD
+    public String head() {
+        return "body-that-must-not-be-sent";
+    }
+
+    @HEAD
+    @Path("/headers-only")
+    public Response headersOnly() {
+        return Response.ok().build();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/newrules/responsecontracts/jaxrs/JaxRsRawStringMapper.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/newrules/responsecontracts/jaxrs/JaxRsRawStringMapper.java
@@ -1,0 +1,11 @@
+package io.github.jdubois.bootui.engine.restapi.newrules.responsecontracts.jaxrs;
+
+import org.jboss.resteasy.reactive.server.ServerExceptionMapper;
+
+public class JaxRsRawStringMapper {
+
+    @ServerExceptionMapper
+    public String handle(IllegalArgumentException exception) {
+        return exception.getMessage();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/newrules/responsecontracts/spring/SpringRawStringAdvice.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/newrules/responsecontracts/spring/SpringRawStringAdvice.java
@@ -1,0 +1,16 @@
+package io.github.jdubois.bootui.engine.restapi.newrules.responsecontracts.spring;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class SpringRawStringAdvice {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String handle(IllegalArgumentException exception) {
+        return exception.getMessage();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/newrules/responsecontracts/spring/SpringResponseContractController.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/newrules/responsecontracts/spring/SpringResponseContractController.java
@@ -1,0 +1,42 @@
+package io.github.jdubois.bootui.engine.restapi.newrules.responsecontracts.spring;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/widgets")
+public class SpringResponseContractController {
+
+    @RequestMapping(method = RequestMethod.HEAD)
+    public String head() {
+        return "body-that-must-not-be-sent";
+    }
+
+    @RequestMapping(path = "/headers-only", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> headersOnly() {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/update")
+    public String updateWidget() {
+        return "updated";
+    }
+
+    @GetMapping("/post-process")
+    public String postProcess() {
+        return "processed";
+    }
+
+    @GetMapping("/put-aside")
+    public String putAside() {
+        return "aside";
+    }
+
+    @GetMapping("/patch-version")
+    public String patchVersion() {
+        return "versioned";
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/phase2/bad/Phase2BadController.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/phase2/bad/Phase2BadController.java
@@ -16,8 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * Controller that intentionally trips the Phase 2 REST API Advisor additions and tightened rules:
  * RAPI-MAP-008 (mutation without an id), RAPI-RESP-008 (CREATED body with no Location),
- * RAPI-VER-005 (inconsistent produces), RAPI-DTO-003 (non-GET raw collection), and RAPI-VALID-001
- * (bare {@code @NotNull} on a request body).
+ * RAPI-VER-005 (inconsistent produces), and RAPI-VALID-001 (bare {@code @NotNull} on a request body).
  */
 @RestController
 @RequestMapping("/api/items")

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/phase2/good/Phase2GoodController.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/phase2/good/Phase2GoodController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Controller that should pass all Phase 2 REST API Advisor additions and the tightened existing
- * rules (RAPI-MAP-008, RAPI-RESP-008, RAPI-VER-005, RAPI-DTO-003, RAPI-VALID-001).
+ * rules (RAPI-MAP-008, RAPI-RESP-008, RAPI-VER-005, RAPI-VALID-001).
  */
 @RestController
 @RequestMapping("/api/orders")

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -378,14 +378,13 @@ last report, and dismissing a rule persists to `.bootui/boot-ui.yml` exactly as 
 ### REST API
 
 The REST API panel runs a curated, zero-config ruleset against the host application's own web layer
-(`@RestController` / `@Controller` handler methods) at runtime. Like the Architecture panel, it detects the
-application's base package from the `@SpringBootApplication` configuration, imports the compiled controllers from that
-package with ArchUnit's `ClassFileImporter` (bounded to the application's own classes), and derives a read-only handler
+(`@RestController` / `@Controller` handler methods on Spring or JAX-RS resources on Quarkus) at runtime. Like the
+Architecture panel, it imports the compiled handlers from bounded application base packages and derives a read-only
 model — HTTP method(s), path(s), parameters and their annotations, return type, `produces`/`consumes`, validation flags,
-and declared throws. It then evaluates 36 universally-sensible REST best-practice rules across eight categories: routing
+and declared throws. It then evaluates 53 REST best-practice rules across eight categories: routing
 and HTTP-method mapping, resource naming, status codes and responses, input validation and binding, DTO and payload
 contracts, pagination, versioning and content negotiation, and error handling and documentation. The `RAPI-DOC-*`
-documentation rules only run when springdoc-openapi is on the host classpath.
+documentation rules only run when Swagger or MicroProfile OpenAPI annotations are on the host classpath.
 
 The advisor deliberately avoids security concerns (CORS, authentication, authorization), which remain owned by the
 Security panel. The scan runs on demand and caches the last report; each rule is registered with a stable

--- a/docs/REST-API-CHECKS.md
+++ b/docs/REST-API-CHECKS.md
@@ -8,7 +8,7 @@ Each rule is a small class registered in
 [`RestApiRuleRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleRegistry.java)
 and implemented in
 [`RestApiRules.java`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRules.java),
-both in the framework-neutral `bootui-engine` module so the same 51 rules run identically on Spring Boot and Quarkus. The
+both in the framework-neutral `bootui-engine` module so the same 53 rules run identically on Spring Boot and Quarkus. The
 list intentionally stays compact and reviewable; adding a new rule means adding one focused class plus a registry entry.
 
 ## What BootUI does
@@ -19,8 +19,10 @@ files from those packages with ArchUnit's `ClassFileImporter`, derives a read-on
 path(s), parameters and their annotations, return type, `produces`/`consumes`, validation flags, declared throws) once,
 and evaluates every registered rule against that model. Importing is bounded to the application's own base package(s) —
 never the entire classpath — and runs only on demand when the scan action is invoked, caching the last report in the
-controller. A handful of rules reason about Spring-only types with no JAX-RS equivalent (RFC 9457 `ProblemDetail`); on
-Quarkus those report `SKIPPED` with an explanatory reason instead of misfiring — see RAPI-ERR-003 and RAPI-ERR-006 below.
+controller. A handful of rules reason about Spring-specific types (`ProblemDetail`/`ErrorResponse` convenience types or
+Spring Data `Pageable`); on Quarkus those report `SKIPPED` with an explanatory reason instead of misfiring. RFC 9457
+itself is framework-neutral; the limitation is that the bounded model cannot reliably prove that an arbitrary JAX-RS
+payload implements its schema — see RAPI-PAGE-002, RAPI-ERR-003, and RAPI-ERR-006 below.
 
 The handler model unwraps common async/reactive return-type wrappers before classifying the response body, so the
 body-shape rules below (RAPI-DTO-001/002/004/005, RAPI-RESP-004, RAPI-PAGE-001/002, RAPI-NAME-002) see the real payload
@@ -57,7 +59,7 @@ Findings are ranked in the scanner's severity order:
 - `LOW`
 - `INFO`
 
-The catalogue below ships **51 rules across 8 categories** (8 HIGH, 10 MEDIUM, 18 LOW, 15 INFO; no active CRITICAL
+The catalogue below ships **53 rules across 8 categories** (8 HIGH, 10 MEDIUM, 20 LOW, 15 INFO; no active CRITICAL
 rules). The `RAPI-DOC-*` documentation rules only run when OpenAPI annotations are present on the host classpath —
 Swagger/springdoc-openapi (`io.swagger.v3.oas.annotations`) on Spring, or MicroProfile OpenAPI
 (`org.eclipse.microprofile.openapi.annotations`, honored by Quarkus's `quarkus-smallrye-openapi`) on either framework;
@@ -84,7 +86,7 @@ otherwise they are reported as `SKIPPED`.
 ### RAPI-MAP-003 - State-changing handlers are not mapped to GET
 
 - **Severity**: HIGH
-- **Detects**: GET must be safe and idempotent. A create/update/delete-style handler mapped to GET can be triggered by crawlers, prefetching, or caching.
+- **Detects**: GET must be safe and idempotent. A create/update/delete/save-style handler mapped to GET can be triggered by crawlers, prefetching, or caching. Ambiguous HTTP-verb prefixes are intentionally excluded, so names such as `postProcess`, `putAside`, and `patchVersion` do not create false positives.
 - **Recommendation**: Map state-changing operations to POST/PUT/PATCH/DELETE instead of GET.
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9110.html>
 
@@ -232,6 +234,13 @@ otherwise they are reported as `SKIPPED`.
 - **Recommendation**: Return ResponseEntity.created(uri).body(...) so the 201 response also carries the Location of the new resource.
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9110.html#section-15.3.2>
 
+### RAPI-RESP-009 - HEAD handlers do not return response bodies
+
+- **Severity**: LOW
+- **Detects**: A dedicated HEAD handler returns a body even though RFC 9110 requires a HEAD response to omit message content. This catches both Spring `RequestMethod.HEAD` handlers and JAX-RS `@HEAD` resource methods.
+- **Recommendation**: Return void or a headers-only response from dedicated HEAD handlers; let the framework derive HEAD from GET when no distinct metadata calculation is needed.
+- **Learn more**: <https://www.rfc-editor.org/rfc/rfc9110.html>
+
 ## Input validation & binding
 
 ### RAPI-VALID-001 - @RequestBody is validated
@@ -265,7 +274,7 @@ otherwise they are reported as `SKIPPED`.
 ### RAPI-VALID-005 - Consider an Idempotency-Key header on creation endpoints
 
 - **Severity**: INFO
-- **Detects**: A POST creation endpoint (method name starting with create/add/save/insert/register/new) has no client-supplied Idempotency-Key header (@RequestHeader on Spring, @HeaderParam/@RestHeader on JAX-RS), so a client cannot safely retry the request after a network failure without risking a duplicate resource. The Idempotency-Key HTTP header is still an IETF HTTPAPI working-group Internet-Draft, but it formalises a pattern already used by Stripe, PayPal, and Azure.
+- **Detects**: A POST creation endpoint (method name starting with create/add/save/insert/register/new) has no client-supplied Idempotency-Key header (@RequestHeader on Spring, @HeaderParam/@RestHeader on JAX-RS), so a client cannot safely retry the request after a network failure without risking a duplicate resource. `draft-ietf-httpapi-idempotency-key-header-07` expired in April 2026 without becoming an RFC, but the header remains useful de-facto guidance implemented by major payment APIs.
 - **Recommendation**: Worth a design review: accept an Idempotency-Key header and de-duplicate retried requests by that key for non-idempotent creation endpoints.
 - **Learn more**: <https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/>
 
@@ -311,8 +320,8 @@ otherwise they are reported as `SKIPPED`.
 ### RAPI-PAGE-002 - Pageable handlers return a paged type
 
 - **Severity**: LOW
-- **Detects**: A handler that accepts a Pageable but returns a raw List/array discards the paging metadata (total elements, total pages) that Page or Slice would carry.
-- **Recommendation**: Return Page or Slice when the handler accepts a Pageable, so paging metadata reaches the client.
+- **Detects**: A Spring handler that accepts Spring Data Pageable but returns a raw List/array discards the paging metadata (total elements, total pages) that Page or Slice would carry. On JAX-RS/Quarkus the rule reports `SKIPPED`: the current model sees explicit page/size/cursor parameters but has no reliable framework-neutral metadata proving which response type is the application's pagination envelope.
+- **Recommendation**: On Spring, return Page or Slice when the handler accepts Pageable. On JAX-RS, document and return an explicit pagination envelope.
 - **Learn more**: <https://docs.spring.io/spring-data/commons/reference/repositories/core-extensions.html>
 
 ### RAPI-PAGE-003 - Consistent pagination parameter vocabulary across handlers
@@ -385,7 +394,7 @@ otherwise they are reported as `SKIPPED`.
 ### RAPI-ERR-003 - Prefer RFC 9457 ProblemDetail
 
 - **Severity**: INFO
-- **Detects**: @ExceptionHandler methods that model errors as ad-hoc maps/strings instead of ProblemDetail produce non-standard error payloads. Not applicable on JAX-RS/Quarkus: Spring's `ProblemDetail` type has no equivalent there, so the rule reports `SKIPPED`.
+- **Detects**: @ExceptionHandler methods that model errors as ad-hoc maps/strings instead of Spring's ProblemDetail convenience type produce non-standard error payloads. On JAX-RS/Quarkus the rule reports `SKIPPED`: RFC 9457 is framework-neutral, but the current model cannot reliably prove that an arbitrary JAX-RS DTO implements the problem-details schema.
 - **Recommendation**: Return ProblemDetail (or ErrorResponse) from @ExceptionHandler methods for RFC 9457 compliant errors.
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9457.html>
 
@@ -399,14 +408,14 @@ otherwise they are reported as `SKIPPED`.
 ### RAPI-ERR-005 - Broad @ExceptionHandler should not collapse all errors to one status
 
 - **Severity**: LOW
-- **Detects**: @ExceptionHandler(Exception.class) or Throwable is the only exception handler present (so every error - validation, not-found, server fault - collapses to one status), or it maps to a fixed non-5xx status. A broad catch-all mapped to a 5xx status (RFC 9110 §15.6.1) that coexists with specific handlers for other exception types is a deliberate, correct last-resort fallback and is not flagged.
+- **Detects**: @ExceptionHandler(Exception.class) or Throwable is the only exception handler declared by its advice/mapper class (so that class collapses every error it handles to one status), or it maps to a fixed non-5xx status. The comparison is per declaring class, not application-wide. A broad catch-all mapped to a 5xx status (RFC 9110 §15.6.1) that coexists with specific handlers in the same class is a deliberate last-resort fallback and is not flagged.
 - **Recommendation**: Catch specific exception types and map each to its appropriate status (e.g. 400, 404, 409), and keep any Exception/Throwable catch-all as a last-resort fallback mapped to a 5xx status.
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9457.html>
 
 ### RAPI-ERR-006 - Prefer ErrorResponseException over @ResponseStatus on exceptions
 
 - **Severity**: INFO
-- **Detects**: The project uses ProblemDetail (RFC 9457) for error responses but some application exception classes are annotated with @ResponseStatus instead, mixing error-handling approaches. Not applicable on JAX-RS/Quarkus: Spring's `ProblemDetail` type has no equivalent there, so the rule reports `SKIPPED`.
+- **Detects**: The project uses Spring's ProblemDetail (RFC 9457) support for error responses but some application exception classes are annotated with @ResponseStatus instead, mixing Spring error-handling approaches. On JAX-RS/Quarkus the rule reports `SKIPPED` because both inspected types are Spring-specific; RFC 9457 itself remains framework-neutral.
 - **Recommendation**: Replace @ResponseStatus on exception classes with ErrorResponseException (or a subclass) so all errors consistently produce RFC 9457 ProblemDetail responses.
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9457.html>
 
@@ -414,8 +423,15 @@ otherwise they are reported as `SKIPPED`.
 
 - **Severity**: INFO
 - **Detects**: A handler or exception handler maps to 429 Too Many Requests or 503 Service Unavailable with no statically-visible Retry-After header, leaving clients to guess when it is safe to retry. This is a weak, advisory signal: an imperatively-set header cannot be detected by static analysis, so treat this as a reminder rather than a confirmed defect.
-- **Recommendation**: Set a Retry-After header (RFC 9110 §10.2.3) alongside 429 (RFC 6585 §4) or 503 responses so clients know when to retry.
+- **Recommendation**: Set a Retry-After header (RFC 9110 §10.2.3) alongside 429 (RFC 6585 §4) or 503 responses so clients know when to retry. For quota visibility, `RateLimit` and `RateLimit-Policy` are complementary fields from the active `draft-ietf-httpapi-ratelimit-headers`; as of July 2026 they are not an RFC.
 - **Learn more**: <https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.3>
+
+### RAPI-ERR-008 - Exception handlers return structured errors
+
+- **Severity**: LOW
+- **Detects**: A Spring `@ExceptionHandler` or Quarkus REST `@ServerExceptionMapper` returns a raw String, exposing an unstructured error contract with no stable fields for type, status, detail, or correlation metadata.
+- **Recommendation**: Return a typed error DTO or an RFC 9457 problem-details representation instead of a raw String.
+- **Learn more**: <https://www.rfc-editor.org/rfc/rfc9457.html>
 
 ### RAPI-DOC-001 - Endpoints are documented
 
@@ -434,6 +450,6 @@ otherwise they are reported as `SKIPPED`.
 ### RAPI-DOC-003 - Deprecated endpoints signal deprecation to HTTP clients
 
 - **Severity**: INFO
-- **Detects**: A handler (or its declaring class) is annotated @Deprecated but has no accompanying @Operation(deprecated = true). @Deprecated only communicates to compile-time Java consumers; HTTP clients calling the endpoint directly need an out-of-band signal (RFC 8594 Sunset header, or the still-draft Deprecation header). Skipped when no OpenAPI annotations are present on the classpath (see RAPI-DOC-001).
-- **Recommendation**: Add @Operation(deprecated = true) alongside @Deprecated so the generated OpenAPI document signals deprecation to HTTP clients, and consider RFC 8594's Sunset header for a concrete retirement date.
-- **Learn more**: <https://www.rfc-editor.org/rfc/rfc8594.html>
+- **Detects**: A handler (or its declaring class) is annotated @Deprecated but has no accompanying @Operation(deprecated = true). @Deprecated only communicates to compile-time Java consumers; HTTP clients need an OpenAPI deprecation marker and can also receive the standardized `Deprecation` response header defined by RFC 9745. Skipped when no OpenAPI annotations are present on the classpath (see RAPI-DOC-001).
+- **Recommendation**: Add @Operation(deprecated = true) alongside @Deprecated, and consider RFC 9745's `Deprecation` header plus RFC 8594's `Sunset` header for runtime notice and a concrete retirement date.
+- **Learn more**: <https://www.rfc-editor.org/rfc/rfc9745.html>


### PR DESCRIPTION
## What does this PR do?

Improves the framework-neutral REST API advisor by correcting standards metadata and applicability guidance, narrowing mutation-name heuristics, and adding focused checks for HEAD handlers with bodies and raw-string exception responses.

## Why is this change needed?

The advisor still described RFC 9745 as a draft, treated the expired Idempotency-Key draft as active, and used imprecise Quarkus and pagination applicability wording. It also produced false positives for names such as `postProcess`, `putAside`, and `patchVersion`.

Primary references:

- [RFC 9745: The Deprecation HTTP Response Header Field](https://www.rfc-editor.org/rfc/rfc9745.html)
- [RFC 9110: HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110.html)
- [Expired Idempotency-Key draft-07](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-idempotency-key-header-07)
- [Active RateLimit header fields draft-11](https://datatracker.ietf.org/doc/html/draft-ietf-httpapi-ratelimit-headers-11)
- [RFC 9457: Problem Details for HTTP APIs](https://www.rfc-editor.org/rfc/rfc9457.html)

N/A (audit follow-up; no linked issue).

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Commands run:

- `./mvnw -B -ntp -pl bootui-engine test`
- `./mvnw -B -ntp -pl bootui-spring-sample-app -am -Dtest=SpringApiConformanceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -B -ntp -pl bootui-quarkus-integration-tests/base -am -Dtest=BootUiQuarkusApiConformanceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -B -ntp spotless:check`

Manual validation:

1. Start either sample application and open `/bootui/#/rest-api`.
2. Run the REST API checks and confirm the report evaluates 53 rules.
3. Inspect RAPI-DOC-003, RAPI-VALID-005, RAPI-PAGE-002, and RAPI-ERR-007 metadata for the updated RFC/draft and framework-applicability wording.
4. On Quarkus, confirm the Spring-specific RFC 9457 and Spring Data pagination rules report precise `SKIPPED` reasons rather than claiming RFC 9457 is Spring-only.

## Screenshots (UI changes)

N/A - no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
