### PR TITLE
Fix mobile navigation focus containment

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
@@ -104,6 +104,60 @@ test.describe('BootUI app shell', () => {
     await expect(contributeLink.locator('.bi-github')).toBeVisible()
   })
 
+  test('mobile navigation contains focus and closes without stranding it', async ({page}) => {
+    await page.setViewportSize({width: 390, height: 844})
+    await page.goto('/bootui/')
+
+    const drawer = page.locator('#bootui-mobile-navigation')
+    const toggle = page.locator('.nav-hamburger')
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+    await expect(drawer).toHaveAttribute('inert', '')
+    await expect(toggle).toHaveAttribute('aria-controls', 'bootui-mobile-navigation')
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(toggle).toHaveAccessibleName('Open navigation menu')
+
+    await page.keyboard.press('Tab')
+    await expect(toggle).toBeFocused()
+
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('button', {name: 'Close navigation menu'}).first()).toBeFocused()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    await expect(toggle).toHaveAttribute('aria-label', 'Close navigation menu')
+    await expect(drawer).not.toHaveAttribute('aria-hidden', 'true')
+    await expect(drawer).toHaveAttribute('aria-modal', 'true')
+    await expect(page.locator('.bootui-workspace')).toHaveAttribute('inert', '')
+
+    const firstDrawerLink = drawer.locator('.brand-card')
+    const lastDrawerLink = drawer.locator('.contribute-card')
+    await firstDrawerLink.focus()
+    await page.keyboard.press('Shift+Tab')
+    await expect(lastDrawerLink).toBeFocused()
+    await page.keyboard.press('Tab')
+    await expect(firstDrawerLink).toBeFocused()
+
+    await page.keyboard.press('Escape')
+    await expect(toggle).toBeFocused()
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+
+    await page.keyboard.press('Enter')
+    await expect(page.getByRole('button', {name: 'Close navigation menu'}).first()).toBeFocused()
+    const backdropBounds = await page.locator('.bootui-nav-backdrop').boundingBox()
+    if (!backdropBounds) throw new Error('Navigation backdrop is not visible')
+    await page.mouse.click(backdropBounds.x + backdropBounds.width - 4, backdropBounds.y + backdropBounds.height / 2)
+    await expect(toggle).toBeFocused()
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+
+    await page.keyboard.press('Enter')
+    const architectureLink = drawer.getByRole('link', {name: 'Architecture'})
+    await architectureLink.focus()
+    await page.keyboard.press('Enter')
+    await expect(page).toHaveURL(/#\/architecture$/)
+    await expect(page.locator('main.content-stage')).toBeFocused()
+    await expect(drawer).toHaveAttribute('aria-hidden', 'true')
+    expect(await drawer.evaluate((element) => element.contains(document.activeElement))).toBe(false)
+  })
+
   test('main content scrolls while the sidebar stays fixed', async ({page}) => {
     // A short viewport guarantees the main content overflows the window.
     await page.setViewportSize({width: 1280, height: 400})

--- a/bootui-ui/src/main/frontend/src/App.test.js
+++ b/bootui-ui/src/main/frontend/src/App.test.js
@@ -6,6 +6,7 @@ import {routes} from './routes.js'
 
 const TestPanel = {template: '<section />'}
 const namedRoutes = routes.filter((route) => route.name && route.meta?.title)
+const NARROW_QUERY = '(max-width: 991.98px)'
 
 function shellRoutes() {
   return routes.map((route) => (route.redirect ? route : {...route, component: TestPanel}))
@@ -83,7 +84,25 @@ function restoreLocalStorage() {
   }
 }
 
+function stubMatchMedia(narrow = false) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn((query) => ({
+      matches: query === NARROW_QUERY ? narrow : false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  )
+}
+
 async function mountApp(initialPath = '/overview') {
+  if (typeof window.matchMedia !== 'function') stubMatchMedia()
+  vi.resetModules()
   const {default: App} = await import('./App.vue')
   const router = createRouter({
     history: createMemoryHistory(),
@@ -162,6 +181,93 @@ describe('App sidebar navigation', () => {
 
     expect(securityToggle.attributes('aria-expanded')).toBe('true')
     expect(document.activeElement).toBe(securityToggle.element)
+  })
+
+  it('hides and disables only the closed mobile drawer', async () => {
+    stubMatchMedia(true)
+    const {wrapper} = await mountApp()
+    const drawer = wrapper.find('#bootui-mobile-navigation')
+    const toggle = wrapper.find('.nav-hamburger')
+
+    expect(drawer.attributes('aria-hidden')).toBe('true')
+    expect(drawer.attributes()).toHaveProperty('inert')
+    expect(drawer.attributes('role')).toBe('dialog')
+    expect(toggle.attributes('aria-controls')).toBe('bootui-mobile-navigation')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    expect(toggle.attributes('aria-label')).toBe('Open navigation menu')
+    expect(wrapper.find('.bootui-workspace').attributes()).not.toHaveProperty('inert')
+  })
+
+  it('leaves the desktop sidebar exposed without mobile modal restrictions', async () => {
+    const {wrapper} = await mountApp()
+    const sidebar = wrapper.find('#bootui-mobile-navigation')
+
+    expect(sidebar.attributes('aria-hidden')).toBeUndefined()
+    expect(sidebar.attributes('aria-modal')).toBeUndefined()
+    expect(sidebar.attributes('role')).toBeUndefined()
+    expect(sidebar.attributes()).not.toHaveProperty('inert')
+    expect(wrapper.find('.bootui-workspace').attributes()).not.toHaveProperty('inert')
+  })
+
+  it('contains mobile drawer focus and restores it to the toggle on Escape', async () => {
+    stubMatchMedia(true)
+    const {wrapper} = await mountApp()
+    const drawer = wrapper.find('#bootui-mobile-navigation')
+    const toggle = wrapper.find('.nav-hamburger')
+
+    toggle.element.focus()
+    await toggle.trigger('click')
+    await flushPromises()
+
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+    expect(toggle.attributes('aria-label')).toBe('Close navigation menu')
+    expect(drawer.attributes('aria-hidden')).toBeUndefined()
+    expect(drawer.attributes('aria-modal')).toBe('true')
+    expect(drawer.attributes()).not.toHaveProperty('inert')
+    expect(wrapper.find('.bootui-workspace').attributes()).toHaveProperty('inert')
+    expect(document.activeElement).toBe(wrapper.find('.sidebar-toggle').element)
+
+    const first = wrapper.find('.brand-card')
+    const last = wrapper.find('.contribute-card')
+    first.element.focus()
+    await drawer.trigger('keydown', {key: 'Tab', shiftKey: true})
+    expect(document.activeElement).toBe(last.element)
+
+    last.element.focus()
+    await drawer.trigger('keydown', {key: 'Tab'})
+    expect(document.activeElement).toBe(first.element)
+
+    await drawer.trigger('keydown', {key: 'Escape'})
+    await flushPromises()
+
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+    expect(drawer.attributes('aria-hidden')).toBe('true')
+    expect(document.activeElement).toBe(toggle.element)
+  })
+
+  it('moves focus out of the drawer after route and backdrop closure', async () => {
+    stubMatchMedia(true)
+    const {router, wrapper} = await mountApp()
+    const toggle = wrapper.find('.nav-hamburger')
+
+    toggle.element.focus()
+    await toggle.trigger('click')
+    await flushPromises()
+    await wrapper.find('.bootui-nav-backdrop').trigger('click')
+    await flushPromises()
+    expect(document.activeElement).toBe(toggle.element)
+
+    await toggle.trigger('click')
+    await flushPromises()
+    const architectureLink = wrapper.find('a[href="/architecture"]')
+    architectureLink.element.focus()
+    await architectureLink.trigger('click')
+    await flushPromises()
+
+    expect(router.currentRoute.value.name).toBe('architecture')
+    expect(wrapper.find('#bootui-mobile-navigation').attributes('aria-hidden')).toBe('true')
+    expect(document.activeElement).toBe(wrapper.find('main').element)
+    expect(wrapper.find('#bootui-mobile-navigation').element.contains(document.activeElement)).toBe(false)
   })
 })
 

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {apiFetch} from './api.js'
-import {computed, onBeforeUnmount, onMounted, provide, reactive, ref, watch} from 'vue'
+import {computed, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, watch} from 'vue'
 import {useRoute, useRouter} from 'vue-router'
 import {
   applyTheme,
@@ -33,11 +33,29 @@ const narrowMediaQuery =
   typeof window !== 'undefined' && typeof window.matchMedia === 'function' ? window.matchMedia(NARROW_QUERY) : null
 const isNarrow = ref(narrowMediaQuery?.matches === true)
 const mobileNavOpen = ref(false)
+const mobileNavRef = ref(null)
+const mobileNavCloseRef = ref(null)
+const mobileNavToggleRef = ref(null)
+const mainContentRef = ref(null)
+const mobileDrawerOpen = computed(() => isNarrow.value && mobileNavOpen.value)
+const mobileDrawerClosed = computed(() => isNarrow.value && !mobileNavOpen.value)
+const mobileNavToggleLabel = computed(() => (mobileDrawerOpen.value ? 'Close navigation menu' : 'Open navigation menu'))
+let mobileNavInvoker = null
 
-function onNarrowChange(e) {
-  isNarrow.value = e.matches === true
-  if (!isNarrow.value) {
+async function onNarrowChange(e) {
+  const becomingNarrow = e.matches === true
+  const activeElement = document.activeElement
+  const focusWasInSidebar =
+    becomingNarrow && activeElement instanceof HTMLElement && mobileNavRef.value?.contains(activeElement)
+  if (focusWasInSidebar) activeElement.blur()
+
+  isNarrow.value = becomingNarrow
+  if (!becomingNarrow) {
     mobileNavOpen.value = false
+    mobileNavInvoker = null
+  } else if (focusWasInSidebar) {
+    await nextTick()
+    mobileNavToggleRef.value?.focus()
   }
 }
 
@@ -64,9 +82,11 @@ watch(sidebarCollapsed, (v) => localStorage.setItem('bootui.sidebar.collapsed', 
 
 watch(
   () => route.name,
-  (name) => {
+  async (name) => {
     if (name) recordRecentPanel(name)
-    mobileNavOpen.value = false
+    if (mobileDrawerOpen.value) {
+      await closeMobileNav('content')
+    }
   },
   {immediate: true}
 )
@@ -79,18 +99,74 @@ function toggleSidebar() {
 
 function onSidebarToggle() {
   if (isNarrow.value) {
-    mobileNavOpen.value = false
+    dismissMobileNav()
   } else {
     toggleSidebar()
   }
 }
 
-function openMobileNav() {
+async function openMobileNav() {
+  if (!isNarrow.value || mobileNavOpen.value) return
+  mobileNavInvoker = mobileNavToggleRef.value
   mobileNavOpen.value = true
+  await nextTick()
+  mobileNavCloseRef.value?.focus()
 }
 
-function closeMobileNav() {
+async function closeMobileNav(focusTarget = 'toggle') {
+  if (!mobileDrawerOpen.value) return
+  const activeElement = document.activeElement
+  if (activeElement instanceof HTMLElement && mobileNavRef.value?.contains(activeElement)) {
+    activeElement.blur()
+  }
   mobileNavOpen.value = false
+  await nextTick()
+  const target =
+    focusTarget === 'content'
+      ? mainContentRef.value
+      : mobileNavInvoker?.isConnected
+        ? mobileNavInvoker
+        : mobileNavToggleRef.value
+  target?.focus()
+  mobileNavInvoker = null
+}
+
+function dismissMobileNav() {
+  closeMobileNav('toggle')
+}
+
+async function onSidebarLinkClick(navigate, event) {
+  const navigatingFromMobileDrawer = mobileDrawerOpen.value
+  await navigate(event)
+  if (navigatingFromMobileDrawer && mobileDrawerOpen.value) {
+    await closeMobileNav('content')
+  }
+}
+
+function onMobileNavKeydown(event) {
+  if (!mobileDrawerOpen.value) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    dismissMobileNav()
+    return
+  }
+  if (event.key !== 'Tab') return
+
+  const focusable = mobileNavRef.value?.querySelectorAll(
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  )
+  if (!focusable?.length) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement
+  if (event.shiftKey && (active === first || active === mobileNavRef.value)) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && active === last) {
+    event.preventDefault()
+    first.focus()
+  }
 }
 
 function syncTheme(theme) {
@@ -476,6 +552,13 @@ onBeforeUnmount(() => {
 })
 
 function onGlobalKeydown(e) {
+  if (mobileDrawerOpen.value) {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      dismissMobileNav()
+    }
+    return
+  }
   if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
     e.preventDefault()
     commandPaletteOpen.value = !commandPaletteOpen.value
@@ -493,7 +576,7 @@ function onGlobalKeydown(e) {
     <div class="ambient-orb ambient-orb-one"></div>
     <div class="ambient-orb ambient-orb-two"></div>
 
-    <div v-if="isNarrow && mobileNavOpen" class="bootui-nav-backdrop" @click="closeMobileNav"></div>
+    <div v-if="mobileDrawerOpen" aria-hidden="true" class="bootui-nav-backdrop" @click="dismissMobileNav"></div>
 
     <section v-if="authenticationRequired" class="authentication-gate" aria-labelledby="authentication-title">
       <div class="authentication-card">
@@ -526,28 +609,42 @@ function onGlobalKeydown(e) {
 
     <template v-else>
       <aside
+        id="bootui-mobile-navigation"
+        ref="mobileNavRef"
+        :aria-hidden="mobileDrawerClosed ? 'true' : undefined"
+        :aria-label="isNarrow ? 'Navigation menu' : undefined"
+        :aria-modal="mobileDrawerOpen ? 'true' : undefined"
         :class="{
           'bootui-sidebar--collapsed': collapsedRail,
           'bootui-sidebar--drawer': isNarrow,
-          'bootui-sidebar--open': isNarrow && mobileNavOpen
+          'bootui-sidebar--open': mobileDrawerOpen
         }"
+        :inert="mobileDrawerClosed ? true : undefined"
+        :role="isNarrow ? 'dialog' : undefined"
         class="bootui-sidebar"
+        @keydown="onMobileNavKeydown"
       >
         <div class="brand-area">
-          <router-link class="brand-card text-decoration-none" to="/overview">
-            <span class="brand-mark"><i class="bi bi-cup-hot-fill"></i></span>
-            <span class="brand-text">
-              <span class="brand-name">BootUI</span>
-              <span class="brand-subtitle">Local developer console</span>
-            </span>
+          <router-link v-slot="{href, navigate}" custom to="/overview">
+            <a :href="href" class="brand-card text-decoration-none" @click="onSidebarLinkClick(navigate, $event)">
+              <span class="brand-mark"><i class="bi bi-cup-hot-fill"></i></span>
+              <span class="brand-text">
+                <span class="brand-name">BootUI</span>
+                <span class="brand-subtitle">Local developer console</span>
+              </span>
+            </a>
           </router-link>
           <button
+            ref="mobileNavCloseRef"
+            :aria-label="isNarrow ? 'Close navigation menu' : sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
             class="sidebar-toggle"
             :title="isNarrow ? 'Close menu' : sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+            type="button"
             @click="onSidebarToggle"
           >
             <i
               :class="isNarrow ? 'bi-x-lg' : sidebarCollapsed ? 'bi-chevron-double-right' : 'bi-chevron-double-left'"
+              aria-hidden="true"
               class="bi"
             ></i>
           </button>
@@ -612,7 +709,7 @@ function onGlobalKeydown(e) {
                   :href="href"
                   :title="routeAvailabilityLabel(r)"
                   class="nav-link bootui-nav-link"
-                  @click="navigate"
+                  @click="onSidebarLinkClick(navigate, $event)"
                 >
                   <i :class="['bi', r.meta.icon]"></i>
                   <span class="bootui-nav-link__label">{{ navTitle(r) }}</span>
@@ -692,11 +789,19 @@ function onGlobalKeydown(e) {
         </div>
       </transition>
 
-      <div class="bootui-workspace">
+      <div :inert="mobileDrawerOpen ? true : undefined" class="bootui-workspace">
         <header class="topbar">
           <div class="topbar-lead">
-            <button class="nav-hamburger" type="button" aria-label="Open navigation menu" @click="openMobileNav">
-              <i class="bi bi-list"></i>
+            <button
+              ref="mobileNavToggleRef"
+              :aria-expanded="mobileDrawerOpen"
+              :aria-label="mobileNavToggleLabel"
+              aria-controls="bootui-mobile-navigation"
+              class="nav-hamburger"
+              type="button"
+              @click="openMobileNav"
+            >
+              <i aria-hidden="true" class="bi bi-list"></i>
             </button>
             <div class="topbar-heading">
               <div class="eyebrow">Inspecting</div>
@@ -731,7 +836,7 @@ function onGlobalKeydown(e) {
           </div>
         </header>
 
-        <main class="content-stage">
+        <main ref="mainContentRef" class="content-stage" tabindex="-1">
           <div
             v-if="shellErrorMessage"
             :class="['alert', shellServerUnreachable ? 'alert-warning' : 'alert-danger']"


### PR DESCRIPTION
## Summary

- make the mobile navigation drawer inert and hidden from assistive technology while closed, without changing the desktop sidebar
- add complete toggle semantics plus modal focus entry, containment, Escape/backdrop dismissal, route focus handoff, and invoking-toggle restoration
- cover the behavior with focused Vue tests and mobile Chromium keyboard flows

## Validation

- `cd bootui-ui/src/main/frontend && npm test` — 75 files, 520 tests passed
- `cd bootui-ui/src/main/frontend && npm run build`
- `cd bootui-ui/src/main/frontend && npm run format:check`
- `cd bootui-spring-sample-app/e2e && npm run format:check`
- `./mvnw -B -ntp spotless:check`
- `./mvnw -Dmaven.repo.local=.m2 -B -ntp -pl bootui-spring-sample-app -am -DskipTests install`
- `cd bootui-spring-sample-app/e2e && SERVER_PORT=18080 BOOTUI_SAMPLE_PORT=18080 BOOTUI_MAVEN_REPO_LOCAL=../../.m2 npm test -- tests/app-shell.spec.js` — 9 tests passed
- Impeccable detector on `App.vue` — clean