### PR TITLE
Label frontend form controls for assistive technology

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/http-probe.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/http-probe.spec.js
@@ -5,8 +5,8 @@ test.describe('HTTP Probe view', () => {
   test('sends a GET request to the sample API and shows the response body', async ({openView, page}) => {
     await openView('http-probe', 'HTTP Probe')
 
-    await page.locator('select.form-select').selectOption('GET')
-    await page.getByPlaceholder('/api/sample/hello').fill('/api/hello')
+    await page.getByLabel('Method').selectOption('GET')
+    await page.getByLabel('Path').fill('/api/hello')
     await page.locator('button.btn-primary', {hasText: 'Send'}).click()
 
     const responseCard = page.locator('.card', {hasText: /^Response/})
@@ -19,9 +19,9 @@ test.describe('HTTP Probe view', () => {
     await openView('http-probe', 'HTTP Probe')
 
     await expect(page.locator('textarea')).toHaveCount(0)
-    await page.locator('select.form-select').selectOption('POST')
-    await expect(page.locator('textarea')).toBeVisible()
-    await page.locator('textarea').fill('{"message":"hello"}')
+    await page.getByLabel('Method').selectOption('POST')
+    await expect(page.getByLabel('Request body')).toBeVisible()
+    await page.getByLabel('Request body').fill('{"message":"hello"}')
     await expect(page.locator('.form-text', {hasText: 'Content-Type:'})).toBeVisible()
   })
 
@@ -31,8 +31,8 @@ test.describe('HTTP Probe view', () => {
       if (request.url().endsWith('/bootui/api/http-probe')) probeRequests.push(request)
     })
     await openView('http-probe', 'HTTP Probe')
-    await page.locator('select.form-select').selectOption('DELETE')
-    const path = page.getByPlaceholder('/api/sample/hello')
+    await page.getByLabel('Method').selectOption('DELETE')
+    const path = page.getByLabel('Path')
     await path.fill('/api/hello')
 
     await path.press('Enter')
@@ -47,14 +47,27 @@ test.describe('HTTP Probe view', () => {
   test('clear resets the form back to defaults', async ({openView, page}) => {
     await openView('http-probe', 'HTTP Probe')
 
-    await page.locator('select.form-select').selectOption('POST')
-    await page.getByPlaceholder('/api/sample/hello').fill('/something')
-    await page.locator('textarea').fill('{"k":1}')
+    await page.getByLabel('Method').selectOption('POST')
+    await page.getByLabel('Path').fill('/something')
+    await page.getByLabel('Request body').fill('{"k":1}')
 
     await page.getByRole('button', {name: /Clear/}).click()
 
-    await expect(page.locator('select.form-select')).toHaveValue('GET')
-    await expect(page.getByPlaceholder('/api/sample/hello')).toHaveValue('')
-    await expect(page.locator('textarea')).toHaveCount(0)
+    await expect(page.getByLabel('Method')).toHaveValue('GET')
+    await expect(page.getByLabel('Path')).toHaveValue('')
+    await expect(page.getByLabel('Request body')).toHaveCount(0)
+  })
+
+  test('keeps form controls programmatically named in dark mode', async ({openView, page}) => {
+    await openView('http-probe', 'HTTP Probe')
+    await page.evaluate(() => {
+      document.documentElement.dataset.bootuiTheme = 'dark'
+    })
+
+    await expect(page.getByLabel('Method')).toBeVisible()
+    await expect(page.getByLabel('Path')).toBeVisible()
+
+    await page.getByLabel('Method').selectOption('POST')
+    await expect(page.getByLabel('Request body')).toBeVisible()
   })
 })

--- a/bootui-ui/src/main/frontend/src/accessibility.test.js
+++ b/bootui-ui/src/main/frontend/src/accessibility.test.js
@@ -1,0 +1,190 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {parse as parseTemplate} from '@vue/compiler-dom'
+import {parse as parseSfc} from '@vue/compiler-sfc'
+import {describe, expect, it} from 'vitest'
+
+const sourceRoot = path.dirname(fileURLToPath(import.meta.url))
+const formControlTags = new Set(['input', 'select', 'textarea'])
+const staticallyEmptyExpressions = new Set(["''", '""', '``', 'null', 'undefined', 'false'])
+
+function vueFiles(directory) {
+  return fs.readdirSync(directory, {withFileTypes: true}).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      return vueFiles(entryPath)
+    }
+    return entry.name.endsWith('.vue') ? [entryPath] : []
+  })
+}
+
+function attributeKey(node, name) {
+  for (const property of node.props) {
+    if (property.type === 6 && property.name === name && property.value?.content) {
+      return `static:${property.value.content}`
+    }
+    if (
+      property.type === 7 &&
+      property.name === 'bind' &&
+      property.arg?.type === 4 &&
+      property.arg.content === name &&
+      property.exp?.type === 4 &&
+      expressionCanProvideText(property.exp.content)
+    ) {
+      return `dynamic:${property.exp.content}`
+    }
+  }
+  return null
+}
+
+function expressionCanProvideText(expression) {
+  const normalized = expression?.trim()
+  return Boolean(normalized) && !staticallyEmptyExpressions.has(normalized)
+}
+
+function hasNonEmptyAttribute(node, name) {
+  return node.props.some(
+    (property) =>
+      (property.type === 6 && property.name === name && property.value?.content.trim()) ||
+      (property.type === 7 &&
+        property.name === 'bind' &&
+        property.arg?.type === 4 &&
+        property.arg.content === name &&
+        expressionCanProvideText(property.exp?.content))
+  )
+}
+
+function staticAttribute(node, name) {
+  return node.props.find((property) => property.type === 6 && property.name === name)?.value?.content
+}
+
+function hasAccessibleText(node) {
+  if (node.type === 2) {
+    return Boolean(node.content.trim())
+  }
+  if (node.type === 5) {
+    return expressionCanProvideText(node.content.content)
+  }
+  if (node.type !== 1 || staticAttribute(node, 'aria-hidden') === 'true') {
+    return false
+  }
+  if (hasNonEmptyAttribute(node, 'aria-label')) {
+    return true
+  }
+  return node.children.some(hasAccessibleText)
+}
+
+function inspectTemplate(template, lineOffset = 0) {
+  const labels = []
+  const controls = []
+  const elements = []
+  const ast = parseTemplate(template)
+
+  function visit(node, ancestors = []) {
+    if (node.type === 1) {
+      elements.push(node)
+      if (node.tag === 'label') {
+        labels.push(node)
+      }
+      if (formControlTags.has(node.tag)) {
+        controls.push({node, ancestors})
+      }
+      node.children.forEach((child) => visit(child, [...ancestors, node]))
+      return
+    }
+    node.children?.forEach((child) => visit(child, ancestors))
+  }
+
+  visit(ast)
+  const elementsById = Map.groupBy(
+    elements.filter((element) => attributeKey(element, 'id')),
+    (element) => attributeKey(element, 'id')
+  )
+  const labelTargets = new Set(
+    labels
+      .filter(hasAccessibleText)
+      .map((label) => attributeKey(label, 'for'))
+      .filter(Boolean)
+  )
+  const duplicateIds = [...elementsById]
+    .filter(([, matchingElements]) => matchingElements.length > 1)
+    .map(([id, matchingElements]) => `line ${lineOffset + matchingElements[0].loc.start.line}: duplicate id ${id}`)
+
+  function hasValidLabelledBy(node) {
+    const labelledBy = node.props.find(
+      (property) =>
+        (property.type === 6 && property.name === 'aria-labelledby') ||
+        (property.type === 7 &&
+          property.name === 'bind' &&
+          property.arg?.type === 4 &&
+          property.arg.content === 'aria-labelledby')
+    )
+    if (!labelledBy) {
+      return false
+    }
+    const targetIds =
+      labelledBy.type === 6
+        ? (labelledBy.value?.content.split(/\s+/).filter(Boolean) ?? []).map((id) => `static:${id}`)
+        : [attributeKey(node, 'aria-labelledby')].filter(Boolean)
+    return targetIds.some((id) => elementsById.get(id)?.some(hasAccessibleText))
+  }
+
+  const unnamedControls = controls
+    .filter(({node}) => !(node.tag === 'input' && staticAttribute(node, 'type') === 'hidden'))
+    .filter(({node, ancestors}) => {
+      const id = attributeKey(node, 'id')
+      return !(
+        hasNonEmptyAttribute(node, 'aria-label') ||
+        hasValidLabelledBy(node) ||
+        ancestors.some((ancestor) => ancestor.tag === 'label' && hasAccessibleText(ancestor)) ||
+        (id && labelTargets.has(id))
+      )
+    })
+    .map(({node}) => `line ${lineOffset + node.loc.start.line}: unnamed <${node.tag}>`)
+
+  return [...duplicateIds, ...unnamedControls]
+}
+
+describe('frontend accessibility', () => {
+  it('gives every native form control an accessible name', () => {
+    const unnamedControls = vueFiles(sourceRoot).flatMap((file) => {
+      const {descriptor} = parseSfc(fs.readFileSync(file, 'utf8'), {filename: file})
+      if (!descriptor.template) {
+        return []
+      }
+      return inspectTemplate(descriptor.template.content, descriptor.template.loc.start.line - 1).map(
+        (issue) => `${path.relative(sourceRoot, file)}:${issue}`
+      )
+    })
+
+    expect(unnamedControls).toEqual([])
+  })
+
+  it.each([
+    ['placeholder-only controls', '<input placeholder="Filter items">'],
+    ['empty labels', '<label for="filter"></label><input id="filter">'],
+    [
+      'broken aria-labelledby references',
+      '<span id="filter-label">Filter items</span><input aria-labelledby="missing-label">'
+    ],
+    ['statically empty dynamic aria-labels', `<input :aria-label="''">`],
+    ['statically empty interpolated labels', `<label for="filter">{{ '' }}</label><input id="filter">`],
+    [
+      'statically empty dynamic aria-labelledby references',
+      `<span :id="''">Filter items</span><input :aria-labelledby="''">`
+    ]
+  ])('rejects %s', (_description, template) => {
+    expect(inspectTemplate(template)).toHaveLength(1)
+  })
+
+  it('rejects duplicate ids', () => {
+    expect(
+      inspectTemplate('<label for="filter">Filter</label><input id="filter"><span id="filter">Help</span>')
+    ).toEqual(['line 1: duplicate id static:filter'])
+  })
+
+  it('accepts matching dynamic label associations', () => {
+    expect(inspectTemplate('<label :for="inputId">Auto-refresh</label><input :id="inputId">')).toEqual([])
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -528,7 +528,12 @@ const detectedFrameworkLabel = computed(() => {
           <div class="card-body">
             <div class="d-flex justify-content-between align-items-center mb-2">
               <h6 class="mb-0">Token usage (last {{ series.minutes }} min)</h6>
-              <select v-model="windowMinutes" class="form-select form-select-sm w-auto" @change="onWindowChange">
+              <select
+                v-model="windowMinutes"
+                aria-label="Token usage time window"
+                class="form-select form-select-sm w-auto"
+                @change="onWindowChange"
+              >
                 <option :value="15">15 min</option>
                 <option :value="60">60 min</option>
                 <option :value="240">240 min</option>
@@ -677,25 +682,34 @@ const detectedFrameworkLabel = computed(() => {
           <div class="col-md-4">
             <input
               v-model="tableSearch"
+              aria-label="Search recent chats"
               class="form-control form-control-sm"
               placeholder="Search model, provider, span…"
               type="search"
             />
           </div>
           <div class="col-md-2">
-            <select v-model="providerFilter" class="form-select form-select-sm">
+            <select
+              v-model="providerFilter"
+              aria-label="Filter recent chats by provider"
+              class="form-select form-select-sm"
+            >
               <option value="">All providers</option>
               <option v-for="p in distinctProviders" :key="p" :value="p">{{ p }}</option>
             </select>
           </div>
           <div class="col-md-3">
-            <select v-model="modelFilter" class="form-select form-select-sm">
+            <select v-model="modelFilter" aria-label="Filter recent chats by model" class="form-select form-select-sm">
               <option value="">All models</option>
               <option v-for="m in distinctModels" :key="m" :value="m">{{ m }}</option>
             </select>
           </div>
           <div class="col-md-2">
-            <select v-model="statusFilter" class="form-select form-select-sm">
+            <select
+              v-model="statusFilter"
+              aria-label="Filter recent chats by status"
+              class="form-select form-select-sm"
+            >
               <option value="">All statuses</option>
               <option value="OK">OK</option>
               <option value="ERROR">ERROR</option>

--- a/bootui-ui/src/main/frontend/src/views/Beans.vue
+++ b/bootui-ui/src/main/frontend/src/views/Beans.vue
@@ -46,10 +46,10 @@ watch([filter, classification], scheduleReload)
 
     <div class="row g-2 mb-3">
       <div class="col-md-8">
-        <input v-model="filter" class="form-control" placeholder="Filter by name or type…" />
+        <input v-model="filter" aria-label="Filter beans" class="form-control" placeholder="Filter by name or type…" />
       </div>
       <div class="col-md-4">
-        <select v-model="classification" class="form-select">
+        <select v-model="classification" aria-label="Filter beans by classification" class="form-select">
           <option value="">All classifications</option>
           <option value="APPLICATION">Application</option>
           <option value="FRAMEWORK">Framework</option>

--- a/bootui-ui/src/main/frontend/src/views/Conditions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.vue
@@ -170,7 +170,7 @@ onBeforeUnmount(() => {
         </a>
       </li>
     </ul>
-    <input v-model="filter" class="form-control mb-3" placeholder="Filter…" />
+    <input v-model="filter" aria-label="Filter conditions" class="form-control mb-3" placeholder="Filter…" />
     <p class="small text-muted">{{ matchedCount }} of {{ totalCount }} {{ tab }} entries matched</p>
     <div v-for="e in entries" :key="e.autoConfigurationClass + e.condition + e.message" class="mb-2">
       <div class="d-flex">

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -347,11 +347,16 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
       <div class="col-md-6">
         <div class="input-group">
           <span class="input-group-text"><i class="bi bi-search"></i></span>
-          <input v-model="filter" class="form-control" placeholder="Filter by name or value…" />
+          <input
+            v-model="filter"
+            aria-label="Filter configuration properties"
+            class="form-control"
+            placeholder="Filter by name or value…"
+          />
         </div>
       </div>
       <div class="col-md-4">
-        <select v-if="data" v-model="sourceFilter" class="form-select">
+        <select v-if="data" v-model="sourceFilter" aria-label="Filter by property source" class="form-select">
           <option value="">All property sources</option>
           <option v-for="s in data.sources" :key="s" :value="s">{{ s }}</option>
         </select>
@@ -388,6 +393,7 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
               <input
                 ref="newNameInput"
                 v-model="newRowName"
+                aria-label="New configuration property name"
                 :disabled="readOnly"
                 class="form-control form-control-sm font-monospace"
                 list="bootPropertySuggestions"
@@ -429,6 +435,7 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
               <div class="input-group input-group-sm">
                 <input
                   v-model="newRowValue"
+                  aria-label="New configuration property value"
                   :disabled="readOnly"
                   :placeholder="
                     hasDefaultValue(selectedNewSuggestion)
@@ -487,6 +494,7 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
                 <input
                   ref="editInput"
                   v-model="editedValue"
+                  :aria-label="`Edit value for ${p.name}`"
                   :disabled="readOnly"
                   class="form-control form-control-sm font-monospace"
                   @keyup.enter="saveEdit(p)"

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -997,14 +997,19 @@ watch(
 
                 <div class="row g-2 mb-3 align-items-end">
                   <div class="col-md-4">
-                    <label class="form-label">Category</label>
-                    <select v-model="categoryFilter" class="form-select">
+                    <label class="form-label" for="copilot-category-filter">Category</label>
+                    <select id="copilot-category-filter" v-model="categoryFilter" class="form-select">
                       <option v-for="cat in categories" :key="cat" :value="cat">{{ cat }}</option>
                     </select>
                   </div>
                   <div class="col-md-6">
-                    <label class="form-label">Filter</label>
-                    <input v-model="textFilter" class="form-control" placeholder="Tool name, summary, or type…" />
+                    <label class="form-label" for="copilot-text-filter">Filter</label>
+                    <input
+                      id="copilot-text-filter"
+                      v-model="textFilter"
+                      class="form-control"
+                      placeholder="Tool name, summary, or type…"
+                    />
                   </div>
                   <div class="col-md-2 text-end small text-muted">
                     {{ filteredEvents.length }} / {{ detail.recentEvents.length }}

--- a/bootui-ui/src/main/frontend/src/views/Data.vue
+++ b/bootui-ui/src/main/frontend/src/views/Data.vue
@@ -107,10 +107,15 @@ onMounted(load)
     <template v-else-if="report">
       <div class="row g-2 mb-3">
         <div class="col-md-6">
-          <input v-model="filter" class="form-control" placeholder="Filter by interface, entity, or bean name…" />
+          <input
+            v-model="filter"
+            aria-label="Filter repositories"
+            class="form-control"
+            placeholder="Filter by interface, entity, or bean name…"
+          />
         </div>
         <div class="col-md-3">
-          <select v-model="storeFilter" class="form-select">
+          <select v-model="storeFilter" aria-label="Filter repositories by store" class="form-select">
             <option value="">All stores</option>
             <option v-for="s in stores" :key="s" :value="s">{{ s }}</option>
           </select>

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -246,7 +246,12 @@ async function responseMessage(res) {
     <template v-else-if="report">
       <div class="row g-2 mb-3">
         <div class="col-md-8">
-          <input v-model="filter" class="form-control" placeholder="Filter by name, type, status, or image…" />
+          <input
+            v-model="filter"
+            aria-label="Filter dev services"
+            class="form-control"
+            placeholder="Filter by name, type, status, or image…"
+          />
         </div>
         <div class="col-md-4 text-end small text-muted align-self-center">
           {{ filtered.length }} / {{ report.total }} services

--- a/bootui-ui/src/main/frontend/src/views/Email.vue
+++ b/bootui-ui/src/main/frontend/src/views/Email.vue
@@ -180,6 +180,7 @@ function downloadUrl(id) {
           <div class="mb-3">
             <input
               v-model="filter"
+              aria-label="Filter captured emails"
               class="form-control form-control-sm"
               placeholder="Filter by sender, recipient, or subject…"
             />

--- a/bootui-ui/src/main/frontend/src/views/Exceptions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Exceptions.vue
@@ -255,6 +255,7 @@ onMounted(() => {
             <div class="col-lg-6">
               <input
                 v-model="filter"
+                aria-label="Filter exception groups"
                 class="form-control form-control-sm"
                 placeholder="Filter by exception type, message, or location…"
               />

--- a/bootui-ui/src/main/frontend/src/views/Flyway.vue
+++ b/bootui-ui/src/main/frontend/src/views/Flyway.vue
@@ -135,7 +135,12 @@ onMounted(load)
 
       <div class="row g-2 mb-3">
         <div class="col-md-6">
-          <input v-model="filter" class="form-control" placeholder="Filter by version, description, or script…" />
+          <input
+            v-model="filter"
+            aria-label="Filter migrations"
+            class="form-control"
+            placeholder="Filter by version, description, or script…"
+          />
         </div>
         <div class="col-md-6 text-end small text-muted align-self-center">
           {{ report.total }} migration(s) across {{ report.databases.length }} database(s)

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.vue
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.vue
@@ -319,6 +319,7 @@ onBeforeUnmount(() => {
                 <input
                   v-model="filter"
                   :disabled="!hasHistogram"
+                  aria-label="Filter heap histogram classes"
                   class="form-control form-control-sm"
                   style="width: 220px"
                   type="text"

--- a/bootui-ui/src/main/frontend/src/views/HttpExchanges.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpExchanges.vue
@@ -159,12 +159,17 @@ onMounted(() => {
 
     <div class="row g-2 mb-3">
       <div class="col-lg-6">
-        <label class="form-label">Path or trace filter</label>
-        <input v-model="filter" class="form-control" placeholder="Filter by path, query, URL, or trace id…" />
+        <label class="form-label" for="http-exchanges-filter">Path or trace filter</label>
+        <input
+          id="http-exchanges-filter"
+          v-model="filter"
+          class="form-control"
+          placeholder="Filter by path, query, URL, or trace id…"
+        />
       </div>
       <div class="col-sm-6 col-lg-3">
-        <label class="form-label">Method</label>
-        <select v-model="method" class="form-select">
+        <label class="form-label" for="http-exchanges-method">Method</label>
+        <select id="http-exchanges-method" v-model="method" class="form-select">
           <option value="">All methods</option>
           <option>GET</option>
           <option>POST</option>
@@ -176,8 +181,8 @@ onMounted(() => {
         </select>
       </div>
       <div class="col-sm-6 col-lg-3">
-        <label class="form-label">Status</label>
-        <select v-model="statusClass" class="form-select">
+        <label class="form-label" for="http-exchanges-status">Status</label>
+        <select id="http-exchanges-status" v-model="statusClass" class="form-select">
           <option value="">All statuses</option>
           <option value="2xx">2xx success</option>
           <option value="3xx">3xx redirect</option>

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -154,8 +154,8 @@ function clearForm() {
       <div class="card-body">
         <div class="row g-3 align-items-start">
           <div class="col-md-3 col-lg-2">
-            <label class="form-label">Method</label>
-            <select v-model="method" class="form-select">
+            <label class="form-label" for="http-probe-method">Method</label>
+            <select id="http-probe-method" v-model="method" class="form-select">
               <option value="GET">GET</option>
               <option value="HEAD">HEAD</option>
               <option value="POST">POST</option>
@@ -165,8 +165,9 @@ function clearForm() {
             </select>
           </div>
           <div class="col-md-9 col-lg-10">
-            <label class="form-label">Path</label>
+            <label class="form-label" for="http-probe-path">Path</label>
             <input
+              id="http-probe-path"
               v-model="path"
               class="form-control font-monospace"
               placeholder="/api/sample/hello"
@@ -177,8 +178,9 @@ function clearForm() {
         </div>
 
         <div v-if="showRequestBody" class="mt-3">
-          <label class="form-label">Request body</label>
+          <label class="form-label" for="http-probe-body">Request body</label>
           <textarea
+            id="http-probe-body"
             v-model="requestBody"
             class="form-control font-monospace"
             placeholder='{

--- a/bootui-ui/src/main/frontend/src/views/JvmTuning.vue
+++ b/bootui-ui/src/main/frontend/src/views/JvmTuning.vue
@@ -138,12 +138,15 @@ async function copyKubernetesYaml() {
 
           <div class="row g-3 mb-3">
             <div class="col-md-5">
-              <label class="form-label small fw-semibold">Target JVM process memory (MB)</label>
+              <label class="form-label small fw-semibold" for="jvm-target-memory">
+                Target JVM process memory (MB)
+              </label>
               <div class="input-group input-group-sm">
                 <button aria-label="Decrease" class="btn btn-outline-secondary" type="button" @click="stepTotal(-64)">
                   −
                 </button>
                 <input
+                  id="jvm-target-memory"
                   v-model.number="totalMemoryMb"
                   class="form-control text-center"
                   max="65536"
@@ -158,11 +161,12 @@ async function copyKubernetesYaml() {
               </div>
             </div>
             <div class="col-md-4">
-              <label class="form-label small fw-semibold">
+              <label class="form-label small fw-semibold" for="jvm-thread-budget">
                 Platform thread budget
                 <span class="text-muted fw-normal"> (currently {{ data.calculation.liveThreadCount }}) </span>
               </label>
               <input
+                id="jvm-thread-budget"
                 v-model.number="threadCount"
                 class="form-control form-control-sm"
                 max="10000"
@@ -172,8 +176,9 @@ async function copyKubernetesYaml() {
               />
             </div>
             <div class="col-md-3">
-              <label class="form-label small fw-semibold">Headroom (%)</label>
+              <label class="form-label small fw-semibold" for="jvm-headroom">Headroom (%)</label>
               <input
+                id="jvm-headroom"
                 v-model.number="headRoomPercent"
                 class="form-control form-control-sm"
                 max="30"

--- a/bootui-ui/src/main/frontend/src/views/Liquibase.vue
+++ b/bootui-ui/src/main/frontend/src/views/Liquibase.vue
@@ -144,6 +144,7 @@ onMounted(load)
         <div class="col-md-6">
           <input
             v-model="filter"
+            aria-label="Filter change sets"
             class="form-control"
             placeholder="Filter by id, author, change-log, or description…"
           />

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
@@ -801,25 +801,25 @@ function clearFilters() {
 
       <div class="d-flex flex-wrap align-items-end gap-2 mb-3">
         <div class="activity-text-filter">
-          <label class="form-label small mb-1">Filter</label>
+          <label class="form-label small mb-1" for="activity-text-filter">Filter</label>
           <input
+            id="activity-text-filter"
             v-model="textFilter"
             type="search"
             class="form-control form-control-sm"
             placeholder="Path, status, SQL, exception…"
-            aria-label="Free-text activity filter"
           />
         </div>
         <div>
-          <label class="form-label small mb-1">Type</label>
-          <select v-model="typeFilter" class="form-select form-select-sm">
+          <label class="form-label small mb-1" for="activity-type-filter">Type</label>
+          <select id="activity-type-filter" v-model="typeFilter" class="form-select form-select-sm">
             <option value="">All types</option>
             <option v-for="type in TYPES" :key="type" :value="type">{{ type }}</option>
           </select>
         </div>
         <div>
-          <label class="form-label small mb-1">Severity</label>
-          <select v-model="severityFilter" class="form-select form-select-sm">
+          <label class="form-label small mb-1" for="activity-severity-filter">Severity</label>
+          <select id="activity-severity-filter" v-model="severityFilter" class="form-select form-select-sm">
             <option value="">All severities</option>
             <option v-for="severity in SEVERITIES" :key="severity" :value="severity">{{ severity }}</option>
           </select>

--- a/bootui-ui/src/main/frontend/src/views/LogTail.vue
+++ b/bootui-ui/src/main/frontend/src/views/LogTail.vue
@@ -133,12 +133,17 @@ onBeforeUnmount(() => disconnect(false))
 
     <div class="row g-3 mb-3 align-items-end">
       <div class="col-lg-4">
-        <label class="form-label">Filter</label>
-        <input v-model="textFilter" class="form-control" placeholder="Logger prefix or message text" />
+        <label class="form-label" for="log-tail-text-filter">Filter</label>
+        <input
+          id="log-tail-text-filter"
+          v-model="textFilter"
+          class="form-control"
+          placeholder="Logger prefix or message text"
+        />
       </div>
       <div class="col-sm-4 col-lg-2">
-        <label class="form-label">Level</label>
-        <select v-model="levelFilter" class="form-select">
+        <label class="form-label" for="log-tail-level-filter">Level</label>
+        <select id="log-tail-level-filter" v-model="levelFilter" class="form-select">
           <option value="ALL">All</option>
           <option value="INFO+">Info+</option>
           <option value="WARN+">Warn+</option>

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -75,7 +75,12 @@ watch(filter, scheduleReload)
     <PanelHeader icon="bi-journal-text" title="Loggers" :error="error" />
     <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Logger levels are read-only.</ReadOnlyNotice>
     <FlashBanner :message="message" @dismiss="clear" />
-    <input v-model="filter" class="form-control mb-3" placeholder="Filter loggers by name…" />
+    <input
+      v-model="filter"
+      aria-label="Filter loggers"
+      class="form-control mb-3"
+      placeholder="Filter loggers by name…"
+    />
     <p v-if="data" class="small text-muted">{{ matchedCount }} of {{ totalCount }} loggers matched</p>
     <div class="table-responsive">
       <table class="table table-sm table-hover loggers-table">

--- a/bootui-ui/src/main/frontend/src/views/Mappings.vue
+++ b/bootui-ui/src/main/frontend/src/views/Mappings.vue
@@ -44,7 +44,7 @@ watch(filter, scheduleReload)
 <template>
   <div>
     <PanelHeader icon="bi-signpost-2" title="HTTP mappings" :error="error" />
-    <input v-model="filter" class="form-control mb-3" placeholder="Filter…" />
+    <input v-model="filter" aria-label="Filter HTTP mappings" class="form-control mb-3" placeholder="Filter…" />
     <p class="small text-muted">{{ matchedCount }} of {{ totalCount }} mappings matched</p>
     <div class="table-responsive">
       <table class="table table-sm table-hover">

--- a/bootui-ui/src/main/frontend/src/views/Metrics.vue
+++ b/bootui-ui/src/main/frontend/src/views/Metrics.vue
@@ -214,8 +214,13 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
               <div class="text-muted small">{{ filteredMeters.length }} of {{ data.total }} meters</div>
             </div>
             <div class="card-body border-bottom">
-              <input v-model="search" class="form-control form-control-sm mb-2" placeholder="Search meters" />
-              <select v-model="typeFilter" class="form-select form-select-sm">
+              <input
+                v-model="search"
+                aria-label="Search meters"
+                class="form-control form-control-sm mb-2"
+                placeholder="Search meters"
+              />
+              <select v-model="typeFilter" aria-label="Filter meters by type" class="form-select form-select-sm">
                 <option value="">All meter types</option>
                 <option v-for="type in metricTypes" :key="type" :value="type">{{ type }}</option>
               </select>
@@ -256,8 +261,13 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
             <div class="card-body">
               <div class="row g-3 align-items-stretch">
                 <div class="col-md-4">
-                  <label class="form-label small text-muted">Statistic</label>
-                  <select :value="selectedStatistic" class="form-select" @change="changeStatistic">
+                  <label class="form-label small text-muted" for="metric-statistic">Statistic</label>
+                  <select
+                    id="metric-statistic"
+                    :value="selectedStatistic"
+                    class="form-select"
+                    @change="changeStatistic"
+                  >
                     <option
                       v-for="measurement in detail.measurements"
                       :key="measurement.statistic"

--- a/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
+++ b/bootui-ui/src/main/frontend/src/views/ProfileDiff.vue
@@ -63,7 +63,12 @@ onMounted(load)
         <span v-else class="text-muted small">(none)</span>
       </div>
 
-      <input v-model="filter" class="form-control mb-3" placeholder="Filter by property name or value…" />
+      <input
+        v-model="filter"
+        aria-label="Filter profile differences"
+        class="form-control mb-3"
+        placeholder="Filter by property name or value…"
+      />
 
       <div v-if="filteredSources.length === 0" class="alert alert-info">
         <i class="bi bi-info-circle me-1"></i>

--- a/bootui-ui/src/main/frontend/src/views/RestClientTrace.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestClientTrace.vue
@@ -373,7 +373,11 @@ function clearTrace() {
               Recent calls <span class="badge bg-secondary">{{ filteredEntries.length }}</span>
             </h5>
             <div class="d-flex flex-wrap gap-2">
-              <select v-model="methodFilter" class="form-select form-select-sm rest-filter-select">
+              <select
+                v-model="methodFilter"
+                aria-label="Filter recent calls by HTTP method"
+                class="form-select form-select-sm rest-filter-select"
+              >
                 <option value="">All methods</option>
                 <option v-for="method in methods" :key="method" :value="method">{{ method }}</option>
               </select>
@@ -389,6 +393,7 @@ function clearTrace() {
               </div>
               <input
                 v-model="filter"
+                aria-label="Filter recent REST client calls"
                 class="form-control form-control-sm trace-filter"
                 placeholder="Filter by URI, host, method, client, or thread…"
               />

--- a/bootui-ui/src/main/frontend/src/views/Scheduled.vue
+++ b/bootui-ui/src/main/frontend/src/views/Scheduled.vue
@@ -86,7 +86,12 @@ function formatExpression(task) {
     <template v-else-if="report">
       <div class="row g-2 mb-3">
         <div class="col-md-8">
-          <input v-model="filter" class="form-control" placeholder="Filter by runnable name or expression…" />
+          <input
+            v-model="filter"
+            aria-label="Filter scheduled tasks"
+            class="form-control"
+            placeholder="Filter by runnable name or expression…"
+          />
         </div>
         <div class="col-md-4 text-end small text-muted align-self-center">
           {{ filtered.length }} / {{ report.total }} tasks

--- a/bootui-ui/src/main/frontend/src/views/SpringCache.vue
+++ b/bootui-ui/src/main/frontend/src/views/SpringCache.vue
@@ -227,6 +227,7 @@ function showReadOnlyMessage() {
           </h5>
           <input
             v-model="cacheFilter"
+            aria-label="Filter caches"
             class="form-control form-control-sm cache-filter"
             placeholder="Filter by manager, cache, or implementation…"
           />
@@ -296,6 +297,7 @@ function showReadOnlyMessage() {
           </h5>
           <input
             v-model="operationFilter"
+            aria-label="Filter cache operations"
             class="form-control form-control-sm cache-filter"
             placeholder="Filter by bean, method, operation, or cache…"
           />

--- a/bootui-ui/src/main/frontend/src/views/SpringSecurity.vue
+++ b/bootui-ui/src/main/frontend/src/views/SpringSecurity.vue
@@ -312,6 +312,7 @@ onMounted(() => {
       <template v-else-if="endpoints">
         <input
           v-model="endpointFilter"
+          aria-label="Filter secured endpoints"
           class="form-control form-control-sm mb-2"
           placeholder="Filter by pattern, method, handler, or rule…"
         />
@@ -382,13 +383,19 @@ onMounted(() => {
       </p>
       <div class="row g-2 mb-3">
         <div class="col-auto">
-          <select v-model="explainMethod" class="form-select form-select-sm" style="width: auto">
+          <select
+            v-model="explainMethod"
+            aria-label="HTTP method to explain"
+            class="form-select form-select-sm"
+            style="width: auto"
+          >
             <option v-for="m in httpMethods" :key="m" :value="m">{{ m }}</option>
           </select>
         </div>
         <div class="col">
           <input
             v-model="explainPath"
+            aria-label="Request path to explain"
             class="form-control form-control-sm"
             placeholder="/api/example"
             @keyup.enter="explain"

--- a/bootui-ui/src/main/frontend/src/views/SqlTrace.vue
+++ b/bootui-ui/src/main/frontend/src/views/SqlTrace.vue
@@ -341,7 +341,11 @@ function clearTrace() {
               Recent executions <span class="badge bg-secondary">{{ filteredEntries.length }}</span>
             </h5>
             <div class="d-flex flex-wrap gap-2">
-              <select v-model="categoryFilter" class="form-select form-select-sm sql-filter-select">
+              <select
+                v-model="categoryFilter"
+                aria-label="Filter SQL executions by category"
+                class="form-select form-select-sm sql-filter-select"
+              >
                 <option value="">All categories</option>
                 <option v-for="category in categories" :key="category" :value="category">{{ category }}</option>
               </select>
@@ -357,6 +361,7 @@ function clearTrace() {
               </div>
               <input
                 v-model="filter"
+                aria-label="Filter SQL executions"
                 class="form-control form-control-sm trace-filter"
                 placeholder="Filter by SQL, category, connection, thread, or parameter…"
               />

--- a/bootui-ui/src/main/frontend/src/views/Startup.vue
+++ b/bootui-ui/src/main/frontend/src/views/Startup.vue
@@ -193,7 +193,13 @@ function treeStepHasChildren(stepId) {
       <div class="col-12 col-md-7 col-lg-6 px-0">
         <div class="input-group mb-2">
           <span class="input-group-text"><i class="bi bi-search"></i></span>
-          <input v-model="filter" class="form-control" placeholder="Filter by step name…" type="search" />
+          <input
+            v-model="filter"
+            aria-label="Filter startup steps"
+            class="form-control"
+            placeholder="Filter by step name…"
+            type="search"
+          />
           <button
             :disabled="loading || report.steps.length === 0"
             class="btn btn-outline-secondary"

--- a/bootui-ui/src/main/frontend/src/views/Threads.vue
+++ b/bootui-ui/src/main/frontend/src/views/Threads.vue
@@ -183,10 +183,15 @@ watch([filter, state], scheduleReload)
 
       <div class="row g-2 mb-3">
         <div class="col-md-8">
-          <input v-model="filter" class="form-control" placeholder="Filter by name, state, or stack frame…" />
+          <input
+            v-model="filter"
+            aria-label="Filter threads"
+            class="form-control"
+            placeholder="Filter by name, state, or stack frame…"
+          />
         </div>
         <div class="col-md-4">
-          <select v-model="state" class="form-select">
+          <select v-model="state" aria-label="Filter threads by state" class="form-select">
             <option value="">All states</option>
             <option v-for="count in stateCounts" :key="count.state" :value="count.state">
               {{ count.state }} ({{ count.count }})

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -241,6 +241,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
         <div class="mb-3">
           <input
             v-model="filter"
+            aria-label="Filter traces"
             class="form-control form-control-sm"
             placeholder="Filter by trace id, path, root span, or service…"
           />

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -300,6 +300,7 @@ onMounted(loadDependencies)
             <div class="d-flex flex-wrap gap-2">
               <input
                 v-model="search"
+                aria-label="Filter runtime dependencies"
                 class="form-control form-control-sm dependency-search"
                 placeholder="Search group, artifact, or version"
               />

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
@@ -105,6 +105,7 @@ defineExpose({focusInput})
         <input
           ref="inputEl"
           v-model="query"
+          aria-label="Search panels"
           class="cp-input"
           placeholder="Search panels by name or keyword…"
           type="search"


### PR DESCRIPTION
## What does this PR do?

Labels every genuine unnamed native form control in the shared Vue frontend without changing visible copy, styling, data binding, or behavior.

The latest `main` inventory found 58 unnamed `input`, `select`, and `textarea` elements across 31 Vue files. Existing visible labels now use explicit `for`/`id` associations; compact filters and search controls that do not have an appropriate visible label use concise, action-oriented `aria-label` values. The HTTP Probe browser tests now select controls by accessible name in light and dark themes.

A source-wide Vitest regression guard parses all Vue SFC templates and fails on unnamed native controls, empty or broken label references, compile-time empty names, and duplicate IDs. Negative fixtures pin each failure mode.

## Why is this change needed?

Audit issue 3 found that placeholder text and adjacent but unassociated labels left form controls without reliable programmatic names. Screen-reader and voice-control users could not consistently identify or target those controls.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Validation performed:

- `npm test` in `bootui-ui/src/main/frontend`: 76 files, 525 tests passed
- Focused form-label regression: 9 tests passed, including negative fixtures
- `npx playwright test tests/http-probe.spec.js` on an isolated sample-app port: 5 tests passed
- `./mvnw -Dmaven.repo.local=.m2 -B -ntp -pl bootui-spring-sample-app -am -DskipTests install`: build successful
- `./mvnw -B -ntp spotless:check`: build successful
- Frontend and Playwright `format:check`: passed

## Screenshots (UI changes)

Not applicable: visible labels and copy are unchanged; this change adds programmatic associations and names.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (not required; no public behavior or copy changed)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
