### PR TITLE
fix(ui): improve keyboard accessibility

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/activity.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/activity.spec.js
@@ -165,7 +165,8 @@ test.describe('Live Activity view', () => {
     await openView('activity', 'Live Activity')
     const productsRow = page.locator('.activity-table tbody tr', {hasText: '/api/sample/products'}).first()
     await expect(productsRow).toBeVisible({timeout: 15_000})
-    await productsRow.getByRole('button', {name: /Profile/}).click()
+    const profileButton = productsRow.getByRole('button', {name: /Profile/})
+    await profileButton.click()
 
     const drawer = page.locator('.activity-drawer')
     await expect(drawer).toBeVisible()
@@ -173,6 +174,7 @@ test.describe('Live Activity view', () => {
 
     await page.keyboard.press('Escape')
     await expect(drawer).toHaveCount(0)
+    await expect(profileButton).toBeFocused()
   })
 
   test('links KPI cards to their dedicated panels', async ({openView, page}) => {

--- a/bootui-spring-sample-app/e2e/tests/stream-status.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/stream-status.spec.js
@@ -205,6 +205,9 @@ test.describe('stream connection status', () => {
 
     await emitLatestStreamEvent(page, 'open')
     await expect(page.locator('.stream-status-indicator')).toBeHidden()
-    await expect(page.locator('[role="status"][aria-live="polite"]')).toHaveText('Stream connected.')
+    const streamAnnouncement = page.locator('.stream-status-announcement')
+    await expect(streamAnnouncement).toHaveAttribute('role', 'status')
+    await expect(streamAnnouncement).toHaveAttribute('aria-live', 'polite')
+    await expect(streamAnnouncement).toHaveText('Stream connected.')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Ai.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Ai.test.js
@@ -56,5 +56,8 @@ describe('Ai', () => {
     await sortButton.trigger('click')
     expect(modelHeader.attributes('aria-sort')).toBe('ascending')
     expect(wrapper.get('table tbody tr code').text()).toBe('alpha')
+    expect(wrapper.get('[role="progressbar"][aria-label="alpha token share"]').attributes('aria-valuetext')).toBe(
+      '50% of tokens'
+    )
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -8,6 +8,7 @@ import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import AiSetupChecklist from './components/AiSetupChecklist.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import ProgressBar from './components/ProgressBar.vue'
 
 const overview = ref(null)
 const series = ref(null)
@@ -690,9 +691,12 @@ const detectedFrameworkLabel = computed(() => {
                     <td class="text-end">{{ formatNumber(row.totalTokens) }}</td>
                     <td class="text-end">{{ formatNumber(row.avgTokens) }}</td>
                     <td style="width: 30%">
-                      <div class="progress" style="height: 6px">
-                        <div :style="{width: row.pct + '%'}" class="progress-bar" role="progressbar"></div>
-                      </div>
+                      <ProgressBar
+                        :label="`${row.model} token share`"
+                        :value="row.pct"
+                        :value-text="`${row.pct}% of tokens`"
+                        style="height: 6px"
+                      />
                     </td>
                   </tr>
                 </tbody>

--- a/bootui-ui/src/main/frontend/src/views/Copilot.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.test.js
@@ -200,4 +200,72 @@ describe('Copilot', () => {
     await flushPromises()
     expect(wrapper.get('[role="tab"].active').text()).toContain('Activity')
   })
+
+  it('links tabs to panels and supports roving keyboard navigation', async () => {
+    const session = {
+      id: 'session-one',
+      updatedAtEpochMillis: Date.now(),
+      eventCount: 2,
+      errorCount: 1,
+      inputTokens: 123,
+      outputTokens: 45
+    }
+    const detail = {
+      summary: {...session, turnCount: 1},
+      counts: {total: 2, byCategory: {}, errors: 1},
+      turns: [{index: 0, summary: 'A turn', eventCount: 1}],
+      recentEvents: [],
+      failureEvents: [{id: 'failure', category: 'SHELL', summary: 'Failed', success: false}],
+      warnings: []
+    }
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url) => {
+        if (url === 'api/copilot/dashboard') {
+          return Promise.resolve(jsonResponse(dashboard({recentSessions: [session]})))
+        }
+        if (url === 'api/copilot/sessions') {
+          return Promise.resolve(jsonResponse(sessionList({total: 1, returned: 1, sessions: [session]})))
+        }
+        if (url === 'api/copilot/sessions/session-one') return Promise.resolve(jsonResponse(detail))
+        return Promise.resolve(jsonResponse({}, false, 404))
+      })
+    )
+
+    wrapper = mount(Copilot, {attachTo: document.body})
+    await flushPromises()
+    await wrapper.get('button.session-row-target').trigger('click')
+    await flushPromises()
+
+    const tabs = wrapper.findAll('[role="tab"]')
+    expect(tabs.map((tab) => tab.attributes('tabindex'))).toEqual(['0', '-1', '-1'])
+    expect(tabs[0].attributes()).toMatchObject({
+      id: 'session-detail-activity-tab',
+      'aria-controls': 'session-detail-activity-panel',
+      'aria-selected': 'true'
+    })
+    expect(wrapper.get('#session-detail-activity-panel').attributes('aria-labelledby')).toBe(
+      'session-detail-activity-tab'
+    )
+    for (const tab of tabs) {
+      expect(wrapper.find(`#${tab.attributes('aria-controls')}`).exists()).toBe(true)
+    }
+
+    tabs[0].element.focus()
+    await tabs[0].trigger('keydown', {key: 'ArrowLeft'})
+    expect(document.activeElement).toBe(wrapper.get('#session-detail-failures-tab').element)
+    expect(wrapper.get('#session-detail-failures-tab').attributes('tabindex')).toBe('0')
+    expect(wrapper.get('#session-detail-failures-panel').attributes('aria-labelledby')).toBe(
+      'session-detail-failures-tab'
+    )
+
+    await wrapper.get('#session-detail-failures-tab').trigger('keydown', {key: 'Home'})
+    expect(document.activeElement).toBe(wrapper.get('#session-detail-activity-tab').element)
+
+    await wrapper.get('#session-detail-activity-tab').trigger('keydown', {key: 'End'})
+    expect(document.activeElement).toBe(wrapper.get('#session-detail-failures-tab').element)
+
+    await wrapper.get('#session-detail-failures-tab').trigger('keydown', {key: 'ArrowRight'})
+    expect(document.activeElement).toBe(wrapper.get('#session-detail-activity-tab').element)
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -1,12 +1,13 @@
 <script setup>
 import {apiFetch, getJson} from '../api.js'
-import {computed, ref, watch} from 'vue'
+import {computed, nextTick, ref, watch} from 'vue'
 import {useRoute} from 'vue-router'
 import {formatClockTime, formatNumber} from '../utils/format.js'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import ProgressBar from './components/ProgressBar.vue'
 
 const route = useRoute()
 const panelConfigs = {
@@ -68,6 +69,7 @@ const categories = [
   'FALLBACK',
   'OTHER'
 ]
+const detailTabs = ['activity', 'turns', 'failures']
 
 const sessions = computed(() => sessionList.value?.sessions ?? [])
 const available = computed(() => sessionList.value?.available !== false)
@@ -447,6 +449,36 @@ function showFailures() {
   textFilter.value = ''
 }
 
+function detailTabId(tab) {
+  return `session-detail-${tab}-tab`
+}
+
+function detailPanelId(tab) {
+  return `session-detail-${tab}-panel`
+}
+
+function activateDetailTab(tab) {
+  if (tab === 'activity') showActivity(categoryFilter.value)
+  if (tab === 'turns') showTurns()
+  if (tab === 'failures') showFailures()
+}
+
+async function onDetailTabKeydown(event, currentTab) {
+  const currentIndex = detailTabs.indexOf(currentTab)
+  let targetIndex
+  if (event.key === 'ArrowRight') targetIndex = (currentIndex + 1) % detailTabs.length
+  else if (event.key === 'ArrowLeft') targetIndex = (currentIndex - 1 + detailTabs.length) % detailTabs.length
+  else if (event.key === 'Home') targetIndex = 0
+  else if (event.key === 'End') targetIndex = detailTabs.length - 1
+  else return
+
+  event.preventDefault()
+  const targetTab = detailTabs[targetIndex]
+  activateDetailTab(targetTab)
+  await nextTick()
+  document.getElementById(detailTabId(targetTab))?.focus()
+}
+
 async function revealRaw(event) {
   if (rawById.value[event.id] !== undefined) {
     rawById.value = {...rawById.value, [event.id]: undefined}
@@ -743,9 +775,12 @@ watch(
                       <span class="fw-semibold">{{ row.label }}</span>
                       <span class="text-muted">{{ formatNumber(row.count) }} · {{ row.percent }}%</span>
                     </div>
-                    <div class="progress metric-progress" role="progressbar" :aria-valuenow="row.percent">
-                      <div class="progress-bar" :style="{width: row.percent + '%'}"></div>
-                    </div>
+                    <ProgressBar
+                      :label="`${row.label} event share`"
+                      :value="row.percent"
+                      :value-text="`${row.percent}% of events`"
+                      class="metric-progress"
+                    />
                   </div>
                 </div>
               </div>
@@ -765,9 +800,14 @@ watch(
                     class="d-flex align-items-center gap-2 mb-2"
                   >
                     <code class="tool-label">{{ tool.label }}</code>
-                    <div class="progress flex-grow-1 metric-progress" role="progressbar" :aria-valuenow="tool.percent">
-                      <div class="progress-bar bg-dark" :style="{width: Math.max(4, tool.percent) + '%'}"></div>
-                    </div>
+                    <ProgressBar
+                      bar-class="bg-dark"
+                      class="flex-grow-1 metric-progress"
+                      :label="`${tool.label} tool event share`"
+                      :min-visible-percent="4"
+                      :value="tool.percent"
+                      :value-text="`${tool.percent}% of events`"
+                    />
                     <span class="small text-muted">{{ formatNumber(tool.count) }}</span>
                   </div>
                   <div v-if="dashboard?.otherToolEventCount" class="small text-muted mt-2">
@@ -787,9 +827,14 @@ watch(
                       <span class="text-truncate">{{ model.label }}</span>
                       <span class="text-muted">{{ formatNumber(model.count) }}</span>
                     </div>
-                    <div class="progress metric-progress" role="progressbar" :aria-valuenow="model.percent">
-                      <div class="progress-bar bg-info" :style="{width: Math.max(4, model.percent) + '%'}"></div>
-                    </div>
+                    <ProgressBar
+                      bar-class="bg-info"
+                      :label="`${model.label} session share`"
+                      :min-visible-percent="4"
+                      :value="model.percent"
+                      :value-text="`${model.percent}% of sessions`"
+                      class="metric-progress"
+                    />
                   </div>
                 </div>
               </div>
@@ -1025,33 +1070,48 @@ watch(
                 <ul class="nav nav-tabs mb-3" role="tablist">
                   <li class="nav-item">
                     <button
+                      :id="detailTabId('activity')"
+                      :aria-controls="detailPanelId('activity')"
+                      :aria-selected="activeDetailTab === 'activity'"
                       :class="{active: activeDetailTab === 'activity'}"
+                      :tabindex="activeDetailTab === 'activity' ? 0 : -1"
                       class="nav-link"
                       role="tab"
                       type="button"
-                      @click="showActivity(categoryFilter)"
+                      @click="activateDetailTab('activity')"
+                      @keydown="onDetailTabKeydown($event, 'activity')"
                     >
                       Activity feed
                     </button>
                   </li>
                   <li class="nav-item">
                     <button
+                      :id="detailTabId('turns')"
+                      :aria-controls="detailPanelId('turns')"
+                      :aria-selected="activeDetailTab === 'turns'"
                       :class="{active: activeDetailTab === 'turns'}"
+                      :tabindex="activeDetailTab === 'turns' ? 0 : -1"
                       class="nav-link"
                       role="tab"
                       type="button"
-                      @click="showTurns()"
+                      @click="activateDetailTab('turns')"
+                      @keydown="onDetailTabKeydown($event, 'turns')"
                     >
                       Turn story
                     </button>
                   </li>
                   <li class="nav-item">
                     <button
+                      :id="detailTabId('failures')"
+                      :aria-controls="detailPanelId('failures')"
+                      :aria-selected="activeDetailTab === 'failures'"
                       :class="{active: activeDetailTab === 'failures'}"
+                      :tabindex="activeDetailTab === 'failures' ? 0 : -1"
                       class="nav-link"
                       role="tab"
                       type="button"
-                      @click="showFailures()"
+                      @click="activateDetailTab('failures')"
+                      @keydown="onDetailTabKeydown($event, 'failures')"
                     >
                       Failures
                       <span v-if="detail.counts.errors" class="badge text-bg-danger ms-1">{{
@@ -1062,7 +1122,14 @@ watch(
                 </ul>
 
                 <div class="tab-content">
-                  <div v-if="activeDetailTab === 'activity'" class="tab-pane active" role="tabpanel">
+                  <div
+                    v-show="activeDetailTab === 'activity'"
+                    :id="detailPanelId('activity')"
+                    :aria-labelledby="detailTabId('activity')"
+                    class="tab-pane active"
+                    role="tabpanel"
+                    tabindex="0"
+                  >
                     <div v-if="filteredEvents.length === 0" class="text-muted small">No events match this filter.</div>
                     <ul v-else class="list-group">
                       <li v-for="event in filteredEvents" :key="event.id" class="list-group-item">
@@ -1097,7 +1164,14 @@ watch(
                     </ul>
                   </div>
 
-                  <div v-else-if="activeDetailTab === 'turns'" class="tab-pane active" role="tabpanel">
+                  <div
+                    v-show="activeDetailTab === 'turns'"
+                    :id="detailPanelId('turns')"
+                    :aria-labelledby="detailTabId('turns')"
+                    class="tab-pane active"
+                    role="tabpanel"
+                    tabindex="0"
+                  >
                     <div v-if="!detail.turns || detail.turns.length === 0" class="text-muted small">
                       No turn information available.
                     </div>
@@ -1120,7 +1194,14 @@ watch(
                     </ol>
                   </div>
 
-                  <div v-else-if="activeDetailTab === 'failures'" class="tab-pane active" role="tabpanel">
+                  <div
+                    v-show="activeDetailTab === 'failures'"
+                    :id="detailPanelId('failures')"
+                    :aria-labelledby="detailTabId('failures')"
+                    class="tab-pane active"
+                    role="tabpanel"
+                    tabindex="0"
+                  >
                     <div v-if="failureEvents.length === 0" class="text-muted small">No failures recorded.</div>
                     <ul v-else class="list-group">
                       <li v-for="event in failureEvents" :key="event.id" class="list-group-item">

--- a/bootui-ui/src/main/frontend/src/views/DevTools.test.js
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.test.js
@@ -40,7 +40,7 @@ describe('DevTools', () => {
     wrapper = mount(DevTools)
     await flushPromises()
 
-    const alert = wrapper.get('[role="alert"]')
+    const alert = wrapper.get('.alert-secondary[role="alert"]')
     expect(alert.classes()).toContain('alert-secondary')
     expect(alert.text()).toContain('DevTools status is unavailable')
   })

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
@@ -337,6 +337,34 @@ describe('LiveActivity', () => {
     expect(drawer.text()).toContain('at com.example.TodoRepository.findById(TodoRepository.java:42)')
   })
 
+  it('restores focus to the drawer opener after close button, Escape, and backdrop closes', async () => {
+    vi.stubGlobal('requestAnimationFrame', (callback) => callback())
+    vi.stubGlobal('fetch', stubFetch(activityReport(), requestProfile()))
+
+    wrapper = mountLiveActivity({attachTo: document.body})
+    await flushPromises()
+    const opener = wrapper.get('button.bootui-keyboard-target')
+
+    for (const close of ['button', 'escape', 'backdrop']) {
+      opener.element.focus()
+      await opener.trigger('click')
+      await flushPromises()
+      expect(wrapper.get('.activity-drawer').element).toBe(document.activeElement)
+
+      if (close === 'button') {
+        await wrapper.get('.activity-drawer .btn-close').trigger('click')
+      } else if (close === 'escape') {
+        window.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}))
+      } else {
+        await wrapper.get('.activity-drawer-backdrop').trigger('click')
+      }
+
+      await flushPromises()
+      expect(wrapper.find('.activity-drawer').exists()).toBe(false)
+      expect(document.activeElement).toBe(opener.element)
+    }
+  })
+
   it('includes N+1 call sites when copying the plain-text profile report', async () => {
     const writeText = vi.fn().mockResolvedValue()
     vi.stubGlobal('navigator', {clipboard: {writeText}})

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
@@ -54,6 +54,7 @@ const profileLoading = ref(false)
 const profileError = ref(null)
 const profileRequestId = ref(null)
 const drawerEl = ref(null)
+const profileOpenerEl = ref(null)
 
 // "Load older" pagination state. Only ever populated when the backing store is durable (see
 // `persistent` below); stays empty for the default in-memory mode so nothing here changes its
@@ -370,14 +371,25 @@ function entryLink(entry) {
   return deepLink(entry)
 }
 
-function onRowClick(entry) {
+function onRowClick(entry, event) {
   if (entry.profileable) {
-    openProfile(entry)
+    openProfile(entry, event.currentTarget instanceof HTMLElement ? event.currentTarget : null)
   }
 }
 
-async function openProfile(entry) {
+function openProfileFromButton(entry, event) {
+  openProfile(entry, event.currentTarget instanceof HTMLElement ? event.currentTarget : null)
+}
+
+async function openProfile(
+  entry,
+  opener = document.activeElement instanceof HTMLElement ? document.activeElement : null
+) {
   if (!entry.profileable) return
+  profileOpenerEl.value =
+    opener?.matches?.('button, a, input, select, textarea, [tabindex]:not([tabindex="-1"])') === true
+      ? opener
+      : opener?.querySelector?.('.bootui-keyboard-target') || null
   profileRequestId.value = entry.id
   profileLoading.value = true
   profileError.value = null
@@ -397,9 +409,12 @@ async function openProfile(entry) {
 }
 
 function closeProfile() {
+  const opener = profileOpenerEl.value
   profileRequestId.value = null
   profile.value = null
   profileError.value = null
+  profileOpenerEl.value = null
+  requestAnimationFrame(() => opener?.focus?.())
 }
 
 function focusDrawer() {
@@ -884,8 +899,8 @@ function clearFilters() {
                   entry.profileable ? 'activity-row-clickable' : '',
                   hasChildren(entry) ? 'activity-parent-row' : ''
                 ]"
-                data-keyboard-delegate="openProfile(entry)"
-                @click="onRowClick(entry)"
+                data-keyboard-delegate="openProfileFromButton(entry, $event)"
+                @click="onRowClick(entry, $event)"
               >
                 <td class="text-nowrap small">{{ formatClockTime(entry.timestamp) }}</td>
                 <td class="text-nowrap"><i :class="['bi', typeIcon(entry.type), 'me-1']"></i>{{ entry.type }}</td>
@@ -949,7 +964,7 @@ function clearFilters() {
                     v-if="entry.profileable"
                     class="btn btn-outline-primary btn-sm rounded-pill bootui-keyboard-target"
                     type="button"
-                    @click="openProfile(entry)"
+                    @click="openProfileFromButton(entry, $event)"
                   >
                     <i class="bi bi-search me-1"></i>Profile
                   </button>

--- a/bootui-ui/src/main/frontend/src/views/LiveMemory.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveMemory.test.js
@@ -95,5 +95,14 @@ describe('LiveMemory', () => {
     expect(renderedText).not.toContain('JVM memory calculator')
     expect(renderedText).not.toContain('Recommended JVM Options')
     expect(renderedText).not.toContain('Kubernetes calculator')
+    expect(wrapper.get('[role="progressbar"][aria-label="Heap memory used"]').attributes('aria-valuetext')).toBe(
+      '25% of maximum used'
+    )
+    expect(wrapper.get('[role="progressbar"][aria-label="Non-heap memory used"]').attributes('aria-valuenow')).toBe(
+      '50'
+    )
+    expect(
+      wrapper.get('[role="progressbar"][aria-label="G1 Eden Space memory pool used"]').attributes('aria-valuetext')
+    ).toBe('25% used')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/LiveMemory.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveMemory.vue
@@ -1,6 +1,7 @@
 <script setup>
 import PanelHeader from './components/PanelHeader.vue'
 import PanelSkeleton from './components/PanelSkeleton.vue'
+import ProgressBar from './components/ProgressBar.vue'
 import UnavailableState from './components/UnavailableState.vue'
 import {formatBytes, memoryProgressClass, useMemoryReport} from '../utils/memoryReport.js'
 
@@ -35,17 +36,14 @@ const {data, error, lastUpdated, autoRefresh, loading, initialLoading, load} = u
                 <span class="text-muted small">Used</span>
                 <span class="fw-semibold">{{ formatBytes(data.heap.usedBytes) }}</span>
               </div>
-              <div class="progress mb-3" style="height: 10px">
-                <div
-                  :aria-valuenow="data.heap.usedPercent"
-                  :class="memoryProgressClass(data.heap.usedPercent)"
-                  :style="{width: data.heap.usedPercent + '%'}"
-                  aria-valuemax="100"
-                  aria-valuemin="0"
-                  class="progress-bar"
-                  role="progressbar"
-                ></div>
-              </div>
+              <ProgressBar
+                :bar-class="memoryProgressClass(data.heap.usedPercent)"
+                class="mb-3"
+                label="Heap memory used"
+                :value="data.heap.usedPercent"
+                :value-text="`${data.heap.usedPercent}% of maximum used`"
+                style="height: 10px"
+              />
               <div class="row text-center g-2">
                 <div class="col-4">
                   <div class="text-muted small">Used</div>
@@ -76,16 +74,14 @@ const {data, error, lastUpdated, autoRefresh, loading, initialLoading, load} = u
                 <span class="text-muted small">Used</span>
                 <span class="fw-semibold">{{ formatBytes(data.nonHeap.usedBytes) }}</span>
               </div>
-              <div class="progress mb-3" style="height: 10px">
-                <div
-                  :aria-valuenow="data.nonHeap.usedPercent"
-                  :style="{width: Math.min(data.nonHeap.usedPercent, 100) + '%'}"
-                  aria-valuemax="100"
-                  aria-valuemin="0"
-                  class="progress-bar bg-info"
-                  role="progressbar"
-                ></div>
-              </div>
+              <ProgressBar
+                bar-class="bg-info"
+                class="mb-3"
+                label="Non-heap memory used"
+                :value="data.nonHeap.usedPercent"
+                :value-text="`${data.nonHeap.usedPercent}% used`"
+                style="height: 10px"
+              />
               <div class="row text-center g-2">
                 <div class="col-4">
                   <div class="text-muted small">Used</div>
@@ -131,14 +127,14 @@ const {data, error, lastUpdated, autoRefresh, loading, initialLoading, load} = u
                 <td class="text-end">{{ pool.maxBytes < 0 ? '∞' : formatBytes(pool.maxBytes) }}</td>
                 <td>
                   <div class="d-flex align-items-center gap-2">
-                    <div class="progress flex-grow-1" style="height: 6px">
-                      <div
-                        :class="memoryProgressClass(pool.usedPercent)"
-                        :style="{width: Math.min(pool.usedPercent, 100) + '%'}"
-                        class="progress-bar"
-                        role="progressbar"
-                      ></div>
-                    </div>
+                    <ProgressBar
+                      :bar-class="memoryProgressClass(pool.usedPercent)"
+                      class="flex-grow-1"
+                      :label="`${pool.name} memory pool used`"
+                      :value="pool.usedPercent"
+                      :value-text="`${pool.usedPercent}% used`"
+                      style="height: 6px"
+                    />
                     <span class="text-muted small" style="width: 32px; text-align: right">{{ pool.usedPercent }}%</span>
                   </div>
                 </td>

--- a/bootui-ui/src/main/frontend/src/views/components/FlashBanner.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/FlashBanner.test.js
@@ -7,6 +7,7 @@ describe('FlashBanner', () => {
   it('renders nothing when there is no message', () => {
     const wrapper = mount(FlashBanner, {props: {message: null}})
     expect(wrapper.find('.alert').exists()).toBe(false)
+    expect(wrapper.get('[role="status"]').text()).toBe('')
   })
 
   it('renders the message text with the type-specific alert class', () => {
@@ -14,6 +15,20 @@ describe('FlashBanner', () => {
     const alert = wrapper.get('.alert')
     expect(alert.classes()).toContain('alert-success')
     expect(alert.text()).toContain('Saved')
+    expect(alert.attributes()).toMatchObject({
+      role: 'status',
+      'aria-live': 'polite',
+      'aria-atomic': 'true'
+    })
+  })
+
+  it.each(['warning', 'danger'])('announces %s messages assertively', (type) => {
+    const wrapper = mount(FlashBanner, {props: {message: {text: 'Action failed', type}}})
+    expect(wrapper.get('.alert').attributes()).toMatchObject({
+      role: 'alert',
+      'aria-atomic': 'true'
+    })
+    expect(wrapper.get('.alert').attributes('aria-live')).toBeUndefined()
   })
 
   it('omits the icon by default', () => {

--- a/bootui-ui/src/main/frontend/src/views/components/FlashBanner.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/FlashBanner.vue
@@ -21,14 +21,25 @@ const iconClass = computed(() => {
   if (!props.withIcon || !props.message) return null
   return TYPE_ICONS[props.message.type] || 'bi-info-circle-fill'
 })
+
+const liveRole = computed(() => (['danger', 'warning'].includes(props.message?.type) ? 'alert' : 'status'))
 </script>
 
 <template>
-  <div v-if="message" :class="'alert-' + message.type" class="alert d-flex justify-content-between align-items-center">
-    <div>
-      <i v-if="iconClass" :class="['bi', iconClass]"></i>
-      <span :class="{'ms-2': iconClass}">{{ message.text }}</span>
-    </div>
-    <button class="btn-close" type="button" aria-label="Dismiss" @click="$emit('dismiss')"></button>
+  <div
+    :aria-live="liveRole === 'status' ? 'polite' : undefined"
+    :class="
+      message ? ['alert', 'alert-' + message.type, 'd-flex', 'justify-content-between', 'align-items-center'] : []
+    "
+    :role="liveRole"
+    aria-atomic="true"
+  >
+    <template v-if="message">
+      <div>
+        <i v-if="iconClass" :class="['bi', iconClass]" aria-hidden="true"></i>
+        <span :class="{'ms-2': iconClass}">{{ message.text }}</span>
+      </div>
+      <button class="btn-close" type="button" aria-label="Dismiss" @click="$emit('dismiss')"></button>
+    </template>
   </div>
 </template>

--- a/bootui-ui/src/main/frontend/src/views/components/ProgressBar.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/ProgressBar.test.js
@@ -1,0 +1,31 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+
+import ProgressBar from './ProgressBar.vue'
+
+describe('ProgressBar', () => {
+  it('exposes a labelled progress range and clamps the visual fill', () => {
+    const wrapper = mount(ProgressBar, {
+      props: {label: 'Heap memory used', value: 125, valueText: '125% reported'}
+    })
+
+    const progress = wrapper.get('[role="progressbar"]')
+    expect(progress.attributes()).toMatchObject({
+      'aria-label': 'Heap memory used',
+      'aria-valuemin': '0',
+      'aria-valuemax': '100',
+      'aria-valuenow': '100',
+      'aria-valuetext': '125% reported'
+    })
+    expect(progress.get('.progress-bar').attributes('style')).toContain('width: 100%')
+  })
+
+  it('can preserve a minimum visible fill without changing the semantic value', () => {
+    const wrapper = mount(ProgressBar, {
+      props: {label: 'Tool share', value: 1, minVisiblePercent: 4}
+    })
+
+    expect(wrapper.get('[role="progressbar"]').attributes('aria-valuenow')).toBe('1')
+    expect(wrapper.get('.progress-bar').attributes('style')).toContain('width: 4%')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/ProgressBar.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ProgressBar.vue
@@ -1,0 +1,34 @@
+<script setup>
+import {computed} from 'vue'
+
+const props = defineProps({
+  value: {type: Number, required: true},
+  min: {type: Number, default: 0},
+  max: {type: Number, default: 100},
+  label: {type: String, required: true},
+  valueText: {type: String, default: null},
+  barClass: {type: [String, Array, Object], default: ''},
+  minVisiblePercent: {type: Number, default: 0}
+})
+
+const normalizedValue = computed(() => Math.min(props.max, Math.max(props.min, props.value)))
+const percent = computed(() => {
+  if (props.max <= props.min) return 0
+  return ((normalizedValue.value - props.min) / (props.max - props.min)) * 100
+})
+const visiblePercent = computed(() => Math.min(100, Math.max(props.minVisiblePercent, percent.value)))
+</script>
+
+<template>
+  <div
+    :aria-label="label"
+    :aria-valuemax="max"
+    :aria-valuemin="min"
+    :aria-valuenow="normalizedValue"
+    :aria-valuetext="valueText"
+    class="progress"
+    role="progressbar"
+  >
+    <div :class="barClass" :style="{width: visiblePercent + '%'}" class="progress-bar"></div>
+  </div>
+</template>

--- a/bootui-ui/src/main/frontend/src/views/components/StreamStatusIndicator.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/StreamStatusIndicator.test.js
@@ -43,7 +43,7 @@ describe('StreamStatusIndicator', () => {
 
   it('uses one persistent live region instead of announcing the visible chip twice', () => {
     const wrapper = render('unavailable')
-    const liveRegions = wrapper.findAll('[role="status"][aria-live="polite"]')
+    const liveRegions = wrapper.findAll('.stream-status-announcement[role="status"][aria-live="polite"]')
     expect(liveRegions).toHaveLength(1)
     expect(liveRegions[0].classes()).toContain('visually-hidden')
     expect(wrapper.find('.stream-status-indicator').attributes('role')).toBeUndefined()

--- a/bootui-ui/src/main/frontend/src/views/components/StreamStatusIndicator.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/StreamStatusIndicator.vue
@@ -52,7 +52,9 @@ function handleRetry() {
 </script>
 
 <template>
-  <span role="status" aria-live="polite" aria-atomic="true" class="visually-hidden">{{ announcement }}</span>
+  <span role="status" aria-live="polite" aria-atomic="true" class="stream-status-announcement visually-hidden">{{
+    announcement
+  }}</span>
 
   <div v-if="isVisible" class="stream-status-indicator">
     <template v-if="connectionState === 'reconnecting'">


### PR DESCRIPTION
## What does this PR do?

Improves BootUI's shared UI accessibility primitives and keyboard/focus behavior without changing the visual design.

- gives flash messages typed live-region semantics
- adds a reusable, labelled `ProgressBar` and migrates AI Framework, Live Memory, and Copilot metrics
- wires Copilot tabs with stable tab/tab-panel relationships, roving tabindex, and Arrow Left/Right/Home/End navigation
- restores focus to the Live Activity profile opener after close-button, Escape, and backdrop dismissal while preserving the focus trap

## Why is this change needed?

These controls had incomplete screen-reader relationships and keyboard focus behavior. This closes package A3 from the UI accessibility hardening plan and keeps the existing WCAG 2.1 AA light/dark visual system unchanged.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Validation performed:

- `./mvnw -Dmaven.repo.local=.m2 -B -ntp -pl bootui-ui install` — 637 Vitest tests passed and the packaged UI JAR built
- focused Vitest accessibility suite — 43 tests passed
- Playwright Chromium: affected AI Framework, Live Memory, Copilot, and Live Activity suites — 17 tests passed
- Playwright Chromium after final review fixes: Live Activity and Copilot — 11 tests passed
- frontend and e2e Prettier checks passed
- Impeccable detector returned no findings

## Screenshots (UI changes)

Not applicable: this is a semantics and keyboard behavior change with no intended visual changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (not applicable; no public behavior or setup changes)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed