### PR TITLE
fix(log-tail): decouple Spring MVC SSE delivery

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailController.java
@@ -6,6 +6,13 @@ import io.github.jdubois.bootui.engine.logtail.LogTailBuffer;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.context.event.EventListener;
@@ -20,17 +27,56 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @ConditionalOnClass(name = "ch.qos.logback.classic.LoggerContext")
 public class LogTailController {
 
+    private static final AtomicLong THREAD_SEQUENCE = new AtomicLong();
+
     private final BootUiLogAppender appender;
     private final LogTailBuffer buffer;
-    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+    private final Supplier<SseEmitter> emitterFactory;
+    private final int pendingEventCapacity;
+    private final LogTailSseSession.EventSender eventSender;
+    private final ExecutorService streamExecutor;
+    private final CopyOnWriteArrayList<LogTailSseSession> sessions = new CopyOnWriteArrayList<>();
 
     /** Upper bound on simultaneous log-tail streams; this is a local dev tool, not a fan-out hub. */
     static final int MAX_CONCURRENT_STREAMS = 20;
 
+    /**
+     * Per-client pending event bound. It holds the full 500-line replay plus a bounded live burst; a
+     * client that cannot drain it is disconnected rather than consuming memory indefinitely.
+     */
+    static final int MAX_PENDING_EVENTS = LogTailBuffer.DEFAULT_MAX_LINES * 2;
+
+    @Autowired
     public LogTailController(BootUiProperties properties) {
-        this.appender = BootUiLogAppender.install(new LogTailBuffer(
-                LogTailBuffer.DEFAULT_MAX_LINES, properties.getLogTail().getMaxBytes()));
+        this(
+                BootUiLogAppender.install(new LogTailBuffer(
+                        LogTailBuffer.DEFAULT_MAX_LINES, properties.getLogTail().getMaxBytes())),
+                () -> new SseEmitter(0L),
+                MAX_PENDING_EVENTS,
+                LogTailController::sendLog,
+                createStreamExecutor());
+    }
+
+    LogTailController(
+            BootUiLogAppender appender,
+            Supplier<SseEmitter> emitterFactory,
+            int pendingEventCapacity,
+            LogTailSseSession.EventSender eventSender) {
+        this(appender, emitterFactory, pendingEventCapacity, eventSender, createStreamExecutor());
+    }
+
+    private LogTailController(
+            BootUiLogAppender appender,
+            Supplier<SseEmitter> emitterFactory,
+            int pendingEventCapacity,
+            LogTailSseSession.EventSender eventSender,
+            ExecutorService streamExecutor) {
+        this.appender = appender;
         this.buffer = appender.buffer();
+        this.emitterFactory = emitterFactory;
+        this.pendingEventCapacity = pendingEventCapacity;
+        this.eventSender = eventSender;
+        this.streamExecutor = streamExecutor;
     }
 
     @GetMapping("/recent")
@@ -40,38 +86,30 @@ public class LogTailController {
 
     @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter stream() {
-        SseEmitter emitter = new SseEmitter(0L);
-        if (emitters.size() >= MAX_CONCURRENT_STREAMS) {
-            emitter.completeWithError(new IllegalStateException("Too many concurrent BootUI log-tail streams"));
-            return emitter;
-        }
-        emitters.add(emitter);
-
-        LogTailBuffer.Subscription subscription = buffer.subscribeWithReplay(line -> {
-            try {
-                sendLog(emitter, line);
-            } catch (IOException ex) {
-                emitter.completeWithError(ex);
+        SseEmitter emitter = emitterFactory.get();
+        LogTailSseSession session = new LogTailSseSession(
+                emitter, pendingEventCapacity, streamExecutor, eventSender, () -> removeSession(emitter));
+        synchronized (sessions) {
+            if (sessions.size() >= MAX_CONCURRENT_STREAMS) {
+                emitter.completeWithError(new IllegalStateException("Too many concurrent BootUI log-tail streams"));
+                return emitter;
             }
-        });
-        emitter.onCompletion(() -> cleanup(emitter, subscription.unsubscribe()));
-        emitter.onTimeout(() -> cleanup(emitter, subscription.unsubscribe()));
-        emitter.onError(error -> cleanup(emitter, subscription.unsubscribe()));
-
-        try {
-            for (LogLineDto line : subscription.backlog()) {
-                sendLog(emitter, line);
-            }
-        } catch (IOException ex) {
-            cleanup(emitter, subscription.unsubscribe());
-            emitter.completeWithError(ex);
+            sessions.add(session);
         }
+
+        emitter.onCompletion(session::close);
+        emitter.onTimeout(session::close);
+        emitter.onError(error -> session.close());
+        session.start(buffer);
         return emitter;
     }
 
-    private void cleanup(SseEmitter emitter, Runnable unsubscribe) {
-        emitters.remove(emitter);
-        unsubscribe.run();
+    private void removeSession(SseEmitter emitter) {
+        sessions.removeIf(session -> sessionMatches(session, emitter));
+    }
+
+    private boolean sessionMatches(LogTailSseSession session, SseEmitter emitter) {
+        return session.emitter() == emitter;
     }
 
     /**
@@ -88,14 +126,34 @@ public class LogTailController {
      */
     @EventListener(ContextClosedEvent.class)
     void shutdown() {
-        for (SseEmitter emitter : emitters) {
-            emitter.complete();
+        for (LogTailSseSession session : sessions) {
+            session.complete();
         }
-        emitters.clear();
+        sessions.clear();
+        streamExecutor.shutdownNow();
         appender.uninstall();
     }
 
-    private void sendLog(SseEmitter emitter, LogLineDto line) throws IOException {
+    int activeStreamCount() {
+        return sessions.size();
+    }
+
+    private static void sendLog(SseEmitter emitter, LogLineDto line) throws IOException {
         emitter.send(SseEmitter.event().name("log").data(line, MediaType.APPLICATION_JSON));
+    }
+
+    private static ExecutorService createStreamExecutor() {
+        return new ThreadPoolExecutor(
+                0,
+                MAX_CONCURRENT_STREAMS,
+                100L,
+                TimeUnit.MILLISECONDS,
+                new SynchronousQueue<>(),
+                runnable -> {
+                    Thread thread = new Thread(runnable, "bootui-log-tail-stream-" + THREAD_SEQUENCE.incrementAndGet());
+                    thread.setDaemon(true);
+                    return thread;
+                },
+                new ThreadPoolExecutor.AbortPolicy());
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailSseSession.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/LogTailSseSession.java
@@ -1,0 +1,190 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import io.github.jdubois.bootui.core.dto.LogLineDto;
+import io.github.jdubois.bootui.engine.logtail.LogTailBuffer;
+import java.io.IOException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * One Spring MVC log-tail subscription. Buffer callbacks only perform a bounded queue offer; a
+ * dedicated daemon worker owns all potentially blocking {@link SseEmitter} I/O.
+ */
+final class LogTailSseSession implements AutoCloseable {
+
+    @FunctionalInterface
+    interface EventSender {
+        void send(SseEmitter emitter, LogLineDto line) throws IOException;
+    }
+
+    private static final Runnable NOOP = () -> {};
+
+    private final SseEmitter emitter;
+    private final ArrayBlockingQueue<LogLineDto> pending;
+    private final ExecutorService workerExecutor;
+    private final EventSender sender;
+    private final Runnable onClose;
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final AtomicBoolean finished = new AtomicBoolean();
+    private final Object lifecycleMonitor = new Object();
+
+    private Runnable unsubscribe = NOOP;
+    private boolean workerScheduled;
+    private volatile Thread workerThread;
+    private TerminalAction terminalAction;
+
+    LogTailSseSession(
+            SseEmitter emitter,
+            int queueCapacity,
+            ExecutorService workerExecutor,
+            EventSender sender,
+            Runnable onClose) {
+        this.emitter = emitter;
+        this.pending = new ArrayBlockingQueue<>(queueCapacity);
+        this.workerExecutor = workerExecutor;
+        this.sender = sender;
+        this.onClose = onClose;
+    }
+
+    SseEmitter emitter() {
+        return emitter;
+    }
+
+    void start(LogTailBuffer buffer) {
+        boolean overflow = false;
+        RejectedExecutionException rejected = null;
+        synchronized (lifecycleMonitor) {
+            if (closed.get()) {
+                return;
+            }
+
+            LogTailBuffer.Subscription subscription = buffer.subscribeWithReplay(this::enqueue);
+            unsubscribe = subscription.unsubscribe();
+            for (LogLineDto line : subscription.backlog()) {
+                if (!pending.offer(line)) {
+                    overflow = true;
+                    break;
+                }
+            }
+
+            if (!overflow && !closed.get()) {
+                try {
+                    workerExecutor.execute(this::sendLoop);
+                    workerScheduled = true;
+                } catch (RejectedExecutionException ex) {
+                    rejected = ex;
+                }
+            }
+        }
+
+        if (overflow) {
+            fail(overloadError());
+        } else if (rejected != null) {
+            fail(new IllegalStateException("No BootUI log-tail stream worker is available", rejected));
+        }
+    }
+
+    private void enqueue(LogLineDto line) {
+        boolean overflow;
+        synchronized (lifecycleMonitor) {
+            if (closed.get()) {
+                return;
+            }
+            overflow = !pending.offer(line);
+        }
+        if (overflow) {
+            fail(overloadError());
+        }
+    }
+
+    private void sendLoop() {
+        workerThread = Thread.currentThread();
+        try {
+            while (!closed.get()) {
+                LogLineDto line = pending.take();
+                sender.send(emitter, line);
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            if (!closed.get()) {
+                fail(new IllegalStateException("BootUI log-tail stream worker was interrupted", ex));
+            }
+        } catch (IOException | IllegalStateException ex) {
+            fail(ex);
+        } finally {
+            workerThread = null;
+            runTerminalAction();
+            finish();
+        }
+    }
+
+    void complete() {
+        releaseResources(new TerminalAction(null));
+    }
+
+    private void fail(Throwable error) {
+        releaseResources(new TerminalAction(error));
+    }
+
+    private void releaseResources(TerminalAction requestedTerminalAction) {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+
+        Runnable currentUnsubscribe;
+        boolean currentWorkerScheduled;
+        Thread currentWorkerThread;
+        synchronized (lifecycleMonitor) {
+            currentUnsubscribe = unsubscribe;
+            unsubscribe = NOOP;
+            pending.clear();
+            terminalAction = requestedTerminalAction;
+            currentWorkerScheduled = workerScheduled;
+            currentWorkerThread = workerThread;
+        }
+        currentUnsubscribe.run();
+        if (currentWorkerThread != null && currentWorkerThread != Thread.currentThread()) {
+            currentWorkerThread.interrupt();
+        }
+        if (!currentWorkerScheduled) {
+            runTerminalAction();
+            finish();
+        }
+    }
+
+    private void runTerminalAction() {
+        TerminalAction action;
+        synchronized (lifecycleMonitor) {
+            action = terminalAction;
+            terminalAction = null;
+        }
+        if (action == null) {
+            return;
+        }
+        if (action.error() == null) {
+            emitter.complete();
+        } else {
+            emitter.completeWithError(action.error());
+        }
+    }
+
+    private void finish() {
+        if (finished.compareAndSet(false, true)) {
+            onClose.run();
+        }
+    }
+
+    private static IllegalStateException overloadError() {
+        return new IllegalStateException("BootUI log-tail stream disconnected because its pending event queue is full");
+    }
+
+    @Override
+    public void close() {
+        releaseResources(null);
+    }
+
+    private record TerminalAction(Throwable error) {}
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LogTailSseSessionTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LogTailSseSessionTests.java
@@ -1,0 +1,290 @@
+package io.github.jdubois.bootui.autoconfigure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.github.jdubois.bootui.core.dto.LogLineDto;
+import io.github.jdubois.bootui.engine.logtail.LogTailBuffer;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class LogTailSseSessionTests {
+
+    @Test
+    void blockedEmitterDoesNotHoldPublisherAndEventsRemainOrdered() throws Exception {
+        LogTailBuffer buffer = new LogTailBuffer();
+        BootUiLogAppender appender = freshAppender(buffer);
+        TestEmitter emitter = new TestEmitter();
+        CountDownLatch firstSendStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirstSend = new CountDownLatch(1);
+        List<String> sent = new CopyOnWriteArrayList<>();
+        AtomicInteger sendCount = new AtomicInteger();
+        LogTailController controller = new LogTailController(appender, () -> emitter, 4, (ignored, line) -> {
+            sent.add(line.message());
+            if (sendCount.incrementAndGet() == 1) {
+                firstSendStarted.countDown();
+                awaitLatch(releaseFirstSend);
+            }
+        });
+        ExecutorService publisher = Executors.newSingleThreadExecutor();
+
+        try {
+            controller.stream();
+            Future<?> firstPublication = publisher.submit(() -> buffer.add(line("first")));
+            firstPublication.get(1, TimeUnit.SECONDS);
+            assertThat(firstSendStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+            Future<?> secondPublication = publisher.submit(() -> buffer.add(line("second")));
+            secondPublication.get(1, TimeUnit.SECONDS);
+
+            releaseFirstSend.countDown();
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(() -> assertThat(sent).containsExactly("first", "second"));
+        } finally {
+            releaseFirstSend.countDown();
+            emitter.fireCompletion();
+            controller.shutdown();
+            publisher.shutdownNow();
+        }
+    }
+
+    @Test
+    void sendFailureUnsubscribesAndStopsFurtherDelivery() {
+        LogTailBuffer buffer = new LogTailBuffer();
+        BootUiLogAppender appender = freshAppender(buffer);
+        TestEmitter emitter = new TestEmitter();
+        AtomicInteger attempts = new AtomicInteger();
+        IOException failure = new IOException("client disconnected");
+        LogTailController controller = new LogTailController(appender, () -> emitter, 4, (ignored, line) -> {
+            attempts.incrementAndGet();
+            throw failure;
+        });
+
+        try {
+            controller.stream();
+            buffer.add(line("first"));
+
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+                assertThat(controller.activeStreamCount()).isZero();
+                assertThat(emitter.completedError.get()).isSameAs(failure);
+            });
+
+            buffer.add(line("second"));
+            assertThat(attempts).hasValue(1);
+        } finally {
+            controller.shutdown();
+        }
+    }
+
+    @Test
+    void completionAndTimeoutReleaseTheirSubscriptions() {
+        LogTailBuffer buffer = new LogTailBuffer();
+        BootUiLogAppender appender = freshAppender(buffer);
+        TestEmitter completed = new TestEmitter();
+        TestEmitter timedOut = new TestEmitter();
+        List<TestEmitter> emitters = new CopyOnWriteArrayList<>(List.of(completed, timedOut));
+        AtomicInteger sends = new AtomicInteger();
+        LogTailController controller = new LogTailController(
+                appender, () -> emitters.remove(0), 4, (ignored, line) -> sends.incrementAndGet());
+
+        try {
+            controller.stream();
+            controller.stream();
+            assertThat(controller.activeStreamCount()).isEqualTo(2);
+
+            completed.fireCompletion();
+            timedOut.fireTimeout();
+
+            await().atMost(Duration.ofSeconds(2))
+                    .untilAsserted(
+                            () -> assertThat(controller.activeStreamCount()).isZero());
+            buffer.add(line("after-cleanup"));
+            assertThat(sends).hasValue(0);
+        } finally {
+            controller.shutdown();
+        }
+    }
+
+    @Test
+    void queueOverflowDisconnectsSlowSubscriberWithoutBlockingPublisher() throws Exception {
+        LogTailBuffer buffer = new LogTailBuffer();
+        BootUiLogAppender appender = freshAppender(buffer);
+        TestEmitter emitter = new TestEmitter();
+        CountDownLatch firstSendStarted = new CountDownLatch(1);
+        CountDownLatch holdSender = new CountDownLatch(1);
+        CountDownLatch completionStarted = new CountDownLatch(1);
+        CountDownLatch releaseCompletion = new CountDownLatch(1);
+        emitter.blockErrorCompletion(completionStarted, releaseCompletion);
+        AtomicReference<Thread> worker = new AtomicReference<>();
+        LogTailController controller = new LogTailController(appender, () -> emitter, 2, (ignored, line) -> {
+            worker.set(Thread.currentThread());
+            firstSendStarted.countDown();
+            awaitLatch(holdSender);
+        });
+        ExecutorService publisher = Executors.newSingleThreadExecutor();
+
+        try {
+            controller.stream();
+            publisher.submit(() -> buffer.add(line("sending"))).get(1, TimeUnit.SECONDS);
+            assertThat(firstSendStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+            Future<?> burst = publisher.submit(() -> {
+                buffer.add(line("queued-1"));
+                buffer.add(line("queued-2"));
+                buffer.add(line("overflow"));
+            });
+            burst.get(1, TimeUnit.SECONDS);
+            assertThat(completionStarted.await(1, TimeUnit.SECONDS)).isTrue();
+            releaseCompletion.countDown();
+
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+                assertThat(controller.activeStreamCount()).isZero();
+                assertThat(emitter.completedError.get())
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("pending event queue is full");
+                assertThat(worker.get().isAlive()).isFalse();
+            });
+        } finally {
+            holdSender.countDown();
+            releaseCompletion.countDown();
+            controller.shutdown();
+            publisher.shutdownNow();
+        }
+    }
+
+    @Test
+    void shutdownCompletesEmitterAndInterruptsWorker() throws Exception {
+        LogTailBuffer buffer = new LogTailBuffer();
+        BootUiLogAppender appender = freshAppender(buffer);
+        TestEmitter emitter = new TestEmitter();
+        AtomicReference<Thread> worker = new AtomicReference<>();
+        CountDownLatch sendStarted = new CountDownLatch(1);
+        CountDownLatch holdSender = new CountDownLatch(1);
+        CountDownLatch completionStarted = new CountDownLatch(1);
+        CountDownLatch releaseCompletion = new CountDownLatch(1);
+        emitter.blockCompletion(completionStarted, releaseCompletion);
+        LogTailController controller = new LogTailController(appender, () -> emitter, 4, (ignored, line) -> {
+            worker.set(Thread.currentThread());
+            sendStarted.countDown();
+            awaitLatch(holdSender);
+        });
+
+        controller.stream();
+        buffer.add(line("blocked"));
+        await().atMost(Duration.ofSeconds(2)).until(() -> sendStarted.getCount() == 0);
+
+        ExecutorService shutdownExecutor = Executors.newSingleThreadExecutor();
+        Future<?> shutdown = shutdownExecutor.submit(controller::shutdown);
+
+        try {
+            shutdown.get(1, TimeUnit.SECONDS);
+            assertThat(completionStarted.await(1, TimeUnit.SECONDS)).isTrue();
+            releaseCompletion.countDown();
+            await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+                assertThat(controller.activeStreamCount()).isZero();
+                assertThat(emitter.completions).hasValue(1);
+                assertThat(worker.get().isAlive()).isFalse();
+                assertThat(appender.isStarted()).isFalse();
+            });
+        } finally {
+            releaseCompletion.countDown();
+            shutdownExecutor.shutdownNow();
+        }
+    }
+
+    private static BootUiLogAppender freshAppender(LogTailBuffer buffer) {
+        BootUiLogAppender appender = new BootUiLogAppender(buffer);
+        appender.setName("TEST_APPENDER_" + System.nanoTime());
+        appender.start();
+        return appender;
+    }
+
+    private static LogLineDto line(String message) {
+        return new LogLineDto(0L, "INFO", "test", message, "publisher");
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static final class TestEmitter extends SseEmitter {
+
+        private Runnable completion = () -> {};
+        private Runnable timeout = () -> {};
+        private Consumer<Throwable> error = ignored -> {};
+        private final AtomicInteger completions = new AtomicInteger();
+        private final AtomicReference<Throwable> completedError = new AtomicReference<>();
+        private CountDownLatch completionStarted = new CountDownLatch(0);
+        private CountDownLatch releaseCompletion = new CountDownLatch(0);
+        private CountDownLatch errorCompletionStarted = new CountDownLatch(0);
+        private CountDownLatch releaseErrorCompletion = new CountDownLatch(0);
+
+        private TestEmitter() {
+            super(0L);
+        }
+
+        @Override
+        public void onCompletion(Runnable callback) {
+            completion = callback;
+        }
+
+        @Override
+        public void onTimeout(Runnable callback) {
+            timeout = callback;
+        }
+
+        @Override
+        public void onError(Consumer<Throwable> callback) {
+            error = callback;
+        }
+
+        @Override
+        public void complete() {
+            completionStarted.countDown();
+            awaitLatch(releaseCompletion);
+            completions.incrementAndGet();
+        }
+
+        @Override
+        public void completeWithError(Throwable ex) {
+            completedError.set(ex);
+            errorCompletionStarted.countDown();
+            awaitLatch(releaseErrorCompletion);
+            error.accept(ex);
+        }
+
+        private void blockCompletion(CountDownLatch started, CountDownLatch release) {
+            completionStarted = started;
+            releaseCompletion = release;
+        }
+
+        private void blockErrorCompletion(CountDownLatch started, CountDownLatch release) {
+            errorCompletionStarted = started;
+            releaseErrorCompletion = release;
+        }
+
+        private void fireCompletion() {
+            completion.run();
+        }
+
+        private void fireTimeout() {
+            timeout.run();
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Decouples Spring MVC Log Tail SSE writes from host application logging threads using ordered, bounded per-subscriber queues and a capped daemon worker pool.

## Why is this change needed?

`BootUiLogAppender` publishes synchronously into `LogTailBuffer`, and the MVC controller previously called `SseEmitter.send` in that callback. A slow or disconnected browser could therefore block the application thread that emitted the log.

Each subscriber now queues up to 1,000 events without blocking the publisher. Its worker serializes backlog and live events in order; queue overflow disconnects that subscriber explicitly. Completion, timeout, send failure, overload, and context shutdown all unsubscribe, clear pending data, and stop the worker. Terminal emitter calls also stay on the worker because Spring serializes `send` and `completeWithError` on the same write lock.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Validation run:

- `./mvnw -Dmaven.repo.local=.m2 -B -ntp -pl bootui-engine,bootui-spring-autoconfigure -am test` — 1,472 tests passed
- `./mvnw -Dmaven.repo.local=.m2 -B -ntp spotless:check` — passed

Focused tests prove blocked sends and blocked terminal completion do not hold publication or shutdown, preserve event ordering, disconnect on bounded-queue overflow, and clean up on completion, timeout, send failure, and shutdown.

## Screenshots (UI changes)

N/A — no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes — N/A; wire contract and configuration are unchanged
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed