### PR TITLE
fix(ui): ensure subtle text meets AA contrast

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,8 +13,10 @@ colors:
   accessible-warning-strong: "#6f5300"
   accessible-warning-strong-dark: "#e0a800"
   ink: "#152033"
-  slate-muted: "#64748b"
-  slate-subtle: "#94a3b8"
+  slate-muted: "#56667b"
+  slate-subtle: "#5b6b80"
+  slate-muted-dark-theme: "#a3b1c6"
+  slate-subtle-dark-theme: "#94a3b8"
   surface-white: "#ffffff"
   surface-frost: "#ffffffd1"
   border-ink: "#0f172a14"
@@ -176,8 +178,8 @@ Saturated **status fills** back badges, latency-heat rows, and advisor severity,
 
 ### Neutral
 - **Ink** (`#152033`): primary body and heading text on light surfaces (near-navy, not pure black). Dark theme inverts to **Ink (Dark)** (`#e2e8f0`).
-- **Slate Muted** (`#64748b`): secondary text, captions, and nav-group labels. Verified for AA at body sizes on the light shell.
-- **Slate Subtle** (`#94a3b8`): tertiary/disabled hints and placeholder-weight text only — never load-bearing body copy.
+- **Slate Muted** (`#56667b` light, `#a3b1c6` dark): secondary text, captions, and nav-group labels.
+- **Slate Subtle** (`#5b6b80` light, `#94a3b8` dark): tertiary/disabled hints, helper text, metadata, and placeholders. It remains visually secondary through size, weight, and placement rather than reduced opacity, and clears AA on the body, card, input, and selected/tinted surfaces.
 - **Surface White / Frost** (`#ffffff` solid, `#ffffffd1` = `rgba(255,255,255,0.82)` frosted): card and panel fills. Dark theme uses **Surface (Dark)** (`#1e293b`).
 - **Border Ink** (`#0f172a14` = `rgba(15,23,42,0.08)`): the hairline that separates frosted panels from the gradient field.
 - **Body Field**: `linear-gradient(135deg, #f6fbf8 0%, #eef6ff 46%, #f7f4ff 100%)` (mint → sky → lilac) plus a soft radial green orb — the "control room ambiance." Dark theme: `linear-gradient(135deg, #0d1a12, #0f1929, #100f1a)`.

--- a/bootui-spring-sample-app/e2e/tests/theme-contrast.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/theme-contrast.spec.js
@@ -1,0 +1,109 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+function parseColor(value) {
+  const channels = value.match(/[\d.]+/g)?.map(Number)
+  if (!channels || channels.length < 3) throw new Error(`Unsupported computed color: ${value}`)
+  return {
+    red: channels[0],
+    green: channels[1],
+    blue: channels[2],
+    alpha: channels[3] ?? 1
+  }
+}
+
+function composite(foreground, background) {
+  const alpha = foreground.alpha + background.alpha * (1 - foreground.alpha)
+  return {
+    red: (foreground.red * foreground.alpha + background.red * background.alpha * (1 - foreground.alpha)) / alpha,
+    green: (foreground.green * foreground.alpha + background.green * background.alpha * (1 - foreground.alpha)) / alpha,
+    blue: (foreground.blue * foreground.alpha + background.blue * background.alpha * (1 - foreground.alpha)) / alpha,
+    alpha
+  }
+}
+
+function linearChannel(channel) {
+  const srgb = channel / 255
+  return srgb <= 0.04045 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(color) {
+  return 0.2126 * linearChannel(color.red) + 0.7152 * linearChannel(color.green) + 0.0722 * linearChannel(color.blue)
+}
+
+function contrastRatio(foreground, background) {
+  const foregroundLuminance = relativeLuminance(foreground)
+  const backgroundLuminance = relativeLuminance(background)
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  )
+}
+
+test('keeps placeholders, helper text, and selected identifiers readable in both themes', async ({page, openView}) => {
+  for (const theme of ['light', 'dark']) {
+    await page.goto('/bootui/')
+    await page.evaluate((value) => localStorage.setItem('bootui.theme', value), theme)
+    await page.reload()
+    await expect(page.locator('html')).toHaveAttribute('data-bootui-theme', theme)
+
+    await openView('loggers', 'Loggers')
+    const placeholderColors = await page.locator('input[placeholder="Filter loggers by name…"]').evaluate((input) => {
+      const rootStyle = getComputedStyle(document.documentElement)
+      return {
+        background: getComputedStyle(input).backgroundColor,
+        placeholder: getComputedStyle(input, '::placeholder').color,
+        subtleToken: rootStyle.getPropertyValue('--bootui-text-subtle').trim(),
+        surfaceSolid: rootStyle.getPropertyValue('--bootui-surface-solid').trim()
+      }
+    })
+    expect(placeholderColors.placeholder).toBe(
+      await page.evaluate((token) => {
+        const probe = document.createElement('span')
+        probe.style.color = token
+        document.body.append(probe)
+        const computed = getComputedStyle(probe).color
+        probe.remove()
+        return computed
+      }, placeholderColors.subtleToken)
+    )
+    const inputBackground = composite(
+      parseColor(placeholderColors.background),
+      parseColor(
+        await page.evaluate((token) => {
+          const probe = document.createElement('span')
+          probe.style.color = token
+          document.body.append(probe)
+          const computed = getComputedStyle(probe).color
+          probe.remove()
+          return computed
+        }, placeholderColors.surfaceSolid)
+      )
+    )
+    expect(contrastRatio(parseColor(placeholderColors.placeholder), inputBackground)).toBeGreaterThanOrEqual(4.5)
+
+    await openView('health', 'Health')
+    await expect(page.locator('.last-fetched-text')).toBeVisible()
+    const helperUsesSubtleToken = await page.locator('.last-fetched-text').evaluate((helper) => {
+      const rootStyle = getComputedStyle(document.documentElement)
+      const probe = document.createElement('span')
+      probe.style.color = rootStyle.getPropertyValue('--bootui-text-subtle')
+      document.body.append(probe)
+      const tokenColor = getComputedStyle(probe).color
+      probe.remove()
+      return getComputedStyle(helper).color === tokenColor
+    })
+    expect(helperUsesSubtleToken).toBe(true)
+
+    await openView('metrics', 'Metrics')
+    const selectedMeter = page.locator('.meter-list .list-group-item-action.active').first()
+    await expect(selectedMeter).toBeVisible()
+    const selectedIdentifierColors = await selectedMeter.evaluate((row) => ({
+      background: getComputedStyle(row).backgroundColor,
+      foreground: getComputedStyle(row.querySelector('code')).color
+    }))
+    expect(
+      contrastRatio(parseColor(selectedIdentifierColors.foreground), parseColor(selectedIdentifierColors.background))
+    ).toBeGreaterThanOrEqual(4.5)
+  }
+})

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -933,8 +933,8 @@ function onGlobalKeydown(e) {
   --bootui-green-dark: #146c43;
   --bootui-blue: #0d6efd;
   --bootui-text: #152033;
-  --bootui-text-muted: #64748b;
-  --bootui-text-subtle: #94a3b8;
+  --bootui-text-muted: #56667b;
+  --bootui-text-subtle: #5b6b80;
 
   /* Status / severity palette (consistent meaning across light & dark) */
   --bootui-danger: #dc3545;
@@ -982,7 +982,7 @@ function onGlobalKeydown(e) {
   --bootui-nav-active-bg: linear-gradient(135deg, #198754, #0d6efd);
   --bootui-nav-active-color: #ffffff;
   --bootui-nav-group-bg: rgba(255, 255, 255, 0.58);
-  --bootui-nav-group-color: #64748b;
+  --bootui-nav-group-color: var(--bootui-text-muted);
   --bootui-nav-link-color: #334155;
 
   /* Chart legend */
@@ -1065,8 +1065,8 @@ function onGlobalKeydown(e) {
   --bootui-green-dark: #4ade80;
   --bootui-blue: #60a5fa;
   --bootui-text: #e2e8f0;
-  --bootui-text-muted: #94a3b8;
-  --bootui-text-subtle: #64748b;
+  --bootui-text-muted: #a3b1c6;
+  --bootui-text-subtle: #94a3b8;
 
   /* Status text re-lit for dark-surface contrast (see Semantic Status) */
   --bootui-warning-text-strong: #e0a800;
@@ -1095,7 +1095,7 @@ function onGlobalKeydown(e) {
   --bootui-nav-active-bg: linear-gradient(135deg, #198754, #2563eb);
   --bootui-nav-active-color: #ffffff;
   --bootui-nav-group-bg: rgba(30, 41, 59, 0.7);
-  --bootui-nav-group-color: #94a3b8;
+  --bootui-nav-group-color: var(--bootui-text-muted);
   --bootui-nav-link-color: #cbd5e1;
 
   /* Chart legend */
@@ -1140,8 +1140,9 @@ function onGlobalKeydown(e) {
   color: var(--bootui-text);
 }
 
-:global(:root[data-bootui-theme='dark'] .form-control::placeholder) {
+:global(.form-control::placeholder) {
   color: var(--bootui-text-subtle);
+  opacity: 1;
 }
 
 :global(:root[data-bootui-theme='dark'] .text-muted) {
@@ -1694,7 +1695,6 @@ function onGlobalKeydown(e) {
   background: rgba(148, 163, 184, 0.08);
   border-color: rgba(100, 116, 139, 0.12);
   color: var(--bootui-text-subtle);
-  opacity: 0.72;
 }
 
 .bootui-nav-section--unavailable .bootui-nav-group__count {
@@ -1725,11 +1725,14 @@ function onGlobalKeydown(e) {
 .bootui-nav-link__status {
   color: var(--bootui-text-subtle);
   font-size: 0.95rem;
-  opacity: 0.65;
 }
 
 .bootui-nav-link--unavailable {
-  opacity: 0.55;
+  color: var(--bootui-text-subtle);
+}
+
+.bootui-nav-link.active .bootui-nav-link__status {
+  color: inherit;
 }
 
 .bootui-nav-link--unavailable .bootui-nav-link__label {

--- a/bootui-ui/src/main/frontend/src/themeContrast.test.js
+++ b/bootui-ui/src/main/frontend/src/themeContrast.test.js
@@ -1,0 +1,142 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {parse as parseSfc} from '@vue/compiler-sfc'
+import {describe, expect, it} from 'vitest'
+
+const sourceRoot = path.dirname(fileURLToPath(import.meta.url))
+const appSource = fs.readFileSync(path.join(sourceRoot, 'App.vue'), 'utf8')
+const {descriptor} = parseSfc(appSource, {filename: 'App.vue'})
+const css = descriptor.styles.map((style) => style.content).join('\n')
+const commandPaletteSource = fs.readFileSync(path.join(sourceRoot, 'views/components/CommandPalette.vue'), 'utf8')
+const {descriptor: commandPaletteDescriptor} = parseSfc(commandPaletteSource, {filename: 'CommandPalette.vue'})
+const commandPaletteCss = commandPaletteDescriptor.styles.map((style) => style.content).join('\n')
+
+function cssBlock(marker) {
+  const markerIndex = css.indexOf(marker)
+  if (markerIndex < 0) throw new Error(`Missing CSS block: ${marker}`)
+  const openingBrace = css.indexOf('{', markerIndex)
+  let depth = 0
+  for (let index = openingBrace; index < css.length; index += 1) {
+    if (css[index] === '{') depth += 1
+    if (css[index] === '}') depth -= 1
+    if (depth === 0) return css.slice(openingBrace + 1, index)
+  }
+  throw new Error(`Unclosed CSS block: ${marker}`)
+}
+
+function declarations(block) {
+  return Object.fromEntries(
+    [...block.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)].map((match) => [match[1], match[2].trim()])
+  )
+}
+
+const lightTokens = declarations(cssBlock(':global(:root) {'))
+const darkTokens = {...lightTokens, ...declarations(cssBlock(":global(:root[data-bootui-theme='dark']) {"))}
+
+function parseColor(value) {
+  if (value.startsWith('#')) {
+    let hex = value.slice(1)
+    if (hex.length === 3 || hex.length === 4) {
+      hex = [...hex].map((digit) => digit.repeat(2)).join('')
+    }
+    if (hex.length !== 6 && hex.length !== 8) throw new Error(`Unsupported hex color: ${value}`)
+    return {
+      red: Number.parseInt(hex.slice(0, 2), 16),
+      green: Number.parseInt(hex.slice(2, 4), 16),
+      blue: Number.parseInt(hex.slice(4, 6), 16),
+      alpha: hex.length === 8 ? Number.parseInt(hex.slice(6, 8), 16) / 255 : 1
+    }
+  }
+
+  const rgba = value.match(/^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:\s*[,/]\s*([\d.]+))?\s*\)$/)
+  if (!rgba) throw new Error(`Unsupported CSS color: ${value}`)
+  return {
+    red: Number(rgba[1]),
+    green: Number(rgba[2]),
+    blue: Number(rgba[3]),
+    alpha: rgba[4] === undefined ? 1 : Number(rgba[4])
+  }
+}
+
+function composite(foreground, background) {
+  const alpha = foreground.alpha + background.alpha * (1 - foreground.alpha)
+  return {
+    red: (foreground.red * foreground.alpha + background.red * background.alpha * (1 - foreground.alpha)) / alpha,
+    green: (foreground.green * foreground.alpha + background.green * background.alpha * (1 - foreground.alpha)) / alpha,
+    blue: (foreground.blue * foreground.alpha + background.blue * background.alpha * (1 - foreground.alpha)) / alpha,
+    alpha
+  }
+}
+
+function linearChannel(channel) {
+  const srgb = channel / 255
+  return srgb <= 0.04045 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(color) {
+  return 0.2126 * linearChannel(color.red) + 0.7152 * linearChannel(color.green) + 0.0722 * linearChannel(color.blue)
+}
+
+function contrastRatio(foreground, background) {
+  const foregroundLuminance = relativeLuminance(foreground)
+  const backgroundLuminance = relativeLuminance(background)
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance)
+  const darker = Math.min(foregroundLuminance, backgroundLuminance)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+function backgroundStops(tokens) {
+  return [...tokens['--bootui-bg-body'].matchAll(/#[\da-f]{6}/gi)].map((match) => parseColor(match[0]))
+}
+
+function relevantSurfaces(tokens) {
+  const surface = parseColor(tokens['--bootui-surface'])
+  const surfaceSolid = parseColor(tokens['--bootui-surface-solid'])
+  const surfaceAlt = parseColor(tokens['--bootui-surface-alt'])
+  const sidebar = parseColor(tokens['--bootui-sidebar-bg'])
+  const selectedTint = parseColor(tokens['--bootui-nav-hover-bg'])
+  const surfaces = []
+
+  for (const [index, background] of backgroundStops(tokens).entries()) {
+    const raised = composite(surface, background)
+    const sunken = composite(surfaceAlt, raised)
+    const inputOnBody = composite(surfaceAlt, background)
+    const sidebarSurface = composite(sidebar, background)
+    surfaces.push(
+      [`body stop ${index + 1}`, background],
+      [`raised surface on body stop ${index + 1}`, raised],
+      [`sunken surface on body stop ${index + 1}`, sunken],
+      [`input surface on body stop ${index + 1}`, inputOnBody],
+      [`sidebar surface on body stop ${index + 1}`, sidebarSurface],
+      [`selected raised surface on body stop ${index + 1}`, composite(selectedTint, raised)],
+      [`selected sunken surface on body stop ${index + 1}`, composite(selectedTint, sunken)],
+      [`selected sidebar surface on body stop ${index + 1}`, composite(selectedTint, sidebarSurface)]
+    )
+  }
+
+  surfaces.push(
+    ['solid card surface', surfaceSolid],
+    ['selected solid card surface', composite(selectedTint, surfaceSolid)]
+  )
+  return surfaces
+}
+
+describe.each([
+  ['light', lightTokens],
+  ['dark', darkTokens]
+])('%s theme text contrast', (_theme, tokens) => {
+  it.each(['--bootui-text-muted', '--bootui-text-subtle'])('%s clears WCAG AA on every relevant surface', (token) => {
+    const foreground = parseColor(tokens[token])
+    const failures = relevantSurfaces(tokens)
+      .map(([name, background]) => ({name, ratio: contrastRatio(foreground, background)}))
+      .filter(({ratio}) => ratio < 4.5)
+
+    expect(failures).toEqual([])
+  })
+})
+
+it('routes standard and command-palette placeholders through the accessible subtle token', () => {
+  expect(css).toMatch(/:global\(\.form-control::placeholder\)\s*\{[^}]*color:\s*var\(--bootui-text-subtle\)/s)
+  expect(commandPaletteCss).toMatch(/\.cp-input::placeholder\s*\{[^}]*color:\s*var\(--bootui-text-subtle/s)
+})

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
@@ -270,7 +270,7 @@ defineExpose({focusInput})
 }
 
 .cp-search-icon {
-  color: var(--bootui-text-muted, #64748b);
+  color: var(--bootui-text-muted, #56667b);
   flex-shrink: 0;
   font-size: 1rem;
 }
@@ -285,14 +285,15 @@ defineExpose({focusInput})
 }
 
 .cp-input::placeholder {
-  color: var(--bootui-text-muted, #94a3b8);
+  color: var(--bootui-text-subtle, #5b6b80);
+  opacity: 1;
 }
 
 .cp-esc-hint {
   background: var(--bootui-surface, #fff);
   border: 1px solid var(--bootui-border, rgba(15, 23, 42, 0.12));
   border-radius: var(--bootui-radius-xs);
-  color: var(--bootui-text-muted, #94a3b8);
+  color: var(--bootui-text-muted, #56667b);
   font-size: 0.7rem;
   padding: 0.15rem 0.4rem;
 }
@@ -338,7 +339,7 @@ defineExpose({focusInput})
 }
 
 .cp-item-group {
-  color: var(--bootui-text-muted, #94a3b8);
+  color: var(--bootui-text-muted, #56667b);
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -348,7 +349,7 @@ defineExpose({focusInput})
   align-items: center;
   background: var(--bootui-nav-group-bg, rgba(100, 116, 139, 0.08));
   border-radius: var(--bootui-radius-xs);
-  color: var(--bootui-text-muted, #94a3b8);
+  color: var(--bootui-text-muted, #56667b);
   display: inline-flex;
   font-size: 0.65rem;
   font-weight: 700;
@@ -361,7 +362,7 @@ defineExpose({focusInput})
 .cp-item-shortcut {
   background: var(--bootui-nav-group-bg, rgba(100, 116, 139, 0.08));
   border-radius: var(--bootui-radius-xs);
-  color: var(--bootui-text-muted, #94a3b8);
+  color: var(--bootui-text-muted, #56667b);
   font-size: 0.65rem;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -375,7 +376,7 @@ defineExpose({focusInput})
 }
 
 .cp-section-label {
-  color: var(--bootui-text-subtle, #94a3b8);
+  color: var(--bootui-text-subtle, #5b6b80);
   font-size: 0.68rem;
   font-weight: 800;
   letter-spacing: 0.08em;
@@ -384,7 +385,7 @@ defineExpose({focusInput})
 }
 
 .cp-empty {
-  color: var(--bootui-text-muted, #94a3b8);
+  color: var(--bootui-text-muted, #56667b);
   font-size: 0.9rem;
   padding: 1.5rem;
   text-align: center;

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
@@ -134,7 +134,7 @@ onBeforeUnmount(stopRelativeTimer)
 }
 
 .last-fetched-text {
-  color: var(--bootui-text-subtle, #94a3b8);
+  color: var(--bootui-text-subtle, #5b6b80);
   font-size: 0.78rem;
   white-space: nowrap;
 }

--- a/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
@@ -194,7 +194,7 @@ function onRun() {
 }
 
 .scanner-score--secondary {
-  color: #64748b;
+  color: var(--bootui-text-muted, #56667b);
 }
 
 .min-w-0 {


### PR DESCRIPTION
## What does this PR do?

Corrects BootUI's light/dark muted and subtle semantic text tokens, routes placeholders through the accessible subtle token, and removes opacity-based re-fading from unavailable navigation text.

## Why is this change needed?

Audit issue 7 found dark placeholders at only 3.75:1 on `#0f172a` and 3.07:1 on `#1e293b`. The new palette clears WCAG 2.1 AA across body, raised, sunken, card, input, sidebar, and selected/tinted surfaces in both themes.

Closes #

N/A — design audit finding 7.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable
- Full Vitest suite (542 tests)
- Production Vite build
- Playwright contrast coverage in light and dark themes
- Frontend/e2e Prettier checks, Maven Spotless, and Impeccable detector

## Screenshots (UI changes)

N/A — semantic contrast correction with browser-computed color coverage.

## Checklist

- [x] Design documentation updated for the semantic token changes
- [x] Public API kept backward compatible
- [x] No secrets, tokens, or local paths committed