### PR TITLE
Revert ineffective CI performance changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,31 +3,8 @@ name: Build (Java 17 baseline)
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      # Root project-meta markdown that no test reads (unlike docs/FEATURES.md, docs/*-CHECKS.md, etc.,
-      # which bootui-conformance/routes.test.js consistency checks parse) plus screenshot assets and the
-      # design-skill sidecar, both non-functional. docs/ page content otherwise stays covered.
-      - 'CHANGELOG.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'README.md'
-      - 'PRODUCT.md'
-      - 'DESIGN.md'
-      - 'docs/images/**'
-      - '.impeccable/**'
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'README.md'
-      - 'PRODUCT.md'
-      - 'DESIGN.md'
-      - 'docs/images/**'
-      - '.impeccable/**'
   workflow_dispatch:
 
 concurrency:
@@ -39,19 +16,13 @@ permissions:
   checks: write
 
 jobs:
-  # The full reactor `clean install` used to run sequentially in a single `build` job (shared modules,
-  # then the Spring adapter, then the Quarkus adapter, one after another). The two adapters don't depend
-  # on each other, only on the shared modules (bootui-core/-engine/-ui/-conformance), so they now build in
-  # parallel as their own jobs once `build-shared` has installed those shared artifacts. This shortens the
-  # critical path to shared-build-time + max(spring-build-time, quarkus-build-time) instead of the sum of
-  # all three.
-  build-shared:
-    name: Build (shared modules)
-    # Opt-in larger/faster runner: set the BOOTUI_CI_RUNNER repository or organization variable (Settings >
-    # Secrets and variables > Actions > Variables) to a larger GitHub-hosted runner label (e.g.
-    # ubuntu-latest-4-cores) if your plan has one available. Defaults to the standard free runner, since
-    # not every plan has larger runners enabled and an unavailable label would fail the job outright.
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
+  build:
+    name: Build (Java ${{ matrix.java }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '17' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -59,11 +30,11 @@ jobs:
       - name: Check GitHub Action references
         run: bash .github/scripts/check-action-references.sh
 
-      - name: Set up JDK 17
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: ${{ matrix.java }}
           cache: maven
 
       - name: Set up Node.js
@@ -75,50 +46,53 @@ jobs:
             bootui-ui/src/main/frontend/package-lock.json
             bootui-spring-sample-app/e2e/package-lock.json
 
-      # bootui-ui is a dependency of both Spring and Quarkus adapters, so its frontend-maven-plugin
-      # Node.js/npm download (into bootui-ui/node, outside target/ so it survives `mvn clean`) otherwise
-      # repeats in every job below that builds it. Cache hit skips the download entirely.
-      - name: Cache frontend build tools
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: bootui-ui/node
-          key: frontend-tools-${{ runner.os }}-${{ hashFiles('pom.xml') }}
-
-      # Whole-reactor formatting check: fast (no compilation), so it stays here rather than being
-      # duplicated across the split build-spring/build-quarkus jobs below.
       - name: Check Maven formatting
         run: ./mvnw -B -ntp spotless:check
 
-      # Builds and installs only the modules every adapter depends on: bootui-core, bootui-engine,
-      # bootui-ui (the packaged Vue SPA), and bootui-conformance (the shared HTTP contract test-support
-      # library both adapters' sample apps depend on in test scope). Installing these into the local Maven
-      # repository lets build-spring/build-quarkus below resolve them as ordinary dependencies (restored
-      # from the cache saved at the end of this job) instead of rebuilding them from source.
-      - name: Build shared modules
-        run: ./mvnw -T 1C -B -ntp -pl bootui-core,bootui-engine,bootui-ui,bootui-conformance -am clean install
+      # -T 1C: one reactor thread per available CPU core. Safe because every module that triggers Quarkus
+      # build-time augmentation declares an explicit provided-scope dependency on bootui-quarkus-deployment
+      # (so the reactor always orders it first) and every @QuarkusTest-bearing module pins Surefire's
+      # forkCount to a value that does not race Quarkus's own test-bootstrap classloading (see the
+      # maven-surefire-plugin comment in the root pom and the forkCount comment in
+      # bootui-quarkus-integration-tests/base/pom.xml).
+      - name: Build all modules
+        run: ./mvnw -T 1C -B -ntp clean install
 
       - name: Check frontend formatting
         working-directory: bootui-ui/src/main/frontend
         run: npm run format:check
 
-      # Shares the shared-module Maven artifacts with the build-spring/build-quarkus jobs below (and,
-      # through them, the e2e/quarkus-e2e jobs) so those jobs never recompile bootui-core/-engine/-ui/
-      # -conformance from source. Scoped to this project's own group id (not the whole ~/.m2/repository,
-      # which setup-java's own `cache: maven` already handles per-job for third-party dependencies) and
-      # keyed uniquely per run so it is always a fresh write with no cross-run staleness or restore-key
-      # ambiguity.
-      - name: Save shared Maven artifacts for downstream jobs
-        if: success()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-shared-${{ github.run_id }}
+      - name: Install Playwright dependencies
+        working-directory: bootui-spring-sample-app/e2e
+        run: npm ci --ignore-scripts
+
+      - name: Check Playwright formatting
+        working-directory: bootui-spring-sample-app/e2e
+        run: npm run format:check
+
+      - name: Install Playwright browsers
+        working-directory: bootui-spring-sample-app/e2e
+        run: ./node_modules/.bin/playwright install --with-deps chromium
+
+      - name: Run Playwright end-to-end tests
+        working-directory: bootui-spring-sample-app/e2e
+        run: npm test
+
+      - name: Run WebFlux Playwright end-to-end tests
+        if: ${{ !cancelled() }}
+        working-directory: bootui-spring-sample-app/e2e
+        run: npm run test:webflux
+
+      - name: Run custom-path Playwright end-to-end tests
+        if: ${{ !cancelled() }}
+        working-directory: bootui-spring-sample-app/e2e
+        run: npm run test:custom-path
 
       - name: Publish Java test report
         if: ${{ !cancelled() }}
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
-          name: Java tests (Surefire, shared modules)
+          name: Java tests (Surefire)
           path: '**/target/surefire-reports/TEST-*.xml'
           reporter: java-junit
           fail-on-error: false
@@ -134,72 +108,80 @@ jobs:
           fail-on-error: false
           fail-on-empty: false
 
-      - name: Upload JUnit test reports
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-test-reports-shared
-          path: |
-            **/target/surefire-reports/TEST-*.xml
-            bootui-ui/src/main/frontend/test-results/vitest-junit.xml
-          if-no-files-found: ignore
-          retention-days: 7
-
-  build-spring:
-    name: Build (Spring adapter)
-    needs: build-shared
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: maven
-
-      - name: Restore shared Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-shared-${{ github.run_id }}
-          fail-on-cache-miss: true
-
-      # No -am: bootui-core/-engine/-ui/-conformance are resolved as ordinary dependencies from the
-      # restored local repository above, instead of being rebuilt from source as reactor modules.
-      - name: Build Spring adapter modules
-        run: >
-          ./mvnw -T 1C -B -ntp
-          -pl bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-boot-starter-reactive,bootui-spring-sample-app,bootui-spring-webflux-sample-app
-          clean install
-
-      # Shares the now-installed Spring adapter artifacts with the `e2e` job below, so it can build only
-      # the sample-app module(s) it needs instead of the whole upstream Spring reactor again.
-      - name: Save Spring Maven artifacts for downstream jobs
-        if: success()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-spring-${{ github.run_id }}
-
-      - name: Publish Java test report
+      - name: Publish end-to-end test report
         if: ${{ !cancelled() }}
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         with:
-          name: Java tests (Surefire, Spring adapter)
-          path: '**/target/surefire-reports/TEST-*.xml'
-          reporter: java-junit
+          name: End-to-end tests (Playwright)
+          path: bootui-spring-sample-app/e2e/test-results/junit/results.xml
+          reporter: jest-junit
           fail-on-error: false
           fail-on-empty: false
+
+      - name: Publish WebFlux end-to-end test report
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: WebFlux end-to-end tests (Playwright)
+          path: bootui-spring-sample-app/e2e/test-results-webflux/junit/results.xml
+          reporter: jest-junit
+          fail-on-error: false
+          fail-on-empty: false
+
+      - name: Publish custom-path end-to-end test report
+        if: ${{ !cancelled() }}
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        with:
+          name: Custom-path end-to-end tests (Playwright)
+          path: bootui-spring-sample-app/e2e/test-results-custom-path/junit/results.xml
+          reporter: jest-junit
+          fail-on-error: false
+          fail-on-empty: false
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: |
+            bootui-spring-sample-app/e2e/playwright-report/
+            bootui-spring-sample-app/e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload WebFlux Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-webflux
+          path: |
+            bootui-spring-sample-app/e2e/playwright-report-webflux/
+            bootui-spring-sample-app/e2e/test-results-webflux/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload custom-path Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-custom-path
+          path: |
+            bootui-spring-sample-app/e2e/playwright-report-custom-path/
+            bootui-spring-sample-app/e2e/test-results-custom-path/
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Upload JUnit test reports
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: junit-test-reports-spring
-          path: '**/target/surefire-reports/TEST-*.xml'
+          name: junit-test-reports
+          path: |
+            **/target/surefire-reports/TEST-*.xml
+            bootui-ui/src/main/frontend/test-results/vitest-junit.xml
+            bootui-spring-sample-app/e2e/test-results/junit/results.xml
+            bootui-spring-sample-app/e2e/test-results-webflux/junit/results.xml
+            bootui-spring-sample-app/e2e/test-results-custom-path/junit/results.xml
           if-no-files-found: ignore
           retention-days: 7
 
@@ -212,240 +194,9 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-  build-quarkus:
-    name: Build (Quarkus adapter)
-    needs: build-shared
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: maven
-
-      - name: Restore shared Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-shared-${{ github.run_id }}
-          fail-on-cache-miss: true
-
-      # No -am: bootui-core/-engine/-ui/-conformance are resolved as ordinary dependencies from the
-      # restored local repository above, instead of being rebuilt from source as reactor modules.
-      # bootui-quarkus-integration-tests submodules must be listed individually: selecting the aggregator
-      # module in -pl does not pull in its children (see the same note in jdk-compatibility.yml).
-      # bootui-quarkus-integration-tests/hibernate is normally wired into the root reactor only via the
-      # JDK-gated `quarkus-sample-app` profile ([17,26)); listing it explicitly here preserves that
-      # coverage since -pl bypasses the root <modules> list the profile contributes to.
-      - name: Build Quarkus adapter modules
-        run: >
-          ./mvnw -T 1C -B -ntp
-          -pl bootui-quarkus-parent,bootui-quarkus,bootui-quarkus-deployment,bootui-quarkus-sample-app,bootui-quarkus-integration-tests/base,bootui-quarkus-integration-tests/otel,bootui-quarkus-integration-tests/health,bootui-quarkus-integration-tests/micrometer,bootui-quarkus-integration-tests/scheduler,bootui-quarkus-integration-tests/security,bootui-quarkus-integration-tests/cache,bootui-quarkus-integration-tests/email,bootui-quarkus-integration-tests/rabbit,bootui-quarkus-integration-tests/flyway,bootui-quarkus-integration-tests/liquibase,bootui-quarkus-integration-tests/datasource,bootui-quarkus-integration-tests/rest-client,bootui-quarkus-integration-tests/prod-shell-guard,bootui-quarkus-integration-tests/hibernate
-          clean install
-
-      # Shares the now-installed Quarkus adapter artifacts with the `quarkus-e2e` job below, so it can
-      # build only the sample-app module instead of the whole upstream Quarkus reactor again.
-      - name: Save Quarkus Maven artifacts for downstream jobs
-        if: success()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-quarkus-${{ github.run_id }}
-
-      - name: Publish Java test report
-        if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        with:
-          name: Java tests (Surefire, Quarkus adapter)
-          path: '**/target/surefire-reports/TEST-*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          fail-on-empty: false
-
-      - name: Upload JUnit test reports
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-test-reports-quarkus
-          path: '**/target/surefire-reports/TEST-*.xml'
-          if-no-files-found: ignore
-          retention-days: 7
-
-  # Aggregate gate job: keeps a job named "Build (Java 17)" green/red as one required status check,
-  # exactly as the single monolithic `build` job used to, so branch protection rules that require that
-  # check by name keep working unchanged even though the actual work now happens in the three jobs above.
-  build:
-    name: Build (Java 17)
-    needs: [ build-shared, build-spring, build-quarkus ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: All build jobs succeeded
-        run: echo "build-shared, build-spring and build-quarkus all succeeded."
-
-  # The three Spring Playwright suites (main MVC, WebFlux, custom-path) used to run sequentially in the
-  # old monolithic `build` job, only after the full reactor `clean install` finished. Each suite only
-  # needs its own sample-app module(s) built (mirroring the `quarkus-e2e` job's `-pl ... -DskipTests
-  # install` pattern below), so they run here as an independent parallel matrix that only waits on
-  # `build-spring` (not the whole reactor, and not `build-quarkus`, which runs concurrently).
-  e2e:
-    name: Spring end-to-end (${{ matrix.suite.name }})
-    # Needs build-spring (not just build-shared) because it restores the bootui-m2-spring cache below,
-    # which build-spring is the sole writer of: it contains both the shared modules and the already-built
-    # Spring adapter modules, so this job's own build step only needs to compile the sample app itself.
-    needs: build-spring
-    # See the `build-shared` job comment above for BOOTUI_CI_RUNNER; defaults to the standard free runner.
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        suite:
-          - name: mvc
-            modules: bootui-spring-sample-app
-            npm_script: test
-            report_dir: playwright-report
-            results_dir: test-results
-            format_check: true
-          - name: webflux
-            modules: bootui-spring-webflux-sample-app
-            npm_script: test:webflux
-            report_dir: playwright-report-webflux
-            results_dir: test-results-webflux
-            format_check: false
-          - name: custom-path
-            modules: bootui-spring-sample-app,bootui-spring-webflux-sample-app
-            npm_script: test:custom-path
-            report_dir: playwright-report-custom-path
-            results_dir: test-results-custom-path
-            format_check: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: maven
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '24.18.0'
-          cache: npm
-          cache-dependency-path: |
-            bootui-ui/src/main/frontend/package-lock.json
-            bootui-spring-sample-app/e2e/package-lock.json
-
-      # Restore-only: the `build-shared` job is the sole writer of this key (see its comment above). With
-      # three matrix entries here plus `quarkus-e2e` also reading it, using the read+write `actions/cache`
-      # action in every job would race all of them to save the same key on a cache miss (e.g. right after
-      # the key changes) — actions/cache tolerates that (only the first save wins, the rest just warn), but
-      # it is wasted upload time on every job that loses the race. Restore-only avoids that entirely; a
-      # miss here simply falls through to frontend-maven-plugin's normal download, exactly as it would
-      # without any cache at all.
-      - name: Restore frontend build tools cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: bootui-ui/node
-          key: frontend-tools-${{ runner.os }}-${{ hashFiles('pom.xml') }}
-
-      # Restores the shared modules + Spring adapter modules that build-spring already built and
-      # installed, so the step below only needs to compile the sample app module(s) themselves instead of
-      # rebuilding the whole upstream reactor (bootui-core/-engine/-ui/-conformance/-spring-autoconfigure/
-      # -spring-boot-starter*) a second time.
-      - name: Restore Spring Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-spring-${{ github.run_id }}
-          fail-on-cache-miss: true
-
-      # No -am: upstream modules are resolved from the restored local repository above instead of being
-      # rebuilt from source as reactor modules, so only the module(s) this suite's webServer(s) actually
-      # boot are compiled.
-      - name: Build sample app module(s) for this suite
-        run: ./mvnw -T 1C -B -ntp -pl "${{ matrix.suite.modules }}" -DskipTests install
-
-      - name: Install Playwright dependencies
-        working-directory: bootui-spring-sample-app/e2e
-        run: npm ci --ignore-scripts
-
-      - name: Check Playwright formatting
-        if: matrix.suite.format_check
-        working-directory: bootui-spring-sample-app/e2e
-        run: npm run format:check
-
-      # Cache the downloaded browser binaries by the pinned @playwright/test version, so a run only
-      # re-downloads chromium when the package-lock.json version actually changes. --with-deps still runs
-      # every time to keep the runner's OS-level dependencies current, but it is fast when the browser
-      # binary itself is already cached. All three matrix entries share this key (same e2e package-lock.json),
-      # so only the `mvc` entry does the read+write save; `webflux`/`custom-path` restore-only to avoid
-      # racing `mvc` (and each other) to save the identical key on a cache miss.
-      - name: Cache Playwright browsers
-        if: matrix.suite.name == 'mvc'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-spring-${{ runner.os }}-${{ hashFiles('bootui-spring-sample-app/e2e/package-lock.json') }}
-
-      - name: Restore Playwright browsers cache
-        if: matrix.suite.name != 'mvc'
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-spring-${{ runner.os }}-${{ hashFiles('bootui-spring-sample-app/e2e/package-lock.json') }}
-
-      - name: Install Playwright browsers
-        working-directory: bootui-spring-sample-app/e2e
-        run: ./node_modules/.bin/playwright install --with-deps chromium
-
-      - name: Run Playwright end-to-end tests
-        working-directory: bootui-spring-sample-app/e2e
-        run: npm run ${{ matrix.suite.npm_script }}
-
-      - name: Publish end-to-end test report
-        if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        with:
-          name: End-to-end tests (Playwright, ${{ matrix.suite.name }})
-          path: bootui-spring-sample-app/e2e/${{ matrix.suite.results_dir }}/junit/results.xml
-          reporter: jest-junit
-          fail-on-error: false
-          fail-on-empty: false
-
-      - name: Upload Playwright report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: playwright-report-${{ matrix.suite.name }}
-          path: |
-            bootui-spring-sample-app/e2e/${{ matrix.suite.report_dir }}/
-            bootui-spring-sample-app/e2e/${{ matrix.suite.results_dir }}/
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Upload JUnit test report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-test-reports-e2e-${{ matrix.suite.name }}
-          path: bootui-spring-sample-app/e2e/${{ matrix.suite.results_dir }}/junit/results.xml
-          if-no-files-found: ignore
-          retention-days: 7
-
   quarkus-e2e:
     name: Quarkus end-to-end (Java 17)
-    # Needs build-quarkus (not just build-shared) because it restores the bootui-m2-quarkus cache below,
-    # which build-quarkus is the sole writer of: it contains both the shared modules and the already-built
-    # Quarkus adapter modules, so this job's own build step only needs to compile the sample app itself.
-    needs: build-quarkus
-    # See the `build-shared` job comment above for BOOTUI_CI_RUNNER; defaults to the standard free runner.
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -462,36 +213,24 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24.18.0'
+          node-version: '24.16.0'
           cache: npm
           cache-dependency-path: |
-            bootui-ui/src/main/frontend/package-lock.json
             bootui-quarkus-sample-app/e2e/package-lock.json
 
-      # Restore-only: see the same-named step's comment in the `e2e` job above — `build-shared` is the
-      # sole writer of this key, so every other reader here avoids racing to save it.
-      - name: Restore frontend build tools cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: bootui-ui/node
-          key: frontend-tools-${{ runner.os }}-${{ hashFiles('pom.xml') }}
-
-      # Restores the shared modules + Quarkus adapter modules that build-quarkus already built and
-      # installed, so the step below only needs to compile the sample app module instead of rebuilding the
-      # whole upstream reactor (bootui-core/-engine/-ui/-conformance/-quarkus/-quarkus-deployment) again.
-      - name: Restore Quarkus Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-quarkus-${{ github.run_id }}
-          fail-on-cache-miss: true
-
-      # Installs just the sample app into the local Maven repository so Playwright's `quarkus:dev` web
-      # server can resolve it. BootUI activates automatically under `quarkus:dev` (dev mode); it stays dark
-      # in a packaged prod run. No -am: bootui-quarkus/-quarkus-deployment are resolved from the restored
-      # local repository above instead of being rebuilt from source as reactor modules.
-      - name: Build BootUI Quarkus sample app
-        run: ./mvnw -T 1C -B -ntp -pl bootui-quarkus-sample-app -DskipTests install
+      # Build and install the BootUI Quarkus extension + the sample app into the local Maven
+      # repository so Playwright's `quarkus:dev` web server can resolve them. BootUI activates
+      # automatically under `quarkus:dev` (dev mode); it stays dark in a packaged prod run.
+      # bootui-quarkus-sample-app (and every Quarkus consumer module) declares an explicit provided-scope
+      # dependency on bootui-quarkus-deployment, so plain -am now resolves it into the reactor; Quarkus
+      # would otherwise only pull the -deployment counterpart in at augmentation time (not via Maven's
+      # dependency graph), which is invisible to -am and, under a parallel (-T) build, is also an
+      # unordered race with the deployment module's own build.
+      # -T 1C is safe here even without the Surefire forkCount guards above: -DskipTests means no
+      # @QuarkusTest classloading race is possible, and -am's ordering relies only on the same explicit
+      # provided-scope bootui-quarkus-deployment dependency called out above.
+      - name: Build BootUI Quarkus extension and sample app
+        run: ./mvnw -T 1C -B -ntp -pl bootui-quarkus-sample-app -am -DskipTests install
 
       - name: Install Playwright dependencies
         working-directory: bootui-quarkus-sample-app/e2e
@@ -500,16 +239,6 @@ jobs:
       - name: Check Playwright formatting
         working-directory: bootui-quarkus-sample-app/e2e
         run: npm run format:check
-
-      # Cache the downloaded browser binaries by the pinned @playwright/test version, so a run only
-      # re-downloads chromium when the package-lock.json version actually changes. --with-deps still runs
-      # every time to keep the runner's OS-level dependencies current, but it is fast when the browser
-      # binary itself is already cached.
-      - name: Cache Playwright browsers
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-quarkus-${{ runner.os }}-${{ hashFiles('bootui-quarkus-sample-app/e2e/package-lock.json') }}
 
       - name: Install Playwright browsers
         working-directory: bootui-quarkus-sample-app/e2e

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,44 +5,15 @@ name: CodeQL
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      # Same non-functional paths build.yml ignores: root project-meta markdown, screenshots, and the
-      # design-skill sidecar don't affect either the Java or JS/TS CodeQL databases.
-      - 'CHANGELOG.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'README.md'
-      - 'PRODUCT.md'
-      - 'DESIGN.md'
-      - 'docs/images/**'
-      - '.impeccable/**'
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'README.md'
-      - 'PRODUCT.md'
-      - 'DESIGN.md'
-      - 'docs/images/**'
-      - '.impeccable/**'
   schedule:
     - cron: '0 6 * * 1'
-
-# A newer push/PR update supersedes any CodeQL run already in flight for the same ref, so we don't burn
-# runner time analyzing a commit that's no longer at the head of the branch/PR.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    # Opt-in larger/faster runner: see build.yml for the BOOTUI_CI_RUNNER variable this mirrors.
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
@@ -80,18 +51,6 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: '24.18.0'
-          cache: npm
-          cache-dependency-path: bootui-ui/src/main/frontend/package-lock.json
-
-      # bootui-ui is part of the reactor `package` build below, so its frontend-maven-plugin Node.js/npm
-      # download (into bootui-ui/node, outside target/ so it survives `mvn clean`) is otherwise repeated
-      # on every CodeQL run. Cache hit skips the download entirely, same as build.yml.
-      - name: Cache frontend build tools
-        if: steps.code-scanning.outputs.enabled == 'true' && matrix.language == 'java-kotlin'
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: bootui-ui/node
-          key: frontend-tools-${{ runner.os }}-${{ hashFiles('pom.xml') }}
 
       - name: Initialize CodeQL
         if: steps.code-scanning.outputs.enabled == 'true'
@@ -104,8 +63,7 @@ jobs:
         # CodeQL only needs the Java sources compiled for analysis, so we skip
         # tests and the frontend bundling/release plumbing that the full
         # build.yml `clean install` runs. `package` is sufficient and faster here.
-        # `-T 1C` builds independent reactor modules in parallel (one thread per core), same as build.yml.
-        run: ./mvnw -T 1C -B -ntp -DskipTests package
+        run: ./mvnw -B -ntp -DskipTests package
 
       - name: Perform CodeQL Analysis
         if: steps.code-scanning.outputs.enabled == 'true'

--- a/.github/workflows/jdk-compatibility.yml
+++ b/.github/workflows/jdk-compatibility.yml
@@ -1,39 +1,13 @@
 name: JDK compatibility (21/25)
 
-# Keeps Java 17 as the full CI-equivalent/build-release baseline (build.yml + release.yml), while adding
-# focused compatibility checks on newer supported JDKs for every PR/push and a weekly scheduled run.
-#
-# Mirrors build.yml's parallel-jobs-plus-cache shape: a `compat-shared` job installs the modules every
-# adapter depends on (bootui-core/-engine/-ui/-conformance) once per JDK, then `compat-spring` and
-# `compat-quarkus` restore those artifacts and build/test their own adapter in parallel instead of
-# sequentially, shortening the critical path per JDK to shared-time + max(spring-time, quarkus-time).
+# Keeps Java 17 as the full CI-equivalent/build-release baseline (build.yml + release.yml),
+# while adding focused compatibility checks on newer supported JDKs for every PR/push and
+# a weekly scheduled run.
 on:
   push:
     branches: [ main ]
-    paths-ignore:
-      # Keep this list identical to build.yml's: root project-meta markdown that no test reads, plus
-      # screenshot assets and the design-skill sidecar, both non-functional.
-      - 'CHANGELOG.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'README.md'
-      - 'PRODUCT.md'
-      - 'DESIGN.md'
-      - 'docs/images/**'
-      - '.impeccable/**'
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'CODE_OF_CONDUCT.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'README.md'
-      - 'PRODUCT.md'
-      - 'DESIGN.md'
-      - 'docs/images/**'
-      - '.impeccable/**'
   schedule:
     # Every Monday at 07:05 UTC.
     - cron: '5 7 * * 1'
@@ -45,202 +19,38 @@ concurrency:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
-  compat-shared:
-    name: Compatibility (shared modules, Java ${{ matrix.java }})
-    # See build.yml's build-shared job comment for BOOTUI_CI_RUNNER; defaults to the standard free runner.
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '21', '25' ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-          cache: maven
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '24.18.0'
-          cache: npm
-          cache-dependency-path: bootui-ui/src/main/frontend/package-lock.json
-
-      # Restore-only: build.yml's own build-shared job is the sole writer of this key (same runner.os +
-      # pom.xml hash, independent of the JDK running the reactor), so a hit here skips the
-      # frontend-maven-plugin Node.js/npm download entirely; a miss falls through to the normal download.
-      - name: Restore frontend build tools cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: bootui-ui/node
-          key: frontend-tools-${{ runner.os }}-${{ hashFiles('pom.xml') }}
-
-      # Builds and installs only the modules every adapter depends on, exactly as build.yml's build-shared
-      # job does for Java 17, so compat-spring/compat-quarkus below can resolve them as ordinary
-      # dependencies instead of rebuilding them from source.
-      - name: Build shared modules
-        run: ./mvnw -T 1C -B -ntp -pl bootui-core,bootui-engine,bootui-ui,bootui-conformance -am clean install
-
-      # Scoped to this project's own group id and keyed per JDK + run, mirroring build.yml's
-      # bootui-m2-shared-${{ github.run_id }} cache but split per matrix.java so the 21 and 25 runs (which
-      # execute concurrently) never race to write or read each other's artifacts.
-      - name: Save shared Maven artifacts for downstream jobs
-        if: success()
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-jdk${{ matrix.java }}-shared-${{ github.run_id }}
-
-      - name: Publish Java test report
-        if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        with:
-          name: Java tests (Surefire, shared modules, Java ${{ matrix.java }})
-          path: '**/target/surefire-reports/TEST-*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          fail-on-empty: false
-
-      - name: Upload JUnit test reports
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-test-reports-jdk${{ matrix.java }}-shared
-          path: '**/target/surefire-reports/TEST-*.xml'
-          if-no-files-found: ignore
-          retention-days: 7
-
-  compat-spring:
-    name: Compatibility (Spring adapter, Java ${{ matrix.java }})
-    needs: compat-shared
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '21', '25' ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-          cache: maven
-
-      - name: Restore shared Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-jdk${{ matrix.java }}-shared-${{ github.run_id }}
-          fail-on-cache-miss: true
-
-      # No -am: bootui-core/-engine/-ui/-conformance are resolved as ordinary dependencies from the
-      # restored local repository above instead of being rebuilt from source as reactor modules.
-      - name: Build and test Spring adapter modules
-        run: >
-          ./mvnw -T 1C -B -ntp
-          -pl bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-boot-starter-reactive,bootui-spring-sample-app,bootui-spring-webflux-sample-app
-          clean test
-
-      - name: Publish Java test report
-        if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        with:
-          name: Java tests (Surefire, Spring adapter, Java ${{ matrix.java }})
-          path: '**/target/surefire-reports/TEST-*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          fail-on-empty: false
-
-      - name: Upload JUnit test reports
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-test-reports-jdk${{ matrix.java }}-spring
-          path: '**/target/surefire-reports/TEST-*.xml'
-          if-no-files-found: ignore
-          retention-days: 7
-
-  compat-quarkus:
-    name: Compatibility (Quarkus adapter, Java ${{ matrix.java }})
-    needs: compat-shared
-    runs-on: ${{ vars.BOOTUI_CI_RUNNER || 'ubuntu-latest' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [ '21', '25' ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: ${{ matrix.java }}
-          cache: maven
-
-      - name: Restore shared Maven artifacts
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository/com/julien-dubois
-          key: bootui-m2-jdk${{ matrix.java }}-shared-${{ github.run_id }}
-          fail-on-cache-miss: true
-
-      # No -am: bootui-core/-engine/-ui/-conformance are resolved as ordinary dependencies from the
-      # restored local repository above instead of being rebuilt from source as reactor modules. The
-      # Quarkus base integration-tests submodule is listed directly because selecting its aggregator does
-      # not include child modules in a Maven -pl build. Installs (rather than just testing)
-      # bootui-quarkus/-quarkus-deployment so the sample-app augmentation step below can resolve them from
-      # the local repository too, instead of needing -am to rebuild them from source.
-      - name: Build and test Quarkus adapter modules
-        run: >
-          ./mvnw -T 1C -B -ntp
-          -pl bootui-quarkus-parent,bootui-quarkus,bootui-quarkus-deployment,bootui-quarkus-integration-tests/base
-          clean install
-
-      # Ensures Quarkus build-time augmentation runs on supported JDKs (17/21/25) and catches
-      # ByteBuddy/build-plugin regressions without running browser tests. No -am: bootui-quarkus/
-      # -quarkus-deployment (and the shared modules) were already installed above/restored from cache.
-      - name: Exercise Quarkus sample app augmentation
-        run: ./mvnw -T 1C -B -ntp -pl bootui-quarkus-sample-app -DskipTests install
-
-      - name: Publish Java test report
-        if: ${{ !cancelled() }}
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        with:
-          name: Java tests (Surefire, Quarkus adapter, Java ${{ matrix.java }})
-          path: '**/target/surefire-reports/TEST-*.xml'
-          reporter: java-junit
-          fail-on-error: false
-          fail-on-empty: false
-
-      - name: Upload JUnit test reports
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: junit-test-reports-jdk${{ matrix.java }}-quarkus
-          path: '**/target/surefire-reports/TEST-*.xml'
-          if-no-files-found: ignore
-          retention-days: 7
-
-  # Aggregate gate job: keeps a job named "Focused compatibility" green/red as one required status check,
-  # exactly as build.yml's `build` gate job does, so branch protection rules keep working unchanged even
-  # though the actual work now happens per-JDK in the three matrixed jobs above.
   compatibility:
-    name: Focused compatibility
-    needs: [ compat-shared, compat-spring, compat-quarkus ]
+    name: Focused compatibility (Java ${{ matrix.java }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '21', '25' ]
     steps:
-      - name: All compatibility jobs succeeded
-        run: echo "compat-shared, compat-spring and compat-quarkus all succeeded on Java 21 and 25."
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+
+      - name: Build and test shared engine + adapters
+        # Focused coverage for Java 21/25: run the servlet, reactive and Quarkus
+        # conformance suites while avoiding browser and optional-extension suites.
+        # Select the Quarkus base module directly because selecting its aggregator
+        # does not include child modules in a Maven -pl build.
+        run: >
+          ./mvnw -T 1C -B -ntp
+          -pl bootui-spring-sample-app,bootui-spring-webflux-sample-app,bootui-quarkus-integration-tests/base
+          -am test
+
+      - name: Exercise Quarkus sample app augmentation
+        # Ensures Quarkus build-time augmentation runs on supported JDKs (17/21/25) and
+        # catches ByteBuddy/build-plugin regressions without running browser tests.
+        run: ./mvnw -T 1C -B -ntp -pl bootui-quarkus-sample-app -am -DskipTests install

--- a/bootui-ui/pom.xml
+++ b/bootui-ui/pom.xml
@@ -32,12 +32,7 @@
                 <artifactId>frontend-maven-plugin</artifactId>
                 <configuration>
                     <workingDirectory>${frontend.dir}</workingDirectory>
-                    <!-- Installed outside target/ (not target/node) so a CI cache keyed on node.version/npm.version
-                         survives `mvn clean`, letting parallel jobs that each build this module (the main build job,
-                         the Spring e2e matrix, and the Quarkus e2e job; see .github/workflows/build.yml) skip
-                         re-downloading the Node.js/npm binaries. Already covered by the existing "node/" .gitignore
-                         entry. -->
-                    <installDirectory>${project.basedir}/node</installDirectory>
+                    <installDirectory>${project.build.directory}/node</installDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
## What does this PR do?

Reverts the ten CI performance changes introduced on August 6 and restores the Build, CodeQL, JDK compatibility workflows, and frontend tool installation path to their pre-experiment state.

## Why is this change needed?

Live benchmarking did not demonstrate an overall Build improvement. The later job splitting made Build approximately 4% slower and JDK compatibility approximately 14% slower, while the remaining caching, runner, path-filtering, CodeQL, and Playwright parallelization changes added substantial complexity without a convincing benefit.

This combines the existing four-change job-split revert with the six remaining performance commits, avoiding a partially reverted workflow design.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Validated with `./mvnw -B -ntp spotless:check` and `.github/scripts/check-action-references.sh`. The four affected files exactly match their state immediately before the optimization experiment.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed