### PR TITLE
Sanitize MCP internal error responses

### DIFF
--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractMcpConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractMcpConformanceTest.java
@@ -183,6 +183,25 @@ public abstract class AbstractMcpConformanceTest {
     }
 
     @Test
+    void testMcpUnknownToolRetainsSafeActionableError() {
+        assumeTrue(enableMcp());
+        try {
+            Response response = probe().request(
+                            "POST",
+                            "/bootui/api/mcp",
+                            Map.of("Content-Type", "application/json"),
+                            "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\","
+                                    + "\"params\":{\"name\":\"does_not_exist\"}}");
+            assertThat(response.status()).isEqualTo(200);
+            JsonNode error = response.json().path("error");
+            assertThat(error.path("code").asInt()).isEqualTo(-32602);
+            assertThat(error.path("message").asText()).isEqualTo("Unknown tool: does_not_exist");
+        } finally {
+            disableMcp();
+        }
+    }
+
+    @Test
     void testMcpPromptsWhenEnabled() {
         assumeTrue(enableMcp());
         try {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpDispatchOutcome.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpDispatchOutcome.java
@@ -78,7 +78,8 @@ public sealed interface McpDispatchOutcome
      * A JSON-RPC protocol error (an {@code error} envelope).
      *
      * @param code the JSON-RPC error code (see {@link McpProtocol})
-     * @param message the human-readable error message
+     * @param message the human-readable error message; unexpected failures use the detail-free {@link
+     *     McpProtocol#INTERNAL_ERROR_MESSAGE}
      */
     record ProtocolError(int code, String message) implements McpDispatchOutcome {}
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpDispatcher.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpDispatcher.java
@@ -11,7 +11,10 @@ import io.github.jdubois.bootui.engine.mcp.McpDispatchOutcome.ToolCallResult;
 import io.github.jdubois.bootui.engine.mcp.McpDispatchOutcome.ToolsListResult;
 import io.github.jdubois.bootui.spi.McpPanelPolicy;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Semaphore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Framework- and JSON-free core of the BootUI MCP server: it routes an already-parsed
@@ -24,12 +27,14 @@ import java.util.concurrent.Semaphore;
  * {@code ObjectMapper} (Jackson 3 on Spring Boot, Jackson 2 on Quarkus). The control flow here is a
  * one-to-one translation of the original Spring {@code BootUiMcpService} so both adapters answer
  * byte-identically: a refused panel gate is an in-band {@link ToolCallError} ({@code isError:true});
- * malformed tool calls are JSON-RPC {@link ProtocolError}s; a tool handler throwing a
- * {@link RuntimeException} becomes a JSON-RPC {@link ProtocolError} ({@code -32603}); serialization of
- * a successful payload (the only remaining Jackson step) is performed and error-handled by the adapter
- * codec.
+ * malformed tool calls are JSON-RPC {@link ProtocolError}s; an unexpected failure becomes the standard,
+ * detail-free JSON-RPC internal error ({@code -32603}) and is sent to the server-side diagnostic
+ * reporter. Serialization of a successful payload (the only remaining Jackson step) is performed and
+ * error-handled by the adapter codec.
  */
 public final class McpDispatcher {
+
+    private static final Logger log = LoggerFactory.getLogger(McpDispatcher.class);
 
     private final List<McpTool> tools;
     private final List<McpPrompt> prompts;
@@ -38,6 +43,7 @@ public final class McpDispatcher {
     private final String instructions;
     private final int maxResults;
     private final Semaphore toolCallSemaphore;
+    private final McpFailureReporter failureReporter;
 
     /**
      * @param tools the advertised tool catalog, in order (each adapter wires its own controllers /
@@ -57,13 +63,39 @@ public final class McpDispatcher {
             String instructions,
             int maxResults,
             int maxConcurrentCalls) {
+        this(
+                tools,
+                prompts,
+                policy,
+                serverVersion,
+                instructions,
+                maxResults,
+                maxConcurrentCalls,
+                (operation, failure) -> log.error("BootUI MCP failure while {}", operation, failure));
+    }
+
+    /**
+     * Creates a dispatcher with an adapter-owned diagnostic reporter.
+     *
+     * @param failureReporter receives each unexpected failure exactly once with its original stack trace
+     */
+    public McpDispatcher(
+            List<McpTool> tools,
+            List<McpPrompt> prompts,
+            McpPanelPolicy policy,
+            String serverVersion,
+            String instructions,
+            int maxResults,
+            int maxConcurrentCalls,
+            McpFailureReporter failureReporter) {
         this.tools = List.copyOf(tools);
         this.prompts = List.copyOf(prompts);
-        this.policy = policy;
+        this.policy = Objects.requireNonNull(policy, "policy");
         this.serverVersion = serverVersion == null ? "dev" : serverVersion;
         this.instructions = instructions;
         this.maxResults = Math.max(1, maxResults);
         this.toolCallSemaphore = new Semaphore(Math.max(1, maxConcurrentCalls));
+        this.failureReporter = Objects.requireNonNull(failureReporter, "failureReporter");
     }
 
     /**
@@ -102,6 +134,17 @@ public final class McpDispatcher {
      * notification with no applicable response; the adapter then emits no body (HTTP 202).
      */
     public McpDispatchOutcome dispatch(McpRequest request) {
+        try {
+            return dispatchRequest(request);
+        } catch (RuntimeException | Error failure) {
+            failureReporter.report("dispatching a request", failure);
+            return request != null && request.notification()
+                    ? new NoResponse()
+                    : new ProtocolError(McpProtocol.INTERNAL_ERROR, McpProtocol.INTERNAL_ERROR_MESSAGE);
+        }
+    }
+
+    private McpDispatchOutcome dispatchRequest(McpRequest request) {
         String method = request.method();
         if (method == null || method.isEmpty()) {
             return request.notification()
@@ -160,10 +203,6 @@ public final class McpDispatcher {
         try {
             Object payload = tool.invoke(arguments);
             return new ToolCallResult(payload);
-        } catch (RuntimeException ex) {
-            // A tool handler failure becomes a JSON-RPC error (-32603), exactly as the original Spring
-            // service reported a generic RuntimeException out of the tools/call switch.
-            return new ProtocolError(McpProtocol.INTERNAL_ERROR, ex.getMessage());
         } finally {
             toolCallSemaphore.release();
         }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpFailureReporter.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpFailureReporter.java
@@ -1,0 +1,14 @@
+package io.github.jdubois.bootui.engine.mcp;
+
+/**
+ * Receives unexpected MCP failures for server-side diagnostics.
+ *
+ * <p>Implementations must retain the original throwable and stack trace. The operation is fixed
+ * server-generated context and never contains client input.
+ */
+@FunctionalInterface
+public interface McpFailureReporter {
+
+    /** Reports one unexpected failure at the boundary that converts it to a safe JSON-RPC error. */
+    void report(String operation, Throwable failure);
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpProtocol.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpProtocol.java
@@ -65,6 +65,8 @@ public final class McpProtocol {
     public static final String MISSING_ID_ARGUMENT_MESSAGE = "Missing required argument: id";
     /** Fallback in-band tool-error text when a tool fails without a message. */
     public static final String TOOL_CALL_FAILED_MESSAGE = "Tool call failed";
+    /** Standard JSON-RPC message for an unexpected server-side failure. */
+    public static final String INTERNAL_ERROR_MESSAGE = "Internal error";
     /** Reported when the server refuses another concurrent {@code tools/call}. */
     public static final String RATE_LIMITED_MESSAGE = "MCP server is at capacity; try again shortly.";
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/package-info.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/package-info.java
@@ -4,9 +4,10 @@
  * <p>This package owns the transport-agnostic JSON-RPC 2.0 <em>dispatch</em> — method routing,
  * notification handling, per-panel gating (via the {@link io.github.jdubois.bootui.spi.McpPanelPolicy}
  * SPI), tool lookup, argument normalization / {@code max-results} capping, and the
- * {@code initialize}/{@code ping}/{@code tools/list}/{@code tools/call} outcomes — returning a sealed
- * {@link io.github.jdubois.bootui.engine.mcp.McpDispatchOutcome}. It contains no Jackson or framework
- * types: Spring Boot 4 ships Jackson 3 ({@code tools.jackson.*}) and Quarkus ships Jackson 2
+ * {@code initialize}/{@code ping}/{@code tools/list}/{@code tools/call} outcomes, and detail-free
+ * internal-error handling with an adapter-owned diagnostic reporter — returning a sealed {@link
+ * io.github.jdubois.bootui.engine.mcp.McpDispatchOutcome}. It contains no Jackson or framework types:
+ * Spring Boot 4 ships Jackson 3 ({@code tools.jackson.*}) and Quarkus ships Jackson 2
  * ({@code com.fasterxml.jackson.*}) — incompatible artifacts and packages — so each adapter keeps a
  * thin envelope codec that parses a request node into {@link io.github.jdubois.bootui.engine.mcp.McpRequest}
  * and renders the outcome back to JSON (echoing the id, serializing the tool payload with its own

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/mcp/McpDispatcherTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/mcp/McpDispatcherTests.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
@@ -55,6 +56,7 @@ class McpDispatcherTests {
             args -> Map.of("id", args.id()));
 
     private final FakePolicy policy = new FakePolicy();
+    private final RecordingFailureReporter diagnostics = new RecordingFailureReporter();
 
     private McpDispatcher dispatcher() {
         return new McpDispatcher(
@@ -64,7 +66,8 @@ class McpDispatcherTests {
                 "1.2.3",
                 "instructions text",
                 50,
-                20);
+                20,
+                diagnostics);
     }
 
     @Test
@@ -232,15 +235,73 @@ class McpDispatcherTests {
     }
 
     @Test
-    void toolHandlerRuntimeExceptionBecomesProtocolError() {
+    void toolHandlerRuntimeExceptionBecomesDetailFreeInternalErrorAndIsReportedOnce() {
+        IllegalStateException failure = new IllegalStateException(
+                "password=hunter2 jdbc:postgresql://localhost/private /Users/admin/.ssh/id_rsa");
         McpTool boom = new McpTool("boom", "Boom.", McpToolSchema.NONE, "overview", false, args -> {
-            throw new IllegalStateException("kaboom");
+            throw failure;
         });
-        McpDispatcher dispatcher = new McpDispatcher(List.of(boom), policy, "1.0", "x", 50, 20);
+        McpDispatcher dispatcher = new McpDispatcher(List.of(boom), List.of(), policy, "1.0", "x", 50, 20, diagnostics);
 
         McpDispatchOutcome outcome = dispatcher.dispatch(call("boom"));
 
-        assertThat(outcome).isEqualTo(new ProtocolError(McpProtocol.INTERNAL_ERROR, "kaboom"));
+        assertThat(outcome)
+                .isEqualTo(new ProtocolError(McpProtocol.INTERNAL_ERROR, McpProtocol.INTERNAL_ERROR_MESSAGE));
+        assertThat(outcome.toString())
+                .doesNotContain("hunter2", "jdbc:postgresql", "/Users/admin", "IllegalStateException");
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isSameAs(failure);
+        assertThat(diagnostics.operation()).isEqualTo("dispatching a request");
+    }
+
+    @Test
+    void toolHandlerRuntimeExceptionForNotificationProducesNoResponseAndIsReportedOnce() {
+        IllegalStateException failure =
+                new IllegalStateException("SENSITIVE_NOTIFICATION_SENTINEL /private/runtime/path");
+        McpTool boom = new McpTool("boom", "Boom.", McpToolSchema.NONE, "overview", false, args -> {
+            throw failure;
+        });
+        McpDispatcher dispatcher = new McpDispatcher(List.of(boom), List.of(), policy, "1.0", "x", 50, 20, diagnostics);
+        McpRequest notification = new McpRequest(JSONRPC, "tools/call", true, null, "boom", null, null, null);
+
+        McpDispatchOutcome outcome = dispatcher.dispatch(notification);
+
+        assertThat(outcome).isInstanceOf(NoResponse.class);
+        assertThat(outcome.toString()).doesNotContain("SENSITIVE_NOTIFICATION_SENTINEL", "/private/runtime/path");
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isSameAs(failure);
+        assertThat(diagnostics.operation()).isEqualTo("dispatching a request");
+    }
+
+    @Test
+    void panelPolicyRuntimeExceptionBecomesDetailFreeInternalErrorAndIsReportedOnce() {
+        IllegalStateException failure = new IllegalStateException("token=ghp_sensitive_policy_token");
+        policy.failure = failure;
+
+        McpDispatchOutcome outcome = dispatcher().dispatch(call("get_overview"));
+
+        assertThat(outcome)
+                .isEqualTo(new ProtocolError(McpProtocol.INTERNAL_ERROR, McpProtocol.INTERNAL_ERROR_MESSAGE));
+        assertThat(outcome.toString()).doesNotContain("ghp_sensitive_policy_token");
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isSameAs(failure);
+    }
+
+    @Test
+    void toolHandlerErrorBecomesDetailFreeInternalErrorAndIsReportedOnce() {
+        AssertionError failure = new AssertionError("SELECT secret FROM credentials");
+        McpTool boom = new McpTool("boom", "Boom.", McpToolSchema.NONE, "overview", false, args -> {
+            throw failure;
+        });
+        McpDispatcher dispatcher = new McpDispatcher(List.of(boom), List.of(), policy, "1.0", "x", 50, 20, diagnostics);
+
+        McpDispatchOutcome outcome = dispatcher.dispatch(call("boom"));
+
+        assertThat(outcome)
+                .isEqualTo(new ProtocolError(McpProtocol.INTERNAL_ERROR, McpProtocol.INTERNAL_ERROR_MESSAGE));
+        assertThat(outcome.toString()).doesNotContain("SELECT", "credentials", "AssertionError");
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isSameAs(failure);
     }
 
     @Test
@@ -326,9 +387,13 @@ class McpDispatcherTests {
     private static final class FakePolicy implements McpPanelPolicy {
         private final Set<String> disabled = new HashSet<>();
         private final Set<String> readOnly = new HashSet<>();
+        private RuntimeException failure;
 
         @Override
         public boolean isEnabled(String panelId) {
+            if (failure != null) {
+                throw failure;
+            }
             return !disabled.contains(panelId);
         }
 
@@ -345,6 +410,31 @@ class McpDispatcherTests {
         @Override
         public String readOnlyReason(String panelId) {
             return "read-only:" + panelId;
+        }
+    }
+
+    private static final class RecordingFailureReporter implements McpFailureReporter {
+        private final AtomicInteger count = new AtomicInteger();
+        private final AtomicReference<String> operation = new AtomicReference<>();
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        @Override
+        public void report(String operation, Throwable failure) {
+            count.incrementAndGet();
+            this.operation.set(operation);
+            this.failure.set(failure);
+        }
+
+        private int count() {
+            return count.get();
+        }
+
+        private String operation() {
+            return operation.get();
+        }
+
+        private Throwable failure() {
+            return failure.get();
         }
     }
 }

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -32,6 +32,7 @@ import io.github.jdubois.bootui.quarkus.mappings.QuarkusMappings;
 import io.github.jdubois.bootui.quarkus.mappings.RawMapping;
 import io.github.jdubois.bootui.quarkus.mcp.BootUiMcpProducer;
 import io.github.jdubois.bootui.quarkus.mcp.QuarkusMcpEnvelope;
+import io.github.jdubois.bootui.quarkus.mcp.QuarkusMcpFailureReporter;
 import io.github.jdubois.bootui.quarkus.mcp.QuarkusMcpTools;
 import io.github.jdubois.bootui.quarkus.scheduled.QuarkusScheduledTaskProvider;
 import io.github.jdubois.bootui.quarkus.scheduled.QuarkusScheduledTasks;
@@ -299,6 +300,7 @@ class BootUiQuarkusProcessor {
                         BootUiMcpProducer.class,
                         QuarkusMcpTools.class,
                         QuarkusMcpEnvelope.class,
+                        QuarkusMcpFailureReporter.class,
                         BootUiQuarkusSafetyFilter.class,
                         BootUiPathRewriteFilter.class,
                         BootUiQuarkusAuthenticationFilter.class,

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/BootUiMcpProducer.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/BootUiMcpProducer.java
@@ -29,7 +29,8 @@ public class BootUiMcpProducer {
 
     @Produces
     @Singleton
-    public McpDispatcher mcpDispatcher(QuarkusMcpTools tools, Config config) {
+    public McpDispatcher mcpDispatcher(
+            QuarkusMcpTools tools, Config config, QuarkusMcpFailureReporter failureReporter) {
         int maxResults =
                 config.getOptionalValue("bootui.mcp.max-results", Integer.class).orElse(200);
         int maxConcurrentCalls = maxConcurrentCalls(config);
@@ -41,7 +42,8 @@ public class BootUiMcpProducer {
                 serverVersion(),
                 INSTRUCTIONS,
                 maxResults,
-                maxConcurrentCalls);
+                maxConcurrentCalls,
+                failureReporter);
     }
 
     public static int maxConcurrentCalls(Config config) {

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpEnvelope.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpEnvelope.java
@@ -23,8 +23,6 @@ import io.github.jdubois.bootui.engine.mcp.McpRequest;
 import io.github.jdubois.bootui.engine.mcp.McpToolDescriptor;
 import io.github.jdubois.bootui.engine.mcp.McpToolSchema;
 import jakarta.inject.Singleton;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Quarkus (Jackson 2) JSON-RPC envelope codec for the BootUI MCP server — the byte-for-byte twin of
@@ -34,14 +32,15 @@ import java.util.logging.Logger;
 @Singleton
 public class QuarkusMcpEnvelope {
 
-    private static final Logger LOG = Logger.getLogger(QuarkusMcpEnvelope.class.getName());
-
     private final McpDispatcher dispatcher;
     private final ObjectMapper objectMapper;
+    private final QuarkusMcpFailureReporter failureReporter;
 
-    public QuarkusMcpEnvelope(McpDispatcher dispatcher, ObjectMapper objectMapper) {
+    public QuarkusMcpEnvelope(
+            McpDispatcher dispatcher, ObjectMapper objectMapper, QuarkusMcpFailureReporter failureReporter) {
         this.dispatcher = dispatcher;
         this.objectMapper = objectMapper;
+        this.failureReporter = failureReporter;
     }
 
     /** Parse raw request bytes into a Jackson node. */
@@ -67,8 +66,13 @@ public class QuarkusMcpEnvelope {
         if (jsonrpc == null || !McpProtocol.JSONRPC_VERSION.equals(jsonrpc.asText())) {
             return error(id, McpProtocol.INVALID_REQUEST, "Request must include jsonrpc: \"2.0\"");
         }
-        McpDispatchOutcome outcome = dispatcher.dispatch(parse(request));
-        return render(outcome, id);
+        try {
+            McpDispatchOutcome outcome = dispatcher.dispatch(parse(request));
+            return render(outcome, id);
+        } catch (RuntimeException | Error failure) {
+            failureReporter.report("rendering a response", failure);
+            return error(id, McpProtocol.INTERNAL_ERROR, McpProtocol.INTERNAL_ERROR_MESSAGE);
+        }
     }
 
     /**
@@ -232,9 +236,9 @@ public class QuarkusMcpEnvelope {
         try {
             payloadNode = objectMapper.valueToTree(call.payload());
             text = objectMapper.writeValueAsString(payloadNode);
-        } catch (JsonProcessingException | RuntimeException ex) {
-            LOG.log(Level.FINE, "BootUI MCP tool result serialization failed", ex);
-            return error(id, McpProtocol.INTERNAL_ERROR, ex.getMessage());
+        } catch (JsonProcessingException | RuntimeException | Error failure) {
+            failureReporter.report("serializing a tool result", failure);
+            return error(id, McpProtocol.INTERNAL_ERROR, McpProtocol.INTERNAL_ERROR_MESSAGE);
         }
         ObjectNode result = JsonNodeFactory.instance.objectNode();
         ArrayNode content = JsonNodeFactory.instance.arrayNode();

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpFailureReporter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpFailureReporter.java
@@ -1,0 +1,18 @@
+package io.github.jdubois.bootui.quarkus.mcp;
+
+import io.github.jdubois.bootui.engine.mcp.McpFailureReporter;
+import jakarta.inject.Singleton;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/** Quarkus logging bridge for unexpected failures contained by the shared MCP boundary. */
+@Singleton
+public class QuarkusMcpFailureReporter implements McpFailureReporter {
+
+    private static final Logger LOG = Logger.getLogger(QuarkusMcpFailureReporter.class.getName());
+
+    @Override
+    public void report(String operation, Throwable failure) {
+        LOG.log(Level.SEVERE, "BootUI MCP failure while " + operation, failure);
+    }
+}

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpEnvelopeTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpEnvelopeTest.java
@@ -1,0 +1,177 @@
+package io.github.jdubois.bootui.quarkus.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.jdubois.bootui.engine.mcp.McpDispatcher;
+import io.github.jdubois.bootui.engine.mcp.McpProtocol;
+import io.github.jdubois.bootui.engine.mcp.McpTool;
+import io.github.jdubois.bootui.engine.mcp.McpToolSchema;
+import io.github.jdubois.bootui.engine.panel.BootUiPanels;
+import io.github.jdubois.bootui.spi.McpPanelPolicy;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class QuarkusMcpEnvelopeTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void toolHandlerExceptionReturnsCanonicalInternalErrorWithoutSensitiveDetails() {
+        IllegalStateException failure =
+                new IllegalStateException("token=ghp_secret jdbc:postgresql://localhost/private /home/admin/key.pem");
+        McpTool tool = tool(args -> {
+            throw failure;
+        });
+        RecordingFailureReporter diagnostics = new RecordingFailureReporter();
+        QuarkusMcpEnvelope envelope = envelope(tool, diagnostics);
+
+        JsonNode response = envelope.handle(callRequest(41));
+
+        assertThat(response.toString())
+                .isEqualTo("{\"jsonrpc\":\"2.0\",\"id\":41,\"error\":{\"code\":-32603,\"message\":\"Internal error\"}}")
+                .doesNotContain("ghp_secret", "jdbc:postgresql", "/home/admin", "IllegalStateException");
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isSameAs(failure);
+        assertThat(diagnostics.operation()).isEqualTo("dispatching a request");
+    }
+
+    @Test
+    void toolHandlerExceptionForNotificationProducesNoBodyAndIsReportedOnce() {
+        IllegalStateException failure =
+                new IllegalStateException("SENSITIVE_NOTIFICATION_SENTINEL /private/quarkus/runtime/path");
+        McpTool tool = tool(args -> {
+            throw failure;
+        });
+        RecordingFailureReporter diagnostics = new RecordingFailureReporter();
+        QuarkusMcpEnvelope envelope = envelope(tool, diagnostics);
+
+        JsonNode response = envelope.handle(callNotification());
+
+        assertThat(response).isNull();
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isSameAs(failure);
+        assertThat(diagnostics.failure().getMessage())
+                .as("the original detail remains available only to server diagnostics")
+                .contains("SENSITIVE_NOTIFICATION_SENTINEL");
+        assertThat(diagnostics.operation()).isEqualTo("dispatching a request");
+    }
+
+    @Test
+    void toolResultSerializationFailureReturnsCanonicalInternalErrorAndIsReportedOnce() {
+        McpTool tool = tool(args -> new Object() {
+            @SuppressWarnings("unused")
+            public String getValue() {
+                throw new IllegalStateException("password=hunter2 SELECT * FROM secrets /Users/admin/private.txt");
+            }
+        });
+        RecordingFailureReporter diagnostics = new RecordingFailureReporter();
+        QuarkusMcpEnvelope envelope = envelope(tool, diagnostics);
+
+        JsonNode response = envelope.handle(callRequest(42));
+
+        assertThat(response.toString())
+                .isEqualTo("{\"jsonrpc\":\"2.0\",\"id\":42,\"error\":{\"code\":-32603,\"message\":\"Internal error\"}}")
+                .doesNotContain("hunter2", "SELECT", "/Users/admin", "IllegalStateException");
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isNotNull();
+        assertThat(diagnostics.operation()).isEqualTo("serializing a tool result");
+    }
+
+    @Test
+    void expectedUnknownToolErrorRetainsItsActionableMessageWithoutDiagnostics() {
+        RecordingFailureReporter diagnostics = new RecordingFailureReporter();
+        QuarkusMcpEnvelope envelope = envelope(tool(args -> "ok"), diagnostics);
+        ObjectNode request = callRequest(43);
+        ((ObjectNode) request.path("params")).put("name", "does_not_exist");
+
+        JsonNode response = envelope.handle(request);
+
+        assertThat(response.path("error").path("code").asInt()).isEqualTo(McpProtocol.INVALID_PARAMS);
+        assertThat(response.path("error").path("message").asText()).isEqualTo("Unknown tool: does_not_exist");
+        assertThat(diagnostics.count()).isZero();
+    }
+
+    private QuarkusMcpEnvelope envelope(McpTool tool, RecordingFailureReporter diagnostics) {
+        McpDispatcher dispatcher = new McpDispatcher(
+                List.of(tool), List.of(), new AllowAllPolicy(), "1.2.3", "instructions", 50, 20, diagnostics);
+        return new QuarkusMcpEnvelope(dispatcher, objectMapper, diagnostics);
+    }
+
+    private static McpTool tool(
+            java.util.function.Function<io.github.jdubois.bootui.engine.mcp.McpArguments, Object> handler) {
+        return new McpTool(
+                "get_overview", "Read the overview.", McpToolSchema.NONE, BootUiPanels.OVERVIEW, false, handler);
+    }
+
+    private static ObjectNode callRequest(int id) {
+        ObjectNode request = JsonNodeFactory.instance.objectNode();
+        request.put("jsonrpc", "2.0");
+        request.put("id", id);
+        request.put("method", "tools/call");
+        ObjectNode params = JsonNodeFactory.instance.objectNode();
+        params.put("name", "get_overview");
+        params.set("arguments", JsonNodeFactory.instance.objectNode());
+        request.set("params", params);
+        return request;
+    }
+
+    private static ObjectNode callNotification() {
+        ObjectNode request = callRequest(0);
+        request.remove("id");
+        return request;
+    }
+
+    private static final class AllowAllPolicy implements McpPanelPolicy {
+
+        @Override
+        public boolean isEnabled(String panelId) {
+            return true;
+        }
+
+        @Override
+        public String disabledReason(String panelId) {
+            return "disabled";
+        }
+
+        @Override
+        public boolean isReadOnly(String panelId) {
+            return false;
+        }
+
+        @Override
+        public String readOnlyReason(String panelId) {
+            return "read-only";
+        }
+    }
+
+    private static final class RecordingFailureReporter extends QuarkusMcpFailureReporter {
+        private final AtomicInteger count = new AtomicInteger();
+        private final AtomicReference<String> operation = new AtomicReference<>();
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        @Override
+        public void report(String operation, Throwable failure) {
+            count.incrementAndGet();
+            this.operation.set(operation);
+            this.failure.set(failure);
+        }
+
+        private int count() {
+            return count.get();
+        }
+
+        private String operation() {
+            return operation.get();
+        }
+
+        private Throwable failure() {
+            return failure.get();
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/mcp/BootUiMcpService.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/mcp/BootUiMcpService.java
@@ -13,6 +13,7 @@ import io.github.jdubois.bootui.engine.mcp.McpDispatchOutcome.ToolCallError;
 import io.github.jdubois.bootui.engine.mcp.McpDispatchOutcome.ToolCallResult;
 import io.github.jdubois.bootui.engine.mcp.McpDispatchOutcome.ToolsListResult;
 import io.github.jdubois.bootui.engine.mcp.McpDispatcher;
+import io.github.jdubois.bootui.engine.mcp.McpFailureReporter;
 import io.github.jdubois.bootui.engine.mcp.McpGuidance;
 import io.github.jdubois.bootui.engine.mcp.McpPrompt;
 import io.github.jdubois.bootui.engine.mcp.McpProtocol;
@@ -66,6 +67,7 @@ public class BootUiMcpService {
 
     private final McpDispatcher dispatcher;
     private final ObjectMapper objectMapper;
+    private final McpFailureReporter failureReporter;
 
     public BootUiMcpService(
             BootUiMcpTools tools, BootUiProperties properties, ObjectMapper objectMapper, String serverVersion) {
@@ -82,7 +84,22 @@ public class BootUiMcpService {
 
     private BootUiMcpService(
             List<McpTool> tools, BootUiProperties properties, ObjectMapper objectMapper, String serverVersion) {
+        this(
+                tools,
+                properties,
+                objectMapper,
+                serverVersion,
+                (operation, failure) -> log.error("BootUI MCP failure while {}", operation, failure));
+    }
+
+    BootUiMcpService(
+            List<McpTool> tools,
+            BootUiProperties properties,
+            ObjectMapper objectMapper,
+            String serverVersion,
+            McpFailureReporter failureReporter) {
         this.objectMapper = objectMapper;
+        this.failureReporter = failureReporter;
         int maxResults = Math.max(1, properties.getMcp().getMaxResults());
         int maxConcurrentCalls = Math.max(1, properties.getMcp().getMaxConcurrentCalls());
         this.dispatcher = new McpDispatcher(
@@ -92,7 +109,8 @@ public class BootUiMcpService {
                 serverVersion,
                 INSTRUCTIONS,
                 maxResults,
-                maxConcurrentCalls);
+                maxConcurrentCalls,
+                failureReporter);
     }
 
     /** Parse raw request bytes into a Jackson node. */
@@ -118,8 +136,13 @@ public class BootUiMcpService {
         if (jsonrpc == null || !McpProtocol.JSONRPC_VERSION.equals(jsonrpc.asString())) {
             return error(id, McpProtocol.INVALID_REQUEST, "Request must include jsonrpc: \"2.0\"");
         }
-        McpDispatchOutcome outcome = dispatcher.dispatch(parse(request));
-        return render(outcome, id);
+        try {
+            McpDispatchOutcome outcome = dispatcher.dispatch(parse(request));
+            return render(outcome, id);
+        } catch (RuntimeException | Error failure) {
+            failureReporter.report("rendering a response", failure);
+            return error(id, McpProtocol.INTERNAL_ERROR, McpProtocol.INTERNAL_ERROR_MESSAGE);
+        }
     }
 
     private static McpRequest parse(JsonNode request) {
@@ -275,9 +298,9 @@ public class BootUiMcpService {
         try {
             payloadNode = objectMapper.valueToTree(call.payload());
             text = objectMapper.writeValueAsString(payloadNode);
-        } catch (RuntimeException ex) {
-            log.debug("BootUI MCP tool result serialization failed", ex);
-            return error(id, McpProtocol.INTERNAL_ERROR, ex.getMessage());
+        } catch (RuntimeException | Error failure) {
+            failureReporter.report("serializing a tool result", failure);
+            return error(id, McpProtocol.INTERNAL_ERROR, McpProtocol.INTERNAL_ERROR_MESSAGE);
         }
         ObjectNode result = JsonNodeFactory.instance.objectNode();
         ArrayNode content = JsonNodeFactory.instance.arrayNode();

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/mcp/BootUiMcpServiceTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/mcp/BootUiMcpServiceTests.java
@@ -3,10 +3,13 @@ package io.github.jdubois.bootui.autoconfigure.mcp;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.engine.mcp.McpFailureReporter;
 import io.github.jdubois.bootui.engine.mcp.McpTool;
 import io.github.jdubois.bootui.engine.mcp.McpToolSchema;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
@@ -164,21 +167,53 @@ class BootUiMcpServiceTests {
     }
 
     @Test
-    void toolHandlerExceptionWithoutMessageReportsGenericErrorMessage() {
+    void toolHandlerExceptionReturnsCanonicalInternalErrorWithoutSensitiveDetails() {
+        IllegalStateException failure =
+                new IllegalStateException("token=ghp_secret jdbc:mysql://localhost/private /home/admin/key.pem");
         List<McpTool> tools = List.of(new McpTool(
                 "get_overview", "Read the overview.", McpToolSchema.NONE, BootUiPanels.OVERVIEW, false, args -> {
-                    throw new IllegalStateException();
+                    throw failure;
                 }));
-        BootUiMcpService failing = new BootUiMcpService(new BootUiMcpTools(tools), properties, objectMapper, "1.2.3");
+        RecordingFailureReporter diagnostics = new RecordingFailureReporter();
+        BootUiMcpService failing = new BootUiMcpService(tools, properties, objectMapper, "1.2.3", diagnostics);
 
         JsonNode response = failing.handle(callRequest("get_overview", 9));
 
+        assertThat(response.toString())
+                .isEqualTo("{\"jsonrpc\":\"2.0\",\"id\":9,\"error\":{\"code\":-32603,\"message\":\"Internal error\"}}");
         assertThat(response.path("error").path("code").asInt()).isEqualTo(-32603);
-        assertThat(response.path("error").path("message").asString()).isEqualTo("Error");
+        assertThat(response.path("error").path("message").asString()).isEqualTo("Internal error");
+        assertThat(response.toString())
+                .doesNotContain("ghp_secret", "jdbc:mysql", "/home/admin", "IllegalStateException");
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isSameAs(failure);
+        assertThat(diagnostics.operation()).isEqualTo("dispatching a request");
     }
 
     @Test
-    void toolResultSerializationFailureReturnsInternalError() {
+    void toolHandlerExceptionForNotificationProducesNoBodyAndIsReportedOnce() {
+        IllegalStateException failure =
+                new IllegalStateException("SENSITIVE_NOTIFICATION_SENTINEL /private/spring/runtime/path");
+        List<McpTool> tools = List.of(new McpTool(
+                "get_overview", "Read the overview.", McpToolSchema.NONE, BootUiPanels.OVERVIEW, false, args -> {
+                    throw failure;
+                }));
+        RecordingFailureReporter diagnostics = new RecordingFailureReporter();
+        BootUiMcpService failing = new BootUiMcpService(tools, properties, objectMapper, "1.2.3", diagnostics);
+
+        JsonNode response = failing.handle(callNotification("get_overview"));
+
+        assertThat(response).isNull();
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isSameAs(failure);
+        assertThat(diagnostics.failure().getMessage())
+                .as("the original detail remains available only to server diagnostics")
+                .contains("SENSITIVE_NOTIFICATION_SENTINEL");
+        assertThat(diagnostics.operation()).isEqualTo("dispatching a request");
+    }
+
+    @Test
+    void toolResultSerializationFailureReturnsCanonicalInternalErrorAndIsReportedOnce() {
         List<McpTool> tools = List.of(new McpTool(
                 "get_overview",
                 "Read the overview.",
@@ -188,14 +223,21 @@ class BootUiMcpServiceTests {
                 args -> new Object() {
                     @SuppressWarnings("unused")
                     public String getValue() {
-                        throw new IllegalStateException("cannot serialize");
+                        throw new IllegalStateException(
+                                "password=hunter2 SELECT * FROM secrets /Users/admin/private.txt");
                     }
                 }));
-        BootUiMcpService failing = new BootUiMcpService(new BootUiMcpTools(tools), properties, objectMapper, "1.2.3");
+        RecordingFailureReporter diagnostics = new RecordingFailureReporter();
+        BootUiMcpService failing = new BootUiMcpService(tools, properties, objectMapper, "1.2.3", diagnostics);
 
         JsonNode response = failing.handle(callRequest("get_overview", 10));
 
         assertThat(response.path("error").path("code").asInt()).isEqualTo(-32603);
+        assertThat(response.path("error").path("message").asString()).isEqualTo("Internal error");
+        assertThat(response.toString()).doesNotContain("hunter2", "SELECT", "/Users/admin", "IllegalStateException");
+        assertThat(diagnostics.count()).isEqualTo(1);
+        assertThat(diagnostics.failure()).isNotNull();
+        assertThat(diagnostics.operation()).isEqualTo("serializing a tool result");
     }
 
     private static McpToolSchema schema() {
@@ -207,6 +249,13 @@ class BootUiMcpServiceTests {
         params.put("name", toolName);
         params.set("arguments", JsonNodeFactory.instance.objectNode());
         return request("tools/call", id, params);
+    }
+
+    private ObjectNode callNotification(String toolName) {
+        ObjectNode params = JsonNodeFactory.instance.objectNode();
+        params.put("name", toolName);
+        params.set("arguments", JsonNodeFactory.instance.objectNode());
+        return request("tools/call", null, params);
     }
 
     private ObjectNode params(String key, String value) {
@@ -226,5 +275,30 @@ class BootUiMcpServiceTests {
             request.set("params", params);
         }
         return request;
+    }
+
+    private static final class RecordingFailureReporter implements McpFailureReporter {
+        private final AtomicInteger count = new AtomicInteger();
+        private final AtomicReference<String> operation = new AtomicReference<>();
+        private final AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        @Override
+        public void report(String operation, Throwable failure) {
+            count.incrementAndGet();
+            this.operation.set(operation);
+            this.failure.set(failure);
+        }
+
+        private int count() {
+            return count.get();
+        }
+
+        private String operation() {
+            return operation.get();
+        }
+
+        private Throwable failure() {
+            return failure.get();
+        }
     }
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1556,6 +1556,9 @@ absent) are simply not advertised. The server inherits BootUI's full safety mode
   read-only or `bootui.read-only=true`, returning a clear tool error instead of running.
 - Values pass through the same secret masking and `bootui.expose-values` mode as the REST API, and paginated reads are
   capped by `bootui.mcp.max-results`.
+- Unexpected server failures return only JSON-RPC `-32603` with the message `Internal error`; exception messages, stack
+  traces, paths, queries, and credentials are never included. BootUI logs the original throwable once on the server,
+  while expected protocol, disabled-server, and panel-policy errors keep their actionable messages.
 
 Connection details (transport, protocol revision, and the `bootui.mcp.max-results` cap) are shown alongside a
 ready-to-use, copyable MCP client configuration JSON pointing at this running app — the `servers` block a GitHub Copilot

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1856,6 +1856,10 @@ Design rules:
   `GET /bootui/api/mcp-server` status response for human inspection. The transport endpoint itself returns 405 to `GET`
   because BootUI does not offer a server-to-client SSE stream. No new runtime dependencies beyond what BootUI already ships.
   The Spring AI MCP server starter is intentionally not used because it targets Spring Boot 3.x.
+- **Detail-free internal errors.** Unexpected dispatch, tool, policy, or result-serialization failures return the standard
+  JSON-RPC internal error (`-32603`, message `Internal error`) without exception text or debug fields. The original
+  throwable and stack trace are logged once on the server; expected validation, disabled-server, panel-policy, and
+  unknown-method/tool errors retain their specific safe messages.
 - **Reuse, don't reimplement.** Each tool delegates to the same controller/service the REST API and panels use and
   returns the existing DTO records, so contracts stay stable and masked.
 - **Tool surface.** Advisor scans as action tools (`architecture_scan`, `spring_scan`, `hibernate_scan`, `memory_scan`,


### PR DESCRIPTION
## What does this PR do?

Hardens the shared MCP JSON-RPC boundary so unexpected dispatcher, policy, tool, and adapter serialization failures return only the standard `-32603` / `Internal error` contract on Spring Boot and Quarkus.

A framework-neutral `McpFailureReporter` preserves the original throwable and stack trace exactly once in server logs. Expected parse/validation, unknown method/tool, disabled-server, panel-policy, and capacity errors retain their existing safe actionable responses.

## Why is this change needed?

Audit issue 12 found that runtime exception messages could cross the MCP wire and disclose secrets, filesystem paths, SQL, tokens, implementation details, or stack information.

## How was it tested?

- [x] `./mvnw -Dmaven.repo.local=.m2 -B -ntp clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added focused engine, Spring Jackson 3, Quarkus Jackson 2, and shared conformance coverage
- [x] Spring and Quarkus API conformance suites pass
- [x] Java, frontend, and e2e formatting checks pass

## Screenshots (UI changes)

N/A — no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed