### PR TITLE
Fix Memory advisor runtime heuristics

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/ContainerMemoryLimitDetector.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/ContainerMemoryLimitDetector.java
@@ -16,23 +16,28 @@ final class ContainerMemoryLimitDetector {
     private static final List<Path> STANDARD_CGROUP_LIMIT_FILES =
             List.of(Path.of("/sys/fs/cgroup/memory.max"), Path.of("/sys/fs/cgroup/memory/memory.limit_in_bytes"));
 
-    private final List<Path> limitFiles;
+    private static final List<Path> STANDARD_CGROUP_CURRENT_FILES =
+            List.of(Path.of("/sys/fs/cgroup/memory.current"), Path.of("/sys/fs/cgroup/memory/memory.usage_in_bytes"));
 
-    private ContainerMemoryLimitDetector(List<Path> limitFiles) {
+    private final List<Path> limitFiles;
+    private final List<Path> currentFiles;
+
+    ContainerMemoryLimitDetector(List<Path> limitFiles, List<Path> currentFiles) {
         this.limitFiles = List.copyOf(limitFiles);
+        this.currentFiles = List.copyOf(currentFiles);
     }
 
     static ContainerMemoryLimitDetector standard() {
-        return new ContainerMemoryLimitDetector(STANDARD_CGROUP_LIMIT_FILES);
+        return new ContainerMemoryLimitDetector(STANDARD_CGROUP_LIMIT_FILES, STANDARD_CGROUP_CURRENT_FILES);
     }
 
     static ContainerMemoryLimitDetector disabled() {
-        return new ContainerMemoryLimitDetector(List.of());
+        return new ContainerMemoryLimitDetector(List.of(), List.of());
     }
 
     OptionalLong detectLimit() {
         for (Path limitFile : limitFiles) {
-            OptionalLong limit = readLimit(limitFile);
+            OptionalLong limit = readValue(limitFile);
             if (limit.isPresent()) {
                 return limit;
             }
@@ -40,14 +45,24 @@ final class ContainerMemoryLimitDetector {
         return OptionalLong.empty();
     }
 
-    private OptionalLong readLimit(Path limitFile) {
-        if (!Files.isRegularFile(limitFile)) {
+    OptionalLong detectCurrentUsage() {
+        for (Path currentFile : currentFiles) {
+            OptionalLong current = readValue(currentFile);
+            if (current.isPresent()) {
+                return current;
+            }
+        }
+        return OptionalLong.empty();
+    }
+
+    private OptionalLong readValue(Path file) {
+        if (!Files.isRegularFile(file)) {
             return OptionalLong.empty();
         }
         try {
-            return parseLimit(Files.readString(limitFile));
+            return parseLimit(Files.readString(file));
         } catch (IOException ex) {
-            log.log(Level.DEBUG, "Could not read cgroup memory limit from " + limitFile, ex);
+            log.log(Level.DEBUG, "Could not read cgroup memory value from " + file, ex);
             return OptionalLong.empty();
         }
     }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCollector.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCollector.java
@@ -19,8 +19,6 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -47,12 +45,6 @@ final class MemoryCollector {
 
     private static final int MAX_HISTOGRAM_CLASSES = 200;
 
-    private static final List<Path> CGROUP_LIMIT_FILES =
-            List.of(Path.of("/sys/fs/cgroup/memory.max"), Path.of("/sys/fs/cgroup/memory/memory.limit_in_bytes"));
-
-    private static final List<Path> CGROUP_CURRENT_FILES =
-            List.of(Path.of("/sys/fs/cgroup/memory.current"), Path.of("/sys/fs/cgroup/memory/memory.usage_in_bytes"));
-
     @FunctionalInterface
     interface HistogramSource {
         /** Returns the raw {@code GC.class_histogram} output, or {@code null} when unavailable. */
@@ -61,6 +53,7 @@ final class MemoryCollector {
 
     private final ThreadDumpReportSupplier threadReportSupplier;
     private final HistogramSource histogramSource;
+    private final ContainerMemoryLimitDetector containerMemoryDetector;
 
     @FunctionalInterface
     interface ThreadDumpReportSupplier {
@@ -68,8 +61,16 @@ final class MemoryCollector {
     }
 
     MemoryCollector(ThreadDumpReportSupplier threadReportSupplier, HistogramSource histogramSource) {
+        this(threadReportSupplier, histogramSource, ContainerMemoryLimitDetector.standard());
+    }
+
+    MemoryCollector(
+            ThreadDumpReportSupplier threadReportSupplier,
+            HistogramSource histogramSource,
+            ContainerMemoryLimitDetector containerMemoryDetector) {
         this.threadReportSupplier = threadReportSupplier;
         this.histogramSource = histogramSource;
+        this.containerMemoryDetector = containerMemoryDetector;
     }
 
     MemoryContext collect() {
@@ -193,9 +194,9 @@ final class MemoryCollector {
             gcNames.add(gc.getName());
         }
 
-        OptionalLong containerLimitValue = detectContainerLimit();
+        OptionalLong containerLimitValue = containerMemoryDetector.detectLimit();
         Long containerLimit = containerLimitValue.isPresent() ? containerLimitValue.getAsLong() : null;
-        OptionalLong containerCurrentValue = detectContainerCurrentUsage();
+        OptionalLong containerCurrentValue = containerMemoryDetector.detectCurrentUsage();
         Long containerCurrent = containerCurrentValue.isPresent() ? containerCurrentValue.getAsLong() : null;
 
         return new MemoryData(
@@ -277,9 +278,10 @@ final class MemoryCollector {
         int availableProcessors = ManagementFactory.getOperatingSystemMXBean().getAvailableProcessors();
         long freeSwap = readOsBeanLong("FreeSwapSpaceSize");
         long totalSwap = readOsBeanLong("TotalSwapSpaceSize");
+        long freePhysicalMemory = readOsBeanLong("FreePhysicalMemorySize");
         long totalPhysicalMemory = readOsBeanLong("TotalPhysicalMemorySize");
         Boolean useCompressedOops = readVmOptionBoolean("UseCompressedOops");
-        LastGcPause lastGcPause = readLastGcPause();
+        LastGcEvent lastGcEvent = readLastGcEvent();
 
         return new RuntimeData(
                 gc.uptimeMillis(),
@@ -293,49 +295,53 @@ final class MemoryCollector {
                 totalSwap,
                 useCompressedOops,
                 totalPhysicalMemory,
-                lastGcPause.millis(),
-                lastGcPause.collectorName());
+                lastGcEvent.durationMillis(),
+                lastGcEvent.collectorName(),
+                freePhysicalMemory);
     }
 
     /**
-     * The duration and originating collector of the single most recent garbage collection (MEM-GC-006's
-     * outlier-pause rule). {@link #unavailable()} on a non-HotSpot JVM or before any collection has run.
+     * A collector's latest event on the shared JVM-uptime time base exposed by {@code GcInfo}.
      */
-    private record LastGcPause(long millis, String collectorName) {
-        static LastGcPause unavailable() {
-            return new LastGcPause(-1, null);
+    record LastGcEventCandidate(long endTimeMillis, long durationMillis, String collectorName) {}
+
+    /**
+     * The duration and originating collector of the single most recently completed garbage collection.
+     */
+    record LastGcEvent(long durationMillis, String collectorName) {
+        static LastGcEvent unavailable() {
+            return new LastGcEvent(-1, null);
         }
     }
 
     /**
-     * Reads the duration of the single most recent garbage collection across all collectors via the
-     * HotSpot-specific {@code com.sun.management.GarbageCollectorMXBean.getLastGcInfo()} extension,
-     * keeping the longest pause (and its collector name) when more than one collector has run since
-     * the JVM started. Unlike the generic scalar reads elsewhere in this class, this directly uses the
-     * {@code com.sun.management} types (there is no generic string-keyed JMX attribute for the
-     * composite "last GC info" value); the whole lookup is wrapped so a non-HotSpot JVM degrades to
-     * {@link LastGcPause#unavailable()} instead of failing this (or any other) scan.
+     * Reads each collector bean's latest event and compares {@code GcInfo.endTime}, whose JVM-uptime
+     * time base is shared across beans. Comparing durations would select the longest historical event,
+     * not the event that actually completed most recently.
      */
-    private static LastGcPause readLastGcPause() {
+    private static LastGcEvent readLastGcEvent() {
         try {
-            long longestDurationMillis = -1;
-            String longestCollectorName = null;
+            List<LastGcEventCandidate> candidates = new ArrayList<>();
             for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
                 if (bean instanceof com.sun.management.GarbageCollectorMXBean sunBean) {
                     com.sun.management.GcInfo info = sunBean.getLastGcInfo();
-                    if (info != null && info.getDuration() > longestDurationMillis) {
-                        longestDurationMillis = info.getDuration();
-                        longestCollectorName = bean.getName();
+                    if (info != null) {
+                        candidates.add(new LastGcEventCandidate(info.getEndTime(), info.getDuration(), bean.getName()));
                     }
                 }
             }
-            return longestDurationMillis >= 0
-                    ? new LastGcPause(longestDurationMillis, longestCollectorName)
-                    : LastGcPause.unavailable();
+            return latestGcEvent(candidates);
         } catch (RuntimeException | LinkageError ex) {
             // com.sun.management is a HotSpot extension; degrade gracefully on other JVMs.
-            return LastGcPause.unavailable();
+            return LastGcEvent.unavailable();
         }
+    }
+
+    static LastGcEvent latestGcEvent(List<LastGcEventCandidate> candidates) {
+        return candidates.stream()
+                .max(Comparator.comparingLong(LastGcEventCandidate::endTimeMillis))
+                .map(candidate -> new LastGcEvent(candidate.durationMillis(), candidate.collectorName()))
+                .orElseGet(LastGcEvent::unavailable);
     }
 
     private static List<HeapClassHistogramEntryDto> parseHistogram(String raw) {
@@ -492,48 +498,6 @@ final class MemoryCollector {
         } catch (NumberFormatException ex) {
             return -1;
         }
-    }
-
-    private static OptionalLong detectContainerLimit() {
-        for (Path file : CGROUP_LIMIT_FILES) {
-            if (!Files.isRegularFile(file)) {
-                continue;
-            }
-            try {
-                String value = Files.readString(file).trim();
-                if (value.isEmpty() || "max".equals(value)) {
-                    continue;
-                }
-                long parsed = Long.parseLong(value);
-                if (parsed > 0 && parsed < Long.MAX_VALUE / 2) {
-                    return OptionalLong.of(parsed);
-                }
-            } catch (RuntimeException | java.io.IOException ex) {
-                // best-effort detection; ignore unreadable cgroup files
-            }
-        }
-        return OptionalLong.empty();
-    }
-
-    private static OptionalLong detectContainerCurrentUsage() {
-        for (Path file : CGROUP_CURRENT_FILES) {
-            if (!Files.isRegularFile(file)) {
-                continue;
-            }
-            try {
-                String value = Files.readString(file).trim();
-                if (value.isEmpty() || "max".equals(value)) {
-                    continue;
-                }
-                long parsed = Long.parseLong(value);
-                if (parsed > 0 && parsed < Long.MAX_VALUE / 2) {
-                    return OptionalLong.of(parsed);
-                }
-            } catch (RuntimeException | java.io.IOException ex) {
-                // best-effort detection; ignore unreadable cgroup files
-            }
-        }
-        return OptionalLong.empty();
     }
 
     /**

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryContext.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryContext.java
@@ -333,8 +333,8 @@ record MemoryContext(
      * memory, thread, or heap-content snapshots: JVM uptime, cumulative GC time/count, the pending
      * finalization backlog, the parsed {@code -Xms}/{@code -Xss} sizes used by the native-memory
      * and GC-overhead rules, OS-level metrics (available processors, physical memory, swap space,
-     * and the UseCompressedOops VM option), and the single most recent GC pause duration/collector
-     * (used by MEM-GC-006's outlier-pause rule) collected once per scan for GC and footprint
+     * and the UseCompressedOops VM option), and the single most recently completed GC event's
+     * duration/collector (used by MEM-GC-006) collected once per scan for GC and footprint
      * heuristics.
      */
     record RuntimeData(
@@ -349,15 +349,16 @@ record MemoryContext(
             long totalSwapSpaceBytes,
             Boolean useCompressedOops,
             long totalPhysicalMemoryBytes,
-            long lastGcPauseMillis,
-            String lastGcPauseCollectorName) {
+            long lastGcDurationMillis,
+            String lastGcCollectorName,
+            long freePhysicalMemoryBytes) {
 
         static final long DEFAULT_THREAD_STACK_BYTES = 1024L * 1024;
 
         /**
          * Backward-compatible constructor for callers that predate the total-physical-memory
-         * reading (MEM-GC-004's server-class-machine ergonomics skip) and the last-GC-pause reading
-         * (MEM-GC-006's pause-latency outlier rule). Both default to "unknown"/"unavailable" (-1) so
+         * reading (MEM-GC-004's server-class-machine ergonomics skip), the latest-GC-event reading
+         * (MEM-GC-006), and free physical memory (MEM-FOOTPRINT-004). They default to unavailable so
          * existing behavior is preserved when these newer fields are not supplied.
          */
         RuntimeData(
@@ -384,7 +385,43 @@ record MemoryContext(
                     useCompressedOops,
                     -1,
                     -1,
-                    null);
+                    null,
+                    -1);
+        }
+
+        /**
+         * Backward-compatible constructor for callers that predate collection of free physical
+         * memory in the runtime snapshot.
+         */
+        RuntimeData(
+                long uptimeMillis,
+                long gcCollectionTimeMillis,
+                long gcCollectionCount,
+                int objectPendingFinalizationCount,
+                long initialHeapBytes,
+                long threadStackBytes,
+                int availableProcessors,
+                long freeSwapSpaceBytes,
+                long totalSwapSpaceBytes,
+                Boolean useCompressedOops,
+                long totalPhysicalMemoryBytes,
+                long lastGcDurationMillis,
+                String lastGcCollectorName) {
+            this(
+                    uptimeMillis,
+                    gcCollectionTimeMillis,
+                    gcCollectionCount,
+                    objectPendingFinalizationCount,
+                    initialHeapBytes,
+                    threadStackBytes,
+                    availableProcessors,
+                    freeSwapSpaceBytes,
+                    totalSwapSpaceBytes,
+                    useCompressedOops,
+                    totalPhysicalMemoryBytes,
+                    lastGcDurationMillis,
+                    lastGcCollectorName,
+                    -1);
         }
 
         static RuntimeData empty() {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRuleRegistry.java
@@ -28,12 +28,13 @@ final class MemoryRuleRegistry {
             new BufferPoolGrowthWithoutReleaseRule(),
             // GC configuration
             new MissingHeapSizingInContainerRule(),
+            new ContainerSupportDisabledRule(),
             new HighGcOverheadRule(),
             new RecentGcOverheadRule(),
             new UnequalInitialAndMaxHeapRule(),
             new SerialGcOnMultiCoreRule(),
             new G1FullGcFrequencyRule(),
-            new GcPauseLatencyOutlierRule(),
+            new GcEventDurationOutlierRule(),
             // Threads
             new DeadlockDetectedRule(),
             new HighBlockedThreadRatioRule(),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRules.java
@@ -400,6 +400,34 @@ final class MissingHeapSizingInContainerRule extends AbstractMemoryRule {
     }
 }
 
+final class ContainerSupportDisabledRule extends AbstractMemoryRule {
+
+    ContainerSupportDisabledRule() {
+        super(new MemoryRuleDefinition(
+                "MEM-GC-007",
+                "JVM container awareness is explicitly disabled",
+                MemoryCategory.GC_CONFIGURATION,
+                "HIGH",
+                "Detects -XX:-UseContainerSupport while a cgroup memory limit is visible. Container support is enabled by default on supported JDKs; disabling it makes JVM ergonomics use host-level memory and CPU information instead of container constraints, which can oversize the heap and JVM worker pools.",
+                "Remove -XX:-UseContainerSupport so heap, GC, JIT, and common-pool ergonomics respect the container limits; use explicit -Xmx/-XX:MaxRAMPercentage and -XX:ActiveProcessorCount only when deliberate overrides are required.",
+                "https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html"));
+    }
+
+    @Override
+    io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
+        MemoryData memory = context.memory();
+        if (memory.containerMemoryLimitBytes() == null) {
+            return skipped("No container memory limit was detected.");
+        }
+        if (memory.hasJvmArgument("-XX:-UseContainerSupport")) {
+            return violation("-XX:-UseContainerSupport is set despite a detected cgroup memory limit of "
+                    + MemoryFormat.bytes(memory.containerMemoryLimitBytes())
+                    + "; JVM ergonomics may size against the host and exceed the container.");
+        }
+        return pass();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Threads
 // ---------------------------------------------------------------------------
@@ -781,10 +809,10 @@ final class CommittedFootprintNearContainerLimitRule extends AbstractMemoryRule 
     CommittedFootprintNearContainerLimitRule() {
         super(new MemoryRuleDefinition(
                 "MEM-FOOTPRINT-001",
-                "Committed native footprint is close to the container limit",
+                "Configured JVM memory leaves little container headroom",
                 MemoryCategory.NATIVE_MEMORY,
                 "HIGH",
-                "Estimates the JVM's committed native-memory budget (committed heap, committed non-heap such as Metaspace and code cache, direct buffers, and an approximate thread-stack reservation) against the detected container memory limit. When this estimate approaches the limit the container can be OOM-killed by the kernel even though the heap alone looks healthy. The estimate is approximate and excludes some JVM/native overhead (GC structures, JIT, native libraries).",
+                "Estimates the JVM's configured memory envelope (maximum heap, currently committed non-heap such as Metaspace and code cache, direct-buffer capacity, and approximate thread-stack reservations) against the detected container limit. Using maximum rather than currently committed heap exposes configurations that leave too little native headroom before the heap grows. The estimate is conservative but incomplete: it excludes GC structures, JIT working memory, native libraries, and non-NIO native allocations.",
                 "Lower -Xmx/-XX:MaxRAMPercentage, reduce thread counts or direct-buffer use, or raise the container memory limit so the total committed footprint keeps headroom.",
                 "https://docs.oracle.com/en/java/javase/21/troubleshoot/diagnostic-tools.html"));
     }
@@ -797,20 +825,20 @@ final class CommittedFootprintNearContainerLimitRule extends AbstractMemoryRule 
             return skipped("No container memory limit was detected.");
         }
         long stacks = (long) context.threads().total() * context.runtime().threadStackBytes();
-        long footprint = Math.max(0, memory.heapCommitted())
+        long configuredFootprint = Math.max(0, memory.heapMax())
                 + Math.max(0, memory.nonHeapCommitted())
                 + Math.max(0, memory.directBufferCapacity())
                 + Math.max(0, stacks);
-        if (MemoryFormat.percentOf(footprint, limit) >= THRESHOLD_PERCENT) {
-            int percent = MemoryFormat.percentOf(footprint, limit);
-            return violation("Estimated committed footprint " + MemoryFormat.bytes(footprint) + " is " + percent
-                    + "% of the container memory limit " + MemoryFormat.bytes(limit) + " (committed heap "
-                    + MemoryFormat.bytes(memory.heapCommitted()) + " + committed non-heap "
+        if (MemoryFormat.percentOf(configuredFootprint, limit) >= THRESHOLD_PERCENT) {
+            int percent = MemoryFormat.percentOf(configuredFootprint, limit);
+            return violation("Configured JVM memory envelope " + MemoryFormat.bytes(configuredFootprint) + " is "
+                    + percent + "% of the container memory limit " + MemoryFormat.bytes(limit) + " (maximum heap "
+                    + MemoryFormat.bytes(memory.heapMax()) + " + committed non-heap "
                     + MemoryFormat.bytes(memory.nonHeapCommitted()) + " + direct buffers "
                     + MemoryFormat.bytes(memory.directBufferCapacity()) + " + ~"
                     + context.threads().total()
                     + " thread stacks " + MemoryFormat.bytes(stacks)
-                    + "); the container risks an out-of-memory kill.");
+                    + "); too little headroom remains for untracked native memory.");
         }
         return pass();
     }
@@ -932,7 +960,7 @@ final class CompressedOopsCliffRule extends AbstractMemoryRule {
         }
         long alignment = parseObjectAlignmentBytes(memory.inputArguments());
         long boundary = alignment * COMPRESSED_OOPS_HEAP_PER_ALIGNMENT_BYTE;
-        long upperBound = boundary + boundary / 2;
+        long upperBound = boundary + boundary / 4;
         if (heapMax > boundary && heapMax <= upperBound) {
             return violation("Max heap " + MemoryFormat.bytes(heapMax) + " is just above the ~"
                     + MemoryFormat.bytes(boundary) + " compressed-oops boundary"
@@ -1306,9 +1334,8 @@ final class ContainerMemoryPressureRule extends AbstractMemoryRule {
 final class SerialGcOnMultiCoreRule extends AbstractMemoryRule {
 
     /**
-     * Oracle's historical JVM ergonomics documentation defines a "server-class machine" as one with
-     * 2+ CPUs and at least ~2 GiB of memory; below that threshold Serial GC is the JVM's own correct
-     * default choice, not a misconfiguration. See the class-level {@code learnMoreUrl}.
+     * JDK 17, 21, and 25 select G1 ergonomically on a server-class machine (2+ CPUs and roughly 2 GiB
+     * of memory); below that threshold Serial GC remains an expected default.
      */
     private static final long SERVER_CLASS_MEMORY_THRESHOLD_BYTES = 2 * MemoryFormat.GIGABYTE;
 
@@ -1320,7 +1347,7 @@ final class SerialGcOnMultiCoreRule extends AbstractMemoryRule {
                 "LOW",
                 "Detects the Serial GC collector (bean names 'Copy' and/or 'MarkSweepCompact') running on a JVM with two or more available processors and roughly 2 GiB or more of memory (container limit, else total physical memory). Serial GC is single-threaded and is JVM ergonomics' own correct default below Oracle's historical 'server-class machine' threshold (fewer than 2 CPUs, or less than ~2 GiB of memory) -- so this rule does not fire in that region. Above both thresholds, staying on Serial GC underutilises multi-core hosts and causes long STW pauses at scale.",
                 "Switch to G1 (-XX:+UseG1GC), ZGC (-XX:+UseZGC), or Parallel GC (-XX:+UseParallelGC) to use all available cores, unless binary size or footprint constraints explicitly require Serial.",
-                "https://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html"));
+                "https://openjdk.org/jeps/248"));
     }
 
     @Override
@@ -1530,7 +1557,7 @@ final class HighSwapUtilizationRule extends AbstractMemoryRule {
                 + Math.max(0, context.memory().nonHeapCommitted())
                 + Math.max(0, context.memory().directBufferCapacity())
                 + Math.max(0, stacks);
-        long freePhysical = readFreePhysical(context);
+        long freePhysical = context.runtime().freePhysicalMemoryBytes();
         if (freePhysical >= 0 && footprint <= freePhysical) {
             // JVM likely fits in RAM; high swap may be from other processes.
             return pass();
@@ -1540,68 +1567,48 @@ final class HighSwapUtilizationRule extends AbstractMemoryRule {
                 + MemoryFormat.bytes(footprint)
                 + " exceeds free physical memory; the JVM may be partially swapped out.");
     }
-
-    private static long readFreePhysical(MemoryContext context) {
-        // com.sun.management.OperatingSystemMXBean.getFreePhysicalMemorySize() is collected via the
-        // same JMX path as the swap stats; approximate it from the OS bean via JMX attribute.
-        try {
-            javax.management.MBeanServer server = java.lang.management.ManagementFactory.getPlatformMBeanServer();
-            javax.management.ObjectName name = new javax.management.ObjectName("java.lang:type=OperatingSystem");
-            Object value = server.getAttribute(name, "FreePhysicalMemorySize");
-            if (value instanceof Number n) {
-                return n.longValue();
-            }
-        } catch (Exception | Error ignored) {
-            // attribute may not exist on non-HotSpot JVMs
-        }
-        return -1;
-    }
 }
 
 // ---------------------------------------------------------------------------
-// GC configuration (single-pause outlier)
+// GC configuration (latest-event duration)
 // ---------------------------------------------------------------------------
 
-final class GcPauseLatencyOutlierRule extends AbstractMemoryRule {
+final class GcEventDurationOutlierRule extends AbstractMemoryRule {
 
     private static final long PAUSE_THRESHOLD_MILLIS = 1_000L;
 
-    GcPauseLatencyOutlierRule() {
-        super(
-                new MemoryRuleDefinition(
-                        "MEM-GC-006",
-                        "Most recent GC pause was an outlier",
-                        MemoryCategory.GC_CONFIGURATION,
-                        "MEDIUM",
-                        "Reads the duration of the single most recent garbage collection via"
-                                + " com.sun.management.GarbageCollectorMXBean.getLastGcInfo() and flags when that one pause"
-                                + " exceeds " + PAUSE_THRESHOLD_MILLIS + " ms. This complements the lifetime and recent"
-                                + " GC-overhead-ratio checks (MEM-GC-002/MEM-GC-003): a JVM can stay well under those ratio"
-                                + " thresholds on average while still hiding one catastrophic outlier pause, and a single"
-                                + " long stop-the-world pause can itself cause a request-latency spike or health-check"
-                                + " timeout even when overall GC overhead looks healthy. This is a single-sample reading"
-                                + " taken fresh on every scan, not a cross-scan trend.",
-                        "Capture GC logs (-Xlog:gc*:file=gc.log:time,level,tags) around the outlier and check the reported"
-                                + " cause; consider a lower-pause-target collector (G1's -XX:MaxGCPauseMillis, ZGC, or"
-                                + " Shenandoah) or reduce the allocation/promotion rate that triggered the long pause.",
-                        "https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/GarbageCollectorMXBean.html"));
+    GcEventDurationOutlierRule() {
+        super(new MemoryRuleDefinition(
+                "MEM-GC-006",
+                "Most recently completed GC event was long",
+                MemoryCategory.GC_CONFIGURATION,
+                "MEDIUM",
+                "Compares GcInfo.endTime across collector beans to identify the garbage-collection event that"
+                        + " actually completed most recently, then flags when its duration exceeds "
+                        + PAUSE_THRESHOLD_MILLIS + " ms. GcInfo duration is elapsed collection time and is not"
+                        + " necessarily a stop-the-world pause for concurrent collectors. This complements the"
+                        + " lifetime and recent GC-overhead-ratio checks (MEM-GC-002/MEM-GC-003): a JVM can stay"
+                        + " under those ratio thresholds while still reporting a long collection event. This is"
+                        + " a single-sample reading taken fresh on every scan, not a cross-scan trend.",
+                "Capture unified GC logs (-Xlog:gc*:file=gc.log:time,level,tags) and inspect the event's phases"
+                        + " and cause before tuning heap size, allocation rate, or collector pause goals.",
+                "https://docs.oracle.com/en/java/javase/21/docs/api/jdk.management/com/sun/management/GcInfo.html"));
     }
 
     @Override
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
-        long pauseMillis = context.runtime().lastGcPauseMillis();
-        if (pauseMillis < 0) {
-            return skipped("The most recent GC pause duration is not available (requires a HotSpot JVM and at"
+        long durationMillis = context.runtime().lastGcDurationMillis();
+        if (durationMillis < 0) {
+            return skipped("The most recent GC event duration is not available (requires a HotSpot JVM and at"
                     + " least one collection since JVM start).");
         }
-        if (pauseMillis < PAUSE_THRESHOLD_MILLIS) {
+        if (durationMillis < PAUSE_THRESHOLD_MILLIS) {
             return pass();
         }
-        String collectorName = context.runtime().lastGcPauseCollectorName();
+        String collectorName = context.runtime().lastGcCollectorName();
         String collectorNote = collectorName != null && !collectorName.isBlank() ? " (" + collectorName + ")" : "";
-        return violation("The most recent GC pause took " + pauseMillis + " ms" + collectorNote
-                + ", a single-pause outlier at or above the " + PAUSE_THRESHOLD_MILLIS
-                + " ms threshold; this can cause a latency spike independent of average GC overhead.");
+        return violation("The most recently completed GC event took " + durationMillis + " ms" + collectorNote
+                + ", at or above the " + PAUSE_THRESHOLD_MILLIS + " ms threshold.");
     }
 }
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCollectorTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCollectorTests.java
@@ -1,0 +1,38 @@
+package io.github.jdubois.bootui.engine.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.OptionalLong;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MemoryCollectorTests {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void latestGcEventIsSelectedByCompletionTimestampNotLongestDuration() {
+        MemoryCollector.LastGcEvent latest = MemoryCollector.latestGcEvent(List.of(
+                new MemoryCollector.LastGcEventCandidate(2_000, 1_500, "G1 Old Generation"),
+                new MemoryCollector.LastGcEventCandidate(5_000, 25, "G1 Young Generation")));
+
+        assertThat(latest.durationMillis()).isEqualTo(25);
+        assertThat(latest.collectorName()).isEqualTo("G1 Young Generation");
+    }
+
+    @Test
+    void cgroupLimitAndCurrentUsageShareTheSamePathReader() throws Exception {
+        Path limit = tempDir.resolve("memory.max");
+        Path current = tempDir.resolve("memory.current");
+        Files.writeString(limit, "1073741824\n");
+        Files.writeString(current, "536870912\n");
+        ContainerMemoryLimitDetector detector = new ContainerMemoryLimitDetector(List.of(limit), List.of(current));
+
+        assertThat(detector.detectLimit()).isEqualTo(OptionalLong.of(1_073_741_824L));
+        assertThat(detector.detectCurrentUsage()).isEqualTo(OptionalLong.of(536_870_912L));
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryRulesTests.java
@@ -138,6 +138,15 @@ class MemoryRulesTests {
         assertThat(result.sampleViolations().get(0)).contains("object alignment 16 bytes");
     }
 
+    @Test
+    void heapFarAboveCompressedOopsBoundaryIsNotDescribedAsJustAbove() {
+        MemoryData memory =
+                memory(10 * GB, 47 * GB, List.of(), null, List.of("-Xmx47g"), List.of("G1 Young Generation"));
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-HEAP-004")).isNull();
+    }
+
     // --- MEM-FOOTPRINT-002: platform thread stack reservation --------------------------------
 
     @Test
@@ -846,7 +855,57 @@ class MemoryRulesTests {
         assertThat(find(scan(context), "MEM-GC-001")).isNull();
     }
 
-    // --- MEM-FOOTPRINT-004: high swap utilization (test coverage gap) ------------------------
+    // --- MEM-GC-007: container support explicitly disabled -----------------------------------
+
+    @Test
+    void disabledContainerSupportWithCgroupLimitIsHighPriority() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of("-Xmx2g", "-XX:-UseContainerSupport"));
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-GC-007");
+
+        assertThat(result).isNotNull();
+        assertThat(result.severity()).isEqualTo("HIGH");
+        assertThat(result.sampleViolations().get(0)).contains("-XX:-UseContainerSupport");
+    }
+
+    @Test
+    void disabledContainerSupportWithoutCgroupLimitIsNotFlagged() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), null, List.of("-XX:-UseContainerSupport"));
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-GC-007")).isNull();
+    }
+
+    // --- MEM-FOOTPRINT-001: configured container headroom ------------------------------------
+
+    @Test
+    void maximumHeapIsUsedForConfiguredContainerHeadroom() {
+        MemoryData memory = new MemoryData(
+                256 * MB,
+                512 * MB,
+                7 * GB,
+                128 * MB,
+                512 * MB,
+                -1,
+                List.of(),
+                64 * MB,
+                64 * MB,
+                10,
+                -1,
+                List.of("-Xmx7g"),
+                List.of("G1 Young Generation"),
+                8 * GB,
+                null);
+        MemoryContext context = context(memory, threads(128), PostGcHeapData.unavailable(), healthyRuntime());
+
+        MemoryRuleResultDto result = find(scan(context), "MEM-FOOTPRINT-001");
+
+        assertThat(result).isNotNull();
+        assertThat(result.sampleViolations().get(0)).contains("maximum heap").contains("headroom");
+    }
+
+    // --- MEM-FOOTPRINT-004: high swap utilization --------------------------------------------
 
     @Test
     void noSwapConfiguredIsSkipped() {
@@ -878,11 +937,8 @@ class MemoryRulesTests {
 
     @Test
     void highSwapWithFootprintExceedingFreePhysicalIsFlagged() {
-        // 90% swap used, well above the 50% threshold. The committed footprint is set to an
-        // unrealistically large value (hundreds of petabytes) so that it exceeds the free physical
-        // memory of any real test/CI machine, deterministically exercising the violation branch
-        // without needing to mock the live OperatingSystemMXBean read.
-        long hugeFootprint = 900_000L * GB;
+        // 90% swap used, with a deterministic free-physical-memory snapshot below the footprint.
+        long hugeFootprint = 2 * GB;
         MemoryData memory = new MemoryData(
                 hugeFootprint,
                 hugeFootprint,
@@ -899,13 +955,24 @@ class MemoryRulesTests {
                 List.of("G1 Young Generation"),
                 null,
                 null);
-        RuntimeData runtime = new RuntimeData(300_000, 1_500, 50, 0, -1, MB, 4, 100 * MB, 1 * GB, null);
+        RuntimeData runtime =
+                new RuntimeData(300_000, 1_500, 50, 0, -1, MB, 4, 100 * MB, 1 * GB, null, -1, -1, null, 1 * GB);
         MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
 
         MemoryRuleResultDto result = find(scan(context), "MEM-FOOTPRINT-004");
 
         assertThat(result).isNotNull();
         assertThat(result.sampleViolations().get(0)).contains("90%");
+    }
+
+    @Test
+    void highSwapFromOtherProcessesIsNotFlaggedWhenJvmFitsInFreePhysicalMemory() {
+        RuntimeData runtime =
+                new RuntimeData(300_000, 1_500, 50, 0, -1, MB, 4, 100 * MB, 1 * GB, null, -1, -1, null, 4 * GB);
+        MemoryContext context =
+                context(healthyMemoryForSwap(), ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
+
+        assertThat(find(scan(context), "MEM-FOOTPRINT-004")).isNull();
     }
 
     // --- MEM-CLASS-001: excessive loaded classes (test coverage gap) -------------------------
@@ -940,10 +1007,10 @@ class MemoryRulesTests {
         assertThat(find(scan(context), "MEM-CLASS-001")).isNull();
     }
 
-    // --- MEM-GC-006: GC pause-latency outlier (new rule) -------------------------------------
+    // --- MEM-GC-006: latest GC event duration -------------------------------------------------
 
     @Test
-    void gcPauseAboveThresholdIsFlagged() {
+    void latestGcEventAboveThresholdIsFlagged() {
         RuntimeData runtime = runtimeWithLastGcPause(1_500, "G1 Young Generation");
         MemoryContext context = context(
                 memory(256 * MB, 2 * GB, List.of(), null, List.of()),
@@ -959,7 +1026,7 @@ class MemoryRulesTests {
     }
 
     @Test
-    void gcPauseBelowThresholdIsNotFlagged() {
+    void latestGcEventBelowThresholdIsNotFlagged() {
         RuntimeData runtime = runtimeWithLastGcPause(200, "G1 Young Generation");
         MemoryContext context = context(
                 memory(256 * MB, 2 * GB, List.of(), null, List.of()),
@@ -971,7 +1038,7 @@ class MemoryRulesTests {
     }
 
     @Test
-    void gcPauseUnavailableIsSkipped() {
+    void latestGcEventUnavailableIsSkipped() {
         MemoryContext context = context(
                 memory(256 * MB, 2 * GB, List.of(), null, List.of()),
                 ThreadData.empty(),

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryScannerTests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 class MemoryScannerTests {
 
-    private static final int RULE_COUNT = 35;
+    private static final int RULE_COUNT = 36;
     private static final long MB = 1024L * 1024;
     private static final long GB = 1024L * 1024 * 1024;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-06T08:00:00Z"), ZoneOffset.UTC);
@@ -179,7 +179,7 @@ class MemoryScannerTests {
     }
 
     @Test
-    void committedFootprintNearContainerLimitIsFlagged() {
+    void configuredMemoryNearContainerLimitIsFlagged() {
         MemoryData memory = new MemoryData(
                 300 * MB,
                 700 * MB,

--- a/docs/MEMORY-CHECKS.md
+++ b/docs/MEMORY-CHECKS.md
@@ -1,6 +1,6 @@
 # Memory advisor checks
 
-The Memory panel runs a fixed, on-demand ruleset against the host JVM's **live management beans**. It takes a read-only snapshot of heap and memory-pool usage, garbage-collector and class-loading counters, a thread census, a handful of process-level scalars (uptime, cumulative GC time, pending finalizers, parsed `-Xms`/`-Xss`), and an optional class histogram, then evaluates a curated set of memory-health checks. It never mutates the JVM, forces a heap dump on page load, intercepts live traffic, or surfaces secrets.
+The Memory panel runs a fixed, on-demand ruleset against the host JVM's **live management beans**. It takes a read-only snapshot of heap and memory-pool usage, garbage-collector and class-loading counters, a thread census, process-level scalars (uptime, cumulative GC time, pending finalizers, parsed `-Xms`/`-Xss`, physical memory, and swap), and an optional class histogram, then evaluates a curated set of memory-health checks. Rules read only this immutable snapshot; they never perform their own JMX or filesystem I/O. The advisor never mutates the JVM, forces a heap dump on page load, intercepts live traffic, or surfaces secrets.
 
 Most checks are single-snapshot heuristics, while the recent-GC check compares the current scan with the previous scan and heap-pressure checks prefer post-histogram heap readings when available. Snapshot and lifetime counters can still be skewed by transient garbage, startup spikes, or past bursts, so several findings are explicit prompts to confirm with a second reading, the Live Memory panel, or a profiler rather than verdicts. The right remediation still depends on the application's workload, heap sizing, and deployment topology.
 
@@ -12,7 +12,7 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 
 ## Known limitations
 
-- **Container-limit detection assumes the process's cgroup is the container root.** Every container-aware check (MEM-FOOTPRINT-001/002/003/004, MEM-GC-001, MEM-GC-004, MEM-POOL-004) reads fixed root-level cgroup paths (for example `/sys/fs/cgroup/memory.max`), which is correct under the default modern Docker/Kubernetes setup where the process's own cgroup **is** the container root. It is not correct under `--cgroupns=host` or some older/nested container runtimes, where the process's actual cgroup lives elsewhere in the hierarchy; in that situation these hardcoded root paths silently read as "no container memory limit detected" instead of a reported error, which is a silent false negative across every container-aware rule above. A full fix would resolve the process's own cgroup path via `/proc/self/cgroup` and `/proc/self/mountinfo` rather than assuming the root path; this is a known gap, not yet implemented.
+- **Container-limit detection assumes the process's cgroup is the container root.** Every container-aware check (MEM-FOOTPRINT-001/002/003/004, MEM-GC-001/004/007, MEM-POOL-004) uses one shared detector for the fixed root-level cgroup limit/current paths (for example `/sys/fs/cgroup/memory.max`). This is correct under the default modern Docker/Kubernetes setup where the process's own cgroup **is** the container root. It is not correct under `--cgroupns=host` or some older/nested container runtimes, where the process's actual cgroup lives elsewhere in the hierarchy; in that situation these paths read as "no container memory limit detected." A full fix would resolve the process's cgroup path via `/proc/self/cgroup` and `/proc/self/mountinfo`; no supported public JVM API exposes HotSpot's internal cgroup metrics.
 
 ## Severity scale
 
@@ -50,7 +50,7 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-HEAP-004 - Max heap is just above the compressed-oops threshold
 
 - **Severity**: INFO
-- **Detects**: A max heap just above the boundary where the JVM disables compressed ordinary object pointers, after which 64-bit references take more space and a heap just over the boundary can hold fewer live objects than one capped just below it. The boundary defaults to ~32 GiB but scales with -XX:ObjectAlignmentInBytes. The rule reads the live `UseCompressedOops` VM option via HotSpot JMX when available, falling back to the input-arguments heuristic on non-HotSpot JVMs; it is skipped for ZGC and when compressed oops are disabled.
+- **Detects**: A max heap in the narrow 25% window just above the boundary where the JVM disables compressed ordinary object pointers, after which 64-bit references take more space and a heap just over the boundary can hold fewer live objects than one capped just below it. The documented boundary is `4 GiB * ObjectAlignmentInBytes` (32 GiB at the default 8-byte alignment), so the default warning window is above 32 GiB through 40 GiB; deliberately larger heaps such as 47 GiB are not described as "just above." The rule reads the live `UseCompressedOops` VM option via HotSpot JMX when available, falling back to the input-arguments heuristic on non-HotSpot JVMs; it is skipped for ZGC and when compressed oops are disabled.
 - **Recommendation**: Either cap the heap just below the compressed-oops boundary, or grow it well past this range (and scale out) when a larger heap is genuinely required.
 - **Learn more**: <https://wiki.openjdk.org/display/HotSpot/CompressedOops>
 
@@ -77,11 +77,11 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 
 ## Native memory
 
-### MEM-FOOTPRINT-001 - Committed native footprint is close to the container limit
+### MEM-FOOTPRINT-001 - Configured JVM memory leaves little container headroom
 
 - **Severity**: HIGH
-- **Detects**: Estimates the JVM's committed native-memory budget (committed heap, committed non-heap such as Metaspace and code cache, direct buffers, and an approximate thread-stack reservation) against the detected container memory limit. When this estimate approaches the limit the container can be OOM-killed by the kernel even though the heap alone looks healthy. The estimate is approximate and excludes some JVM/native overhead (GC structures, JIT, native libraries).
-- **Recommendation**: Lower -Xmx/-XX:MaxRAMPercentage, reduce thread counts or direct-buffer use, or raise the container memory limit so the total committed footprint keeps headroom.
+- **Detects**: Estimates the configured JVM memory envelope (maximum heap, currently committed non-heap such as Metaspace and code cache, direct-buffer capacity, and an approximate thread-stack reservation) against the detected container limit. At 90% or more, the configuration leaves too little room for native memory as the heap grows. Using maximum rather than currently committed heap catches unsafe sizing before that memory is committed. The estimate is conservative but incomplete: it excludes GC structures, JIT working memory, native libraries, and non-NIO native allocations.
+- **Recommendation**: Lower -Xmx/-XX:MaxRAMPercentage, reduce thread counts or direct-buffer use, or raise the container memory limit so the configured envelope keeps native headroom.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/troubleshoot/diagnostic-tools.html>
 
 ### MEM-FOOTPRINT-002 - Platform thread stacks reserve a large amount of native memory
@@ -101,7 +101,7 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-FOOTPRINT-004 - High swap utilization while JVM footprint exceeds free physical memory
 
 - **Severity**: MEDIUM
-- **Detects**: Reads swap space statistics from the platform `OperatingSystemMXBean` (HotSpot: `com.sun.management.OperatingSystemMXBean`) and flags when used swap is at least 50% of total swap AND the estimated JVM committed footprint (heap + non-heap + direct buffers + thread-stack reservation) exceeds free physical memory. This combination strongly suggests the JVM is partially swapped out, which causes latency spikes on heap access. The check is skipped on platforms where swap statistics are unavailable.
+- **Detects**: Uses swap and free-physical-memory values collected once with the rest of the runtime snapshot, and flags when used swap is at least 50% of total swap AND the estimated JVM committed footprint (heap + non-heap + direct buffers + thread-stack reservation) exceeds free physical memory. This combination suggests the JVM may be partially swapped out. The check is skipped where these operating-system MXBean values are unavailable.
 - **Recommendation**: Reduce the JVM's committed footprint (lower -Xmx, reduce thread count, tune direct-buffer use) or add physical memory; avoid large heaps on hosts with active swap.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/troubleshoot/diagnostic-tools.html>
 
@@ -168,7 +168,7 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-GC-002 - Cumulative GC time is a large share of uptime
 
 - **Severity**: MEDIUM
-- **Detects**: Compares total **stop-the-world** time spent in garbage collection since JVM start against the JVM uptime. Concurrent-cycle beans (ZGC Cycles, Shenandoah Cycles, G1 Concurrent GC) are excluded from the time sum because their concurrent phases run while the application is executing; including them would inflate "overhead" for apps that deliberately chose a concurrent collector. A high lifetime ratio is a classic sign of an undersized heap or an excessive allocation rate. This is a cumulative average and can be skewed by a one-off startup spike, so corroborate with live GC metrics.
+- **Detects**: After at least 10 minutes of uptime, flags when total **stop-the-world** collection time is at least 10% of JVM uptime. Concurrent-cycle beans (ZGC Cycles, Shenandoah Cycles, G1 Concurrent GC) are excluded because their concurrent phases run while the application executes. No collector-independent universal threshold exists, so the rule retains this conservative review threshold rather than tuning it from anecdotal application sizes. The cumulative average can be skewed by startup, so corroborate it with recent GC metrics.
 - **Recommendation**: Increase the heap (-Xmx/-XX:MaxRAMPercentage), reduce the allocation rate, or review the collector choice if GC consistently consumes this much time.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/gctuning/factors-affecting-garbage-collection-performance.html>
 
@@ -182,9 +182,9 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-GC-004 - Serial GC selected on a multi-core system
 
 - **Severity**: LOW
-- **Detects**: The Serial GC collector (GarbageCollectorMXBean names "Copy" and/or "MarkSweepCompact") running on a JVM with two or more available processors **and** roughly 2 GiB or more of memory (the detected container memory limit, else total physical memory). Oracle's historical JVM ergonomics documentation defines a "server-class machine" as 2+ CPUs and ~2 GiB+ of memory; below that threshold Serial GC is the JVM's own correct ergonomic default, not a misconfiguration, so the rule does not fire there — this avoids false positives on small containers (for example 2 vCPUs with a 512 MiB–1 GiB memory limit) that legitimately get Serial GC by ergonomics. Above both thresholds, staying on Serial GC underutilises multi-core hosts and causes long STW pauses.
+- **Detects**: The Serial GC collector (GarbageCollectorMXBean names "Copy" and/or "MarkSweepCompact") running on a JVM with two or more available processors **and** roughly 2 GiB or more of memory (the detected container memory limit, else total physical memory). On supported JDK 17/21/25 releases, G1 is selected ergonomically for server-class machines while Serial remains expected in constrained environments, so the rule avoids false positives on small containers. Above both thresholds, explicitly or unexpectedly staying on Serial underutilises multi-core hosts and causes long stop-the-world pauses.
 - **Recommendation**: Switch to G1 (-XX:+UseG1GC), ZGC (-XX:+UseZGC), or Parallel GC (-XX:+UseParallelGC) to use all available cores, unless binary size or footprint constraints explicitly require Serial.
-- **Learn more**: <https://docs.oracle.com/javase/8/docs/technotes/guides/vm/server-class.html>
+- **Learn more**: <https://openjdk.org/jeps/248>
 
 ### MEM-GC-005 - G1 Full GC occurred between scans
 
@@ -193,12 +193,19 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 - **Recommendation**: Increase -Xmx or tune -XX:G1HeapRegionSize to reduce humongous allocations; consider -XX:G1ReservePercent and -XX:InitiatingHeapOccupancyPercent to give G1 more headroom for concurrent marking.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/gctuning/garbage-first-g1-garbage-collector1.html>
 
-### MEM-GC-006 - Most recent GC pause was an outlier
+### MEM-GC-006 - Most recently completed GC event was long
 
 - **Severity**: MEDIUM
-- **Detects**: Reads the duration of the single most recent garbage collection via `com.sun.management.GarbageCollectorMXBean.getLastGcInfo()` and flags when that one pause exceeds 1000 ms. This complements the lifetime and recent GC-overhead-*ratio* checks (MEM-GC-002/MEM-GC-003): a JVM can stay well under those ratio thresholds on average while still hiding one catastrophic outlier pause, and a single long stop-the-world pause can itself cause a request-latency spike or health-check timeout even when overall GC overhead looks healthy. This is a single-sample reading taken fresh on every scan, not a cross-scan trend, so it is skipped when no collection has happened yet or on non-HotSpot JVMs without this MXBean extension.
-- **Recommendation**: Capture GC logs (-Xlog:gc*:file=gc.log:time,level,tags) around the outlier and check the reported cause; consider a lower-pause-target collector (G1's -XX:MaxGCPauseMillis, ZGC, or Shenandoah) or reduce the allocation/promotion rate that triggered the long pause.
-- **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/GarbageCollectorMXBean.html>
+- **Detects**: Reads each HotSpot collector bean's `getLastGcInfo()`, compares `GcInfo.endTime` values on their shared JVM-uptime time base, and evaluates the event that actually completed most recently. It flags when that event's duration is at least 1000 ms. Duration is elapsed collection time and is not necessarily a stop-the-world pause for a concurrent collector, so the finding deliberately says "GC event" rather than "pause." This is a fresh single-sample reading, not a cross-scan trend.
+- **Recommendation**: Capture unified GC logs (`-Xlog:gc*:file=gc.log:time,level,tags`) and inspect the event's phases and cause before tuning heap size, allocation rate, or collector pause goals.
+- **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/api/jdk.management/com/sun/management/GcInfo.html>
+
+### MEM-GC-007 - JVM container awareness is explicitly disabled
+
+- **Severity**: HIGH
+- **Detects**: A visible cgroup memory limit together with `-XX:-UseContainerSupport`. Container support defaults to enabled on JDK 17/21/25; disabling it makes JVM ergonomics use host-level memory and CPU information, which can oversize the heap, GC/JIT worker pools, and common pools relative to the container and lead to throttling or an abrupt cgroup OOM kill.
+- **Recommendation**: Remove `-XX:-UseContainerSupport` so JVM ergonomics respect container limits. Use explicit `-Xmx`/`-XX:MaxRAMPercentage` and `-XX:ActiveProcessorCount` only for deliberate overrides.
+- **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html>
 
 ### MEM-HEAP-005 - Initial and maximum heap differ for a low-latency collector
 
@@ -274,7 +281,7 @@ Heap-content checks require a class histogram, which is collected only on an exp
 ### MEM-CLASS-001 - Very large number of loaded classes with little unloading
 
 - **Severity**: INFO
-- **Detects**: A high loaded-class count combined with little or no class unloading, which can indicate a classloader leak or runaway dynamic class generation and pressures Metaspace. A large class count that is matched by active unloading is treated as a legitimately large application instead. Caveat: the threshold is not framework-neutral in practice — frameworks that generate proxy/lambda/configuration classes at runtime (for example Spring Boot's CGLIB/JDK dynamic proxies, autoconfiguration, and lambda forms) structurally load more classes than an equivalent application built with a framework that does most of this at build time (for example Quarkus); two applications of the same real size can sit at very different distances from this threshold purely because of framework style, not application growth or a leak.
+- **Detects**: At least 50,000 currently loaded classes with less than 1% as many unloads, which can indicate a classloader leak or runaway dynamic class generation and pressures Metaspace. No OpenJDK/Oracle source defines a universally healthy class count, so this remains an INFO-level review heuristic and was not retuned from anecdotal application sizes. Frameworks that generate proxies and configuration classes at runtime can structurally load more classes than build-time-oriented frameworks; compare repeated readings and Metaspace pressure rather than treating the count alone as proof of a leak.
 - **Recommendation**: If the application does not legitimately use this many classes, look for classloader leaks (redeploys, scripting, proxy generation).
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/troubleshoot/troubleshoot-class-loading.html>
 


### PR DESCRIPTION
## What does this PR do?

Corrects Memory advisor GC-event selection and container-memory heuristics, keeps rule evaluation pure, and updates deterministic coverage and documentation.

## Why is this change needed?

MEM-GC-006 selected the longest per-collector `lastGcInfo` duration rather than the event that actually completed most recently. The compressed-oops warning window also described heaps as large as 47 GiB as "just above" 32 GiB, MEM-FOOTPRINT-004 performed live JMX I/O inside a rule, and container-aware checks duplicated cgroup path handling.

This PR now compares `GcInfo.endTime` across collector beans and accurately labels the result as GC-event duration rather than necessarily a stop-the-world pause. It narrows MEM-HEAP-004 to 25% above the documented `4 GiB * ObjectAlignmentInBytes` boundary, moves free-physical-memory collection into `MemoryCollector`/`RuntimeData`, shares cgroup limit/current reads, and bases MEM-FOOTPRINT-001 on maximum heap plus committed/native reservations so configured headroom is evaluated before heap growth. It also adds HIGH-priority MEM-GC-007 for explicit `-XX:-UseContainerSupport` under a detected cgroup limit.

MEM-GC-002 and MEM-CLASS-001 remain conservatively unchanged because OpenJDK/Oracle provide no universal application-size threshold. No young-GC-frequency rule was added because MXBean collector names are implementation strings and an on-demand two-scan interval is not robust enough for a framework-neutral warning.

Primary references:
- [`GcInfo` timestamps and duration](https://docs.oracle.com/en/java/javase/21/docs/api/jdk.management/com/sun/management/GcInfo.html)
- [JDK 21 `java` options: object alignment, compressed oops, and container support](https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html)
- [JEP 248: G1 default on server configurations](https://openjdk.org/jeps/248)
- [JEP 307: G1 parallel full GC fallback](https://openjdk.org/jeps/307)

Closes: N/A (advisor audit follow-up)

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional validation:
- `./mvnw -B -ntp -pl bootui-engine -am clean test`
- Focused 108-test Memory suite on Temurin 17.0.19, 21.0.11, and 25.0.3
- Spring Boot `SpringApiConformanceTest`: 17/17 passed
- Quarkus `BootUiQuarkusApiConformanceTest`: 17/17 passed
- `./mvnw -B -ntp spotless:check`
- Manual comparison of rule semantics and labels against the primary OpenJDK/JMX references above

## Screenshots (UI changes)

N/A — no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed