### PR TITLE
Add seven-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       spring-boot:
@@ -19,6 +21,8 @@ updates:
     directory: /bootui-ui/src/main/frontend
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       vue:
@@ -36,6 +40,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       vuepress:
@@ -48,6 +54,8 @@ updates:
     directory: /bootui-spring-sample-app/e2e
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       playwright:
@@ -59,6 +67,8 @@ updates:
     directory: /bootui-quarkus-sample-app/e2e
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       playwright:
@@ -72,4 +82,6 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10


### PR DESCRIPTION
## What does this PR do?

Configures `cooldown.default-days: 7` for every Maven, npm, and GitHub Actions Dependabot update entry.

## Why is this change needed?

This gives newly published releases seven days to stabilize before Dependabot proposes routine updates, reducing update churn.

No linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

The YAML was parsed successfully, and all six update entries were checked for the seven-day cooldown.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed