### PR TITLE
Fix application homepage link under custom paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,16 +195,18 @@ non-default port, point the proxy at it with `BOOTUI_API_PROXY_TARGET`. Use
 run `./mvnw install -pl bootui-ui` once to re-bundle the assets into the JAR.
 
 To develop against custom BootUI mounts, set `BOOTUI_DEV_PATH` for the Vite shell base and, when the API path is not
-`<BOOTUI_DEV_PATH>/api`, set `BOOTUI_DEV_API_PATH` independently:
+`<BOOTUI_DEV_PATH>/api`, set `BOOTUI_DEV_API_PATH` independently. When the host application has a non-root context,
+also set `BOOTUI_DEV_APPLICATION_PATH` so the Overview link targets that application root:
 
 ```bash
-BOOTUI_DEV_PATH=/dev-console \
-  BOOTUI_DEV_API_PATH=/internal/bootui-api \
+BOOTUI_DEV_PATH=/host/dev-console \
+  BOOTUI_DEV_API_PATH=/host/internal/bootui-api \
+  BOOTUI_DEV_APPLICATION_PATH=/host \
   BOOTUI_API_PROXY_TARGET=http://localhost:8083 \
   npm run dev
 ```
 
-Then open <http://localhost:5173/dev-console/>. These values affect only Vite development; the packaged build uses
+Then open <http://localhost:5173/host/dev-console/>. These values affect only Vite development; the packaged build uses
 relative asset URLs and receives the actual UI/API paths from the backend at runtime.
 
 ### Bootstrap Icons subsetting

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiCustomPathBootTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiCustomPathBootTest.java
@@ -40,6 +40,7 @@ class BootUiCustomPathBootTest {
         assertThat(bareShell.status()).isEqualTo(200);
         assertThat(shell.body())
                 .contains("<base href=\"/host/dev-console/\" />")
+                .contains("content=\"/host/\" name=\"bootui-application-path\"")
                 .contains("content=\"/host/internal/bootui-api\" name=\"bootui-api-path\"");
         assertThat(asset.find()).isTrue();
         assertThat(probe.get("/host/dev-console/" + asset.group(1)).status()).isEqualTo(200);

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusIndexResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusIndexResource.java
@@ -41,6 +41,9 @@ public class QuarkusIndexResource {
     private static final Pattern EXISTING_API_PATH =
             Pattern.compile("(?i)<meta\\b[^>]*\\bname=[\"']bootui-api-path[\"']");
 
+    private static final Pattern EXISTING_APPLICATION_PATH =
+            Pattern.compile("(?i)<meta\\b[^>]*\\bname=[\"']bootui-application-path[\"']");
+
     private final Config config;
 
     private volatile String cachedTemplate;
@@ -54,7 +57,8 @@ public class QuarkusIndexResource {
     public Response index() {
         String baseHref = QuarkusBootUiPaths.applicationPath(config, QuarkusBootUiPaths.uiPath(config)) + "/";
         String apiPath = QuarkusBootUiPaths.applicationPath(config, QuarkusBootUiPaths.apiPath(config));
-        String html = injectRuntimePaths(template(), baseHref, apiPath);
+        String applicationPath = QuarkusBootUiPaths.applicationPath(config, "/");
+        String html = injectRuntimePaths(template(), baseHref, apiPath, applicationPath);
         return Response.ok(html, MediaType.TEXT_HTML_TYPE).build();
     }
 
@@ -96,18 +100,23 @@ public class QuarkusIndexResource {
         return html.substring(0, insertAt) + baseTag + html.substring(insertAt);
     }
 
-    static String injectRuntimePaths(String html, String baseHref, String apiPath) {
+    static String injectRuntimePaths(String html, String baseHref, String apiPath, String applicationPath) {
         String rewritten = injectBaseHref(html, baseHref);
-        if (EXISTING_API_PATH.matcher(rewritten).find()) {
-            return rewritten;
+        rewritten = injectRuntimePath(rewritten, EXISTING_API_PATH, "bootui-api-path", apiPath);
+        return injectRuntimePath(rewritten, EXISTING_APPLICATION_PATH, "bootui-application-path", applicationPath);
+    }
+
+    private static String injectRuntimePath(String html, Pattern existingPath, String name, String path) {
+        if (existingPath.matcher(html).find()) {
+            return html;
         }
-        Matcher matcher = HEAD_OPEN.matcher(rewritten);
+        Matcher matcher = HEAD_OPEN.matcher(html);
         if (!matcher.find()) {
-            return rewritten;
+            return html;
         }
         int insertAt = matcher.end();
-        String meta = "\n    <meta content=\"" + escapeAttribute(apiPath) + "\" name=\"bootui-api-path\" />";
-        return rewritten.substring(0, insertAt) + meta + rewritten.substring(insertAt);
+        String meta = "\n    <meta content=\"" + escapeAttribute(path) + "\" name=\"" + name + "\" />";
+        return html.substring(0, insertAt) + meta + html.substring(insertAt);
     }
 
     private static String escapeAttribute(String value) {

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusBootUiPathsTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusBootUiPathsTest.java
@@ -24,6 +24,7 @@ class QuarkusBootUiPathsTest {
         assertThat(QuarkusBootUiPaths.apiPath(configured)).isEqualTo("/internal/bootui-api");
         assertThat(QuarkusBootUiPaths.applicationPath(configured, QuarkusBootUiPaths.uiPath(configured)))
                 .isEqualTo("/host/dev-console");
+        assertThat(QuarkusBootUiPaths.applicationPath(configured, "/")).isEqualTo("/host/");
     }
 
     @Test

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/QuarkusIndexResourceTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/QuarkusIndexResourceTest.java
@@ -46,11 +46,12 @@ class QuarkusIndexResourceTest {
     void injectsApplicationRootAwareApiPathWithoutDuplication() {
         String html = "<html><head></head><body></body></html>";
 
-        String once = QuarkusIndexResource.injectRuntimePaths(html, "/host/console/", "/host/internal/api");
-        String twice = QuarkusIndexResource.injectRuntimePaths(once, "/ignored/", "/ignored/api");
+        String once = QuarkusIndexResource.injectRuntimePaths(html, "/host/console/", "/host/internal/api", "/host/");
+        String twice = QuarkusIndexResource.injectRuntimePaths(once, "/ignored/", "/ignored/api", "/ignored/");
 
         assertThat(twice)
                 .contains("<base href=\"/host/console/\" />")
+                .contains("content=\"/host/\" name=\"bootui-application-path\"")
                 .contains("content=\"/host/internal/api\" name=\"bootui-api-path\"")
                 .doesNotContain("/ignored/api");
     }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiIndexController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiIndexController.java
@@ -52,7 +52,8 @@ public class ReactiveBootUiIndexController {
         String contextPath = exchange.getRequest().getPath().contextPath().value();
         String baseHref = contextPath + properties.getPath() + "/";
         String apiPath = contextPath + properties.getApiPath();
-        String html = BootUiIndexController.injectRuntimePaths(template(), baseHref, apiPath);
+        String applicationPath = contextPath.isEmpty() ? "/" : contextPath + "/";
+        String html = BootUiIndexController.injectRuntimePaths(template(), baseHref, apiPath, applicationPath);
         byte[] bytes = html.getBytes(StandardCharsets.UTF_8);
         ServerHttpResponse response = exchange.getResponse();
         response.getHeaders().setContentType(MediaType.TEXT_HTML);

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiIndexController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/BootUiIndexController.java
@@ -48,6 +48,9 @@ public class BootUiIndexController {
     private static final Pattern EXISTING_API_PATH =
             Pattern.compile("(?i)<meta\\b[^>]*\\bname=[\"']bootui-api-path[\"']");
 
+    private static final Pattern EXISTING_APPLICATION_PATH =
+            Pattern.compile("(?i)<meta\\b[^>]*\\bname=[\"']bootui-application-path[\"']");
+
     private final BootUiProperties properties;
 
     private final Resource indexResource;
@@ -71,7 +74,8 @@ public class BootUiIndexController {
         String contextPath = request.getContextPath();
         String baseHref = contextPath + properties.getPath() + "/";
         String apiPath = contextPath + properties.getApiPath();
-        String html = injectRuntimePaths(template(), baseHref, apiPath);
+        String applicationPath = contextPath.isEmpty() ? "/" : contextPath + "/";
+        String html = injectRuntimePaths(template(), baseHref, apiPath, applicationPath);
         response.setContentType(MediaType.TEXT_HTML_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.getWriter().write(html);
@@ -116,20 +120,38 @@ public class BootUiIndexController {
     }
 
     /**
-     * Injects the document base plus the application-root-aware API path consumed by the shared SPA.
+     * Injects the document base plus the application-root-aware API and host-application paths consumed
+     * by the shared SPA.
      */
+    public static String injectRuntimePaths(String html, String baseHref, String apiPath, String applicationPath) {
+        String rewritten = injectRuntimePaths(html, baseHref, apiPath);
+        return injectRuntimePath(rewritten, EXISTING_APPLICATION_PATH, "bootui-application-path", applicationPath);
+    }
+
+    /**
+     * Preserves the original shell-rewriting contract for callers that do not supply the host
+     * application path.
+     *
+     * @deprecated use {@link #injectRuntimePaths(String, String, String, String)} so the shared SPA can
+     *     link back to the host application root
+     */
+    @Deprecated(since = "1.12.0", forRemoval = false)
     public static String injectRuntimePaths(String html, String baseHref, String apiPath) {
         String rewritten = injectBaseHref(html, baseHref);
-        if (EXISTING_API_PATH.matcher(rewritten).find()) {
-            return rewritten;
+        return injectRuntimePath(rewritten, EXISTING_API_PATH, "bootui-api-path", apiPath);
+    }
+
+    private static String injectRuntimePath(String html, Pattern existingPath, String name, String path) {
+        if (existingPath.matcher(html).find()) {
+            return html;
         }
-        Matcher matcher = HEAD_OPEN.matcher(rewritten);
+        Matcher matcher = HEAD_OPEN.matcher(html);
         if (!matcher.find()) {
-            return rewritten;
+            return html;
         }
         int insertAt = matcher.end();
-        String meta = "\n    <meta content=\"" + escapeAttribute(apiPath) + "\" name=\"bootui-api-path\" />";
-        return rewritten.substring(0, insertAt) + meta + rewritten.substring(insertAt);
+        String meta = "\n    <meta content=\"" + escapeAttribute(path) + "\" name=\"" + name + "\" />";
+        return html.substring(0, insertAt) + meta + html.substring(insertAt);
     }
 
     private static String escapeAttribute(String value) {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiIndexControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiIndexControllerTests.java
@@ -45,6 +45,7 @@ class ReactiveBootUiIndexControllerTests {
                 .expectBody(String.class)
                 .value(body -> assertThat(body)
                         .contains("<base href=\"/bootui/\" />")
+                        .contains("content=\"/\" name=\"bootui-application-path\"")
                         .contains("content=\"/bootui/api\" name=\"bootui-api-path\""));
     }
 
@@ -92,6 +93,7 @@ class ReactiveBootUiIndexControllerTests {
 
         assertThat(exchange.getResponse().getBodyAsString().block())
                 .contains("<base href=\"/host/devtools/\" />")
+                .contains("content=\"/host/\" name=\"bootui-application-path\"")
                 .contains("content=\"/host/internal/bootui-api\" name=\"bootui-api-path\"");
     }
 

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/BootUiIndexControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/BootUiIndexControllerTests.java
@@ -47,6 +47,7 @@ class BootUiIndexControllerTests {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(content().string(containsString("<base href=\"/bootui/\" />")))
+                .andExpect(content().string(containsString("content=\"/\" name=\"bootui-application-path\"")))
                 .andExpect(content().string(containsString("content=\"/bootui/api\" name=\"bootui-api-path\"")));
     }
 
@@ -69,18 +70,20 @@ class BootUiIndexControllerTests {
         mvc.perform(get("/api/bootui").contextPath("/api"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("<base href=\"/api/bootui/\" />")))
+                .andExpect(content().string(containsString("content=\"/api/\" name=\"bootui-application-path\"")))
                 .andExpect(content().string(containsString("content=\"/api/bootui/api\" name=\"bootui-api-path\"")));
     }
 
     @Test
     void baseHrefHonorsCustomPathProperty() throws Exception {
         BootUiProperties properties = new BootUiProperties();
-        properties.setPath("/devtools");
+        properties.setPath("/tools/devtools");
         MockMvc mvc = buildMvc(properties);
 
-        mvc.perform(get("/devtools"))
+        mvc.perform(get("/host/tools/devtools").contextPath("/host"))
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("<base href=\"/devtools/\" />")));
+                .andExpect(content().string(containsString("<base href=\"/host/tools/devtools/\" />")))
+                .andExpect(content().string(containsString("content=\"/host/\" name=\"bootui-application-path\"")));
     }
 
     @Test
@@ -134,10 +137,23 @@ class BootUiIndexControllerTests {
     void injectsApiPathMetadataWithoutDuplicatingIt() {
         String html = "<html><head></head><body></body></html>";
 
-        String once = BootUiIndexController.injectRuntimePaths(html, "/console/", "/console/api");
-        String twice = BootUiIndexController.injectRuntimePaths(once, "/ignored/", "/ignored/api");
+        String once = BootUiIndexController.injectRuntimePaths(html, "/console/", "/console/api", "/");
+        String twice = BootUiIndexController.injectRuntimePaths(once, "/ignored/", "/ignored/api", "/ignored/");
 
         assertThat(twice).contains("content=\"/console/api\" name=\"bootui-api-path\"");
+        assertThat(twice).contains("content=\"/\" name=\"bootui-application-path\"");
         assertThat(twice).doesNotContain("/ignored/api");
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void originalRuntimePathOverloadRemainsCompatible() {
+        String result =
+                BootUiIndexController.injectRuntimePaths("<html><head></head></html>", "/console/", "/console/api");
+
+        assertThat(result)
+                .contains("<base href=\"/console/\" />")
+                .contains("content=\"/console/api\" name=\"bootui-api-path\"")
+                .doesNotContain("bootui-application-path");
     }
 }

--- a/bootui-spring-sample-app/e2e/tests-custom-path/custom-path.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-custom-path/custom-path.spec.js
@@ -11,6 +11,7 @@ test('loads the SPA and assets only from the configured path', async ({page, req
   await expect(page).toHaveURL(new RegExp(`${UI_PATH}/#/overview$`))
   await expect(page.locator('.brand-name')).toHaveText('BootUI')
   await expect(page.locator('base')).toHaveAttribute('href', `${UI_PATH}/`)
+  await expect(page.locator('meta[name="bootui-application-path"]')).toHaveAttribute('content', '/host/')
   await expect(page.locator('meta[name="bootui-api-path"]')).toHaveAttribute('content', API_PATH)
 
   const resourcePaths = await page.evaluate(() =>
@@ -24,6 +25,11 @@ test('loads the SPA and assets only from the configured path', async ({page, req
 
   expect((await request.get('/host/bootui/')).status()).toBe(404)
   expect((await request.get('/host/bootui/api/overview')).status()).toBe(404)
+
+  const home = page.getByRole('link', {name: 'Application homepage'})
+  await expect(home).toHaveAttribute('href', '/host/')
+  await home.click()
+  await expect(page).toHaveURL(/\/host\/$/)
 })
 
 test('uses the configured API path for queries, SSE, and security', async ({page, request}) => {

--- a/bootui-spring-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/overview.spec.js
@@ -74,4 +74,16 @@ test.describe('Overview view', () => {
       'https://github.com/jdubois/boot-ui'
     )
   })
+
+  test('returns to the host application homepage', async ({openView, page}) => {
+    await openView('overview', 'Overview')
+
+    await expect(page.locator('meta[name="bootui-application-path"]')).toHaveAttribute('content', '/')
+    const home = page.getByRole('link', {name: 'Application homepage'})
+    await expect(home).toHaveAttribute('href', '/')
+    await home.click()
+
+    await expect(page).toHaveURL(/\/$/)
+    await expect(page.getByRole('heading', {name: 'Welcome to the BootUI sample app'})).toBeVisible()
+  })
 })

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiCustomPathIntegrationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiCustomPathIntegrationTests.java
@@ -49,6 +49,7 @@ class BootUiCustomPathIntegrationTests {
         assertThat(bareShell.status()).isEqualTo(200);
         assertThat(shell.body())
                 .contains("<base href=\"" + UI_PATH + "/\"")
+                .contains("content=\"/host/\" name=\"bootui-application-path\"")
                 .contains("content=\"" + API_PATH + "\" name=\"bootui-api-path\"");
         assertThat(asset.find()).isTrue();
         assertThat(probe.get(UI_PATH + "/" + asset.group(1)).status()).isEqualTo(200);

--- a/bootui-ui/src/main/frontend/src/utils/bootUiPath.js
+++ b/bootui-ui/src/main/frontend/src/utils/bootUiPath.js
@@ -9,6 +9,27 @@ export function normalizeBootUiApiPath(rawPath) {
   return normalizePath(rawPath, false)
 }
 
+export function normalizeBootUiApplicationPath(rawPath) {
+  if (typeof rawPath !== 'string' || !rawPath.trim()) {
+    throw new Error('BootUI application path must not be blank')
+  }
+  const normalized = withoutTrailingSlash(rawPath.trim())
+  if (normalized === '/') return '/'
+  if (
+    !normalized.startsWith('/') ||
+    normalized
+      .slice(1)
+      .split('/')
+      .some((segment) => segment === '.' || segment === '..') ||
+    normalized.includes('?') ||
+    normalized.includes('#') ||
+    !SAFE_PATH.test(normalized)
+  ) {
+    throw new Error(`Invalid BootUI application path: '${normalized}'`)
+  }
+  return normalized + '/'
+}
+
 function normalizePath(rawPath, rejectInternalChild) {
   if (typeof rawPath !== 'string' || !rawPath.trim()) {
     throw new Error('BootUI path must not be blank')
@@ -49,6 +70,19 @@ export function getBootUiBasePath() {
 
 export function getBootUiApiPath() {
   return configuredApiPath() ?? getBootUiBasePath() + '/api'
+}
+
+export function getBootUiApplicationPath() {
+  if (typeof document === 'undefined') return '/'
+  const content = document.querySelector('meta[name="bootui-application-path"]')?.getAttribute('content')
+  if (!content) return '/'
+  try {
+    const base = typeof window === 'undefined' ? 'http://localhost/' : window.location.href
+    const pathname = new URL(content, base).pathname.replace(/^\/+/, '/')
+    return pathname === '/' ? '/' : withoutTrailingSlash(pathname) + '/'
+  } catch {
+    return '/'
+  }
 }
 
 export function resolveBootUiApiUrl(input) {

--- a/bootui-ui/src/main/frontend/src/utils/bootUiPath.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/bootUiPath.test.js
@@ -1,8 +1,10 @@
 import {afterEach, describe, expect, it} from 'vitest'
 
 import {
+  getBootUiApplicationPath,
   getBootUiApiPath,
   getBootUiBasePath,
+  normalizeBootUiApplicationPath,
   normalizeBootUiApiPath,
   normalizeBootUiPath,
   resolveBootUiApiUrl
@@ -16,18 +18,32 @@ describe('BootUI runtime paths', () => {
   it('reads application-root-aware UI and API paths from injected markup', () => {
     document.head.innerHTML = `
       <base href="/host/dev-console/" />
+      <meta content="/host/" name="bootui-application-path" />
       <meta content="/host/internal/bootui-api" name="bootui-api-path" />
     `
 
     expect(getBootUiBasePath()).toBe('/host/dev-console')
+    expect(getBootUiApplicationPath()).toBe('/host/')
     expect(getBootUiApiPath()).toBe('/host/internal/bootui-api')
     expect(resolveBootUiApiUrl('api/overview?limit=5')).toBe('/host/internal/bootui-api/overview?limit=5')
   })
 
   it('keeps relative API URLs and the default path when runtime markup is absent', () => {
     expect(getBootUiBasePath()).toBe('/bootui')
+    expect(getBootUiApplicationPath()).toBe('/')
     expect(getBootUiApiPath()).toBe('/bootui/api')
     expect(resolveBootUiApiUrl('api/overview')).toBe('api/overview')
+  })
+
+  it('normalizes application roots and keeps the target same-origin without query or hash data', () => {
+    document.head.innerHTML =
+      '<meta content="https://elsewhere.example//host///?source=bootui#details" name="bootui-application-path" />'
+
+    expect(getBootUiApplicationPath()).toBe('/host/')
+    expect(normalizeBootUiApplicationPath('/')).toBe('/')
+    expect(normalizeBootUiApplicationPath(' /host/// ')).toBe('/host/')
+    expect(() => normalizeBootUiApplicationPath('/host?source=bootui')).toThrow('Invalid')
+    expect(() => normalizeBootUiApplicationPath('/host/../admin')).toThrow('Invalid')
   })
 
   it('normalizes safe development paths and rejects ambiguous routes', () => {

--- a/bootui-ui/src/main/frontend/src/views/Overview.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Overview.test.js
@@ -79,6 +79,7 @@ const allPanels = {
 
 describe('Overview', () => {
   afterEach(() => {
+    document.head.innerHTML = ''
     vi.unstubAllGlobals()
   })
 
@@ -90,6 +91,16 @@ describe('Overview', () => {
     expect(wrapper.text()).toContain('Overall score')
     // The marketing hero is gone; the host-app link is demoted to a small header action.
     expect(wrapper.find('a[href="/"]').text()).toContain('Application homepage')
+  })
+
+  it('links to the injected application root instead of the origin root', async () => {
+    document.head.innerHTML = '<meta content="/host/" name="bootui-application-path" />'
+    stubFetch({})
+
+    const wrapper = mountOverview(allPanels)
+    await flushPromises()
+
+    expect(wrapper.get('a[href="/host/"]').text()).toContain('Application homepage')
   })
 
   it('renders a card per available scanner and hides unavailable ones', async () => {

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -1,5 +1,6 @@
 <script setup>
 import {apiFetch, getJson} from '../api.js'
+import {getBootUiApplicationPath} from '../utils/bootUiPath.js'
 import {computed, inject, onActivated, onMounted, reactive, ref} from 'vue'
 import {describeLoadError} from '../utils/loadError.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
@@ -9,6 +10,7 @@ import ScannerScoreCard from './components/ScannerScoreCard.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const injectedPanels = inject('panels', null)
+const applicationPath = getBootUiApplicationPath()
 
 // Locally fetched panel availability when the shell has not provided it yet.
 const localPanels = ref(null)
@@ -305,7 +307,7 @@ onActivated(refreshScores)
       :refreshable="false"
     >
       <template #actions>
-        <a class="btn btn-outline-secondary btn-sm" href="/">
+        <a class="btn btn-outline-secondary btn-sm" :href="applicationPath">
           <i class="bi bi-house-door me-1"></i>
           Application homepage
         </a>

--- a/bootui-ui/src/main/frontend/vite.config.js
+++ b/bootui-ui/src/main/frontend/vite.config.js
@@ -4,7 +4,7 @@ import {defineConfig} from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import checker from 'vite-plugin-checker'
 import {generateBootstrapIconsSubset} from './scripts/generate-icon-subset.mjs'
-import {normalizeBootUiApiPath, normalizeBootUiPath} from './src/utils/bootUiPath.js'
+import {normalizeBootUiApiPath, normalizeBootUiApplicationPath, normalizeBootUiPath} from './src/utils/bootUiPath.js'
 
 const frontendRoot = path.dirname(fileURLToPath(import.meta.url))
 
@@ -34,13 +34,15 @@ function bootstrapIconsSubsetPlugin() {
 // is served from a trailing-slash shell URL, those relative URLs resolve correctly
 // under the configured BootUI path and the host application's root. An absolute
 // build base would ignore those runtime paths and 404. The dev server uses the
-// configured dev base and API path so its proxy matches the runtime metadata.
+// configured dev base, application path, and API path so its runtime metadata
+// matches the packaged shell contract.
 //
 // Override the dev-server base and proxy path with BOOTUI_DEV_PATH (e.g.
 // BOOTUI_DEV_PATH=/my-console) when developing against an app that uses a
 // non-default bootui.path. The path must start with '/' and must not be '/'.
 const devBasePath = normalizeBootUiPath(process.env.BOOTUI_DEV_PATH || '/bootui')
 const devApiPath = normalizeBootUiApiPath(process.env.BOOTUI_DEV_API_PATH || devBasePath + '/api')
+const devApplicationPath = normalizeBootUiApplicationPath(process.env.BOOTUI_DEV_APPLICATION_PATH || '/')
 
 function devRuntimePathPlugin() {
   return {
@@ -50,7 +52,12 @@ function devRuntimePathPlugin() {
       order: 'pre',
       handler(html, context) {
         if (!context.server) return html
-        return html.replace(/<head([^>]*)>/i, `<head$1>\n    <meta content="${devApiPath}" name="bootui-api-path" />`)
+        return html.replace(
+          /<head([^>]*)>/i,
+          `<head$1>
+    <meta content="${devApplicationPath}" name="bootui-application-path" />
+    <meta content="${devApiPath}" name="bootui-api-path" />`
+        )
       }
     }
   }

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -140,6 +140,12 @@ Both values are application-relative. Spring's `server.servlet.context-path` or 
 `/host` is served at `/host/dev-console`; the generated shell injects that browser-visible base and API path for the
 shared Vue application.
 
+The generated shell also injects the normalized, same-origin host-application path used by the Overview panel's
+**Application homepage** link. It is `/` at the default application root and includes exactly one trailing slash for a
+custom root (for example, `/host/`). The link therefore returns to `/` from `/bootui/` and to `/host/` from
+`/host/dev-console/`, independently of `bootui.path` depth and `bootui.api-path`, without carrying BootUI query or hash
+state.
+
 Path configuration is normalized once and then used by every adapter:
 
 - leading/trailing whitespace and one or more trailing slashes are removed;


### PR DESCRIPTION
## Summary
- inject the normalized same-origin host application path into the shared runtime shell on Spring MVC, WebFlux, Quarkus, and Vite
- derive the Overview application-home link from that framework-neutral metadata instead of hardcoding `/`
- cover root and custom-context navigation in unit, integration, conformance, and Playwright tests

## Testing
- 546 frontend tests
- Spring MVC/WebFlux and Quarkus shell path tests
- Spring and Quarkus API conformance tests
- default Overview Playwright tests
- custom-path Playwright tests for Spring MVC and WebFlux
- Maven Spotless and frontend/e2e formatting checks