### PR TITLE
Confirm state-changing UI actions

### DIFF
--- a/bootui-quarkus-sample-app/e2e/tests/threads.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/threads.spec.js
@@ -1,5 +1,5 @@
 // @ts-check
-import {expect, test} from './fixtures.js'
+import {acceptConfirm, expect, test} from './fixtures.js'
 
 /**
  * Threads renders the same shared Threads.vue on both adapters over a byte-identical DTO; the data is
@@ -41,7 +41,8 @@ test.describe('Threads view', () => {
 
     // The button is a real POST /bootui/api/threads/download that streams a text attachment; Chromium
     // reports that as a Playwright download event rather than a navigation.
-    const [download] = await Promise.all([page.waitForEvent('download'), downloadButton.click()])
+    await downloadButton.click()
+    const [download] = await Promise.all([page.waitForEvent('download'), acceptConfirm(page)])
 
     expect(download.suggestedFilename()).toBe('thread-dump.txt')
     const stream = await download.createReadStream()

--- a/bootui-spring-sample-app/e2e/tests/config.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/config.spec.js
@@ -25,6 +25,7 @@ test.describe('Configuration view', () => {
     await page.locator('tr.table-warning input').first().fill(propertyName)
     await page.locator('tr.table-warning input').nth(1).fill(propertyValue)
     await page.locator('tr.table-warning button.btn-success', {hasText: 'Save'}).click()
+    await acceptConfirm(page)
 
     // Wait for the banner confirmation.
     await expect(page.locator('.alert.alert-success')).toContainText(

--- a/bootui-spring-sample-app/e2e/tests/http-probe.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/http-probe.spec.js
@@ -25,6 +25,25 @@ test.describe('HTTP Probe view', () => {
     await expect(page.locator('.form-text', {hasText: 'Content-Type:'})).toBeVisible()
   })
 
+  test('Enter requires confirmation before sending an unsafe request', async ({openView, page}) => {
+    const probeRequests = []
+    page.on('request', (request) => {
+      if (request.url().endsWith('/bootui/api/http-probe')) probeRequests.push(request)
+    })
+    await openView('http-probe', 'HTTP Probe')
+    await page.locator('select.form-select').selectOption('DELETE')
+    const path = page.getByPlaceholder('/api/sample/hello')
+    await path.fill('/api/hello')
+
+    await path.press('Enter')
+
+    await expect(page.getByRole('heading', {name: 'Send DELETE request?'})).toBeVisible()
+    expect(probeRequests).toHaveLength(0)
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('heading', {name: 'Send DELETE request?'})).toBeHidden()
+    expect(probeRequests).toHaveLength(0)
+  })
+
   test('clear resets the form back to defaults', async ({openView, page}) => {
     await openView('http-probe', 'HTTP Probe')
 

--- a/bootui-spring-sample-app/e2e/tests/threads.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/threads.spec.js
@@ -27,4 +27,20 @@ test.describe('Threads view', () => {
     await page.getByPlaceholder(/Filter by name, state, or stack frame/).fill('zzz-no-such-thread')
     await expect(page.locator('text=No threads match your filters.')).toBeVisible()
   })
+
+  test('requires confirmation before requesting a thread dump', async ({openView, page}) => {
+    const downloadRequests = []
+    page.on('request', (request) => {
+      if (request.url().includes('/bootui/api/threads/download')) downloadRequests.push(request)
+    })
+    await openView('threads', 'Threads')
+
+    await page.getByRole('button', {name: /Download dump/}).click()
+
+    await expect(page.getByRole('heading', {name: 'Download thread dump?'})).toBeVisible()
+    expect(downloadRequests).toHaveLength(0)
+    await page.getByRole('button', {name: 'Cancel'}).click()
+    await expect(page.getByRole('heading', {name: 'Download thread dump?'})).toBeHidden()
+    expect(downloadRequests).toHaveLength(0)
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/Config.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Config.test.js
@@ -1,6 +1,9 @@
 import {flushPromises, mount} from '@vue/test-utils'
-import {afterEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {ref} from 'vue'
+
+const {confirm} = vi.hoisted(() => ({confirm: vi.fn()}))
+vi.mock('../utils/useConfirm.js', () => ({useConfirm: () => ({confirm})}))
 
 import Config from './Config.vue'
 
@@ -12,10 +15,27 @@ const EMPTY_CONFIG = {
   propertySuggestions: []
 }
 
-async function mountConfig(provide) {
+function deferred() {
+  let resolve
+  const promise = new Promise((resolver) => {
+    resolve = resolver
+  })
+  return {promise, resolve}
+}
+
+function configWith(properties) {
+  return {
+    ...EMPTY_CONFIG,
+    properties,
+    overrideCount: properties.filter((property) => property.override).length,
+    page: {matched: properties.length, total: properties.length}
+  }
+}
+
+async function mountConfig(provide, fetchMock) {
   vi.stubGlobal(
     'fetch',
-    vi.fn(() => Promise.resolve(new Response(JSON.stringify(EMPTY_CONFIG), {status: 200})))
+    fetchMock || vi.fn(() => Promise.resolve(new Response(JSON.stringify(EMPTY_CONFIG), {status: 200})))
   )
 
   const wrapper = mount(Config, provide ? {global: {provide}} : undefined)
@@ -24,6 +44,11 @@ async function mountConfig(provide) {
 }
 
 describe('Config', () => {
+  beforeEach(() => {
+    confirm.mockReset()
+    confirm.mockResolvedValue(true)
+  })
+
   afterEach(() => {
     vi.unstubAllGlobals()
   })
@@ -52,5 +77,101 @@ describe('Config', () => {
     expect(wrapper.find('input[list="bootPropertySuggestions"]').attributes('placeholder')).toBe(
       'quarkus.application.name'
     )
+  })
+
+  it('keeps a new override intact when file-write confirmation is cancelled', async () => {
+    confirm.mockResolvedValueOnce(false)
+    const fetchMock = vi.fn(() => Promise.resolve(new Response(JSON.stringify(EMPTY_CONFIG), {status: 200})))
+    const wrapper = await mountConfig(undefined, fetchMock)
+    await wrapper.get('button.btn-success').trigger('click')
+    const inputs = wrapper.findAll('tr.table-warning input')
+    await inputs[0].setValue('sample.timeout')
+    await inputs[1].setValue('30s')
+
+    await wrapper.get('tr.table-warning button.btn-success').trigger('click')
+    await flushPromises()
+
+    expect(confirm).toHaveBeenCalledWith({
+      title: 'Create configuration override?',
+      message:
+        'Write this property override to .bootui/application-bootui.properties. The running app may require a restart before the new value takes full effect.',
+      resource: 'sample.timeout',
+      confirmLabel: 'Create override'
+    })
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(false)
+    expect(inputs[0].element.value).toBe('sample.timeout')
+    expect(inputs[1].element.value).toBe('30s')
+  })
+
+  it('waits for one confirmation when Enter updates an override', async () => {
+    const confirmation = deferred()
+    confirm.mockReturnValueOnce(confirmation.promise)
+    const property = {
+      name: 'sample.greeting',
+      value: 'hello',
+      defaultValue: null,
+      source: 'applicationConfig',
+      override: false,
+      masked: false,
+      description: null
+    }
+    const config = configWith([property])
+    const fetchMock = vi.fn((url, init) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve(new Response(JSON.stringify({message: 'Restart may be required.'}), {status: 200}))
+      }
+      return Promise.resolve(new Response(JSON.stringify(config), {status: 200}))
+    })
+    const wrapper = await mountConfig(undefined, fetchMock)
+    await wrapper.get('button.btn-primary').trigger('click')
+    const input = wrapper.get('input.font-monospace')
+    await input.setValue('bonjour')
+
+    await input.trigger('keyup', {key: 'Enter'})
+    await input.trigger('keyup', {key: 'Enter'})
+    await flushPromises()
+
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Update configuration override?',
+        resource: 'sample.greeting',
+        confirmLabel: 'Update override'
+      })
+    )
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'POST')).toBe(false)
+    expect(input.element.value).toBe('bonjour')
+
+    confirmation.resolve(true)
+    await flushPromises()
+
+    const posts = fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')
+    expect(posts).toHaveLength(1)
+    expect(JSON.parse(posts[0][1].body)).toEqual({name: 'sample.greeting', value: 'bonjour'})
+  })
+
+  it('does not delete an override when confirmation is cancelled', async () => {
+    confirm.mockResolvedValueOnce(false)
+    const config = configWith([
+      {
+        name: 'sample.greeting',
+        value: 'hello',
+        defaultValue: null,
+        source: 'bootuiOverrides',
+        override: true,
+        masked: false,
+        description: null
+      }
+    ])
+    const fetchMock = vi.fn(() => Promise.resolve(new Response(JSON.stringify(config), {status: 200})))
+    const wrapper = await mountConfig(undefined, fetchMock)
+
+    await wrapper.get('button[title="Remove override"]').trigger('click')
+    await flushPromises()
+
+    expect(confirm).toHaveBeenCalledWith(
+      expect.objectContaining({title: 'Remove override?', resource: 'sample.greeting'})
+    )
+    expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(false)
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -29,6 +29,7 @@ const showOnlyOverrides = ref(false)
 const editingName = ref(null)
 const editedValue = ref('')
 const saving = ref(false)
+const confirmingMutation = ref(false)
 const newRow = ref(null)
 const newRowName = ref('')
 const newRowValue = ref('')
@@ -123,7 +124,10 @@ function startEdit(p) {
   newRow.value = null
   editingName.value = p.name
   editedValue.value = p.value == null ? '' : String(p.value)
-  nextTick(() => editInput.value?.focus())
+  nextTick(() => {
+    const input = Array.isArray(editInput.value) ? editInput.value[0] : editInput.value
+    input?.focus()
+  })
 }
 
 function cancelEdit() {
@@ -136,7 +140,7 @@ async function saveEdit(p) {
     showReadOnlyMessage()
     return
   }
-  await postOverride(p.name, editedValue.value)
+  await postOverride(p.name, editedValue.value, 'update')
 }
 
 function startCreate() {
@@ -204,17 +208,32 @@ async function saveCreate() {
     newRowError.value = 'Use letters, digits, dots, dashes, underscores or brackets only.'
     return
   }
-  await postOverride(name, newRowValue.value, () => {
+  await postOverride(name, newRowValue.value, 'create', () => {
     newRow.value = null
     newRowError.value = null
   })
 }
 
-async function postOverride(name, value, onSuccess) {
-  if (readOnly.value) {
+async function postOverride(name, value, action, onSuccess) {
+  if (readOnly.value || saving.value || confirmingMutation.value) {
+    if (!readOnly.value) return
     showReadOnlyMessage()
     return
   }
+  confirmingMutation.value = true
+  let confirmed
+  try {
+    confirmed = await confirm({
+      title: action === 'create' ? 'Create configuration override?' : 'Update configuration override?',
+      message:
+        'Write this property override to .bootui/application-bootui.properties. The running app may require a restart before the new value takes full effect.',
+      resource: name,
+      confirmLabel: action === 'create' ? 'Create override' : 'Update override'
+    })
+  } finally {
+    confirmingMutation.value = false
+  }
+  if (!confirmed) return
   saving.value = true
   try {
     const res = await apiFetch('api/config/overrides', {
@@ -240,20 +259,25 @@ async function postOverride(name, value, onSuccess) {
 }
 
 async function removeOverride(name) {
-  if (readOnly.value) {
+  if (readOnly.value || saving.value || confirmingMutation.value) {
+    if (!readOnly.value) return
     showReadOnlyMessage()
     return
   }
-  if (
-    !(await confirm({
+  confirmingMutation.value = true
+  let confirmed
+  try {
+    confirmed = await confirm({
       title: 'Remove override?',
-      message: `Remove the override for "${name}"? The property falls back to its underlying value.`,
+      message: `Remove the override for "${name}" from .bootui/application-bootui.properties? The property falls back to its underlying value.`,
       resource: name,
       confirmLabel: 'Remove',
       danger: true
-    }))
-  )
-    return
+    })
+  } finally {
+    confirmingMutation.value = false
+  }
+  if (!confirmed) return
   saving.value = true
   try {
     const res = await apiFetch(`api/config/overrides/${encodeURIComponent(name)}`, {method: 'DELETE'})
@@ -434,7 +458,11 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
             </td>
             <td><span class="badge bg-warning text-dark">new override</span></td>
             <td class="text-end">
-              <button :disabled="saving || readOnly" class="btn btn-sm btn-success" @click="saveCreate">
+              <button
+                :disabled="saving || confirmingMutation || readOnly"
+                class="btn btn-sm btn-success"
+                @click="saveCreate"
+              >
                 <i class="bi bi-check-lg"></i> Save
               </button>
               <button :disabled="saving" class="btn btn-sm btn-outline-secondary ms-1" @click="cancelCreate">
@@ -484,7 +512,11 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
             </td>
             <td class="text-end align-top pt-1">
               <template v-if="editingName === p.name">
-                <button :disabled="saving || readOnly" class="btn btn-sm btn-success" @click="saveEdit(p)">
+                <button
+                  :disabled="saving || confirmingMutation || readOnly"
+                  class="btn btn-sm btn-success"
+                  @click="saveEdit(p)"
+                >
                   <i class="bi bi-check-lg"></i> Save
                 </button>
                 <button :disabled="saving" class="btn btn-sm btn-outline-secondary ms-1" @click="cancelEdit">
@@ -492,12 +524,16 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
                 </button>
               </template>
               <template v-else>
-                <button :disabled="saving || readOnly" class="btn btn-sm btn-primary" @click="startEdit(p)">
+                <button
+                  :disabled="saving || confirmingMutation || readOnly"
+                  class="btn btn-sm btn-primary"
+                  @click="startEdit(p)"
+                >
                   <i class="bi bi-pencil"></i> Edit
                 </button>
                 <button
                   v-if="p.override"
-                  :disabled="saving || readOnly"
+                  :disabled="saving || confirmingMutation || readOnly"
                   class="btn btn-sm btn-outline-danger ms-1"
                   title="Remove override"
                   @click="removeOverride(p.name)"

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.test.js
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.test.js
@@ -4,13 +4,37 @@ import {ref} from 'vue'
 
 import HttpProbe from './HttpProbe.vue'
 
-const {apiFetch} = vi.hoisted(() => ({apiFetch: vi.fn()}))
+const {apiFetch, confirm} = vi.hoisted(() => ({apiFetch: vi.fn(), confirm: vi.fn()}))
 
 vi.mock('../api.js', () => ({apiFetch}))
+vi.mock('../utils/useConfirm.js', () => ({useConfirm: () => ({confirm})}))
+
+function deferred() {
+  let resolve
+  const promise = new Promise((resolver) => {
+    resolve = resolver
+  })
+  return {promise, resolve}
+}
+
+function response(overrides = {}) {
+  return {
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    body: 'response',
+    durationMs: 12,
+    error: null,
+    truncated: false,
+    ...overrides
+  }
+}
 
 describe('HttpProbe', () => {
   beforeEach(() => {
     apiFetch.mockReset()
+    confirm.mockReset()
+    confirm.mockResolvedValue(true)
   })
 
   it('describes the Spring Boot app in the subtitle by default', () => {
@@ -27,17 +51,7 @@ describe('HttpProbe', () => {
   })
 
   it('warns when the response body was truncated', async () => {
-    apiFetch.mockResolvedValue({
-      json: async () => ({
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        body: 'partial response',
-        durationMs: 12,
-        error: null,
-        truncated: true
-      })
-    })
+    apiFetch.mockResolvedValue({json: async () => response({body: 'partial response', truncated: true})})
     const wrapper = mount(HttpProbe)
 
     await wrapper.get('button.btn-primary').trigger('click')
@@ -45,5 +59,82 @@ describe('HttpProbe', () => {
 
     expect(wrapper.text()).toContain('Response body was truncated at the configured byte limit.')
     expect(wrapper.text()).toContain('partial response')
+    expect(confirm).not.toHaveBeenCalled()
+  })
+
+  it.each(['GET', 'HEAD'])('sends safe %s probes without confirmation', async (method) => {
+    apiFetch.mockResolvedValue({json: async () => response()})
+    const wrapper = mount(HttpProbe)
+    await wrapper.get('select').setValue(method)
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(confirm).not.toHaveBeenCalled()
+    expect(apiFetch).toHaveBeenCalledOnce()
+    expect(JSON.parse(apiFetch.mock.calls[0][1].body)).toMatchObject({method})
+  })
+
+  it('waits for confirmation before sending an unsafe probe', async () => {
+    const confirmation = deferred()
+    confirm.mockReturnValueOnce(confirmation.promise)
+    apiFetch.mockResolvedValue({json: async () => response()})
+    const wrapper = mount(HttpProbe)
+    await wrapper.get('select').setValue('POST')
+    await wrapper.get('input').setValue('/api/orders')
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(confirm).toHaveBeenCalledWith({
+      title: 'Send POST request?',
+      message: 'This request may change state in your running app. Review the method and path before continuing.',
+      resource: 'POST /api/orders',
+      confirmLabel: 'Send POST',
+      danger: true
+    })
+    expect(apiFetch).not.toHaveBeenCalled()
+
+    confirmation.resolve(true)
+    await flushPromises()
+
+    expect(apiFetch).toHaveBeenCalledOnce()
+    expect(JSON.parse(apiFetch.mock.calls[0][1].body)).toMatchObject({
+      method: 'POST',
+      path: '/api/orders'
+    })
+  })
+
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'])('cancels unsafe %s probes without sending a request', async (method) => {
+    confirm.mockResolvedValueOnce(false)
+    const wrapper = mount(HttpProbe)
+    await wrapper.get('select').setValue(method)
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(apiFetch).not.toHaveBeenCalled()
+  })
+
+  it('routes Enter through one confirmation without bypassing or duplicating the request', async () => {
+    const confirmation = deferred()
+    confirm.mockReturnValueOnce(confirmation.promise)
+    const wrapper = mount(HttpProbe)
+    await wrapper.get('select').setValue('PATCH')
+    const pathInput = wrapper.get('input')
+    await pathInput.setValue('/api/orders/1')
+
+    await pathInput.trigger('keyup', {key: 'Enter'})
+    await pathInput.trigger('keyup', {key: 'Enter'})
+    await flushPromises()
+
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(apiFetch).not.toHaveBeenCalled()
+
+    confirmation.resolve(false)
+    await flushPromises()
+
+    expect(apiFetch).not.toHaveBeenCalled()
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -3,12 +3,14 @@ import {apiFetch} from '../api.js'
 import {computed, inject, ref} from 'vue'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {formatLoadError} from '../utils/loadError.js'
+import {useConfirm} from '../utils/useConfirm.js'
 import PanelHeader from './components/PanelHeader.vue'
 import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
+const {confirm} = useConfirm()
 const panels = inject('panels', ref(null))
 const frameworkLabel = computed(() => (panels.value?.platform === 'quarkus' ? 'Quarkus' : 'Spring Boot'))
 const probeSubtitle = computed(
@@ -18,9 +20,11 @@ const method = ref('GET')
 const path = ref('')
 const requestBody = ref('')
 const loading = ref(false)
+const confirming = ref(false)
 const response = ref(null)
 
 const methodsWithBody = ['POST', 'PUT', 'PATCH']
+const safeMethods = new Set(['GET', 'HEAD'])
 
 const showRequestBody = computed(() => methodsWithBody.includes(method.value))
 
@@ -52,7 +56,8 @@ const statusBadgeClass = computed(() => {
 })
 
 async function sendProbe() {
-  if (readOnly.value) {
+  if (readOnly.value || loading.value || confirming.value) {
+    if (!readOnly.value) return
     response.value = {
       status: 0,
       statusText: 'Read-only',
@@ -63,17 +68,34 @@ async function sendProbe() {
     }
     return
   }
+  const request = {
+    method: method.value,
+    path: normalizePath(path.value),
+    body: showRequestBody.value && requestBody.value ? requestBody.value : null,
+    headers: requestHeaders.value
+  }
+  if (!safeMethods.has(request.method)) {
+    confirming.value = true
+    let confirmed
+    try {
+      confirmed = await confirm({
+        title: `Send ${request.method} request?`,
+        message: 'This request may change state in your running app. Review the method and path before continuing.',
+        resource: `${request.method} ${request.path}`,
+        confirmLabel: `Send ${request.method}`,
+        danger: true
+      })
+    } finally {
+      confirming.value = false
+    }
+    if (!confirmed) return
+  }
   loading.value = true
   try {
     const res = await apiFetch('api/http-probe', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
-      body: JSON.stringify({
-        method: method.value,
-        path: normalizePath(path.value),
-        body: showRequestBody.value && requestBody.value ? requestBody.value : null,
-        headers: requestHeaders.value
-      })
+      body: JSON.stringify(request)
     })
     response.value = await res.json()
   } catch (error) {
@@ -102,6 +124,7 @@ function clearForm() {
   requestBody.value = ''
   response.value = null
   loading.value = false
+  confirming.value = false
 }
 </script>
 
@@ -109,12 +132,12 @@ function clearForm() {
   <div>
     <PanelHeader icon="bi-send" title="HTTP Probe" :subtitle="probeSubtitle">
       <template #actions>
-        <button :disabled="loading" class="btn btn-outline-secondary" @click="clearForm">
+        <button :disabled="loading || confirming" class="btn btn-outline-secondary" @click="clearForm">
           <i class="bi bi-x-circle me-1"></i>Clear
         </button>
         <SpinnerButton
           :loading="loading"
-          :disabled="loading || readOnly"
+          :disabled="loading || confirming || readOnly"
           class="btn btn-primary"
           icon="bi-send"
           label="Send"
@@ -134,6 +157,7 @@ function clearForm() {
             <label class="form-label">Method</label>
             <select v-model="method" class="form-select">
               <option value="GET">GET</option>
+              <option value="HEAD">HEAD</option>
               <option value="POST">POST</option>
               <option value="PUT">PUT</option>
               <option value="DELETE">DELETE</option>

--- a/bootui-ui/src/main/frontend/src/views/Threads.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Threads.test.js
@@ -1,10 +1,21 @@
 import {flushPromises, mount} from '@vue/test-utils'
-import {afterEach, describe, expect, it, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const {confirm} = vi.hoisted(() => ({confirm: vi.fn()}))
+vi.mock('../utils/useConfirm.js', () => ({useConfirm: () => ({confirm})}))
 
 import Threads from './Threads.vue'
 import AutoRefreshToggle from './components/AutoRefreshToggle.vue'
 
 let wrappers = []
+
+function deferred() {
+  let resolve
+  const promise = new Promise((resolver) => {
+    resolve = resolver
+  })
+  return {promise, resolve}
+}
 
 function thread(overrides = {}) {
   return {
@@ -57,11 +68,12 @@ function report(overrides = {}) {
   }
 }
 
-async function mountWithReport(body, panel = {}) {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), {status: 200})))
-  )
+async function mountWithReport(
+  body,
+  panel = {},
+  fetchMock = vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), {status: 200})))
+) {
+  vi.stubGlobal('fetch', fetchMock)
   const wrapper = mount(Threads, {props: {panel}})
   wrappers.push(wrapper)
   await flushPromises()
@@ -69,6 +81,11 @@ async function mountWithReport(body, panel = {}) {
 }
 
 describe('Threads', () => {
+  beforeEach(() => {
+    confirm.mockReset()
+    confirm.mockResolvedValue(true)
+  })
+
   afterEach(() => {
     wrappers.forEach((wrapper) => wrapper.unmount())
     wrappers = []
@@ -152,7 +169,9 @@ describe('Threads', () => {
     expect(wrapper.text()).toContain('Thread-dump download is read-only')
   })
 
-  it('posts to the download endpoint when triggered', async () => {
+  it('waits for confirmation before posting to the download endpoint', async () => {
+    const confirmation = deferred()
+    confirm.mockReturnValueOnce(confirmation.promise)
     const fetchMock = vi.fn((url) => {
       if (typeof url === 'string' && url.includes('download')) {
         return Promise.resolve(new Response('dump', {status: 200}))
@@ -170,8 +189,35 @@ describe('Threads', () => {
     await wrapper.find('button.btn-outline-primary').trigger('click')
     await flushPromises()
 
+    expect(confirm).toHaveBeenCalledWith({
+      title: 'Download thread dump?',
+      message: 'Capture a fresh raw thread dump from the running application and download it to this device.',
+      resource: 'thread-dump.txt',
+      confirmLabel: 'Download'
+    })
+    expect(
+      fetchMock.mock.calls.some(([url, init]) => String(url).includes('threads/download') && init?.method === 'POST')
+    ).toBe(false)
+
+    confirmation.resolve(true)
+    await flushPromises()
+
     expect(
       fetchMock.mock.calls.some(([url, init]) => String(url).includes('threads/download') && init?.method === 'POST')
     ).toBe(true)
+  })
+
+  it('does not post a thread dump when confirmation is cancelled', async () => {
+    confirm.mockResolvedValueOnce(false)
+    const fetchMock = vi.fn(() => Promise.resolve(new Response(JSON.stringify(report()), {status: 200})))
+    const wrapper = await mountWithReport(report(), {}, fetchMock)
+
+    await wrapper.find('button.btn-outline-primary').trigger('click')
+    await flushPromises()
+
+    expect(confirm).toHaveBeenCalledOnce()
+    expect(
+      fetchMock.mock.calls.some(([url, init]) => String(url).includes('threads/download') && init?.method === 'POST')
+    ).toBe(false)
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Threads.vue
+++ b/bootui-ui/src/main/frontend/src/views/Threads.vue
@@ -4,17 +4,20 @@ import {apiFetch} from '../api.js'
 import {formatNumber} from '../utils/format.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import {useConfirm} from '../utils/useConfirm.js'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
 import PanelHeader from './components/PanelHeader.vue'
 import ServerListFooter from './components/ServerListFooter.vue'
 
 const props = defineProps(panelProps)
 const {readOnly, readOnlyReason} = usePanelState(props)
+const {confirm} = useConfirm()
 
 const filter = ref('')
 const state = ref('')
 const expanded = ref(new Set())
 const downloading = ref(false)
+const confirmingDownload = ref(false)
 const downloadError = ref(null)
 
 const {
@@ -91,7 +94,20 @@ function isExpanded(id) {
 }
 
 async function downloadDump() {
-  if (readOnly.value || downloading.value) return
+  if (readOnly.value || downloading.value || confirmingDownload.value) return
+  confirmingDownload.value = true
+  let confirmed
+  try {
+    confirmed = await confirm({
+      title: 'Download thread dump?',
+      message: 'Capture a fresh raw thread dump from the running application and download it to this device.',
+      resource: 'thread-dump.txt',
+      confirmLabel: 'Download'
+    })
+  } finally {
+    confirmingDownload.value = false
+  }
+  if (!confirmed) return
   downloading.value = true
   downloadError.value = null
   try {
@@ -130,7 +146,7 @@ watch([filter, state], scheduleReload)
     >
       <template #actions>
         <button
-          :disabled="readOnly || downloading || !available"
+          :disabled="readOnly || downloading || confirmingDownload || !available"
           :title="readOnly ? readOnlyReason : 'Download a raw thread dump snapshot'"
           class="btn btn-outline-primary btn-sm"
           type="button"

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -367,6 +367,7 @@ Features:
 - Add a runtime-only override for a new property key.
 - Edit a runtime override.
 - Remove a runtime override.
+- Require explicit confirmation before creating, updating, or removing an override file entry.
 - Show whether a displayed value comes from a BootUI runtime override.
 - Clearly label modified values as local, runtime-only, and not persisted to `application.properties`, environment
   variables, or config server.
@@ -384,6 +385,8 @@ Acceptance criteria:
 - BootUI never writes secrets or modified values back to source files by default.
 - Every property mutation is local-development-only and is persisted only to BootUI's override file,
   `.bootui/application-bootui.properties` by default.
+- The UI does not write the override file until the developer explicitly confirms the pending create, update, or remove
+  action.
 - Mutating a property returns a clear result that states whether the new value is visible in the Spring `Environment`
   and whether restart/rebind may be required.
 
@@ -692,11 +695,13 @@ Features:
 - Normalize method and path.
 - Restrict targets to localhost.
 - Support request bodies only for methods that can carry a body.
+- Require explicit confirmation before sending any method other than `GET` or `HEAD`.
 - Display status, selected response headers, body, timing, and errors.
 
 Acceptance criteria:
 
 - BootUI never proxies arbitrary external URLs.
+- `GET` and `HEAD` probes run directly; unsafe probes do not reach the backend until the developer confirms them.
 - Unsafe-body behavior is explicit and predictable.
 - Response headers are filtered to a small allow-list.
 
@@ -1468,6 +1473,7 @@ Acceptance criteria:
 - The panel fails closed, returning a stable empty report with an explained unavailable reason when thread information
   cannot be read.
 - The raw dump download is a `POST` and is blocked when the panel is read-only.
+- The UI does not issue the download `POST` until the developer explicitly confirms the capture.
 
 ## 6. Technical architecture
 


### PR DESCRIPTION
## What does this PR do?

Requires BootUI's branded confirmation dialog before thread-dump downloads, unsafe HTTP probes, and configuration override file writes.

The unsafe HTTP Probe path covers POST, PUT, PATCH, and DELETE while GET and HEAD remain direct. Button clicks and Enter share the same guarded path, and pending confirmations block duplicate submissions. Configuration create, update, and delete preserve entered values until the user decides.

## Why is this change needed?

Audit issue 2 found three surfaces that violated BootUI's "never surprise the user" rule: thread dumps posted immediately, unsafe probes could bypass confirmation through Enter, and configuration overrides wrote `.bootui/application-bootui.properties` without confirmation.

This reuses the app-level native `<dialog>`/`useConfirm()` pattern, including modal focus handling, Escape/cancel behavior, focus restoration, and danger styling for potentially state-changing probes.

### API compatibility decision

No server contract changed. These three endpoints do not currently carry confirmation fields, and adding required request fields would gratuitously break BootUI's stable shared API and duplicate changes across both adapters. The confirmation is a browser UX safety gate; existing server-side localhost, CSRF, activation, and read-only enforcement remains intact. Contracts that already include confirmation fields continue to enforce them server-side.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Validation:

- `npm test` — 516 frontend tests passed
- Focused Vitest — 32 tests passed across Threads, HTTP Probe, Configuration, and ConfirmDialog
- Spring API conformance — 17 tests passed
- Quarkus API conformance — passed
- Focused Playwright — 10 tests passed across Threads, HTTP Probe, and Configuration
- `npm run format:check` — frontend and Playwright suites passed
- `./mvnw -B -ntp spotless:check` — passed
- Impeccable UI detector — no findings on the three changed views

## Screenshots (UI changes)

Not included: this change reuses the existing branded confirmation dialog without visual-system changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
