### PR TITLE
fix(ui): theme AI chart colors

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/ai.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/ai.spec.js
@@ -3,6 +3,30 @@ import {expect, test} from './fixtures.js'
 
 const chatSpanId = '1111111111111111'
 
+function parseColor(value) {
+  const channels = value.match(/[\d.]+/g)?.map(Number)
+  if (!channels || channels.length < 3) throw new Error(`Unsupported computed color: ${value}`)
+  return {red: channels[0], green: channels[1], blue: channels[2]}
+}
+
+function linearChannel(channel) {
+  const srgb = channel / 255
+  return srgb <= 0.04045 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(color) {
+  return 0.2126 * linearChannel(color.red) + 0.7152 * linearChannel(color.green) + 0.0722 * linearChannel(color.blue)
+}
+
+function contrastRatio(foreground, background) {
+  const foregroundLuminance = relativeLuminance(parseColor(foreground))
+  const backgroundLuminance = relativeLuminance(parseColor(background))
+  return (
+    (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+    (Math.min(foregroundLuminance, backgroundLuminance) + 0.05)
+  )
+}
+
 const overview = {
   enabled: true,
   springAiDetected: true,
@@ -88,6 +112,60 @@ test.describe('AI Framework view', () => {
     await expect(page.locator('.chat-detail-row').getByText('docs', {exact: true})).toBeVisible()
     await page.locator('.chat-detail-row summary', {hasText: 'gen_ai'}).click()
     await expect(page.locator('.chat-detail-row').getByText('gen_ai.system')).toBeVisible()
+  })
+
+  test('applies accessible chart tokens in light and dark themes', async ({openView, page}) => {
+    await stubAi(page, overview)
+    const renderedThemes = []
+
+    for (const theme of ['light', 'dark']) {
+      await page.goto('/bootui/')
+      await page.evaluate((value) => localStorage.setItem('bootui.theme', value), theme)
+      await page.reload()
+      await expect(page.locator('html')).toHaveAttribute('data-bootui-theme', theme)
+      await openView('ai', /AI Framework/)
+
+      const chart = page.getByRole('img', {name: /Token usage over the last/})
+      await chart.hover({position: {x: 500, y: 20}})
+      const tooltip = page.locator('.ai-chart-tooltip')
+      await expect(tooltip).toBeVisible()
+
+      const colors = await tooltip.evaluate((tooltipElement) => {
+        const rootStyle = getComputedStyle(document.documentElement)
+        const resolveToken = (name) => {
+          const probe = document.createElement('span')
+          probe.style.color = rootStyle.getPropertyValue(name)
+          document.body.append(probe)
+          const color = getComputedStyle(probe).color
+          probe.remove()
+          return color
+        }
+        return {
+          axis: getComputedStyle(document.querySelector('.ai-chart-axis-label')).fill,
+          axisToken: resolveToken('--bootui-chart-axis'),
+          input: getComputedStyle(tooltipElement.querySelector('.ai-chart-tooltip-input')).color,
+          output: getComputedStyle(tooltipElement.querySelector('.ai-chart-tooltip-output')).color,
+          calls: getComputedStyle(tooltipElement.querySelector('.ai-chart-tooltip-calls')).color,
+          tooltipText: getComputedStyle(tooltipElement).color,
+          tooltipBackground: getComputedStyle(tooltipElement).backgroundColor,
+          selection: getComputedStyle(document.querySelector('.ai-chart-selection')).stroke,
+          selectionToken: resolveToken('--bootui-chart-selection'),
+          surface: resolveToken('--bootui-surface-solid')
+        }
+      })
+
+      expect(colors.axis).toBe(colors.axisToken)
+      expect(colors.selection).toBe(colors.selectionToken)
+      expect(contrastRatio(colors.axis, colors.surface)).toBeGreaterThanOrEqual(4.5)
+      expect(contrastRatio(colors.selection, colors.surface)).toBeGreaterThanOrEqual(3)
+      for (const foreground of [colors.tooltipText, colors.input, colors.output, colors.calls]) {
+        expect(contrastRatio(foreground, colors.tooltipBackground)).toBeGreaterThanOrEqual(4.5)
+      }
+      renderedThemes.push(colors)
+    }
+
+    expect(renderedThemes[1].tooltipBackground).not.toBe(renderedThemes[0].tooltipBackground)
+    expect(renderedThemes[1].axis).not.toBe(renderedThemes[0].axis)
   })
 
   test('shows disabled mode when telemetry is unavailable', async ({page}) => {

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -988,10 +988,19 @@ function onGlobalKeydown(e) {
   --bootui-nav-group-color: var(--bootui-text-muted);
   --bootui-nav-link-color: #334155;
 
-  /* Chart legend */
+  /* Data visualization */
+  --bootui-chart-grid: #dee2e6;
+  --bootui-chart-axis: #56667b;
   --bootui-chart-input: #0d6efd;
   --bootui-chart-output: #6610f2;
   --bootui-chart-calls: #198754;
+  --bootui-chart-selection: #64748b;
+  --bootui-chart-span: #dee2e6;
+  --bootui-chart-tool: #0d6efd;
+  --bootui-chart-vector: #fd7e14;
+  --bootui-chart-tooltip-bg: #ffffff;
+  --bootui-chart-tooltip-border: #cbd5e1;
+  --bootui-chart-tooltip-text: #152033;
 
   /* Skeleton loaders */
   --bootui-skeleton-base: #e2e8f0;
@@ -1101,10 +1110,19 @@ function onGlobalKeydown(e) {
   --bootui-nav-group-color: var(--bootui-text-muted);
   --bootui-nav-link-color: #cbd5e1;
 
-  /* Chart legend */
+  /* Data visualization */
+  --bootui-chart-grid: #475569;
+  --bootui-chart-axis: #a3b1c6;
   --bootui-chart-input: #6ea8fe;
   --bootui-chart-output: #c084fc;
   --bootui-chart-calls: #75b798;
+  --bootui-chart-selection: #94a3b8;
+  --bootui-chart-span: #475569;
+  --bootui-chart-tool: #6ea8fe;
+  --bootui-chart-vector: #fd9843;
+  --bootui-chart-tooltip-bg: #1e293b;
+  --bootui-chart-tooltip-border: #64748b;
+  --bootui-chart-tooltip-text: #e2e8f0;
 
   /* Skeleton loaders */
   --bootui-skeleton-base: #334155;

--- a/bootui-ui/src/main/frontend/src/views/Ai.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Ai.test.js
@@ -1,10 +1,93 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {parse as parseSfc} from '@vue/compiler-sfc'
 import {flushPromises, mount} from '@vue/test-utils'
 import {afterEach, describe, expect, it, vi} from 'vitest'
 
 import Ai from './Ai.vue'
 
+const viewsRoot = path.dirname(fileURLToPath(import.meta.url))
+const appSource = fs.readFileSync(path.join(viewsRoot, '../App.vue'), 'utf8')
+const {descriptor: appDescriptor} = parseSfc(appSource, {filename: 'App.vue'})
+const appCss = appDescriptor.styles.map((style) => style.content).join('\n')
+
 function jsonResponse(body) {
   return {ok: true, status: 200, json: () => Promise.resolve(body)}
+}
+
+function cssBlock(marker) {
+  const markerIndex = appCss.indexOf(marker)
+  if (markerIndex < 0) throw new Error(`Missing CSS block: ${marker}`)
+  const openingBrace = appCss.indexOf('{', markerIndex)
+  let depth = 0
+  for (let index = openingBrace; index < appCss.length; index += 1) {
+    if (appCss[index] === '{') depth += 1
+    if (appCss[index] === '}') depth -= 1
+    if (depth === 0) return appCss.slice(openingBrace + 1, index)
+  }
+  throw new Error(`Unclosed CSS block: ${marker}`)
+}
+
+function declarations(block) {
+  return Object.fromEntries(
+    [...block.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)].map((match) => [match[1], match[2].trim()])
+  )
+}
+
+const lightTokens = declarations(cssBlock(':global(:root) {'))
+const darkTokens = {...lightTokens, ...declarations(cssBlock(":global(:root[data-bootui-theme='dark']) {"))}
+
+function parseColor(value) {
+  const hex = value.slice(1)
+  return {
+    red: Number.parseInt(hex.slice(0, 2), 16),
+    green: Number.parseInt(hex.slice(2, 4), 16),
+    blue: Number.parseInt(hex.slice(4, 6), 16)
+  }
+}
+
+function linearChannel(channel) {
+  const srgb = channel / 255
+  return srgb <= 0.04045 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance(color) {
+  return 0.2126 * linearChannel(color.red) + 0.7152 * linearChannel(color.green) + 0.0722 * linearChannel(color.blue)
+}
+
+function contrastRatio(foreground, background) {
+  const foregroundLuminance = relativeLuminance(parseColor(foreground))
+  const backgroundLuminance = relativeLuminance(parseColor(background))
+  const lighter = Math.max(foregroundLuminance, backgroundLuminance)
+  const darker = Math.min(foregroundLuminance, backgroundLuminance)
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+function aiOverview() {
+  return {
+    enabled: true,
+    springAiDetected: true,
+    langChain4jDetected: false,
+    totalChats: 2,
+    errorCount: 0,
+    totalInputTokens: 120,
+    totalOutputTokens: 30,
+    averageDurationNanos: 1_000_000,
+    tokensByModel: {zeta: 100, alpha: 50},
+    callsByModel: {zeta: 1, alpha: 5},
+    recent: []
+  }
+}
+
+function tokenSeries() {
+  return {
+    minutes: 60,
+    buckets: [
+      {epochMinute: 30_000_000, inputTokens: 40, outputTokens: 10, callCount: 1},
+      {epochMinute: 30_000_001, inputTokens: 80, outputTokens: 20, callCount: 2}
+    ]
+  }
 }
 
 describe('Ai', () => {
@@ -21,21 +104,7 @@ describe('Ai', () => {
       'fetch',
       vi.fn((url) => {
         if (url === 'api/ai/overview') {
-          return Promise.resolve(
-            jsonResponse({
-              enabled: true,
-              springAiDetected: true,
-              langChain4jDetected: false,
-              totalChats: 2,
-              errorCount: 0,
-              totalInputTokens: 120,
-              totalOutputTokens: 30,
-              averageDurationNanos: 1_000_000,
-              tokensByModel: {zeta: 100, alpha: 50},
-              callsByModel: {zeta: 1, alpha: 5},
-              recent: []
-            })
-          )
+          return Promise.resolve(jsonResponse(aiOverview()))
         }
         return Promise.resolve(jsonResponse({buckets: []}))
       })
@@ -58,6 +127,60 @@ describe('Ai', () => {
     expect(wrapper.get('table tbody tr code').text()).toBe('alpha')
     expect(wrapper.get('[role="progressbar"][aria-label="alpha token share"]').attributes('aria-valuetext')).toBe(
       '50% of tokens'
+    )
+  })
+
+  it('renders chart colors through BootUI theme tokens', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url) => Promise.resolve(jsonResponse(url === 'api/ai/overview' ? aiOverview() : tokenSeries())))
+    )
+
+    wrapper = mount(Ai)
+    await flushPromises()
+
+    expect(wrapper.get('.ai-chart-grid').attributes('stroke')).toBe('var(--bootui-chart-grid)')
+    expect(wrapper.get('.ai-chart-grid').attributes('aria-hidden')).toBe('true')
+    expect(wrapper.findAll('.ai-chart-axis-label').map((label) => label.attributes('fill'))).toEqual([
+      'var(--bootui-chart-axis)',
+      'var(--bootui-chart-axis)',
+      'var(--bootui-chart-axis)'
+    ])
+    expect(wrapper.get('.ai-chart-input-area').attributes('fill')).toBe('var(--bootui-chart-input)')
+    expect(wrapper.get('.ai-chart-output-area').attributes('fill')).toBe('var(--bootui-chart-output)')
+    expect(wrapper.get('.ai-chart-output-line').attributes('stroke')).toBe('var(--bootui-chart-output)')
+    expect(wrapper.get('.ai-chart-calls-line').attributes('stroke')).toBe('var(--bootui-chart-calls)')
+
+    const chartContainer = wrapper.get('.ai-chart-container')
+    chartContainer.element.getBoundingClientRect = () => ({left: 0, width: 600})
+    await chartContainer.trigger('mousemove', {clientX: 600})
+
+    expect(wrapper.get('.ai-chart-selection').attributes('stroke')).toBe('var(--bootui-chart-selection)')
+    expect(wrapper.get('.ai-chart-selection').attributes('aria-hidden')).toBe('true')
+    expect(wrapper.get('.ai-chart-tooltip').classes()).not.toContain('bg-white')
+    expect(wrapper.get('.ai-chart-tooltip-input').text()).toBe('In: 80')
+    expect(wrapper.get('.ai-chart-tooltip-output').text()).toBe('Out: 20')
+    expect(wrapper.get('.ai-chart-tooltip-calls').text()).toBe('Calls: 2')
+  })
+
+  it.each([
+    ['light', lightTokens],
+    ['dark', darkTokens]
+  ])('keeps meaningful chart text AA-compliant in the %s theme', (_theme, tokens) => {
+    const tooltipBackground = tokens['--bootui-chart-tooltip-bg']
+    const textPairs = [
+      [tokens['--bootui-chart-axis'], tokens['--bootui-surface-solid']],
+      [tokens['--bootui-chart-tooltip-text'], tooltipBackground],
+      [tokens['--bootui-chart-input'], tooltipBackground],
+      [tokens['--bootui-chart-output'], tooltipBackground],
+      [tokens['--bootui-chart-calls'], tooltipBackground]
+    ]
+
+    for (const [foreground, background] of textPairs) {
+      expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5)
+    }
+    expect(contrastRatio(tokens['--bootui-chart-selection'], tokens['--bootui-surface-solid'])).toBeGreaterThanOrEqual(
+      3
     )
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -214,8 +214,7 @@ const miniTimeline = computed(() => {
   }
 
   const bars = []
-  // base chat span bar
-  bars.push({x: 0, w: width, y: baseY, h: barH, color: '#dee2e6', title: 'Chat span'})
+  bars.push({x: 0, w: width, y: baseY, h: barH, color: 'var(--bootui-chart-span)', title: 'Chat span'})
 
   const children = []
   if (detail.value.toolCalls) {
@@ -227,7 +226,7 @@ const miniTimeline = computed(() => {
           w: Math.max(2, toX(tc.durationNanos)),
           y: baseY,
           h: barH,
-          color: '#0d6efd',
+          color: 'var(--bootui-chart-tool)',
           title: `${tc.name || 'tool'} ${(tc.durationNanos / 1_000_000).toFixed(1)}ms`
         })
       }
@@ -242,7 +241,7 @@ const miniTimeline = computed(() => {
           w: Math.max(2, toX(vo.durationNanos)),
           y: baseY,
           h: barH,
-          color: '#fd7e14',
+          color: 'var(--bootui-chart-vector)',
           title: `${vo.operation || 'vector'} ${(vo.durationNanos / 1_000_000).toFixed(1)}ms`
         })
       }
@@ -547,7 +546,7 @@ const detectedFrameworkLabel = computed(() => {
             </div>
             <div
               ref="chartContainerRef"
-              class="position-relative"
+              class="ai-chart-container position-relative"
               @mouseleave="onChartMouseleave"
               @mousemove="onChartMousemove"
             >
@@ -558,19 +557,61 @@ const detectedFrameworkLabel = computed(() => {
                 role="img"
                 style="max-height: 100px"
               >
-                <line :x1="0" :x2="chart.width" :y1="chart.halfY" :y2="chart.halfY" stroke="#dee2e6" stroke-width="1" />
-                <text :x="2" :y="8" fill="#6c757d" font-size="9">{{ formatNumber(chart.maxTokens) }}</text>
-                <text :x="2" :y="chart.halfY - 2" fill="#6c757d" font-size="9">
+                <line
+                  :x1="0"
+                  :x2="chart.width"
+                  :y1="chart.halfY"
+                  :y2="chart.halfY"
+                  aria-hidden="true"
+                  class="ai-chart-grid"
+                  stroke="var(--bootui-chart-grid)"
+                  stroke-width="1"
+                />
+                <text :x="2" :y="8" class="ai-chart-axis-label" fill="var(--bootui-chart-axis)" font-size="9">
+                  {{ formatNumber(chart.maxTokens) }}
+                </text>
+                <text
+                  :x="2"
+                  :y="chart.halfY - 2"
+                  class="ai-chart-axis-label"
+                  fill="var(--bootui-chart-axis)"
+                  font-size="9"
+                >
                   {{ formatNumber(Math.round(chart.maxTokens / 2)) }}
                 </text>
-                <text :x="2" :y="chart.height - 1" fill="#6c757d" font-size="9">0</text>
-                <polygon :points="chart.inputAreaPts" fill="#0d6efd" fill-opacity="0.6" />
-                <polygon :points="chart.outputAreaPts" fill="#6610f2" fill-opacity="0.6" />
-                <polyline :points="chart.outputLinePts" fill="none" stroke="#6610f2" stroke-width="1.5" />
+                <text
+                  :x="2"
+                  :y="chart.height - 1"
+                  class="ai-chart-axis-label"
+                  fill="var(--bootui-chart-axis)"
+                  font-size="9"
+                >
+                  0
+                </text>
+                <polygon
+                  :points="chart.inputAreaPts"
+                  class="ai-chart-input-area"
+                  fill="var(--bootui-chart-input)"
+                  fill-opacity="0.6"
+                />
+                <polygon
+                  :points="chart.outputAreaPts"
+                  class="ai-chart-output-area"
+                  fill="var(--bootui-chart-output)"
+                  fill-opacity="0.6"
+                />
+                <polyline
+                  :points="chart.outputLinePts"
+                  class="ai-chart-output-line"
+                  fill="none"
+                  stroke="var(--bootui-chart-output)"
+                  stroke-width="1.5"
+                />
                 <polyline
                   :points="chart.callLinePts"
+                  class="ai-chart-calls-line"
                   fill="none"
-                  stroke="#198754"
+                  stroke="var(--bootui-chart-calls)"
                   stroke-dasharray="4 2"
                   stroke-width="1.5"
                 />
@@ -581,20 +622,21 @@ const detectedFrameworkLabel = computed(() => {
                   :y1="0"
                   :y2="chart.height"
                   aria-hidden="true"
-                  stroke="#adb5bd"
+                  class="ai-chart-selection"
+                  stroke="var(--bootui-chart-selection)"
                   stroke-width="1"
                 />
               </svg>
               <div
                 v-if="tooltipData"
                 :style="{left: tooltipData.x + '%'}"
-                class="position-absolute bg-white border rounded p-1 small shadow-sm"
+                class="ai-chart-tooltip position-absolute rounded p-1 small shadow-sm"
                 style="top: 0; transform: translateX(-50%); pointer-events: none; white-space: nowrap; z-index: 10"
               >
                 <div class="fw-semibold">{{ tooltipData.time }}</div>
-                <div style="color: var(--bootui-chart-input)">In: {{ tooltipData.input }}</div>
-                <div style="color: var(--bootui-chart-output)">Out: {{ tooltipData.output }}</div>
-                <div style="color: var(--bootui-chart-calls)">Calls: {{ tooltipData.calls }}</div>
+                <div class="ai-chart-tooltip-input">In: {{ tooltipData.input }}</div>
+                <div class="ai-chart-tooltip-output">Out: {{ tooltipData.output }}</div>
+                <div class="ai-chart-tooltip-calls">Calls: {{ tooltipData.calls }}</div>
               </div>
             </div>
             <div class="d-flex justify-content-between text-muted small mt-1 px-1">
@@ -1051,5 +1093,23 @@ code {
 }
 .kpi-card-body {
   min-height: 90px;
+}
+
+.ai-chart-tooltip {
+  background: var(--bootui-chart-tooltip-bg);
+  border: 1px solid var(--bootui-chart-tooltip-border);
+  color: var(--bootui-chart-tooltip-text);
+}
+
+.ai-chart-tooltip-input {
+  color: var(--bootui-chart-input);
+}
+
+.ai-chart-tooltip-output {
+  color: var(--bootui-chart-output);
+}
+
+.ai-chart-tooltip-calls {
+  color: var(--bootui-chart-calls);
 }
 </style>


### PR DESCRIPTION
## What does this PR do?

Routes the AI usage chart, hover selection, tooltip, and span timeline through light/dark BootUI design tokens instead of fixed Bootstrap-era colors.

This is package A4, stacked on #721.

## Why is this change needed?

The AI chart hardcoded light-theme SVG and tooltip colors, making labels and hover details unreliable in dark mode. The dedicated chart tokens now preserve the existing data, interactions, and `ProgressBar` behavior while meeting WCAG 2.1 AA for meaningful chart text in both themes.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Additional validation:
- `npm test` — 640 frontend tests passed
- `npm run build`
- `npm test -- tests/ai.spec.js` — 5 Chromium tests passed, including computed light/dark chart contrast
- Full Playwright suite — 139 passed, 6 skipped; one unrelated A3 `stream-status.spec.js` strict-locator failure remains reproducible in isolation
- Frontend and e2e Prettier checks; Maven Spotless check

## Screenshots (UI changes)

Not included: this is a focused theme-token correction with browser-computed color coverage in both themes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (not applicable; no behavior or public contract change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed
