### PR TITLE
Fix WebFlux CI regressions

### DIFF
--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfigurationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfigurationTests.java
@@ -661,12 +661,11 @@ class BootUiReactiveAutoConfigurationTests {
         // Full-stack proof (real DispatcherHandler, real WebFluxAutoConfiguration) that the shared,
         // unmodified PanelsController correctly self-detects a genuine reactive ApplicationContext and
         // (a) reports the "spring-boot-reactive" platform discriminator and (b) marks the panels with no
-        // faithful reactive equivalent (HTTP Sessions), or not yet ported (Spring Security advisor, MCP
-        // Server - neither is wired into this autoconfiguration, see its class Javadoc), as unavailable
-        // with a WebFlux-specific reason - complementing PanelsControllerTests' unit-level coverage of the
-        // same behavior with an end-to-end HTTP round trip through the real reactive autoconfiguration
-        // stack. Live Activity IS wired into this autoconfiguration (ReactiveLiveActivityController), so it
-        // must report available here too.
+        // faithful reactive equivalent (HTTP Sessions), or not yet ported (Spring Security advisor), as
+        // unavailable with a WebFlux-specific reason - complementing PanelsControllerTests' unit-level
+        // coverage of the same behavior with an end-to-end HTTP round trip through the real reactive
+        // autoconfiguration stack. MCP Server and Live Activity are wired into this autoconfiguration, so
+        // both must report available here.
         webFluxRunner()
                 .withPropertyValues("bootui.enabled=ON", "bootui.allow-non-localhost=true")
                 .run(context -> {
@@ -698,9 +697,7 @@ class BootUiReactiveAutoConfigurationTests {
                             .jsonPath("$.panels[?(@.id=='" + BootUiPanels.SPRING_SECURITY + "')].unavailableReason")
                             .<List<String>>value(singleReasonStartingWith("Not yet ported for Spring WebFlux"))
                             .jsonPath("$.panels[?(@.id=='" + BootUiPanels.MCP_SERVER + "')].available")
-                            .isEqualTo(false)
-                            .jsonPath("$.panels[?(@.id=='" + BootUiPanels.MCP_SERVER + "')].unavailableReason")
-                            .<List<String>>value(singleReasonStartingWith("Not yet ported for Spring WebFlux"))
+                            .isEqualTo(true)
                             .jsonPath("$.panels[?(@.id=='" + BootUiPanels.ACTIVITY + "')].available")
                             .isEqualTo(true);
                 });

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/PanelsControllerTests.java
@@ -304,10 +304,9 @@ class PanelsControllerTests {
         // (reactive) ApplicationContext - the same shared PanelsController that BootUiReactiveAutoConfiguration
         // imports unmodified must detect it and (a) report the reactive platform discriminator and (b) mark the
         // panels that have no faithful reactive equivalent (HTTP Sessions), are not yet ported (Spring
-        // Security advisor, MCP Server), or are servlet-only by design (REST Client) as unavailable with
-        // a WebFlux-specific reason, instead of relying on incidental classpath presence. Live Activity is
-        // ported reactively (it merges signals already captured by other reactive/shared controllers), so it
-        // stays available here too.
+        // Security advisor), or are servlet-only by design (REST Client) as unavailable with a
+        // WebFlux-specific reason, instead of relying on incidental classpath presence. MCP Server and Live
+        // Activity are ported reactively, so they stay available here too.
         try (GenericReactiveWebApplicationContext context = new GenericReactiveWebApplicationContext()) {
             context.refresh();
             PanelsController controller =
@@ -328,9 +327,7 @@ class PanelsControllerTests {
                     .andExpect(jsonPath(panelPath(BootUiPanels.SPRING_SECURITY) + ".unavailableReason")
                             .value(startsWith("Not yet ported for Spring WebFlux")))
                     .andExpect(jsonPath(panelPath(BootUiPanels.MCP_SERVER) + ".available")
-                            .value(false))
-                    .andExpect(jsonPath(panelPath(BootUiPanels.MCP_SERVER) + ".unavailableReason")
-                            .value(startsWith("Not yet ported for Spring WebFlux")))
+                            .value(true))
                     .andExpect(jsonPath(panelPath(BootUiPanels.REST_CLIENT_TRACE) + ".available")
                             .value(false))
                     .andExpect(jsonPath(panelPath(BootUiPanels.REST_CLIENT_TRACE) + ".unavailableReason")


### PR DESCRIPTION
## What does this PR do?

Updates the WebFlux panel manifest tests to expect the newly ported MCP Server panel to be available. It also corrects the shared conformance inventory so panels with nested primary endpoints, including Mappings at `/bootui/api/mappings/flat`, are tested through their actual API paths.

## Why is this change needed?

The MCP Server was enabled for WebFlux, but two existing assertions still expected it to be unavailable. Once those stale assertions were fixed, the compatibility workflows exposed a second issue: the conformance suite incorrectly probed Mappings at the legacy root path, which is not registered on WebFlux.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Ran the affected Spring autoconfigure reactor tests, WebFlux API conformance, and the Spring MVC and Quarkus API conformance runners. Checked Java formatting with `./mvnw -B -ntp spotless:check`.

## Screenshots (UI changes)

N/A - test-only change.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed