### PR TITLE
Fix Security advisor validation gaps

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityChecks.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 final class QuarkusSecurityChecks {
 
     private static final String VIOLATION = "VIOLATION";
-    private static final int RULE_COUNT = 45;
+    private static final int RULE_COUNT = 48;
     private static final String GUIDE = "https://quarkus.io/guides/security-overview";
     private static final Pattern MAX_AGE = Pattern.compile("max-age\\s*=\\s*(\\d+)");
     private static final long HSTS_MIN_MAX_AGE = 31536000L;
@@ -64,6 +64,18 @@ final class QuarkusSecurityChecks {
                     1,
                     List.of("quarkus.http.auth.form.enabled=true, quarkus-rest-csrf absent"),
                     "Add the io.quarkus:quarkus-rest-csrf extension and embed the CSRF token in forms."));
+        }
+        if (s.formAuth() && "enabled".equals(s.insecureRequests()) && !s.behindProxy()) {
+            v.add(rule(
+                    "QS-AUTH-012",
+                    "Form authentication without TLS",
+                    "Authentication",
+                    "HIGH",
+                    "Form authentication is enabled while insecure HTTP requests are accepted, exposing submitted"
+                            + " credentials to passive network observers and active interception.",
+                    1,
+                    List.of("quarkus.http.auth.form.enabled=true, quarkus.http.insecure-requests=enabled"),
+                    "Set quarkus.http.insecure-requests=redirect (or disabled) and configure TLS."));
         }
         if (s.jwtConfigured() && !s.jwtIssuerConfigured()) {
             v.add(rule(
@@ -249,6 +261,18 @@ final class QuarkusSecurityChecks {
                     1,
                     List.of("quarkus.tls.trust-all=true (default or a named bucket)"),
                     "Remove trust-all; import the peer's CA into a trust-store instead."));
+        }
+        if (s.insecureIdentityProviderUrl()) {
+            v.add(rule(
+                    "QS-TLS-004",
+                    "Identity-provider and JWK endpoints should use HTTPS",
+                    "Transport",
+                    "HIGH",
+                    "An OIDC auth-server URL or remote JWT key location uses plain HTTP, allowing discovery"
+                            + " metadata or signing keys to be modified by an active network attacker.",
+                    1,
+                    List.of("quarkus.oidc.auth-server-url or mp.jwt.verify.publickey.location uses http://"),
+                    "Use HTTPS identity-provider and JWK endpoints with certificate validation enabled."));
         }
         boolean explicitWildcardCors = s.corsEnabled() && isExplicitWildcardOrigin(s.corsOrigins());
         boolean unsetOriginsCors =
@@ -456,17 +480,30 @@ final class QuarkusSecurityChecks {
                     "Remove the override so the Health UI is only available outside production, or protect it"
                             + " via the management interface / a permission policy."));
         }
-        if (s.oidcConfigured() && !s.oidcAudienceConfigured()) {
+        if (s.oidcConfigured() && s.oidcServiceTokenConsumer() && !s.oidcAudienceConfigured()) {
             v.add(rule(
                     "QS-OIDC-001",
                     "OIDC without token audience validation",
                     "OIDC",
-                    "MEDIUM",
+                    "HIGH",
                     "OIDC is configured without quarkus.oidc.token.audience, so a token minted for a different"
-                            + " client/audience by the same provider is accepted.",
+                            + " service/audience by the same provider can be accepted by this resource server.",
                     1,
                     List.of("quarkus.oidc.auth-server-url set, quarkus.oidc.token.audience absent"),
                     "Set quarkus.oidc.token.audience to this service's expected audience."));
+        }
+        if (s.oidcConfigured() && s.oidcIssuerAny()) {
+            v.add(rule(
+                    "QS-OIDC-004",
+                    "OIDC token issuer validation is bypassed",
+                    "OIDC",
+                    "HIGH",
+                    "quarkus.oidc.token.issuer=any disables issuer matching, so a correctly signed token from an"
+                            + " unintended issuer can be accepted.",
+                    1,
+                    List.of("quarkus.oidc.token.issuer=any"),
+                    "Remove token.issuer=any and configure the exact trusted issuer; use explicit tenant"
+                            + " resolution when multiple issuers are intentional."));
         }
         boolean oidcWebApp = "web-app".equals(s.oidcApplicationType()) || "hybrid".equals(s.oidcApplicationType());
         if (oidcWebApp && !s.oidcCookieForceSecure() && !s.sslConfigured()) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusSecuritySnapshot.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusSecuritySnapshot.java
@@ -38,7 +38,7 @@ import java.util.List;
  * @param behindProxy whether the app runs behind a TLS-terminating reverse proxy (forwarded headers trusted)
  * @param jwtIssuerConfigured whether a JWT issuer ({@code mp.jwt.verify.issuer}) is configured
  * @param proactiveAuthDisabled whether {@code quarkus.http.auth.proactive=false}
- * @param oidcAudienceConfigured whether OIDC token audience validation is configured
+ * @param oidcAudienceConfigured whether every service/hybrid default or named OIDC tenant validates token audience
  * @param oidcApplicationType the {@code quarkus.oidc.application-type} (service/web-app/hybrid; may be empty)
  * @param oidcCookieForceSecure whether OIDC forces the Secure flag on its session cookie
  * @param tlsTrustAll whether outbound TLS certificate validation is globally disabled
@@ -91,6 +91,9 @@ import java.util.List;
  *     public client
  * @param oidcPkceRequired whether {@code quarkus.oidc.authentication.pkce-required=true}
  * @param healthUiAlwaysInclude whether {@code quarkus.smallrye-health.ui.always-include=true}
+ * @param insecureIdentityProviderUrl whether a configured OIDC auth-server or remote JWT key URL uses plain HTTP
+ * @param oidcIssuerAny whether OIDC token issuer validation is explicitly bypassed with {@code token.issuer=any}
+ * @param oidcServiceTokenConsumer whether any default or named OIDC tenant consumes service bearer tokens
  */
 public record QuarkusSecuritySnapshot(
         boolean oidcConfigured,
@@ -152,7 +155,10 @@ public record QuarkusSecuritySnapshot(
         boolean formSessionTimeoutExcessive,
         boolean oidcHasClientSecret,
         boolean oidcPkceRequired,
-        boolean healthUiAlwaysInclude) {
+        boolean healthUiAlwaysInclude,
+        boolean insecureIdentityProviderUrl,
+        boolean oidcIssuerAny,
+        boolean oidcServiceTokenConsumer) {
 
     public QuarkusSecuritySnapshot {
         permissions = permissions == null ? List.of() : List.copyOf(permissions);
@@ -162,6 +168,137 @@ public record QuarkusSecuritySnapshot(
                 nonApplicationRootPath == null || nonApplicationRootPath.isBlank() ? "/q" : nonApplicationRootPath;
         insecureMessagingChannels =
                 insecureMessagingChannels == null ? List.of() : List.copyOf(insecureMessagingChannels);
+    }
+
+    public QuarkusSecuritySnapshot(
+            boolean oidcConfigured,
+            boolean jwtConfigured,
+            boolean basicAuth,
+            boolean formAuth,
+            boolean mtls,
+            String insecureRequests,
+            boolean sslConfigured,
+            boolean corsEnabled,
+            String corsOrigins,
+            boolean corsCredentials,
+            boolean hstsHeader,
+            boolean cspHeader,
+            boolean oidcTlsVerificationNone,
+            boolean swaggerUiAlwaysInclude,
+            boolean openApiAlwaysInclude,
+            boolean csrfPresent,
+            List<QuarkusSecurityPermission> permissions,
+            int rolesAllowedCount,
+            int permitAllCount,
+            int denyAllCount,
+            int authenticatedCount,
+            int endpointCount,
+            int securedEndpointCount,
+            List<String> suspectedSecretKeys,
+            boolean behindProxy,
+            boolean jwtIssuerConfigured,
+            boolean proactiveAuthDisabled,
+            boolean oidcAudienceConfigured,
+            String oidcApplicationType,
+            boolean oidcCookieForceSecure,
+            boolean tlsTrustAll,
+            String corsMethods,
+            String corsHeaders,
+            String hstsHeaderValue,
+            String cspHeaderValue,
+            boolean xFrameOptionsHeader,
+            boolean xContentTypeOptionsHeader,
+            boolean denyUnannotatedEndpoints,
+            boolean managementEnabled,
+            boolean managementHostNonLoopback,
+            boolean managementHostUnpinnedForProd,
+            boolean jwtAlgorithmUnpinnedForRemoteJwks,
+            boolean jdbcClearPasswordMapperEnabled,
+            boolean embeddedUsersEnabled,
+            boolean jwtAudiencesConfigured,
+            boolean jwtInlinePublicKey,
+            boolean referrerPolicyHeader,
+            boolean permissionsPolicyHeader,
+            String nonApplicationRootPath,
+            boolean grpcReflectionEnabledInProd,
+            boolean graphqlPresent,
+            boolean graphqlIntrospectionEnabled,
+            boolean graphqlUiAlwaysInclude,
+            List<String> insecureMessagingChannels,
+            boolean formCookieHttpOnly,
+            boolean formCookieSameSiteNone,
+            boolean formSessionTimeoutExcessive,
+            boolean oidcHasClientSecret,
+            boolean oidcPkceRequired,
+            boolean healthUiAlwaysInclude) {
+        this(
+                oidcConfigured,
+                jwtConfigured,
+                basicAuth,
+                formAuth,
+                mtls,
+                insecureRequests,
+                sslConfigured,
+                corsEnabled,
+                corsOrigins,
+                corsCredentials,
+                hstsHeader,
+                cspHeader,
+                oidcTlsVerificationNone,
+                swaggerUiAlwaysInclude,
+                openApiAlwaysInclude,
+                csrfPresent,
+                permissions,
+                rolesAllowedCount,
+                permitAllCount,
+                denyAllCount,
+                authenticatedCount,
+                endpointCount,
+                securedEndpointCount,
+                suspectedSecretKeys,
+                behindProxy,
+                jwtIssuerConfigured,
+                proactiveAuthDisabled,
+                oidcAudienceConfigured,
+                oidcApplicationType,
+                oidcCookieForceSecure,
+                tlsTrustAll,
+                corsMethods,
+                corsHeaders,
+                hstsHeaderValue,
+                cspHeaderValue,
+                xFrameOptionsHeader,
+                xContentTypeOptionsHeader,
+                denyUnannotatedEndpoints,
+                managementEnabled,
+                managementHostNonLoopback,
+                managementHostUnpinnedForProd,
+                jwtAlgorithmUnpinnedForRemoteJwks,
+                jdbcClearPasswordMapperEnabled,
+                embeddedUsersEnabled,
+                jwtAudiencesConfigured,
+                jwtInlinePublicKey,
+                referrerPolicyHeader,
+                permissionsPolicyHeader,
+                nonApplicationRootPath,
+                grpcReflectionEnabledInProd,
+                graphqlPresent,
+                graphqlIntrospectionEnabled,
+                graphqlUiAlwaysInclude,
+                insecureMessagingChannels,
+                formCookieHttpOnly,
+                formCookieSameSiteNone,
+                formSessionTimeoutExcessive,
+                oidcHasClientSecret,
+                oidcPkceRequired,
+                healthUiAlwaysInclude,
+                false,
+                false,
+                oidcConfigured
+                        && (oidcApplicationType == null
+                                || oidcApplicationType.isBlank()
+                                || "service".equalsIgnoreCase(oidcApplicationType)
+                                || "hybrid".equalsIgnoreCase(oidcApplicationType)));
     }
 
     public boolean anyAuthMechanism() {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScannerTest.java
@@ -19,7 +19,7 @@ class QuarkusSecurityScannerTest {
 
     /**
      * Mutable builder whose defaults describe a hardened Quarkus app that fires zero rules, so each test can
-     * flip exactly the fields under test. Mirrors the 60-field {@link QuarkusSecuritySnapshot} positional record.
+     * flip exactly the fields under test. Mirrors the {@link QuarkusSecuritySnapshot} positional record.
      */
     private static final class Snap {
         // Auth mechanisms — basic auth on, over redirected HTTP, is a clean baseline.
@@ -96,6 +96,9 @@ class QuarkusSecurityScannerTest {
         boolean oidcHasClientSecret = true;
         boolean oidcPkceRequired = true;
         boolean healthUiAlwaysInclude = false;
+        boolean insecureIdentityProviderUrl = false;
+        boolean oidcIssuerAny = false;
+        boolean oidcServiceTokenConsumer = true;
 
         QuarkusSecuritySnapshot build() {
             return new QuarkusSecuritySnapshot(
@@ -158,7 +161,10 @@ class QuarkusSecurityScannerTest {
                     formTimeoutExcessive,
                     oidcHasClientSecret,
                     oidcPkceRequired,
-                    healthUiAlwaysInclude);
+                    healthUiAlwaysInclude,
+                    insecureIdentityProviderUrl,
+                    oidcIssuerAny,
+                    oidcServiceTokenConsumer);
         }
     }
 
@@ -482,7 +488,18 @@ class QuarkusSecurityScannerTest {
         s.oidc = true;
         s.oidcAudience = false;
         SecurityReport r = scan(s);
-        assertThat(find(r, "QS-OIDC-001").severity()).isEqualTo("MEDIUM");
+        assertThat(find(r, "QS-OIDC-001").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void oidcWebAppWithoutAudienceDoesNotFlagOidc001() {
+        Snap s = new Snap();
+        s.oidc = true;
+        s.oidcAudience = false;
+        s.oidcAppType = "web-app";
+        s.oidcServiceTokenConsumer = false;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-OIDC-001")).isNull();
     }
 
     @Test
@@ -585,6 +602,44 @@ class QuarkusSecurityScannerTest {
         s.jdbcClearPasswordMapper = true;
         SecurityReport r = scan(s);
         assertThat(find(r, "QS-AUTH-010").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void formAuthOverPlainHttpFlagsAuth012() {
+        Snap s = new Snap();
+        s.form = true;
+        s.csrf = true;
+        s.insecure = "enabled";
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-012").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void formAuthBehindTlsTerminatingProxyDoesNotFlagAuth012() {
+        Snap s = new Snap();
+        s.form = true;
+        s.csrf = true;
+        s.insecure = "enabled";
+        s.behindProxy = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-AUTH-012")).isNull();
+    }
+
+    @Test
+    void insecureIdentityProviderUrlFlagsTls004() {
+        Snap s = new Snap();
+        s.insecureIdentityProviderUrl = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-TLS-004").severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void oidcIssuerAnyFlagsOidc004() {
+        Snap s = new Snap();
+        s.oidc = true;
+        s.oidcIssuerAny = true;
+        SecurityReport r = scan(s);
+        assertThat(find(r, "QS-OIDC-004").severity()).isEqualTo("HIGH");
     }
 
     @Test
@@ -939,6 +994,6 @@ class QuarkusSecurityScannerTest {
         s.secured = 0;
         SecurityReport r = scan(s);
         assertThat(r.results()).allSatisfy(x -> assertThat(x.id()).startsWith("QS-"));
-        assertThat(r.scan().rulesEvaluated()).isEqualTo(45);
+        assertThat(r.scan().rulesEvaluated()).isEqualTo(48);
     }
 }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/security/QuarkusSecuritySnapshotProviderImpl.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/security/QuarkusSecuritySnapshotProviderImpl.java
@@ -48,7 +48,8 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
 
     @Override
     public QuarkusSecuritySnapshot snapshot() {
-        boolean oidc = has("quarkus.oidc.auth-server-url");
+        Set<String> oidcTenants = oidcTenantPrefixes();
+        boolean oidc = !oidcTenants.isEmpty();
         boolean jwt = has("mp.jwt.verify.publickey")
                 || has("mp.jwt.verify.publickey.location")
                 || has("mp.jwt.verify.issuer");
@@ -67,7 +68,8 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
         boolean corsCreds = corsCredentials(corsOrigins);
         boolean hsts = has("quarkus.http.header.\"Strict-Transport-Security\".value");
         boolean csp = has("quarkus.http.header.\"Content-Security-Policy\".value");
-        boolean oidcVerifyNone = "none".equalsIgnoreCase(str("quarkus.oidc.tls.verification", ""));
+        boolean oidcVerifyNone =
+                oidcTenants.stream().anyMatch(prefix -> "none".equalsIgnoreCase(str(prefix + ".tls.verification", "")));
         boolean swagger = bool("quarkus.swagger-ui.always-include", false);
         boolean openapi = bool("quarkus.smallrye-openapi.always-include", false);
         boolean csrfExtensionPresent = bool(CSRF_KEY, false);
@@ -78,9 +80,19 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 || bool("quarkus.http.proxy.allow-x-forwarded", false);
         boolean jwtIssuer = has("mp.jwt.verify.issuer");
         boolean proactiveAuthDisabled = !bool("quarkus.http.auth.proactive", true);
-        boolean oidcAudience = has("quarkus.oidc.token.audience");
-        String oidcAppType = str("quarkus.oidc.application-type", "").toLowerCase();
-        boolean oidcCookieForceSecure = bool("quarkus.oidc.authentication.cookie-force-secure", false);
+        boolean oidcServiceTokenConsumer = oidcTenants.stream().anyMatch(this::isServiceOidcTenant);
+        boolean oidcAudience = !oidcServiceTokenConsumer
+                || oidcTenants.stream()
+                        .filter(this::isServiceOidcTenant)
+                        .allMatch(prefix -> has(prefix + ".token.audience"));
+        boolean oidcWebApp = oidcTenants.stream().anyMatch(this::isWebOidcTenant);
+        String oidcAppType = oidcWebApp
+                ? (oidcServiceTokenConsumer ? "hybrid" : "web-app")
+                : (oidcServiceTokenConsumer ? "service" : "");
+        boolean oidcCookieForceSecure = !oidcWebApp
+                || oidcTenants.stream()
+                        .filter(this::isWebOidcTenant)
+                        .allMatch(prefix -> bool(prefix + ".authentication.cookie-force-secure", false));
         boolean tlsTrustAll = bool("quarkus.tls.trust-all", false) || namedTlsBucketTrustAll();
         String corsMethods = str("quarkus.http.cors.methods", null);
         String corsHeaders = str("quarkus.http.cors.headers", null);
@@ -117,10 +129,19 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
         boolean formCookieSameSiteNone =
                 "none".equalsIgnoreCase(str("quarkus.http.auth.form.cookie-same-site", "strict"));
         boolean formSessionTimeoutExcessive = formSessionTimeoutExcessive();
-        boolean oidcHasClientSecret =
-                has("quarkus.oidc.credentials.secret") || has("quarkus.oidc.credentials.client-secret.value");
-        boolean oidcPkceRequired = bool("quarkus.oidc.authentication.pkce-required", false);
+        boolean oidcHasClientSecret = !oidcWebApp
+                || oidcTenants.stream().filter(this::isWebOidcTenant).allMatch(this::oidcTenantHasClientSecret);
+        boolean oidcPkceRequired = !oidcWebApp
+                || oidcTenants.stream()
+                        .filter(this::isWebOidcTenant)
+                        .allMatch(prefix -> oidcTenantHasClientSecret(prefix)
+                                || bool(prefix + ".authentication.pkce-required", false));
         boolean healthUiAlwaysInclude = bool("quarkus.smallrye-health.ui.always-include", false);
+        boolean insecureIdentityProviderUrl =
+                oidcTenants.stream().anyMatch(prefix -> isHttpUrl(str(prefix + ".auth-server-url", null)))
+                        || isHttpUrl(str("mp.jwt.verify.publickey.location", null));
+        boolean oidcIssuerAny =
+                oidcTenants.stream().anyMatch(prefix -> "any".equalsIgnoreCase(str(prefix + ".token.issuer", "")));
 
         return new QuarkusSecuritySnapshot(
                 oidc,
@@ -182,7 +203,10 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 formSessionTimeoutExcessive,
                 oidcHasClientSecret,
                 oidcPkceRequired,
-                healthUiAlwaysInclude);
+                healthUiAlwaysInclude,
+                insecureIdentityProviderUrl,
+                oidcIssuerAny,
+                oidcServiceTokenConsumer);
     }
 
     private static boolean isLoopbackHost(String host) {
@@ -195,6 +219,39 @@ public class QuarkusSecuritySnapshotProviderImpl implements QuarkusSecuritySnaps
                 || h.startsWith("127.")
                 || h.equals("::1")
                 || h.equals("0:0:0:0:0:0:0:1");
+    }
+
+    private static boolean isHttpUrl(String value) {
+        return value != null && value.trim().toLowerCase().startsWith("http://");
+    }
+
+    private Set<String> oidcTenantPrefixes() {
+        Set<String> prefixes = new java.util.LinkedHashSet<>();
+        for (String name : config.getPropertyNames()) {
+            if (name.equals("quarkus.oidc.auth-server-url") && has(name) && bool("quarkus.oidc.tenant-enabled", true)) {
+                prefixes.add("quarkus.oidc");
+            } else if (name.startsWith("quarkus.oidc.") && name.endsWith(".auth-server-url") && has(name)) {
+                String prefix = name.substring(0, name.length() - ".auth-server-url".length());
+                if (bool(prefix + ".tenant-enabled", true)) {
+                    prefixes.add(prefix);
+                }
+            }
+        }
+        return prefixes;
+    }
+
+    private boolean isServiceOidcTenant(String prefix) {
+        String applicationType = str(prefix + ".application-type", "service");
+        return "service".equalsIgnoreCase(applicationType) || "hybrid".equalsIgnoreCase(applicationType);
+    }
+
+    private boolean isWebOidcTenant(String prefix) {
+        String applicationType = str(prefix + ".application-type", "service");
+        return "web-app".equalsIgnoreCase(applicationType) || "hybrid".equalsIgnoreCase(applicationType);
+    }
+
+    private boolean oidcTenantHasClientSecret(String prefix) {
+        return has(prefix + ".credentials.secret") || has(prefix + ".credentials.client-secret.value");
     }
 
     /** Raw-scans for any named TLS registry bucket ({@code quarkus.tls.<name>.key-store.*}) configuring a keystore,

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/security/QuarkusSecuritySnapshotProviderImplTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/security/QuarkusSecuritySnapshotProviderImplTest.java
@@ -1,0 +1,96 @@
+package io.github.jdubois.bootui.quarkus.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.spi.QuarkusSecuritySnapshot;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class QuarkusSecuritySnapshotProviderImplTest {
+
+    @Test
+    void detectsPlainHttpOidcAndJwtEndpointsWithoutRetainingTheirValues() {
+        QuarkusSecuritySnapshot snapshot = snapshot(Map.of(
+                "quarkus.oidc.auth-server-url", "http://identity.internal/realms/app",
+                "mp.jwt.verify.publickey.location", "http://keys.internal/jwks.json"));
+
+        assertThat(snapshot.insecureIdentityProviderUrl()).isTrue();
+    }
+
+    @Test
+    void acceptsHttpsIdentityEndpoints() {
+        QuarkusSecuritySnapshot snapshot = snapshot(Map.of(
+                "quarkus.oidc.auth-server-url", "https://identity.example/realms/app",
+                "mp.jwt.verify.publickey.location", "https://identity.example/jwks.json"));
+
+        assertThat(snapshot.insecureIdentityProviderUrl()).isFalse();
+    }
+
+    @Test
+    void detectsExplicitIssuerAnyBypass() {
+        QuarkusSecuritySnapshot snapshot = snapshot(Map.of(
+                "quarkus.oidc.auth-server-url", "https://identity.example/realms/app",
+                "quarkus.oidc.token.issuer", "any"));
+
+        assertThat(snapshot.oidcIssuerAny()).isTrue();
+    }
+
+    @Test
+    void includesNamedOidcTenantsInSecurityChecks() {
+        QuarkusSecuritySnapshot snapshot = snapshot(Map.of(
+                "quarkus.oidc.partner.auth-server-url", "http://identity.internal/realms/partner",
+                "quarkus.oidc.partner.application-type", "service",
+                "quarkus.oidc.partner.token.issuer", "any"));
+
+        assertThat(snapshot.oidcConfigured()).isTrue();
+        assertThat(snapshot.oidcServiceTokenConsumer()).isTrue();
+        assertThat(snapshot.oidcAudienceConfigured()).isFalse();
+        assertThat(snapshot.insecureIdentityProviderUrl()).isTrue();
+        assertThat(snapshot.oidcIssuerAny()).isTrue();
+    }
+
+    @Test
+    void namedWebAppTenantDoesNotRequireResourceServerAudience() {
+        QuarkusSecuritySnapshot snapshot = snapshot(Map.of(
+                "quarkus.oidc.portal.auth-server-url", "https://identity.example/realms/portal",
+                "quarkus.oidc.portal.application-type", "web-app"));
+
+        assertThat(snapshot.oidcServiceTokenConsumer()).isFalse();
+        assertThat(snapshot.oidcAudienceConfigured()).isTrue();
+    }
+
+    @Test
+    void aggregatesNamedWebAppHardeningSettings() {
+        QuarkusSecuritySnapshot snapshot = snapshot(Map.of(
+                "quarkus.oidc.portal.auth-server-url", "https://identity.example/realms/portal",
+                "quarkus.oidc.portal.application-type", "web-app",
+                "quarkus.oidc.portal.tls.verification", "none"));
+
+        assertThat(snapshot.oidcApplicationType()).isEqualTo("web-app");
+        assertThat(snapshot.oidcTlsVerificationNone()).isTrue();
+        assertThat(snapshot.oidcCookieForceSecure()).isFalse();
+        assertThat(snapshot.oidcHasClientSecret()).isFalse();
+        assertThat(snapshot.oidcPkceRequired()).isFalse();
+    }
+
+    @Test
+    void ignoresExplicitlyDisabledNamedTenant() {
+        QuarkusSecuritySnapshot snapshot = snapshot(Map.of(
+                "quarkus.oidc.legacy.auth-server-url", "http://identity.internal/realms/legacy",
+                "quarkus.oidc.legacy.tenant-enabled", "false",
+                "quarkus.oidc.legacy.token.issuer", "any"));
+
+        assertThat(snapshot.oidcConfigured()).isFalse();
+        assertThat(snapshot.insecureIdentityProviderUrl()).isFalse();
+        assertThat(snapshot.oidcIssuerAny()).isFalse();
+    }
+
+    private static QuarkusSecuritySnapshot snapshot(Map<String, String> properties) {
+        var config = new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(properties, "test", 1000))
+                .build();
+        return new QuarkusSecuritySnapshotProviderImpl(config).snapshot();
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
@@ -67,6 +67,17 @@ record SecurityContext(
      * chain installs an HTTPS-redirect filter.
      */
     boolean isTlsConfigured() {
+        if (isGlobalTlsConfigured()) {
+            return true;
+        }
+        return chains.stream().anyMatch(SecurityContext::hasHttpsRedirect);
+    }
+
+    boolean isTlsConfiguredFor(FilterChainModel chain) {
+        return isGlobalTlsConfigured() || hasHttpsRedirect(chain);
+    }
+
+    private boolean isGlobalTlsConfigured() {
         if (isPropertyTrue("server.ssl.enabled")
                 || firstProperty("server.ssl.key-store") != null
                 || firstProperty("server.ssl.bundle") != null
@@ -77,9 +88,11 @@ record SecurityContext(
         if (forwarded != null && ("framework".equalsIgnoreCase(forwarded) || "native".equalsIgnoreCase(forwarded))) {
             return true;
         }
-        return chains.stream()
-                .anyMatch(
-                        chain -> chain.hasFilter("ChannelProcessingFilter") || chain.hasFilter("HttpsRedirectFilter"));
+        return false;
+    }
+
+    private static boolean hasHttpsRedirect(FilterChainModel chain) {
+        return chain.hasFilter("ChannelProcessingFilter") || chain.hasFilter("HttpsRedirectFilter");
     }
 
     /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
@@ -31,6 +31,8 @@ final class SecurityModel {
      * @param cspPolicyDirectives the {@code ContentSecurityPolicyHeaderWriter}'s configured
      *     {@code policyDirectives}, when a CSP writer is present and the field could be read,
      *     {@code null} otherwise
+     * @param cspReportOnly whether the CSP writer emits Content-Security-Policy-Report-Only instead of
+     *     an enforcing policy
      * @param authorizationRuleShadowed {@code TRUE} when an earlier, broader {@code
      *     authorizeHttpRequests} matcher in this chain shadows a later, narrower one (so the later
      *     rule can never take effect), {@code FALSE} when no shadowing was detected, {@code null}
@@ -50,6 +52,7 @@ final class SecurityModel {
             Long hstsMaxAgeSeconds,
             Boolean hstsIncludeSubdomains,
             String cspPolicyDirectives,
+            Boolean cspReportOnly,
             Boolean authorizationRuleShadowed,
             Integer rememberMeKeyLength) {
 
@@ -91,6 +94,7 @@ final class SecurityModel {
                     null,
                     null,
                     null,
+                    null,
                     null);
         }
 
@@ -119,7 +123,35 @@ final class SecurityModel {
                     hstsIncludeSubdomains,
                     cspPolicyDirectives,
                     null,
+                    null,
                     null);
+        }
+
+        FilterChainModel(
+                int index,
+                String matcher,
+                List<String> filterNames,
+                Boolean permitsAllAnonymous,
+                Boolean sessionFixationDisabled,
+                List<String> headerWriterNames,
+                Long hstsMaxAgeSeconds,
+                Boolean hstsIncludeSubdomains,
+                String cspPolicyDirectives,
+                Boolean authorizationRuleShadowed,
+                Integer rememberMeKeyLength) {
+            this(
+                    index,
+                    matcher,
+                    filterNames,
+                    permitsAllAnonymous,
+                    sessionFixationDisabled,
+                    headerWriterNames,
+                    hstsMaxAgeSeconds,
+                    hstsIncludeSubdomains,
+                    cspPolicyDirectives,
+                    null,
+                    authorizationRuleShadowed,
+                    rememberMeKeyLength);
         }
 
         boolean hasFilter(String simpleClassName) {
@@ -136,6 +168,12 @@ final class SecurityModel {
 
         boolean hasHeaderWriterContaining(String fragment) {
             return headerWriterNames.stream().anyMatch(name -> name.contains(fragment));
+        }
+
+        boolean hasCspDirective(String directive) {
+            return !Boolean.TRUE.equals(cspReportOnly)
+                    && cspPolicyDirectives != null
+                    && hasDirective(cspPolicyDirectives.toLowerCase(Locale.ROOT), directive.toLowerCase(Locale.ROOT));
         }
 
         /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuleRegistry.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuleRegistry.java
@@ -13,6 +13,7 @@ final class SecurityRuleRegistry {
             new DefaultInMemoryUserRule(),
             new DefaultLoginPageProductionRule(),
             new BasicAuthWithoutTlsRule(),
+            new FormLoginWithoutTlsRule(),
             new UsernameEnumerationRiskRule(),
             new GeneratedUserInProductionRule(),
             // Authorization
@@ -66,6 +67,7 @@ final class SecurityRuleRegistry {
             new ResourceServerValidationRule(),
             new JwtAudienceValidationRule(),
             new JwtStaticKeyRule(),
+            new InsecureJwtMetadataUrlRule(),
             // Configuration hygiene
             new SecurityDebugRule(),
             new H2ConsoleFrameOptionsRule(),

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
@@ -242,13 +242,39 @@ final class BasicAuthWithoutTlsRule extends AbstractSecurityRule {
 
     @Override
     SecurityRuleResultDto evaluateRule(SecurityContext context) {
-        if (!context.isProductionProfileActive() || context.isTlsConfigured()) {
+        if (!context.isProductionProfileActive()) {
             return pass();
         }
         List<String> details = new ArrayList<>();
         for (FilterChainModel chain : context.chains()) {
-            if (chain.hasFilter("BasicAuthenticationFilter")) {
+            if (chain.hasFilter("BasicAuthenticationFilter") && !context.isTlsConfiguredFor(chain)) {
                 details.add(chain.describe() + " authenticates with HTTP Basic while no TLS is configured.");
+            }
+        }
+        return violation(details);
+    }
+}
+
+final class FormLoginWithoutTlsRule extends AbstractSecurityRule {
+
+    FormLoginWithoutTlsRule() {
+        super(
+                new SecurityRuleDefinition(
+                        "SEC-AUTH-010",
+                        "Form login should run only over HTTPS",
+                        SecurityCategory.AUTHENTICATION,
+                        "HIGH",
+                        "Detects an interactive form-login chain while no server-side TLS, HTTPS redirect, or forwarded-header strategy is configured. Submitting credentials over HTTP exposes them to passive network observers and active interception.",
+                        "Enforce HTTPS via server.ssl.* (or a forwarded-headers strategy when TLS terminates upstream) for every formLogin() chain.",
+                        "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#transmit-passwords-only-over-tls-or-other-strong-transport"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        List<String> details = new ArrayList<>();
+        for (FilterChainModel chain : context.chains()) {
+            if (chain.hasFilter("UsernamePasswordAuthenticationFilter") && !context.isTlsConfiguredFor(chain)) {
+                details.add(chain.describe() + " accepts form credentials while no TLS is configured.");
             }
         }
         return violation(details);
@@ -500,11 +526,11 @@ final class CsrfGloballyDisabledRule extends AbstractSecurityRule {
     CsrfGloballyDisabledRule() {
         super(new SecurityRuleDefinition(
                 "SEC-CSRF-002",
-                "CSRF should not be disabled without stateless authentication",
+                "CSRF protection should stay on for HTTP Basic authentication",
                 SecurityCategory.CSRF,
                 "MEDIUM",
-                "Detects chains with no CsrfFilter and no bearer-token (stateless) authentication to justify the removal.",
-                "Disable CSRF only when the chain is stateless (e.g. bearer tokens); otherwise keep the CsrfFilter.",
+                "Detects an HTTP Basic chain with no CsrfFilter. Basic authentication is stateless, but browsers automatically resend its credentials, so state-changing requests remain vulnerable to CSRF.",
+                "Keep CSRF protection enabled for browser-reachable HTTP Basic endpoints, or use bearer credentials that browsers do not attach automatically.",
                 "https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html"));
     }
 
@@ -512,12 +538,9 @@ final class CsrfGloballyDisabledRule extends AbstractSecurityRule {
     SecurityRuleResultDto evaluateRule(SecurityContext context) {
         List<String> details = new ArrayList<>();
         for (FilterChainModel chain : context.chains()) {
-            if (chain.isStateful()) {
-                continue; // covered by SEC-CSRF-001
-            }
-            boolean stateless = chain.hasFilterContaining("BearerTokenAuthenticationFilter");
-            if (!chain.hasFilter("CsrfFilter") && !stateless) {
-                details.add(chain.describe() + " disables CSRF but is not a stateless token API.");
+            if (!chain.isStateful() && chain.hasFilter("BasicAuthenticationFilter") && !chain.hasFilter("CsrfFilter")) {
+                details.add(chain.describe()
+                        + " disables CSRF for HTTP Basic; browsers automatically resend Basic credentials.");
             }
         }
         return violation(details);
@@ -579,7 +602,7 @@ final class SessionCookieSecureRule extends AbstractSecurityRule {
         if ("false".equalsIgnoreCase(String.valueOf(value))) {
             return violation(List.of("server.servlet.session.cookie.secure is explicitly false."));
         }
-        if (value == null && context.isProductionProfileActive()) {
+        if (value == null && context.isProductionProfileActive() && context.hasStatefulChain()) {
             return violation(
                     List.of("server.servlet.session.cookie.secure is not set while a production profile is active."));
         }
@@ -667,10 +690,10 @@ final class BearerTokenStatefulRule extends AbstractSecurityRule {
         super(
                 new SecurityRuleDefinition(
                         "SEC-SESSION-006",
-                        "Bearer token authentication chains should be stateless",
+                        "Bearer-token authentication chains should be stateless",
                         SecurityCategory.SESSION,
                         "HIGH",
-                        "Detects a chain with both a Bearer token filter (stateless) and session management filters (stateful).",
+                        "Detects a chain with both a bearer-token filter (stateless) and session management filters (stateful).",
                         "Configure sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) to avoid creating HTTP sessions for REST API calls.",
                         "https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-stateless"));
     }
@@ -680,7 +703,7 @@ final class BearerTokenStatefulRule extends AbstractSecurityRule {
         List<String> details = new ArrayList<>();
         for (FilterChainModel chain : context.chains()) {
             if (chain.hasFilterContaining("BearerTokenAuthenticationFilter") && chain.isStateful()) {
-                details.add(chain.describe() + " accepts Bearer tokens but also maintains stateful sessions.");
+                details.add(chain.describe() + " accepts bearer tokens but also maintains stateful sessions.");
             }
         }
         return violation(details);
@@ -825,7 +848,7 @@ final class FrameOptionsRule extends AbstractSecurityRule {
         for (FilterChainModel chain : context.chains()) {
             if (chain.headerWriterFilterPresent()
                     && !chain.hasHeaderWriterContaining("XFrameOptions")
-                    && !chain.hasHeaderWriterContaining("ContentSecurityPolicy")) {
+                    && !chain.hasCspDirective("frame-ancestors")) {
                 details.add(chain.describe() + " emits no X-Frame-Options or frame-ancestors header.");
             }
         }
@@ -1536,10 +1559,6 @@ final class JwtAudienceValidationRule extends AbstractSecurityRule {
         if (!issuerBased) {
             return pass();
         }
-        String audiences = context.firstProperty("spring.security.oauth2.resourceserver.jwt.audiences");
-        if (audiences != null) {
-            return pass();
-        }
         if (!context.oauth2TokenValidatorTypes().isEmpty()) {
             // A custom OAuth2TokenValidator bean (including a DelegatingOAuth2TokenValidator that
             // composes an audience check alongside the default issuer/timestamp validators) may
@@ -1561,6 +1580,35 @@ final class JwtAudienceValidationRule extends AbstractSecurityRule {
         return violation(
                 List.of(
                         "Resource server uses issuer/JWK validation; confirm a custom audience (aud) validator is registered."));
+    }
+}
+
+final class InsecureJwtMetadataUrlRule extends AbstractSecurityRule {
+
+    InsecureJwtMetadataUrlRule() {
+        super(new SecurityRuleDefinition(
+                "SEC-OAUTH-004",
+                "JWT issuer and JWK endpoints should use HTTPS",
+                SecurityCategory.OAUTH2,
+                "HIGH",
+                "Detects an issuer-uri or jwk-set-uri that uses plain HTTP. Discovery metadata or signing keys fetched without transport authentication can be modified by an active network attacker.",
+                "Use HTTPS issuer and JWK endpoints with certificate validation enabled; reserve HTTP endpoints for isolated test environments.",
+                "https://www.rfc-editor.org/rfc/rfc8414.html#section-3.3"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        List<String> details = new ArrayList<>();
+        addIfInsecureUrl(context, details, "spring.security.oauth2.resourceserver.jwt.issuer-uri");
+        addIfInsecureUrl(context, details, "spring.security.oauth2.resourceserver.jwt.jwk-set-uri");
+        return violation(details);
+    }
+
+    private static void addIfInsecureUrl(SecurityContext context, List<String> details, String key) {
+        String value = context.firstProperty(key);
+        if (value != null && value.toLowerCase(Locale.ROOT).startsWith("http://")) {
+            details.add(key + " uses plain HTTP.");
+        }
     }
 }
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -311,6 +311,7 @@ final class SecurityScanner {
                 headerWriters.hstsMaxAgeSeconds(),
                 headerWriters.hstsIncludeSubdomains(),
                 headerWriters.cspPolicyDirectives(),
+                headerWriters.cspReportOnly(),
                 authorizationRuleShadowed,
                 rememberMeKeyLength);
     }
@@ -474,9 +475,13 @@ final class SecurityScanner {
      * via the same reflection helper used for {@link #bcryptStrength(Object)}).
      */
     private record HeaderWriterInfo(
-            List<String> names, Long hstsMaxAgeSeconds, Boolean hstsIncludeSubdomains, String cspPolicyDirectives) {}
+            List<String> names,
+            Long hstsMaxAgeSeconds,
+            Boolean hstsIncludeSubdomains,
+            String cspPolicyDirectives,
+            Boolean cspReportOnly) {}
 
-    private static final HeaderWriterInfo NO_HEADER_WRITERS = new HeaderWriterInfo(List.of(), null, null, null);
+    private static final HeaderWriterInfo NO_HEADER_WRITERS = new HeaderWriterInfo(List.of(), null, null, null, null);
 
     private static HeaderWriterInfo detectHeaderWriters(List<Filter> filters) {
         for (Filter filter : filters) {
@@ -488,6 +493,7 @@ final class SecurityScanner {
             Long hstsMaxAgeSeconds = null;
             Boolean hstsIncludeSubdomains = null;
             String cspPolicyDirectives = null;
+            Boolean cspReportOnly = null;
             if (writers instanceof Iterable<?> iterable) {
                 for (Object writer : iterable) {
                     if (writer == null) {
@@ -505,10 +511,14 @@ final class SecurityScanner {
                     } else if (simpleName.contains("ContentSecurityPolicy")
                             && readField(writer, "policyDirectives") instanceof String directives) {
                         cspPolicyDirectives = directives;
+                        if (readField(writer, "reportOnly") instanceof Boolean reportOnly) {
+                            cspReportOnly = reportOnly;
+                        }
                     }
                 }
             }
-            return new HeaderWriterInfo(names, hstsMaxAgeSeconds, hstsIncludeSubdomains, cspPolicyDirectives);
+            return new HeaderWriterInfo(
+                    names, hstsMaxAgeSeconds, hstsIncludeSubdomains, cspPolicyDirectives, cspReportOnly);
         }
         return NO_HEADER_WRITERS;
     }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
@@ -64,6 +64,27 @@ class SecurityRulesTests {
     }
 
     @Test
+    void reportOnlyCspFrameAncestorsDoesNotSatisfyClickjackingRule() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("ContentSecurityPolicyHeaderWriter"),
+                null,
+                null,
+                "default-src 'self'; frame-ancestors 'none'",
+                Boolean.TRUE,
+                null,
+                null);
+
+        SecurityRuleResultDto result = new FrameOptionsRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
     void headerWritersDisabledDoesNotFireWhenHeaderWriterFilterPresent() {
         FilterChainModel chain = chain(
                 "any request",
@@ -74,6 +95,30 @@ class SecurityRulesTests {
                         "AuthorizationFilter"));
 
         SecurityRuleResultDto result = new HeaderWritersDisabledRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void redirectOnDifferentChainDoesNotSuppressPlaintextFormLogin() {
+        FilterChainModel apiChain =
+                chain("PathPattern [/api/**]", List.of("HttpsRedirectFilter", "AuthorizationFilter"));
+        FilterChainModel formChain =
+                chain("PathPattern [/**]", List.of("UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result =
+                new FormLoginWithoutTlsRule().evaluate(context(List.of(apiChain, formChain), new MockEnvironment()));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void redirectOnFormLoginChainPasses() {
+        FilterChainModel formChain = chain(
+                "PathPattern [/**]",
+                List.of("HttpsRedirectFilter", "UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(singleChain(formChain));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
@@ -400,14 +445,15 @@ class SecurityRulesTests {
     }
 
     @Test
-    void jwtAudiencePassesWhenAudiencesConfigured() {
+    void jwtAudienceDoesNotTrustRemovedAudiencesProperty() {
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com")
                 .withProperty("spring.security.oauth2.resourceserver.jwt.audiences", "bootui");
 
         SecurityRuleResultDto result = new JwtAudienceValidationRule().evaluate(context(environment));
 
-        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("MEDIUM");
     }
 
     @Test
@@ -824,6 +870,101 @@ class SecurityRulesTests {
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
 
+    @Test
+    void redirectOnDifferentChainDoesNotSuppressPlaintextBasicAuth() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+        FilterChainModel webChain =
+                chain("PathPattern [/web/**]", List.of("HttpsRedirectFilter", "AuthorizationFilter"));
+        FilterChainModel basicChain =
+                chain("PathPattern [/api/**]", List.of("BasicAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result =
+                new BasicAuthWithoutTlsRule().evaluate(context(List.of(webChain, basicChain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    // --- SEC-AUTH-010: form login requires TLS -----------------------------------------------
+
+    @Test
+    void formLoginWithoutTlsFires() {
+        FilterChainModel chain =
+                chain("any request", List.of("UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("HIGH");
+    }
+
+    @Test
+    void formLoginWithTlsPasses() {
+        MockEnvironment environment = new MockEnvironment().withProperty("server.ssl.enabled", "true");
+        FilterChainModel chain =
+                chain("any request", List.of("UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-CSRF-002: stateless HTTP Basic remains CSRF-relevant ----------------------------
+
+    @Test
+    void csrfDisabledForStatelessHttpBasicFires() {
+        FilterChainModel chain = chain("any request", List.of("BasicAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new CsrfGloballyDisabledRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void csrfDisabledForBearerTokenApiPasses() {
+        FilterChainModel chain =
+                chain("any request", List.of("BearerTokenAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new CsrfGloballyDisabledRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void csrfDisabledForUnauthenticatedChainPasses() {
+        FilterChainModel chain = chain("any request", List.of("AnonymousAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new CsrfGloballyDisabledRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-SESSION-002: unset Secure only matters when sessions exist ----------------------
+
+    @Test
+    void unsetSessionCookieSecurePassesForStatelessChainInProduction() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
+        FilterChainModel chain =
+                chain("any request", List.of("BearerTokenAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new SessionCookieSecureRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void explicitlyFalseSessionCookieSecureStillFiresForStatelessChain() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("server.servlet.session.cookie.secure", "false");
+        FilterChainModel chain =
+                chain("any request", List.of("BearerTokenAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new SessionCookieSecureRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
     // --- SEC-AUTH-008: hideUserNotFoundExceptions should stay enabled -----------------------
 
     @Test
@@ -961,6 +1102,69 @@ class SecurityRulesTests {
     }
 
     // --- SEC-HEAD-008: weak HSTS policy ------------------------------------------------------
+
+    @Test
+    void cspWithoutFrameAncestorsDoesNotSatisfyClickjackingRule() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("ContentSecurityPolicyHeaderWriter"),
+                null,
+                null,
+                "default-src 'self'");
+
+        SecurityRuleResultDto result = new FrameOptionsRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void cspFrameAncestorsSatisfiesClickjackingRule() {
+        FilterChainModel chain = new FilterChainModel(
+                0,
+                "any request",
+                List.of("HeaderWriterFilter"),
+                null,
+                null,
+                List.of("ContentSecurityPolicyHeaderWriter"),
+                null,
+                null,
+                "default-src 'self'; frame-ancestors 'none'");
+
+        SecurityRuleResultDto result = new FrameOptionsRule().evaluate(singleChain(chain));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-OAUTH-004: remote identity metadata must use HTTPS ------------------------------
+
+    @Test
+    void insecureIssuerUriFires() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "http://issuer.example.com");
+
+        SecurityRuleResultDto result = new InsecureJwtMetadataUrlRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .containsExactly("spring.security.oauth2.resourceserver.jwt.issuer-uri uses plain HTTP.");
+    }
+
+    @Test
+    void secureIssuerAndJwkUrisPass() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com")
+                .withProperty(
+                        "spring.security.oauth2.resourceserver.jwt.jwk-set-uri",
+                        "https://issuer.example.com/.well-known/jwks.json");
+
+        SecurityRuleResultDto result = new InsecureJwtMetadataUrlRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
 
     @Test
     void weakHstsMaxAgeFiresViolation() {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -23,7 +23,7 @@ import org.springframework.security.web.FilterChainProxy;
 
 class SecurityScannerTests {
 
-    private static final int RULE_COUNT = 59;
+    private static final int RULE_COUNT = 61;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 
     @Test
@@ -119,16 +119,14 @@ class SecurityScannerTests {
                         "PermissionsPolicyHeaderWriter",
                         "CrossOriginOpenerPolicyHeaderWriter",
                         "CrossOriginEmbedderPolicyHeaderWriter"));
-        MockEnvironment environment = new MockEnvironment()
-                .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com")
-                .withProperty("spring.security.oauth2.resourceserver.jwt.audiences", "bootui");
+        MockEnvironment environment = new MockEnvironment();
         SecurityContext context = new SecurityContext(
                 List.of(chain),
                 List.of(new PasswordEncoderModel(
                         "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder", null)),
                 List.of(),
                 false,
-                List.of(),
+                List.of("com.example.AudienceValidatingJwtDecoder"),
                 true,
                 false,
                 false,
@@ -170,9 +168,7 @@ class SecurityScannerTests {
                         "PermissionsPolicyHeaderWriter",
                         "CrossOriginOpenerPolicyHeaderWriter",
                         "CrossOriginEmbedderPolicyHeaderWriter"));
-        MockEnvironment environment = new MockEnvironment()
-                .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com")
-                .withProperty("spring.security.oauth2.resourceserver.jwt.audiences", "bootui");
+        MockEnvironment environment = new MockEnvironment();
         environment.getPropertySources().addLast(bootUiActuatorDefaultsInDefaultPropertiesSource());
         ConfigurationPropertySources.attach(environment);
         SecurityContext context = new SecurityContext(
@@ -181,7 +177,7 @@ class SecurityScannerTests {
                         "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder", null)),
                 List.of(),
                 false,
-                List.of(),
+                List.of("com.example.AudienceValidatingJwtDecoder"),
                 true,
                 false,
                 false,
@@ -224,8 +220,6 @@ class SecurityScannerTests {
                         "CrossOriginOpenerPolicyHeaderWriter",
                         "CrossOriginEmbedderPolicyHeaderWriter"));
         MockEnvironment environment = new MockEnvironment()
-                .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com")
-                .withProperty("spring.security.oauth2.resourceserver.jwt.audiences", "bootui")
                 .withProperty("management.endpoints.web.exposure.include", "env,beans")
                 .withProperty("management.endpoint.health.show-details", "always");
         environment.getPropertySources().addLast(bootUiActuatorDefaultsInDefaultPropertiesSource());
@@ -236,7 +230,7 @@ class SecurityScannerTests {
                         "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder", null)),
                 List.of(),
                 false,
-                List.of(),
+                List.of("com.example.AudienceValidatingJwtDecoder"),
                 true,
                 false,
                 false,
@@ -453,9 +447,7 @@ class SecurityScannerTests {
     }
 
     private static MockEnvironment resourceServerEnvironment() {
-        return new MockEnvironment()
-                .withProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri", "https://issuer.example.com")
-                .withProperty("spring.security.oauth2.resourceserver.jwt.audiences", "bootui");
+        return new MockEnvironment();
     }
 
     private static SecurityContext hardenedContext(List<PasswordEncoderModel> encoders, MockEnvironment environment) {
@@ -464,7 +456,7 @@ class SecurityScannerTests {
                 encoders,
                 List.of(),
                 false,
-                List.of(),
+                List.of("com.example.AudienceValidatingJwtDecoder"),
                 true,
                 false,
                 false,

--- a/docs/QUARKUS-CHECKS.md
+++ b/docs/QUARKUS-CHECKS.md
@@ -11,6 +11,9 @@ own classes. It never intercepts live traffic, exposes credentials or secrets, o
 configuration. Findings are heuristic review prompts; the right remediation depends on the application's
 threat model and deployment topology.
 
+OIDC checks aggregate the active default tenant and active named tenants; a tenant with
+`quarkus.oidc[.<tenant>].tenant-enabled=false` is excluded.
+
 This is the Quarkus replacement for the Spring ruleset in [SECURITY-CHECKS.md](SECURITY-CHECKS.md):
 the panel and DTO are shared, but the rules are framework-specific (Elytron/OIDC vs Spring Security),
 so there is no overlap. Spring-only concepts (filter chains, `FilterChainProxy`, method-security
@@ -93,6 +96,12 @@ A `quarkus-elytron-security-jdbc` `principal-query` uses the `clear-password-map
 compared/stored in plain text rather than hashed. Switch to `bcrypt-password-mapper` (or another hashing
 mapper) and re-hash stored passwords.
 
+### QS-AUTH-012 - Form authentication without TLS (HIGH)
+`quarkus.http.auth.form.enabled=true` while `quarkus.http.insecure-requests=enabled` accepts passwords over
+plain HTTP, exposing them to passive network observers and active intermediaries. Set
+`quarkus.http.insecure-requests=redirect` (or `disabled`) and configure TLS. Suppressed when forwarded headers
+indicate that a trusted reverse proxy terminates TLS.
+
 > **Retired: QS-AUTH-011** (JDBC identity store bcrypt work-factor too low) was removed. The rule checked
 > `principal-query.*.bcrypt-password-mapper.work-factor`, a property that does not exist:
 > `BcryptPasswordKeyMapperConfig` (quarkus-elytron-security-jdbc) has no work-factor/cost-factor field at all
@@ -146,6 +155,11 @@ to pin TLS independently for a REST client, gRPC, or OIDC connection). Acceptabl
 (`quarkus.tls.<name>.trust-all`), disabling certificate validation for outbound TLS (REST clients, OIDC,
 datasources, gRPC) on that bucket, enabling man-in-the-middle attacks. Remove `trust-all`; import the peer's
 CA into a trust-store instead.
+
+### QS-TLS-004 - Identity-provider and JWK endpoints should use HTTPS (HIGH)
+`quarkus.oidc.auth-server-url` (for the default or any named tenant) or
+`mp.jwt.verify.publickey.location` uses plain HTTP, allowing OIDC discovery metadata or JWT signing keys to be
+modified by an active network attacker. Use HTTPS endpoints with certificate validation enabled.
 
 ## CORS
 
@@ -248,9 +262,14 @@ production, or protect it via the management interface / a permission policy.
 
 ## OIDC
 
-### QS-OIDC-001 - OIDC without token audience validation (MEDIUM)
-OIDC is configured without `quarkus.oidc.token.audience`, so a token minted for a different client/audience
-by the same provider is accepted. Set `quarkus.oidc.token.audience` to this service's expected audience.
+### QS-OIDC-001 - OIDC service without token audience validation (HIGH)
+OIDC is configured for a default or named `service`/`hybrid` token-consuming tenant without that tenant's
+`quarkus.oidc[.<tenant>].token.audience`, so an access token minted for a different service by the same trusted
+provider can be accepted. Set the tenant's token audience to this resource server's expected audience. Pure
+`web-app` authorization-code clients are excluded because their primary authentication artifact is an OIDC
+ID token whose audience is validated against the client id by the protocol implementation; applying this
+resource-server rule to them would be a false positive. The severity is HIGH for service/M2M flows because
+RFC 8725 requires each JWT application to validate that the token was issued for it.
 
 ### QS-OIDC-002 - OIDC web-app session cookie not forced secure (MEDIUM)
 An OIDC `web-app`/`hybrid` app stores the session in a cookie but `cookie-force-secure` is off and the app
@@ -263,6 +282,12 @@ An OIDC `web-app`/`hybrid` client has no client secret configured (`quarkus.oidc
 `quarkus.oidc.authentication.pkce-required` is not enabled (the Quarkus default is `false`), leaving the
 authorization-code flow vulnerable to interception. Set `quarkus.oidc.authentication.pkce-required=true` for
 public clients.
+
+### QS-OIDC-004 - OIDC token issuer validation is bypassed (HIGH)
+`quarkus.oidc[.<tenant>].token.issuer=any` disables issuer matching for the default or a named tenant. A token
+with a valid signature but an unintended issuer can then be accepted, especially when keys are shared or
+federated. Remove `token.issuer=any` and pin the exact trusted issuer; use explicit tenant resolution when
+multiple issuers are intentional.
 
 ## Management
 

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -99,6 +99,13 @@ includes up to a handful of sample details plus a remediation link.
 - **Recommendation**: Register a real UserDetailsService, AuthenticationProvider, or external identity provider before running in production; do not rely on the console-logged generated password.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/spring-security.html>
 
+### SEC-AUTH-010 - Form login should run only over HTTPS
+
+- **Severity**: HIGH
+- **Detects**: Detects an interactive form-login chain while no server-side TLS, HTTPS redirect, or forwarded-header strategy is configured. Passwords submitted over HTTP are visible to passive network observers and active intermediaries.
+- **Recommendation**: Enforce HTTPS via server.ssl.* (or a forwarded-headers strategy when TLS terminates upstream) for every formLogin() chain.
+- **Learn more**: <https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#transmit-passwords-only-over-tls-or-other-strong-transport>
+
 ## Authorization
 
 ### SEC-AUTHZ-001 - Every filter chain should enforce authorization
@@ -145,11 +152,11 @@ includes up to a handful of sample details plus a remediation link.
 - **Recommendation**: Keep CSRF enabled for browser, cookie, or session authenticated chains; only disable it for stateless token APIs.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html>
 
-### SEC-CSRF-002 - CSRF should not be disabled without stateless authentication
+### SEC-CSRF-002 - CSRF protection should stay on for HTTP Basic authentication
 
 - **Severity**: MEDIUM
-- **Detects**: Detects chains with no CsrfFilter and no bearer-token (stateless) authentication to justify the removal.
-- **Recommendation**: Disable CSRF only when the chain is stateless (e.g. bearer tokens); otherwise keep the CsrfFilter.
+- **Detects**: Detects a stateless HTTP Basic chain with no CsrfFilter. Statelessness alone does not remove CSRF risk when a browser automatically resends the username and password on cross-site requests.
+- **Recommendation**: Keep CSRF protection enabled for browser-reachable HTTP Basic endpoints, or use bearer credentials that browsers do not attach automatically.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html>
 
 ## Session management
@@ -164,7 +171,7 @@ includes up to a handful of sample details plus a remediation link.
 ### SEC-SESSION-002 - Session cookie should set the Secure flag
 
 - **Severity**: MEDIUM
-- **Detects**: Detects server.servlet.session.cookie.secure=false, or unset while a production profile is active.
+- **Detects**: Detects server.servlet.session.cookie.secure=false, or unset while a production profile is active and at least one filter chain actually uses HTTP sessions. An explicit false remains a finding even when current chains are stateless because it is an unsafe host-level setting.
 - **Recommendation**: Set server.servlet.session.cookie.secure=true so the session cookie is only sent over HTTPS.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/servlet.html>
 
@@ -189,10 +196,10 @@ includes up to a handful of sample details plus a remediation link.
 - **Recommendation**: Set server.servlet.session.timeout to a bounded value appropriate for the application's risk profile.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/servlet.html>
 
-### SEC-SESSION-006 - Bearer token authentication chains should be stateless
+### SEC-SESSION-006 - Bearer-token authentication chains should be stateless
 
 - **Severity**: HIGH
-- **Detects**: Detects a chain with both a Bearer token filter (stateless) and session management filters (stateful).
+- **Detects**: Detects a chain with both a bearer-token filter (stateless) and session management filters (stateful).
 - **Recommendation**: Configure sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) to avoid creating HTTP sessions for REST API calls.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-stateless>
 
@@ -229,7 +236,7 @@ includes up to a handful of sample details plus a remediation link.
 ### SEC-HEAD-002 - X-Frame-Options (clickjacking protection) should stay enabled
 
 - **Severity**: HIGH
-- **Detects**: Detects chains whose header writers omit X-Frame-Options / frame-ancestors protection.
+- **Detects**: Detects chains whose header writers omit X-Frame-Options and whose enforcing Content-Security-Policy does not contain a frame-ancestors directive. An unrelated CSP writer, or a report-only CSP, does not provide clickjacking protection.
 - **Recommendation**: Keep the default XFrameOptionsHeaderWriter (DENY/SAMEORIGIN) or a frame-ancestors CSP instead of disabling frame options globally.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/exploits/headers.html#servlet-headers-frame-options>
 
@@ -410,7 +417,7 @@ custom source is never misreported as verified-safe.
 ### SEC-OAUTH-002 - Validate the JWT audience claim
 
 - **Severity**: MEDIUM (INFO when a custom OAuth2TokenValidator or a custom JwtDecoder is present)
-- **Detects**: Notes that issuer-based resource servers do not validate the aud claim unless a custom OAuth2TokenValidator bean (including one composed via DelegatingOAuth2TokenValidator) or a custom JwtDecoder is registered; either is reported as an INFO advisory because it may already validate the claim.
+- **Detects**: Notes that issuer-based resource servers do not validate the aud claim unless a custom OAuth2TokenValidator bean (including one composed via DelegatingOAuth2TokenValidator) or a custom JwtDecoder is registered; either is reported as an INFO advisory because it may already validate the claim. The removed `spring.security.oauth2.resourceserver.jwt.audiences` property is deliberately ignored on Spring Security 7 and cannot suppress this finding.
 - **Recommendation**: Add an audience OAuth2TokenValidator to the JwtDecoder so tokens minted for other resource servers are rejected.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-validation>
 
@@ -420,6 +427,13 @@ custom source is never misreported as verified-safe.
 - **Detects**: Detects a resource server pinned to a static public key (public-key-location) with no issuer or JWK set URI.
 - **Recommendation**: Use a jwk-set-uri / issuer-uri so signing keys can rotate, rather than a single embedded public key.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html>
+
+### SEC-OAUTH-004 - JWT issuer and JWK endpoints should use HTTPS
+
+- **Severity**: HIGH
+- **Detects**: Detects `spring.security.oauth2.resourceserver.jwt.issuer-uri` or `jwk-set-uri` using plain HTTP. Discovery metadata or signing keys fetched without transport authentication can be modified by an active network attacker.
+- **Recommendation**: Use HTTPS issuer and JWK endpoints with certificate validation enabled; reserve HTTP endpoints for isolated test environments.
+- **Learn more**: <https://www.rfc-editor.org/rfc/rfc8414.html#section-3.3>
 
 ## Configuration hygiene
 


### PR DESCRIPTION
## Summary

- correct Spring Security 7 regressions in JWT audience, clickjacking, session-cookie, and CSRF checks
- add symmetric plaintext form-login and insecure identity/JWK endpoint findings for Spring and Quarkus
- harden Quarkus OIDC checks for service/M2M audiences, `token.issuer=any`, named tenants, and disabled tenants
- preserve the framework-neutral SPI boundary, existing `QuarkusSecuritySnapshot` constructor compatibility, and value masking

## Threat rationale

- the removed `spring.security.oauth2.resourceserver.jwt.audiences` property can no longer prove `aud` validation, so trusting it creates a token-confusion false negative
- a CSP only prevents framing when an enforcing `frame-ancestors` directive is present; an unrelated or report-only CSP does not stop clickjacking
- HTTP Basic remains CSRF-relevant even when stateless because browsers automatically replay credentials
- passwords, OIDC discovery metadata, and JWK sets sent or fetched over HTTP are exposed to interception or active substitution
- resource servers must validate that JWTs target their service; Quarkus service/hybrid tenants without an audience and tenants using `token.issuer=any` weaken token substitution defenses

## Key behavior changes

- `SEC-OAUTH-002` ignores the obsolete Spring audience property
- `SEC-HEAD-002` inspects enforcing CSP directives
- `SEC-SESSION-002` skips an unset Secure-cookie property for stateless chains, while explicit `false` still reports
- `SEC-CSRF-002` targets stateless HTTP Basic precisely
- `SEC-AUTH-010` / `QS-AUTH-012` report form credentials accepted without TLS, with per-chain/proxy handling
- `SEC-OAUTH-004` / `QS-TLS-004` report HTTP issuer, auth-server, or JWK endpoints without exposing their values
- `QS-OIDC-001` applies at HIGH severity to active service/hybrid default and named tenants; pure web-app tenants are excluded
- `QS-OIDC-004` reports active tenants configured with `token.issuer=any`

## Sources reviewed

- Spring Security 7 JWT, CSRF, session-management, HTTP Basic, and security-header references
- Quarkus OIDC expanded configuration and bearer-token guidance
- OWASP Authentication and CSRF Prevention Cheat Sheets
- RFC 8414 (authorization-server metadata transport) and RFC 8725 (JWT audience validation)

## Tests

- focused Spring and Quarkus Security advisor suites
- full `bootui-quarkus` reactor tests
- Spring and Quarkus shared HTTP conformance suites
- `spotless:check` and `git diff --check`

The full Spring auto-configuration suite otherwise passed but repeatedly hit its existing 5-second timeout in `BootUiReactiveAutoConfigurationTests.servesThePhase3ReadEndpointsOverHttp`; the focused Security suites and Spring HTTP conformance suite pass.

## Manual validation

- reviewed Spring Security 7 writer/filter behavior and Quarkus default/named tenant property semantics against the sources above
- verified report-only CSP and cross-chain HTTPS redirect regressions
- verified disabled named tenants do not produce findings and findings retain only boolean/key metadata, never configured URL or secret values