### PR TITLE
Fix Quarkus Docker image startup on 3.38

### DIFF
--- a/Dockerfile-quarkus
+++ b/Dockerfile-quarkus
@@ -125,6 +125,12 @@ ENV QUARKUS_ANALYTICS_DISABLED=true
 # setting).
 ENV QUARKUS_OTEL_TRACES_EXPORTER=none
 
+# Quarkus 3.38 bundles Grafana LGTM Observability Dev Services with quarkus-opentelemetry and enables
+# them in dev mode. This standalone container deliberately has no Docker socket, so disable that
+# Docker-backed service instead of leaving its generated grafana.endpoint / otel-collector.url
+# properties unresolved. BootUI's in-process trace capture remains enabled.
+ENV QUARKUS_OBSERVABILITY_ENABLED=false
+
 # A modest, bounded footprint. Dev mode (augmentation) needs more headroom than a packaged prod jar,
 # so this is more generous than the Spring image's 200m prod heap. The JVM reads JAVA_TOOL_OPTIONS
 # itself; override the whole set at runtime with -e JAVA_TOOL_OPTIONS="...".


### PR DESCRIPTION
## What does this PR do?

Disables Quarkus's Docker-backed Observability Dev Service in the standalone Quarkus sample image while preserving BootUI's in-process trace capture.

## Why is this change needed?

Quarkus 3.38 now bundles Grafana LGTM Observability Dev Services with `quarkus-opentelemetry`. The published sample image intentionally has no Docker socket, so the service cannot start and Quarkus fails with unresolved `grafana.endpoint` and `otel-collector.url` configuration before the smoke test can pass.

N/A (no linked issue).

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable
- [x] Built the Quarkus sample and its reactor dependencies with an isolated Maven repository
- [x] Started the Quarkus 3.38 sample with the image runtime configuration and verified `/bootui/api/panels` and `/bootui/` load

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no public behaviour change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed