### PR TITLE
Fix keyboard access for clickable rows and cards

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/copilot.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/copilot.spec.js
@@ -191,10 +191,24 @@ test.describe('Copilot panel', () => {
     await expect(page.getByText('1 / 5 sessions')).toBeVisible()
     await expect(page.getByText('bootui.copilot.max-sessions')).toBeVisible()
 
+    const sessionSelector = page.getByRole('button', {name: 'View session session-one'})
+    await sessionSelector.click()
+    await expect(page.getByRole('tab', {name: /Activity/})).toHaveClass(/active/)
+
     await page.getByRole('button', {name: 'Show failures for session-one'}).click()
     await expect(page.getByRole('tab', {name: /Failures/})).toHaveClass(/active/)
     await expect(page.getByText('SHELL · bash · failed')).toBeVisible()
     await expect(page.getByText('FILE_EDIT · apply_patch · failed')).toBeVisible()
+
+    await sessionSelector.focus()
+    await sessionSelector.press('Enter')
+    await expect(page.getByRole('tab', {name: /Activity/})).toHaveClass(/active/)
+
+    await page.getByRole('button', {name: 'Show failures for session-one'}).click()
+    await expect(page.getByRole('tab', {name: /Failures/})).toHaveClass(/active/)
+    await sessionSelector.focus()
+    await sessionSelector.press('Space')
+    await expect(page.getByRole('tab', {name: /Activity/})).toHaveClass(/active/)
 
     await page.getByRole('tab', {name: 'Turn story'}).click()
     await expect(page.getByRole('tab', {name: 'Turn story'})).toHaveClass(/active/)

--- a/bootui-spring-sample-app/e2e/tests/sql-trace.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/sql-trace.spec.js
@@ -26,6 +26,15 @@ test.describe('SQL Trace view', () => {
     // Expanding a row reveals the full statement and connection metadata.
     const selectRow = executions.locator('tbody tr.sql-row', {hasText: 'sample_products'}).first()
     await selectRow.click()
+    const rowToggle = selectRow.locator('button.sql-row-toggle')
+    await expect(rowToggle).toHaveAttribute('aria-expanded', 'true')
+
+    await rowToggle.focus()
+    await rowToggle.press('Space')
+    await expect(rowToggle).toHaveAttribute('aria-expanded', 'false')
+    await rowToggle.press('Enter')
+    await expect(rowToggle).toHaveAttribute('aria-expanded', 'true')
+
     await expect(executions).toContainText('Connection')
     await expect(executions).toContainText('Thread')
   })

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1275,7 +1275,8 @@ function onGlobalKeydown(e) {
 .bootui-nav-group__toggle:focus-visible,
 .nav-hamburger:focus-visible,
 .cp-trigger:focus-visible,
-.theme-toggle:focus-visible {
+.theme-toggle:focus-visible,
+:global(.bootui-keyboard-target:focus-visible) {
   outline: 2px solid var(--bootui-blue);
   outline-offset: 2px;
 }

--- a/bootui-ui/src/main/frontend/src/accessibility.test.js
+++ b/bootui-ui/src/main/frontend/src/accessibility.test.js
@@ -7,6 +7,7 @@ import {describe, expect, it} from 'vitest'
 
 const sourceRoot = path.dirname(fileURLToPath(import.meta.url))
 const formControlTags = new Set(['input', 'select', 'textarea'])
+const nativeInteractiveTags = new Set(['a', 'button', 'router-link', 'summary'])
 const staticallyEmptyExpressions = new Set(["''", '""', '``', 'null', 'undefined', 'false'])
 
 function vueFiles(directory) {
@@ -57,6 +58,80 @@ function hasNonEmptyAttribute(node, name) {
 
 function staticAttribute(node, name) {
   return node.props.find((property) => property.type === 6 && property.name === name)?.value?.content
+}
+
+function modifierNames(directive) {
+  return directive.modifiers.map((modifier) => modifier.content ?? modifier)
+}
+
+function eventDirective(node, eventName, modifier) {
+  return node.props.find(
+    (property) =>
+      property.type === 7 &&
+      property.name === 'on' &&
+      property.arg?.type === 4 &&
+      property.arg.content === eventName &&
+      (!modifier || modifierNames(property).includes(modifier))
+  )
+}
+
+function hasButtonRole(node) {
+  if (staticAttribute(node, 'role') === 'button') {
+    return true
+  }
+  const dynamicRole = node.props.find(
+    (property) =>
+      property.type === 7 && property.name === 'bind' && property.arg?.type === 4 && property.arg.content === 'role'
+  )
+  return /['"]button['"]/.test(dynamicRole?.exp?.content ?? '')
+}
+
+function hasKeyboardReachableTabindex(node) {
+  const tabindex = node.props.find(
+    (property) =>
+      (property.type === 6 && property.name === 'tabindex') ||
+      (property.type === 7 &&
+        property.name === 'bind' &&
+        property.arg?.type === 4 &&
+        property.arg.content === 'tabindex')
+  )
+  if (!tabindex) {
+    return false
+  }
+  if (tabindex.type === 6) {
+    return /^\d+$/.test(tabindex.value?.content.trim() ?? '')
+  }
+  const expression = tabindex.exp?.content.trim()
+  return expressionCanProvideText(expression) && !/^(?:['"`])?-\d+(?:['"`])?$/.test(expression)
+}
+
+function hasKeyboardClickEquivalent(node) {
+  const enter = eventDirective(node, 'keydown', 'enter')
+  const space = eventDirective(node, 'keydown', 'space')
+  return (
+    hasButtonRole(node) &&
+    hasAccessibleText(node) &&
+    hasKeyboardReachableTabindex(node) &&
+    enter &&
+    space &&
+    modifierNames(space).includes('prevent')
+  )
+}
+
+function hasNativeInteractiveDescendant(node, delegatedExpression) {
+  return node.children.some(
+    (child) =>
+      child.type === 1 &&
+      ((nativeInteractiveTags.has(child.tag) &&
+        hasAccessibleText(child) &&
+        eventDirective(child, 'click')?.exp?.content.trim() === delegatedExpression) ||
+        hasNativeInteractiveDescendant(child, delegatedExpression))
+  )
+}
+
+function hasKeyboardDelegate(node) {
+  const delegatedExpression = staticAttribute(node, 'data-keyboard-delegate')?.trim()
+  return Boolean(delegatedExpression) && hasNativeInteractiveDescendant(node, delegatedExpression)
 }
 
 function hasAccessibleText(node) {
@@ -143,7 +218,26 @@ function inspectTemplate(template, lineOffset = 0) {
     })
     .map(({node}) => `line ${lineOffset + node.loc.start.line}: unnamed <${node.tag}>`)
 
-  return [...duplicateIds, ...unnamedControls]
+  const inaccessibleClickTargets = elements
+    .filter((node) => {
+      const click = eventDirective(node, 'click')
+      if (!click?.exp || node.tagType !== 0 || nativeInteractiveTags.has(node.tag)) {
+        return false
+      }
+      if (
+        modifierNames(click).includes('self') ||
+        staticAttribute(node, 'aria-hidden') === 'true' ||
+        staticAttribute(node, 'role') === 'option' ||
+        hasKeyboardDelegate(node) ||
+        (node.tag === 'dialog' && (eventDirective(node, 'keydown', 'esc') || eventDirective(node, 'cancel')))
+      ) {
+        return false
+      }
+      return !hasKeyboardClickEquivalent(node)
+    })
+    .map((node) => `line ${lineOffset + node.loc.start.line}: keyboard-inaccessible click target <${node.tag}>`)
+
+  return [...duplicateIds, ...unnamedControls, ...inaccessibleClickTargets]
 }
 
 describe('frontend accessibility', () => {
@@ -186,5 +280,64 @@ describe('frontend accessibility', () => {
 
   it('accepts matching dynamic label associations', () => {
     expect(inspectTemplate('<label :for="inputId">Auto-refresh</label><input :id="inputId">')).toEqual([])
+  })
+
+  it('rejects non-semantic click targets without complete keyboard support', () => {
+    expect(inspectTemplate('<div @click="select"></div>')).toEqual(['line 1: keyboard-inaccessible click target <div>'])
+    expect(
+      inspectTemplate('<tr role="button" tabindex="0" @click="select" @keydown.enter="select"></tr>')
+    ).toHaveLength(1)
+    expect(
+      inspectTemplate(
+        '<tr role="button" tabindex="0" @click="select" @keydown.enter="select" @keydown.space="select"></tr>'
+      )
+    ).toHaveLength(1)
+    expect(
+      inspectTemplate(
+        '<div role="button" tabindex="0" @click="select" @keydown.enter="select" @keydown.space.prevent="select"></div>'
+      )
+    ).toHaveLength(1)
+    expect(
+      inspectTemplate(
+        '<div role="button" tabindex="-1" @click="select" @keydown.enter="select" @keydown.space.prevent="select">Select</div>'
+      )
+    ).toHaveLength(1)
+    expect(
+      inspectTemplate(
+        '<div role="button" tabindex @click="select" @keydown.enter="select" @keydown.space.prevent="select">Select</div>'
+      )
+    ).toHaveLength(1)
+    expect(
+      inspectTemplate('<tr data-keyboard-delegate="select" @click="select"><td>Missing action</td></tr>')
+    ).toHaveLength(1)
+    expect(
+      inspectTemplate(
+        '<tr data-keyboard-delegate="select" @click="select"><td><button type="button">Select</button></td></tr>'
+      )
+    ).toHaveLength(1)
+    expect(
+      inspectTemplate(
+        '<tr data-keyboard-delegate="select" @click="select"><td><button type="button" @click.stop="help">Help</button></td></tr>'
+      )
+    ).toHaveLength(1)
+  })
+
+  it('accepts native controls and complete keyboard equivalents', () => {
+    expect(inspectTemplate('<button type="button" @click="select">Select</button>')).toEqual([])
+    expect(
+      inspectTemplate(
+        '<tr role="button" tabindex="0" aria-label="Select row" @click="select" @keydown.enter="select" @keydown.space.prevent="select"></tr>'
+      )
+    ).toEqual([])
+    expect(
+      inspectTemplate(
+        '<div role="button" :tabindex="enabled ? 0 : undefined" @click="select" @keydown.enter="select" @keydown.space.prevent="select">Select</div>'
+      )
+    ).toEqual([])
+    expect(
+      inspectTemplate(
+        '<tr data-keyboard-delegate="select" @click="select"><td><button type="button" @click.stop="select">Select</button></td></tr>'
+      )
+    ).toEqual([])
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Ai.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Ai.test.js
@@ -1,0 +1,60 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import Ai from './Ai.vue'
+
+function jsonResponse(body) {
+  return {ok: true, status: 200, json: () => Promise.resolve(body)}
+}
+
+describe('Ai', () => {
+  let wrapper
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = null
+    vi.unstubAllGlobals()
+  })
+
+  it('uses native buttons and aria-sort for sortable table headers', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url) => {
+        if (url === 'api/ai/overview') {
+          return Promise.resolve(
+            jsonResponse({
+              enabled: true,
+              springAiDetected: true,
+              langChain4jDetected: false,
+              totalChats: 2,
+              errorCount: 0,
+              totalInputTokens: 120,
+              totalOutputTokens: 30,
+              averageDurationNanos: 1_000_000,
+              tokensByModel: {zeta: 100, alpha: 50},
+              callsByModel: {zeta: 1, alpha: 5},
+              recent: []
+            })
+          )
+        }
+        return Promise.resolve(jsonResponse({buckets: []}))
+      })
+    )
+
+    wrapper = mount(Ai)
+    await flushPromises()
+
+    const modelHeader = wrapper.findAll('th').find((header) => header.text().trim() === 'Model')
+    const sortButton = modelHeader.get('button.sort-button')
+    expect(sortButton.element.tagName).toBe('BUTTON')
+    expect(modelHeader.attributes('aria-sort')).toBe('none')
+
+    await sortButton.trigger('click')
+    expect(modelHeader.attributes('aria-sort')).toBe('descending')
+    expect(wrapper.get('table tbody tr code').text()).toBe('zeta')
+
+    await sortButton.trigger('click')
+    expect(modelHeader.attributes('aria-sort')).toBe('ascending')
+    expect(wrapper.get('table tbody tr code').text()).toBe('alpha')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -132,6 +132,11 @@ function sortTable(col) {
   }
 }
 
+function ariaSort(activeColumn, column, direction) {
+  if (activeColumn !== column) return 'none'
+  return direction === 'asc' ? 'ascending' : 'descending'
+}
+
 const distinctProviders = computed(() => {
   if (!overview.value || !overview.value.recent) return []
   return [...new Set(overview.value.recent.map((c) => c.provider).filter(Boolean))].sort()
@@ -612,41 +617,61 @@ const detectedFrameworkLabel = computed(() => {
                 </caption>
                 <thead>
                   <tr>
-                    <th scope="col" class="cursor-pointer user-select-none" @click="sortByModel('model')">
-                      Model
-                      <i
-                        v-if="byModelSort === 'model'"
-                        :class="byModelSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                        class="bi"
-                      ></i>
+                    <th scope="col" :aria-sort="ariaSort(byModelSort, 'model', byModelSortDir)">
+                      <button class="sort-button bootui-keyboard-target" type="button" @click="sortByModel('model')">
+                        Model
+                        <i
+                          v-if="byModelSort === 'model'"
+                          aria-hidden="true"
+                          :class="byModelSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                          class="bi"
+                        ></i>
+                      </button>
                     </th>
-                    <th scope="col" class="text-end cursor-pointer user-select-none" @click="sortByModel('calls')">
-                      Calls
-                      <i
-                        v-if="byModelSort === 'calls'"
-                        :class="byModelSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                        class="bi"
-                      ></i>
+                    <th scope="col" :aria-sort="ariaSort(byModelSort, 'calls', byModelSortDir)">
+                      <button
+                        class="sort-button bootui-keyboard-target text-end"
+                        type="button"
+                        @click="sortByModel('calls')"
+                      >
+                        Calls
+                        <i
+                          v-if="byModelSort === 'calls'"
+                          aria-hidden="true"
+                          :class="byModelSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                          class="bi"
+                        ></i>
+                      </button>
                     </th>
-                    <th
-                      scope="col"
-                      class="text-end cursor-pointer user-select-none"
-                      @click="sortByModel('totalTokens')"
-                    >
-                      Total tokens
-                      <i
-                        v-if="byModelSort === 'totalTokens'"
-                        :class="byModelSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                        class="bi"
-                      ></i>
+                    <th scope="col" :aria-sort="ariaSort(byModelSort, 'totalTokens', byModelSortDir)">
+                      <button
+                        class="sort-button bootui-keyboard-target text-end"
+                        type="button"
+                        @click="sortByModel('totalTokens')"
+                      >
+                        Total tokens
+                        <i
+                          v-if="byModelSort === 'totalTokens'"
+                          aria-hidden="true"
+                          :class="byModelSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                          class="bi"
+                        ></i>
+                      </button>
                     </th>
-                    <th scope="col" class="text-end cursor-pointer user-select-none" @click="sortByModel('avgTokens')">
-                      Avg tokens/call
-                      <i
-                        v-if="byModelSort === 'avgTokens'"
-                        :class="byModelSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                        class="bi"
-                      ></i>
+                    <th scope="col" :aria-sort="ariaSort(byModelSort, 'avgTokens', byModelSortDir)">
+                      <button
+                        class="sort-button bootui-keyboard-target text-end"
+                        type="button"
+                        @click="sortByModel('avgTokens')"
+                      >
+                        Avg tokens/call
+                        <i
+                          v-if="byModelSort === 'avgTokens'"
+                          aria-hidden="true"
+                          :class="byModelSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                          class="bi"
+                        ></i>
+                      </button>
                     </th>
                     <th scope="col"></th>
                   </tr>
@@ -724,45 +749,64 @@ const detectedFrameworkLabel = computed(() => {
             </caption>
             <thead>
               <tr>
-                <th scope="col" class="cursor-pointer user-select-none" @click="sortTable('startEpochNanos')">
-                  Started
-                  <i
-                    v-if="tableSort === 'startEpochNanos'"
-                    :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                    class="bi"
-                  ></i>
+                <th scope="col" :aria-sort="ariaSort(tableSort, 'startEpochNanos', tableSortDir)">
+                  <button
+                    class="sort-button bootui-keyboard-target"
+                    type="button"
+                    @click="sortTable('startEpochNanos')"
+                  >
+                    Started
+                    <i
+                      v-if="tableSort === 'startEpochNanos'"
+                      aria-hidden="true"
+                      :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                      class="bi"
+                    ></i>
+                  </button>
                 </th>
-                <th scope="col" class="cursor-pointer user-select-none" @click="sortTable('provider')">
-                  Provider
-                  <i
-                    v-if="tableSort === 'provider'"
-                    :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                    class="bi"
-                  ></i>
+                <th scope="col" :aria-sort="ariaSort(tableSort, 'provider', tableSortDir)">
+                  <button class="sort-button bootui-keyboard-target" type="button" @click="sortTable('provider')">
+                    Provider
+                    <i
+                      v-if="tableSort === 'provider'"
+                      aria-hidden="true"
+                      :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                      class="bi"
+                    ></i>
+                  </button>
                 </th>
-                <th scope="col" class="cursor-pointer user-select-none" @click="sortTable('requestModel')">
-                  Model
-                  <i
-                    v-if="tableSort === 'requestModel'"
-                    :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                    class="bi"
-                  ></i>
+                <th scope="col" :aria-sort="ariaSort(tableSort, 'requestModel', tableSortDir)">
+                  <button class="sort-button bootui-keyboard-target" type="button" @click="sortTable('requestModel')">
+                    Model
+                    <i
+                      v-if="tableSort === 'requestModel'"
+                      aria-hidden="true"
+                      :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                      class="bi"
+                    ></i>
+                  </button>
                 </th>
-                <th scope="col" class="cursor-pointer user-select-none" @click="sortTable('totalTokens')">
-                  Tokens
-                  <i
-                    v-if="tableSort === 'totalTokens'"
-                    :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                    class="bi"
-                  ></i>
+                <th scope="col" :aria-sort="ariaSort(tableSort, 'totalTokens', tableSortDir)">
+                  <button class="sort-button bootui-keyboard-target" type="button" @click="sortTable('totalTokens')">
+                    Tokens
+                    <i
+                      v-if="tableSort === 'totalTokens'"
+                      aria-hidden="true"
+                      :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                      class="bi"
+                    ></i>
+                  </button>
                 </th>
-                <th scope="col" class="cursor-pointer user-select-none" @click="sortTable('durationNanos')">
-                  Duration
-                  <i
-                    v-if="tableSort === 'durationNanos'"
-                    :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
-                    class="bi"
-                  ></i>
+                <th scope="col" :aria-sort="ariaSort(tableSort, 'durationNanos', tableSortDir)">
+                  <button class="sort-button bootui-keyboard-target" type="button" @click="sortTable('durationNanos')">
+                    Duration
+                    <i
+                      v-if="tableSort === 'durationNanos'"
+                      aria-hidden="true"
+                      :class="tableSortDir === 'asc' ? 'bi-caret-up-fill' : 'bi-caret-down-fill'"
+                      class="bi"
+                    ></i>
+                  </button>
                 </th>
                 <th scope="col">Status</th>
                 <th scope="col">Finish reason</th>
@@ -986,8 +1030,20 @@ const detectedFrameworkLabel = computed(() => {
 code {
   overflow-wrap: anywhere;
 }
-.cursor-pointer {
+.sort-button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
   cursor: pointer;
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  width: 100%;
+}
+
+.sort-button.text-end {
+  justify-content: flex-end;
 }
 .kpi-card-body {
   min-height: 90px;

--- a/bootui-ui/src/main/frontend/src/views/Copilot.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.test.js
@@ -151,4 +151,53 @@ describe('Copilot', () => {
 
     expect(wrapper.get('.activity-tooltip').text()).toBe('Events: 4 · Failures: 1')
   })
+
+  it('keeps the session selector and nested activity actions independent', async () => {
+    const session = {
+      id: 'session-one',
+      updatedAtEpochMillis: Date.now() - 60_000,
+      eventCount: 2,
+      errorCount: 1,
+      inputTokens: 123,
+      outputTokens: 45
+    }
+    const detail = {
+      summary: session,
+      counts: {total: 2, byCategory: {SHELL: 2}, errors: 1},
+      turns: [],
+      recentEvents: [],
+      failureEvents: [{id: 'failure', category: 'SHELL', summary: 'SHELL failed', success: false}],
+      warnings: []
+    }
+    const fetchMock = vi.fn((url) => {
+      if (url === 'api/copilot/dashboard') {
+        return Promise.resolve(jsonResponse(dashboard({recentSessions: [session]})))
+      }
+      if (url === 'api/copilot/sessions') {
+        return Promise.resolve(jsonResponse(sessionList({total: 1, returned: 1, sessions: [session]})))
+      }
+      if (url === 'api/copilot/sessions/session-one') {
+        return Promise.resolve(jsonResponse(detail))
+      }
+      return Promise.resolve(jsonResponse({}, false, 404))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    wrapper = mount(Copilot)
+    await flushPromises()
+
+    const selectSession = wrapper.get('button.session-row-target')
+    expect(selectSession.attributes('aria-label')).toBe('View session session-one')
+    await selectSession.trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[role="tab"].active').text()).toContain('Activity')
+
+    await wrapper.get('button[aria-label="Show failures for session-one"]').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[role="tab"].active').text()).toContain('Failures')
+
+    await selectSession.trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[role="tab"].active').text()).toContain('Activity')
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -871,8 +871,14 @@ watch(
                   :key="session.id"
                   :class="{active: session.id === selectedSessionId}"
                   class="list-group-item list-group-item-action session-row"
-                  @click="pickSession(session.id)"
                 >
+                  <button
+                    :aria-current="session.id === selectedSessionId ? 'true' : undefined"
+                    :aria-label="`View session ${session.id}`"
+                    class="bootui-keyboard-target session-row-target"
+                    type="button"
+                    @click="pickSession(session.id)"
+                  ></button>
                   <div class="d-flex justify-content-between align-items-start">
                     <div class="me-2 text-truncate">
                       <div class="fw-semibold text-truncate">
@@ -890,7 +896,7 @@ watch(
                       <div>
                         <button
                           :aria-label="`Show activity for ${session.id}`"
-                          class="badge text-bg-secondary border-0 me-1"
+                          class="badge text-bg-secondary border-0 me-1 bootui-keyboard-target session-row-action"
                           type="button"
                           @click.stop="pickSession(session.id, {tab: 'activity'})"
                         >
@@ -899,7 +905,7 @@ watch(
                         <button
                           v-if="session.errorCount > 0"
                           :aria-label="`Show failures for ${session.id}`"
-                          class="badge text-bg-danger border-0"
+                          class="badge text-bg-danger border-0 bootui-keyboard-target session-row-action"
                           type="button"
                           @click.stop="pickSession(session.id, {tab: 'failures'})"
                         >
@@ -1284,6 +1290,30 @@ watch(
 
 .session-row {
   cursor: pointer;
+  position: relative;
+}
+
+.session-row-target {
+  background: transparent;
+  border: 0;
+  border-radius: inherit;
+  inset: 0;
+  position: absolute;
+  z-index: 1;
+}
+
+.session-row-target:focus-visible {
+  outline-offset: -3px;
+}
+
+.session-row.active .bootui-keyboard-target:focus-visible {
+  box-shadow: 0 0 0 4px var(--bootui-blue);
+  outline-color: var(--bs-body-bg);
+}
+
+.session-row-action {
+  position: relative;
+  z-index: 2;
 }
 
 .session-list {

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
@@ -158,6 +158,37 @@ describe('LiveActivity', () => {
     expect(row.text()).not.toContain('N+1')
   })
 
+  it('keeps row pointer activation and nested keyboard actions independent', async () => {
+    const child = requestEntry({
+      id: 'sql-1',
+      parentId: 'req-1',
+      profileable: false,
+      type: 'SQL',
+      summary: 'select from todo'
+    })
+    const fetchMock = stubFetch(activityReport({entries: [requestEntry(), child]}), requestProfile())
+    vi.stubGlobal('fetch', fetchMock)
+
+    wrapper = mount(LiveActivity)
+    await flushPromises()
+
+    const row = wrapper.get('tr.activity-row-clickable')
+    expect(row.attributes('role')).toBeUndefined()
+    expect(row.attributes('tabindex')).toBeUndefined()
+
+    const disclosure = row.get('button.activity-disclosure')
+    await disclosure.trigger('keydown', {key: 'Enter'})
+    await disclosure.trigger('click')
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith('api/activity/request/'))).toHaveLength(0)
+
+    await row.trigger('click')
+    await flushPromises()
+
+    await row.get('button.btn-outline-primary').trigger('click')
+    await flushPromises()
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith('api/activity/request/'))).toHaveLength(2)
+  })
+
   it('renders a scheduled-task-run entry with its own icon and links the KPI card to the Scheduled Tasks panel', async () => {
     const scheduledEntry = {
       id: 'sched-1',

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
@@ -895,9 +895,8 @@ function clearFilters() {
                   entry.profileable ? 'activity-row-clickable' : '',
                   hasChildren(entry) ? 'activity-parent-row' : ''
                 ]"
-                :tabindex="entry.profileable ? 0 : undefined"
+                data-keyboard-delegate="openProfile(entry)"
                 @click="onRowClick(entry)"
-                @keydown.enter="onRowClick(entry)"
               >
                 <td class="text-nowrap small">{{ formatClockTime(entry.timestamp) }}</td>
                 <td class="text-nowrap"><i :class="['bi', typeIcon(entry.type), 'me-1']"></i>{{ entry.type }}</td>
@@ -959,7 +958,7 @@ function clearFilters() {
                   </router-link>
                   <button
                     v-if="entry.profileable"
-                    class="btn btn-outline-primary btn-sm rounded-pill"
+                    class="btn btn-outline-primary btn-sm rounded-pill bootui-keyboard-target"
                     type="button"
                     @click="openProfile(entry)"
                   >

--- a/bootui-ui/src/main/frontend/src/views/RestClientTrace.test.js
+++ b/bootui-ui/src/main/frontend/src/views/RestClientTrace.test.js
@@ -188,6 +188,24 @@ describe('RestClientTrace', () => {
     expect(text).toContain('trace-42')
   })
 
+  it('provides a native keyboard action without changing row pointer behavior', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(traceReport())))
+
+    wrapper = mount(RestClientTrace, {props: {panel: {id: 'rest-client-trace'}}})
+    await flushPromises()
+
+    const row = wrapper.get('tr.rest-row')
+    const toggle = row.get('button.rest-row-toggle')
+    expect(toggle.element.tagName).toBe('BUTTON')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+
+    await toggle.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+
+    await row.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+  })
+
   it('filters calls by URI text', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(traceReport())))
 

--- a/bootui-ui/src/main/frontend/src/views/RestClientTrace.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestClientTrace.vue
@@ -420,9 +420,22 @@ function clearTrace() {
               </thead>
               <tbody>
                 <template v-for="entry in filteredEntries" :key="entry.id">
-                  <tr class="rest-row" @click="toggleRow(entry)">
+                  <tr class="rest-row" data-keyboard-delegate="toggleRow(entry)" @click="toggleRow(entry)">
                     <td class="text-muted">
-                      <i class="bi" :class="isExpanded(entry) ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
+                      <button
+                        class="btn btn-sm btn-link p-0 bootui-keyboard-target rest-row-toggle"
+                        type="button"
+                        :aria-controls="`rest-details-${entry.id}`"
+                        :aria-expanded="isExpanded(entry)"
+                        :aria-label="`${isExpanded(entry) ? 'Collapse' : 'Expand'} details for ${entry.method} call to ${entry.host}${entry.path}`"
+                        @click.stop="toggleRow(entry)"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="bi"
+                          :class="isExpanded(entry) ? 'bi-chevron-down' : 'bi-chevron-right'"
+                        ></i>
+                      </button>
                     </td>
                     <td class="text-nowrap font-monospace small">{{ formatClockTime(entry.timestamp) }}</td>
                     <td>
@@ -442,7 +455,7 @@ function clearTrace() {
                     </td>
                     <td class="text-nowrap small">{{ entry.clientType }}</td>
                   </tr>
-                  <tr v-if="isExpanded(entry)" class="rest-detail-row">
+                  <tr v-if="isExpanded(entry)" :id="`rest-details-${entry.id}`" class="rest-detail-row">
                     <td></td>
                     <td colspan="6">
                       <dl class="row mb-0 small">

--- a/bootui-ui/src/main/frontend/src/views/SqlTrace.test.js
+++ b/bootui-ui/src/main/frontend/src/views/SqlTrace.test.js
@@ -151,6 +151,24 @@ describe('SqlTrace', () => {
     expect(text).toContain('com.example.TodoRepository.findById(TodoRepository.java:42)')
   })
 
+  it('provides a native keyboard action without changing row pointer behavior', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(traceReport())))
+
+    wrapper = mount(SqlTrace, {props: {panel: {id: 'sql-trace'}}})
+    await flushPromises()
+
+    const row = wrapper.get('tr.sql-row')
+    const toggle = row.get('button.sql-row-toggle')
+    expect(toggle.element.tagName).toBe('BUTTON')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+
+    await toggle.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+
+    await row.trigger('click')
+    expect(toggle.attributes('aria-expanded')).toBe('false')
+  })
+
   it('filters executions by SQL text', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(traceReport())))
 

--- a/bootui-ui/src/main/frontend/src/views/SqlTrace.vue
+++ b/bootui-ui/src/main/frontend/src/views/SqlTrace.vue
@@ -387,9 +387,22 @@ function clearTrace() {
               </thead>
               <tbody>
                 <template v-for="entry in filteredEntries" :key="entry.id">
-                  <tr class="sql-row" @click="toggleRow(entry)">
+                  <tr class="sql-row" data-keyboard-delegate="toggleRow(entry)" @click="toggleRow(entry)">
                     <td class="text-muted">
-                      <i class="bi" :class="isExpanded(entry) ? 'bi-chevron-down' : 'bi-chevron-right'"></i>
+                      <button
+                        class="btn btn-sm btn-link p-0 bootui-keyboard-target sql-row-toggle"
+                        type="button"
+                        :aria-controls="`sql-details-${entry.id}`"
+                        :aria-expanded="isExpanded(entry)"
+                        :aria-label="`${isExpanded(entry) ? 'Collapse' : 'Expand'} details for ${entry.category} query at ${formatClockTime(entry.timestamp)}`"
+                        @click.stop="toggleRow(entry)"
+                      >
+                        <i
+                          aria-hidden="true"
+                          class="bi"
+                          :class="isExpanded(entry) ? 'bi-chevron-down' : 'bi-chevron-right'"
+                        ></i>
+                      </button>
                     </td>
                     <td class="text-nowrap font-monospace small">{{ formatClockTime(entry.timestamp) }}</td>
                     <td>
@@ -411,7 +424,7 @@ function clearTrace() {
                       <span v-if="entry.slow" class="badge text-bg-warning ms-1">slow</span>
                     </td>
                   </tr>
-                  <tr v-if="isExpanded(entry)" class="sql-detail-row">
+                  <tr v-if="isExpanded(entry)" :id="`sql-details-${entry.id}`" class="sql-detail-row">
                     <td></td>
                     <td colspan="6">
                       <dl class="row mb-0 small">


### PR DESCRIPTION
## Summary
- replace pointer-only trace rows, Copilot session cards, and AI sort headers with native or explicitly delegated keyboard controls
- preserve Live Activity nested actions and row pointer behavior without overriding table semantics
- add branded focus states plus source-wide and mounted regression coverage

## Validation
- 536 frontend tests
- Vite production build
- 5 focused Chromium tests (Copilot, SQL Trace, REST Client)
- frontend and e2e Prettier checks
- Maven Spotless check
- Impeccable detector (no findings)