### PR TITLE
Offload blocking BootUI handlers on WebFlux

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfiguration.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfiguration.java
@@ -24,6 +24,7 @@ import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveActivitySignalFil
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveAgentSessionController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveApiAuthenticationFilter;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiExceptionHandler;
+import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiHandlerAdapter;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiIndexController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiMcpController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiMcpServerController;
@@ -66,6 +67,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.aot.AotDetector;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -130,6 +132,11 @@ import tools.jackson.databind.ObjectMapper;
  *       the handful of duplicated beans above that do I/O or reflection at construction time) so
  *       rarely-visited panels are not eagerly constructed at context startup, matching the servlet
  *       adapter's resource profile.</li>
+ *   <li>{@link ReactiveBootUiHandlerAdapter} is the centralized WebFlux execution boundary for BootUI
+ *       API controller methods. It delegates to WebFlux's configured request-mapping adapter on bounded
+ *       elastic threads, so shared synchronous controllers can keep their servlet contract while
+ *       blocking network, scan, classpath, heap/JVM, download, and filesystem work never runs on Reactor
+ *       Netty event loops.</li>
  * </ul>
  *
  * <p><strong>Server-Sent Events panels (Phase 3 of the WebFlux port).</strong> Live Activity aside (see
@@ -514,6 +521,17 @@ public class BootUiReactiveAutoConfiguration {
     @Bean
     public ReactivePanelAccessFilter bootUiReactivePanelAccessFilter(BootUiProperties properties) {
         return new ReactivePanelAccessFilter(properties);
+    }
+
+    @Bean
+    public ReactiveBootUiHandlerAdapter bootUiReactiveHandlerAdapter(
+            @Qualifier("requestMappingHandlerAdapter")
+                    ObjectProvider<
+                                    org.springframework.web.reactive.result.method.annotation
+                                            .RequestMappingHandlerAdapter>
+                            delegateProvider,
+            ApplicationContext applicationContext) {
+        return new ReactiveBootUiHandlerAdapter(delegateProvider, applicationContext);
     }
 
     @Bean

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiHandlerAdapter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiHandlerAdapter.java
@@ -1,0 +1,130 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import java.util.Arrays;
+import java.util.concurrent.Executor;
+import java.util.stream.Stream;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.reactive.HandlerAdapter;
+import org.springframework.web.reactive.HandlerResult;
+import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * BootUI-only WebFlux adapter boundary that keeps API handlers off Reactor Netty event-loop threads.
+ *
+ * <p>Most controllers shared with the servlet adapter intentionally return plain DTOs or
+ * {@code ResponseEntity} values. Their handler bodies can perform blocking work such as advisor scans,
+ * classpath inspection, JVM diagnostics, filesystem access, downloads, and bounded network calls. This
+ * adapter delegates to WebFlux's fully configured {@link RequestMappingHandlerAdapter}, preserving its
+ * argument resolution, validation, response, and exception contracts. Its dedicated delegate uses
+ * WebFlux's native blocking-method scheduler on {@link Schedulers#boundedElastic()}, so handler
+ * invocation stays off the event loop even when asynchronous request-body decoding completes there.</p>
+ *
+ * <p>Selection follows BootUI's centralized controller convention: API controllers declare a
+ * class-level mapping rooted at {@code ${bootui.api-path:...}}. This avoids a per-controller or
+ * per-endpoint allowlist, so newly shared handlers inherit the correct execution model automatically.
+ * The adapter declines host-application and shell handlers, leaving the application's global WebFlux
+ * blocking-execution policy untouched.</p>
+ */
+public final class ReactiveBootUiHandlerAdapter implements HandlerAdapter, Ordered, SmartInitializingSingleton {
+
+    private static final String API_PATH_PLACEHOLDER_PREFIX = "${bootui.api-path:";
+
+    private final ObjectProvider<RequestMappingHandlerAdapter> delegateProvider;
+    private final ApplicationContext applicationContext;
+    private final Executor executor;
+    private volatile RequestMappingHandlerAdapter bootUiDelegate;
+
+    public ReactiveBootUiHandlerAdapter(
+            ObjectProvider<RequestMappingHandlerAdapter> delegateProvider, ApplicationContext applicationContext) {
+        this(
+                delegateProvider,
+                applicationContext,
+                command -> Schedulers.boundedElastic().schedule(command));
+    }
+
+    ReactiveBootUiHandlerAdapter(
+            ObjectProvider<RequestMappingHandlerAdapter> delegateProvider,
+            ApplicationContext applicationContext,
+            Executor executor) {
+        this.delegateProvider = delegateProvider;
+        this.applicationContext = applicationContext;
+        this.executor = executor;
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    @Override
+    public boolean supports(Object handler) {
+        return handler instanceof HandlerMethod handlerMethod && isBootUiApi(handlerMethod);
+    }
+
+    @Override
+    public Mono<HandlerResult> handle(ServerWebExchange exchange, Object handler) {
+        return bootUiDelegate().handle(exchange, handler);
+    }
+
+    @Override
+    public void afterSingletonsInstantiated() {
+        RequestMappingHandlerAdapter delegate = delegateProvider.getIfAvailable();
+        if (delegate != null) {
+            bootUiDelegate = createBootUiDelegate(delegate);
+        }
+    }
+
+    private RequestMappingHandlerAdapter bootUiDelegate() {
+        RequestMappingHandlerAdapter delegate = bootUiDelegate;
+        if (delegate == null) {
+            synchronized (this) {
+                delegate = bootUiDelegate;
+                if (delegate == null) {
+                    delegate = createBootUiDelegate(delegateProvider.getObject());
+                    bootUiDelegate = delegate;
+                }
+            }
+        }
+        return delegate;
+    }
+
+    private RequestMappingHandlerAdapter createBootUiDelegate(RequestMappingHandlerAdapter source) {
+        RequestMappingHandlerAdapter delegate = new RequestMappingHandlerAdapter();
+        delegate.setMessageReaders(source.getMessageReaders());
+        delegate.setWebBindingInitializer(source.getWebBindingInitializer());
+        delegate.setArgumentResolverConfigurer(source.getArgumentResolverConfigurer());
+        delegate.setContentTypeResolver(source.getContentTypeResolver());
+        delegate.setReactiveAdapterRegistry(source.getReactiveAdapterRegistry());
+        delegate.setBlockingExecutor(executor);
+        delegate.setBlockingMethodPredicate(handlerMethod -> true);
+        delegate.setApplicationContext(applicationContext);
+        try {
+            delegate.afterPropertiesSet();
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to initialize BootUI's reactive handler adapter", ex);
+        }
+        return delegate;
+    }
+
+    static boolean isBootUiApi(HandlerMethod handlerMethod) {
+        return isBootUiApi(handlerMethod.getBeanType());
+    }
+
+    static boolean isBootUiApi(Class<?> controllerType) {
+        RequestMapping mapping = AnnotatedElementUtils.findMergedAnnotation(controllerType, RequestMapping.class);
+        if (mapping == null) {
+            return false;
+        }
+        return Stream.concat(Arrays.stream(mapping.path()), Arrays.stream(mapping.value()))
+                .anyMatch(path -> path.startsWith(API_PATH_PLACEHOLDER_PREFIX));
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveRestClientTraceController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveRestClientTraceController.java
@@ -33,7 +33,7 @@ import reactor.core.publisher.Flux;
  * clients actually present and customized.</p>
  */
 @RestController
-@RequestMapping("/bootui/api/rest-client-trace")
+@RequestMapping("${bootui.api-path:/bootui/api}/rest-client-trace")
 public class ReactiveRestClientTraceController {
 
     private final ObjectProvider<RestClientTraceRecorder> recorderProvider;

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSecurityController.java
@@ -28,7 +28,7 @@ import reactor.core.scheduler.Schedulers;
  */
 @RestController
 @Lazy
-@RequestMapping("/bootui/api/security")
+@RequestMapping("${bootui.api-path:/bootui/api}/security")
 public class ReactiveSecurityController {
 
     private final ReactiveSecurityAdvisorService advisor;

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSpringSecurityController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveSpringSecurityController.java
@@ -46,7 +46,7 @@ import reactor.core.publisher.Mono;
 @RestController
 @Lazy
 @ConditionalOnClass(SecurityWebFilterChain.class)
-@RequestMapping("/bootui/api/spring-security")
+@RequestMapping("${bootui.api-path:/bootui/api}/spring-security")
 public class ReactiveSpringSecurityController {
 
     private final ReactiveSpringSecurityService securityService;

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfigurationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfigurationTests.java
@@ -9,6 +9,7 @@ import io.github.jdubois.bootui.autoconfigure.graalvm.GraalVmController;
 import io.github.jdubois.bootui.autoconfigure.memory.MemoryController;
 import io.github.jdubois.bootui.autoconfigure.pentesting.PentestingController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiExceptionHandler;
+import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiHandlerAdapter;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiIndexController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiStaticResourceConfigurer;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveClaudeCodeController;
@@ -89,6 +90,7 @@ class BootUiReactiveAutoConfigurationTests {
                         .hasSingleBean(BootUiReactiveAutoConfiguration.class)
                         .hasSingleBean(ReactiveLocalhostOnlyFilter.class)
                         .hasSingleBean(ReactivePanelAccessFilter.class)
+                        .hasSingleBean(ReactiveBootUiHandlerAdapter.class)
                         .hasSingleBean(KafkaActivityRecorder.class)
                         .hasSingleBean(JmsActivityRecorder.class)
                         .hasSingleBean(ReactiveBootUiIndexController.class)

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiHandlerAdapterTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiHandlerAdapterTests.java
@@ -1,0 +1,186 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiReactiveAutoConfiguration;
+import io.github.jdubois.bootui.autoconfigure.BootUiReactiveSpringSecurityAutoConfiguration;
+import io.github.jdubois.bootui.autoconfigure.architecture.ArchitectureController;
+import io.github.jdubois.bootui.autoconfigure.graalvm.GraalVmController;
+import io.github.jdubois.bootui.autoconfigure.web.GitHubController;
+import io.github.jdubois.bootui.autoconfigure.web.HeapDumpController;
+import io.github.jdubois.bootui.autoconfigure.web.ThreadDumpController;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerAdapter;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+class ReactiveBootUiHandlerAdapterTests {
+
+    @Test
+    void invokesBodyBearingActionOnConfiguredExecutorAfterDelayedDecode() {
+        StaticApplicationContext applicationContext = new StaticApplicationContext();
+        applicationContext.refresh();
+        RequestMappingHandlerAdapter delegate = configuredDelegate(applicationContext);
+        ExecutorService executor =
+                Executors.newSingleThreadExecutor(runnable -> new Thread(runnable, "bootui-handler-test"));
+        Scheduler bodyScheduler = Schedulers.newSingle("reactor-http-nio-test");
+        ReactiveBootUiHandlerAdapter adapter =
+                new ReactiveBootUiHandlerAdapter(provider(delegate), applicationContext, executor);
+        AtomicReference<String> handlerThread = new AtomicReference<>();
+        HandlerMethod handler = handlerMethod(new BodyActionController(handlerThread));
+        var body = reactor.core.publisher.Flux.just(DefaultDataBufferFactory.sharedInstance.wrap(
+                        "payload".getBytes(java.nio.charset.StandardCharsets.UTF_8)))
+                .delayElements(Duration.ofMillis(10), bodyScheduler);
+        MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/bootui/api/action")
+                .contentType(MediaType.TEXT_PLAIN)
+                .body(body));
+
+        try {
+            adapter.handle(exchange, handler).block(Duration.ofSeconds(5));
+        } finally {
+            executor.shutdownNow();
+            bodyScheduler.dispose();
+            applicationContext.close();
+        }
+
+        assertThat(handlerThread.get()).startsWith("bootui-handler-test");
+    }
+
+    @Test
+    void supportsBootUiApiControllersButNotShellOrHostControllers() {
+        ReactiveBootUiHandlerAdapter adapter = new ReactiveBootUiHandlerAdapter(
+                provider(mock(RequestMappingHandlerAdapter.class)), new StaticApplicationContext());
+
+        assertThat(adapter.getOrder()).isEqualTo(Ordered.HIGHEST_PRECEDENCE);
+        assertThat(adapter.supports(handlerMethod(new DefaultApiController()))).isTrue();
+        assertThat(adapter.supports(handlerMethod(new CustomApiController()))).isTrue();
+        assertThat(adapter.supports(handlerMethod(new ShellController()))).isFalse();
+        assertThat(adapter.supports(handlerMethod(new HostApplicationController())))
+                .isFalse();
+        assertThat(adapter.supports("not a handler method")).isFalse();
+    }
+
+    @Test
+    void coversEveryApiControllerImportedByTheReactiveAutoConfigurations() {
+        List<Class<?>> primaryControllers = importedControllers(BootUiReactiveAutoConfiguration.class);
+        List<Class<?>> securityControllers = importedControllers(BootUiReactiveSpringSecurityAutoConfiguration.class);
+
+        assertThat(primaryControllers)
+                .contains(
+                        GitHubController.class,
+                        ArchitectureController.class,
+                        HeapDumpController.class,
+                        ThreadDumpController.class,
+                        GraalVmController.class)
+                .allMatch(ReactiveBootUiHandlerAdapter::isBootUiApi);
+        assertThat(securityControllers).allMatch(ReactiveBootUiHandlerAdapter::isBootUiApi);
+        assertThat(ReactiveBootUiHandlerAdapter.isBootUiApi(ReactiveBootUiIndexController.class))
+                .isFalse();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> ObjectProvider<T> provider(T value) {
+        ObjectProvider<T> provider = mock(ObjectProvider.class);
+        when(provider.getObject()).thenReturn(value);
+        when(provider.getIfAvailable()).thenReturn(value);
+        return provider;
+    }
+
+    private static RequestMappingHandlerAdapter configuredDelegate(StaticApplicationContext applicationContext) {
+        RequestMappingHandlerAdapter delegate = new RequestMappingHandlerAdapter();
+        delegate.setMessageReaders(ServerCodecConfigurer.create().getReaders());
+        delegate.setReactiveAdapterRegistry(ReactiveAdapterRegistry.getSharedInstance());
+        delegate.setApplicationContext(applicationContext);
+        try {
+            delegate.afterPropertiesSet();
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+        return delegate;
+    }
+
+    private static HandlerMethod handlerMethod(Object controller) {
+        Method method = Arrays.stream(controller.getClass().getDeclaredMethods())
+                .filter(candidate -> candidate.getName().equals("handle"))
+                .findFirst()
+                .orElseThrow();
+        return new HandlerMethod(controller, method);
+    }
+
+    private static List<Class<?>> importedControllers(Class<?> configurationClass) {
+        Import imports = configurationClass.getAnnotation(Import.class);
+        return Arrays.stream(imports.value())
+                .filter(type -> AnnotatedElementUtils.hasAnnotation(type, RestController.class))
+                .toList();
+    }
+
+    @RequestMapping("${bootui.api-path:${bootui.path:/bootui}/api}/overview")
+    private static final class DefaultApiController {
+
+        @GetMapping
+        void handle() {}
+    }
+
+    @RequestMapping("${bootui.api-path:/bootui/api}/security")
+    private static final class CustomApiController {
+
+        @GetMapping
+        void handle() {}
+    }
+
+    @RequestMapping("${bootui.path:/bootui}")
+    private static final class ShellController {
+
+        @GetMapping
+        void handle() {}
+    }
+
+    @RequestMapping("/api/orders")
+    private static final class HostApplicationController {
+
+        @GetMapping
+        void handle() {}
+    }
+
+    @RequestMapping("${bootui.api-path:/bootui/api}/action")
+    private static final class BodyActionController {
+
+        private final AtomicReference<String> handlerThread;
+
+        private BodyActionController(AtomicReference<String> handlerThread) {
+            this.handlerThread = handlerThread;
+        }
+
+        @PostMapping
+        String handle(@RequestBody String body) {
+            handlerThread.set(Thread.currentThread().getName());
+            return body;
+        }
+    }
+}

--- a/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxCustomPathIntegrationTest.java
+++ b/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxCustomPathIntegrationTest.java
@@ -12,9 +12,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootTest(
-        classes = BootUiWebfluxSampleApplication.class,
+        classes = {
+            BootUiWebfluxSampleApplication.class,
+            WebFluxCustomPathIntegrationTest.ExecutionThreadProbeController.class
+        },
         webEnvironment = WebEnvironment.RANDOM_PORT,
         properties = {
             "spring.profiles.active=dev",
@@ -52,6 +60,9 @@ class WebFluxCustomPathIntegrationTest {
         assertThat(asset.find()).isTrue();
         assertThat(probe.get(UI_PATH + "/" + asset.group(1)).status()).isEqualTo(200);
         assertThat(probe.get(API_PATH + "/overview").status()).isEqualTo(200);
+        assertThat(probe.get(API_PATH + "/rest-client-trace").status()).isEqualTo(200);
+        assertThat(probe.get(API_PATH + "/spring-security").status()).isEqualTo(200);
+        assertThat(probe.get(API_PATH + "/security").status()).isEqualTo(200);
     }
 
     @Test
@@ -84,10 +95,27 @@ class WebFluxCustomPathIntegrationTest {
                 API_PATH + "/mcp",
                 headers,
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}");
+        Response restClientClear = probe.request("POST", API_PATH + "/rest-client-trace/clear", headers, "");
+        Response securityScan = probe.request("POST", API_PATH + "/security/scan", headers, "");
 
         assertThat(logger.status()).isEqualTo(200);
         assertThat(download.status()).isEqualTo(200);
         assertThat(mcp.status()).isEqualTo(200);
+        assertThat(restClientClear.status()).isEqualTo(200);
+        assertThat(securityScan.status()).isEqualTo(200);
+    }
+
+    @Test
+    void runsCustomPathReadAndActionHandlersOffTheNettyEventLoop() {
+        BootUiHttpProbe probe = probe();
+        Response read = probe.get(API_PATH + "/execution-thread");
+        Response action =
+                probe.request("POST", API_PATH + "/execution-thread", stateChangingHeaders(probe), "{\"probe\":true}");
+
+        assertThat(read.status()).isEqualTo(200);
+        assertThat(action.status()).isEqualTo(200);
+        assertThat(read.body()).isNotBlank().doesNotContain("http-nio");
+        assertThat(action.body()).isNotBlank().doesNotContain("http-nio");
     }
 
     private static Map<String, String> stateChangingHeaders(BootUiHttpProbe probe) {
@@ -96,5 +124,20 @@ class WebFluxCustomPathIntegrationTest {
         headers.put("Content-Type", "application/json");
         probe.cookie("XSRF-TOKEN").ifPresent(token -> headers.put("X-XSRF-TOKEN", token));
         return headers;
+    }
+
+    @RestController
+    @RequestMapping("${bootui.api-path:/bootui/api}/execution-thread")
+    static class ExecutionThreadProbeController {
+
+        @GetMapping
+        String read() {
+            return Thread.currentThread().getName();
+        }
+
+        @PostMapping
+        String action(@RequestBody String request) {
+            return Thread.currentThread().getName();
+        }
     }
 }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -307,6 +307,9 @@ bootui.trust-container-gateway=AUTO     # auto-trust the container gateway in de
 
 The [Running inside a Docker container](#running-inside-a-docker-container) guidance below applies unchanged. Per-panel
 `bootui.panels.*` enable / read-only toggles and the `bootui.read-only` master switch are enforced identically as well.
+Accepted BootUI API requests also cross a centralized bounded-elastic execution boundary after those checks, keeping
+blocking scans, diagnostics, downloads, filesystem operations, and bounded network calls off Reactor Netty event-loop
+threads. This applies automatically at custom `bootui.api-path` mounts and does not affect application routes.
 
 ### Which panels are available on Spring WebFlux
 

--- a/docs/WEBFLUX-SUPPORT.md
+++ b/docs/WEBFLUX-SUPPORT.md
@@ -78,6 +78,15 @@ both, so exactly one of the two autoconfigurations activates.
   while an earlier blocker prevents the packaged `/bootui/**` resources from leaking as a legacy alias. The generated
   shell injects the browser-visible UI/API paths for the shared SPA, and the authentication cookie is scoped to the
   composed API path.
+- **One blocking-execution boundary for the shared controller surface.**
+  `ReactiveBootUiHandlerAdapter` delegates BootUI controller dispatch to WebFlux's fully configured request-mapping
+  adapter on Reactor's bounded-elastic scheduler. This keeps argument resolution, blocking network calls,
+  advisor/classpath scans, heap and JVM diagnostics, downloads, and filesystem handlers off Reactor Netty event-loop
+  threads without duplicating scheduler code across the controllers shared with Spring MVC. Selection follows the
+  existing class-level `${bootui.api-path:...}` mapping convention rather than an endpoint allowlist, so custom API
+  mounts and newly shared controllers inherit it automatically. The shell, static assets, host-application controllers,
+  the host's own WebFlux blocking-execution policy, and requests rejected by the preceding safety filters remain
+  untouched.
 - **Same platform-aware manifest mechanism the Quarkus adapter established.** `PanelsController` — a single shared
   bean bulk-imported unmodified by both autoconfigurations — detects the running context type
   (`applicationContext instanceof ReactiveWebApplicationContext`) and reports `platform:
@@ -106,6 +115,11 @@ RabbitMQ · JMS. `KafkaController`, `RabbitController`, and `JmsController`, plu
 their Live Activity `MESSAGING` capture work identically to the servlet adapter with zero adapter changes. JMS remains
 an imperative, blocking broker API, but its work runs on the application's JMS template/listener threads; the WebFlux
 panel only reads the shared in-memory recorder.
+
+These controllers keep their synchronous servlet-facing signatures. On WebFlux, the centralized
+`ReactiveBootUiHandlerAdapter` dispatches their argument resolution and handler invocation on bounded-elastic threads,
+so controller-local scheduler annotations or endpoint allowlists are not required and new shared handlers cannot
+accidentally inherit the Reactor Netty event loop.
 
 [^spring-advisor-reactive]: The `SpringController` wiring itself needed no adapter change, but the ruleset it runs
     (`SpringScanner`/`SpringRules`) is reactive-aware internally: it detects a WebFlux `ReactiveWebApplicationContext`


### PR DESCRIPTION
## Summary
- add a BootUI-only, highest-precedence WebFlux `HandlerAdapter` that delegates to a dedicated clone of Spring's configured request-mapping adapter with native blocking-method scheduling on Reactor bounded elastic
- classify every API controller imported by the reactive auto-configurations through the existing `${bootui.api-path:...}` mapping convention, leaving shell and host handlers plus host WebFlux execution policy untouched
- fix the remaining hardcoded reactive routes for REST Client, raw Spring Security, and the Security advisor
- add delayed-body off-event-loop coverage plus real-Netty custom-path read/action integration tests and update WebFlux docs

## Validation
- `./mvnw -Dmaven.repo.local=.m2 -B -ntp spotless:check`
- `./mvnw -Dmaven.repo.local=.m2 -B -ntp -pl bootui-spring-autoconfigure -Dtest=ReactiveBootUiHandlerAdapterTests,BootUiReactiveAutoConfigurationTests,ReactiveRestClientTraceControllerTests,ReactiveSpringSecurityControllerTests test`
- `./mvnw -Dmaven.repo.local=.m2 -B -ntp -pl bootui-spring-webflux-sample-app -am test` (37 tests, 0 failures; Spring auto-config, WebFlux sample, conformance all green)