### PR TITLE
Fix Vulnerabilities advisor version and scan semantics

### DIFF
--- a/bootui-engine/pom.xml
+++ b/bootui-engine/pom.xml
@@ -74,6 +74,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.9.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.tngtech.archunit</groupId>
             <artifactId>archunit-junit5</artifactId>
             <scope>test</scope>

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScore.java
@@ -45,9 +45,8 @@ import java.util.Map;
  * {@code CVSS:4.x} vectors, and callers fall back to the {@code database_specific.severity} label for those
  * advisories.
  *
- * <p>CVSS v2 vectors (unprefixed, e.g. {@code "AV:N/AC:L/Au:N/C:P/I:P/A:P"}) are likewise not scored: the
- * format was superseded in 2015 and zero occurrences were found across a 170-advisory sample of real
- * OSV.dev responses for popular Maven packages.
+ * <p>CVSS v2 vectors (unprefixed, e.g. {@code "AV:N/AC:L/Au:N/C:P/I:P/A:P"}) are not scored by this
+ * v3-specific implementation.
  */
 final class CvssV3BaseScore {
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
@@ -145,18 +145,13 @@ public final class DependencyReports {
     }
 
     /**
-     * Parses an OSV {@code severity[].score} value into a numeric Base Score.
+     * Parses a supported OSV {@code severity[].score} value into a numeric Base Score.
      *
      * <p>Per the <a href="https://ossf.github.io/osv-schema/">OSV schema</a>, {@code score} is a CVSS
-     * vector string for {@code CVSS_V2}/{@code CVSS_V3}/{@code CVSS_V4} severity types (prefixed
-     * {@code "CVSS:3.1/..."} etc. for v3+) &mdash; never a bare number for any of those types. Empirically,
-     * real OSV.dev responses for the {@code CVSS_V3} type always carry the {@code "CVSS:3.0/"} or
-     * {@code "CVSS:3.1/"} prefix, which this method dispatches to {@link CvssV3BaseScore}. Other CVSS
-     * versions (v4.0, and the legacy unprefixed v2 format) are not computed &mdash; see
-     * {@link CvssV3BaseScore}'s class Javadoc for why v4.0 is deliberately excluded; v2 was excluded because
-     * zero occurrences appeared in a 170-advisory sample of real Maven-ecosystem OSV.dev responses. A bare
-     * numeric string (not documented by the schema for any known type, but accepted defensively in case a
-     * database ever emits one) still parses via {@link Double#parseDouble(String)}.
+     * vector string for {@code CVSS_V2}/{@code CVSS_V3}/{@code CVSS_V4} severity types. This method computes
+     * only prefixed CVSS v3.0/v3.1 vectors via {@link CvssV3BaseScore}; the unprefixed CVSS v2 notation and
+     * CVSS v4 vectors are left to the caller's database-specific severity fallback. A bare numeric string,
+     * although not a CVSS value in the OSV schema, is accepted defensively.
      *
      * @return the Base Score, or {@code null} if it can't be determined from {@code value}
      */
@@ -252,8 +247,9 @@ public final class DependencyReports {
      * Whether at least one of {@code fixedVersions} is newer than {@code currentVersion}, using the
      * lightweight {@link MavenVersionComparator} (BootUI takes no dependency on Maven's own
      * {@code ComparableVersion}). Backs {@link DependencyVulnerabilityDto#fixAvailable()}, which lets the UI
-     * distinguish "OSV reports no fix yet" ({@code fixedVersions} empty &mdash; this returns {@code false})
-     * from a genuine upgrade target.
+     * distinguish a reported fixed-version upgrade target from an advisory without a {@code fixed} event.
+     * The latter does not prove that no fix exists: OSV ranges may instead close with {@code last_affected},
+     * which identifies the final vulnerable version without naming the first non-vulnerable version.
      *
      * <p>An inconclusive per-version comparison (blank/unparseable input) is treated as "a fix is
      * available": OSV positively reported a {@code fixed} event for this advisory, so failing to parse the
@@ -266,6 +262,7 @@ public final class DependencyReports {
         if (fixedVersions == null || fixedVersions.isEmpty()) {
             return false;
         }
+
         for (String fixedVersion : fixedVersions) {
             Integer compared = MavenVersionComparator.compare(currentVersion, fixedVersion);
             if (compared == null || compared < 0) {
@@ -273,6 +270,27 @@ public final class DependencyReports {
             }
         }
         return false;
+    }
+
+    /**
+     * Returns the first distinct package/version scan inputs, preserving inventory order and applying the
+     * configured bound after de-duplication.
+     */
+    public static List<DependencyDto> scanCandidates(List<DependencyDto> dependencies, int maxPackages) {
+        Map<String, DependencyDto> distinct = new LinkedHashMap<>();
+        for (DependencyDto dependency : dependencies) {
+            distinct.putIfAbsent(dependency.packageName() + ":" + dependency.version(), dependency);
+        }
+        return distinct.values().stream().limit(Math.max(1, maxPackages)).toList();
+    }
+
+    /** Returns the number of distinct package/version inputs in the inventory. */
+    public static int scanCandidateCount(List<DependencyDto> dependencies) {
+        Set<String> distinct = new LinkedHashSet<>();
+        for (DependencyDto dependency : dependencies) {
+            distinct.add(dependency.packageName() + ":" + dependency.version());
+        }
+        return distinct.size();
     }
 
     /**

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/MavenVersionComparator.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/MavenVersionComparator.java
@@ -1,23 +1,26 @@
 package io.github.jdubois.bootui.engine.vulnerabilities;
 
 import java.math.BigInteger;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
- * Minimal version comparator for Maven-style dotted version strings (e.g. {@code "2.17.1"}), used only to
- * derive {@link DependencyReports#fixAvailable(String, java.util.List)} &mdash; whether at least one of an
- * advisory's {@code fixedVersions} is newer than the dependency's currently-resolved version.
+ * Compares the Maven version forms used by OSV fixed-version events.
  *
- * <p>This is deliberately lightweight rather than a full implementation of Maven's own version-ordering
- * rules (as in {@code org.apache.maven.artifact.versioning.ComparableVersion}, which BootUI does not
- * depend on): each version is split on non-alphanumeric separators (typically {@code .} and {@code -}), and
- * same-position segments are compared numerically when both are all-digit, falling back to a
- * case-insensitive string compare otherwise, with a missing trailing segment treated as smaller (so
- * {@code "1.2"} sorts below {@code "1.2.1"}). This handles the common case of plain dotted-numeric Maven
- * versions correctly &mdash; including the classic lexical-compare bug where {@code "1.9"} would otherwise
- * look "greater" than {@code "1.10"} &mdash; without attempting qualifier/pre-release precedence
- * (`-alpha`/`-rc`/`-SNAPSHOT` ordering, etc).
+ * <p>The recognized qualifiers and aliases follow Maven {@code ComparableVersion}: {@code alpha < beta <
+ * milestone < rc < snapshot < release < sp}, with {@code a}/{@code b}/{@code m} shorthand before a number,
+ * {@code cr} as an alias for {@code rc}, and {@code ga}/{@code final}/{@code release} as aliases for the
+ * unqualified release. Unknown qualifiers sort after the recognized qualifiers, case-insensitively.
  */
 final class MavenVersionComparator {
+
+    private static final List<String> QUALIFIERS = List.of("alpha", "beta", "milestone", "rc", "snapshot", "", "sp");
+
+    private static final Map<String, String> ALIASES = Map.of("ga", "", "final", "", "release", "", "cr", "rc");
 
     private MavenVersionComparator() {}
 
@@ -29,43 +32,172 @@ final class MavenVersionComparator {
         if (left == null || left.isBlank() || right == null || right.isBlank()) {
             return null;
         }
-        String[] leftParts = left.trim().split("[.\\-_]");
-        String[] rightParts = right.trim().split("[.\\-_]");
-        int length = Math.max(leftParts.length, rightParts.length);
-        for (int i = 0; i < length; i++) {
-            String leftPart = i < leftParts.length ? leftParts[i] : "";
-            String rightPart = i < rightParts.length ? rightParts[i] : "";
-            int compared = compareSegment(leftPart, rightPart);
-            if (compared != 0) {
-                return compared;
-            }
-        }
-        return 0;
+        return parse(left).compareTo(parse(right));
     }
 
-    private static int compareSegment(String left, String right) {
-        boolean leftNumeric = isNumeric(left);
-        boolean rightNumeric = isNumeric(right);
-        if (leftNumeric && rightNumeric) {
-            return new BigInteger(left).compareTo(new BigInteger(right));
-        }
-        if (leftNumeric != rightNumeric) {
-            // A present numeric segment outranks a missing/non-numeric one at the same position -- this is
-            // what makes a shorter version (e.g. "1.2", trailing segment absent) sort below "1.2.1".
-            return leftNumeric ? 1 : -1;
-        }
-        return left.compareToIgnoreCase(right);
-    }
+    private static ListItem parse(String version) {
+        String normalized = version.trim().toLowerCase(Locale.ROOT);
+        ListItem root = new ListItem();
+        ListItem current = root;
+        Deque<ListItem> hierarchy = new ArrayDeque<>();
+        hierarchy.push(current);
+        int start = 0;
+        boolean digits = false;
 
-    private static boolean isNumeric(String value) {
-        if (value.isEmpty()) {
-            return false;
-        }
-        for (int i = 0; i < value.length(); i++) {
-            if (!Character.isDigit(value.charAt(i))) {
-                return false;
+        for (int i = 0; i < normalized.length(); i++) {
+            char value = normalized.charAt(i);
+            if (value == '.') {
+                current.add(i == start ? NumericItem.ZERO : item(digits, normalized.substring(start, i), false));
+                start = i + 1;
+            } else if (value == '-') {
+                current.add(i == start ? NumericItem.ZERO : item(digits, normalized.substring(start, i), false));
+                start = i + 1;
+                current = nested(current, hierarchy);
+            } else if (Character.isDigit(value)) {
+                if (!digits && i > start) {
+                    if (!current.isEmpty()) {
+                        current = nested(current, hierarchy);
+                    }
+                    current.add(item(false, normalized.substring(start, i), true));
+                    start = i;
+                    current = nested(current, hierarchy);
+                }
+                digits = true;
+            } else {
+                if (digits && i > start) {
+                    current.add(item(true, normalized.substring(start, i), false));
+                    start = i;
+                    current = nested(current, hierarchy);
+                }
+                digits = false;
             }
         }
-        return true;
+        if (normalized.length() > start) {
+            if (!digits && !current.isEmpty()) {
+                current = nested(current, hierarchy);
+            }
+            current.add(item(digits, normalized.substring(start), false));
+        }
+        while (!hierarchy.isEmpty()) {
+            hierarchy.pop().normalize();
+        }
+        return root;
+    }
+
+    private static ListItem nested(ListItem parent, Deque<ListItem> hierarchy) {
+        ListItem child = new ListItem();
+        parent.add(child);
+        hierarchy.push(child);
+        return child;
+    }
+
+    private static Item item(boolean digits, String value, boolean followedByNumber) {
+        if (digits) {
+            return new NumericItem(new BigInteger(value));
+        }
+        if (followedByNumber) {
+            value = switch (value) {
+                case "a" -> "alpha";
+                case "b" -> "beta";
+                case "m" -> "milestone";
+                default -> value;
+            };
+        }
+        return new StringItem(ALIASES.getOrDefault(value, value));
+    }
+
+    private sealed interface Item extends Comparable<Item> permits NumericItem, StringItem, ListItem {
+
+        int compareToNull();
+    }
+
+    private record NumericItem(BigInteger value) implements Item {
+
+        private static final NumericItem ZERO = new NumericItem(BigInteger.ZERO);
+
+        @Override
+        public int compareTo(Item other) {
+            if (other == null) {
+                return compareToNull();
+            }
+            if (other instanceof NumericItem number) {
+                return value.compareTo(number.value);
+            }
+            return 1;
+        }
+
+        @Override
+        public int compareToNull() {
+            return value.signum();
+        }
+    }
+
+    private record StringItem(String value) implements Item {
+
+        @Override
+        public int compareTo(Item other) {
+            if (other == null) {
+                return compareToNull();
+            }
+            if (other instanceof StringItem string) {
+                return comparableQualifier(value).compareTo(comparableQualifier(string.value));
+            }
+            return -1;
+        }
+
+        @Override
+        public int compareToNull() {
+            return comparableQualifier(value).compareTo(comparableQualifier(""));
+        }
+
+        private static String comparableQualifier(String qualifier) {
+            int index = QUALIFIERS.indexOf(qualifier);
+            return index < 0 ? QUALIFIERS.size() + "-" + qualifier : String.valueOf(index);
+        }
+    }
+
+    private static final class ListItem extends ArrayList<Item> implements Item {
+
+        @Override
+        public int compareTo(Item other) {
+            if (other == null) {
+                return compareToNull();
+            }
+            if (!(other instanceof ListItem list)) {
+                return other instanceof NumericItem ? -1 : 1;
+            }
+            int length = Math.max(size(), list.size());
+            for (int i = 0; i < length; i++) {
+                Item left = i < size() ? get(i) : null;
+                Item right = i < list.size() ? list.get(i) : null;
+                int compared = left == null ? (right == null ? 0 : -right.compareToNull()) : left.compareTo(right);
+                if (compared != 0) {
+                    return compared;
+                }
+            }
+            return 0;
+        }
+
+        @Override
+        public int compareToNull() {
+            for (Item item : this) {
+                int compared = item.compareToNull();
+                if (compared != 0) {
+                    return compared;
+                }
+            }
+            return 0;
+        }
+
+        private void normalize() {
+            for (int i = size() - 1; i >= 0; i--) {
+                Item item = get(i);
+                if (item.compareToNull() == 0) {
+                    remove(i);
+                } else if (!(item instanceof ListItem)) {
+                    break;
+                }
+            }
+        }
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
@@ -260,4 +260,16 @@ class DependencyReportsTests {
         assertThat(dependency.vulnerabilityCount()).isEqualTo(1);
         assertThat(dependency.highestSeverity()).isEqualTo("HIGH");
     }
+
+    @Test
+    void scanCandidatesDeduplicatesPackageVersionsBeforeApplyingTheLimit() {
+        DependencyDto first = dependency("org.example", "first", "1.0.0");
+        DependencyDto duplicate = dependency("org.example", "first", "1.0.0");
+        DependencyDto second = dependency("org.example", "second", "2.0.0");
+
+        assertThat(DependencyReports.scanCandidates(List.of(first, duplicate, second), 2))
+                .containsExactly(first, second);
+        assertThat(DependencyReports.scanCandidateCount(List.of(first, duplicate, second)))
+                .isEqualTo(2);
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/MavenVersionComparatorTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/MavenVersionComparatorTests.java
@@ -1,0 +1,90 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.junit.jupiter.api.Test;
+
+class MavenVersionComparatorTests {
+
+    @Test
+    void followsMavenComparableVersionQualifierOrdering() {
+        List<String> ordered =
+                List.of("1.0-alpha1", "1.0-beta1", "1.0-milestone1", "1.0-rc1", "1.0-SNAPSHOT", "1.0", "1.0-sp1");
+
+        for (int i = 0; i < ordered.size() - 1; i++) {
+            assertThat(MavenVersionComparator.compare(ordered.get(i), ordered.get(i + 1)))
+                    .isNegative();
+        }
+    }
+
+    @Test
+    void recognizesMavenQualifierAliasesAndReleaseForms() {
+        assertThat(MavenVersionComparator.compare("1.0-a1", "1.0-alpha1")).isZero();
+        assertThat(MavenVersionComparator.compare("1.0-b1", "1.0-beta1")).isZero();
+        assertThat(MavenVersionComparator.compare("1.0-m1", "1.0-milestone1")).isZero();
+        assertThat(MavenVersionComparator.compare("1.0-cr1", "1.0-rc1")).isZero();
+        assertThat(MavenVersionComparator.compare("1.0-ga", "1.0")).isZero();
+        assertThat(MavenVersionComparator.compare("1.0-final", "1.0-release")).isZero();
+    }
+
+    @Test
+    void comparesNumericSegmentsWithoutLexicalOrderingBugs() {
+        assertThat(MavenVersionComparator.compare("1.9", "1.10")).isNegative();
+        assertThat(MavenVersionComparator.compare("1.0", "1.0.0")).isZero();
+        assertThat(MavenVersionComparator.compare("1.0.1", "1.1")).isNegative();
+    }
+
+    @Test
+    void ordersUnknownQualifiersAfterKnownQualifiers() {
+        assertThat(MavenVersionComparator.compare("1.0-sp", "1.0-vendor")).isNegative();
+        assertThat(MavenVersionComparator.compare("1.0-vendor1", "1.0-vendor2")).isNegative();
+    }
+
+    @Test
+    void matchesMavenComparableVersionAcrossRepresentativeForms() {
+        List<String> versions = List.of(
+                "1",
+                "1.0",
+                "1.0.0",
+                "1.0-0",
+                "1.0-1",
+                "1.0.1",
+                "1-1",
+                "1alpha",
+                "1-0alpha",
+                "1.0alpha1",
+                "1.0.alpha1",
+                "1-alpha-beta",
+                "1.0-alpha",
+                "1.0-alpha1",
+                "1.0-a1",
+                "1.0-beta2",
+                "1.0-b2",
+                "1.0-milestone1",
+                "1.0-m1",
+                "1.0-rc1",
+                "1.0-cr1",
+                "1.0-SNAPSHOT",
+                "1.0",
+                "1.0-ga",
+                "1.0-final",
+                "1.0-release",
+                "1.0-sp",
+                "1.0-sp1",
+                "1.0-vendor",
+                "1.0-vendor1",
+                "1.0-20240101.120000-1",
+                "2.0");
+
+        for (String left : versions) {
+            for (String right : versions) {
+                int expected = Integer.signum(new ComparableVersion(left).compareTo(new ComparableVersion(right)));
+                assertThat(Integer.signum(MavenVersionComparator.compare(left, right)))
+                        .as("%s compared with %s", left, right)
+                        .isEqualTo(expected);
+            }
+        }
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
@@ -151,6 +151,10 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return index >= 0 ? index : REFERENCE_TYPE_PRIORITY.size();
     }
 
+    /**
+     * Collects only OSV {@code fixed} events. A {@code last_affected} event is deliberately not presented as
+     * a fixed version: it names the final vulnerable version, not the first non-vulnerable upgrade target.
+     */
     private static List<String> fixedVersions(JsonNode affected, String packageName) {
         Set<String> versions = new LinkedHashSet<>();
         if (!affected.isArray()) {
@@ -243,8 +247,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     @Override
     public DependenciesReport scan(List<DependencyDto> dependencies) {
         long scannedAt = Instant.now().toEpochMilli();
-        List<DependencyDto> packages =
-                dependencies.stream().limit(Math.max(1, settings.maxPackages())).toList();
+        List<DependencyDto> packages = DependencyReports.scanCandidates(dependencies, settings.maxPackages());
         if (packages.isEmpty()) {
             return DependencyReports.report(
                     true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
@@ -255,7 +258,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
             List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
             enriched = applyEpss(enriched);
-            boolean limited = packages.size() < dependencies.size()
+            boolean limited = packages.size() < DependencyReports.scanCandidateCount(dependencies)
                     || uniqueIds(vulnerabilityIds).size() > Math.max(1, settings.maxAdvisories());
             String status =
                     limited || queryResult.paginationTruncated() || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.quarkus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
@@ -161,6 +162,25 @@ class OsvVulnerabilityScannerTest {
                 .orElseThrow();
         assertThat(arc.highestSeverity()).isEqualTo("NONE");
         assertThat(arc.vulnerabilities()).isEmpty();
+    }
+
+    @Test
+    void deduplicatesIdenticalPackageVersionInputsBeforeQueryingOsv() {
+        AtomicInteger queryCount = new AtomicInteger();
+        server.createContext("/v1/querybatch", exchange -> {
+            queryCount.set(new ObjectMapper()
+                    .readTree(exchange.getRequestBody())
+                    .path("queries")
+                    .size());
+            writeResponse(exchange, 200, "{\"results\":[{}]}");
+        });
+        DependencyDto duplicate = dependency("org.acme", "widget", "1.0.0");
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(duplicate, duplicate));
+
+        assertThat(queryCount).hasValue(1);
+        assertThat(report.scan().packagesScanned()).isEqualTo(1);
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
     }
 
     @Test
@@ -512,13 +532,13 @@ class OsvVulnerabilityScannerTest {
     }
 
     @Test
-    void fixAvailableIsFalseWhenOsvReportsNoFixedVersions() {
+    void lastAffectedIsNotMisrepresentedAsAFixedVersion() {
         handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-no-fix\"}]}]}");
         handle(
                 "/v1/vulns/GHSA-no-fix",
                 "{\"id\":\"GHSA-no-fix\",\"database_specific\":{\"severity\":\"HIGH\"},"
                         + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"},"
-                        + "\"ranges\":[{\"events\":[{\"introduced\":\"0\"}]}]}]}");
+                        + "\"ranges\":[{\"events\":[{\"introduced\":\"0\"},{\"last_affected\":\"1.0.0\"}]}]}]}");
 
         DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
@@ -6,11 +6,19 @@ import io.github.jdubois.bootui.engine.vulnerabilities.DependencyProvider;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
 final class DependencyCatalog implements DependencyProvider {
 
@@ -95,12 +103,72 @@ final class DependencyCatalog implements DependencyProvider {
         if (!fileName.startsWith(artifactId + "-" + version) || !fileName.endsWith(".jar")) {
             return null;
         }
+        DependencyDto pomDependency = dependencyFromAdjacentPom(versionPath, artifactId, version);
+        if (pomDependency != null) {
+            return pomDependency;
+        }
         String groupId = groupId(artifactPath.getParent());
         if (groupId == null) {
             return null;
         }
         String packageName = groupId + ":" + artifactId;
         return new DependencyDto(groupId, artifactId, version, packageName, "Java classpath", 0, "NONE", List.of());
+    }
+
+    private DependencyDto dependencyFromAdjacentPom(Path versionPath, String artifactId, String version) {
+        Path pom = versionPath.resolve(artifactId + "-" + version + ".pom");
+        if (!Files.isRegularFile(pom)) {
+            return null;
+        }
+        try (InputStream input = Files.newInputStream(pom)) {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            Element project = factory.newDocumentBuilder().parse(input).getDocumentElement();
+            String pomArtifactId = childText(project, "artifactId");
+            String pomGroupId = childText(project, "groupId");
+            String pomVersion = childText(project, "version");
+            Element parent = child(project, "parent");
+            if (pomGroupId == null && parent != null) {
+                pomGroupId = childText(parent, "groupId");
+            }
+            if (pomVersion == null && parent != null) {
+                pomVersion = childText(parent, "version");
+            }
+            if (!artifactId.equals(pomArtifactId)
+                    || !version.equals(pomVersion)
+                    || pomGroupId == null
+                    || pomGroupId.contains("${")) {
+                return null;
+            }
+            String packageName = pomGroupId + ":" + artifactId;
+            return new DependencyDto(
+                    pomGroupId, artifactId, version, packageName, "Adjacent Maven POM", 0, "NONE", List.of());
+        } catch (IOException | ParserConfigurationException | SAXException | IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private static String childText(Element parent, String name) {
+        Element child = child(parent, name);
+        return child == null ? null : BlankStrings.blankToNullTrimmed(child.getTextContent());
+    }
+
+    private static Element child(Element parent, String name) {
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node instanceof Element element
+                    && (name.equals(element.getLocalName()) || name.equals(element.getNodeName()))) {
+                return element;
+            }
+        }
+        return null;
     }
 
     private String groupId(Path groupPath) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -129,6 +129,10 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return index >= 0 ? index : REFERENCE_TYPE_PRIORITY.size();
     }
 
+    /**
+     * Collects only OSV {@code fixed} events. A {@code last_affected} event is deliberately not presented as
+     * a fixed version: it names the final vulnerable version, not the first non-vulnerable upgrade target.
+     */
     private static List<String> fixedVersions(JsonNode affected, String packageName) {
         Set<String> versions = new LinkedHashSet<>();
         if (!affected.isArray()) {
@@ -221,9 +225,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     @Override
     public DependenciesReport scan(List<DependencyDto> dependencies) {
         long scannedAt = Instant.now().toEpochMilli();
-        List<DependencyDto> packages = dependencies.stream()
-                .limit(Math.max(1, properties.getMaxPackages()))
-                .toList();
+        List<DependencyDto> packages = DependencyReports.scanCandidates(dependencies, properties.getMaxPackages());
         if (packages.isEmpty()) {
             return DependencyReports.report(
                     true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
@@ -234,7 +236,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
             List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
             enriched = applyEpss(enriched);
-            boolean limited = packages.size() < dependencies.size()
+            boolean limited = packages.size() < DependencyReports.scanCandidateCount(dependencies)
                     || uniqueIds(vulnerabilityIds).size() > Math.max(1, properties.getMaxAdvisories());
             String status =
                     limited || queryResult.paginationTruncated() || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
@@ -4,13 +4,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 
 class DependencyCatalogTests {
+
+    @TempDir
+    Path tempDir;
 
     private static ResourcePatternResolver emptyResolver() {
         return new ResourcePatternResolver() {
@@ -50,6 +56,51 @@ class DependencyCatalogTests {
                             org.assertj.core.api.Assertions.tuple(
                                     "org.apache.tomcat.embed:tomcat-embed-core", "11.0.21"),
                             org.assertj.core.api.Assertions.tuple("org.postgresql:postgresql", "42.7.10"));
+        } finally {
+            if (previousClassPath == null) {
+                System.clearProperty("java.class.path");
+            } else {
+                System.setProperty("java.class.path", previousClassPath);
+            }
+        }
+    }
+
+    @Test
+    void discoversCoordinatesFromAnAdjacentPomInANonstandardRepositoryPath() throws Exception {
+        Path versionDirectory = tempDir.resolve("custom-cache/acme-widget/2.1.0");
+        Files.createDirectories(versionDirectory);
+        Path jar = Files.createFile(versionDirectory.resolve("acme-widget-2.1.0.jar"));
+        Files.writeString(versionDirectory.resolve("acme-widget-2.1.0.pom"), """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.acme.libs</groupId>
+                  <artifactId>acme-widget</artifactId>
+                  <version>2.1.0</version>
+                </project>
+                """);
+
+        List<DependencyDto> dependencies = withClassPath(jar.toString());
+
+        assertThat(dependencies)
+                .extracting(DependencyDto::packageName, DependencyDto::version, DependencyDto::source)
+                .containsExactly(org.assertj.core.api.Assertions.tuple(
+                        "com.acme.libs:acme-widget", "2.1.0", "Adjacent Maven POM"));
+    }
+
+    @Test
+    void doesNotInventAGroupIdForANonstandardPathWithoutMavenMetadata() throws Exception {
+        Path versionDirectory = tempDir.resolve("custom-cache/acme-widget/2.1.0");
+        Files.createDirectories(versionDirectory);
+        Path jar = Files.createFile(versionDirectory.resolve("acme-widget-2.1.0.jar"));
+
+        assertThat(withClassPath(jar.toString())).isEmpty();
+    }
+
+    private List<DependencyDto> withClassPath(String classPath) {
+        String previousClassPath = System.getProperty("java.class.path");
+        try {
+            System.setProperty("java.class.path", classPath);
+            return new DependencyCatalog(emptyResolver()).dependencies();
         } finally {
             if (previousClassPath == null) {
                 System.clearProperty("java.class.path");

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 class OsvVulnerabilityScannerTests {
@@ -104,6 +105,36 @@ class OsvVulnerabilityScannerTests {
         assertThat(vulnerability.fixAvailable()).isTrue();
         assertThat(vulnerability.epssScore()).isEqualTo(0.02345d);
         assertThat(vulnerability.epssPercentile()).isEqualTo(0.9213d);
+    }
+
+    @Test
+    void deduplicatesIdenticalPackageVersionInputsBeforeQueryingOsv() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        AtomicInteger queryCount = new AtomicInteger();
+        server.createContext("/v1/querybatch", exchange -> {
+            JsonNode request = new ObjectMapper().readTree(exchange.getRequestBody());
+            queryCount.set(request.path("queries").size());
+            byte[] body = "{\"results\":[{}]}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+        DependencyDto duplicate = dependency("org.example", "sample", "1.0.0");
+
+        DependenciesReport report = scanner.scan(List.of(duplicate, duplicate));
+
+        assertThat(queryCount).hasValue(1);
+        assertThat(report.scan().packagesScanned()).isEqualTo(1);
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
     }
 
     @Test
@@ -781,7 +812,7 @@ class OsvVulnerabilityScannerTests {
     }
 
     @Test
-    void fixAvailableIsFalseWhenOsvReportsNoFixedVersions() throws Exception {
+    void lastAffectedIsNotMisrepresentedAsAFixedVersion() throws Exception {
         server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext("/v1/querybatch", exchange -> {
             byte[] body = """
@@ -800,7 +831,7 @@ class OsvVulnerabilityScannerTests {
                   "affected": [
                     {
                       "package": { "ecosystem": "Maven", "name": "org.example:sample" },
-                      "ranges": [{ "events": [{ "introduced": "0" }] }]
+                      "ranges": [{ "events": [{ "introduced": "0" }, { "last_affected": "1.0.0" }] }]
                     }
                   ]
                 }

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/SpringVulnerabilitiesDisabledIntegrationTest.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/SpringVulnerabilitiesDisabledIntegrationTest.java
@@ -1,0 +1,46 @@
+package io.github.jdubois.bootui.sample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(
+        classes = BootUiSampleApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.profiles.active=dev",
+            "spring.docker.compose.enabled=false",
+            "bootui.show-banner=false",
+            "bootui.vulnerabilities.osv-enabled=false",
+            "bootui.vulnerabilities.osv-base-uri=http://127.0.0.1:1",
+            "bootui.overrides-file=target/vulnerabilities-disabled-it/application-bootui.properties"
+        })
+class SpringVulnerabilitiesDisabledIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void disabledScannerKeepsInventoryLocalAndRefusesTheScan() {
+        BootUiHttpProbe probe = new BootUiHttpProbe("http://localhost:" + port);
+
+        JsonNode inventory = probe.get("/bootui/api/vulnerabilities").json();
+        assertThat(inventory.path("scan").path("status").asText()).isEqualTo("NOT_SCANNED");
+        assertThat(inventory.path("scanningEnabled").asBoolean()).isFalse();
+        assertThat(inventory.path("dependencies").size()).isGreaterThan(0);
+
+        probe.get("/bootui/api/overview");
+        String token = probe.cookie("XSRF-TOKEN").orElseThrow();
+        Response scan = probe.request("POST", "/bootui/api/vulnerabilities/scan", Map.of("X-XSRF-TOKEN", token), "");
+        assertThat(scan.status()).isEqualTo(200);
+        assertThat(scan.json().path("scan").path("status").asText()).isEqualTo("DISABLED");
+        assertThat(scan.json().path("scanningEnabled").asBoolean()).isFalse();
+    }
+}

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/SpringVulnerabilitiesIntegrationTest.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/SpringVulnerabilitiesIntegrationTest.java
@@ -1,0 +1,191 @@
+package io.github.jdubois.bootui.sample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SpringBootTest(
+        classes = BootUiSampleApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.profiles.active=dev",
+            "spring.docker.compose.enabled=false",
+            "bootui.show-banner=false",
+            "bootui.vulnerabilities.epss-enabled=false",
+            "bootui.overrides-file=target/vulnerabilities-it/application-bootui.properties"
+        })
+class SpringVulnerabilitiesIntegrationTest {
+
+    private static final String ADVISORY_ID = "GHSA-spring-it-0001";
+    private static final Path DISMISSALS_FILE = Path.of("target/vulnerabilities-it/boot-ui.yml");
+    private static final AtomicInteger QUERY_CALLS = new AtomicInteger();
+    private static HttpServer osv;
+
+    @LocalServerPort
+    int port;
+
+    private BootUiHttpProbe probe;
+
+    @DynamicPropertySource
+    static void vulnerabilityProperties(DynamicPropertyRegistry registry) {
+        startOsvStub();
+        registry.add(
+                "bootui.vulnerabilities.osv-base-uri",
+                () -> "http://127.0.0.1:" + osv.getAddress().getPort());
+    }
+
+    @BeforeAll
+    static void clearDismissals() throws IOException {
+        Files.deleteIfExists(DISMISSALS_FILE);
+    }
+
+    @AfterAll
+    static void stopOsvStub() throws IOException {
+        Files.deleteIfExists(DISMISSALS_FILE);
+        if (osv != null) {
+            osv.stop(0);
+        }
+    }
+
+    @Test
+    void supportsLocalInventoryExplicitScanCacheAndDismissalLifecycle() {
+        JsonNode inventory = get("/bootui/api/vulnerabilities").json();
+
+        assertThat(inventory.path("scan").path("status").asText()).isEqualTo("NOT_SCANNED");
+        assertThat(inventory.path("dependencies").size()).isGreaterThan(0);
+        assertThat(QUERY_CALLS).hasValue(0);
+
+        JsonNode scanned = write("POST", "/bootui/api/vulnerabilities/scan").json();
+
+        assertThat(scanned.path("scan").path("status").asText()).isIn("SCANNED", "PARTIAL");
+        assertThat(scanned.path("scan").path("vulnerabilitiesFound").asInt()).isEqualTo(1);
+        assertThat(scanned.path("vulnerable").asInt()).isEqualTo(1);
+        assertThat(firstVulnerableDependency(scanned)
+                        .path("vulnerabilities")
+                        .get(0)
+                        .path("id")
+                        .asText())
+                .isEqualTo(ADVISORY_ID);
+        assertThat(QUERY_CALLS).hasValue(1);
+
+        JsonNode cached = get("/bootui/api/vulnerabilities").json();
+
+        assertThat(cached.path("scan").path("status").asText()).isIn("SCANNED", "PARTIAL");
+        assertThat(cached.path("scan").path("vulnerabilitiesFound").asInt()).isEqualTo(1);
+        assertThat(QUERY_CALLS).hasValue(1);
+
+        JsonNode dependency = firstVulnerableDependency(cached);
+        String packageName = dependency.path("packageName").asText();
+        String dismissalKey = ADVISORY_ID + "::" + packageName;
+
+        assertThat(write("POST", "/bootui/api/dismissed-rules/" + dismissalKey).status())
+                .isEqualTo(200);
+        JsonNode dismissed = get("/bootui/api/vulnerabilities").json();
+        assertThat(findDependency(dismissed, packageName)
+                        .path("vulnerabilityCount")
+                        .asInt())
+                .isZero();
+        assertThat(findDependency(dismissed, packageName)
+                        .path("vulnerabilities")
+                        .get(0)
+                        .path("dismissed")
+                        .asBoolean())
+                .isTrue();
+        assertThat(dismissed.path("vulnerable").asInt()).isZero();
+
+        assertThat(write("DELETE", "/bootui/api/dismissed-rules/" + dismissalKey)
+                        .status())
+                .isEqualTo(200);
+        JsonNode restored = get("/bootui/api/vulnerabilities").json();
+        assertThat(findDependency(restored, packageName)
+                        .path("vulnerabilityCount")
+                        .asInt())
+                .isEqualTo(1);
+        assertThat(restored.path("vulnerable").asInt()).isEqualTo(1);
+    }
+
+    private Response get(String path) {
+        Response response = probe().get(path);
+        assertThat(response.status()).isEqualTo(200);
+        return response;
+    }
+
+    private Response write(String method, String path) {
+        probe().get("/bootui/api/overview");
+        String token = probe().cookie("XSRF-TOKEN").orElseThrow();
+        return probe().request(method, path, Map.of("X-XSRF-TOKEN", token), "");
+    }
+
+    private BootUiHttpProbe probe() {
+        if (probe == null) {
+            probe = new BootUiHttpProbe("http://localhost:" + port);
+        }
+        return probe;
+    }
+
+    private static JsonNode firstVulnerableDependency(JsonNode body) {
+        for (JsonNode dependency : body.path("dependencies")) {
+            if (!dependency.path("vulnerabilities").isEmpty()) {
+                return dependency;
+            }
+        }
+        throw new AssertionError("No vulnerable dependency found");
+    }
+
+    private static JsonNode findDependency(JsonNode body, String packageName) {
+        for (JsonNode dependency : body.path("dependencies")) {
+            if (packageName.equals(dependency.path("packageName").asText())) {
+                return dependency;
+            }
+        }
+        throw new AssertionError("Dependency not found: " + packageName);
+    }
+
+    private static void startOsvStub() {
+        try {
+            osv = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            osv.createContext("/v1/querybatch", exchange -> {
+                QUERY_CALLS.incrementAndGet();
+                respond(exchange, "{\"results\":[{\"vulns\":[{\"id\":\"" + ADVISORY_ID + "\"}]}]}");
+            });
+            osv.createContext(
+                    "/v1/vulns/",
+                    exchange -> respond(
+                            exchange,
+                            "{\"id\":\"" + ADVISORY_ID + "\",\"summary\":\"Spring integration advisory\","
+                                    + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":"
+                                    + "\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"}]}"));
+            osv.start();
+        } catch (IOException ex) {
+            throw new IllegalStateException("Could not start the OSV stub", ex);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, String body) throws IOException {
+        exchange.getRequestBody().readAllBytes();
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+}

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
@@ -238,7 +238,7 @@ describe('Vulnerabilities', () => {
     expect(wrapper.text()).not.toContain('EPSS')
   })
 
-  it('shows "No fix published yet" when fixedVersions is empty', async () => {
+  it('does not claim that no fix exists when OSV reports no fixed event', async () => {
     const noFix = dependency(
       'org.example:no-fix',
       '1.0.0',
@@ -247,7 +247,7 @@ describe('Vulnerabilities', () => {
     )
     const {wrapper} = await mountWithReports([report([noFix])])
 
-    expect(wrapper.text()).toContain('No fix published yet')
+    expect(wrapper.text()).toContain('No fixed version reported by OSV')
   })
 
   it('shows the upgrade target when a newer fixed version is available', async () => {
@@ -260,7 +260,7 @@ describe('Vulnerabilities', () => {
     const {wrapper} = await mountWithReports([report([fixable])])
 
     expect(wrapper.text()).toContain('fixed in 1.2.0')
-    expect(wrapper.text()).not.toContain('No fix published yet')
+    expect(wrapper.text()).not.toContain('No fixed version reported by OSV')
   })
 
   it('shows "already on a fixed version" when fixedVersions is non-empty but fixAvailable is false', async () => {
@@ -273,7 +273,7 @@ describe('Vulnerabilities', () => {
     const {wrapper} = await mountWithReports([report([alreadyFixed])])
 
     expect(wrapper.text()).toContain('already on a fixed version')
-    expect(wrapper.text()).not.toContain('No fix published yet')
+    expect(wrapper.text()).not.toContain('No fixed version reported by OSV')
   })
 
   it('links a CVE alias to NVD and a GHSA alias to GitHub Advisories', async () => {

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -372,7 +372,7 @@ onMounted(loadDependencies)
                         <span v-else-if="vulnerability.fixedVersions.length" class="small text-muted">
                           already on a fixed version (&ge; {{ vulnerability.fixedVersions.join(', ') }})
                         </span>
-                        <span v-else class="small text-muted fst-italic">No fix published yet</span>
+                        <span v-else class="small text-muted fst-italic">No fixed version reported by OSV</span>
                         <span v-if="vulnerability.dismissed" class="badge text-bg-light border">Dismissed</span>
                         <button
                           :disabled="dismissLoading"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -567,8 +567,8 @@ two are mutually exclusive, and some advisories only carry severity at the packa
 first before falling back to the top-level array. A CVSS v3.0/v3.1 vector (from either level) is parsed into a real
 numeric Base Score using the formula from the
 [FIRST.org CVSS v3.1 specification](https://www.first.org/cvss/v3-1/specification-document); CVSS v4.0 has no
-closed-form Base Score equation (its MacroVector lookup table is a much larger undertaking) and legacy CVSS v2 is
-essentially unseen in real Maven-ecosystem OSV advisories, so both fall back to the advisory's
+closed-form Base Score equation (its MacroVector lookup table is a much larger undertaking), and BootUI's calculator is
+intentionally v3-specific rather than implementing the separate CVSS v2 formula, so both fall back to the advisory's
 `database_specific.severity` label (`CRITICAL`/`HIGH`/`MODERATE`/`LOW`, normalized to BootUI's `MEDIUM` label) when no
 v3 score is present at either level. An advisory with neither a parseable CVSS v3 score nor a `database_specific` label
 renders as `UNKNOWN` rather than being silently dropped. Advisories carrying a `withdrawn` timestamp are excluded from
@@ -600,11 +600,12 @@ spelling out the percentile). EPSS lookups can be disabled independently of OSV 
 the OSV results — it simply omits the badge for that scan.
 
 Each advisory also carries a derived `fixAvailable` boolean, computed by comparing the dependency's currently-resolved
-version against the advisory's `fixedVersions` with a lightweight Maven-version-aware comparison. This lets the UI
-distinguish three states unambiguously: a genuine upgrade target ("fixed in `x.y.z`"), a dependency that already sits at
-or above every fixed version OSV reported ("already on a fixed version"), and an advisory with no `fixedVersions` at all
-("No fix published yet") — previously all three collapsed into the same blank space in the UI, which was ambiguous
-between "no fix exists yet" and "we don't know."
+version against the advisory's `fixedVersions` with Maven `ComparableVersion` qualifier ordering, including
+alpha/beta/milestone/RC/SNAPSHOT/release/service-pack semantics. This lets the UI distinguish a genuine upgrade target
+("fixed in `x.y.z`") from a dependency already at or above every fixed version OSV reported. When OSV reports no
+`fixed` event, the UI says only "No fixed version reported by OSV": under the OSV 1.8 schema a range may instead close
+with a mutually exclusive `last_affected` event, which identifies the final vulnerable version without naming the first
+non-vulnerable version, so absence of `fixedVersions` is not proof that no fix exists.
 
 Like every other advisor, a vulnerability can be **dismissed** when it does not apply to your project (already
 patched downstream, accepted risk, or a fix not yet available upstream) — see the shared dismiss/restore explanation
@@ -619,7 +620,10 @@ On Quarkus the panel is identical, listing the local inventory first and contact
 scan, over the same report contract, the same CVSS/withdrawn/partial-failure handling, the same pagination/batch-
 chunking, the same EPSS enrichment, and the same dismiss/restore workflow. The one platform difference is dependency
 discovery: the Spring adapter scans the classpath for `META-INF/maven/*/pom.properties`, which is unreliable under the
-Quarkus runtime classloader, so the Quarkus inventory is captured at build time from the application's resolved runtime
+Quarkus runtime classloader. For JARs without embedded metadata, Spring also reads an adjacent Maven POM (including in
+nonstandard local-repository paths), and only falls back to path-derived coordinates when a literal `repository`
+directory makes the group path unambiguous; it never guesses a group id from an arbitrary cache path. The Quarkus
+inventory is captured at build time from the application's resolved runtime
 dependency model and read back at runtime (mirroring the Architecture panel's build-time base-package discovery). The
 OSV and EPSS lookups are identical, and `bootui.vulnerabilities.osv-enabled=false` /
 `bootui.vulnerabilities.epss-enabled=false` disable on-demand scanning / EPSS enrichment on both adapters.

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -454,6 +454,8 @@ The Kafka panel is a dedicated, filterable view over the same producer/consumer 
 | `bootui.vulnerabilities.max-packages`        | `250`   | Maximum packages included in one OSV batch query.       |
 | `bootui.vulnerabilities.max-advisories`      | `200`   | Maximum advisory details fetched after a package query. |
 | `bootui.vulnerabilities.osv-base-uri`        | `https://api.osv.dev` | Base URI of the OSV.dev API queried during a scan. Mainly useful for pointing scans at a local stub in tests. |
+| `bootui.vulnerabilities.epss-enabled`        | `true`  | Enrich CVE-aliased advisories with FIRST.org EPSS probability and percentile data during the user-initiated scan. EPSS failure never discards OSV results. |
+| `bootui.vulnerabilities.epss-base-uri`       | `https://api.first.org` | Base URI of the FIRST.org EPSS API queried during a scan. Mainly useful for pointing scans at a local stub in tests. |
 
 ### Heap Dump
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -604,9 +604,10 @@ Features:
   lookups can be disabled independently of OSV scanning, and a failed/unreachable EPSS request never fails the scan or
   discards the underlying OSV results — it just omits the EPSS figures.
 - Derive an explicit `fixAvailable` signal per advisory by comparing the dependency's currently-resolved version
-  against the advisory's `fixedVersions` (lightweight Maven-version-aware comparison), so the UI can render an
-  unambiguous "no fix published yet" state instead of leaving an empty `fixedVersions` list ambiguous between "checked,
-  none published" and "unknown".
+  against the advisory's `fixedVersions` using Maven `ComparableVersion` qualifier semantics. An empty list means only
+  that OSV reported no `fixed` event: a range may instead end with `last_affected`, which names the final vulnerable
+  version but does not identify the first non-vulnerable upgrade target. The UI must not conflate that state with proof
+  that no fix exists.
 - Support disabling OSV scans with `bootui.vulnerabilities.osv-enabled=false`.
 - Allow dismissing/restoring an individual vulnerability finding for a specific dependency, excluding it from the
   vulnerable count and severity rollups until restored, consistent with the dismiss/restore workflow shared by every


### PR DESCRIPTION
## What does this PR do?

Hardens the Vulnerabilities advisor’s Maven fix detection, OSV scan input handling, Spring dependency discovery, cross-adapter coverage, and public documentation.

## Why is this change needed?

- Matches Maven 3.9.16 `ComparableVersion` ordering for separators, numeric transitions, and recognized `alpha`/`beta`/`milestone`/`rc`/`snapshot`/release/`sp` qualifiers and aliases, so `fixAvailable` is reliable.
- De-duplicates package/version scan inputs before applying bounds and avoids falsely reporting duplicate-only scans as partial.
- Reads adjacent POM metadata for Spring classpath JARs in nonstandard repository paths without inventing group IDs.
- Treats OSV `last_affected` as the final vulnerable version, not a fixed upgrade target, and clarifies the UI copy.
- Documents EPSS configuration and narrows inaccurate CVSS/comparator claims.
- Adds Spring integration coverage matching Quarkus GET, explicit scan, cache, dismiss/restore, and disabled/no-network behavior.

Standards checked:
- [Maven 3.9.16 `ComparableVersion`](https://github.com/apache/maven/blob/maven-3.9.16/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java)
- [OSV schema range events](https://ossf.github.io/osv-schema/#affectedrangesevents-fields): `fixed` and `last_affected` are mutually exclusive; `upstream` remains distinct from aliases and is intentionally not merged here.
- [FIRST EPSS API](https://www.first.org/epss/api)
- [FIRST CVSS v3.1 specification](https://www.first.org/cvss/v3-1/specification-document); CVSS v4 remains out of this focused change.

Closes # N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally — not run; focused reactor suites, both conformance suites, and an isolated sample-app install were run instead.
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end through the Playwright suite.
- [x] Added or updated tests where applicable.

Validation included:
- Maven 3.9.16 parity tests that compare every representative version pair directly against `ComparableVersion`.
- Full `bootui-engine` suite (1,323 tests).
- Focused Spring and Quarkus OSV scanner suites plus Spring vulnerability integration tests.
- Spring and Quarkus shared HTTP conformance suites.
- Frontend Vitest and formatting checks.
- Isolated sample-app package/install and full Chromium Playwright suite.
- `./mvnw -B -ntp spotless:check`.

## Screenshots (UI changes)

Not applicable — the visible change is copy-only: “No fixed version reported by OSV.”

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes.
- [x] Public API kept backward compatible, or a migration note added to the PR description.
- [x] No secrets, tokens, or local paths committed.