### PR TITLE
Fix VuePress heading anchor offset

### DIFF
--- a/docs/.vuepress/styles/index.css
+++ b/docs/.vuepress/styles/index.css
@@ -960,13 +960,18 @@ html[data-theme='dark'] [vp-content] code {
   }
 }
 
+/* Keep VuePress's heading box aligned with its router without letting the offset padding intercept clicks. */
 [vp-content] h1,
 [vp-content] h2,
 [vp-content] h3,
 [vp-content] h4,
 [vp-content] h5,
 [vp-content] h6 {
-  margin-top: 1.5rem;
-  padding-top: 0;
-  scroll-margin-top: calc(1rem + var(--header-offset));
+  margin-top: calc(0.5rem - var(--header-offset));
+  padding-top: calc(1rem + var(--header-offset));
+  pointer-events: none;
+}
+
+[vp-content] .header-anchor {
+  pointer-events: auto;
 }


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

Restores VuePress's padding-based heading offset so hash-linked section titles stay visible below the fixed navbar, while limiting pointer events to the visible anchor text.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

VuePress scrolls and tracks section headings using their element position, so the CSS `scroll-margin-top` override was ignored and headings such as Kafka landed behind the navbar. The padding-based offset also keeps the sidebar's active heading and URL hash synchronized.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- [x] `npm run docs:build`
- [x] Verified direct hash URLs and left-sidebar navigation in headless Chrome at desktop and mobile widths

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

N/A - this is an anchor positioning correction with no visual redesign.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed