### PR TITLE
Fix Spring and Quarkus application advisor rules

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppChecks.java
@@ -118,7 +118,7 @@ final class QuarkusAppChecks {
                             + " build — Dev Services only runs during augmentation/dev/test, never in a"
                             + " LaunchMode.NORMAL packaged JAR or native executable — but its presence usually"
                             + " means leftover or copy-pasted config that should be cleaned up.",
-                    s.prodProfileKeys().size(),
+                    1,
                     List.of("%prod devservices.enabled=true"),
                     "Remove the unused %prod devservices override; it does not start containers in production"
                             + " but can confuse readers of the config.",
@@ -225,8 +225,11 @@ final class QuarkusAppChecks {
                             + " the job, causing duplicate work in a scaled-out deployment.",
                     s.scheduledCount(),
                     List.of(s.scheduledCount() + " @Scheduled method(s), no clustered scheduler"),
-                    "Use the Quartz extension with quarkus.quartz.clustered=true, or confirm single-instance"
-                            + " deployment.",
+                    "For multi-instance deployment, use the Quartz extension with"
+                            + " quarkus.quartz.clustered=true, select a persistent JDBC store"
+                            + " (quarkus.quartz.store-type=jdbc-tx or jdbc-cmt), configure its datasource, and"
+                            + " install the matching Quartz database schema (for example with Flyway). Otherwise"
+                            + " confirm single-instance deployment.",
                     SCHEDULER_GUIDE));
         }
         if (s.prodProfileKeys().isEmpty()) {
@@ -275,7 +278,7 @@ final class QuarkusAppChecks {
                     "QA-WEB-004",
                     "Graceful shutdown timeout never configured",
                     "Web",
-                    "LOW",
+                    "INFO",
                     "Neither quarkus.shutdown.timeout nor quarkus.http.shutdown.timeout is set. Quarkus's"
                             + " graceful shutdown is opt-in: with no timeout configured, the application exits"
                             + " immediately on SIGTERM instead of draining in-flight requests.",

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusAppSnapshot.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusAppSnapshot.java
@@ -16,7 +16,8 @@ import java.util.List;
  * @param singletonCount number of {@code @Singleton} app beans
  * @param requestScopedCount number of {@code @RequestScoped} app beans
  * @param dependentScopedCount number of explicit {@code @Dependent} app beans
- * @param mutableAppScopedFields {@code @ApplicationScoped} bean fields that are public or non-final (shared mutable state)
+ * @param mutableAppScopedFields mutable {@code @ApplicationScoped} bean fields, excluding known immutable final
+ *     value types (shared mutable state)
  * @param configPropertyCount number of {@code @ConfigProperty} injection sites
  * @param endpointCount discovered JAX-RS endpoint methods
  * @param defaultScopeResourceCount JAX-RS resources with no explicit CDI scope
@@ -49,9 +50,8 @@ import java.util.List;
  * @param virtualThreadSynchronizedCount {@code @RunOnVirtualThread} sites that are also {@code synchronized}
  *     (a class-level {@code @RunOnVirtualThread} counts every {@code synchronized} method in that class)
  * @param jdkMajorVersion the build JDK's major version (0 if undetermined)
- * @param mutableSingletonFields {@code @Singleton} bean fields that are public or non-final (shared mutable
- *     state, the same risk as {@link #mutableAppScopedFields()} since a {@code @Singleton} is also one
- *     instance shared across threads)
+ * @param mutableSingletonFields mutable {@code @Singleton} bean fields, excluding known immutable final value
+ *     types (the same shared-state risk as {@link #mutableAppScopedFields()})
  * @param legacySchemaGenerationPropertyUsed whether the deprecated {@code quarkus.hibernate-orm.database.generation}
  *     property (or a profile/named-persistence-unit variant) is used instead of the current
  *     {@code quarkus.hibernate-orm.schema-management.strategy}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
@@ -211,7 +211,9 @@ class QuarkusAppScannerTest {
         s.prodDevServices = true;
         s.prodProfileKeys = List.of("%prod.x.devservices.enabled");
         SpringReport r = scan(s);
-        assertThat(find(r, "QA-PROD-001").severity()).isEqualTo("LOW");
+        SpringRuleResultDto finding = find(r, "QA-PROD-001");
+        assertThat(finding.severity()).isEqualTo("LOW");
+        assertThat(finding.violationCount()).isOne();
     }
 
     @Test
@@ -262,7 +264,10 @@ class QuarkusAppScannerTest {
         s.jdbcDatasource = true;
         s.datasourceMaxSizeConfigured = false;
         SpringReport r = scan(s);
-        assertThat(find(r, "QA-DB-001").severity()).isEqualTo("LOW");
+        SpringRuleResultDto finding = find(r, "QA-DB-001");
+        assertThat(finding.severity()).isEqualTo("LOW");
+        assertThat(finding.description()).contains("defaults to a max pool size of 50");
+        assertThat(finding.sampleViolations()).singleElement().asString().contains("Agroal default: 50");
     }
 
     @Test
@@ -319,7 +324,12 @@ class QuarkusAppScannerTest {
     void scheduledWithoutClusteringIsFlagged() {
         Snap firing = new Snap();
         firing.scheduled = 1;
-        assertThat(find(scan(firing), "QA-SCH-001").severity()).isEqualTo("LOW");
+        SpringRuleResultDto finding = find(scan(firing), "QA-SCH-001");
+        assertThat(finding.severity()).isEqualTo("LOW");
+        assertThat(finding.recommendation())
+                .contains("store-type=jdbc-tx or jdbc-cmt")
+                .contains("datasource")
+                .contains("schema");
 
         Snap clustered = new Snap();
         clustered.scheduled = 1;
@@ -372,7 +382,7 @@ class QuarkusAppScannerTest {
         Snap s = new Snap();
         s.shutdownTimeoutConfigured = false;
         SpringReport r = scan(s);
-        assertThat(find(r, "QA-WEB-004").severity()).isEqualTo("LOW");
+        assertThat(find(r, "QA-WEB-004").severity()).isEqualTo("INFO");
         assertThat(find(r, "QA-WEB-002")).isNull();
     }
 

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -734,7 +734,7 @@ class BootUiQuarkusProcessor {
     record VirtualThreadCounts(int sites, int synchronizedSites) {}
 
     /**
-     * Public-or-non-final, non-static, non-injected fields on every class annotated {@code scopeAnnotation}.
+     * Mutable, non-static, non-injected fields on every class annotated {@code scopeAnnotation}.
      * Shared by QA-CDI-001 ({@code @ApplicationScoped}) and QA-CDI-003 ({@code @Singleton}) — both scopes are
      * a single instance shared across threads, so a mutable field on either is unsynchronised shared state.
      */
@@ -751,12 +751,41 @@ class BootUiQuarkusProcessor {
                 boolean isStatic = (f.flags() & 0x0008) != 0;
                 boolean injected =
                         f.hasAnnotation(INJECT) || f.hasAnnotation(CONFIG_PROPERTY) || f.hasAnnotation(REST_CLIENT);
-                if (!isStatic && !injected && (isPublic || !isFinal)) {
+                boolean mutableReference = !isKnownImmutableValueType(f.type(), app);
+                if (!isStatic && !injected && (!isFinal || (isPublic && mutableReference))) {
                     result.add(cls.simpleName() + "." + f.name());
                 }
             }
         }
         return result;
+    }
+
+    private static boolean isKnownImmutableValueType(Type type, IndexView index) {
+        if (type.kind() == Type.Kind.PRIMITIVE) {
+            return true;
+        }
+        DotName name = type.name();
+        if (name == null) {
+            return false;
+        }
+        String value = name.toString();
+        if (value.equals("java.lang.String")
+                || value.equals("java.lang.Boolean")
+                || value.equals("java.lang.Byte")
+                || value.equals("java.lang.Character")
+                || value.equals("java.lang.Double")
+                || value.equals("java.lang.Float")
+                || value.equals("java.lang.Integer")
+                || value.equals("java.lang.Long")
+                || value.equals("java.lang.Short")
+                || value.equals("java.math.BigDecimal")
+                || value.equals("java.math.BigInteger")
+                || value.equals("java.util.UUID")
+                || value.startsWith("java.time.")) {
+            return true;
+        }
+        ClassInfo classInfo = index.getClassByName(name);
+        return classInfo != null && classInfo.isEnum();
     }
 
     static int classAnnotations(IndexView index, DotName annotation) {

--- a/bootui-quarkus-deployment/src/test/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessorAppIdiomsTest.java
+++ b/bootui-quarkus-deployment/src/test/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessorAppIdiomsTest.java
@@ -6,6 +6,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -86,11 +87,13 @@ class BootUiQuarkusProcessorAppIdiomsTest {
         assertThat(BootUiQuarkusProcessor.mutableFieldsOf(index, APPLICATION_SCOPED))
                 .containsExactlyInAnyOrder(
                         "MutableAppScopedBean.publicMutableField",
-                        "MutableAppScopedBean.publicFinalField",
+                        "MutableAppScopedBean.publicFinalMutableReference",
                         "MutableAppScopedBean.privateMutableField")
                 .as("static fields, @Inject fields, and @ConfigProperty fields are never a shared-state risk")
                 .doesNotContain(
                         "MutableAppScopedBean.staticField",
+                        "MutableAppScopedBean.publicFinalValueField",
+                        "MutableAppScopedBean.publicFinalStringField",
                         "MutableAppScopedBean.injectedField",
                         "MutableAppScopedBean.configPropertyField");
     }
@@ -160,7 +163,9 @@ class BootUiQuarkusProcessorAppIdiomsTest {
     @ApplicationScoped
     static class MutableAppScopedBean {
         public int publicMutableField;
-        public final int publicFinalField = 1;
+        public final int publicFinalValueField = 1;
+        public final String publicFinalStringField = "immutable";
+        public final List<String> publicFinalMutableReference = new java.util.ArrayList<>();
         private int privateMutableField;
         private static int staticField;
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringContext.java
@@ -3,10 +3,14 @@ package io.github.jdubois.bootui.autoconfigure.spring;
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.BeanRef;
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.CacheManagerRef;
 import java.time.Duration;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
 import org.springframework.core.env.Environment;
 
 /**
@@ -108,6 +112,23 @@ record SpringContext(
         } catch (RuntimeException ex) {
             return false;
         }
+    }
+
+    Set<String> propertyNamesWithPrefix(String prefix) {
+        if (!(environment instanceof ConfigurableEnvironment configurable)) {
+            return Set.of();
+        }
+        Set<String> names = new LinkedHashSet<>();
+        for (var source : configurable.getPropertySources()) {
+            if (source instanceof EnumerablePropertySource<?> enumerable) {
+                for (String name : enumerable.getPropertyNames()) {
+                    if (name.startsWith(prefix)) {
+                        names.add(name);
+                    }
+                }
+            }
+        }
+        return Set.copyOf(names);
     }
 
     boolean isVirtualThreadsEnabled() {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRuleRegistry.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRuleRegistry.java
@@ -25,6 +25,7 @@ final class SpringRuleRegistry {
             new RemovedOrRenamedPropertyRule(),
             new MissingApplicationNameRule(),
             new ConfigOnNotFoundIgnoreRule(),
+            new Jackson2DefaultsCompatibilityRule(),
             // Profiles and environment
             new NoActiveProfileRule(),
             new DevToolsOnClasspathRule(),
@@ -48,6 +49,7 @@ final class SpringRuleRegistry {
             // Data and persistence
             new OpenSessionInViewEnabledRule(),
             new InMemoryDatasourceInProductionRule(),
+            new InMemoryR2dbcInProductionRule(),
             // Actuator and management
             new ActuatorExposeAllRule(),
             new SensitiveActuatorEndpointsExposedRule(),

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
@@ -364,7 +364,10 @@ final class DebugOrTraceLoggingRule extends AbstractSpringRule {
         }
         for (String logger : VERBOSE_LOGGERS) {
             String level = context.firstProperty("logging.level." + logger);
-            if (level != null && ("debug".equalsIgnoreCase(level) || "trace".equalsIgnoreCase(level))) {
+            if (level != null
+                    && ("debug".equalsIgnoreCase(level)
+                            || "trace".equalsIgnoreCase(level)
+                            || "all".equalsIgnoreCase(level))) {
                 findings.add("logging.level." + logger + "=" + level
                         + " emits verbose framework logging that can leak internals and slow the application.");
             }
@@ -449,6 +452,12 @@ final class RemovedOrRenamedPropertyRule extends AbstractSpringRule {
             new String[] {"spring.http.client.read-timeout", "renamed to spring.http.clients.read-timeout"},
             new String[] {"spring.http.client.redirects", "renamed to spring.http.clients.redirects"},
             new String[] {"spring.http.client.ssl.bundle", "renamed to spring.http.clients.ssl.bundle"},
+            new String[] {"spring.http.reactiveclient.connect-timeout", "renamed to spring.http.clients.connect-timeout"
+            },
+            new String[] {"spring.http.reactiveclient.connector", "renamed to spring.http.clients.reactive.connector"},
+            new String[] {"spring.http.reactiveclient.read-timeout", "renamed to spring.http.clients.read-timeout"},
+            new String[] {"spring.http.reactiveclient.redirects", "renamed to spring.http.clients.redirects"},
+            new String[] {"spring.http.reactiveclient.ssl.bundle", "renamed to spring.http.clients.ssl.bundle"},
             // --- spring.data.mongodb.* connection keys -> spring.mongodb.* (spring-boot-mongodb).
             // Only these 13 connection-related keys moved; spring.data.mongodb.auto-index-creation,
             // .field-naming-strategy, .gridfs.*, and .representation.big-decimal are unrelated
@@ -481,7 +490,12 @@ final class RemovedOrRenamedPropertyRule extends AbstractSpringRule {
             new String[] {"spring.session.redis.namespace", "renamed to spring.session.data.redis.namespace"},
             new String[] {"spring.session.redis.repository-type", "renamed to spring.session.data.redis.repository-type"
             },
-            new String[] {"spring.session.redis.save-mode", "renamed to spring.session.data.redis.save-mode"});
+            new String[] {"spring.session.redis.save-mode", "renamed to spring.session.data.redis.save-mode"},
+            // --- MongoDB-backed Spring Session moved out of Spring Boot 4 ------------------------
+            new String[] {
+                "spring.session.mongodb.collection-name",
+                "removed with Boot's MongoDB session auto-configuration; migrate to org.mongodb:mongodb-spring-session"
+            });
 
     RemovedOrRenamedPropertyRule() {
         super(new SpringRuleDefinition(
@@ -554,6 +568,32 @@ final class ConfigOnNotFoundIgnoreRule extends AbstractSpringRule {
         if (value != null && "ignore".equalsIgnoreCase(value)) {
             return violation("spring.config.on-not-found=ignore silently skips missing config imports instead of"
                     + " failing fast.");
+        }
+        return pass();
+    }
+}
+
+final class Jackson2DefaultsCompatibilityRule extends AbstractSpringRule {
+
+    Jackson2DefaultsCompatibilityRule() {
+        super(new SpringRuleDefinition(
+                "SPRING-CONFIG-006",
+                "Remove the temporary Jackson 2 defaults compatibility mode",
+                SpringCategory.CONFIGURATION,
+                "LOW",
+                "spring.jackson.use-jackson2-defaults=true makes Jackson 3 retain Spring Boot's former Jackson 2"
+                        + " defaults. It is useful during migration, but can hide serialization changes that still"
+                        + " need to be reviewed before the compatibility mode is removed.",
+                "Add serialization compatibility tests, migrate affected payloads explicitly, then remove"
+                        + " spring.jackson.use-jackson2-defaults=true.",
+                "https://docs.spring.io/spring-boot/reference/features/json.html"));
+    }
+
+    @Override
+    SpringRuleResultDto evaluateRule(SpringContext context) {
+        if (context.isPropertyTrue("spring.jackson.use-jackson2-defaults")) {
+            return violation("spring.jackson.use-jackson2-defaults=true keeps Jackson 2-compatible defaults on"
+                    + " Jackson 3 and should remain a temporary migration aid.");
         }
         return pass();
     }
@@ -770,8 +810,8 @@ final class ConnectionPoolSmallForVirtualThreadsRule extends AbstractSpringRule 
                 "Connection pool may bottleneck virtual threads",
                 SpringCategory.PERFORMANCE,
                 "LOW",
-                "Virtual threads are enabled while the HikariCP connection pool keeps a small (default)"
-                        + " maximum size, so many virtual threads can contend for few database connections.",
+                "Virtual threads are enabled while HikariCP is left at its unreviewed default maximum pool size"
+                        + " of 10, so many virtual threads can contend for few database connections.",
                 "Review spring.datasource.hikari.maximum-pool-size against the expected concurrency, and"
                         + " size it for the database rather than the (now cheap) thread count.",
                 "https://docs.spring.io/spring-boot/reference/data/sql.html"));
@@ -782,13 +822,10 @@ final class ConnectionPoolSmallForVirtualThreadsRule extends AbstractSpringRule 
         if (!context.isVirtualThreadsEnabled() || !context.hikariDataSourcePresent()) {
             return pass();
         }
-        Integer maxPoolSize = context.firstIntegerProperty("spring.datasource.hikari.maximum-pool-size");
-        int effective = maxPoolSize != null ? maxPoolSize : DEFAULT_HIKARI_POOL_SIZE;
-        if (effective <= DEFAULT_HIKARI_POOL_SIZE) {
-            String configured =
-                    maxPoolSize != null ? String.valueOf(maxPoolSize) : "default " + DEFAULT_HIKARI_POOL_SIZE;
-            return violation("Virtual threads are enabled but the HikariCP maximum pool size is " + configured
-                    + "; review whether it matches the database's capacity rather than the now-cheap thread count.");
+        if (!context.hasProperty("spring.datasource.hikari.maximum-pool-size")) {
+            return violation("Virtual threads are enabled but HikariCP maximum-pool-size is unset, leaving the"
+                    + " unreviewed default of " + DEFAULT_HIKARI_POOL_SIZE
+                    + "; size the pool for the database's capacity rather than the now-cheap thread count.");
         }
         return pass();
     }
@@ -1064,12 +1101,13 @@ final class HttpClientTimeoutsUnsetRule extends AbstractSpringRule {
                 "Set HTTP client timeouts",
                 SpringCategory.WEB,
                 "INFO",
-                "A RestClient, WebClient, or RestTemplate bean is defined but no global HTTP client timeouts"
-                        + " are set (spring.http.clients.connect-timeout / read-timeout — the same property"
-                        + " namespace configures both imperative clients and the reactive WebClient in Spring"
-                        + " Boot 4), so a slow or unresponsive dependency can block indefinitely.",
-                "Set spring.http.clients.connect-timeout and spring.http.clients.read-timeout (or configure"
-                        + " timeouts per client) so outbound calls fail fast.",
+                "A RestClient, WebClient, or RestTemplate bean is defined but neither complete global timeout"
+                        + " defaults nor complete named HTTP service-client timeouts are configured. The client then"
+                        + " relies on implementation-specific defaults that may not match the dependency's latency"
+                        + " budget.",
+                "Set spring.http.clients.connect-timeout and spring.http.clients.read-timeout globally, or set"
+                        + " both spring.http.serviceclient.<name>.connect-timeout and .read-timeout for every named"
+                        + " HTTP service client.",
                 "https://docs.spring.io/spring-boot/reference/io/rest-client.html"));
     }
 
@@ -1086,13 +1124,35 @@ final class HttpClientTimeoutsUnsetRule extends AbstractSpringRule {
         if (connectSet && readSet) {
             return pass();
         }
+        var namedProperties = context.propertyNamesWithPrefix("spring.http.serviceclient.");
+        var clientNames = namedProperties.stream()
+                .map(name -> name.substring("spring.http.serviceclient.".length()))
+                .filter(name -> name.contains("."))
+                .map(name -> name.substring(0, name.indexOf('.')))
+                .distinct()
+                .sorted()
+                .toList();
+        if (!clientNames.isEmpty()) {
+            List<String> incomplete = clientNames.stream()
+                    .filter(name -> !(connectSet
+                                    || context.hasProperty("spring.http.serviceclient." + name + ".connect-timeout"))
+                            || !(readSet || context.hasProperty("spring.http.serviceclient." + name + ".read-timeout")))
+                    .toList();
+            if (incomplete.isEmpty()) {
+                return pass();
+            }
+            return violation(incomplete.stream()
+                    .map(name -> "Named HTTP service client '" + name
+                            + "' does not set both connect-timeout and read-timeout.")
+                    .toList());
+        }
         if (!connectSet && !readSet) {
             return violation("An HTTP client bean is defined but neither spring.http.clients.connect-timeout nor"
-                    + " spring.http.clients.read-timeout is set.");
+                    + " spring.http.clients.read-timeout is set, and no named service client supplies both.");
         }
         String missing = connectSet ? "spring.http.clients.read-timeout" : "spring.http.clients.connect-timeout";
         return violation("An HTTP client bean is defined but " + missing
-                + " is not set, so outbound calls can still block indefinitely.");
+                + " is not set, leaving timeout behavior to the underlying client implementation.");
     }
 }
 
@@ -1412,6 +1472,42 @@ final class InMemoryDatasourceInProductionRule extends AbstractSpringRule {
                 return violation("spring.datasource.url=" + url + " targets an in-memory database while a"
                         + " production-like profile is active.");
             }
+        }
+        return pass();
+    }
+}
+
+final class InMemoryR2dbcInProductionRule extends AbstractSpringRule {
+
+    private static final List<String> IN_MEMORY_URL_MARKERS =
+            List.of("r2dbc:h2:mem:", "r2dbc:pool:h2:mem:", "r2dbc:hsqldb:mem:", "r2dbc:pool:hsqldb:mem:");
+
+    InMemoryR2dbcInProductionRule() {
+        super(new SpringRuleDefinition(
+                "SPRING-DATA-002",
+                "Do not run production R2DBC on an in-memory database",
+                SpringCategory.PERSISTENCE,
+                "MEDIUM",
+                "A production-like profile is active while spring.r2dbc.url points at an in-process in-memory"
+                        + " database, so data disappears on restart and cannot be shared across instances.",
+                "Point spring.r2dbc.url at a durable database server for production-like profiles; reserve"
+                        + " in-memory R2DBC URLs for tests and local development.",
+                "https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.r2dbc.embedded"));
+    }
+
+    @Override
+    SpringRuleResultDto evaluateRule(SpringContext context) {
+        if (!context.isProductionProfileActive()) {
+            return skipped("No production-like profile is active, so an in-memory R2DBC database is expected in"
+                    + " tests and local development.");
+        }
+        String url = context.firstProperty("spring.r2dbc.url");
+        if (url == null) {
+            return pass();
+        }
+        String normalized = url.toLowerCase(Locale.ROOT);
+        if (IN_MEMORY_URL_MARKERS.stream().anyMatch(normalized::startsWith)) {
+            return violation("Production-like profile uses in-memory R2DBC URL " + url + ".");
         }
         return pass();
     }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
@@ -274,6 +274,18 @@ class SpringRulesTests {
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.http.reactiveclient.connector", "reactor"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        SpringRuleResultDto mongoSession =
+                rule.evaluate(context(env().withProperty("spring.session.mongodb.collection-name", "sessions"))
+                        .build());
+        assertThat(mongoSession.status()).isEqualTo("VIOLATION");
+        assertThat(mongoSession.sampleViolations())
+                .singleElement()
+                .asString()
+                .contains("org.mongodb:mongodb-spring-session");
         // server.servlet.encoding.mapping is deliberately NOT in the rename list (still works as-is).
         assertThat(rule.evaluate(context(env().withProperty("server.servlet.encoding.mapping", "*.html"))
                                 .build())
@@ -440,6 +452,10 @@ class SpringRulesTests {
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("logging.level.root", "ALL"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
         assertThat(rule.evaluate(context(env().withProperty("logging.level.org.springframework", "INFO"))
                                 .build())
                         .status())
@@ -509,6 +525,80 @@ class SpringRulesTests {
                                 .build())
                         .status())
                 .isEqualTo("PASS");
+    }
+
+    @Test
+    void namedHttpServiceClientTimeoutsAreRecognized() {
+        HttpClientTimeoutsUnsetRule rule = new HttpClientTimeoutsUnsetRule();
+
+        SpringRuleResultDto complete = rule.evaluate(
+                context(env().withProperty("spring.http.serviceclient.inventory.base-url", "https://inventory.example")
+                                .withProperty("spring.http.serviceclient.inventory.connect-timeout", "2s")
+                                .withProperty("spring.http.serviceclient.inventory.read-timeout", "5s"))
+                        .restClientBeanPresent(true)
+                        .build());
+        assertThat(complete.status()).isEqualTo("PASS");
+
+        SpringRuleResultDto incomplete = rule.evaluate(
+                context(env().withProperty("spring.http.serviceclient.inventory.base-url", "https://inventory.example")
+                                .withProperty("spring.http.serviceclient.inventory.connect-timeout", "2s"))
+                        .restClientBeanPresent(true)
+                        .build());
+        assertThat(incomplete.status()).isEqualTo("VIOLATION");
+        assertThat(incomplete.sampleViolations()).singleElement().asString().contains("inventory", "read-timeout");
+
+        SpringRuleResultDto inheritedGlobal = rule.evaluate(context(env().withProperty(
+                                "spring.http.clients.connect-timeout", "2s")
+                        .withProperty("spring.http.serviceclient.inventory.base-url", "https://inventory.example")
+                        .withProperty("spring.http.serviceclient.inventory.read-timeout", "5s"))
+                .restClientBeanPresent(true)
+                .build());
+        assertThat(inheritedGlobal.status()).isEqualTo("PASS");
+    }
+
+    @Test
+    void explicitlyReviewedHikariPoolSizeTenDoesNotFlagVirtualThreads() {
+        ConnectionPoolSmallForVirtualThreadsRule rule = new ConnectionPoolSmallForVirtualThreadsRule();
+
+        assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true"))
+                                .hikariDataSourcePresent(true)
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true")
+                                        .withProperty("spring.datasource.hikari.maximum-pool-size", "10"))
+                                .hikariDataSourcePresent(true)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+    }
+
+    @Test
+    void jackson2DefaultsCompatibilityModeIsFlagged() {
+        Jackson2DefaultsCompatibilityRule rule = new Jackson2DefaultsCompatibilityRule();
+
+        assertThat(rule.evaluate(context(env().withProperty("spring.jackson.use-jackson2-defaults", "true"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env()).build()).status()).isEqualTo("PASS");
+    }
+
+    @Test
+    void inMemoryR2dbcUrlIsFlaggedOnlyForProductionLikeProfiles() {
+        InMemoryR2dbcInProductionRule rule = new InMemoryR2dbcInProductionRule();
+        MockEnvironment prod = env().withProperty("spring.r2dbc.url", "r2dbc:h2:mem:///orders");
+        prod.setActiveProfiles("prod");
+
+        assertThat(rule.evaluate(context(prod).build()).status()).isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.r2dbc.url", "r2dbc:h2:mem:///orders"))
+                                .build())
+                        .status())
+                .isEqualTo("SKIPPED");
+
+        MockEnvironment durable = env().withProperty("spring.r2dbc.url", "r2dbc:postgresql://db/orders");
+        durable.setActiveProfiles("production");
+        assertThat(rule.evaluate(context(durable).build()).status()).isEqualTo("PASS");
     }
 
     // ── SPRING-WEB-006 ───────────────────────────────────────────────────────────

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScannerTests.java
@@ -16,7 +16,7 @@ import org.springframework.mock.env.MockEnvironment;
 
 class SpringScannerTests {
 
-    private static final int RULE_COUNT = 39;
+    private static final int RULE_COUNT = 41;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-06T10:00:00Z"), ZoneOffset.UTC);
 
     @Test

--- a/docs/QUARKUS-ADVISOR-CHECKS.md
+++ b/docs/QUARKUS-ADVISOR-CHECKS.md
@@ -35,10 +35,11 @@ in dev/test only (skipped in `NORMAL`/production); profile keys are read live. M
 ## CDI
 
 ### QA-CDI-001 - Shared mutable state on @ApplicationScoped bean (MEDIUM)
-`@ApplicationScoped` beans are single instances shared across threads; public or non-final fields (other
-than injected dependencies — `@Inject`/`@ConfigProperty`/`@RestClient` fields are excluded) hold
-unsynchronised shared state. Make fields `private final`, or move per-request state to a `@RequestScoped`
-bean.
+`@ApplicationScoped` beans are single instances shared across threads; non-final fields and public final
+mutable references (other than injected dependencies — `@Inject`/`@ConfigProperty`/`@RestClient` fields are
+excluded) hold unsynchronised shared state. Public final primitives, strings, boxed primitives, numbers,
+UUIDs, time values, and enums are immutable values and are not flagged. Make mutable fields `private final`
+or expose an immutable value, or move per-request state to a `@RequestScoped` bean.
 
 ### QA-CDI-002 - Public mutable field on a JAX-RS resource (MEDIUM)
 JAX-RS resources default to `@Singleton`, so a public non-final (non-static) field is process-wide shared
@@ -49,8 +50,8 @@ fresh instance per request and carries no shared-state risk, so it is excluded f
 
 ### QA-CDI-003 - Shared mutable state on a @Singleton bean (MEDIUM)
 `@Singleton` beans are a single instance shared across threads, exactly like `@ApplicationScoped` — the same
-unsynchronised-shared-state risk applies to public or non-final fields (other than injected dependencies).
-Make fields `private final`, or move per-request state to a `@RequestScoped` bean.
+unsynchronised-shared-state rule and immutable-value exclusions as QA-CDI-001 apply. Make mutable fields
+`private final`, expose an immutable value, or move per-request state to a `@RequestScoped` bean.
 
 ## Config
 
@@ -92,8 +93,11 @@ unrelated guard elsewhere in the app does not suppress a finding on a genuinely 
 
 ### QA-SCH-001 - Scheduled tasks without a clustered scheduler (LOW)
 `@Scheduled` methods run on every instance; without a clustered scheduler each replica fires the job,
-causing duplicate work in a scaled-out deployment. Use the Quartz extension with
-`quarkus.quartz.clustered=true`, or confirm single-instance deployment.
+causing duplicate work in a scaled-out deployment. For clustering, use the Quartz extension with
+`quarkus.quartz.clustered=true`, select a persistent JDBC store with
+`quarkus.quartz.store-type=jdbc-tx` or `jdbc-cmt`, configure the Quartz datasource (the default datasource is
+used when none is named), and install the database-specific Quartz schema, for example through Flyway.
+Otherwise confirm single-instance deployment.
 
 ## Profiles
 
@@ -157,10 +161,11 @@ so a slow/hanging remote service is normally bounded; this override removes that
 override to keep Quarkus's 15s/30s defaults, or set a specific, bounded timeout appropriate for the remote
 service.
 
-### QA-WEB-004 - Graceful shutdown timeout never configured (LOW)
+### QA-WEB-004 - Graceful shutdown timeout never configured (INFO)
 Neither `quarkus.shutdown.timeout` nor `quarkus.http.shutdown.timeout` is set anywhere. Quarkus's graceful
-shutdown is opt-in — with no timeout configured at all, the application exits immediately on `SIGTERM`
-instead of draining in-flight requests. This is a distinct, lower-severity case from QA-WEB-002 (which fires
+shutdown is opt-in and disabled by default — with no timeout configured at all, the application exits
+immediately on `SIGTERM` instead of draining in-flight requests. Because this is Quarkus's documented default,
+it is informational rather than a configuration error. This is distinct from QA-WEB-002 (which fires
 only when the timeout is explicitly disabled via `=0`); the two are mutually exclusive; see the
 [lifecycle guide](https://quarkus.io/guides/lifecycle#graceful-shutdown). Set `quarkus.shutdown.timeout` to a
 positive duration (e.g. `10s`) so in-flight requests can drain before shutdown.

--- a/docs/SPRING-CHECKS.md
+++ b/docs/SPRING-CHECKS.md
@@ -99,14 +99,14 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-CONFIG-002 - Disable global debug or trace logging
 
 - **Severity**: LOW (MEDIUM when a production-like profile is active)
-- **Detects**: Detects debug=true or trace=true, or broad root/web/sql/org.springframework/org.hibernate loggers set to DEBUG or TRACE, which enable verbose framework logging that can leak internal details or slow down the application.
+- **Detects**: Detects debug=true or trace=true, or broad root/web/sql/org.springframework/org.hibernate loggers set to DEBUG, TRACE, or ALL, which enable verbose framework logging that can leak internal details or slow down the application.
 - **Recommendation**: Remove the debug/trace flags and configure logging levels only for narrow packages that need them.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/logging.html>
 
 ### SPRING-CONFIG-003 - Remove renamed or deleted Spring Boot 4 properties
 
 - **Severity**: MEDIUM
-- **Detects**: Detects configuration keys that were renamed or removed in Spring Boot 4 and therefore no longer take effect, which can silently change behaviour after an upgrade. The curated set (individually source-verified against Spring Boot 4.1.0, 41 keys) covers: common server.undertow.* keys (Undertow was removed entirely); server.error.* (renamed to spring.web.error.*); server.servlet.encoding.* except .mapping, which still works (renamed to spring.servlet.encoding.*); spring.http.client.* (renamed to spring.http.clients.*, with .factory moving to .imperative.factory); spring.data.mongodb.* connection keys such as .host/.uri/.username (renamed to spring.mongodb.*; unrelated Spring Data settings like .gridfs.* and .auto-index-creation stay under spring.data.mongodb and are not flagged); management.tracing.enabled (renamed to management.tracing.export.enabled); and spring.session.redis.* (renamed to spring.session.data.redis.*). spring.dao.exceptiontranslation.enabled is deliberately **not** included: despite Spring Boot's own deprecation metadata suggesting a rename to spring.persistence.exceptiontranslation.enabled, DataSourceTransactionManagerAutoConfiguration still reads the old key directly and it remains fully functional - the "replacement" is an unrelated property gating JPA repository exception translation.
+- **Detects**: Detects configuration keys that were renamed or removed in Spring Boot 4 and therefore no longer take effect, which can silently change behaviour after an upgrade. The curated set (individually source-verified against Spring Boot 4.1.0, 47 keys) covers: common server.undertow.* keys (Undertow was removed entirely); server.error.* (renamed to spring.web.error.*); server.servlet.encoding.* except .mapping, which still works (renamed to spring.servlet.encoding.*); spring.http.client.* and spring.http.reactiveclient.* (renamed to spring.http.clients.*, including the imperative/reactive factory keys); spring.data.mongodb.* connection keys such as .host/.uri/.username (renamed to spring.mongodb.*; unrelated Spring Data settings like .gridfs.* and .auto-index-creation stay under spring.data.mongodb and are not flagged); management.tracing.enabled (renamed to management.tracing.export.enabled); spring.session.redis.* (renamed to spring.session.data.redis.*); and spring.session.mongodb.collection-name, whose Boot-managed MongoDB session auto-configuration was removed when support moved to the MongoDB-maintained `org.mongodb:mongodb-spring-session` artifact. spring.dao.exceptiontranslation.enabled is deliberately **not** included: despite Spring Boot's own deprecation metadata suggesting a rename to spring.persistence.exceptiontranslation.enabled, DataSourceTransactionManagerAutoConfiguration still reads the old key directly and it remains fully functional - the "replacement" is an unrelated property gating JPA repository exception translation.
 - **Recommendation**: Update each key to its Spring Boot 4 equivalent (the spring-boot-properties-migrator module lists the replacements at startup) and remove keys for dropped features.
 - **Learn more**: <https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide>
 
@@ -123,6 +123,13 @@ The panel is always available (a Spring application context always exists). Bean
 - **Detects**: spring.config.on-not-found=ignore makes Spring silently skip imported configuration files that are missing, so a typo or a misplaced file can ship without any error.
 - **Recommendation**: Remove spring.config.on-not-found=ignore (the default fails fast) and use the optional: prefix only on the specific imports that are genuinely optional.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/external-config.html>
+
+### SPRING-CONFIG-006 - Remove the temporary Jackson 2 defaults compatibility mode
+
+- **Severity**: LOW
+- **Detects**: `spring.jackson.use-jackson2-defaults=true` configures Jackson 3 with Spring Boot's former Jackson 2 defaults. This is a useful migration escape hatch, but leaving it enabled indefinitely can hide serialization changes that still need explicit review.
+- **Recommendation**: Add serialization compatibility tests, migrate affected payloads explicitly, then remove `spring.jackson.use-jackson2-defaults=true`.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/features/json.html>
 
 ## Profiles and environment
 
@@ -173,7 +180,7 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-PERF-004 - Connection pool may bottleneck virtual threads
 
 - **Severity**: LOW
-- **Detects**: Virtual threads are enabled while the HikariCP connection pool keeps a small (default) maximum size, so many virtual threads can contend for few database connections.
+- **Detects**: Virtual threads are enabled while `spring.datasource.hikari.maximum-pool-size` is unset, leaving HikariCP's unreviewed default of 10 connections. An explicitly configured value of 10 is treated as reviewed and does not trigger the rule; the advisor does not second-guess a pool size chosen for the database's actual capacity.
 - **Recommendation**: Review spring.datasource.hikari.maximum-pool-size against the expected concurrency, and size it for the database rather than the (now cheap) thread count.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html>
 
@@ -231,8 +238,8 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-WEB-005 - Set HTTP client timeouts
 
 - **Severity**: INFO
-- **Detects**: A RestClient, WebClient, or RestTemplate bean is defined but one or both global HTTP client timeouts are unset (spring.http.clients.connect-timeout / read-timeout - the same property namespace configures both imperative clients and the reactive WebClient in Spring Boot 4), so a slow or unresponsive dependency can block indefinitely.
-- **Recommendation**: Set spring.http.clients.connect-timeout and spring.http.clients.read-timeout (or configure timeouts per client) so outbound calls fail fast.
+- **Detects**: A RestClient, WebClient, or RestTemplate bean is defined but neither both global timeout defaults (`spring.http.clients.connect-timeout` / `read-timeout`) nor both timeouts for every configured named HTTP service client (`spring.http.serviceclient.<name>.connect-timeout` / `read-timeout`) are present. Without a complete pair, behavior falls back to implementation-specific client defaults that may not match the dependency's latency budget.
+- **Recommendation**: Set both global timeout defaults, or configure both timeout properties for every named HTTP service client.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/io/rest-client.html>
 
 ### SPRING-WEB-006 - Configure forwarded-headers handling behind a proxy
@@ -264,6 +271,13 @@ The panel is always available (a Spring application context always exists). Bean
 - **Detects**: A production-like profile is active while spring.datasource.url points at an in-process, in-memory database (an H2 jdbc:h2:mem: or HSQLDB jdbc:hsqldb:mem: URL, or a Derby jdbc:derby:memory: URL). These engines keep their data only in the JVM heap of a single instance: a restart, redeploy, or crash silently discards everything, and the data is invisible to any other instance in a multi-instance deployment. A file-backed embedded URL (for example jdbc:h2:file:) is not flagged.
 - **Recommendation**: Point spring.datasource.url at a durable, shared database server (PostgreSQL, MySQL, SQL Server, ...) for any production-like profile. Reserve the in-memory engines for tests and local development.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.datasource.embedded>
+
+### SPRING-DATA-002 - Do not run production R2DBC on an in-memory database
+
+- **Severity**: MEDIUM
+- **Detects**: A production-like profile is active while `spring.r2dbc.url` points at an in-process H2 or HSQLDB in-memory database. The data disappears on restart and cannot be shared across application instances. Durable server URLs and non-production profiles are not flagged.
+- **Recommendation**: Point `spring.r2dbc.url` at a durable database server for production-like profiles; reserve in-memory R2DBC URLs for tests and local development.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.r2dbc.embedded>
 
 ## Actuator and management
 
@@ -317,15 +331,15 @@ Both rules in this category are `SKIPPED` unconditionally on a servlet (Spring M
 
 ## Rule summary
 
-The Spring Advisor ships **39 curated rules** across eight categories. By declared default severity: **0 CRITICAL**, **1 HIGH**, **19 MEDIUM**, **10 LOW**, **9 INFO**. Context-aware rules can raise SPRING-JPA-001, SPRING-MGMT-001, and SPRING-MGMT-002 to HIGH, and SPRING-MGMT-004 to CRITICAL; SPRING-CONFIG-002 can raise from LOW to MEDIUM.
+The Spring Advisor ships **41 curated rules** across eight categories. By declared default severity: **0 CRITICAL**, **1 HIGH**, **20 MEDIUM**, **11 LOW**, **9 INFO**. Context-aware rules can raise SPRING-JPA-001, SPRING-MGMT-001, and SPRING-MGMT-002 to HIGH, and SPRING-MGMT-004 to CRITICAL; SPRING-CONFIG-002 can raise from LOW to MEDIUM.
 
 | Category | Rules |
 | --- | --- |
 | Bean wiring | SPRING-WIRING-001 ... SPRING-WIRING-009 |
-| Configuration | SPRING-CONFIG-001 ... SPRING-CONFIG-005 |
+| Configuration | SPRING-CONFIG-001 ... SPRING-CONFIG-006 |
 | Profiles and environment | SPRING-PROFILE-001 ... SPRING-PROFILE-003 |
 | Performance and concurrency | SPRING-PERF-001 ... SPRING-PERF-006, SPRING-CACHE-001 |
 | Web and HTTP | SPRING-WEB-001 ... SPRING-WEB-007 |
-| Data and persistence | SPRING-JPA-001, SPRING-DATA-001 |
+| Data and persistence | SPRING-JPA-001, SPRING-DATA-001, SPRING-DATA-002 |
 | Actuator and management | SPRING-MGMT-001 ... SPRING-MGMT-004 |
 | Reactive (WebFlux only) | SPRING-REACTIVE-001, SPRING-REACTIVE-002 |


### PR DESCRIPTION
## Summary

- fixes Spring advisor false positives for reviewed Hikari sizing and named HTTP service-client timeout inheritance
- recognizes `ALL` logging, adds verified Boot 4 property migrations, and flags the Jackson 2 defaults escape hatch plus production in-memory R2DBC URLs
- fixes Quarkus finding counts, immutable final-value handling, Quartz clustering remediation, and graceful-shutdown severity
- updates both advisor references and focused regression coverage

## Documentation validation

Validated against current framework sources and guides:

- [Quarkus 3.37.2 Agroal runtime default](https://github.com/quarkusio/quarkus/blob/3.37.2/extensions/agroal/runtime/src/main/java/io/quarkus/agroal/runtime/DataSourceJdbcRuntimeConfig.java) is `50`; the reported value of `20` is not supported by the pinned source, so this PR retains `50` and adds a regression assertion
- [Quarkus graceful shutdown](https://quarkus.io/guides/lifecycle#graceful-shutdown) is disabled by default
- [Quarkus Quartz](https://quarkus.io/guides/quartz) requires a persistent JDBC store, datasource, and matching schema for clustering
- [Spring Boot 4.1 HTTP client metadata](https://github.com/spring-projects/spring-boot/blob/v4.1.0/module/spring-boot-http-client/src/main/resources/META-INF/additional-spring-configuration-metadata.json) defines global `spring.http.clients.*`, named `spring.http.serviceclient.*`, and reactive-client legacy migrations
- [Spring Boot 4.1 Jackson properties](https://github.com/spring-projects/spring-boot/blob/v4.1.0/module/spring-boot-jackson/src/main/java/org/springframework/boot/jackson/autoconfigure/JacksonProperties.java) defines `spring.jackson.use-jackson2-defaults`
- [MongoDB Spring Session migration](https://github.com/mongodb/mongo-spring-session) documents the artifact and Java package move after Boot-managed Mongo session support was removed

## Manual validation

1. Run the Spring sample and scan the Application Framework advisor with unset vs explicitly configured Hikari size `10`, global and named service-client timeout combinations, Jackson 2 defaults compatibility, and production R2DBC URLs.
2. Run the Quarkus sample and scan the same `spring` panel id with public final scalar values vs public final mutable references, `%prod` Dev Services keys, scheduled tasks, and default graceful shutdown.
3. Confirm the sidebar/header still render the platform-specific Spring/Quarkus title from the shared panel id.

## Automated validation

- `./mvnw -B -ntp spotless:check`
- focused Spring/Quarkus advisor unit and deployment tests
- `SpringApiConformanceTest`
- `BootUiQuarkusApiConformanceTest`
