### PR TITLE
Fix command palette focus containment

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
@@ -126,6 +126,9 @@ test.describe('BootUI app shell', () => {
     await expect(drawer).not.toHaveAttribute('aria-hidden', 'true')
     await expect(drawer).toHaveAttribute('aria-modal', 'true')
     await expect(page.locator('.bootui-workspace')).toHaveAttribute('inert', '')
+    await page.keyboard.press('Control+K')
+    await expect(page.getByRole('dialog', {name: 'Command palette'})).toHaveCount(0)
+    await expect(drawer).toHaveAttribute('aria-modal', 'true')
 
     const firstDrawerLink = drawer.locator('.brand-card')
     const lastDrawerLink = drawer.locator('.contribute-card')
@@ -156,6 +159,69 @@ test.describe('BootUI app shell', () => {
     await expect(page.locator('main.content-stage')).toBeFocused()
     await expect(drawer).toHaveAttribute('aria-hidden', 'true')
     expect(await drawer.evaluate((element) => element.contains(document.activeElement))).toBe(false)
+  })
+
+  test('command palette contains focus, tracks its active option, and hands route focus to content', async ({page}) => {
+    await page.setViewportSize({width: 1280, height: 800})
+    await page.goto('/bootui/')
+
+    const trigger = page.getByRole('button', {name: /Go to panel/})
+    await trigger.focus()
+    await page.keyboard.press('Enter')
+
+    const palette = page.getByRole('dialog', {name: 'Command palette'})
+    const input = palette.getByRole('combobox', {name: 'Search panels'})
+    const listbox = palette.getByRole('listbox', {name: 'Panel results'})
+    await expect(input).toBeFocused()
+    await expect(input).toHaveAttribute('aria-controls', await listbox.getAttribute('id'))
+    await expect(page.locator('.bootui-workspace')).toHaveAttribute('inert', '')
+    await expect(page.locator('#bootui-mobile-navigation')).toHaveAttribute('inert', '')
+
+    const firstActiveId = await input.getAttribute('aria-activedescendant')
+    await page.keyboard.press('ArrowDown')
+    await expect(input).not.toHaveAttribute('aria-activedescendant', firstActiveId)
+    const secondActiveId = await input.getAttribute('aria-activedescendant')
+    await expect(page.locator(`#${secondActiveId}`)).toHaveAttribute('aria-selected', 'true')
+
+    await page.keyboard.press('Tab')
+    await expect(input).toBeFocused()
+    await page.keyboard.press('Shift+Tab')
+    await expect(input).toBeFocused()
+
+    await input.fill('no-panel-has-this-name')
+    await expect(input).not.toHaveAttribute('aria-activedescendant', /.+/)
+
+    await page.keyboard.press('Escape')
+    await expect(palette).toHaveCount(0)
+    await expect(trigger).toBeFocused()
+
+    await page.keyboard.press('Control+K')
+    await expect(input).toBeFocused()
+    await input.fill('Architecture')
+    await page.keyboard.press('Enter')
+
+    await expect(page).toHaveURL(/#\/architecture$/)
+    await expect(palette).toHaveCount(0)
+    await expect(page.locator('main.content-stage')).toBeFocused()
+  })
+
+  test('mobile command palette restores shortcut focus on cancel', async ({page}) => {
+    await page.setViewportSize({width: 390, height: 844})
+    await page.goto('/bootui/')
+
+    const themeToggle = page.locator('.theme-toggle')
+    await themeToggle.focus()
+    await page.keyboard.press('Control+K')
+
+    const palette = page.getByRole('dialog', {name: 'Command palette'})
+    const input = palette.getByRole('combobox', {name: 'Search panels'})
+    await expect(input).toBeFocused()
+    await page.keyboard.press('Tab')
+    await expect(input).toBeFocused()
+    await page.keyboard.press('Escape')
+
+    await expect(palette).toHaveCount(0)
+    await expect(themeToggle).toBeFocused()
   })
 
   test('main content scrolls while the sidebar stays fixed', async ({page}) => {

--- a/bootui-ui/src/main/frontend/src/App.test.js
+++ b/bootui-ui/src/main/frontend/src/App.test.js
@@ -100,7 +100,7 @@ function stubMatchMedia(narrow = false) {
   )
 }
 
-async function mountApp(initialPath = '/overview') {
+async function mountApp(initialPath = '/overview', options = {}) {
   if (typeof window.matchMedia !== 'function') stubMatchMedia()
   vi.resetModules()
   const {default: App} = await import('./App.vue')
@@ -117,7 +117,7 @@ async function mountApp(initialPath = '/overview') {
     global: {
       plugins: [router],
       stubs: {
-        CommandPalette: true,
+        CommandPalette: options.stubCommandPalette === false ? false : true,
         RouterView: {template: '<div />'}
       }
     }
@@ -268,6 +268,82 @@ describe('App sidebar navigation', () => {
     expect(wrapper.find('#bootui-mobile-navigation').attributes('aria-hidden')).toBe('true')
     expect(document.activeElement).toBe(wrapper.find('main').element)
     expect(wrapper.find('#bootui-mobile-navigation').element.contains(document.activeElement)).toBe(false)
+  })
+
+  it('keeps the command palette closed while the mobile navigation modal is open', async () => {
+    stubMatchMedia(true)
+    const {wrapper} = await mountApp('/overview', {stubCommandPalette: false})
+    const toggle = wrapper.find('.nav-hamburger')
+
+    await toggle.trigger('click')
+    await flushPromises()
+    window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', ctrlKey: true}))
+    await flushPromises()
+
+    expect(wrapper.find('[aria-label="Command palette"]').exists()).toBe(false)
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('#bootui-mobile-navigation').attributes('aria-modal')).toBe('true')
+  })
+})
+
+describe('App command palette', () => {
+  beforeEach(() => {
+    stubLocalStorage()
+    mockShellFetch()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    restoreLocalStorage()
+    document.body.innerHTML = ''
+  })
+
+  it('awaits rendering, focuses the search input, makes the background inert, and restores the trigger', async () => {
+    const {wrapper} = await mountApp('/overview', {stubCommandPalette: false})
+    const trigger = wrapper.find('.cp-trigger')
+    trigger.element.focus()
+
+    await trigger.trigger('click')
+    await flushPromises()
+
+    const input = wrapper.find('.cp-input')
+    expect(document.activeElement).toBe(input.element)
+    expect(wrapper.find('.bootui-workspace').attributes()).toHaveProperty('inert')
+    expect(wrapper.find('#bootui-mobile-navigation').attributes()).toHaveProperty('inert')
+
+    await input.trigger('keydown', {key: 'Escape'})
+    await flushPromises()
+
+    expect(wrapper.find('[aria-label="Command palette"]').exists()).toBe(false)
+    expect(document.activeElement).toBe(trigger.element)
+  })
+
+  it('restores the invoking control after opening with the keyboard shortcut', async () => {
+    const {wrapper} = await mountApp('/overview', {stubCommandPalette: false})
+    const themeToggle = wrapper.find('.theme-toggle')
+    themeToggle.element.focus()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', {key: 'k', ctrlKey: true}))
+    await flushPromises()
+    expect(document.activeElement).toBe(wrapper.find('.cp-input').element)
+
+    await wrapper.find('.cp-input').trigger('keydown', {key: 'Escape'})
+    await flushPromises()
+    expect(document.activeElement).toBe(themeToggle.element)
+  })
+
+  it('moves focus to main content after command-palette navigation', async () => {
+    const {router, wrapper} = await mountApp('/overview', {stubCommandPalette: false})
+    await wrapper.find('.cp-trigger').trigger('click')
+    await flushPromises()
+    const input = wrapper.find('.cp-input')
+    await input.setValue('Architecture')
+    await input.trigger('keydown', {key: 'Enter'})
+    await flushPromises()
+
+    expect(router.currentRoute.value.name).toBe('architecture')
+    expect(wrapper.find('[aria-label="Command palette"]').exists()).toBe(false)
+    expect(document.activeElement).toBe(wrapper.find('main').element)
   })
 })
 

--- a/bootui-ui/src/main/frontend/src/App.test.js
+++ b/bootui-ui/src/main/frontend/src/App.test.js
@@ -316,6 +316,14 @@ describe('App command palette', () => {
 
     expect(wrapper.find('[aria-label="Command palette"]').exists()).toBe(false)
     expect(document.activeElement).toBe(trigger.element)
+
+    await trigger.trigger('click')
+    await flushPromises()
+    await wrapper.find('.cp-backdrop').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.find('[aria-label="Command palette"]').exists()).toBe(false)
+    expect(document.activeElement).toBe(trigger.element)
   })
 
   it('restores the invoking control after opening with the keyboard shortcut', async () => {

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -61,6 +61,8 @@ async function onNarrowChange(e) {
 
 const commandPaletteOpen = ref(false)
 const commandPaletteRef = ref(null)
+const commandPaletteTriggerRef = ref(null)
+let commandPaletteInvoker = null
 const themeMediaQuery =
   typeof window !== 'undefined' && typeof window.matchMedia === 'function' ? window.matchMedia(THEME_QUERY) : null
 const themePreference = ref(readThemePreference(typeof window === 'undefined' ? null : window.localStorage))
@@ -73,9 +75,33 @@ const themeToggleText = computed(() => `${darkTheme.value ? 'Light' : 'Dark'} mo
 provide('overview', overview)
 provide('panels', panels)
 
-function openCommandPalette() {
+async function openCommandPalette(event) {
+  if (commandPaletteOpen.value || mobileDrawerOpen.value) return
+  const eventTarget = event?.currentTarget
+  const activeElement = typeof document === 'undefined' ? null : document.activeElement
+  commandPaletteInvoker =
+    eventTarget instanceof HTMLElement
+      ? eventTarget
+      : activeElement instanceof HTMLElement
+        ? activeElement
+        : commandPaletteTriggerRef.value
   commandPaletteOpen.value = true
+  await nextTick()
   commandPaletteRef.value?.focusInput()
+}
+
+async function closeCommandPalette(focusTarget = 'invoker') {
+  if (!commandPaletteOpen.value) return
+  commandPaletteOpen.value = false
+  await nextTick()
+  const target =
+    focusTarget === 'content'
+      ? mainContentRef.value
+      : commandPaletteInvoker?.isConnected
+        ? commandPaletteInvoker
+        : commandPaletteTriggerRef.value
+  target?.focus()
+  commandPaletteInvoker = null
 }
 
 watch(sidebarCollapsed, (v) => localStorage.setItem('bootui.sidebar.collapsed', String(v)))
@@ -559,11 +585,12 @@ function onGlobalKeydown(e) {
     }
     return
   }
-  if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
     e.preventDefault()
-    commandPaletteOpen.value = !commandPaletteOpen.value
     if (commandPaletteOpen.value) {
-      commandPaletteRef.value?.focusInput()
+      closeCommandPalette()
+    } else {
+      openCommandPalette()
     }
   }
 }
@@ -571,14 +598,19 @@ function onGlobalKeydown(e) {
 
 <template>
   <div class="bootui-shell min-vh-100">
-    <CommandPalette v-if="commandPaletteOpen" ref="commandPaletteRef" @close="commandPaletteOpen = false" />
+    <CommandPalette v-if="commandPaletteOpen" ref="commandPaletteRef" @close="closeCommandPalette" />
     <ConfirmDialog />
     <div class="ambient-orb ambient-orb-one"></div>
     <div class="ambient-orb ambient-orb-two"></div>
 
     <div v-if="mobileDrawerOpen" aria-hidden="true" class="bootui-nav-backdrop" @click="dismissMobileNav"></div>
 
-    <section v-if="authenticationRequired" class="authentication-gate" aria-labelledby="authentication-title">
+    <section
+      v-if="authenticationRequired"
+      :inert="commandPaletteOpen ? true : undefined"
+      class="authentication-gate"
+      aria-labelledby="authentication-title"
+    >
       <div class="authentication-card">
         <span class="authentication-icon"><i class="bi bi-shield-lock"></i></span>
         <div>
@@ -619,7 +651,7 @@ function onGlobalKeydown(e) {
           'bootui-sidebar--drawer': isNarrow,
           'bootui-sidebar--open': mobileDrawerOpen
         }"
-        :inert="mobileDrawerClosed ? true : undefined"
+        :inert="commandPaletteOpen || mobileDrawerClosed ? true : undefined"
         :role="isNarrow ? 'dialog' : undefined"
         class="bootui-sidebar"
         @keydown="onMobileNavKeydown"
@@ -747,6 +779,7 @@ function onGlobalKeydown(e) {
       <transition name="flyout-fade">
         <div
           v-if="railFlyout"
+          :inert="commandPaletteOpen ? true : undefined"
           class="bootui-nav-flyout"
           :style="{top: railFlyout.top + 'px', left: railFlyout.left + 'px'}"
           role="group"
@@ -789,7 +822,7 @@ function onGlobalKeydown(e) {
         </div>
       </transition>
 
-      <div :inert="mobileDrawerOpen ? true : undefined" class="bootui-workspace">
+      <div :inert="commandPaletteOpen || mobileDrawerOpen ? true : undefined" class="bootui-workspace">
         <header class="topbar">
           <div class="topbar-lead">
             <button
@@ -810,7 +843,13 @@ function onGlobalKeydown(e) {
             </div>
           </div>
           <div class="topbar-actions">
-            <button class="cp-trigger" title="Open command palette (⌘K)" @click="openCommandPalette">
+            <button
+              ref="commandPaletteTriggerRef"
+              class="cp-trigger"
+              title="Open command palette (⌘K)"
+              type="button"
+              @click="openCommandPalette"
+            >
               <i class="bi bi-search me-1"></i>
               <span class="cp-trigger-label">Go to panel</span>
               <kbd class="cp-trigger-hint">⌘K</kbd>

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.test.js
@@ -1,21 +1,22 @@
 import {flushPromises, mount} from '@vue/test-utils'
 import {createMemoryHistory, createRouter} from 'vue-router'
-import {describe, expect, it, vi} from 'vitest'
+import {afterEach, describe, expect, it, vi} from 'vitest'
 
 import {routes} from '../../routes.js'
 import CommandPalette from './CommandPalette.vue'
 
 const namedRoutes = routes.filter((route) => route.name && route.meta?.title)
 
-async function mountPalette() {
+async function mountPalette(options = {}) {
   const router = createRouter({
     history: createMemoryHistory(),
-    routes
+    routes: routes.map((route) => (route.redirect ? route : {...route, component: {template: '<section />'}}))
   })
   await router.push('/overview')
   await router.isReady()
 
   const wrapper = mount(CommandPalette, {
+    attachTo: options.attachTo,
     global: {
       plugins: [router]
     }
@@ -31,6 +32,10 @@ async function setQuery(wrapper, value) {
 }
 
 describe('CommandPalette', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
   it('lists every navigable panel before filtering', async () => {
     const {wrapper} = await mountPalette()
     const items = wrapper.findAll('.cp-item')
@@ -111,5 +116,67 @@ describe('CommandPalette', () => {
 
     expect(push).not.toHaveBeenCalled()
     expect(wrapper.emitted('close')).toBeUndefined()
+  })
+
+  it('connects the combobox to its listbox and selected option', async () => {
+    const {wrapper} = await mountPalette()
+    const input = wrapper.find('.cp-input')
+    const listbox = wrapper.find('[role="listbox"]')
+    const options = wrapper.findAll('[role="option"]')
+
+    expect(input.attributes('role')).toBe('combobox')
+    expect(input.attributes('aria-expanded')).toBe('true')
+    expect(input.attributes('aria-controls')).toBe(listbox.attributes('id'))
+    expect(input.attributes('aria-activedescendant')).toBe(options[0].attributes('id'))
+    expect(options[0].attributes('aria-selected')).toBe('true')
+
+    await input.trigger('keydown', {key: 'ArrowDown'})
+
+    expect(input.attributes('aria-activedescendant')).toBe(options[1].attributes('id'))
+    expect(options[0].attributes('aria-selected')).toBe('false')
+    expect(options[1].attributes('aria-selected')).toBe('true')
+
+    await input.trigger('keydown', {key: 'End'})
+    expect(input.attributes('aria-activedescendant')).toBe(options.at(-1).attributes('id'))
+
+    await input.trigger('keydown', {key: 'Home'})
+    expect(input.attributes('aria-activedescendant')).toBe(options[0].attributes('id'))
+  })
+
+  it('clears the active descendant when filtering has no results', async () => {
+    const {wrapper} = await mountPalette()
+    const input = await setQuery(wrapper, 'no-panel-has-this-name')
+
+    expect(wrapper.findAll('[role="option"]')).toHaveLength(0)
+    expect(wrapper.find('[role="listbox"]').exists()).toBe(true)
+    expect(input.attributes('aria-activedescendant')).toBeUndefined()
+  })
+
+  it('contains focus and handles Escape once from anywhere inside the dialog', async () => {
+    const {wrapper} = await mountPalette({attachTo: document.body})
+    const input = wrapper.find('.cp-input')
+    wrapper.vm.focusInput()
+
+    expect(document.activeElement).toBe(input.element)
+
+    await input.trigger('keydown', {key: 'Tab'})
+    expect(document.activeElement).toBe(input.element)
+
+    await input.trigger('keydown', {key: 'Tab', shiftKey: true})
+    expect(document.activeElement).toBe(input.element)
+
+    await input.trigger('keydown', {key: 'Escape'})
+    expect(wrapper.emitted('close')).toEqual([['invoker']])
+  })
+
+  it('closes for a content-focus handoff after activating a result', async () => {
+    const {wrapper, router} = await mountPalette()
+    const input = await setQuery(wrapper, 'Architecture')
+
+    await input.trigger('keydown', {key: 'Enter'})
+    await flushPromises()
+
+    expect(router.currentRoute.value.name).toBe('architecture')
+    expect(wrapper.emitted('close')).toEqual([['content']])
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
@@ -7,8 +7,11 @@ import {loadRecentPanels} from '../../utils/recentPanels.js'
 const emit = defineEmits(['close'])
 const router = useRouter()
 const query = ref('')
+const backdropEl = ref(null)
 const inputEl = ref(null)
 const activeIndex = ref(0)
+const inputId = 'bootui-command-palette-input'
+const listboxId = 'bootui-command-palette-listbox'
 
 const searchableRoutes = routes.filter((r) => r.name && r.meta?.title)
 const recentRouteList = loadRecentPanels()
@@ -57,13 +60,28 @@ function isRecent(route) {
   return showRecent.value && recentNames.has(route.name)
 }
 
-watch(query, () => {
-  activeIndex.value = 0
+watch(results, (currentResults) => {
+  activeIndex.value = currentResults.length ? 0 : -1
 })
 
-function navigate(route) {
-  router.push(route.path)
-  emit('close')
+function optionId(route) {
+  return `bootui-command-palette-option-${route.name}`
+}
+
+const activeOptionId = computed(() => {
+  const activeRoute = results.value[activeIndex.value]
+  return activeRoute ? optionId(activeRoute) : undefined
+})
+
+watch(activeIndex, async (index) => {
+  if (index < 0) return
+  await nextTick()
+  backdropEl.value?.querySelector(`[data-option-index="${index}"]`)?.scrollIntoView?.({block: 'nearest'})
+})
+
+async function navigate(route) {
+  await router.push(route.path)
+  emit('close', 'content')
 }
 
 const numberedNavKeys = ['1', '2', '3', '4', '5', '6', '7', '8', '9']
@@ -71,16 +89,24 @@ const numberedNavKeys = ['1', '2', '3', '4', '5', '6', '7', '8', '9']
 function onKeydown(e) {
   if (e.key === 'ArrowDown') {
     e.preventDefault()
-    activeIndex.value = Math.min(activeIndex.value + 1, results.value.length - 1)
+    if (results.value.length) {
+      activeIndex.value = Math.min(Math.max(activeIndex.value + 1, 0), results.value.length - 1)
+    }
   } else if (e.key === 'ArrowUp') {
     e.preventDefault()
-    activeIndex.value = Math.max(activeIndex.value - 1, 0)
+    if (results.value.length) {
+      activeIndex.value = Math.max(activeIndex.value - 1, 0)
+    }
+  } else if (e.key === 'Home') {
+    e.preventDefault()
+    if (results.value.length) activeIndex.value = 0
+  } else if (e.key === 'End') {
+    e.preventDefault()
+    if (results.value.length) activeIndex.value = results.value.length - 1
   } else if (e.key === 'Enter') {
     e.preventDefault()
     const selected = results.value[activeIndex.value]
     if (selected) navigate(selected)
-  } else if (e.key === 'Escape') {
-    emit('close')
   } else if (!query.value.trim() && numberedNavKeys.includes(e.key) && !e.metaKey && !e.ctrlKey && !e.altKey) {
     const idx = numberedNavKeys.indexOf(e.key)
     if (idx < results.value.length) {
@@ -90,24 +116,71 @@ function onKeydown(e) {
   }
 }
 
+function close() {
+  emit('close', 'invoker')
+}
+
+function onDialogKeydown(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    close()
+    return
+  }
+  if (event.key !== 'Tab') return
+
+  const focusable = backdropEl.value?.querySelectorAll(
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  )
+  if (!focusable?.length) {
+    event.preventDefault()
+    return
+  }
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement
+  if (event.shiftKey && (active === first || !backdropEl.value?.contains(active))) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && (active === last || !backdropEl.value?.contains(active))) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
 function focusInput() {
-  nextTick(() => inputEl.value?.focus())
+  inputEl.value?.focus()
 }
 
 defineExpose({focusInput})
 </script>
 
 <template>
-  <div class="cp-backdrop" role="dialog" aria-modal="true" aria-label="Command palette" @click.self="$emit('close')">
+  <div
+    ref="backdropEl"
+    class="cp-backdrop"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Command palette"
+    @click.self="close"
+    @keydown="onDialogKeydown"
+  >
     <div class="cp-panel">
       <div class="cp-search-row">
-        <i class="bi bi-search cp-search-icon"></i>
+        <i aria-hidden="true" class="bi bi-search cp-search-icon"></i>
         <input
+          :id="inputId"
           ref="inputEl"
           v-model="query"
+          :aria-activedescendant="activeOptionId"
+          aria-autocomplete="list"
+          :aria-controls="listboxId"
+          aria-expanded="true"
+          aria-haspopup="listbox"
           aria-label="Search panels"
           class="cp-input"
           placeholder="Search panels by name or keyword…"
+          role="combobox"
           type="search"
           autocomplete="off"
           @keydown="onKeydown"
@@ -115,15 +188,24 @@ defineExpose({focusInput})
         <kbd class="cp-esc-hint">Esc</kbd>
       </div>
       <div v-if="showRecent" class="cp-section-label">Recent</div>
-      <ul v-if="results.length" class="cp-list" role="listbox">
+      <ul
+        :id="listboxId"
+        :class="{'cp-list--empty': !results.length}"
+        aria-label="Panel results"
+        class="cp-list"
+        role="listbox"
+      >
         <li
           v-for="(r, i) in results"
+          :id="optionId(r)"
           :key="r.name"
+          :aria-selected="i === activeIndex"
           :class="{active: i === activeIndex}"
           class="cp-item"
+          :data-option-index="i"
           role="option"
-          :aria-selected="i === activeIndex"
           @click="navigate(r)"
+          @mousedown.prevent
           @mouseover="activeIndex = i"
         >
           <span v-if="i < 9 && !query.trim()" class="cp-item-num">{{ i + 1 }}</span>
@@ -139,7 +221,7 @@ defineExpose({focusInput})
           <span class="cp-item-group">{{ r.meta.group }}</span>
         </li>
       </ul>
-      <div v-else class="cp-empty">No panels match "{{ query }}"</div>
+      <div v-if="!results.length" class="cp-empty">No panels match "{{ query }}"</div>
     </div>
   </div>
 </template>
@@ -223,6 +305,11 @@ defineExpose({focusInput})
   padding: 0.5rem;
 }
 
+.cp-list--empty {
+  flex: 0;
+  padding: 0;
+}
+
 .cp-item {
   align-items: center;
   border-radius: 0.75rem;
@@ -301,5 +388,11 @@ defineExpose({focusInput})
   font-size: 0.9rem;
   padding: 1.5rem;
   text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cp-item {
+    transition: none;
+  }
 }
 </style>


### PR DESCRIPTION
## What does this PR do?

Makes the command palette a focus-contained modal with reliable initial focus, invoker restoration, route focus handoff, and a connected ARIA combobox/listbox model.

## Why is this change needed?

The palette previously attempted to focus its input before Vue rendered the `v-if` child, allowed Tab to escape behind the modal, and exposed incomplete active-descendant semantics. This integrates with the mobile drawer focus management from #694 and preserves the input label added by #695.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional validation: 537 frontend tests, production Vite build, focused desktop/mobile Playwright app-shell coverage, frontend/e2e Prettier checks, Maven Spotless, and the Impeccable detector.

## Screenshots (UI changes)

Not applicable — interaction semantics only; no visual redesign.

## Checklist

- [x] Documentation is unchanged because the public panel surface and user-facing behavior remain the same
- [x] Public API kept backward compatible
- [x] No secrets, tokens, or local paths committed