### PR TITLE
fix(ui): guard optional browser storage

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
@@ -104,6 +104,30 @@ test.describe('BootUI app shell', () => {
     await expect(contributeLink.locator('.bi-github')).toBeVisible()
   })
 
+  test('shell and current-page controls work when browser storage is denied before startup', async ({page}) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, 'localStorage', {
+        configurable: true,
+        get() {
+          throw new DOMException('Storage denied by browser policy', 'SecurityError')
+        }
+      })
+    })
+    await page.goto('/bootui/')
+
+    await expect(page.locator('.bootui-shell')).toBeVisible()
+    const root = page.locator('html')
+    const themeToggle = page.locator('.theme-toggle')
+    const initialTheme = await root.getAttribute('data-bs-theme')
+    await themeToggle.click()
+    await expect(root).toHaveAttribute('data-bs-theme', initialTheme === 'dark' ? 'light' : 'dark')
+
+    const sidebar = page.locator('aside.bootui-sidebar')
+    await expect(sidebar).not.toHaveClass(/bootui-sidebar--collapsed/)
+    await page.locator('.sidebar-toggle').click()
+    await expect(sidebar).toHaveClass(/bootui-sidebar--collapsed/)
+  })
+
   test('mobile navigation contains focus and closes without stranding it', async ({page}) => {
     await page.setViewportSize({width: 390, height: 844})
     await page.goto('/bootui/')

--- a/bootui-ui/src/main/frontend/src/App.test.js
+++ b/bootui-ui/src/main/frontend/src/App.test.js
@@ -56,8 +56,8 @@ function mockShellFetch(platform = 'spring-boot') {
   )
 }
 
-function stubLocalStorage() {
-  const storage = new Map()
+function stubLocalStorage(initialValues = {}) {
+  const storage = new Map(Object.entries(initialValues))
   const localStorageStub = {
     clear: () => storage.clear(),
     getItem: (key) => storage.get(key) ?? null,
@@ -73,6 +73,20 @@ function stubLocalStorage() {
     Object.defineProperty(globalThis, 'localStorage', {
       configurable: true,
       value: localStorageStub
+    })
+  }
+  return {localStorageStub, storage}
+}
+
+function stubLocalStorageGetter(getter) {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    get: getter
+  })
+  if (globalThis !== window) {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get: getter
     })
   }
 }
@@ -352,6 +366,118 @@ describe('App command palette', () => {
     expect(router.currentRoute.value.name).toBe('architecture')
     expect(wrapper.find('[aria-label="Command palette"]').exists()).toBe(false)
     expect(document.activeElement).toBe(wrapper.find('main').element)
+  })
+})
+
+describe('App optional browser storage', () => {
+  beforeEach(() => {
+    mockShellFetch()
+    stubMatchMedia()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    restoreLocalStorage()
+    document.body.innerHTML = ''
+    delete document.documentElement.dataset.bootuiTheme
+    delete document.documentElement.dataset.bsTheme
+    document.documentElement.style.removeProperty('color-scheme')
+  })
+
+  it('mounts and keeps theme, sidebar, and recent panels usable when the storage getter is denied', async () => {
+    stubLocalStorageGetter(() => {
+      throw new DOMException('Storage denied', 'SecurityError')
+    })
+
+    const {wrapper} = await mountApp('/overview', {stubCommandPalette: false})
+    expect(wrapper.find('.bootui-shell').exists()).toBe(true)
+
+    await wrapper.find('.theme-toggle').trigger('click')
+    expect(document.documentElement.dataset.bsTheme).toBe('dark')
+
+    await wrapper.find('.sidebar-toggle').trigger('click')
+    expect(wrapper.find('aside.bootui-sidebar').classes()).toContain('bootui-sidebar--collapsed')
+
+    await wrapper.find('.cp-trigger').trigger('click')
+    await flushPromises()
+    expect(wrapper.find('.cp-section-label').text()).toBe('Recent')
+    expect(wrapper.find('.cp-item-title').text()).toBe('Overview')
+  })
+
+  it('keeps current-page controls working when storage methods start throwing', async () => {
+    const target = {
+      getItem() {
+        throw new DOMException('Read denied', 'SecurityError')
+      },
+      setItem() {
+        throw new DOMException('Quota denied', 'QuotaExceededError')
+      },
+      removeItem() {
+        throw new DOMException('Remove denied', 'SecurityError')
+      }
+    }
+    stubLocalStorageGetter(() => target)
+
+    const {wrapper} = await mountApp()
+    await wrapper.find('.theme-toggle').trigger('click')
+    await wrapper.find('.sidebar-toggle').trigger('click')
+
+    expect(document.documentElement.dataset.bsTheme).toBe('dark')
+    expect(wrapper.find('aside.bootui-sidebar').classes()).toContain('bootui-sidebar--collapsed')
+  })
+
+  it('ignores malformed persisted values and synchronizes theme storage events without reading storage', async () => {
+    const values = new Map([
+      ['bootui.sidebar.collapsed', 'sometimes'],
+      ['bootui.theme', 'purple'],
+      ['bootui.expandedGroups', '{bad']
+    ])
+    stubLocalStorageGetter(() => ({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+      removeItem() {
+        throw new DOMException('Cleanup denied', 'SecurityError')
+      }
+    }))
+
+    const {wrapper} = await mountApp()
+    expect(wrapper.find('aside.bootui-sidebar').classes()).not.toContain('bootui-sidebar--collapsed')
+    expect(document.documentElement.dataset.bsTheme).toBe('light')
+    expect(groupToggle(wrapper, 'Advisors').attributes('aria-expanded')).toBe('true')
+
+    stubLocalStorageGetter(() => {
+      throw new DOMException('Storage denied', 'SecurityError')
+    })
+    window.dispatchEvent(new StorageEvent('storage', {key: 'bootui.theme', newValue: 'dark'}))
+    await flushPromises()
+    expect(document.documentElement.dataset.bsTheme).toBe('dark')
+
+    window.dispatchEvent(new StorageEvent('storage', {key: 'bootui.theme', newValue: 'invalid'}))
+    await flushPromises()
+    expect(document.documentElement.dataset.bsTheme).toBe('light')
+  })
+
+  it('persists again after a write-denied period without losing current-page state', async () => {
+    const values = new Map()
+    let denyWrites = true
+    stubLocalStorageGetter(() => ({
+      getItem: (key) => values.get(key) ?? null,
+      setItem(key, value) {
+        if (denyWrites) throw new DOMException('Quota denied', 'QuotaExceededError')
+        values.set(key, value)
+      },
+      removeItem: (key) => values.delete(key)
+    }))
+
+    const {wrapper} = await mountApp()
+    await wrapper.find('.sidebar-toggle').trigger('click')
+    expect(wrapper.find('aside.bootui-sidebar').classes()).toContain('bootui-sidebar--collapsed')
+    expect(values.has('bootui.sidebar.collapsed')).toBe(false)
+
+    denyWrites = false
+    await wrapper.find('.sidebar-toggle').trigger('click')
+    expect(wrapper.find('aside.bootui-sidebar').classes()).not.toContain('bootui-sidebar--collapsed')
+    expect(values.get('bootui.sidebar.collapsed')).toBe('false')
   })
 })
 

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -5,6 +5,7 @@ import {useRoute, useRouter} from 'vue-router'
 import {
   applyTheme,
   nextTheme,
+  normalizeThemePreference,
   readThemePreference,
   resolveTheme,
   THEME_QUERY,
@@ -12,6 +13,7 @@ import {
 } from './utils/theme.js'
 import {describeLoadError} from './utils/loadError.js'
 import {recordRecentPanel} from './utils/recentPanels.js'
+import {safeLocalStorage} from './utils/safeStorage.js'
 import CommandPalette from './views/components/CommandPalette.vue'
 import ConfirmDialog from './views/components/ConfirmDialog.vue'
 
@@ -25,8 +27,8 @@ const authenticationToken = ref('')
 const authenticationError = ref(null)
 const authenticating = ref(false)
 const bearerScheme = 'Bearer'
-const savedCollapsed = localStorage.getItem('bootui.sidebar.collapsed')
-const sidebarCollapsed = ref(savedCollapsed === 'true')
+const SIDEBAR_COLLAPSED_STORAGE_KEY = 'bootui.sidebar.collapsed'
+const sidebarCollapsed = ref(safeLocalStorage.getBoolean(SIDEBAR_COLLAPSED_STORAGE_KEY))
 
 const NARROW_QUERY = '(max-width: 991.98px)'
 const narrowMediaQuery =
@@ -65,7 +67,7 @@ const commandPaletteTriggerRef = ref(null)
 let commandPaletteInvoker = null
 const themeMediaQuery =
   typeof window !== 'undefined' && typeof window.matchMedia === 'function' ? window.matchMedia(THEME_QUERY) : null
-const themePreference = ref(readThemePreference(typeof window === 'undefined' ? null : window.localStorage))
+const themePreference = ref(readThemePreference())
 const systemPrefersDark = ref(themeMediaQuery?.matches === true)
 const resolvedTheme = computed(() => resolveTheme(themePreference.value, systemPrefersDark.value))
 const darkTheme = computed(() => resolvedTheme.value === 'dark')
@@ -104,7 +106,7 @@ async function closeCommandPalette(focusTarget = 'invoker') {
   commandPaletteInvoker = null
 }
 
-watch(sidebarCollapsed, (v) => localStorage.setItem('bootui.sidebar.collapsed', String(v)))
+watch(sidebarCollapsed, (value) => safeLocalStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, value))
 
 watch(
   () => route.name,
@@ -202,11 +204,7 @@ function syncTheme(theme) {
 }
 
 function persistThemePreference(theme) {
-  try {
-    window.localStorage?.setItem(THEME_STORAGE_KEY, theme)
-  } catch {
-    // Ignore unavailable storage; the in-memory theme still applies for this session.
-  }
+  return safeLocalStorage.setItem(THEME_STORAGE_KEY, theme)
 }
 
 function toggleTheme() {
@@ -217,6 +215,12 @@ function toggleTheme() {
 
 function onSystemThemeChange(e) {
   systemPrefersDark.value = e.matches === true
+}
+
+function onStorageChange(event) {
+  if (event.key === THEME_STORAGE_KEY || event.key === null) {
+    themePreference.value = normalizeThemePreference(event.newValue)
+  }
 }
 
 const semanticNavigationGroups = [
@@ -239,18 +243,19 @@ const EXPANDED_GROUPS_STORAGE_KEY = 'bootui.expandedGroups'
 
 function loadExpandedGroups() {
   const defaults = {advisors: true}
-  try {
-    const stored = window.localStorage?.getItem(EXPANDED_GROUPS_STORAGE_KEY)
-    if (stored) {
-      const parsed = JSON.parse(stored)
-      if (parsed && typeof parsed === 'object') {
-        return {...defaults, ...parsed}
-      }
-    }
-  } catch {
-    // Ignore unavailable or malformed storage; fall back to defaults.
+  const stored = safeLocalStorage.getJson(EXPANDED_GROUPS_STORAGE_KEY, null)
+  if (!stored || Array.isArray(stored) || typeof stored !== 'object') {
+    if (stored !== null) safeLocalStorage.removeItem(EXPANDED_GROUPS_STORAGE_KEY)
+    return defaults
   }
-  return defaults
+  const validGroupKeys = new Set([
+    ...semanticNavigationGroups.map((group) => group.key),
+    unavailableNavigationGroup.key
+  ])
+  const expanded = Object.fromEntries(
+    Object.entries(stored).filter(([key, value]) => validGroupKeys.has(key) && typeof value === 'boolean')
+  )
+  return {...defaults, ...expanded}
 }
 
 const expandedGroups = reactive(loadExpandedGroups())
@@ -554,11 +559,7 @@ watch(
 watch(
   expandedGroups,
   (groups) => {
-    try {
-      window.localStorage?.setItem(EXPANDED_GROUPS_STORAGE_KEY, JSON.stringify(groups))
-    } catch {
-      // Ignore storage write failures (e.g. private mode / quota).
-    }
+    safeLocalStorage.setJson(EXPANDED_GROUPS_STORAGE_KEY, groups)
   },
   {deep: true}
 )
@@ -566,12 +567,14 @@ watch(
 onMounted(() => {
   loadShellData()
   window.addEventListener('keydown', onGlobalKeydown)
+  window.addEventListener('storage', onStorageChange)
   themeMediaQuery?.addEventListener?.('change', onSystemThemeChange)
   narrowMediaQuery?.addEventListener?.('change', onNarrowChange)
 })
 
 onBeforeUnmount(() => {
   window.removeEventListener('keydown', onGlobalKeydown)
+  window.removeEventListener('storage', onStorageChange)
   themeMediaQuery?.removeEventListener?.('change', onSystemThemeChange)
   narrowMediaQuery?.removeEventListener?.('change', onNarrowChange)
   clearFlyoutTimer()

--- a/bootui-ui/src/main/frontend/src/utils/recentPanels.js
+++ b/bootui-ui/src/main/frontend/src/utils/recentPanels.js
@@ -1,32 +1,20 @@
+import {safeLocalStorage} from './safeStorage.js'
+
 const STORAGE_KEY = 'bootui.recentPanels'
 const MAX_RECENT_PANELS = 5
 
-function storage() {
-  try {
-    return typeof window !== 'undefined' ? window.localStorage : null
-  } catch {
-    return null
-  }
-}
-
 export function loadRecentPanels() {
-  try {
-    const raw = storage()?.getItem(STORAGE_KEY)
-    if (!raw) return []
-    const parsed = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed.filter((name) => typeof name === 'string') : []
-  } catch {
+  const parsed = safeLocalStorage.getJson(STORAGE_KEY, [])
+  if (!Array.isArray(parsed)) {
+    safeLocalStorage.removeItem(STORAGE_KEY)
     return []
   }
+  return parsed.filter((name) => typeof name === 'string')
 }
 
 export function recordRecentPanel(name) {
   if (!name) return loadRecentPanels()
   const next = [name, ...loadRecentPanels().filter((entry) => entry !== name)].slice(0, MAX_RECENT_PANELS)
-  try {
-    storage()?.setItem(STORAGE_KEY, JSON.stringify(next))
-  } catch {
-    // Ignore unavailable storage (e.g. private mode / quota); recents are best-effort.
-  }
+  safeLocalStorage.setJson(STORAGE_KEY, next)
   return next
 }

--- a/bootui-ui/src/main/frontend/src/utils/safeStorage.js
+++ b/bootui-ui/src/main/frontend/src/utils/safeStorage.js
@@ -1,0 +1,112 @@
+const STORAGE_ERROR_NAMES = new Set(['InvalidStateError', 'NotSupportedError', 'QuotaExceededError', 'SecurityError'])
+
+function isStorageAccessError(error) {
+  if (!error || typeof error !== 'object') return false
+  const isDomException =
+    (typeof DOMException !== 'undefined' && error instanceof DOMException) ||
+    Object.prototype.toString.call(error) === '[object DOMException]'
+  return isDomException && STORAGE_ERROR_NAMES.has(error.name)
+}
+
+function handleStorageError(error, fallback) {
+  if (isStorageAccessError(error)) return fallback
+  throw error
+}
+
+export function createSafeStorage(storageProvider) {
+  const memory = new Map()
+  const dirtyKeys = new Set()
+
+  function storage() {
+    try {
+      return storageProvider?.() ?? null
+    } catch (error) {
+      return handleStorageError(error, null)
+    }
+  }
+
+  function getItem(key) {
+    const fallback = memory.get(key) ?? null
+    if (dirtyKeys.has(key)) return fallback
+
+    const target = storage()
+    if (!target) return fallback
+
+    try {
+      const value = target.getItem(key)
+      if (value === null) memory.delete(key)
+      else memory.set(key, value)
+      return value
+    } catch (error) {
+      return handleStorageError(error, fallback)
+    }
+  }
+
+  function setItem(key, value) {
+    const normalizedValue = String(value)
+    memory.set(key, normalizedValue)
+
+    const target = storage()
+    if (!target) {
+      dirtyKeys.add(key)
+      return false
+    }
+
+    try {
+      target.setItem(key, normalizedValue)
+      dirtyKeys.delete(key)
+      return true
+    } catch (error) {
+      dirtyKeys.add(key)
+      return handleStorageError(error, false)
+    }
+  }
+
+  function removeItem(key) {
+    memory.delete(key)
+
+    const target = storage()
+    if (!target) {
+      dirtyKeys.add(key)
+      return false
+    }
+
+    try {
+      target.removeItem(key)
+      dirtyKeys.delete(key)
+      return true
+    } catch (error) {
+      dirtyKeys.add(key)
+      return handleStorageError(error, false)
+    }
+  }
+
+  function getJson(key, fallback) {
+    const raw = getItem(key)
+    if (raw === null) return fallback
+
+    try {
+      return JSON.parse(raw)
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error
+      removeItem(key)
+      return fallback
+    }
+  }
+
+  function setJson(key, value) {
+    return setItem(key, JSON.stringify(value))
+  }
+
+  function getBoolean(key, fallback = false) {
+    const raw = getItem(key)
+    if (raw === 'true') return true
+    if (raw === 'false') return false
+    if (raw !== null) removeItem(key)
+    return fallback
+  }
+
+  return {getBoolean, getItem, getJson, removeItem, setItem, setJson}
+}
+
+export const safeLocalStorage = createSafeStorage(() => (typeof window === 'undefined' ? null : window.localStorage))

--- a/bootui-ui/src/main/frontend/src/utils/safeStorage.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/safeStorage.test.js
@@ -1,0 +1,115 @@
+import {describe, expect, it, vi} from 'vitest'
+
+import {createSafeStorage} from './safeStorage.js'
+
+function storageException(name = 'SecurityError') {
+  return new DOMException('Browser storage is unavailable', name)
+}
+
+describe('safe storage', () => {
+  it('degrades to memory when the localStorage getter is denied or storage is missing', () => {
+    const denied = createSafeStorage(() => {
+      throw storageException()
+    })
+    const missing = createSafeStorage(() => null)
+
+    expect(denied.getItem('key')).toBeNull()
+    expect(denied.setItem('key', 'value')).toBe(false)
+    expect(denied.getItem('key')).toBe('value')
+    expect(denied.removeItem('key')).toBe(false)
+    expect(denied.getItem('key')).toBeNull()
+
+    expect(missing.setItem('key', 'value')).toBe(false)
+    expect(missing.getItem('key')).toBe('value')
+  })
+
+  it('keeps the last current-page value when reads and writes start failing', () => {
+    const values = new Map([['key', 'persisted']])
+    let denyReads = false
+    let denyWrites = false
+    const target = {
+      getItem(key) {
+        if (denyReads) throw storageException()
+        return values.get(key) ?? null
+      },
+      setItem(key, value) {
+        if (denyWrites) throw storageException('QuotaExceededError')
+        values.set(key, value)
+      },
+      removeItem(key) {
+        if (denyWrites) throw storageException()
+        values.delete(key)
+      }
+    }
+    const storage = createSafeStorage(() => target)
+
+    expect(storage.getItem('key')).toBe('persisted')
+    denyReads = true
+    expect(storage.getItem('key')).toBe('persisted')
+
+    denyReads = false
+    denyWrites = true
+    expect(storage.setItem('key', 'in-memory')).toBe(false)
+    expect(storage.getItem('key')).toBe('in-memory')
+    expect(values.get('key')).toBe('persisted')
+  })
+
+  it('reports persistence only after storage recovers', () => {
+    const values = new Map()
+    let unavailable = true
+    const target = {
+      getItem: (key) => values.get(key) ?? null,
+      setItem(key, value) {
+        if (unavailable) throw storageException('QuotaExceededError')
+        values.set(key, value)
+      },
+      removeItem(key) {
+        if (unavailable) throw storageException()
+        values.delete(key)
+      }
+    }
+    const storage = createSafeStorage(() => target)
+
+    expect(storage.setItem('key', 'first')).toBe(false)
+    expect(storage.getItem('key')).toBe('first')
+
+    unavailable = false
+    expect(storage.setItem('key', 'second')).toBe(true)
+    expect(values.get('key')).toBe('second')
+    expect(storage.removeItem('key')).toBe(true)
+    expect(values.has('key')).toBe(false)
+  })
+
+  it('falls back for malformed JSON and boolean values even when cleanup is denied', () => {
+    const target = {
+      getItem: vi.fn((key) => (key === 'json' ? '{bad' : 'sometimes')),
+      setItem: vi.fn(),
+      removeItem: vi.fn(() => {
+        throw storageException()
+      })
+    }
+    const storage = createSafeStorage(() => target)
+
+    expect(storage.getJson('json', {default: true})).toEqual({default: true})
+    expect(storage.getBoolean('boolean', true)).toBe(true)
+    expect(target.removeItem).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not swallow unrelated application errors', () => {
+    const getterError = new Error('programming error')
+    const methodError = new TypeError('broken adapter')
+
+    expect(() =>
+      createSafeStorage(() => {
+        throw getterError
+      }).getItem('key')
+    ).toThrow(getterError)
+    expect(() =>
+      createSafeStorage(() => ({
+        getItem() {
+          throw methodError
+        }
+      })).getItem('key')
+    ).toThrow(methodError)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/utils/theme.js
+++ b/bootui-ui/src/main/frontend/src/utils/theme.js
@@ -1,3 +1,5 @@
+import {safeLocalStorage} from './safeStorage.js'
+
 export const THEME_QUERY = '(prefers-color-scheme: dark)'
 export const THEME_STORAGE_KEY = 'bootui.theme'
 
@@ -5,12 +7,8 @@ export function normalizeThemePreference(value) {
   return value === 'dark' || value === 'light' ? value : null
 }
 
-export function readThemePreference(storage) {
-  try {
-    return normalizeThemePreference(storage?.getItem(THEME_STORAGE_KEY))
-  } catch {
-    return null
-  }
+export function readThemePreference(storage = safeLocalStorage) {
+  return normalizeThemePreference(storage.getItem(THEME_STORAGE_KEY))
 }
 
 export function resolveTheme(preference, prefersDark) {

--- a/bootui-ui/src/main/frontend/src/utils/theme.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/theme.test.js
@@ -8,6 +8,7 @@ import {
   resolveTheme,
   THEME_STORAGE_KEY
 } from './theme.js'
+import {createSafeStorage} from './safeStorage.js'
 
 describe('theme utilities', () => {
   it('normalizes persisted theme values', () => {
@@ -23,11 +24,13 @@ describe('theme utilities', () => {
     expect(readThemePreference({getItem: (key) => storage.get(key)})).toBe('dark')
     expect(readThemePreference({getItem: () => 'unexpected'})).toBeNull()
     expect(
-      readThemePreference({
-        getItem: () => {
-          throw new Error('storage unavailable')
-        }
-      })
+      readThemePreference(
+        createSafeStorage(() => ({
+          getItem: () => {
+            throw new DOMException('storage unavailable', 'SecurityError')
+          }
+        }))
+      )
     ).toBeNull()
   })
 

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
@@ -135,6 +135,30 @@ describe('LiveActivity', () => {
     expect(wrapper.text()).toContain('—')
   })
 
+  it('keeps filters usable when browser storage reads and writes are denied', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem() {
+        throw new DOMException('Read denied', 'SecurityError')
+      },
+      setItem() {
+        throw new DOMException('Quota denied', 'QuotaExceededError')
+      },
+      removeItem() {
+        throw new DOMException('Remove denied', 'SecurityError')
+      }
+    })
+    vi.stubGlobal('fetch', stubFetch(activityReport(), requestProfile()))
+
+    wrapper = mount(LiveActivity)
+    await flushPromises()
+    const filter = wrapper.get('#activity-text-filter')
+    await filter.setValue('/api/orders')
+
+    expect(filter.element.value).toBe('/api/orders')
+    expect(wrapper.find('button').text()).toBeTruthy()
+    await filter.setValue('')
+  })
+
   it('renders a list-level N+1 badge for a request with a suspected N+1 pattern', async () => {
     vi.stubGlobal(
       'fetch',

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
@@ -9,6 +9,7 @@ import SpinnerButton from './components/SpinnerButton.vue'
 import {formatBytes, formatClockTime, formatNumber} from '../utils/format.js'
 import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
+import {safeLocalStorage} from '../utils/safeStorage.js'
 import {useConfirm} from '../utils/useConfirm.js'
 import {useFlashMessage} from '../utils/useFlashMessage.js'
 import {useEventStreamRefresh} from '../utils/useEventStreamRefresh.js'
@@ -498,33 +499,21 @@ function renderProfileReport() {
 }
 
 function restoreFilters() {
-  try {
-    const raw = localStorage.getItem(FILTERS_STORAGE_KEY)
-    if (!raw) return
-    const saved = JSON.parse(raw)
-    if (typeof saved.type === 'string') typeFilter.value = saved.type
-    if (typeof saved.severity === 'string') severityFilter.value = saved.severity
-    if (typeof saved.text === 'string') textFilter.value = saved.text
-    if (typeof saved.errorsOnly === 'boolean') errorsOnly.value = saved.errorsOnly
-  } catch (_) {
-    // Corrupt or unavailable storage: fall back to defaults silently.
-  }
+  const saved = safeLocalStorage.getJson(FILTERS_STORAGE_KEY, null)
+  if (!saved || Array.isArray(saved) || typeof saved !== 'object') return
+  if (saved.type === '' || TYPES.includes(saved.type)) typeFilter.value = saved.type
+  if (saved.severity === '' || SEVERITIES.includes(saved.severity)) severityFilter.value = saved.severity
+  if (typeof saved.text === 'string') textFilter.value = saved.text
+  if (typeof saved.errorsOnly === 'boolean') errorsOnly.value = saved.errorsOnly
 }
 
 function persistFilters() {
-  try {
-    localStorage.setItem(
-      FILTERS_STORAGE_KEY,
-      JSON.stringify({
-        type: typeFilter.value,
-        severity: severityFilter.value,
-        text: textFilter.value,
-        errorsOnly: errorsOnly.value
-      })
-    )
-  } catch (_) {
-    // Ignore storage write failures (private mode, quota); filters still work in-session.
-  }
+  return safeLocalStorage.setJson(FILTERS_STORAGE_KEY, {
+    type: typeFilter.value,
+    severity: severityFilter.value,
+    text: textFilter.value,
+    errorsOnly: errorsOnly.value
+  })
 }
 
 // A filter change invalidates any accumulated "older" pages (they were queried under the old


### PR DESCRIPTION
## Summary
- centralize local browser persistence behind a safe storage adapter with an in-memory fallback
- migrate sidebar, theme, expanded navigation groups, recent panels, and Live Activity filters
- cover denied getters and methods, malformed values, recovery, theme storage events, and startup denial in Chromium

## Validation
- `npm test` (559 tests)
- `npm run build`
- frontend and e2e `npm run format:check`
- `./mvnw -B -ntp spotless:check`
- packaged sample app build with isolated Maven repository
- Playwright denied-storage app-shell scenario