### PR TITLE
Use a worktree-local Maven repository in app scripts

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -18,7 +18,8 @@ scripts:
   # clash in the shared ~/.m2 registry.
   - name: Setup
     command: >-
-      ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-spring-sample-app -am
+      export MAVEN_OPTS="${MAVEN_OPTS:+$MAVEN_OPTS }-Dmaven.repo.local=.m2"
+      && ./mvnw -B -ntp -pl bootui-spring-sample-app -am
       -DskipTests install
       && npm install
     triggers:
@@ -37,12 +38,13 @@ scripts:
   # Setup, or in a worktree where Setup never ran), Maven downloads whatever is
   # missing -- such as the spring-boot-dependencies BOM or spring-boot-maven-plugin
   # -- instead of failing with "Cannot access central in offline mode".
-  # -Dmaven.repo.local=.m2 still keeps the build isolated from the shared ~/.m2.
+  # MAVEN_OPTS still keeps every Maven invocation isolated from the shared ~/.m2.
   - name: Dev server (sample app)
     command: >-
-      ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-spring-sample-app -am
+      export MAVEN_OPTS="${MAVEN_OPTS:+$MAVEN_OPTS }-Dmaven.repo.local=.m2"
+      && ./mvnw -B -ntp -pl bootui-spring-sample-app -am
       -DskipTests install
-      && ./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-spring-sample-app
+      && ./mvnw -B -ntp -pl bootui-spring-sample-app
       -Dmaven.test.skip=true spring-boot:run -Dspring-boot.run.profiles=dev
       -Dspring-boot.run.arguments=--server.port=$COPILOT_PORT
 


### PR DESCRIPTION
Concurrent Copilot app worktrees install identical local module versions, so sharing `~/.m2` can make one session consume another session's artifacts.

This exports `MAVEN_OPTS` at the start of each Maven-backed app script, preserving any existing options while setting `maven.repo.local=.m2`. Setup and dev-server Maven invocations now consistently use the worktree-local repository without repeating the flag on every command.

This is scoped to GitHub Copilot app scripts and does not alter developer-wide Maven or IntelliJ settings.