### PR TITLE
Fix Hibernate advisor false positives

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateContext.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateContext.java
@@ -151,6 +151,28 @@ record HibernateContext(
                         "hibernate.bytecode.enhancer.enableLazyInitialization");
     }
 
+    boolean isHibernateEnhancementEnabled(HibernateEntityModel entity) {
+        return isHibernateEnhancementEnabled() || entity.isBytecodeEnhanced();
+    }
+
+    boolean isOpenInViewApplicable() {
+        return isPropertyTrue(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY);
+    }
+
+    boolean managesSchemaIndexes() {
+        String value = firstProperty(
+                "spring.jpa.hibernate.ddl-auto",
+                "spring.jpa.properties.hibernate.hbm2ddl.auto",
+                "hibernate.hbm2ddl.auto",
+                "jakarta.persistence.schema-generation.database.action");
+        return value != null
+                && ("create".equalsIgnoreCase(value)
+                        || "create-only".equalsIgnoreCase(value)
+                        || "create-drop".equalsIgnoreCase(value)
+                        || "drop-and-create".equalsIgnoreCase(value)
+                        || "update".equalsIgnoreCase(value));
+    }
+
     boolean isSqlLoggingEnabled() {
         if (isPropertyTrue("spring.jpa.show-sql", "hibernate.show_sql")) {
             return true;

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateEntityModel.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateEntityModel.java
@@ -14,6 +14,8 @@ public record HibernateEntityModel(String name, Class<?> javaType, List<Hibernat
     private static final String BATCH_SIZE = "org.hibernate.annotations.BatchSize";
     private static final String CACHE = "org.hibernate.annotations.Cache";
     private static final String CACHEABLE = "jakarta.persistence.Cacheable";
+    private static final String PERSISTENT_ATTRIBUTE_INTERCEPTABLE =
+            "org.hibernate.engine.spi.PersistentAttributeInterceptable";
 
     public HibernateEntityModel {
         attributes = List.copyOf(attributes);
@@ -64,6 +66,14 @@ public record HibernateEntityModel(String name, Class<?> javaType, List<Hibernat
 
     boolean hasDynamicUpdate() {
         return annotationInHierarchy("org.hibernate.annotations.DynamicUpdate") != null;
+    }
+
+    boolean isImmutable() {
+        return annotationInHierarchy("org.hibernate.annotations.Immutable") != null;
+    }
+
+    boolean isBytecodeEnhanced() {
+        return javaType != null && implementsInterface(javaType, PERSISTENT_ATTRIBUTE_INTERCEPTABLE);
     }
 
     String inheritanceStrategy() {
@@ -149,12 +159,26 @@ public record HibernateEntityModel(String name, Class<?> javaType, List<Hibernat
         if (javaType == null) {
             return false;
         }
+
         try {
             Method method = javaType.getMethod(name, parameterTypes);
             return method.getDeclaringClass() != Object.class;
         } catch (NoSuchMethodException ex) {
             return false;
         }
+    }
+
+    private static boolean implementsInterface(Class<?> type, String interfaceName) {
+        Class<?> current = type;
+        while (current != null) {
+            for (Class<?> candidate : current.getInterfaces()) {
+                if (interfaceName.equals(candidate.getName()) || implementsInterface(candidate, interfaceName)) {
+                    return true;
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return false;
     }
 
     private static boolean hasAnnotation(AnnotatedElement element, String typeName) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
@@ -11,6 +11,7 @@ final class HibernateRuleRegistry {
             new MultipleBagCollectionRule(),
             new MissingBatchFetchRule(),
             new LobLazyFetchRule(),
+            new LazyBasicWithoutEnhancementRule(),
             new CollectionFetchJoinAnnotationRule(),
             // Identifiers
             new IdentityIdentifierRule(),
@@ -24,6 +25,7 @@ final class HibernateRuleRegistry {
             new UnidirectionalOneToManyRule(),
             new ManyToManyListRule(),
             new OrdinalEnumRule(),
+            new ExplicitOrdinalEnumRule(),
             new ManyToManyRemoveCascadeRule(),
             new ManyToOneRemoveCascadeRule(),
             new OneToOneWithoutMapsIdRule(),
@@ -40,6 +42,7 @@ final class HibernateRuleRegistry {
             new LazyOneToOneEnhancementRule(),
             new NonOwningOneToOneEnhancementRule(),
             new MissingForeignKeyIndexRule(),
+            new LegacyWhereAnnotationRule(),
             new UnidirectionalOneToManyJoinColumnRule(),
 
             // Entity design
@@ -83,7 +86,8 @@ final class HibernateRuleRegistry {
 
             // Caching
             new CacheAssociationCoverageRule(),
-            new ReadOnlyCacheOnWritableEntityRule());
+            new ReadOnlyCacheOnWritableEntityRule(),
+            new ImmutableEntityCacheStrategyRule());
 
     private HibernateRuleRegistry() {}
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
@@ -708,7 +708,7 @@ final class OrdinalEnumRule extends AbstractHibernateRule {
                 HibernateCategory.MAPPING,
                 "MEDIUM",
                 "Detects enum attributes that omit @Enumerated and therefore rely on JPA's ORDINAL default.",
-                "Declare the enum mapping explicitly: use STRING, a database-native enum type, a stable converter/code, or an intentional ORDINAL mapping backed by append-only enum ordering and a lookup table or database constraint.",
+                "Declare the enum mapping explicitly. Prefer STRING, a database-native enum type, or a converter with stable database codes.",
                 "https://vladmihalcea.com/the-best-way-to-map-an-enum-type-with-jpa-and-hibernate/"));
     }
 
@@ -730,6 +730,36 @@ final class OrdinalEnumRule extends AbstractHibernateRule {
     }
 }
 
+final class ExplicitOrdinalEnumRule extends AbstractHibernateRule {
+
+    ExplicitOrdinalEnumRule() {
+        super(new HibernateRuleDefinition(
+                "HIB-MAP-022",
+                "Explicit ordinal enum mappings should be reviewed",
+                HibernateCategory.MAPPING,
+                "INFO",
+                "Detects enum attributes explicitly mapped with @Enumerated(ORDINAL).",
+                "Prefer STRING, a database-native enum type, or a converter with stable database codes. Keep ORDINAL only when append-only enum ordering is an explicit schema contract.",
+                "https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2.html"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        List<String> details = new ArrayList<>();
+        for (HibernateEntityModel entity : context.entities()) {
+            for (HibernateAttributeModel attribute : entity.attributes()) {
+                Annotation enumerated = attribute.enumeratedAnnotation();
+                if (attribute.isEnumAttribute()
+                        && enumerated != null
+                        && "ORDINAL".equals(attribute.annotationValueName(enumerated, "value"))) {
+                    details.add(attribute.description() + " explicitly uses EnumType.ORDINAL.");
+                }
+            }
+        }
+        return violation(details);
+    }
+}
+
 final class OpenInViewRule extends AbstractHibernateRule {
 
     OpenInViewRule() {
@@ -739,25 +769,16 @@ final class OpenInViewRule extends AbstractHibernateRule {
                         "Open Session in View should be disabled",
                         HibernateCategory.CONFIGURATION,
                         "MEDIUM",
-                        "Detects spring.jpa.open-in-view=true, including Spring Boot's default when the property is not set.",
+                        "Detects spring.jpa.open-in-view=true in servlet applications, including Spring Boot's servlet default when the property is not set.",
                         "Set spring.jpa.open-in-view=false and fetch data inside transactional service boundaries.",
                         "https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.jpa-and-spring-data.open-in-view"));
     }
 
-    /**
-     * Also checked by SPRING-JPA-001 ({@code OpenSessionInViewEnabledRule}) in the Spring Application
-     * Advisor, which additionally skips when no JPA {@code EntityManagerFactory} or servlet web
-     * context is present — a guard this rule cannot reproduce, since "is this a servlet web
-     * application" is a framework-specific concept the framework-neutral engine cannot see (and on
-     * Quarkus, which has no Open-Session-in-View mechanism at all, the property lookup below simply
-     * never reports it enabled, so the rule is already inert there without needing that guard). Both
-     * rules are kept deliberately: they serve two independently-browsable UI panels (Hibernate vs.
-     * Spring), and the {@link HibernateContext#isProductionProfileActive()} escalation below is
-     * mirrored from SPRING-JPA-001 so the two panels report the same severity for the same
-     * misconfiguration.
-     */
     @Override
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        if (!context.isOpenInViewApplicable()) {
+            return skipped("Open Session in View is not applicable outside a Spring servlet web application.");
+        }
         Boolean value = context.booleanProperty("spring.jpa.open-in-view");
         if (Boolean.FALSE.equals(value)) {
             return pass();
@@ -766,7 +787,9 @@ final class OpenInViewRule extends AbstractHibernateRule {
                 ? "spring.jpa.open-in-view is not set and defaults to enabled, keeping a persistence context open"
                         + " for the entire web request."
                 : "spring.jpa.open-in-view=true keeps a persistence context open for the entire web request.";
-        String severity = context.isProductionProfileActive() ? HibernateRuleSupport.HIGH : HibernateRuleSupport.MEDIUM;
+        String severity = value == null
+                ? HibernateRuleSupport.INFO
+                : context.isProductionProfileActive() ? HibernateRuleSupport.HIGH : HibernateRuleSupport.MEDIUM;
         return violation(severity, detail);
     }
 }
@@ -1300,12 +1323,12 @@ final class LobLazyFetchRule extends AbstractHibernateRule {
         super(
                 new HibernateRuleDefinition(
                         "HIB-FETCH-005",
-                        "@Lob attributes should be loaded lazily",
+                        "Enhanced @Lob attributes should be loaded lazily",
                         HibernateCategory.FETCHING,
                         "MEDIUM",
-                        "Detects @Lob attributes that do not declare @Basic(fetch=LAZY), so they are loaded with every entity hydration.",
-                        "Annotate @Lob fields with @Basic(fetch = FetchType.LAZY) so large CLOB/BLOB payloads load only when accessed; bytecode enhancement is required for non-association lazy loading to actually defer the SQL.",
-                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#basic-binary"));
+                        "Detects @Lob attributes that remain eager on entities where Hibernate bytecode enhancement can honor @Basic(fetch=LAZY).",
+                        "On bytecode-enhanced entities, annotate infrequently accessed @Lob attributes with @Basic(fetch = FetchType.LAZY). Without enhancement, do not add the annotation: Hibernate cannot defer the column load.",
+                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#fetching-basics-lazy"));
     }
 
     @Override
@@ -1313,9 +1336,41 @@ final class LobLazyFetchRule extends AbstractHibernateRule {
         List<String> details = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
             for (HibernateAttributeModel attribute : entity.attributes()) {
-                if (attribute.isLob() && !attribute.hasBasicLazy()) {
+                if (attribute.isLob() && !attribute.hasBasicLazy() && context.isHibernateEnhancementEnabled(entity)) {
                     details.add(attribute.description()
                             + " is annotated with @Lob but does not declare @Basic(fetch = LAZY).");
+                }
+            }
+        }
+        return violation(details);
+    }
+}
+
+final class LazyBasicWithoutEnhancementRule extends AbstractHibernateRule {
+
+    LazyBasicWithoutEnhancementRule() {
+        super(
+                new HibernateRuleDefinition(
+                        "HIB-FETCH-007",
+                        "Lazy basic attributes require bytecode enhancement",
+                        HibernateCategory.FETCHING,
+                        "MEDIUM",
+                        "Detects @Basic(fetch=LAZY) attributes on entities where Hibernate bytecode enhancement is not available.",
+                        "Enable Hibernate bytecode enhancement so lazy basic attributes can defer their columns, or remove the ineffective LAZY declaration.",
+                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#fetching-basics-lazy"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        List<String> details = new ArrayList<>();
+        for (HibernateEntityModel entity : context.entities()) {
+            if (context.isHibernateEnhancementEnabled(entity)) {
+                continue;
+            }
+            for (HibernateAttributeModel attribute : entity.attributes()) {
+                if (attribute.hasBasicLazy()) {
+                    details.add(attribute.description()
+                            + " declares @Basic(fetch = LAZY), but the entity is not bytecode enhanced.");
                 }
             }
         }
@@ -2120,6 +2175,33 @@ final class ReadOnlyCacheOnWritableEntityRule extends AbstractHibernateRule {
     }
 }
 
+final class ImmutableEntityCacheStrategyRule extends AbstractHibernateRule {
+
+    ImmutableEntityCacheStrategyRule() {
+        super(
+                new HibernateRuleDefinition(
+                        "HIB-CACHE-003",
+                        "Immutable cached entities should use READ_ONLY",
+                        HibernateCategory.CACHING,
+                        "INFO",
+                        "Detects @Immutable entities using a mutable second-level cache concurrency strategy.",
+                        "Use @Cache(usage = READ_ONLY) for immutable entities, or remove @Immutable if the entity is expected to change.",
+                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#caching-entity-cache-mapping"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        List<String> details = new ArrayList<>();
+        for (HibernateEntityModel entity : context.entities()) {
+            String usage = entity.hibernateCacheUsageName();
+            if (entity.isImmutable() && usage != null && !"READ_ONLY".equals(usage) && !"NONE".equals(usage)) {
+                details.add(entity.name() + " is @Immutable but uses @Cache(usage=" + usage + ").");
+            }
+        }
+        return violation(details);
+    }
+}
+
 final class FailOnPaginationOverCollectionFetchRule extends AbstractHibernateRule {
 
     FailOnPaginationOverCollectionFetchRule() {
@@ -2267,6 +2349,10 @@ final class MissingForeignKeyIndexRule extends AbstractHibernateRule {
     @SuppressWarnings("java:S1872")
     @Override
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        if (!context.managesSchemaIndexes()) {
+            return skipped(
+                    "Schema indexes are not managed by Hibernate; migration-managed indexes cannot be verified from JPA annotations.");
+        }
         List<String> details = new ArrayList<>();
         List<String> unresolved = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
@@ -2319,19 +2405,20 @@ final class MissingForeignKeyIndexRule extends AbstractHibernateRule {
         Annotation joinColumn = attribute.joinColumnAnnotation();
         if (joinColumn != null) {
             String name = attribute.annotationStringValue(joinColumn, "name");
-            columns.add(normalizeColumn(name, attribute.name()));
+            if (name != null && !name.isBlank()) {
+                columns.add(normalizeIdentifier(name));
+            }
             return columns;
         }
         Annotation joinColumns = attribute.annotation("jakarta.persistence.JoinColumns");
         if (joinColumns != null) {
             for (String name : joinColumnsNames(joinColumns)) {
-                columns.add(normalizeColumn(name, attribute.name()));
+                if (name != null && !name.isBlank()) {
+                    columns.add(normalizeIdentifier(name));
+                }
             }
-            if (!columns.isEmpty()) {
-                return columns;
-            }
+            return columns;
         }
-        columns.add(snakeCase(attribute.name()) + "_id");
         return columns;
     }
 
@@ -2351,13 +2438,6 @@ final class MissingForeignKeyIndexRule extends AbstractHibernateRule {
         return names;
     }
 
-    private String normalizeColumn(String declaredName, String attributeName) {
-        if (declaredName != null && !declaredName.isBlank()) {
-            return declaredName.trim().toLowerCase(Locale.ROOT);
-        }
-        return snakeCase(attributeName) + "_id";
-    }
-
     private Set<String> leadingIndexColumns(Class<?> javaType) {
         Set<String> leading = new HashSet<>();
         Class<?> current = javaType;
@@ -2375,7 +2455,7 @@ final class MissingForeignKeyIndexRule extends AbstractHibernateRule {
                         if (columnList == null || columnList.isBlank()) {
                             continue;
                         }
-                        String first = columnList.split(",")[0].trim().toLowerCase(Locale.ROOT);
+                        String first = normalizeIndexColumn(columnList.split(",")[0]);
                         if (!first.isEmpty()) {
                             leading.add(first);
                         }
@@ -2389,20 +2469,51 @@ final class MissingForeignKeyIndexRule extends AbstractHibernateRule {
         return leading;
     }
 
-    private String snakeCase(String name) {
-        StringBuilder builder = new StringBuilder();
-        for (int i = 0; i < name.length(); i++) {
-            char ch = name.charAt(i);
-            if (Character.isUpperCase(ch)) {
-                if (builder.length() > 0) {
-                    builder.append('_');
+    private String normalizeIndexColumn(String column) {
+        return normalizeIdentifier(column.replaceFirst("(?i)\\s+(ASC|DESC)\\s*$", ""));
+    }
+
+    private String normalizeIdentifier(String identifier) {
+        String normalized = identifier.trim();
+        if ((normalized.startsWith("\"") && normalized.endsWith("\""))
+                || (normalized.startsWith("`") && normalized.endsWith("`"))
+                || (normalized.startsWith("[") && normalized.endsWith("]"))) {
+            normalized = normalized.substring(1, normalized.length() - 1);
+        }
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+}
+
+final class LegacyWhereAnnotationRule extends AbstractHibernateRule {
+
+    private static final String WHERE = "org.hibernate.annotations.Where";
+    private static final String WHERE_JOIN_TABLE = "org.hibernate.annotations.WhereJoinTable";
+
+    LegacyWhereAnnotationRule() {
+        super(new HibernateRuleDefinition(
+                "HIB-MAP-021",
+                "Legacy @Where restrictions should be migrated",
+                HibernateCategory.MAPPING,
+                "MEDIUM",
+                "Detects Hibernate @Where and @WhereJoinTable mappings, deprecated in ORM 6.3 and removed in ORM 7.",
+                "Replace static restrictions with @SQLRestriction/@SQLJoinTableRestriction, or use @SoftDelete for supported soft-delete mappings.",
+                "https://docs.jboss.org/hibernate/orm/7.0/migration-guide/migration-guide.html"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        List<String> details = new ArrayList<>();
+        for (HibernateEntityModel entity : context.entities()) {
+            if (entity.annotationInHierarchy(WHERE) != null || entity.annotationInHierarchy(WHERE_JOIN_TABLE) != null) {
+                details.add(entity.name() + " uses a legacy @Where restriction.");
+            }
+            for (HibernateAttributeModel attribute : entity.attributes()) {
+                if (attribute.annotation(WHERE) != null || attribute.annotation(WHERE_JOIN_TABLE) != null) {
+                    details.add(attribute.description() + " uses a legacy @Where restriction.");
                 }
-                builder.append(Character.toLowerCase(ch));
-            } else {
-                builder.append(ch);
             }
         }
-        return builder.toString();
+        return violation(details);
     }
 }
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateScanner.java
@@ -21,6 +21,8 @@ import java.util.function.Supplier;
  */
 public final class HibernateScanner {
 
+    public static final String OPEN_IN_VIEW_APPLICABLE_PROPERTY = "bootui.internal.hibernate.open-in-view-applicable";
+
     private static final String ANALYZER = "BootUI Hibernate Advisor";
     private static final String DISCLAIMER =
             "Heuristic Hibernate/JPA mapping rules run against the host application's mapped entities only. "

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
@@ -3,16 +3,21 @@ package io.github.jdubois.bootui.engine.hibernate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
+import jakarta.persistence.Basic;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -29,7 +34,11 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.Where;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Persistable;
 
@@ -260,7 +269,9 @@ class HibernateRulesTests {
 
     @Test
     void openInViewRuleFlagsExplicitTrue() {
-        TestEnvironment environment = new TestEnvironment().withProperty("spring.jpa.open-in-view", "true");
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY, "true")
+                .withProperty("spring.jpa.open-in-view", "true");
 
         HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
 
@@ -270,17 +281,20 @@ class HibernateRulesTests {
 
     @Test
     void openInViewRuleFlagsUnsetBootDefault() {
-        TestEnvironment environment = new TestEnvironment();
+        TestEnvironment environment =
+                new TestEnvironment().withProperty(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY, "true");
 
         HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
-        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.MEDIUM);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
     }
 
     @Test
     void openInViewRulePassesWhenExplicitlyDisabled() {
-        TestEnvironment environment = new TestEnvironment().withProperty("spring.jpa.open-in-view", "false");
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY, "true")
+                .withProperty("spring.jpa.open-in-view", "false");
 
         HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
 
@@ -289,13 +303,80 @@ class HibernateRulesTests {
 
     @Test
     void openInViewRuleEscalatesToHighInProduction() {
-        TestEnvironment environment = new TestEnvironment().withProperty("spring.jpa.open-in-view", "true");
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY, "true")
+                .withProperty("spring.jpa.open-in-view", "true");
         environment.setActiveProfiles("prod");
 
         HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
         assertThat(result.severity()).isEqualTo(HibernateRuleSupport.HIGH);
+    }
+
+    @Test
+    void openInViewRuleSkipsOutsideServletApplications() {
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY, "false")
+                .withProperty("spring.jpa.open-in-view", "true");
+
+        HibernateRuleResultDto result = new OpenInViewRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.SKIPPED);
+    }
+
+    // --- HIB-FETCH-005 / HIB-FETCH-007 -------------------------------------
+
+    @Test
+    void lobLazyFetchRuleNeverRecommendsLazyWithoutEnhancement() {
+        HibernateRuleResultDto result =
+                new LobLazyFetchRule().evaluate(context(new TestEnvironment(), EagerLobEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void lobLazyFetchRuleRecommendsLazyWhenEnhancementIsEnabled() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty("hibernate.enhancer.enableLazyInitialization", "true");
+
+        HibernateRuleResultDto result = new LobLazyFetchRule().evaluate(context(environment, EagerLobEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void lazyBasicRuleFlagsIneffectiveLazyAttributeWithoutEnhancement() {
+        HibernateRuleResultDto result =
+                new LazyBasicWithoutEnhancementRule().evaluate(context(new TestEnvironment(), LazyLobEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("not bytecode enhanced"));
+    }
+
+    @Test
+    void lazyBasicRulePassesWhenEnhancementIsEnabled() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty("hibernate.enhancer.enableLazyInitialization", "true");
+
+        HibernateRuleResultDto result =
+                new LazyBasicWithoutEnhancementRule().evaluate(context(environment, LazyLobEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    // --- HIB-MAP-003 --------------------------------------------------------
+
+    @Test
+    void ordinalEnumRuleFlagsExplicitOrdinalAsInfo() {
+        HibernateRuleResultDto result =
+                new ExplicitOrdinalEnumRule().evaluate(context(new TestEnvironment(), ExplicitOrdinalEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("explicitly uses"));
     }
 
     // --- HIB-CONFIG-008 -----------------------------------------------------
@@ -433,20 +514,79 @@ class HibernateRulesTests {
 
     @Test
     void missingForeignKeyIndexRulePassesWhenInferredColumnLeadsIndex() {
+        TestEnvironment environment = new TestEnvironment().withProperty("hibernate.hbm2ddl.auto", "create");
         HibernateRuleResultDto result =
-                new MissingForeignKeyIndexRule().evaluate(context(new TestEnvironment(), IndexedOwnerEntity.class));
+                new MissingForeignKeyIndexRule().evaluate(context(environment, IndexedOwnerEntity.class));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
     @Test
     void missingForeignKeyIndexRuleFlagsWhenColumnIsNotLeadingIndexColumn() {
+        TestEnvironment environment = new TestEnvironment().withProperty("hibernate.hbm2ddl.auto", "update");
         HibernateRuleResultDto result =
-                new MissingForeignKeyIndexRule().evaluate(context(new TestEnvironment(), NonLeadingIndexEntity.class));
+                new MissingForeignKeyIndexRule().evaluate(context(environment, NonLeadingIndexEntity.class));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
         assertThat(result.sampleViolations())
                 .anySatisfy(sample -> assertThat(sample).contains("customer_id"));
+    }
+
+    @Test
+    void missingForeignKeyIndexRuleSkipsMigrationManagedSchemas() {
+        HibernateRuleResultDto result =
+                new MissingForeignKeyIndexRule().evaluate(context(new TestEnvironment(), NonLeadingIndexEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.SKIPPED);
+    }
+
+    @Test
+    void missingForeignKeyIndexRuleRecognizesJakartaDropAndCreate() {
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty("jakarta.persistence.schema-generation.database.action", "drop-and-create");
+
+        HibernateRuleResultDto result =
+                new MissingForeignKeyIndexRule().evaluate(context(environment, NonLeadingIndexEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void missingForeignKeyIndexRuleSkipsImplicitJoinColumnNames() {
+        TestEnvironment environment = new TestEnvironment().withProperty("hibernate.hbm2ddl.auto", "create");
+
+        HibernateRuleResultDto result =
+                new MissingForeignKeyIndexRule().evaluate(context(environment, ImplicitJoinColumnEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    // --- HIB-MAP-021 --------------------------------------------------------
+
+    @Test
+    void legacyWhereRuleFlagsRemovedWhereAnnotation() {
+        HibernateRuleResultDto result =
+                new LegacyWhereAnnotationRule().evaluate(context(new TestEnvironment(), LegacyWhereEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    // --- HIB-CACHE-003 ------------------------------------------------------
+
+    @Test
+    void immutableEntityCacheRuleFlagsMutableCacheStrategy() {
+        HibernateRuleResultDto result = new ImmutableEntityCacheStrategyRule()
+                .evaluate(context(new TestEnvironment(), ImmutableReadWriteCacheEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void immutableEntityCacheRulePassesForReadOnlyStrategy() {
+        HibernateRuleResultDto result = new ImmutableEntityCacheStrategyRule()
+                .evaluate(context(new TestEnvironment(), ImmutableReadOnlyCacheEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
     // --- HIB-MAP-010 --------------------------------------------------------
@@ -976,12 +1116,46 @@ class HibernateRulesTests {
     }
 
     @Entity
+    static class EagerLobEntity {
+        @Id
+        Long id;
+
+        @Lob
+        String payload;
+    }
+
+    @Entity
+    static class LazyLobEntity {
+        @Id
+        Long id;
+
+        @Lob
+        @Basic(fetch = FetchType.LAZY)
+        String payload;
+    }
+
+    enum TestStatus {
+        ACTIVE,
+        DISABLED
+    }
+
+    @Entity
+    static class ExplicitOrdinalEntity {
+        @Id
+        Long id;
+
+        @Enumerated(EnumType.ORDINAL)
+        TestStatus status;
+    }
+
+    @Entity
     @Table(indexes = @jakarta.persistence.Index(name = "idx_customer", columnList = "customer_id"))
     static class IndexedOwnerEntity {
         @Id
         Long id;
 
         @ManyToOne
+        @JoinColumn(name = "customer_id")
         Child customer;
     }
 
@@ -992,7 +1166,40 @@ class HibernateRulesTests {
         Long id;
 
         @ManyToOne
+        @JoinColumn(name = "customer_id")
         Child customer;
+    }
+
+    @Entity
+    static class ImplicitJoinColumnEntity {
+        @Id
+        Long id;
+
+        @ManyToOne
+        Child customer;
+    }
+
+    @Entity
+    @Where(clause = "deleted = false")
+    static class LegacyWhereEntity {
+        @Id
+        Long id;
+    }
+
+    @Entity
+    @Immutable
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
+    static class ImmutableReadWriteCacheEntity {
+        @Id
+        Long id;
+    }
+
+    @Entity
+    @Immutable
+    @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
+    static class ImmutableReadOnlyCacheEntity {
+        @Id
+        Long id;
     }
 
     @Entity

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
@@ -56,13 +56,14 @@ import org.junit.jupiter.api.Test;
 
 class HibernateScannerTests {
 
-    private static final int RULE_COUNT = 69;
+    private static final int RULE_COUNT = 73;
     private static final String AFFECTED_HIBERNATE_VERSION = "7.3.9.Final";
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 
     @Test
     void scanReportsHibernateMappingAndConfigurationFindings() {
         TestEnvironment environment = new TestEnvironment()
+                .withProperty(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY, "true")
                 .withProperty("spring.jpa.hibernate.ddl-auto", "update")
                 .withProperty("spring.jpa.open-in-view", "true");
         HibernateScanner scanner = scanner(environment, ProblemOrder.class);
@@ -240,8 +241,8 @@ class HibernateScannerTests {
                         "HIB-CONFIG-015",
                         "HIB-FETCH-003",
                         "HIB-FETCH-004",
-                        "HIB-FETCH-005",
                         "HIB-FETCH-006",
+                        "HIB-FETCH-007",
                         "HIB-ID-002",
                         "HIB-ID-003",
                         "HIB-ID-004",
@@ -938,7 +939,7 @@ class HibernateScannerTests {
         @Enumerated(EnumType.STRING)
         Status status;
 
-        @Enumerated(EnumType.ORDINAL)
+        @Enumerated(EnumType.STRING)
         Status stableOrdinalStatus;
 
         @Convert(converter = StatusCodeConverter.class)

--- a/bootui-engine/src/test/java/org/hibernate/annotations/Where.java
+++ b/bootui-engine/src/test/java/org/hibernate/annotations/Where.java
@@ -1,0 +1,16 @@
+package org.hibernate.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** Hibernate 6 compatibility fixture for the annotation removed in Hibernate ORM 7. */
+@Target({TYPE, METHOD, FIELD})
+@Retention(RUNTIME)
+public @interface Where {
+    String clause();
+}

--- a/bootui-quarkus-sample-app/e2e/tests/hibernate.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/hibernate.spec.js
@@ -33,4 +33,14 @@ test.describe('Hibernate advisor (Quarkus)', () => {
     const fetchRow = page.locator('.list-group-item', {hasText: 'HIB-FETCH-001'})
     await expect(fetchRow).toContainText('Eager fetching should stay explicit and bounded')
   })
+
+  test('recommends lazy basic loading with bytecode enhancement', async ({openView, page}) => {
+    await openView('hibernate', 'Hibernate')
+
+    await page.getByRole('button', {name: 'Run Hibernate checks'}).click()
+
+    const lobFetchRow = page.locator('.list-group-item', {hasText: 'HIB-FETCH-005'})
+    await expect(lobFetchRow).toContainText('Enhanced @Lob attributes should be loaded lazily', {timeout: 20_000})
+    await expect(lobFetchRow).toContainText('SampleAuditEntry#payload is annotated with @Lob')
+  })
 })

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookup.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookup.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.quarkus.hibernate;
 
+import io.github.jdubois.bootui.engine.hibernate.HibernateScanner;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -165,6 +166,9 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
 
     @Override
     public String apply(String key) {
+        if (HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY.equals(key)) {
+            return "false";
+        }
         if (OPEN_IN_VIEW_KEY.equals(key)) {
             // Quarkus has no Open-Session-in-View; report its effective state so HIB-CONFIG-001 passes
             // rather than assuming Spring Boot's enabled-by-default.

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookupTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookupTest.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.quarkus.hibernate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.jdubois.bootui.engine.hibernate.HibernateScanner;
 import io.github.jdubois.bootui.quarkus.StubConfig;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,8 @@ class QuarkusHibernatePropertyLookupTest {
         // assuming Spring Boot's enabled-by-default web behaviour.
         assertThat(lookup(Map.of()).apply("spring.jpa.open-in-view")).isEqualTo("false");
         assertThat(lookup(Map.of("spring.jpa.open-in-view", "true")).apply("spring.jpa.open-in-view"))
+                .isEqualTo("false");
+        assertThat(lookup(Map.of()).apply(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY))
                 .isEqualTo("false");
     }
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiEngineConfiguration.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiEngineConfiguration.java
@@ -14,6 +14,7 @@ import io.github.jdubois.bootui.autoconfigure.graalvm.HttpReachabilityMetadataRe
 import io.github.jdubois.bootui.autoconfigure.health.SpringHealthGuidance;
 import io.github.jdubois.bootui.autoconfigure.health.SpringHealthProvider;
 import io.github.jdubois.bootui.autoconfigure.hibernate.SpringHibernateDiscovery;
+import io.github.jdubois.bootui.autoconfigure.hibernate.SpringHibernatePropertyLookup;
 import io.github.jdubois.bootui.autoconfigure.idle.IdleReclaimable;
 import io.github.jdubois.bootui.autoconfigure.kafka.KafkaConsumerCaptureBeanPostProcessor;
 import io.github.jdubois.bootui.autoconfigure.kafka.KafkaProducerCaptureBeanPostProcessor;
@@ -398,13 +399,15 @@ public class BootUiEngineConfiguration {
         HibernateScanner bootUiHibernateScanner(
                 ObjectProvider<EntityManagerFactory> entityManagerFactories,
                 ObjectProvider<ListableBeanFactory> beanFactories,
-                Environment environment) {
+                Environment environment,
+                ApplicationContext applicationContext) {
             // Entity discovery (jakarta metamodel via the engine JpaMetamodelReader) + Spring-Data repository
             // discovery live in the adapter; the engine scanner reads config through a neutral property-lookup
             // + active-profiles seam and runs the metamodel walk only on demand (POST /scan).
             return HibernateScanner.using(
                     () -> SpringHibernateDiscovery.discover(entityManagerFactories, beanFactories),
-                    environment::getProperty,
+                    new SpringHibernatePropertyLookup(
+                            environment, SpringHibernatePropertyLookup.isServletWebApplication(applicationContext)),
                     () -> List.of(environment.getActiveProfiles()),
                     Clock.systemUTC());
         }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/SpringHibernatePropertyLookup.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/hibernate/SpringHibernatePropertyLookup.java
@@ -1,0 +1,46 @@
+package io.github.jdubois.bootui.autoconfigure.hibernate;
+
+import io.github.jdubois.bootui.engine.hibernate.HibernateScanner;
+import java.util.function.Function;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+/** Adds Spring runtime applicability signals to the engine's neutral property lookup. */
+public final class SpringHibernatePropertyLookup implements Function<String, String> {
+
+    private static final String SERVLET_WEB_APPLICATION_CONTEXT =
+            "org.springframework.web.context.WebApplicationContext";
+
+    private final Environment environment;
+    private final boolean servletWebApplication;
+
+    public SpringHibernatePropertyLookup(Environment environment, boolean servletWebApplication) {
+        this.environment = environment;
+        this.servletWebApplication = servletWebApplication;
+    }
+
+    public static boolean isServletWebApplication(ApplicationContext applicationContext) {
+        return implementsType(applicationContext.getClass(), SERVLET_WEB_APPLICATION_CONTEXT);
+    }
+
+    @Override
+    public String apply(String key) {
+        if (HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY.equals(key)) {
+            return Boolean.toString(servletWebApplication);
+        }
+        return environment.getProperty(key);
+    }
+
+    private static boolean implementsType(Class<?> type, String typeName) {
+        Class<?> current = type;
+        while (current != null) {
+            for (Class<?> candidate : current.getInterfaces()) {
+                if (typeName.equals(candidate.getName()) || implementsType(candidate, typeName)) {
+                    return true;
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return false;
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiEngineConfigurationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiEngineConfigurationTests.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -116,7 +117,8 @@ class BootUiEngineConfigurationTests {
         when(beanFactories.getIfAvailable()).thenReturn(null);
 
         HibernateScanner scanner = new BootUiEngineConfiguration.HibernateAdvisorConfiguration()
-                .bootUiHibernateScanner(entityManagerFactories, beanFactories, environment);
+                .bootUiHibernateScanner(
+                        entityManagerFactories, beanFactories, environment, mock(ApplicationContext.class));
         HibernateReport report = scanner.scan();
 
         HibernateRuleResultDto ddlAuto = report.results().stream()

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernate/SpringHibernatePropertyLookupTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernate/SpringHibernatePropertyLookupTests.java
@@ -1,0 +1,43 @@
+package io.github.jdubois.bootui.autoconfigure.hibernate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.engine.hibernate.HibernateScanner;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.web.context.support.GenericWebApplicationContext;
+
+class SpringHibernatePropertyLookupTests {
+
+    @Test
+    void reportsOpenInViewApplicableOnlyForServletApplications() {
+        MockEnvironment environment = new MockEnvironment();
+
+        assertThat(new SpringHibernatePropertyLookup(environment, true)
+                        .apply(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY))
+                .isEqualTo("true");
+        assertThat(new SpringHibernatePropertyLookup(environment, false)
+                        .apply(HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY))
+                .isEqualTo("false");
+    }
+
+    @Test
+    void delegatesRegularPropertiesToTheEnvironment() {
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.jpa.open-in-view", "false");
+
+        assertThat(new SpringHibernatePropertyLookup(environment, true).apply("spring.jpa.open-in-view"))
+                .isEqualTo("false");
+    }
+
+    @Test
+    void detectsServletContextWithoutLinkingTheOptionalTypeInMainCode() {
+        try (GenericApplicationContext nonWeb = new GenericApplicationContext();
+                GenericWebApplicationContext servlet = new GenericWebApplicationContext()) {
+            assertThat(SpringHibernatePropertyLookup.isServletWebApplication(nonWeb))
+                    .isFalse();
+            assertThat(SpringHibernatePropertyLookup.isServletWebApplication(servlet))
+                    .isTrue();
+        }
+    }
+}

--- a/bootui-spring-sample-app/e2e/tests/hibernate.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/hibernate.spec.js
@@ -41,8 +41,6 @@ test.describe('Hibernate Advisor view', () => {
     await expect(page.getByText(/SampleOrder#details is an owning @OneToOne without @MapsId/)).toBeVisible()
     await expect(page.getByText('@NotFound(IGNORE) should be reviewed')).toBeVisible()
     await expect(page.getByText(/SampleOrder#customer uses @NotFound\(action=IGNORE\)/)).toBeVisible()
-    await expect(page.getByText('@Lob attributes should be loaded lazily')).toBeVisible()
-    await expect(page.getByText(/SampleAuditEntry#payload is annotated with @Lob/)).toBeVisible()
     await expect(page.getByText('BigDecimal columns should declare precision and scale')).toBeVisible()
     await expect(
       page.getByText(/SampleAuditEntry#amount is a BigDecimal column without explicit precision/)
@@ -54,5 +52,15 @@ test.describe('Hibernate Advisor view', () => {
     await expect(page.getByText('Native paged @Query must declare countQuery')).toBeVisible()
     await expect(page.getByText(/SampleOrderRepository#findPageNative/)).toBeVisible()
     await expect(page.getByRole('link', {name: 'Learn more'}).first()).toBeVisible()
+  })
+
+  test('does not recommend lazy basic loading without bytecode enhancement', async ({openView, page}) => {
+    await openView('hibernate', 'Hibernate')
+
+    await page.getByRole('button', {name: 'Run Hibernate checks'}).click()
+
+    await expect(page.getByText('No Hibernate Advisor data yet')).toHaveCount(0, {timeout: 30_000})
+    await expect(page.getByText('Enhanced @Lob attributes should be loaded lazily')).toHaveCount(0)
+    await expect(page.getByText(/SampleAuditEntry#payload is annotated with @Lob/)).toHaveCount(0)
   })
 })

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleAuditEntry.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleAuditEntry.java
@@ -26,7 +26,7 @@ public class SampleAuditEntry {
     // Intentionally an unbounded String column to trigger HIB-MAP-013 (missing explicit length).
     private String summary;
 
-    // Intentionally @Lob without @Basic(fetch=LAZY) to trigger HIB-FETCH-005 (Lob loaded eagerly).
+    // Intentionally @Lob without @Basic(fetch=LAZY); HIB-FETCH-005 only fires when enhancement can honor LAZY.
     @Lob
     private String payload;
 

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -89,14 +89,19 @@ includes up to a handful of sample mapped members plus a remediation link.
   `QuarkusHibernatePropertyLookup`, so a global batch-fetch size configured with the native Quarkus property name is
   read back correctly and this rule does not false-positive.
 
-### HIB-FETCH-005 - @Lob attributes should be loaded lazily
+### HIB-FETCH-005 - Enhanced @Lob attributes should be loaded lazily
 
 - **Severity**: MEDIUM
-- **Inspects**: persistent attributes annotated with `@Lob`.
-- **Fires when**: a `@Lob` attribute does not declare `@Basic(fetch = FetchType.LAZY)`.
+- **Inspects**: persistent attributes annotated with `@Lob` on bytecode-enhanced entities.
+- **Fires when**: enhancement is available and a `@Lob` attribute does not declare
+  `@Basic(fetch = FetchType.LAZY)`.
 - **Why it matters**: large CLOB/BLOB payloads are read for every entity hydration unless lazy loading is requested.
-- **Recommendation**: annotate `@Lob` fields with `@Basic(fetch = FetchType.LAZY)`; lazy loading of non-association
-  attributes requires Hibernate's bytecode enhancer to actually defer the SQL.
+- **Recommendation**: on enhanced entities, annotate infrequently accessed `@Lob` fields with
+  `@Basic(fetch = FetchType.LAZY)`.
+- **Enhancement requirement**: Hibernate ORM 7 requires bytecode enhancement to honor lazy basic attributes. This rule
+  deliberately does not recommend `@Basic(fetch = LAZY)` when enhancement is unavailable; HIB-FETCH-007 instead reports
+  existing ineffective lazy-basic declarations. Quarkus enhances entities at build time, while Spring applications must
+  configure enhancement explicitly.
 
 ### HIB-FETCH-006 - Collection associations should not declare @Fetch(JOIN)
 
@@ -107,6 +112,15 @@ includes up to a handful of sample mapped members plus a remediation link.
   products.
 - **Recommendation**: prefer `@Fetch(FetchMode.SELECT)` or `SUBSELECT` for collections, and request `JOIN FETCH` only in
   the specific queries that need the graph.
+
+### HIB-FETCH-007 - Lazy basic attributes require bytecode enhancement
+
+- **Severity**: MEDIUM
+- **Inspects**: attributes declaring `@Basic(fetch = FetchType.LAZY)` and the owning entity's enhancement state.
+- **Fires when**: a lazy basic attribute belongs to an entity that is not bytecode enhanced.
+- **Why it matters**: without enhancement, Hibernate cannot intercept access to a basic field and the requested lazy
+  column loading is ineffective.
+- **Recommendation**: enable Hibernate bytecode enhancement, or remove the misleading `LAZY` declaration.
 
 ## Identifiers
 
@@ -235,9 +249,8 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Fires when**: an enum attribute omits `@Enumerated` and therefore relies on JPA's default ordinal storage.
 - **Why it matters**: default ordinal persistence is easy to enable accidentally, and reordering enum constants changes the
   stored meaning unless the ordinal values are treated as a stable schema contract.
-- **Recommendation**: declare the mapping explicitly. Use `@Enumerated(EnumType.STRING)`, a database-native enum type, an
-  explicit converter with stable database codes, or an intentional `@Enumerated(EnumType.ORDINAL)` mapping backed by
-  append-only enum ordering plus a lookup/description table or database constraint.
+- **Recommendation**: use `@Enumerated(EnumType.STRING)`, a database-native enum type, or an explicit converter with
+  stable database codes.
 
 ### HIB-MAP-004 - Many-to-many associations should not cascade remove
 
@@ -393,12 +406,16 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Severity**: INFO
 - **Inspects**: `@ManyToOne` and owning `@OneToOne` join columns against the leading columns of `@Index` declarations in
   the entity's `@Table` mapping.
-- **Fires when**: a foreign-key association's join column is not the leading column of any JPA-declared `@Index`.
+- **Fires when**: Hibernate/Jakarta schema management is set to a schema-creating mode (`create`, `create-only`,
+  `create-drop`, `drop-and-create`, or `update`), an association declares an explicit join-column name, and that column
+  is not the leading column of any JPA-declared `@Index`.
 - **Why it matters**: databases do not always index foreign keys automatically. An unindexed foreign key forces full table
   scans when joining the association or when deleting parent rows for constraint and cascade checks, which can lead to
   lock contention and deadlocks.
 - **Recommendation**: declare an `@Index` in `@Table` with the foreign-key column as the leading column. If you manage the
   schema with Flyway/Liquibase, ensure the index exists in your migrations.
+- **Noise controls**: inferred join-column names are skipped because a physical naming strategy can rewrite them, and
+  migration-managed schemas are skipped because JPA annotations cannot prove whether the migration created an index.
 
 ### HIB-MAP-020 - Unidirectional @OneToMany with @JoinColumn issues extra UPDATE statements
 
@@ -411,6 +428,25 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Recommendation**: make the association bidirectional with `@ManyToOne` on the child and `@OneToMany(mappedBy=...)` on
   the parent so the child's foreign key is written in the `INSERT`. A read-only `@JoinColumn(insertable=false,
   updatable=false)` is exempt.
+
+### HIB-MAP-021 - Legacy @Where restrictions should be migrated
+
+- **Severity**: MEDIUM
+- **Inspects**: entity and persistent-attribute annotations by name, without linking the optional Hibernate 6 type.
+- **Fires when**: `org.hibernate.annotations.Where` or `WhereJoinTable` is present.
+- **Why it matters**: Hibernate deprecated these annotations in ORM 6.3 and removed them in ORM 7, so mappings must be
+  migrated before or during an ORM 7 upgrade.
+- **Recommendation**: use `@SQLRestriction` / `@SQLJoinTableRestriction`, or Hibernate's `@SoftDelete` for supported
+  soft-delete mappings.
+
+### HIB-MAP-022 - Explicit ordinal enum mappings should be reviewed
+
+- **Severity**: INFO
+- **Inspects**: enum attributes declaring `@Enumerated(EnumType.ORDINAL)`.
+- **Fires when**: ordinal storage is explicit, so the mapping is intentional but still carries a schema-evolution risk.
+- **Why it matters**: inserting or reordering enum constants changes the meaning of existing numeric values.
+- **Recommendation**: prefer `STRING`, a database-native enum, or a stable-code converter. Keep `ORDINAL` only when
+  append-only ordering is an explicit schema contract.
 
 ## Entity design
 
@@ -532,6 +568,11 @@ includes up to a handful of sample mapped members plus a remediation link.
 
 ## Query
 
+All HIB-QUERY rules currently inspect Spring Data repository metadata. Quarkus/Panache does not expose equivalent
+runtime repository/query metadata with enough fidelity to evaluate these rules reliably, so they remain unavailable on
+Quarkus rather than guessing from Panache method names or generated bytecode. Mapping, identifier, fetching, configuration,
+and caching rules still run on Quarkus against the live JPA metamodel.
+
 ### HIB-QUERY-001 - @Modifying queries should clear or flush the persistence context
 
 - **Severity**: HIGH
@@ -614,16 +655,16 @@ includes up to a handful of sample mapped members plus a remediation link.
 
 ### HIB-CONFIG-001 - Open Session in View should be disabled
 
-- **Severity**: MEDIUM (HIGH when a production-like profile is active)
-- **Inspects**: `spring.jpa.open-in-view` and active Spring profiles.
-- **Fires when**: the property is `true` or absent, matching Spring Boot's default for web applications.
+- **Severity**: INFO when inferred from Spring Boot's absent-property default; MEDIUM for explicit `true`; HIGH for
+  explicit `true` under a production-like profile
+- **Inspects**: adapter-provided servlet applicability, `spring.jpa.open-in-view`, and active Spring profiles.
+- **Fires when**: the application is a Spring servlet web application and the property is `true` or absent, matching
+  Spring Boot's servlet default.
 - **Why it matters**: lazy loading after the service transaction has completed can hide missing fetch plans and move data
   access into the web layer.
 - **Recommendation**: set `spring.jpa.open-in-view=false` and fetch data inside transactional service boundaries.
-- **Note**: the Spring panel's SPRING-JPA-001 checks the same property and mirrors this same production-profile
-  escalation, but additionally skips when no JPA `EntityManagerFactory` or servlet web context is present - a
-  framework-specific guard this framework-neutral rule cannot reproduce. Both are kept so each panel reports the
-  finding for its own domain.
+- **Applicability**: the Spring adapter supplies the servlet-context signal to the framework-neutral engine. Reactive,
+  non-web, and Quarkus applications skip this rule; Quarkus has no Open Session in View mechanism.
 
 ### HIB-CONFIG-003 - Lazy loading outside transactions should stay disabled
 
@@ -849,3 +890,12 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Why it matters**: `READ_ONLY` throws when Hibernate detects state changes and silently misses updates from other
   transactions on the same entity.
 - **Recommendation**: switch to `READ_WRITE` or `NONSTRICT_READ_WRITE` for mutable entities.
+
+### HIB-CACHE-003 - Immutable cached entities should use READ_ONLY
+
+- **Severity**: INFO
+- **Inspects**: entity-level Hibernate `@Immutable` and `@Cache(usage=...)`.
+- **Fires when**: an immutable cached entity uses `READ_WRITE`, `NONSTRICT_READ_WRITE`, or `TRANSACTIONAL`.
+- **Why it matters**: Hibernate documents `READ_ONLY` as the simplest, safest, and best-performing strategy for immutable
+  entities; mutable strategies add coordination overhead for updates the mapping forbids.
+- **Recommendation**: use `@Cache(usage = READ_ONLY)`, or remove `@Immutable` if the entity is expected to change.

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -304,6 +304,8 @@ No equivalent, low value, or superseded by Quarkus's own tooling:
   Spring's `BufferingApplicationStartup`, only coarse boot totals — so it is reported *not applicable*, not
   *not yet*, alongside GraalVM/CRaC).
 - **Different security/data stacks:** `Spring Security`, `Spring Data` (Quarkus uses Elytron/OIDC and Panache).
+- **Hibernate advisor query rules:** mapping/configuration rules run against Quarkus' JPA metamodel, but HIB-QUERY rules
+  remain unavailable because Panache exposes no reliable runtime equivalent of Spring Data repository query metadata.
 - **Servlet-only / low value on a reactive stack:** `HTTP Sessions`.
 - **Superseded or moot:** `GraalVM` readiness (Quarkus is native-first with its own build), `CRaC` (native focus makes
   it niche), `DevTools` (**Implemented as `NOT_APPLICABLE`** — Quarkus has built-in dev-mode live reload, so there is no


### PR DESCRIPTION
## What does this PR do?

Makes the Hibernate advisor enhancement-aware and platform-aware, narrows noisy checks, and adds four high-confidence advisories.

## Why is this change needed?

Several rules could produce unfixable or misleading findings:

- `HIB-FETCH-005` recommended `@Basic(fetch = LAZY)` even when Hibernate could not honor it without bytecode enhancement.
- `HIB-CONFIG-001` inferred Spring Boot's servlet OSIV default in non-servlet and Quarkus contexts.
- `HIB-MAP-019` guessed physical join-column names and treated migration-managed indexes as absent.
- Quarkus/Panache query-rule limitations were undocumented.

This PR also adds targeted checks for ineffective lazy basic attributes (`HIB-FETCH-007`), removed Hibernate 6 `@Where` mappings (`HIB-MAP-021`), explicit ordinal enum mappings (`HIB-MAP-022`), and mutable cache strategies on immutable entities (`HIB-CACHE-003`). `HIB-ID-004` remains unchanged after verifying Hibernate ORM 7.1's `GeneratorBinder` maps numeric `AUTO` to `SequenceStyleGenerator`, whose no-sequence fallback is table-backed.

Closes #

## Evidence and manual validation

Validated against upstream sources:

- Hibernate ORM 7.1 `GeneratorBinder` and `SequenceStyleGenerator`
- Hibernate ORM 6.6 deprecated `@Where` source and its removal from ORM 7
- Hibernate ORM 7.1 `CacheConcurrencyStrategy` Javadoc
- Spring Boot 4 `JpaBaseConfiguration` servlet condition and `matchIfMissing=true`
- Quarkus build-time entity enhancement behavior already modeled by `QuarkusHibernatePropertyLookup`

Manual validation steps:

1. Scan a non-enhanced Spring entity with eager `@Lob`: no lazy annotation recommendation is emitted.
2. Add `@Basic(fetch = LAZY)` without enhancement: `HIB-FETCH-007` reports the ineffective mapping.
3. Scan Spring servlet, reactive, and Quarkus apps: absent OSIV is INFO only for servlet; reactive and Quarkus skip it.
4. Use Flyway/Liquibase-managed indexes or an implicit join-column name: `HIB-MAP-019` skips instead of guessing.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `./mvnw -B -ntp -pl bootui-engine,bootui-spring-autoconfigure,bootui-quarkus -am test` (one unrelated reactive timeout passed on immediate focused rerun)
- [x] Focused Hibernate engine and adapter tests
- [x] Spring API conformance (`SpringApiConformanceTest`)
- [x] Quarkus API conformance (`BootUiQuarkusApiConformanceTest`)
- [x] `./mvnw -B -ntp spotless:check`

The Hibernate-present Quarkus integration module is JDK-gated and unavailable on this JDK; the Quarkus adapter suite, property-lookup tests, and Docker-free base conformance suite passed.

## Screenshots (UI changes)

N/A — no Vue or visible layout changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed