### PR TITLE
build(quarkus): unify modules on 3.33 LTS

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,7 @@ bootui-spring-boot-starter  Drop-in dependency (autoconfigure + ui + spring-boot
 bootui-spring-sample-app           Reference Spring Boot 4 app for demos + Playwright e2e
 
 # Quarkus adapter
+bootui-quarkus-parent       Shared Quarkus LTS BOM + plugin management (keeps it nearer than the Spring Boot BOM)
 bootui-quarkus              Runtime: JAX-RS resources + SPI impls + CDI @Produces + Vert.x safety filter
 bootui-quarkus-deployment   Build-time wiring (build steps, bean registration, prod gating)
 bootui-quarkus-integration-tests   @QuarkusTest conformance + smoke (Docker-free)
@@ -77,12 +78,14 @@ Load-bearing rules:
 
 - Java 17 (compiler `release` 17, `-parameters`). Maven Wrapper (`./mvnw`), Maven 3.9.16; do not require a system Maven.
 - Spring Boot 4.1.x (`spring-boot.version` in root `pom.xml`; currently 4.1.0).
-- Quarkus 3.37.x for the extension and integration suites (`quarkus.platform.version` in the root `pom.xml`; currently
-  3.37.2). The Quarkus sample app has a separate platform pin aligned with its Quarkus LangChain4j dependency.
+- Quarkus 3.33 LTS for the runtime, deployment, integration suites, and sample app
+  (`quarkus.platform.version` in the root `pom.xml`; currently 3.33.3.1). They all inherit
+  `bootui-quarkus-parent`, whose nearer Quarkus BOM overrides the root parent's Spring Boot BOM only for Quarkus modules.
+  Keep the sample app's Quarkus LangChain4j BOM compatible with this shared LTS line.
 - Published Maven coordinates use `com.julien-dubois.bootui:*`; Java packages remain `io.github.jdubois.bootui.*`.
 - Node.js / npm for the packaged Vue app are downloaded automatically by the `frontend-maven-plugin` (`node.version` /
   `npm.version` in root `pom.xml`); do not add a manual Node install step for the Maven build.
-- **JDK caveat for the Quarkus sample app:** Hibernate ORM's build-time ByteBuddy enhancement (via its pinned Quarkus
+- **JDK caveat for the Quarkus sample app:** Hibernate ORM's build-time ByteBuddy enhancement (via the shared Quarkus
   platform) cannot read class files newer than the JDKs that platform supports (17, 21 and 25). So `bootui-quarkus-sample-app`
   stays in the always-on reactor (so IDEs such as IntelliJ import it on any JDK), but its Hibernate/Quarkus build-time
   augmentation is gated: a `skip-quarkus-build-on-unsupported-jdk` profile (`<jdk>[26,)</jdk>`) in the module's own pom
@@ -699,7 +702,7 @@ hide newer ones. Keep API, UI,
 
 Subtle constraints that have burned past releases — preserve them when touching `pom.xml` files or the release profile.
 The published artifacts are the shared modules and both adapters (`bootui-core`, `-engine`, `-ui`,
-`-spring-autoconfigure`, `-spring-boot-starter`, `-quarkus`, `-quarkus-deployment`); the demo/test modules (`bootui-spring-sample-app`,
+`-spring-autoconfigure`, `-spring-boot-starter`, `-quarkus-parent`, `-quarkus`, `-quarkus-deployment`); the demo/test modules (`bootui-spring-sample-app`,
 `bootui-quarkus-sample-app`, `bootui-quarkus-integration-tests`, `bootui-conformance`) set
 `<maven.deploy.skip>true</maven.deploy.skip>` — they must still build so the publishing plugin sees the full reactor, but
 must not be published.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,7 @@ jobs:
           # Missing any one artifact causes the release to fail with the coordinate in the error.
           ARTIFACTS=(
             "bootui-parent/${VERSION}/bootui-parent-${VERSION}.pom"
+            "bootui-quarkus-parent/${VERSION}/bootui-quarkus-parent-${VERSION}.pom"
             "bootui-core/${VERSION}/bootui-core-${VERSION}.jar"
             "bootui-engine/${VERSION}/bootui-engine-${VERSION}.jar"
             "bootui-spring-autoconfigure/${VERSION}/bootui-spring-autoconfigure-${VERSION}.jar"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,8 +48,8 @@ Use the root Maven properties as the source of truth for the published adapters 
 
 When updating compatibility text in docs (README, `docs/SETUP.md`, `docs/FEATURES.md`,
 `.github/copilot-instructions.md`), reference those properties and refresh any explicit version strings in the same PR.
-The non-published Quarkus sample app keeps a separate platform pin aligned with its Quarkus LangChain4j dependency; do
-not treat that demo-specific pin as the public compatibility version.
+All Quarkus modules, including the non-published sample app, inherit the Quarkus platform through
+`bootui-quarkus-parent`; keep its LangChain4j BOM compatible with that shared LTS line.
 
 ## Build
 

--- a/Dockerfile-quarkus
+++ b/Dockerfile-quarkus
@@ -125,12 +125,6 @@ ENV QUARKUS_ANALYTICS_DISABLED=true
 # setting).
 ENV QUARKUS_OTEL_TRACES_EXPORTER=none
 
-# Quarkus 3.38 bundles Grafana LGTM Observability Dev Services with quarkus-opentelemetry and enables
-# them in dev mode. This standalone container deliberately has no Docker socket, so disable that
-# Docker-backed service instead of leaving its generated grafana.endpoint / otel-collector.url
-# properties unresolved. BootUI's in-process trace capture remains enabled.
-ENV QUARKUS_OBSERVABILITY_ENABLED=false
-
 # A modest, bounded footprint. Dev mode (augmentation) needs more headroom than a packaged prod jar,
 # so this is more generous than the Spring image's 200m prod heap. The JVM reads JAVA_TOOL_OPTIONS
 # itself; override the whole set at runtime with -e JAVA_TOOL_OPTIONS="...".

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CodeQL](https://github.com/jdubois/boot-ui/actions/workflows/codeql.yml/badge.svg)](https://github.com/jdubois/boot-ui/actions/workflows/codeql.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.x-6db33f?logo=springboot&logoColor=white)](https://spring.io/projects/spring-boot)
-[![Quarkus](https://img.shields.io/badge/Quarkus-3.37.x-4695EB?logo=quarkus&logoColor=white)](https://quarkus.io/)
+[![Quarkus](https://img.shields.io/badge/Quarkus-3.33_LTS-4695EB?logo=quarkus&logoColor=white)](https://quarkus.io/)
 [![Java](https://img.shields.io/badge/Java-17-orange?logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/17/)
 
 BootUI adds an embedded, local-only developer console to your application. It runs on **Spring Boot 4** (servlet or

--- a/bootui-quarkus-deployment/pom.xml
+++ b/bootui-quarkus-deployment/pom.xml
@@ -6,26 +6,15 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-parent</artifactId>
         <version>1.12.0</version>
+        <relativePath>../bootui-quarkus-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-deployment</artifactId>
     <name>BootUI :: Quarkus Extension (Deployment)</name>
     <description>Build-time half of the BootUI Quarkus extension: registers the console's beans, JAX-RS
         resources and the safety filter, and gates them to non-production launch modes.</description>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- Arc deployment brings AdditionalBeanBuildItem + the core deployment API (Feature/IndexDependency/

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -64,7 +64,7 @@ import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationIndexBuildItem;
 import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.builditem.GeneratedServiceProviderBuildItem;
+import io.quarkus.deployment.builditem.GeneratedResourceBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
@@ -74,6 +74,7 @@ import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.resteasy.reactive.server.spi.PreExceptionMapperHandlerBuildItem;
 import io.quarkus.runtime.LaunchMode;
 import jakarta.inject.Singleton;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -226,6 +227,8 @@ class BootUiQuarkusProcessor {
     // which is absent when the REST Client extension is absent — R2).
     private static final String REST_CLIENT_TRACE_LISTENER_CLASS =
             "io.github.jdubois.bootui.quarkus.restclienttrace.QuarkusRestClientTraceListener";
+    private static final String REST_CLIENT_LISTENER_SERVICE =
+            "org.eclipse.microprofile.rest.client.spi.RestClientListener";
 
     // Referenced by class name only: BootUiSqlTraceProducer @Produces an Alternative DataSource that wraps the
     // default Agroal pool, and imports io.agroal.*; the deployment classloader must never load it without a JDBC
@@ -1588,7 +1591,7 @@ class BootUiQuarkusProcessor {
     void registerRestClientTrace(
             LaunchModeBuildItem launchMode,
             Capabilities capabilities,
-            BuildProducer<GeneratedServiceProviderBuildItem> serviceProviders,
+            BuildProducer<GeneratedResourceBuildItem> generatedResources,
             BuildProducer<ExcludedTypeBuildItem> excludedTypes,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         boolean present = launchMode.getLaunchMode() != LaunchMode.NORMAL
@@ -1599,8 +1602,9 @@ class BootUiQuarkusProcessor {
             excludedTypes.produce(new ExcludedTypeBuildItem(REST_CLIENT_TRACE_LISTENER_CLASS));
             return;
         }
-        serviceProviders.produce(new GeneratedServiceProviderBuildItem(
-                "org.eclipse.microprofile.rest.client.spi.RestClientListener", REST_CLIENT_TRACE_LISTENER_CLASS));
+        generatedResources.produce(new GeneratedResourceBuildItem(
+                "META-INF/services/" + REST_CLIENT_LISTENER_SERVICE,
+                (REST_CLIENT_TRACE_LISTENER_CLASS + System.lineSeparator()).getBytes(StandardCharsets.UTF_8)));
     }
 
     /**

--- a/bootui-quarkus-integration-tests/base/pom.xml
+++ b/bootui-quarkus-integration-tests/base/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-integration-tests</artifactId>
@@ -23,22 +23,6 @@
         it proves the engine-backed /bootui/api/** surface and the safety floor behave on Quarkus exactly as
         the shared contract requires. Never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -102,7 +86,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/cache/pom.xml
+++ b/bootui-quarkus-integration-tests/cache/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-cache-integration-tests</artifactId>
@@ -27,22 +27,6 @@
         Like the other Quarkus integration-test modules, this app has NO datasource / messaging dependencies, so
         a @QuarkusTest boots without Docker. It is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -100,7 +84,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/datasource/pom.xml
+++ b/bootui-quarkus-integration-tests/datasource/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-datasource-integration-tests</artifactId>
@@ -26,22 +26,6 @@
     <!--
         Uses an in-memory H2 datasource (quarkus-jdbc-h2), so a @QuarkusTest boots without Docker. Never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -100,7 +84,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/email/pom.xml
+++ b/bootui-quarkus-integration-tests/email/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-email-integration-tests</artifactId>
@@ -28,22 +28,6 @@
         Like the other Quarkus integration-test modules, this app has NO datasource / messaging dependencies, so
         a @QuarkusTest boots without Docker. It is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -86,7 +70,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/flyway/pom.xml
+++ b/bootui-quarkus-integration-tests/flyway/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-flyway-integration-tests</artifactId>
@@ -25,22 +25,6 @@
     <!--
         Uses an in-memory H2 datasource (quarkus-jdbc-h2), so a @QuarkusTest boots without Docker. Never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -96,7 +80,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/health/pom.xml
+++ b/bootui-quarkus-integration-tests/health/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-health-integration-tests</artifactId>
@@ -25,22 +25,6 @@
         Like the other Quarkus integration-test modules, this app has NO datasource / messaging dependencies, so
         a @QuarkusTest boots without Docker. It is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -91,7 +75,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/hibernate/pom.xml
+++ b/bootui-quarkus-integration-tests/hibernate/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-hibernate-integration-tests</artifactId>
@@ -31,22 +31,6 @@
         newer local JDK skips it and stays green. The H2 datasource is in-memory with an explicit JDBC URL, so a
         @QuarkusTest boots with no Docker. The module is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -103,7 +87,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/liquibase/pom.xml
+++ b/bootui-quarkus-integration-tests/liquibase/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-liquibase-integration-tests</artifactId>
@@ -26,22 +26,6 @@
     <!--
         H2 runs in-memory (jdbc:h2:mem), so a @QuarkusTest boots without Docker. It is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -97,7 +81,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/micrometer/pom.xml
+++ b/bootui-quarkus-integration-tests/micrometer/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-micrometer-integration-tests</artifactId>
@@ -26,22 +26,6 @@
         Like the other Quarkus integration-test modules, this app has NO datasource / messaging dependencies, so
         a @QuarkusTest boots without Docker. It is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -92,7 +76,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/otel/pom.xml
+++ b/bootui-quarkus-integration-tests/otel/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-otel-integration-tests</artifactId>
@@ -23,22 +23,6 @@
         Like bootui-quarkus-integration-tests, this module needs no Docker: its only datasource is an in-memory
         H2 pool, so a @QuarkusTest boots without any container. It is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -103,7 +87,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/pom.xml
+++ b/bootui-quarkus-integration-tests/pom.xml
@@ -6,8 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-parent</artifactId>
         <version>1.12.0</version>
+        <relativePath>../bootui-quarkus-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>

--- a/bootui-quarkus-integration-tests/prod-shell-guard/pom.xml
+++ b/bootui-quarkus-integration-tests/prod-shell-guard/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-prod-shell-guard-integration-tests</artifactId>
@@ -21,22 +21,6 @@
         QuarkusProdModeTest and a @QuarkusTest run in the same JUnit Platform launcher session (i.e. the same
         Surefire fork), so this test cannot live alongside base's (or any other submodule's) @QuarkusTest
         classes. Never published.</description>
-
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
@@ -86,7 +70,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/rest-client/pom.xml
+++ b/bootui-quarkus-integration-tests/rest-client/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-rest-client-integration-tests</artifactId>
@@ -28,22 +28,6 @@
         Like the other Quarkus integration-test modules, this app has NO datasource / messaging dependencies, so
         a @QuarkusTest boots without Docker. It is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -94,7 +78,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/scheduler/pom.xml
+++ b/bootui-quarkus-integration-tests/scheduler/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-scheduler-integration-tests</artifactId>
@@ -27,22 +27,6 @@
         Like the other Quarkus integration-test modules, this app has NO datasource / messaging dependencies, so
         a @QuarkusTest boots without Docker. It is never published.
     -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- The extension under test. Brings bootui-engine, bootui-ui (the shared bundle), quarkus-rest and
              quarkus-vertx-http transitively, so this app serves /bootui/ and /bootui/api/** with no extra deps. -->
@@ -93,7 +77,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-integration-tests/security/pom.xml
+++ b/bootui-quarkus-integration-tests/security/pom.xml
@@ -6,9 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
         <version>1.12.0</version>
-        <relativePath>../../pom.xml</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-security-integration-tests</artifactId>
@@ -23,22 +23,6 @@
         the sibling otel module) so a real server-span trace id is available at capture time, proving the Live
         Activity feed's security correlation: a captured security event nests under the REQUEST entry sharing its
         trace id and stamps that request's securedPrincipal.</description>
-
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -100,7 +84,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>

--- a/bootui-quarkus-parent/pom.xml
+++ b/bootui-quarkus-parent/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.julien-dubois.bootui</groupId>
+        <artifactId>bootui-parent</artifactId>
+        <version>1.12.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>bootui-quarkus-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>BootUI :: Quarkus Parent</name>
+    <description>Shared Quarkus LTS dependency and plugin management for the BootUI Quarkus modules.</description>
+
+    <!--
+        Keep the Quarkus BOM one inheritance level closer than bootui-parent's Spring Boot BOM. Maven's
+        nearest-wins dependency management then gives every Quarkus module the platform-tested versions of
+        shared libraries such as Jackson, Netty, and JUnit without affecting the Spring modules.
+    -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-maven-plugin</artifactId>
+                    <version>${quarkus.platform.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>io.quarkus</groupId>
+                    <artifactId>quarkus-extension-maven-plugin</artifactId>
+                    <version>${quarkus.platform.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/bootui-quarkus-sample-app/pom.xml
+++ b/bootui-quarkus-sample-app/pom.xml
@@ -6,8 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-parent</artifactId>
         <version>1.12.0</version>
+        <relativePath>../bootui-quarkus-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus-sample-app</artifactId>
@@ -26,36 +27,20 @@
         unsupported JDK stays green. On a supported JDK the app builds and augments normally; run/demo it with
         `./mvnw -pl bootui-quarkus-sample-app -am install` (or `quarkus:dev`) on a JDK 17/21/25.
 
-        Versions below (Quarkus platform, LangChain4j) stay aligned with each other for demo compatibility and are
-        independent of the published extension's platform property in the root pom.
+        The Quarkus platform comes from the shared Quarkus parent. The sample keeps only its additional
+        LangChain4j BOM, whose 1.12.1 release targets the same Quarkus 3.33 LTS line.
     -->
 
     <properties>
         <!-- Demo/integration module only: never publish to Maven Central (mirrors bootui-spring-sample-app). -->
         <maven.deploy.skip>true</maven.deploy.skip>
 
-        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
-        <!-- 3.33 LTS targets Java 17/21/25, matching this repo's java.version. Bump as needed. -->
-        <quarkus.platform.version>3.38.0</quarkus.platform.version>
-        <!-- Align with the Quarkus platform above: quarkus-langchain4j 1.11.2 targets Quarkus 3.33.2. -->
+        <!-- Quarkus LangChain4j 1.12.1 targets Quarkus 3.33.2 and is compatible with LTS patch releases. -->
         <quarkus-langchain4j.version>1.12.1</quarkus-langchain4j.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <!--
-                Import the Quarkus platform BOM in THIS module's dependencyManagement so Quarkus
-                artifacts resolve from it (nearest-wins) rather than from the Spring Boot BOM that
-                bootui-parent imports. Keep an eye on shared transitive artifacts (Jackson, JUnit).
-            -->
-            <dependency>
-                <groupId>${quarkus.platform.group-id}</groupId>
-                <artifactId>${quarkus.platform.artifact-id}</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>io.quarkiverse.langchain4j</groupId>
                 <artifactId>quarkus-langchain4j-bom</artifactId>
@@ -207,9 +192,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>${quarkus.platform.group-id}</groupId>
+                <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -244,7 +228,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>${quarkus.platform.group-id}</groupId>
+                        <groupId>io.quarkus</groupId>
                         <artifactId>quarkus-maven-plugin</artifactId>
                         <executions>
                             <execution>

--- a/bootui-quarkus/pom.xml
+++ b/bootui-quarkus/pom.xml
@@ -6,8 +6,9 @@
 
     <parent>
         <groupId>com.julien-dubois.bootui</groupId>
-        <artifactId>bootui-parent</artifactId>
+        <artifactId>bootui-quarkus-parent</artifactId>
         <version>1.12.0</version>
+        <relativePath>../bootui-quarkus-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>bootui-quarkus</artifactId>
@@ -16,24 +17,10 @@
         framework-neutral bootui-engine, the analogue of bootui-spring-autoconfigure on Spring Boot.</description>
 
     <!--
-        This is the RUNTIME half of the BootUI Quarkus extension (deployment half: bootui-quarkus-deployment).
-        It inherits bootui-parent for coordinates/formatting but imports the Quarkus BOM in its OWN
-        dependencyManagement so Quarkus artifacts resolve from it (nearest-wins) rather than from the Spring
-        Boot BOM the parent imports. Spring Boot 4 uses Jackson 3 (tools.jackson) and Quarkus uses Jackson 2
-        (com.fasterxml), so the two coexist without a clash.
+        This is the runtime half of the BootUI Quarkus extension (deployment half:
+        bootui-quarkus-deployment). The shared Quarkus parent keeps the Quarkus BOM nearer than
+        bootui-parent's Spring Boot BOM, so Jackson 2 and the rest of the Quarkus platform stay aligned.
     -->
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.platform.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <!-- Framework-neutral DTO/wire contract: the immutable records the engine returns and this adapter
@@ -311,7 +298,6 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
-                <version>${quarkus.platform.version}</version>
                 <executions>
                     <execution>
                         <id>generate-extension-descriptor</id>

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/rabbit/QuarkusRabbitCaptureTests.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/rabbit/QuarkusRabbitCaptureTests.java
@@ -7,6 +7,7 @@ import com.rabbitmq.client.Envelope;
 import io.github.jdubois.bootui.engine.rabbit.RabbitActivityRecorder;
 import io.github.jdubois.bootui.engine.rabbit.RabbitActivityRecorder.Direction;
 import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMetadata;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMetadataTestFactory;
 import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata;
 import java.util.Optional;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -82,7 +83,7 @@ class QuarkusRabbitCaptureTests {
         AMQP.BasicProperties properties =
                 new AMQP.BasicProperties.Builder().correlationId(correlationId).build();
         Envelope envelope = new Envelope(1L, false, exchange, routingKey);
-        IncomingRabbitMQMetadata metadata = new IncomingRabbitMQMetadata(properties, envelope, "orders-in");
+        IncomingRabbitMQMetadata metadata = IncomingRabbitMQMetadataTestFactory.create(properties, envelope);
         return Message.of("sensitive payload", Metadata.of(metadata));
     }
 

--- a/bootui-quarkus/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTestFactory.java
+++ b/bootui-quarkus/src/test/java/io/smallrye/reactive/messaging/rabbitmq/IncomingRabbitMQMetadataTestFactory.java
@@ -1,0 +1,13 @@
+package io.smallrye.reactive.messaging.rabbitmq;
+
+import com.rabbitmq.client.BasicProperties;
+import com.rabbitmq.client.Envelope;
+
+public final class IncomingRabbitMQMetadataTestFactory {
+
+    private IncomingRabbitMQMetadataTestFactory() {}
+
+    public static IncomingRabbitMQMetadata create(BasicProperties properties, Envelope envelope) {
+        return new IncomingRabbitMQMetadata(properties, envelope);
+    }
+}

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -46,7 +46,7 @@ gracefully when optional infrastructure is missing.
 On Quarkus the Overview panel is fully available. Its scoring *dashboard* is rendered entirely in the browser:
 the shell aggregates each advisor's own scan/report endpoints (only those whose panels are available on Quarkus
 contribute) and computes the same combined score, so no backend dashboard service is involved. The shared shell
-chrome around every panel — the header application name, framework and version (for example "Quarkus 3.37"), Java
+chrome around every panel — the header application name, framework and version (for example "Quarkus 3.33"), Java
 version, active profiles, and the active/disabled status — is populated by the same framework-neutral
 `GET /bootui/api/overview` endpoint that both adapters expose for the shell.
 

--- a/docs/REPOSITORY.md
+++ b/docs/REPOSITORY.md
@@ -11,6 +11,7 @@
 - `bootui-conformance`: shared HTTP contract suite and golden panel manifests for all adapters.
 - `bootui-spring-sample-app`: Spring MVC sample app + Playwright e2e coverage.
 - `bootui-spring-webflux-sample-app`: Spring WebFlux sample app.
+- `bootui-quarkus-parent`: shared Quarkus LTS BOM and plugin management.
 - `bootui-quarkus`: Quarkus runtime adapter.
 - `bootui-quarkus-deployment`: Quarkus build-time wiring module.
 - `bootui-quarkus-integration-tests`: Quarkus `@QuarkusTest` suites.
@@ -24,9 +25,10 @@ Spring Boot and Quarkus compatibility references for the published adapters shou
 - `quarkus.platform.version`
 
 When these are updated, refresh matching documentation references in the same pull request (`README.md`,
-`docs/SETUP.md`, `docs/FEATURES.md`, and `.github/copilot-instructions.md`).
-The non-published Quarkus sample app keeps a separate platform pin aligned with its Quarkus LangChain4j dependency;
-that demo-specific pin is not the public compatibility version.
+`docs/SETUP.md`, `docs/FEATURES.md`, and `.github/copilot-instructions.md`). All Quarkus modules inherit
+`bootui-quarkus-parent`, which imports the Quarkus BOM closer than the root parent imports Spring Boot's BOM. This keeps
+the two frameworks' shared transitive dependencies isolated while giving the extension, tests, and sample app one
+Quarkus LTS version.
 
 ## Documentation website
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -334,7 +334,7 @@ BootUI engine.
 
 - Java 17 or later
 - A Quarkus application (built and tested against the version pinned by the root `pom.xml`'s
-  `quarkus.platform.version` property; currently `3.37.2`)
+  `quarkus.platform.version` property; currently the `3.33.3.1` LTS release)
 - Maven or Gradle (or their local wrappers)
 
 ### Add the extension

--- a/pom.xml
+++ b/pom.xml
@@ -46,13 +46,14 @@
         <module>bootui-conformance</module>
         <module>bootui-spring-sample-app</module>
         <module>bootui-spring-webflux-sample-app</module>
+        <module>bootui-quarkus-parent</module>
         <module>bootui-quarkus</module>
         <module>bootui-quarkus-deployment</module>
         <module>bootui-quarkus-integration-tests</module>
         <!--
             The Quarkus sample app stays in the always-on reactor so IDEs (e.g. IntelliJ) import it as a
             Java/Maven module on ANY JDK. Its Hibernate ORM build-time augmentation cannot run on a JDK newer
-            than its pinned Quarkus platform supports, so that work (only) is skipped on JDK 26+ by a profile in
+            than the shared Quarkus LTS platform supports, so that work (only) is skipped on JDK 26+ by a profile in
             the module's own pom; plain compile (release 17) + jar still runs everywhere. The module has no
             tests, so nothing fails on an unsupported JDK.
         -->
@@ -67,8 +68,8 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <spring-boot.version>4.1.0</spring-boot.version>
-        <!-- Quarkus platform for the extension and integration suites; the sample app pins its own compatible platform. -->
-        <quarkus.platform.version>3.37.2</quarkus.platform.version>
+        <!-- Latest Quarkus LTS, shared by the extension, integration tests, and sample app. -->
+        <quarkus.platform.version>3.33.3.1</quarkus.platform.version>
         <!-- testcontainers version is managed by the Spring Boot BOM (2.0.x) -->
         <!-- opentelemetry-proto remains on -alpha as the upstream project does not publish stable releases yet -->
         <opentelemetry-proto.version>1.10.0-alpha</opentelemetry-proto.version>


### PR DESCRIPTION
## What does this PR do?

Unifies the Quarkus runtime, deployment, integration-test, and sample modules on Quarkus 3.33.3.1 LTS through a shared, publishable `bootui-quarkus-parent`.

## Why is this change needed?

The extension modules inherited Quarkus 3.37.2 while the sample app independently pinned 3.38.0, even though Quarkus LangChain4j 1.12.1 targets the 3.33 LTS stream. Centralizing the Quarkus BOM and plugin management prevents future drift while keeping Spring Boot and Quarkus dependency management isolated.

N/A (no linked issue)

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end (not applicable: no Spring or UI behavior changed)
- [x] Added or updated tests where applicable

The full reactor build ran with an isolated Maven repository. The local JDK is 26, so the repository's existing JDK gate skipped Quarkus sample/Hibernate augmentation; GitHub Actions runs those paths on JDK 17.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
