### PR TITLE
Synchronize panel inventory documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -376,7 +376,7 @@ hide newer ones. Keep API, UI,
 - **Configuration**: Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings
 - **Database**: Database Connection Pools, SQL Trace, Spring Data, Flyway, Liquibase
 - **Security**: Spring Security, Security Logs
-- **Services**: Scheduled Tasks, REST Client, AI Framework, Cache, Email, Kafka, RabbitMQ
+- **Services**: Scheduled Tasks, REST Client, AI Framework, Cache, Email, Kafka, RabbitMQ, JMS
 - **Diagnostics**: Traces, Log Tail, Exceptions, HTTP Exchanges, HTTP Probe
 - **Developer Tools**: MCP Server, DevTools, Dev Services, Copilot, Claude Code
 
@@ -412,9 +412,9 @@ hide newer ones. Keep API, UI,
   `LocalhostGuard` write floor: the advisor scans (Architecture, the Quarkus app advisor, Pentesting, Hibernate,
   Security, Memory, REST API, and Vulnerabilities/OSV), Heap Dump (capture/analyze/delete/download), Threads (download),
   Loggers (set level), HTTP Probe, Cache (clear), Kafka (clear), RabbitMQ (clear), Email (clear), Flyway (migrate/clean), Liquibase
-  (update), Traces (clear), REST Client (clear/recording), and the MCP Server toggle. Only GraalVM, CRaC, Conditions,
-  Startup Timeline, HTTP Sessions, Spring Data, Spring Security, and DevTools
-  stay unavailable, most with a panel-specific not-applicable reason. The
+  (update), Traces (clear), REST Client (clear/recording), and the MCP Server toggle. GraalVM, CRaC, Conditions,
+  Startup Timeline, HTTP Sessions, Spring Data, Spring Security, and DevTools are intentionally not applicable; JMS is
+  separately not yet available on Quarkus. The
   **Memory** advisor is the cleanest port: every scanner/rule/context class was already framework-neutral (JMX +
   `java.lang.management` only), so it relocated wholesale into the engine `MemoryScanner` (built via
   `MemoryScanner.create(ThreadDumpService, Clock)`) with the Spring `MemoryController` reduced to thin wiring and a

--- a/bootui-ui/src/main/frontend/src/routes.test.js
+++ b/bootui-ui/src/main/frontend/src/routes.test.js
@@ -8,18 +8,15 @@ const namedRoutes = routes.filter((route) => route.name)
 const repoRoot = findRepositoryRoot(path.dirname(fileURLToPath(import.meta.url)))
 
 function parseBackendPanels() {
-  const source = fs.readFileSync(
-    path.join(repoRoot, 'bootui-engine/src/main/java/io/github/jdubois/bootui/engine/panel/BootUiPanels.java'),
-    'utf8'
+  const source = readRepositoryFile(
+    'bootui-engine/src/main/java/io/github/jdubois/bootui/engine/panel/BootUiPanels.java'
   )
 
   // These regexes intentionally parse the current BootUiPanels source shape:
   // - string constants declared as `public static final String ... = "...";`
   // - panel entries declared as `new Panel(CONSTANT, "Title", true|false, "..."/List.of(...))`
   // If BootUiPanels declaration style changes, this test should be updated with it.
-  const constants = new Map(
-    [...source.matchAll(/public static final String ([A-Z_]+) = "([^"]+)";/g)].map((match) => [match[1], match[2]])
-  )
+  const constants = parseBackendPanelConstants(source)
 
   const panels = [
     ...source.matchAll(/new Panel\(([^,]+),\s*"([^"]+)",\s*(true|false),\s*(List\.of\([^\)]*\)|"[^"]*")\)/g)
@@ -39,11 +36,168 @@ function parseBackendPanels() {
 
 function loadManifest(fileName) {
   return JSON.parse(
-    fs.readFileSync(
-      path.join(repoRoot, 'bootui-conformance/src/main/resources/io/github/jdubois/bootui/conformance', fileName),
-      'utf8'
+    readRepositoryFile(
+      path.join('bootui-conformance/src/main/resources/io/github/jdubois/bootui/conformance', fileName)
     )
   )
+}
+
+function readRepositoryFile(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+function parseBackendPanelConstants(source) {
+  return new Map(
+    [...source.matchAll(/public static final String ([A-Z_]+) = "([^"]+)";/g)].map((match) => [match[1], match[2]])
+  )
+}
+
+function extractParenthesizedInitializer(source, marker) {
+  const markerIndex = source.indexOf(marker)
+  if (markerIndex < 0) {
+    throw new Error(`Missing Java initializer marker: ${marker}`)
+  }
+
+  const openIndex = source.indexOf('(', markerIndex + marker.length)
+  let depth = 0
+  let inString = false
+  let escaped = false
+
+  for (let index = openIndex; index < source.length; index += 1) {
+    const character = source[index]
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === '"') {
+        inString = false
+      }
+      continue
+    }
+    if (character === '"') {
+      inString = true
+    } else if (character === '(') {
+      depth += 1
+    } else if (character === ')') {
+      depth -= 1
+      if (depth === 0) {
+        return source.slice(openIndex + 1, index)
+      }
+    }
+  }
+
+  throw new Error(`Unterminated Java initializer marker: ${marker}`)
+}
+
+function parsePanelReferences(source, marker, constants) {
+  const initializer = extractParenthesizedInitializer(source, marker)
+  return new Set(
+    [...initializer.matchAll(/BootUiPanels\.([A-Z_]+)/g)].map((match) => {
+      const panelId = constants.get(match[1])
+      if (!panelId) {
+        throw new Error(`Unknown BootUiPanels constant: ${match[1]}`)
+      }
+      return panelId
+    })
+  )
+}
+
+function parseQuarkusAvailability() {
+  const backendSource = readRepositoryFile(
+    'bootui-engine/src/main/java/io/github/jdubois/bootui/engine/panel/BootUiPanels.java'
+  )
+  const constants = parseBackendPanelConstants(backendSource)
+  const source = readRepositoryFile(
+    'bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAvailability.java'
+  )
+  const staticPanels = parsePanelReferences(
+    source,
+    'private static final Set<String> AVAILABLE_PANELS = Set.of',
+    constants
+  )
+  const capabilityGated = parsePanelReferences(source, 'this.dynamicAvailability = Map.ofEntries', constants)
+  const capabilityReasons = parsePanelReferences(
+    source,
+    'private static final Map<String, String> CAPABILITY_ABSENT = Map.ofEntries',
+    constants
+  )
+  const notApplicable = parsePanelReferences(
+    source,
+    'private static final Map<String, String> NOT_APPLICABLE = Map.of',
+    constants
+  )
+  const notYetAvailable = parsePanelReferences(
+    source,
+    'private static final Map<String, String> NOT_YET_AVAILABLE_REASONS = Map.of',
+    constants
+  )
+  const detectorMatch = source.match(/BootUiPanels\.([A-Z_]+)\.equals\(panelId\)\s*&&\s*githubAvailable\(\)/)
+  if (!detectorMatch || !constants.has(detectorMatch[1])) {
+    throw new Error('Unable to parse the dynamic GitHub panel detector')
+  }
+  const detectorGated = new Set([constants.get(detectorMatch[1])])
+
+  return {
+    staticPanels,
+    capabilityGated,
+    capabilityReasons,
+    detectorGated,
+    notApplicable,
+    notYetAvailable
+  }
+}
+
+function parseQuarkusSupportTable(markdown) {
+  const appendix = markdown.split('## 11. Appendix — full panel disposition')[1]
+  if (!appendix) {
+    throw new Error('Missing Quarkus support appendix')
+  }
+
+  return appendix
+    .split('\n')
+    .map((line) => line.match(/^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|/))
+    .filter((match) => match && match[1] !== 'Panel' && !match[1].startsWith('-'))
+    .map((match) => ({
+      title: match[1].replaceAll('`', '').trim(),
+      classification: match[3].replaceAll('*', '').replaceAll('`', '').trim()
+    }))
+}
+
+function parseInlineGroupInventory(markdown) {
+  return new Map(
+    [...markdown.matchAll(/^- \*\*([^*]+)\*\*: (.+)$/gm)].map((match) => [
+      match[1],
+      match[2].split(',').map((title) => title.trim())
+    ])
+  )
+}
+
+function parseSpecificationGroupInventory(markdown) {
+  const navigation = markdown.split('### 7.1 Navigation')[1]?.split('### 7.2 UI principles')[0]
+  if (!navigation) {
+    throw new Error('Missing specification navigation section')
+  }
+
+  const inventory = new Map()
+  let currentGroup = null
+  for (const line of navigation.split('\n')) {
+    const group = line.match(/^- ([^:]+):$/)
+    if (group) {
+      currentGroup = group[1]
+      inventory.set(currentGroup, [])
+      continue
+    }
+    const panel = line.match(/^  - (.+)\.$/)
+    if (panel && currentGroup) {
+      inventory.get(currentGroup).push(panel[1])
+    }
+  }
+  return inventory
+}
+
+function sorted(values) {
+  return [...values].sort()
 }
 
 function findRepositoryRoot(startDirectory) {
@@ -145,13 +299,108 @@ describe('routes', () => {
   })
 
   it('documents every panel from the backend panel catalog in docs/FEATURES.md', () => {
-    const features = fs.readFileSync(path.join(repoRoot, 'docs/FEATURES.md'), 'utf8')
+    const features = readRepositoryFile('docs/FEATURES.md')
 
     for (const panel of parseBackendPanels()) {
       const headingLevel = panel.title === 'Overview' ? '##' : '###'
       const escapedTitle = panel.title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
       const headingPattern = new RegExp(`^${headingLevel} ${escapedTitle}$`, 'm')
       expect(headingPattern.test(features)).toBe(true)
+    }
+  })
+
+  it('keeps Quarkus availability counts and support-table classifications derived from code', () => {
+    const backendPanels = parseBackendPanels()
+    const backendIds = new Set(backendPanels.map((panel) => panel.id))
+    const titlesById = new Map(backendPanels.map((panel) => [panel.id, panel.title]))
+    const availability = parseQuarkusAvailability()
+    const conditionalPanels = new Set([...availability.capabilityGated, ...availability.detectorGated])
+    const shippedPanels = new Set([...availability.staticPanels, ...conditionalPanels])
+    const classifiedPanels = [
+      ...availability.staticPanels,
+      ...conditionalPanels,
+      ...availability.notApplicable,
+      ...availability.notYetAvailable
+    ]
+
+    expect(sorted(availability.capabilityReasons)).toEqual(sorted(availability.capabilityGated))
+    expect(new Set(classifiedPanels).size).toBe(classifiedPanels.length)
+    expect(sorted(classifiedPanels)).toEqual(sorted(backendIds))
+
+    const support = readRepositoryFile('docs/QUARKUS-SUPPORT.md')
+    const result = support.match(/\*\*Result:\*\*\s*(\d+) of the (\d+) panels ship on Quarkus/)
+    const availableCounts = support.match(/(\d+) are statically available and (\d+) are capability\/detector-gated/)
+    const unavailableCounts = support.match(
+      /remaining (\d+) panels do not ship:\s*(\d+) are intentionally not applicable[\s\S]*?and (\d+) \(`JMS`\) is not yet available/
+    )
+
+    expect(result?.slice(1).map(Number)).toEqual([shippedPanels.size, backendIds.size])
+    expect(availableCounts?.slice(1).map(Number)).toEqual([availability.staticPanels.size, conditionalPanels.size])
+    expect(unavailableCounts?.slice(1).map(Number)).toEqual([
+      availability.notApplicable.size + availability.notYetAvailable.size,
+      availability.notApplicable.size,
+      availability.notYetAvailable.size
+    ])
+
+    const table = parseQuarkusSupportTable(support)
+    const rowsByTitle = new Map(table.map((row) => [row.title, row]))
+    expect(rowsByTitle.size).toBe(table.length)
+    expect(sorted(rowsByTitle.keys())).toEqual(sorted(backendPanels.map((panel) => panel.title)))
+
+    const shippedClassifications = new Set(['Port', 'Adapt', 'Rebuild', 'Replace'])
+    expect(
+      sorted(table.filter((row) => shippedClassifications.has(row.classification)).map((row) => row.title))
+    ).toEqual(sorted([...shippedPanels].map((id) => titlesById.get(id))))
+    expect(sorted(table.filter((row) => row.classification === 'Drop').map((row) => row.title))).toEqual(
+      sorted([...availability.notApplicable].map((id) => titlesById.get(id)))
+    )
+    expect(sorted(table.filter((row) => row.classification === 'Not yet').map((row) => row.title))).toEqual(
+      sorted([...availability.notYetAvailable].map((id) => titlesById.get(id)))
+    )
+
+    for (const [classification, heading] of [
+      ['Port', /### 5\.1 .+ \((\d+)\)/],
+      ['Adapt', /### 5\.2 .+ \((\d+)\)/],
+      ['Rebuild', /### 5\.3 .+ \((\d+)\)/],
+      ['Replace', /### 5\.4 .+ \((\d+)\)/],
+      ['Drop', /### 5\.5 .+ \((\d+)\)/],
+      ['Not yet', /### 5\.6 .+ \((\d+)\)/]
+    ]) {
+      const documentedCount = Number(support.match(heading)?.[1])
+      expect(documentedCount, `${classification} heading count`).toBe(
+        table.filter((row) => row.classification === classification).length
+      )
+    }
+  })
+
+  it('keeps documented navigation groups aligned with route metadata', () => {
+    const expectedByGroup = new Map(
+      Object.entries({
+        Overview: groups.overview,
+        Advisors: groups.advisors,
+        Runtime: groups.runtime,
+        Configuration: groups.configuration,
+        Database: groups.database,
+        Security: groups.security,
+        Services: groups.services,
+        Diagnostics: groups.diagnostics,
+        'Developer Tools': groups.developerTools
+      }).map(([title, group]) => [
+        title,
+        namedRoutes.filter((route) => route.meta.group === group).map((route) => route.meta.title)
+      ])
+    )
+
+    const instructions = parseInlineGroupInventory(readRepositoryFile('.github/copilot-instructions.md'))
+    for (const [group, expectedTitles] of expectedByGroup) {
+      expect(instructions.get(group), `.github/copilot-instructions.md ${group}`).toEqual(expectedTitles)
+    }
+    expect(instructions.get('Services')).toContain('JMS')
+
+    const specification = parseSpecificationGroupInventory(readRepositoryFile('docs/SPECIFICATION.md'))
+    for (const [group, expectedTitles] of expectedByGroup) {
+      const specificationGroup = group === 'Developer Tools' ? 'Developer tools' : group
+      expect(specification.get(specificationGroup), `docs/SPECIFICATION.md ${group}`).toEqual(expectedTitles)
     }
   })
 

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -168,11 +168,11 @@ extension of the mechanism `App.vue` already uses, so the same UI build renders 
 > **Action-capable panels behave identically to Spring**, behind the shared `LocalhostGuard` write floor: Heap Dump
 > (capture/analyze/delete/download), Threads (download), the advisor scans, Loggers (set level), HTTP Probe, Cache
 > (clear), Flyway (migrate/clean), Liquibase (update), Traces (clear), Email (clear), Kafka (clear), RabbitMQ (clear),
-> REST Client Reactive (clear + recording toggle), and the MCP Server toggle. Only **GraalVM**, **CRaC**,
-> **Conditions**, **Startup Timeline**,
-> **HTTP Sessions**, **Spring Data**, **Spring Security**, and **DevTools** stay unavailable with a panel-specific
-> not-applicable reason (§5.5). The per-panel `**Implemented**` markers below and `docs/FEATURES.md` carry the authoritative, current
-> per-platform detail.
+> REST Client Reactive (clear + recording toggle), and the MCP Server toggle. Eight panels — **GraalVM**, **CRaC**,
+> **Conditions**, **Startup Timeline**, **HTTP Sessions**, **Spring Data**, **Spring Security**, and **DevTools** — are
+> intentionally unavailable with a panel-specific not-applicable reason (§5.5). **JMS** is the sole panel that is not yet
+> available on Quarkus (§5.6). The per-panel `**Implemented**` markers below and `docs/FEATURES.md` carry the authoritative,
+> current per-platform detail.
 
 ### 5.1 Ported as-is — framework-agnostic or same library (17)
 
@@ -326,11 +326,17 @@ No equivalent, low value, or superseded by Quarkus's own tooling:
   it niche), `DevTools` (**Implemented as `NOT_APPLICABLE`** — Quarkus has built-in dev-mode live reload, so there is no
   Spring-style DevTools restart/LiveReload to expose; the panel reports *not applicable* rather than *not yet*).
 
-**Result:** 42 of the 50 panels ship on Quarkus (17 ported as-is, 11 source-swapped, 11 capture-rebuilt, and 3 replaced
-with a Quarkus-native panel), and 8 are
-dropped as *not applicable* (GraalVM, CRaC, Conditions, Startup Timeline, HTTP Sessions, Spring Data, Spring
-Security, DevTools). The Overview dashboard panel is available (its scoring dashboard renders client-side from the
-advisor endpoints, and the shell-chrome `GET /bootui/api/overview` endpoint is served on both adapters).
+### 5.6 Not yet available on Quarkus (1)
+
+- `JMS` uses Spring JMS (`JmsTemplate` and `@JmsListener`) today. Quarkus users can use the implemented Kafka and RabbitMQ
+  panels while a Quarkus-native JMS capture layer remains unimplemented.
+
+**Result:** 43 of the 52 panels ship on Quarkus: 25 are statically available and 18 are capability/detector-gated. The
+remaining 9 panels do not ship: 8 are intentionally not applicable (GraalVM, CRaC, Conditions, Startup Timeline, HTTP
+Sessions, Spring Data, Spring Security, DevTools), and 1 (`JMS`) is not yet available. By portability strategy, the 43
+shipped panels comprise 17 ported as-is, 11 source-swapped, 12 capture-rebuilt, and 3 replaced with a Quarkus-native
+panel. The Overview dashboard panel is available (its scoring dashboard renders client-side from the advisor endpoints,
+and the shell-chrome `GET /bootui/api/overview` endpoint is served on both adapters).
 
 ## 6. Activation & safety on Quarkus
 
@@ -504,7 +510,7 @@ Pentesting, HTTP Probe, MCP Server) need no special ingredients — they work ag
 ## 11. Appendix — full panel disposition
 
 `Port` = ships from shared code · `Adapt` = swap data source via SPI · `Rebuild` = reimplement capture ·
-`Replace` = Quarkus-native panel · `Drop` = not shipped.
+`Replace` = Quarkus-native panel · `Drop` = intentionally not applicable · `Not yet` = not currently shipped.
 
 | Panel               | Tier        | Quarkus | Shared component                 | Quarkus adapter / reason                    |
 | ------------------- | ----------- | ------- | -------------------------------- | ------------------------------------------- |
@@ -535,7 +541,7 @@ Pentesting, HTTP Probe, MCP Server) need no special ingredients — they work ag
 | Scheduled Tasks     | equiv       | Adapt   | Scheduled mapper                 | `ScheduledTaskProvider` → quarkus-scheduler |
 | Architecture        | equiv       | Adapt   | ArchUnit engine                  | `BasePackageProvider` (rules run unmodified) |
 | REST API            | **done**    | Rebuild | REST conventions engine          | JAX-RS handler-model builder                |
-| DB Connection Pools | **done**    | Rebuild | Pool model                       | `DataSourcePoolProvider` → Agroal           |
+| Database Connection Pools | **done**    | Rebuild | Pool model                       | `DataSourcePoolProvider` → Agroal           |
 | SQL Trace           | **done**    | Rebuild | SQL trace model                  | `SqlTraceSource` → Agroal/JDBC              |
 | Live Activity       | **done**    | Rebuild | Activity model                   | `RequestCaptureSource` → Vert.x; OTel trace-id correlation + trace-id-only profile drill-down; optional JDBC persistence backend via `QuarkusActivityCapture` (unconditional producers, identical to Spring); Kafka and RabbitMQ messaging capture via SmallRye `Outgoing`/`IncomingInterceptor` feeding the shared transport recorders; captured email (`MAIL`) reuses the shared `EmailCaptureService` directly, no separate capture needed |
 | HTTP Exchanges      | **done**    | Rebuild | Exchange model                   | `HttpExchangeProvider` → Vert.x             |
@@ -545,13 +551,13 @@ Pentesting, HTTP Probe, MCP Server) need no special ingredients — they work ag
 | Email               | **done**    | Rebuild | Email capture service            | CDI `@Observes SentMail` observer → quarkus-mailer |
 | Kafka               | **done**    | Rebuild | `KafkaActivityRecorder`          | SmallRye `Outgoing`/`IncomingInterceptor` (`Capability.KAFKA`-gated); same recorder as Live Activity |
 | RabbitMQ            | **done**    | Rebuild | `RabbitActivityRecorder`         | SmallRye `Outgoing`/`IncomingInterceptor` (`quarkus-messaging-rabbitmq` class-presence-gated); same recorder as Live Activity |
-| JMS                 | spring-only | Rebuild | `JmsActivityRecorder`            | Quarkus JMS capture not yet implemented; use Kafka/RabbitMQ panels |
+| JMS                 | spring-only | Not yet | `JmsActivityRecorder`            | Quarkus JMS capture not yet implemented; use Kafka/RabbitMQ panels |
 | REST Client         | **done**    | Rebuild | `RestClientTraceRecorder`        | `Capability.REST_CLIENT_REACTIVE`-gated generated `RestClientListener` service provider → metadata-only `QuarkusRestClientTraceFilter`; URI sanitization, status-0 transport failures, trace correlation, SSE/actions, and absent-extension type exclusion |
 | Spring              | **done**    | Replace | Scanning engine                  | new `Quarkus` advisor ruleset               |
 | Cache               | **done**    | Replace | Cache model                      | `CacheProvider` → quarkus-cache             |
 | Beans               | **done**    | Adapt   | Beans service                    | `BeanProvider` → Arc (build-time; low fidelity) |
 | Profile Diff        | **done**    | Adapt   | Config service                   | `ConfigProvider` → SmallRye profiles        |
-| Security (advisor)  | **done**    | Replace | Quarkus security ruleset         | Quarkus-native checks (OIDC/auth/TLS/CORS/annotations); see QUARKUS-CHECKS.md |
+| Security            | **done**    | Replace | Quarkus security ruleset         | Quarkus-native checks (OIDC/auth/TLS/CORS/annotations); see QUARKUS-CHECKS.md |
 | GraalVM             | **done**    | Drop    | —                                | Quarkus native-first; `NOT_APPLICABLE`      |
 | CRaC                | **done**    | Drop    | —                                | native focus; `NOT_APPLICABLE`              |
 | DevTools            | **done**    | Drop    | —                                | Quarkus live reload built in; `NOT_APPLICABLE` |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1890,6 +1890,7 @@ Top-level navigation:
 
 - Overview:
   - Overview.
+  - Live Activity.
   - GitHub.
 - Advisors:
   - Architecture.
@@ -1910,6 +1911,7 @@ Top-level navigation:
   - Threads.
   - Startup Timeline.
   - GraalVM.
+  - CRaC.
 - Configuration:
   - Configuration.
   - Profile Diff.
@@ -1919,6 +1921,7 @@ Top-level navigation:
   - Mappings.
 - Database:
   - Database Connection Pools.
+  - SQL Trace.
   - Spring Data.
   - Flyway.
   - Liquibase.
@@ -1930,14 +1933,18 @@ Top-level navigation:
   - REST Client.
   - AI Framework.
   - Cache.
+  - Email.
+  - Kafka.
+  - RabbitMQ.
+  - JMS.
 - Diagnostics:
   - Traces.
   - Log Tail.
   - Exceptions.
   - HTTP Exchanges.
   - HTTP Probe.
-  - Email.
 - Developer tools:
+  - MCP Server.
   - DevTools.
   - Dev Services.
   - Copilot.
@@ -2030,15 +2037,8 @@ Future compatibility:
 BootUI's 1.0 release surface is complete when:
 
 - A sample Spring Boot app can add the starter and open `/bootui`.
-- The UI shows Overview, Advisors, Runtime, Configuration, Database, Security, Services, Diagnostics, Developer tools, and
-  Disabled / unavailable navigation groups covering Health, HTTP Sessions, Metrics, Live Memory, JVM Tuning, Heap Dump,
-  Threads, Startup Timeline, GraalVM, Configuration, Profile Diff, Loggers, Beans, Conditions, Mappings, Database
-  Connection Pools, Spring Data, Hibernate, Flyway, Liquibase, Spring Security, Security Logs, Security, Pentesting,
-  Vulnerabilities, Scheduled Tasks, REST Client, AI Framework, Cache, Traces, Log Tail, HTTP Exchanges, HTTP Probe,
-  Architecture,
-  REST API, Spring, Memory,
-  DevTools,
-  Dev Services, Copilot, Claude Code, and GitHub.
+- The UI shows the complete grouped panel inventory defined in §7.1, plus the Disabled / unavailable navigation group for
+  panels whose backing infrastructure is unavailable.
 - Secret-like values are masked.
 - BootUI is disabled by default outside local/dev contexts.
 - Tests verify activation and safety behavior.


### PR DESCRIPTION
## Summary
- correct the Quarkus support inventory to the current 52-panel catalog: 25 static, 18 capability/detector-gated, 8 intentionally not applicable, and 1 not yet available
- add JMS to the Services inventories and reconcile the specification navigation list
- extend the route consistency test to derive Quarkus categories from runtime source and validate headline counts, appendix classifications, manifests, and documented route groups

## Validation
- `cd bootui-ui/src/main/frontend && npm test`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-conformance -Dtest=BackendPanelCatalogConsistencyTest test`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-spring-sample-app,bootui-spring-webflux-sample-app,bootui-quarkus-integration-tests/base -am -Dtest=SpringApiConformanceTest,WebFluxApiConformanceTest,BootUiQuarkusApiConformanceTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `cd bootui-ui/src/main/frontend && npm run format:check`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:check`