### PR TITLE
fix: isolate telemetry trace snapshots

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/telemetry/TelemetryStore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/telemetry/TelemetryStore.java
@@ -33,7 +33,7 @@ public class TelemetryStore {
     static final int SELF_TRACE_MEMORY = 4_096;
 
     private final TelemetrySettings settings;
-    private final LinkedHashMap<String, TraceBucket> tracesById;
+    private final LinkedHashMap<String, MutableTraceBucket> tracesById;
 
     /**
      * Trace ids known to belong to BootUI's own API traffic. A trace is remembered here the first
@@ -98,6 +98,9 @@ public class TelemetryStore {
         }
         lock.writeLock().lock();
         try {
+            if (idleSuspended) {
+                return false;
+            }
             String traceId = span.traceId();
             if (selfSpan) {
                 selfTraceIds.put(traceId, Boolean.TRUE);
@@ -107,11 +110,11 @@ public class TelemetryStore {
             if (selfTraceIds.containsKey(traceId)) {
                 return false;
             }
-            TraceBucket bucket = tracesById.remove(traceId);
+            MutableTraceBucket bucket = tracesById.remove(traceId);
             if (bucket == null) {
-                bucket = new TraceBucket(traceId);
+                bucket = new MutableTraceBucket(traceId);
                 while (tracesById.size() >= effectiveMaxTraces()) {
-                    Iterator<Map.Entry<String, TraceBucket>> it =
+                    Iterator<Map.Entry<String, MutableTraceBucket>> it =
                             tracesById.entrySet().iterator();
                     if (!it.hasNext()) {
                         break;
@@ -137,12 +140,13 @@ public class TelemetryStore {
     public List<TraceBucket> recentTraces(int limit) {
         lock.readLock().lock();
         try {
-            List<TraceBucket> ordered = new ArrayList<>(tracesById.values());
-            Collections.reverse(ordered);
-            if (limit > 0 && ordered.size() > limit) {
-                return new ArrayList<>(ordered.subList(0, limit));
+            List<MutableTraceBucket> buckets = new ArrayList<>(tracesById.values());
+            int resultSize = limit > 0 ? Math.min(limit, buckets.size()) : buckets.size();
+            List<TraceBucket> ordered = new ArrayList<>(resultSize);
+            for (int i = buckets.size() - 1; i >= buckets.size() - resultSize; i--) {
+                ordered.add(buckets.get(i).snapshot());
             }
-            return ordered;
+            return List.copyOf(ordered);
         } finally {
             lock.readLock().unlock();
         }
@@ -151,7 +155,8 @@ public class TelemetryStore {
     public TraceBucket findTrace(String traceId) {
         lock.readLock().lock();
         try {
-            return tracesById.get(traceId);
+            MutableTraceBucket bucket = tracesById.get(traceId);
+            return bucket == null ? null : bucket.snapshot();
         } finally {
             lock.readLock().unlock();
         }
@@ -177,7 +182,7 @@ public class TelemetryStore {
         List<NormalizedSpan> out = new ArrayList<>();
         lock.readLock().lock();
         try {
-            for (TraceBucket bucket : tracesById.values()) {
+            for (MutableTraceBucket bucket : tracesById.values()) {
                 out.addAll(bucket.spans);
             }
         } finally {
@@ -215,20 +220,19 @@ public class TelemetryStore {
         idleSuspended = false;
     }
 
-    /**
-     * Holder for a single trace; the spans list is mutated under the store's monitor.
-     */
+    /** Immutable snapshot of a single trace. */
     public static final class TraceBucket {
 
         private final String traceId;
 
         private final List<NormalizedSpan> spans;
 
-        private long lastUpdateEpochNanos;
+        private final long lastUpdateEpochNanos;
 
-        TraceBucket(String traceId) {
+        private TraceBucket(String traceId, List<NormalizedSpan> spans, long lastUpdateEpochNanos) {
             this.traceId = traceId;
-            this.spans = new ArrayList<>();
+            this.spans = List.copyOf(spans);
+            this.lastUpdateEpochNanos = lastUpdateEpochNanos;
         }
 
         public String traceId() {
@@ -241,6 +245,23 @@ public class TelemetryStore {
 
         public long lastUpdateEpochNanos() {
             return lastUpdateEpochNanos;
+        }
+    }
+
+    private static final class MutableTraceBucket {
+
+        private final String traceId;
+
+        private final List<NormalizedSpan> spans = new ArrayList<>();
+
+        private long lastUpdateEpochNanos;
+
+        private MutableTraceBucket(String traceId) {
+            this.traceId = traceId;
+        }
+
+        private TraceBucket snapshot() {
+            return new TraceBucket(traceId, spans, lastUpdateEpochNanos);
         }
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/telemetry/TelemetryStoreTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/telemetry/TelemetryStoreTests.java
@@ -1,9 +1,20 @@
 package io.github.jdubois.bootui.engine.telemetry;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.junit.jupiter.api.Test;
 
 class TelemetryStoreTests {
@@ -63,5 +74,131 @@ class TelemetryStoreTests {
         store.resumeFromIdle();
         assertThat(store.add(span("trace-c", "span-c"), false)).isTrue();
         assertThat(store.retainedTraceCount()).isEqualTo(1);
+    }
+
+    @Test
+    void traceReadsReturnIsolatedImmutableSnapshots() {
+        TelemetryStore store = new TelemetryStore(TelemetrySettings.of(true, true, 500, 500, 4096));
+        store.add(span("trace-a", "span-a"));
+
+        List<TelemetryStore.TraceBucket> recentSnapshot = store.recentTraces(10);
+        TelemetryStore.TraceBucket foundSnapshot = store.findTrace("trace-a");
+        store.add(span("trace-a", "span-b"));
+
+        assertThat(recentSnapshot)
+                .singleElement()
+                .satisfies(bucket -> assertThat(bucket.spans())
+                        .extracting(NormalizedSpan::spanId)
+                        .containsExactly("span-a"));
+        assertThat(foundSnapshot.spans()).extracting(NormalizedSpan::spanId).containsExactly("span-a");
+        assertThat(store.findTrace("trace-a").spans())
+                .extracting(NormalizedSpan::spanId)
+                .containsExactly("span-a", "span-b");
+        assertThatThrownBy(() -> recentSnapshot.add(foundSnapshot)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> foundSnapshot.spans().add(span("trace-a", "span-c")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void concurrentIngestionAndReadsUseConsistentSnapshots() throws Exception {
+        TelemetryStore store = new TelemetryStore(TelemetrySettings.of(true, true, 500, 1000, 4096));
+        int writerCount = 4;
+        int spansPerWriter = 200;
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(writerCount + 1);
+        try {
+            List<Future<?>> writers = new ArrayList<>();
+            for (int writer = 0; writer < writerCount; writer++) {
+                int writerId = writer;
+                writers.add(executor.submit(() -> {
+                    start.await();
+                    for (int i = 0; i < spansPerWriter; i++) {
+                        store.add(span("trace-a", "span-" + writerId + "-" + i));
+                    }
+                    return null;
+                }));
+            }
+            Future<?> reader = executor.submit(() -> {
+                start.await();
+                for (int i = 0; i < 2_000; i++) {
+                    for (TelemetryStore.TraceBucket bucket : store.recentTraces(10)) {
+                        for (NormalizedSpan storedSpan : bucket.spans()) {
+                            assertThat(storedSpan.traceId()).isEqualTo(bucket.traceId());
+                        }
+                    }
+                    TelemetryStore.TraceBucket found = store.findTrace("trace-a");
+                    if (found != null) {
+                        assertThat(found.spans())
+                                .allSatisfy(storedSpan ->
+                                        assertThat(storedSpan.traceId()).isEqualTo(found.traceId()));
+                    }
+                }
+                return null;
+            });
+
+            start.countDown();
+            for (Future<?> writer : writers) {
+                writer.get(10, TimeUnit.SECONDS);
+            }
+            reader.get(10, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+
+        assertThat(store.findTrace("trace-a").spans()).hasSize(writerCount * spansPerWriter);
+    }
+
+    @Test
+    void addRechecksIdleSuspensionAfterWaitingForWriteLock() throws Exception {
+        TelemetryStore store = new TelemetryStore(TelemetrySettings.of(true, true, 500, 500, 4096));
+        ReentrantReadWriteLock storeLock = storeLock(store);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        AtomicReference<Thread> addThread = new AtomicReference<>();
+        storeLock.readLock().lock();
+        try {
+            Future<Boolean> add = executor.submit(() -> {
+                addThread.set(Thread.currentThread());
+                return store.add(span("trace-a", "span-a"), false);
+            });
+            awaitCondition(() -> addThread.get() != null && storeLock.hasQueuedThread(addThread.get()));
+
+            Future<?> suspend = executor.submit(store::suspendForIdle);
+            awaitCondition(() -> storeLock.getQueueLength() == 2);
+
+            storeLock.readLock().unlock();
+            assertThat(add.get(10, TimeUnit.SECONDS)).isFalse();
+            suspend.get(10, TimeUnit.SECONDS);
+        } finally {
+            if (storeLock.getReadHoldCount() > 0) {
+                storeLock.readLock().unlock();
+            }
+            executor.shutdownNow();
+            assertThat(executor.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
+        }
+
+        assertThat(store.retainedTraceCount()).isZero();
+    }
+
+    private static ReentrantReadWriteLock storeLock(TelemetryStore store) throws Exception {
+        Field lockField = TelemetryStore.class.getDeclaredField("lock");
+        lockField.setAccessible(true);
+        return (ReentrantReadWriteLock) lockField.get(store);
+    }
+
+    private static void awaitCondition(Condition condition) throws Exception {
+        long deadline = System.nanoTime() + Duration.ofSeconds(10).toNanos();
+        while (!condition.evaluate()) {
+            if (System.nanoTime() >= deadline) {
+                throw new AssertionError("Condition was not met before timeout");
+            }
+            Thread.sleep(1);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Condition {
+
+        boolean evaluate();
     }
 }


### PR DESCRIPTION
## Summary
- copy trace buckets under the read lock and return immutable span-list/list snapshots
- keep mutable trace buckets fully internal to `TelemetryStore`
- recheck idle suspension after acquiring the ingestion write lock
- add isolation, concurrent ingestion/read, and suspend/add race coverage

## Validation
- `./mvnw -B -ntp spotless:apply`
- `./mvnw -B -ntp spotless:check`
- `./mvnw -B -ntp -pl bootui-engine test -Dtest=TelemetryStoreTests,TelemetrySelfTraceTests,TracesServiceTests,BootUiSpanExporterTests,SpanEnrichmentTests,EngineBoundaryArchitectureTests,SpiBoundaryArchitectureTests`