### PR TITLE
test: cover messaging adapter integration

### DIFF
--- a/bootui-quarkus-integration-tests/pom.xml
+++ b/bootui-quarkus-integration-tests/pom.xml
@@ -16,9 +16,10 @@
     <name>BootUI :: Quarkus Extension (Integration Tests)</name>
     <description>Aggregator for the Docker-free Quarkus integration-test apps. Each sub-module pins a different
         extension set on its classpath to prove BootUI panel light-up in isolation: the base module deliberately
-        has no optional extensions (everything fails closed), and each per-extension module adds exactly one
-        (otel, health, micrometer, scheduler, cache, flyway, liquibase, datasource). The Hibernate module also
-        lives here but is wired into the reactor only on a Hibernate-capable JDK (see the root pom profile).
+        has no optional extensions (everything fails closed), and each per-extension module adds a focused
+        capability fixture. The RabbitMQ module drives synthetic SmallRye metadata with Dev Services disabled,
+        so the default suite requires no broker or Docker. The Hibernate module also lives here but is wired into
+        the reactor only on a Hibernate-capable JDK (see the root pom profile).
         prod-shell-guard is different in kind, not in extension set: it holds the one test that boots a genuine
         LaunchMode.NORMAL artifact via QuarkusProdModeTest, kept out of every other module because Quarkus
         refuses to mix that mechanism with @QuarkusTest in the same Surefire fork.</description>
@@ -36,6 +37,7 @@
         <module>security</module>
         <module>cache</module>
         <module>email</module>
+        <module>rabbit</module>
         <module>flyway</module>
         <module>liquibase</module>
         <module>datasource</module>

--- a/bootui-quarkus-integration-tests/rabbit/pom.xml
+++ b/bootui-quarkus-integration-tests/rabbit/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.julien-dubois.bootui</groupId>
+        <artifactId>bootui-quarkus-integration-tests-aggregator</artifactId>
+        <version>1.12.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>bootui-quarkus-rabbit-integration-tests</artifactId>
+    <name>BootUI :: Quarkus Extension (RabbitMQ Integration Tests)</name>
+    <description>Minimal, Docker-free Quarkus app that adds quarkus-messaging-rabbitmq and proves the
+        capability-present RabbitMQ capture path from CDI-registered SmallRye interceptors through the shared
+        recorder to the panel manifest and REST report. The test invokes synthetic framework metadata directly:
+        it configures no messaging channels, starts no RabbitMQ Dev Service, opens no broker port, and requires no
+        external service.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-quarkus-deployment</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Presence is the deployment-time gate under test. With no mp.messaging.* channels configured,
+             the connector is never started and Quarkus has no reason to provision a RabbitMQ Dev Service. -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-messaging-rabbitmq</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-conformance</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/bootui-quarkus-integration-tests/rabbit/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusRabbitCaptureTest.java
+++ b/bootui-quarkus-integration-tests/rabbit/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusRabbitCaptureTest.java
@@ -1,0 +1,135 @@
+package io.github.jdubois.bootui.quarkus.it;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import io.github.jdubois.bootui.engine.rabbit.RabbitActivityRecorder;
+import io.github.jdubois.bootui.quarkus.rabbit.QuarkusRabbitConsumerCapture;
+import io.github.jdubois.bootui.quarkus.rabbit.QuarkusRabbitProducerCapture;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.smallrye.reactive.messaging.rabbitmq.IncomingRabbitMQMetadata;
+import io.smallrye.reactive.messaging.rabbitmq.OutgoingRabbitMQMetadata;
+import jakarta.inject.Inject;
+import java.net.URL;
+import java.util.Map;
+import java.util.Optional;
+import org.eclipse.microprofile.reactive.messaging.Message;
+import org.eclipse.microprofile.reactive.messaging.Metadata;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Capability-present, broker-free Quarkus RabbitMQ integration coverage.
+ *
+ * <p>The RabbitMQ extension is present so the deployment build step must register both interceptors and
+ * mark the panel available. Synthetic SmallRye metadata drives those injected interceptors directly; no
+ * channel is configured, so no connector, Dev Service, broker port, network call, or timing wait is used.
+ */
+@QuarkusTest
+class BootUiQuarkusRabbitCaptureTest {
+
+    private static final String RAW_CORRELATION_ID = "customer-secret";
+    private static final String SENSITIVE_PAYLOAD = "payload-secret";
+    private static final String SENSITIVE_METADATA = "header-secret";
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    @Inject
+    QuarkusRabbitProducerCapture producerCapture;
+
+    @Inject
+    QuarkusRabbitConsumerCapture consumerCapture;
+
+    @Inject
+    RabbitActivityRecorder recorder;
+
+    @Test
+    void capturesBothDirectionsThroughTheSharedReportAndKeepsJmsUnavailable() {
+        producerCapture.onMessageAck(outgoingMessage());
+        Message<?> consumed = consumerCapture.afterMessageReceive(incomingMessage());
+        consumerCapture.onMessageNack(consumed, new IllegalStateException(SENSITIVE_PAYLOAD));
+        assertThat(recorder.recent()).hasSize(2);
+
+        Response panels = probe().get("/bootui/api/panels");
+        assertThat(panels.status()).isEqualTo(200);
+        JsonNode rabbitPanel = findPanel(panels.json(), "rabbitmq");
+        assertThat(rabbitPanel).isNotNull();
+        assertThat(rabbitPanel.path("available").asBoolean(false)).isTrue();
+        JsonNode jmsPanel = findPanel(panels.json(), "jms");
+        assertThat(jmsPanel).isNotNull();
+        assertThat(jmsPanel.path("available").asBoolean(true)).isFalse();
+        assertThat(jmsPanel.path("unavailableReason").asText()).startsWith("Not yet available on Quarkus");
+
+        Response report = probe().get("/bootui/api/rabbitmq");
+        assertThat(report.status()).isEqualTo(200);
+        JsonNode root = report.json();
+        assertThat(root.path("available").asBoolean(false)).isTrue();
+        assertThat(root.path("capturing").asBoolean(false)).isTrue();
+        assertThat(root.path("captureCorrelationIdEnabled").asBoolean(false)).isTrue();
+        assertThat(root.path("total").asInt()).isEqualTo(2);
+        assertThat(root.path("totalCaptured").asLong()).isEqualTo(2);
+
+        JsonNode consumedDto = root.path("messages").path(0);
+        assertThat(consumedDto.path("direction").asText()).isEqualTo("CONSUME");
+        assertThat(consumedDto.path("exchange").asText()).isEqualTo("orders");
+        assertThat(consumedDto.path("routingKey").asText()).isEqualTo("created");
+        assertThat(consumedDto.path("success").asBoolean(true)).isFalse();
+        assertThat(consumedDto.path("errorMessage").asText()).isEqualTo("Message processing failed");
+        assertThat(consumedDto.path("durationMillis").isNumber()).isTrue();
+
+        JsonNode publishedDto = root.path("messages").path(1);
+        assertThat(publishedDto.path("direction").asText()).isEqualTo("PUBLISH");
+        assertThat(publishedDto.path("routingKey").asText()).isEqualTo("created");
+        assertThat(publishedDto.path("success").asBoolean(false)).isTrue();
+        assertThat(publishedDto.path("correlationId").asText()).hasSize(16).isNotEqualTo(RAW_CORRELATION_ID);
+        assertThat(report.body())
+                .doesNotContain(RAW_CORRELATION_ID)
+                .doesNotContain(SENSITIVE_PAYLOAD)
+                .doesNotContain(SENSITIVE_METADATA);
+
+        Response clear = probe().request("DELETE", "/bootui/api/rabbitmq", Map.of(), null);
+        assertThat(clear.status()).isEqualTo(204);
+        JsonNode afterClear = probe().get("/bootui/api/rabbitmq").json();
+        assertThat(afterClear.path("total").asInt(-1)).isZero();
+        assertThat(afterClear.path("totalCaptured").asLong()).isEqualTo(2);
+    }
+
+    private BootUiHttpProbe probe() {
+        return new BootUiHttpProbe(baseUrl.toExternalForm());
+    }
+
+    private static Message<String> outgoingMessage() {
+        OutgoingRabbitMQMetadata metadata = OutgoingRabbitMQMetadata.builder()
+                .withRoutingKey("created")
+                .withCorrelationId(RAW_CORRELATION_ID)
+                .build();
+        return Message.of(
+                SENSITIVE_PAYLOAD, Metadata.of(metadata, new ArbitraryMetadata(SENSITIVE_METADATA.getBytes(UTF_8))));
+    }
+
+    private static Message<String> incomingMessage() {
+        IncomingRabbitMQMetadata metadata = mock(IncomingRabbitMQMetadata.class);
+        when(metadata.getExchange()).thenReturn("orders");
+        when(metadata.getRoutingKey()).thenReturn("created");
+        when(metadata.getCorrelationId()).thenReturn(Optional.of(RAW_CORRELATION_ID));
+        return Message.of(
+                SENSITIVE_PAYLOAD, Metadata.of(metadata, new ArbitraryMetadata(SENSITIVE_METADATA.getBytes(UTF_8))));
+    }
+
+    private static JsonNode findPanel(JsonNode manifest, String id) {
+        for (JsonNode panel : manifest.path("panels")) {
+            if (id.equals(panel.path("id").asText(null))) {
+                return panel;
+            }
+        }
+        return null;
+    }
+
+    private record ArbitraryMetadata(byte[] value) {}
+}

--- a/bootui-quarkus-integration-tests/rabbit/src/test/resources/application.properties
+++ b/bootui-quarkus-integration-tests/rabbit/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+bootui.rabbitmq.capture-correlation-id=true
+bootui.rabbitmq.max-correlation-id-length=16
+quarkus.rabbitmq.devservices.enabled=false

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/MessagingAdapterIntegrationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/MessagingAdapterIntegrationTests.java
@@ -1,0 +1,394 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.jms.Connection;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import java.util.Map;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.webflux.autoconfigure.HttpHandlerAutoConfiguration;
+import org.springframework.boot.webflux.autoconfigure.WebFluxAutoConfiguration;
+import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
+import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jms.config.DefaultJmsListenerContainerFactory;
+import org.springframework.jms.config.SimpleJmsListenerEndpoint;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.listener.AbstractMessageListenerContainer;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Broker-free integration coverage for the shared Spring messaging adapters.
+ *
+ * <p>Unlike the focused processor/controller unit tests, these tests boot each real auto-configuration,
+ * let Spring post-process application-owned templates and listener factories, drive the framework
+ * callbacks with mocked transports, and read the resulting shared recorder state through the real HTTP
+ * endpoints. No broker connection, socket, background listener, Docker service, or timing wait is used.
+ */
+class MessagingAdapterIntegrationTests {
+
+    private static final String RAW_JMS_MESSAGE_ID = "ID:provider-secret";
+    private static final String RAW_RABBIT_CORRELATION_ID = "customer-secret";
+    private static final String SENSITIVE_PAYLOAD = "payload-secret";
+    private static final String SENSITIVE_HEADER = "header-secret";
+
+    @Test
+    void servletAdapterWiresJmsAndRabbitCaptureThroughTheSharedApi() {
+        servletRunner().run(context -> {
+            assertThat(context).hasNotFailed();
+            exerciseMessagingCallbacks(context);
+
+            MockMvc mvc = MockMvcBuilders.webAppContextSetup(
+                            (WebApplicationContext) context.getSourceApplicationContext())
+                    .build();
+            assertMvcReports(mvc);
+        });
+    }
+
+    @Test
+    void reactiveAdapterWiresJmsAndRabbitCaptureThroughTheSharedApi() {
+        reactiveRunner().run(context -> {
+            assertThat(context).hasNotFailed();
+            exerciseMessagingCallbacks(context);
+
+            WebTestClient client = WebTestClient.bindToApplicationContext(context.getSourceApplicationContext())
+                    .configureClient()
+                    .defaultHeader(
+                            "Authorization",
+                            "Bearer "
+                                    + context.getBean(
+                                                    io.github.jdubois.bootui.engine.safety.ApiTokenAuthenticator.class)
+                                            .token())
+                    .build();
+            assertWebFluxReports(client);
+        });
+    }
+
+    private static void exerciseMessagingCallbacks(ApplicationContext context) {
+        try {
+            JmsTemplate jmsTemplate = context.getBean(JmsTemplate.class);
+            assertThat(jmsTemplate.getClass()).isNotEqualTo(JmsTemplate.class);
+            jmsTemplate.send("orders?token=raw-secret", session -> outgoingJmsMessage());
+
+            DefaultJmsListenerContainerFactory jmsFactory = context.getBean(DefaultJmsListenerContainerFactory.class);
+            SimpleJmsListenerEndpoint endpoint = new SimpleJmsListenerEndpoint();
+            endpoint.setId("orders-listener");
+            endpoint.setDestination("orders");
+            endpoint.setSubscription("orders-sub?token=raw-secret");
+            jakarta.jms.MessageListener listener =
+                    message -> assertThat(message).isNotNull();
+            endpoint.setMessageListener(listener);
+            AbstractMessageListenerContainer container = jmsFactory.createListenerContainer(endpoint);
+            assertThat(container.getMessageListener()).isNotSameAs(listener);
+            ((jakarta.jms.MessageListener) container.getMessageListener()).onMessage(incomingJmsMessage());
+
+            RabbitTemplate rabbitTemplate = context.getBean(RabbitTemplate.class);
+            assertThat(rabbitTemplate.getBeforePublishPostProcessors()).isNotEmpty();
+            Message published = rabbitMessage("orders", "created", null);
+            for (MessagePostProcessor postProcessor : rabbitTemplate.getBeforePublishPostProcessors()) {
+                postProcessor.postProcessMessage(published, null, "orders", "created");
+            }
+
+            SimpleRabbitListenerContainerFactory rabbitFactory =
+                    context.getBean(SimpleRabbitListenerContainerFactory.class);
+            assertThat(rabbitFactory.getAdviceChain()).isNotEmpty();
+            MethodInvocation delivery = mock(MethodInvocation.class);
+            when(delivery.getArguments()).thenReturn(new Object[] {rabbitMessage("orders", "created", "fulfillment")});
+            when(delivery.proceed()).thenReturn(null);
+            ((MethodInterceptor) rabbitFactory.getAdviceChain()[0]).invoke(delivery);
+        } catch (Throwable ex) {
+            throw new AssertionError("Could not drive broker-free messaging callbacks", ex);
+        }
+    }
+
+    private static void assertMvcReports(MockMvc mvc) {
+        try {
+            mvc.perform(get("/bootui/api/panels"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.panels[?(@.id=='jms')].available").value(true))
+                    .andExpect(
+                            jsonPath("$.panels[?(@.id=='rabbitmq')].available").value(true));
+
+            MvcResult jmsResult = mvc.perform(get("/bootui/api/jms"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.available").value(true))
+                    .andExpect(jsonPath("$.total").value(2))
+                    .andExpect(jsonPath("$.totalCaptured").value(2))
+                    .andExpect(jsonPath("$.messages[0].direction").value("CONSUME"))
+                    .andExpect(jsonPath("$.messages[0].destination").value("inbound?token=******"))
+                    .andExpect(jsonPath("$.messages[0].messageId").isNotEmpty())
+                    .andExpect(jsonPath("$.messages[0].subscriptionName").value("orders-sub?token=******"))
+                    .andExpect(jsonPath("$.messages[1].direction").value("PRODUCE"))
+                    .andExpect(jsonPath("$.messages[1].destination").value("orders?token=******"))
+                    .andExpect(jsonPath("$.messages[1].messageId").isNotEmpty())
+                    .andReturn();
+            assertSensitiveValuesAbsent(jmsResult.getResponse().getContentAsString());
+
+            MvcResult rabbitResult = mvc.perform(get("/bootui/api/rabbitmq"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.available").value(true))
+                    .andExpect(jsonPath("$.total").value(2))
+                    .andExpect(jsonPath("$.totalCaptured").value(2))
+                    .andExpect(jsonPath("$.messages[0].direction").value("CONSUME"))
+                    .andExpect(jsonPath("$.messages[0].queue").value("fulfillment"))
+                    .andExpect(jsonPath("$.messages[0].correlationId").isNotEmpty())
+                    .andExpect(jsonPath("$.messages[1].direction").value("PUBLISH"))
+                    .andExpect(jsonPath("$.messages[1].correlationId").isNotEmpty())
+                    .andReturn();
+            assertSensitiveValuesAbsent(rabbitResult.getResponse().getContentAsString());
+
+            mvc.perform(delete("/bootui/api/jms")).andExpect(status().isNoContent());
+            mvc.perform(delete("/bootui/api/rabbitmq")).andExpect(status().isNoContent());
+            mvc.perform(get("/bootui/api/jms"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.total").value(0))
+                    .andExpect(jsonPath("$.totalCaptured").value(2));
+            mvc.perform(get("/bootui/api/rabbitmq"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.total").value(0))
+                    .andExpect(jsonPath("$.totalCaptured").value(2));
+        } catch (Exception ex) {
+            throw new AssertionError("Could not verify servlet messaging reports", ex);
+        }
+    }
+
+    private static void assertWebFluxReports(WebTestClient client) {
+        client.get()
+                .uri("/bootui/api/panels")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.panels[?(@.id=='jms')].available")
+                .isEqualTo(true)
+                .jsonPath("$.panels[?(@.id=='rabbitmq')].available")
+                .isEqualTo(true);
+
+        byte[] jmsBody = client.get()
+                .uri("/bootui/api/jms")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.available")
+                .isEqualTo(true)
+                .jsonPath("$.total")
+                .isEqualTo(2)
+                .jsonPath("$.totalCaptured")
+                .isEqualTo(2)
+                .jsonPath("$.messages[0].direction")
+                .isEqualTo("CONSUME")
+                .jsonPath("$.messages[0].destination")
+                .isEqualTo("inbound?token=******")
+                .jsonPath("$.messages[0].messageId")
+                .isNotEmpty()
+                .jsonPath("$.messages[0].subscriptionName")
+                .isEqualTo("orders-sub?token=******")
+                .jsonPath("$.messages[1].direction")
+                .isEqualTo("PRODUCE")
+                .jsonPath("$.messages[1].messageId")
+                .isNotEmpty()
+                .returnResult()
+                .getResponseBody();
+        assertSensitiveValuesAbsent(new String(jmsBody, UTF_8));
+
+        byte[] rabbitBody = client.get()
+                .uri("/bootui/api/rabbitmq")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.available")
+                .isEqualTo(true)
+                .jsonPath("$.total")
+                .isEqualTo(2)
+                .jsonPath("$.totalCaptured")
+                .isEqualTo(2)
+                .jsonPath("$.messages[0].direction")
+                .isEqualTo("CONSUME")
+                .jsonPath("$.messages[0].queue")
+                .isEqualTo("fulfillment")
+                .jsonPath("$.messages[0].correlationId")
+                .isNotEmpty()
+                .jsonPath("$.messages[1].direction")
+                .isEqualTo("PUBLISH")
+                .jsonPath("$.messages[1].correlationId")
+                .isNotEmpty()
+                .returnResult()
+                .getResponseBody();
+        assertSensitiveValuesAbsent(new String(rabbitBody, UTF_8));
+
+        client.delete().uri("/bootui/api/jms").exchange().expectStatus().isNoContent();
+        client.delete().uri("/bootui/api/rabbitmq").exchange().expectStatus().isNoContent();
+        client.get()
+                .uri("/bootui/api/jms")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.total")
+                .isEqualTo(0)
+                .jsonPath("$.totalCaptured")
+                .isEqualTo(2);
+        client.get()
+                .uri("/bootui/api/rabbitmq")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.total")
+                .isEqualTo(0)
+                .jsonPath("$.totalCaptured")
+                .isEqualTo(2);
+    }
+
+    private static void assertSensitiveValuesAbsent(String json) {
+        assertThat(json)
+                .doesNotContain(RAW_JMS_MESSAGE_ID)
+                .doesNotContain(RAW_RABBIT_CORRELATION_ID)
+                .doesNotContain(SENSITIVE_PAYLOAD)
+                .doesNotContain(SENSITIVE_HEADER);
+    }
+
+    private static TextMessage outgoingJmsMessage() throws JMSException {
+        TextMessage message = mock(TextMessage.class);
+        when(message.getJMSMessageID()).thenReturn(RAW_JMS_MESSAGE_ID);
+        when(message.getText()).thenReturn(SENSITIVE_PAYLOAD);
+        when(message.getStringProperty("secret")).thenReturn(SENSITIVE_HEADER);
+        return message;
+    }
+
+    private static jakarta.jms.Message incomingJmsMessage() throws JMSException {
+        jakarta.jms.Message message = mock(jakarta.jms.Message.class);
+        Queue queue = mock(Queue.class);
+        when(queue.getQueueName()).thenReturn("inbound?token=raw-secret");
+        when(message.getJMSDestination()).thenReturn(queue);
+        when(message.getJMSMessageID()).thenReturn(RAW_JMS_MESSAGE_ID);
+        when(message.getStringProperty("secret")).thenReturn(SENSITIVE_HEADER);
+        return message;
+    }
+
+    private static Message rabbitMessage(String exchange, String routingKey, String queue) {
+        MessageProperties properties = new MessageProperties();
+        properties.setReceivedExchange(exchange);
+        properties.setReceivedRoutingKey(routingKey);
+        properties.setConsumerQueue(queue);
+        properties.setCorrelationId(RAW_RABBIT_CORRELATION_ID);
+        properties.setHeaders(Map.of("secret", SENSITIVE_HEADER));
+        return new Message(SENSITIVE_PAYLOAD.getBytes(UTF_8), properties);
+    }
+
+    private static WebApplicationContextRunner servletRunner() {
+        return new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        DispatcherServletAutoConfiguration.class,
+                        WebMvcAutoConfiguration.class,
+                        BootUiAutoConfiguration.class))
+                .withUserConfiguration(MessagingFixture.class)
+                .withPropertyValues(
+                        "bootui.enabled=ON",
+                        "bootui.allow-non-localhost=true",
+                        "bootui.jms.capture-message-id=true",
+                        "bootui.jms.max-message-id-length=16",
+                        "bootui.rabbitmq.capture-correlation-id=true",
+                        "bootui.rabbitmq.max-correlation-id-length=16");
+    }
+
+    private static ReactiveWebApplicationContextRunner reactiveRunner() {
+        return new ReactiveWebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        HttpHandlerAutoConfiguration.class,
+                        WebFluxAutoConfiguration.class,
+                        BootUiReactiveAutoConfiguration.class))
+                .withUserConfiguration(MessagingFixture.class)
+                .withPropertyValues(
+                        "bootui.enabled=ON",
+                        "bootui.allow-non-localhost=true",
+                        "bootui.jms.capture-message-id=true",
+                        "bootui.jms.max-message-id-length=16",
+                        "bootui.rabbitmq.capture-correlation-id=true",
+                        "bootui.rabbitmq.max-correlation-id-length=16");
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class MessagingFixture {
+
+        @Bean
+        jakarta.jms.ConnectionFactory jmsConnectionFactory() throws Exception {
+            jakarta.jms.ConnectionFactory factory = mock(jakarta.jms.ConnectionFactory.class);
+            Connection connection = mock(Connection.class);
+            Session session = mock(Session.class);
+            MessageProducer producer = mock(MessageProducer.class);
+            when(factory.createConnection()).thenReturn(connection);
+            when(connection.createSession(false, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+            when(session.createQueue(anyString())).thenAnswer(invocation -> {
+                Queue queue = mock(Queue.class);
+                when(queue.getQueueName()).thenReturn(invocation.getArgument(0));
+                return queue;
+            });
+            when(session.createProducer(any(Destination.class))).thenReturn(producer);
+            return factory;
+        }
+
+        @Bean
+        JmsTemplate jmsTemplate(jakarta.jms.ConnectionFactory connectionFactory) {
+            return new JmsTemplate(connectionFactory);
+        }
+
+        @Bean
+        DefaultJmsListenerContainerFactory jmsListenerContainerFactory(
+                jakarta.jms.ConnectionFactory connectionFactory) {
+            DefaultJmsListenerContainerFactory factory = new DefaultJmsListenerContainerFactory();
+            factory.setConnectionFactory(connectionFactory);
+            return factory;
+        }
+
+        @Bean
+        org.springframework.amqp.rabbit.connection.ConnectionFactory rabbitConnectionFactory() {
+            return mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class);
+        }
+
+        @Bean
+        RabbitTemplate rabbitTemplate(org.springframework.amqp.rabbit.connection.ConnectionFactory connectionFactory) {
+            return new RabbitTemplate(connectionFactory);
+        }
+
+        @Bean
+        SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
+                org.springframework.amqp.rabbit.connection.ConnectionFactory connectionFactory) {
+            SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
+            factory.setConnectionFactory(connectionFactory);
+            return factory;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add broker-free Spring MVC and WebFlux integration coverage that boots the real BootUI auto-configuration, post-processes application JMS/RabbitMQ templates and listener factories, drives publish/consume callbacks, and verifies the shared panel manifest/report/clear HTTP path
- add an isolated Quarkus `quarkus-messaging-rabbitmq` integration-test module that proves deployment-time interceptor registration, CDI wiring, shared recorder/report parity, RabbitMQ availability, and explicit JMS unavailability
- assert metadata-only capture: destination sanitization, hashed JMS message IDs and RabbitMQ correlation IDs, generic failures, no payload/arbitrary-header retention, recent-first ordering, lifetime totals, and clear behavior

## Broker-free proof
- Spring uses mocked JMS/RabbitMQ transport objects and synchronous framework callbacks; no listener thread, socket, broker, polling, or Testcontainers dependency
- Quarkus configures no `mp.messaging.*` channel and sets `quarkus.rabbitmq.devservices.enabled=false`; synthetic SmallRye metadata drives the injected interceptors
- the focused Spring and Quarkus tests pass with `DOCKER_HOST=tcp://127.0.0.1:1`
- the default Playwright suite passes under the same unreachable Docker host (129 passed; six Docker-profile-only checks skipped)

## Tests
- focused engine JMS/RabbitMQ recorder and Live Activity assembler tests
- focused Spring JMS/RabbitMQ processor, absence, MVC, WebFlux, API JSON, and clear tests
- focused Quarkus runtime capture/config/availability tests, base absence coverage, shared API conformance, and capability-present RabbitMQ integration test
- full 15-module Docker-free Quarkus integration-test reactor
- Spring MVC and WebFlux API conformance
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 clean install` (29-module reactor)
- Spotless apply/check
- Playwright Chromium suite (129 passed, 6 skipped)