### PR TITLE
Bound Metrics API responses and UI paging

### DIFF
--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
@@ -214,7 +214,7 @@ public abstract class AbstractBootUiApiConformanceTest {
 
     @Test
     void metricsContractIsBoundedAndValidatesQueriesCanonically() {
-        Response bounded = probe().get("/bootui/api/metrics?offset=0&limit=1");
+        Response bounded = probe().get(api("/metrics?offset=0&limit=1"));
         assertThat(bounded.status()).as("bounded metrics list status").isEqualTo(200);
         assertThat(bounded.isJson()).as("bounded metrics list content type").isTrue();
 
@@ -232,14 +232,14 @@ public abstract class AbstractBootUiApiConformanceTest {
                 .as("$.page.total preserves the visible meter total")
                 .isEqualTo(report.path("total").asInt());
 
-        Response invalid = probe().get("/bootui/api/metrics?limit=1001");
+        Response invalid = probe().get(api("/metrics?limit=1001"));
         assertThat(invalid.status()).as("invalid metrics limit status").isEqualTo(400);
         assertThat(invalid.isJson()).as("invalid metrics limit content type").isTrue();
         assertThat(invalid.json().path("error").asText())
                 .as("canonical metrics validation error")
                 .isEqualTo("Metric limit must be between 1 and 1000");
 
-        Response missingName = probe().get("/bootui/api/metrics/detail");
+        Response missingName = probe().get(api("/metrics/detail"));
         assertThat(missingName.status()).as("missing metric name status").isEqualTo(400);
         assertThat(missingName.json().path("error").asText())
                 .as("canonical missing metric name error")
@@ -247,9 +247,8 @@ public abstract class AbstractBootUiApiConformanceTest {
 
         if (!report.path("meters").isEmpty()) {
             String name = report.path("meters").get(0).path("name").asText();
-            Response detail = probe().get("/bootui/api/metrics/detail?name="
-                    + URLEncoder.encode(name, StandardCharsets.UTF_8)
-                    + "&offset=0&limit=1");
+            Response detail = probe().get(api(
+                    "/metrics/detail?name=" + URLEncoder.encode(name, StandardCharsets.UTF_8) + "&offset=0&limit=1"));
             assertThat(detail.status()).as("bounded metric detail status").isEqualTo(200);
             assertThat(detail.isJson()).as("bounded metric detail content type").isTrue();
             assertThat(detail.json().path("samples").size())

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
@@ -14,6 +14,8 @@ import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -207,6 +209,64 @@ public abstract class AbstractBootUiApiConformanceTest {
 
         if (!failures.isEmpty()) {
             fail("Available panel DTO contracts regressed: " + failures);
+        }
+    }
+
+    @Test
+    void metricsContractIsBoundedAndValidatesQueriesCanonically() {
+        Response bounded = probe().get("/bootui/api/metrics?offset=0&limit=1");
+        assertThat(bounded.status()).as("bounded metrics list status").isEqualTo(200);
+        assertThat(bounded.isJson()).as("bounded metrics list content type").isTrue();
+
+        JsonNode report = bounded.json();
+        assertThat(report.path("meters").isArray()).as("$.meters").isTrue();
+        assertThat(report.path("meters").size()).as("bounded meter count").isLessThanOrEqualTo(1);
+        assertThat(report.path("availableTypes").isArray())
+                .as("$.availableTypes")
+                .isTrue();
+        assertThat(report.path("page").path("limit").asInt()).as("$.page.limit").isEqualTo(1);
+        assertThat(report.path("page").path("returned").asInt())
+                .as("$.page.returned")
+                .isEqualTo(report.path("meters").size());
+        assertThat(report.path("page").path("total").asInt())
+                .as("$.page.total preserves the visible meter total")
+                .isEqualTo(report.path("total").asInt());
+
+        Response invalid = probe().get("/bootui/api/metrics?limit=1001");
+        assertThat(invalid.status()).as("invalid metrics limit status").isEqualTo(400);
+        assertThat(invalid.isJson()).as("invalid metrics limit content type").isTrue();
+        assertThat(invalid.json().path("error").asText())
+                .as("canonical metrics validation error")
+                .isEqualTo("Metric limit must be between 1 and 1000");
+
+        Response missingName = probe().get("/bootui/api/metrics/detail");
+        assertThat(missingName.status()).as("missing metric name status").isEqualTo(400);
+        assertThat(missingName.json().path("error").asText())
+                .as("canonical missing metric name error")
+                .isEqualTo("Metric name must not be blank");
+
+        if (!report.path("meters").isEmpty()) {
+            String name = report.path("meters").get(0).path("name").asText();
+            Response detail = probe().get("/bootui/api/metrics/detail?name="
+                    + URLEncoder.encode(name, StandardCharsets.UTF_8)
+                    + "&offset=0&limit=1");
+            assertThat(detail.status()).as("bounded metric detail status").isEqualTo(200);
+            assertThat(detail.isJson()).as("bounded metric detail content type").isTrue();
+            assertThat(detail.json().path("samples").size())
+                    .as("bounded metric sample count")
+                    .isLessThanOrEqualTo(1);
+            assertThat(detail.json().path("samplePage").path("limit").asInt())
+                    .as("$.samplePage.limit")
+                    .isEqualTo(1);
+            assertThat(detail.json().path("samplePage").path("returned").asInt())
+                    .as("$.samplePage.returned")
+                    .isEqualTo(detail.json().path("samples").size());
+            assertThat(detail.json().path("totalSamples").isInt())
+                    .as("$.totalSamples")
+                    .isTrue();
+            assertThat(detail.json().path("samplesTruncated").isBoolean())
+                    .as("$.samplesTruncated")
+                    .isTrue();
         }
     }
 

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricDetailDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricDetailDto.java
@@ -13,4 +13,31 @@ public record MetricDetailDto(
         String type,
         List<MetricMeasurementDto> measurements,
         List<MetricAvailableTagDto> availableTags,
-        List<MetricSampleDto> samples) {}
+        List<MetricSampleDto> samples,
+        int totalSamples,
+        PageMetadata samplePage,
+        boolean samplesTruncated) {
+
+    public MetricDetailDto(
+            boolean metricsAvailable,
+            String name,
+            String description,
+            String baseUnit,
+            String type,
+            List<MetricMeasurementDto> measurements,
+            List<MetricAvailableTagDto> availableTags,
+            List<MetricSampleDto> samples) {
+        this(
+                metricsAvailable,
+                name,
+                description,
+                baseUnit,
+                type,
+                measurements,
+                availableTags,
+                samples,
+                samples.size(),
+                new PageMetadata(samples.size(), samples.size(), 0, samples.size(), samples.size(), false),
+                false);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricsReport.java
@@ -5,4 +5,24 @@ import java.util.List;
 /**
  * Browseable list of Micrometer meters.
  */
-public record MetricsReport(boolean metricsAvailable, int total, List<MetricMeterDto> meters) {}
+public record MetricsReport(
+        boolean metricsAvailable,
+        int total,
+        List<MetricMeterDto> meters,
+        List<String> availableTypes,
+        PageMetadata page) {
+
+    public MetricsReport(boolean metricsAvailable, int total, List<MetricMeterDto> meters) {
+        this(
+                metricsAvailable,
+                total,
+                meters,
+                meters.stream()
+                        .map(MetricMeterDto::type)
+                        .filter(type -> type != null && !type.isBlank())
+                        .distinct()
+                        .sorted()
+                        .toList(),
+                new PageMetadata(total, total, 0, meters.size(), meters.size(), meters.size() < total));
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/metrics/MetricsReportProvider.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/metrics/MetricsReportProvider.java
@@ -7,6 +7,7 @@ import io.github.jdubois.bootui.core.dto.MetricMeterDto;
 import io.github.jdubois.bootui.core.dto.MetricSampleDto;
 import io.github.jdubois.bootui.core.dto.MetricTagDto;
 import io.github.jdubois.bootui.core.dto.MetricsReport;
+import io.github.jdubois.bootui.core.dto.PageMetadata;
 import io.micrometer.core.instrument.Measurement;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -34,7 +36,23 @@ import java.util.function.Supplier;
  */
 public class MetricsReportProvider {
 
+    public static final int DEFAULT_METER_LIMIT = 200;
+
+    public static final int DEFAULT_SAMPLE_LIMIT = 100;
+
+    public static final int MAX_LIMIT = 1000;
+
     private static final int MAX_TAG_VALUES = 100;
+
+    private static final Comparator<String> NULL_SAFE_STRING = Comparator.nullsFirst(Comparator.naturalOrder());
+
+    private static final List<String> VALID_TYPES = java.util.Arrays.stream(Meter.Type.values())
+            .map(Enum::name)
+            .sorted()
+            .toList();
+
+    private static final Comparator<Meter> SAMPLE_ORDER =
+            (left, right) -> compareTags(left.getId().getTags(), right.getId().getTags());
 
     private final Supplier<MeterRegistry> registrySupplier;
 
@@ -46,53 +64,108 @@ public class MetricsReportProvider {
     }
 
     public MetricsReport metrics() {
+        return metrics(null, null, null, null);
+    }
+
+    public MetricsReport metrics(String query, String type, String offset, String limit) {
+        int requestedOffset = parseOffset(offset);
+        int requestedLimit = parseLimit(limit, DEFAULT_METER_LIMIT);
+        String normalizedQuery = normalize(query);
+        String normalizedType = parseType(type);
+
         MeterRegistry registry = registry();
         if (registry == null) {
-            return new MetricsReport(false, 0, List.of());
+            return emptyReport(false, requestedLimit);
         }
 
         Map<String, List<Meter>> metersByName = metersByName(visibleMeters(registry.getMeters()));
-        List<MetricMeterDto> meters = metersByName.entrySet().stream()
+        TreeSet<String> availableTypes = new TreeSet<>();
+        List<Map.Entry<String, List<Meter>>> matching = new ArrayList<>();
+        for (Map.Entry<String, List<Meter>> entry : metersByName.entrySet()) {
+            String meterType = firstType(entry.getValue());
+            if (meterType != null) {
+                availableTypes.add(meterType);
+            }
+            if (matches(
+                    entry.getKey(), firstDescription(entry.getValue()), meterType, normalizedQuery, normalizedType)) {
+                matching.add(entry);
+            }
+        }
+
+        int fromIndex = Math.min(requestedOffset, matching.size());
+        int toIndex = Math.min(fromIndex + requestedLimit, matching.size());
+        List<MetricMeterDto> meters = matching.subList(fromIndex, toIndex).stream()
                 .map(entry -> toMeterDto(entry.getKey(), entry.getValue()))
                 .toList();
-        return new MetricsReport(true, meters.size(), meters);
+        PageMetadata page = new PageMetadata(
+                metersByName.size(),
+                matching.size(),
+                fromIndex,
+                requestedLimit,
+                meters.size(),
+                toIndex < matching.size());
+        return new MetricsReport(true, metersByName.size(), meters, List.copyOf(availableTypes), page);
     }
 
     public MetricDetailDto metric(String name, List<String> tagFilters) {
+        return metric(name, tagFilters, null, null);
+    }
+
+    public MetricDetailDto metric(String name, List<String> tagFilters, String offset, String limit) {
+        String normalizedName = requireName(name);
+        Map<String, String> requiredTags = parseTagFilters(tagFilters);
+        int requestedOffset = parseOffset(offset);
+        int requestedLimit = parseLimit(limit, DEFAULT_SAMPLE_LIMIT);
+
         MeterRegistry registry = registry();
         if (registry == null) {
-            return emptyDetail(false, name);
+            return emptyDetail(false, normalizedName, requestedLimit);
         }
 
         List<Meter> meters = registry.getMeters().stream()
-                .filter(meter -> meter.getId().getName().equals(name))
+                .filter(meter -> meter.getId().getName().equals(normalizedName))
                 .filter(meterFilter)
+                .sorted(SAMPLE_ORDER)
                 .toList();
         if (meters.isEmpty()) {
-            return emptyDetail(true, name);
+            return emptyDetail(true, normalizedName, requestedLimit);
         }
 
-        Map<String, String> requiredTags = parseTagFilters(tagFilters);
         List<Meter> matchingMeters =
                 meters.stream().filter(meter -> hasTags(meter, requiredTags)).toList();
-        List<MetricSampleDto> samples = matchingMeters.stream()
+        int fromIndex = Math.min(requestedOffset, matchingMeters.size());
+        int toIndex = Math.min(fromIndex + requestedLimit, matchingMeters.size());
+        List<MetricSampleDto> samples = matchingMeters.subList(fromIndex, toIndex).stream()
                 .map(this::toSample)
-                .sorted(Comparator.comparing(sample -> sample.tags().toString()))
                 .toList();
+        PageMetadata samplePage = new PageMetadata(
+                matchingMeters.size(),
+                matchingMeters.size(),
+                fromIndex,
+                requestedLimit,
+                samples.size(),
+                toIndex < matchingMeters.size());
 
         return new MetricDetailDto(
                 true,
-                name,
+                normalizedName,
                 firstDescription(meters),
                 firstBaseUnit(meters),
                 firstType(meters),
                 aggregateMeasurements(matchingMeters),
                 availableTags(meters),
-                samples);
+                samples,
+                matchingMeters.size(),
+                samplePage,
+                fromIndex > 0 || toIndex < matchingMeters.size());
     }
 
     private MeterRegistry registry() {
         return registrySupplier.get();
+    }
+
+    private MetricsReport emptyReport(boolean metricsAvailable, int limit) {
+        return new MetricsReport(metricsAvailable, 0, List.of(), List.of(), new PageMetadata(0, 0, 0, limit, 0, false));
     }
 
     private Map<String, List<Meter>> metersByName(List<Meter> meters) {
@@ -108,19 +181,39 @@ public class MetricsReportProvider {
         return meters.stream().filter(meterFilter).toList();
     }
 
+    private boolean matches(
+            String name, String description, String type, String normalizedQuery, String normalizedType) {
+        boolean matchesQuery = normalizedQuery.isEmpty()
+                || normalize(name).contains(normalizedQuery)
+                || normalize(description).contains(normalizedQuery);
+        return matchesQuery && (normalizedType.isEmpty() || normalizedType.equals(type));
+    }
+
     private MetricMeterDto toMeterDto(String name, List<Meter> meters) {
         return new MetricMeterDto(
                 name, firstDescription(meters), firstBaseUnit(meters), firstType(meters), availableTags(meters));
     }
 
-    private MetricDetailDto emptyDetail(boolean metricsAvailable, String name) {
-        return new MetricDetailDto(metricsAvailable, name, null, null, null, List.of(), List.of(), List.of());
+    private MetricDetailDto emptyDetail(boolean metricsAvailable, String name, int limit) {
+        return new MetricDetailDto(
+                metricsAvailable,
+                name,
+                null,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                List.of(),
+                0,
+                new PageMetadata(0, 0, 0, limit, 0, false),
+                false);
     }
 
     private String firstDescription(List<Meter> meters) {
         return meters.stream()
                 .map(meter -> meter.getId().getDescription())
                 .filter(value -> value != null && !value.isBlank())
+                .sorted()
                 .findFirst()
                 .orElse(null);
     }
@@ -129,6 +222,7 @@ public class MetricsReportProvider {
         return meters.stream()
                 .map(meter -> meter.getId().getBaseUnit())
                 .filter(value -> value != null && !value.isBlank())
+                .sorted()
                 .findFirst()
                 .orElse(null);
     }
@@ -138,8 +232,61 @@ public class MetricsReportProvider {
                 .map(meter -> meter.getId().getType())
                 .filter(type -> type != null)
                 .map(Enum::name)
+                .sorted()
                 .findFirst()
                 .orElse(null);
+    }
+
+    private String requireName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("Metric name must not be blank");
+        }
+        return name.trim();
+    }
+
+    private int parseOffset(String value) {
+        if (value == null) {
+            return 0;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            if (parsed >= 0) {
+                return parsed;
+            }
+        } catch (NumberFormatException ignored) {
+            // Render the same stable validation error on every adapter.
+        }
+        throw new IllegalArgumentException("Metric offset must be 0 or greater");
+    }
+
+    private int parseLimit(String value, int defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            if (parsed >= 1 && parsed <= MAX_LIMIT) {
+                return parsed;
+            }
+        } catch (NumberFormatException ignored) {
+            // Render the same stable validation error on every adapter.
+        }
+        throw new IllegalArgumentException("Metric limit must be between 1 and " + MAX_LIMIT);
+    }
+
+    private String parseType(String type) {
+        String normalized = normalize(type).toUpperCase(Locale.ROOT);
+        if (normalized.isEmpty()) {
+            return "";
+        }
+        if (!VALID_TYPES.contains(normalized)) {
+            throw new IllegalArgumentException("Metric type must be one of: " + String.join(", ", VALID_TYPES));
+        }
+        return normalized;
+    }
+
+    private String normalize(String value) {
+        return value == null || value.isBlank() ? "" : value.trim().toLowerCase(Locale.ROOT);
     }
 
     private Map<String, String> parseTagFilters(List<String> tagFilters) {
@@ -149,7 +296,7 @@ public class MetricsReportProvider {
         }
         for (String tagFilter : tagFilters) {
             int separator = tagFilter == null ? -1 : tagFilter.indexOf(':');
-            if (separator <= 0) {
+            if (separator <= 0 || tagFilter.substring(0, separator).isBlank()) {
                 throw new IllegalArgumentException("Metric tag filters must use key:value syntax");
             }
             tags.put(tagFilter.substring(0, separator), tagFilter.substring(separator + 1));
@@ -167,28 +314,27 @@ public class MetricsReportProvider {
     }
 
     private List<MetricAvailableTagDto> availableTags(List<Meter> meters) {
-        Map<String, TreeSet<String>> valuesByKey = new TreeMap<>();
+        Map<String, BoundedTagValues> valuesByKey = new TreeMap<>();
         for (Meter meter : meters) {
             for (Tag tag : meter.getId().getTags()) {
                 valuesByKey
-                        .computeIfAbsent(tag.getKey(), key -> new TreeSet<>())
+                        .computeIfAbsent(tag.getKey(), key -> new BoundedTagValues())
                         .add(tag.getValue());
             }
         }
 
         List<MetricAvailableTagDto> tags = new ArrayList<>();
-        for (Map.Entry<String, TreeSet<String>> entry : valuesByKey.entrySet()) {
-            List<String> values =
-                    entry.getValue().stream().limit(MAX_TAG_VALUES).toList();
+        for (Map.Entry<String, BoundedTagValues> entry : valuesByKey.entrySet()) {
             tags.add(new MetricAvailableTagDto(
-                    entry.getKey(), values, entry.getValue().size() > MAX_TAG_VALUES));
+                    entry.getKey(), List.copyOf(entry.getValue().values), entry.getValue().truncated));
         }
         return tags;
     }
 
     private MetricSampleDto toSample(Meter meter) {
         List<MetricTagDto> tags = meter.getId().getTags().stream()
-                .sorted(Comparator.comparing(Tag::getKey).thenComparing(Tag::getValue))
+                .sorted(Comparator.comparing(Tag::getKey, NULL_SAFE_STRING)
+                        .thenComparing(Tag::getValue, NULL_SAFE_STRING))
                 .map(tag -> new MetricTagDto(tag.getKey(), tag.getValue()))
                 .toList();
         return new MetricSampleDto(tags, measurements(meter));
@@ -226,5 +372,52 @@ public class MetricsReportProvider {
             measurements.add(new MetricMeasurementDto(entry.getKey().getTagValueRepresentation(), entry.getValue()));
         }
         return measurements;
+    }
+
+    private static int compareTags(List<Tag> left, List<Tag> right) {
+        List<Tag> sortedLeft = left.stream()
+                .sorted(Comparator.comparing(Tag::getKey, NULL_SAFE_STRING)
+                        .thenComparing(Tag::getValue, NULL_SAFE_STRING))
+                .toList();
+        List<Tag> sortedRight = right.stream()
+                .sorted(Comparator.comparing(Tag::getKey, NULL_SAFE_STRING)
+                        .thenComparing(Tag::getValue, NULL_SAFE_STRING))
+                .toList();
+        int commonSize = Math.min(sortedLeft.size(), sortedRight.size());
+        for (int index = 0; index < commonSize; index++) {
+            int keyComparison = NULL_SAFE_STRING.compare(
+                    sortedLeft.get(index).getKey(), sortedRight.get(index).getKey());
+            if (keyComparison != 0) {
+                return keyComparison;
+            }
+            int valueComparison = NULL_SAFE_STRING.compare(
+                    sortedLeft.get(index).getValue(), sortedRight.get(index).getValue());
+            if (valueComparison != 0) {
+                return valueComparison;
+            }
+        }
+        return Integer.compare(sortedLeft.size(), sortedRight.size());
+    }
+
+    private static final class BoundedTagValues {
+
+        private final TreeSet<String> values = new TreeSet<>(NULL_SAFE_STRING);
+
+        private boolean truncated;
+
+        private void add(String value) {
+            if (values.contains(value)) {
+                return;
+            }
+            if (values.size() < MAX_TAG_VALUES) {
+                values.add(value);
+                return;
+            }
+            truncated = true;
+            if (NULL_SAFE_STRING.compare(value, values.last()) < 0) {
+                values.add(value);
+                values.pollLast();
+            }
+        }
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/metrics/MetricsReportProviderTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/metrics/MetricsReportProviderTests.java
@@ -62,6 +62,48 @@ class MetricsReportProviderTests {
         assertThat(meter.availableTags()).hasSize(1);
         assertThat(meter.availableTags().get(0).key()).isEqualTo("outcome");
         assertThat(meter.availableTags().get(0).values()).containsExactly("failure", "success");
+        assertThat(report.availableTypes()).contains("COUNTER");
+        assertThat(report.page().total()).isEqualTo(report.total());
+        assertThat(report.page().returned()).isEqualTo(report.meters().size());
+    }
+
+    @Test
+    void metricsFiltersAndPagesInDeterministicNameOrder() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Counter.builder("zeta.requests").description("Target traffic").register(registry);
+        Counter.builder("alpha.requests").description("Target traffic").register(registry);
+        Gauge.builder("middle.gauge", new AtomicInteger(), AtomicInteger::get)
+                .description("Target traffic")
+                .register(registry);
+
+        MetricsReport report = provider(registry).metrics("target", "counter", "1", "1");
+
+        assertThat(report.total()).isEqualTo(3);
+        assertThat(report.availableTypes()).containsExactly("COUNTER", "GAUGE");
+        assertThat(report.meters()).extracting(MetricMeterDto::name).containsExactly("zeta.requests");
+        assertThat(report.page()).isEqualTo(new io.github.jdubois.bootui.core.dto.PageMetadata(3, 2, 1, 1, 1, false));
+    }
+
+    @Test
+    void metricsUsesBoundedDefaultsAndRejectsInvalidPaging() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        for (int index = 0; index < 205; index++) {
+            registry.counter("sample." + String.format("%03d", index));
+        }
+
+        MetricsReport report = provider(registry).metrics();
+
+        assertThat(report.meters()).hasSize(MetricsReportProvider.DEFAULT_METER_LIMIT);
+        assertThat(report.page().hasMore()).isTrue();
+        assertThatThrownBy(() -> provider(registry).metrics(null, null, "invalid", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Metric offset must be 0 or greater");
+        assertThatThrownBy(() -> provider(registry).metrics(null, null, null, "1001"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Metric limit must be between 1 and 1000");
+        assertThatThrownBy(() -> provider(registry).metrics(null, "not-a-type", null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageStartingWith("Metric type must be one of:");
     }
 
     @Test
@@ -84,6 +126,55 @@ class MetricsReportProviderTests {
         assertThat(detail.samples()).hasSize(1);
         assertThat(detail.samples().get(0).tags().get(0).key()).isEqualTo("outcome");
         assertThat(detail.samples().get(0).tags().get(0).value()).isEqualTo("success");
+    }
+
+    @Test
+    void detailPagesDeterministicallyAndAggregatesEveryMatchingSample() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Counter.builder("bootui.sample.requests")
+                .tag("node", "charlie")
+                .register(registry)
+                .increment(3);
+        Counter.builder("bootui.sample.requests")
+                .tag("node", "alpha")
+                .register(registry)
+                .increment();
+        Counter.builder("bootui.sample.requests")
+                .tag("node", "bravo")
+                .register(registry)
+                .increment(2);
+
+        MetricDetailDto detail = provider(registry).metric("bootui.sample.requests", null, "1", "1");
+
+        assertThat(detail.totalSamples()).isEqualTo(3);
+        assertThat(detail.samples()).hasSize(1);
+        assertThat(detail.samples().get(0).tags().get(0).value()).isEqualTo("bravo");
+        assertThat(detail.measurements()).contains(new MetricMeasurementDto("count", 6.0));
+        assertThat(detail.samplePage())
+                .isEqualTo(new io.github.jdubois.bootui.core.dto.PageMetadata(3, 3, 1, 1, 1, true));
+        assertThat(detail.samplesTruncated()).isTrue();
+    }
+
+    @Test
+    void detailBoundsTagValuesWhileRetainingDeterministicValues() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        for (int index = 104; index >= 0; index--) {
+            Counter.builder("bootui.cardinality")
+                    .tag("route", String.format("route-%03d", index))
+                    .register(registry);
+        }
+
+        MetricDetailDto detail = provider(registry).metric("bootui.cardinality", null, null, "1");
+
+        assertThat(detail.availableTags()).hasSize(1);
+        assertThat(detail.availableTags().get(0).values())
+                .hasSize(100)
+                .startsWith("route-000")
+                .endsWith("route-099");
+        assertThat(detail.availableTags().get(0).truncated()).isTrue();
+        assertThat(detail.totalSamples()).isEqualTo(105);
+        assertThat(detail.samples()).hasSize(1);
+        assertThat(detail.samplesTruncated()).isTrue();
     }
 
     @Test
@@ -156,12 +247,28 @@ class MetricsReportProviderTests {
     }
 
     @Test
+    void detailRejectsBlankNameAndInvalidPaging() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+        assertThatThrownBy(() -> provider(registry).metric(" ", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Metric name must not be blank");
+        assertThatThrownBy(() -> provider(registry).metric("sample", null, "-1", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Metric offset must be 0 or greater");
+        assertThatThrownBy(() -> provider(registry).metric("sample", null, null, "0"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Metric limit must be between 1 and 1000");
+    }
+
+    @Test
     void metricsReportUnavailableWhenNoRegistry() {
         MetricsReport report = provider(null).metrics();
 
         assertThat(report.metricsAvailable()).isFalse();
         assertThat(report.total()).isZero();
         assertThat(report.meters()).isEmpty();
+        assertThat(report.page().limit()).isEqualTo(MetricsReportProvider.DEFAULT_METER_LIMIT);
     }
 
     @Test
@@ -171,5 +278,7 @@ class MetricsReportProviderTests {
         assertThat(detail.metricsAvailable()).isFalse();
         assertThat(detail.name()).isEqualTo("anything");
         assertThat(detail.samples()).isEmpty();
+        assertThat(detail.samplePage().limit()).isEqualTo(MetricsReportProvider.DEFAULT_SAMPLE_LIMIT);
+        assertThat(detail.samplesTruncated()).isFalse();
     }
 }

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusMetricsResourceWithoutMicrometerTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusMetricsResourceWithoutMicrometerTest.java
@@ -49,6 +49,21 @@ class BootUiQuarkusMetricsResourceWithoutMicrometerTest {
                         && response.json().path("meters").isEmpty())
                 .as("an unavailable report carries an empty meters array")
                 .isTrue();
+        assertThat(response.json().path("page").path("limit").asInt())
+                .as("the unavailable response still advertises the bounded default")
+                .isEqualTo(200);
+        assertThat(response.json().path("availableTypes").isArray()
+                        && response.json().path("availableTypes").isEmpty())
+                .as("the unavailable response carries an empty type inventory")
+                .isTrue();
+    }
+
+    @Test
+    void metricsPanelValidatesQueriesBeforeResolvingTheRegistry() {
+        Response response = probe().get("/bootui/api/metrics?offset=invalid");
+
+        assertThat(response.status()).isEqualTo(400);
+        assertThat(response.json().path("error").asText()).isEqualTo("Metric offset must be 0 or greater");
     }
 
     @Test

--- a/bootui-quarkus-integration-tests/micrometer/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusMetricsCaptureTest.java
+++ b/bootui-quarkus-integration-tests/micrometer/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusMetricsCaptureTest.java
@@ -71,6 +71,15 @@ class BootUiQuarkusMetricsCaptureTest {
         assertThat(root.path("metricsAvailable").asBoolean(false))
                 .as("with a Micrometer registry present the report is available")
                 .isTrue();
+        assertThat(root.path("page").path("limit").asInt())
+                .as("the default meter page is bounded")
+                .isEqualTo(200);
+        assertThat(root.path("page").path("returned").asInt())
+                .as("page metadata matches the returned meter array")
+                .isEqualTo(root.path("meters").size());
+        assertThat(root.path("availableTypes").isArray())
+                .as("type filtering choices are part of the shared contract")
+                .isTrue();
 
         List<String> meterNames = new ArrayList<>();
         for (JsonNode meter : root.path("meters")) {
@@ -99,5 +108,16 @@ class BootUiQuarkusMetricsCaptureTest {
         assertThat(leakedSelfPaths)
                 .as("no reported meter may expose a /bootui path tag (BootUI's own traffic must stay hidden)")
                 .isEmpty();
+
+        Response detail = probe().get("/bootui/api/metrics/detail?name=it.sample.host.requests&offset=0&limit=1");
+        assertThat(detail.status()).as("GET /bootui/api/metrics/detail status").isEqualTo(200);
+        assertThat(detail.json().path("totalSamples").asInt()).isEqualTo(1);
+        assertThat(detail.json().path("samplePage").path("limit").asInt()).isEqualTo(1);
+        assertThat(detail.json().path("samples").size()).isEqualTo(1);
+        assertThat(detail.json().path("samplesTruncated").asBoolean(true)).isFalse();
+
+        Response invalid = probe().get("/bootui/api/metrics?limit=many");
+        assertThat(invalid.status()).isEqualTo(400);
+        assertThat(invalid.json().path("error").asText()).isEqualTo("Metric limit must be between 1 and 1000");
     }
 }

--- a/bootui-quarkus-sample-app/e2e/tests/metrics.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/metrics.spec.js
@@ -14,12 +14,17 @@ test.describe('Metrics view', () => {
     const meters = page.locator('.meter-list .list-group-item')
     await expect.poll(async () => meters.count()).toBeGreaterThan(0)
 
-    await page.getByPlaceholder('Search meters').fill('jvm.memory.used')
+    const filteredRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url())
+      return url.pathname.endsWith('/api/metrics') && url.searchParams.get('q') === 'jvm.memory.used'
+    })
+    await page.getByRole('textbox', {name: 'Search meters'}).fill('jvm.memory.used')
+    await filteredRequest
     const meter = page.locator('.meter-list .list-group-item', {hasText: 'jvm.memory.used'}).first()
     if (await meter.count()) {
       await meter.click()
     } else {
-      await page.getByPlaceholder('Search meters').fill('')
+      await page.getByRole('textbox', {name: 'Search meters'}).fill('')
       await meters.first().click()
     }
 
@@ -27,9 +32,10 @@ test.describe('Metrics view', () => {
     await expect(page.locator('svg[aria-label="Live metric value graph"]')).toBeVisible()
     await expect(page.locator('.card', {hasText: 'Samples'})).toBeVisible()
     await expect(page.locator('table tbody tr').first()).toBeVisible()
+    await expect(page.getByText(/Showing \d+–\d+ of \d+/)).toBeVisible()
   })
 
-  test('filters meters by type', async ({openView, page}) => {
+  test('filters meters by type on the server', async ({openView, page}) => {
     await openView('metrics', 'Metrics')
 
     const typeSelect = page.locator('.card-body.border-bottom select')
@@ -37,8 +43,14 @@ test.describe('Metrics view', () => {
     const firstType = await typeSelect.locator('option').nth(1).getAttribute('value')
     expect(firstType).toBeTruthy()
 
+    const filteredRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url())
+      return url.pathname.endsWith('/api/metrics') && url.searchParams.get('type') === firstType
+    })
     await typeSelect.selectOption(firstType)
+    await filteredRequest
     const firstMeter = page.locator('.meter-list .list-group-item').first()
     await expect(firstMeter.locator('.badge')).toHaveText(firstType)
+    await expect(page.getByText(/Filters run on the server/)).toBeVisible()
   })
 })

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/MetricsResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/MetricsResource.java
@@ -34,19 +34,36 @@ public class MetricsResource {
     }
 
     @GET
-    public MetricsReport metrics() {
-        return provider.metrics();
+    public Response metrics(
+            @QueryParam("q") String query,
+            @QueryParam("type") String type,
+            @QueryParam("offset") String offset,
+            @QueryParam("limit") String limit) {
+        try {
+            MetricsReport report = provider.metrics(query, type, offset, limit);
+            return Response.ok(report).build();
+        } catch (IllegalArgumentException ex) {
+            return badRequest(ex);
+        }
     }
 
     @GET
     @Path("/detail")
-    public Response metric(@QueryParam("name") String name, @QueryParam("tag") List<String> tagFilters) {
+    public Response metric(
+            @QueryParam("name") String name,
+            @QueryParam("tag") List<String> tagFilters,
+            @QueryParam("offset") String offset,
+            @QueryParam("limit") String limit) {
         try {
-            return Response.ok(provider.metric(name, tagFilters)).build();
+            return Response.ok(provider.metric(name, tagFilters, offset, limit)).build();
         } catch (IllegalArgumentException ex) {
-            return Response.status(Response.Status.BAD_REQUEST)
-                    .entity(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()))
-                    .build();
+            return badRequest(ex);
         }
+    }
+
+    private Response badRequest(IllegalArgumentException ex) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()))
+                .build();
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MetricsController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/MetricsController.java
@@ -24,14 +24,21 @@ public class MetricsController {
     }
 
     @GetMapping
-    public MetricsReport metrics() {
-        return provider.metrics();
+    public MetricsReport metrics(
+            @RequestParam(name = "q", required = false) String query,
+            @RequestParam(name = "type", required = false) String type,
+            @RequestParam(name = "offset", required = false) String offset,
+            @RequestParam(name = "limit", required = false) String limit) {
+        return provider.metrics(query, type, offset, limit);
     }
 
     @GetMapping("/detail")
     public MetricDetailDto metric(
-            @RequestParam String name, @RequestParam(name = "tag", required = false) List<String> tagFilters) {
-        return provider.metric(name, tagFilters);
+            @RequestParam(required = false) String name,
+            @RequestParam(name = "tag", required = false) List<String> tagFilters,
+            @RequestParam(name = "offset", required = false) String offset,
+            @RequestParam(name = "limit", required = false) String limit) {
+        return provider.metric(name, tagFilters, offset, limit);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MetricsControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/MetricsControllerTests.java
@@ -32,7 +32,7 @@ class MetricsControllerTests {
     @Test
     void metricsDelegatesToProvider() throws Exception {
         MetricsReportProvider provider = mock(MetricsReportProvider.class);
-        when(provider.metrics())
+        when(provider.metrics(eq("jvm"), eq("gauge"), eq("1"), eq("2")))
                 .thenReturn(new MetricsReport(
                         true,
                         1,
@@ -41,7 +41,11 @@ class MetricsControllerTests {
 
         MockMvc mvc = standaloneSetup(new MetricsController(provider)).build();
 
-        mvc.perform(get("/bootui/api/metrics"))
+        mvc.perform(get("/bootui/api/metrics")
+                        .param("q", "jvm")
+                        .param("type", "gauge")
+                        .param("offset", "1")
+                        .param("limit", "2"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.metricsAvailable").value(true))
                 .andExpect(jsonPath("$.total").value(1))
@@ -51,7 +55,7 @@ class MetricsControllerTests {
     @Test
     void detailBindsNameAndTagParametersAndDelegates() throws Exception {
         MetricsReportProvider provider = mock(MetricsReportProvider.class);
-        when(provider.metric(eq("bootui.sample.requests"), eq(List.of("outcome:success"))))
+        when(provider.metric(eq("bootui.sample.requests"), eq(List.of("outcome:success")), eq("2"), eq("10")))
                 .thenReturn(new MetricDetailDto(
                         true, "bootui.sample.requests", null, null, "COUNTER", List.of(), List.of(), List.of()));
 
@@ -59,16 +63,20 @@ class MetricsControllerTests {
 
         mvc.perform(get("/bootui/api/metrics/detail")
                         .param("name", "bootui.sample.requests")
-                        .param("tag", "outcome:success"))
+                        .param("tag", "outcome:success")
+                        .param("offset", "2")
+                        .param("limit", "10"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.metricsAvailable").value(true))
-                .andExpect(jsonPath("$.name").value("bootui.sample.requests"));
+                .andExpect(jsonPath("$.name").value("bootui.sample.requests"))
+                .andExpect(jsonPath("$.samplePage").exists())
+                .andExpect(jsonPath("$.samplesTruncated").value(false));
     }
 
     @Test
     void malformedTagFilterIsMappedToBadRequest() throws Exception {
         MetricsReportProvider provider = mock(MetricsReportProvider.class);
-        when(provider.metric(any(), any()))
+        when(provider.metric(any(), any(), any(), any()))
                 .thenThrow(new IllegalArgumentException("Metric tag filters must use key:value syntax"));
 
         MockMvc mvc = standaloneSetup(new MetricsController(provider)).build();
@@ -77,7 +85,27 @@ class MetricsControllerTests {
                         .param("name", "bootui.sample.requests")
                         .param("tag", "malformed"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").exists());
+                .andExpect(jsonPath("$.error").value("Metric tag filters must use key:value syntax"));
+    }
+
+    @Test
+    void invalidListLimitIsMappedToCanonicalBadRequest() throws Exception {
+        MetricsReportProvider provider = new MetricsReportProvider(() -> null, meter -> true);
+        MockMvc mvc = standaloneSetup(new MetricsController(provider)).build();
+
+        mvc.perform(get("/bootui/api/metrics").param("limit", "many"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Metric limit must be between 1 and 1000"));
+    }
+
+    @Test
+    void missingDetailNameIsMappedToCanonicalBadRequest() throws Exception {
+        MetricsReportProvider provider = new MetricsReportProvider(() -> null, meter -> true);
+        MockMvc mvc = standaloneSetup(new MetricsController(provider)).build();
+
+        mvc.perform(get("/bootui/api/metrics/detail"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Metric name must not be blank"));
     }
 
     @Test

--- a/bootui-spring-sample-app/e2e/tests/metrics.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/metrics.spec.js
@@ -8,12 +8,17 @@ test.describe('Metrics view', () => {
     const meters = page.locator('.meter-list .list-group-item')
     await expect.poll(async () => meters.count()).toBeGreaterThan(0)
 
-    await page.getByPlaceholder('Search meters').fill('jvm.memory.used')
+    const filteredRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url())
+      return url.pathname.endsWith('/api/metrics') && url.searchParams.get('q') === 'jvm.memory.used'
+    })
+    await page.getByRole('textbox', {name: 'Search meters'}).fill('jvm.memory.used')
+    await filteredRequest
     const meter = page.locator('.meter-list .list-group-item', {hasText: 'jvm.memory.used'}).first()
     if (await meter.count()) {
       await meter.click()
     } else {
-      await page.getByPlaceholder('Search meters').fill('')
+      await page.getByRole('textbox', {name: 'Search meters'}).fill('')
       await meters.first().click()
     }
 
@@ -21,9 +26,10 @@ test.describe('Metrics view', () => {
     await expect(page.locator('svg[aria-label="Live metric value graph"]')).toBeVisible()
     await expect(page.locator('.card', {hasText: 'Samples'})).toBeVisible()
     await expect(page.locator('table tbody tr').first()).toBeVisible()
+    await expect(page.getByText(/Showing \d+–\d+ of \d+/)).toBeVisible()
   })
 
-  test('filters meters by type', async ({openView, page}) => {
+  test('filters meters by type on the server', async ({openView, page}) => {
     await openView('metrics', 'Metrics')
 
     const typeSelect = page.locator('.card-body.border-bottom select')
@@ -31,8 +37,14 @@ test.describe('Metrics view', () => {
     const firstType = await typeSelect.locator('option').nth(1).getAttribute('value')
     expect(firstType).toBeTruthy()
 
+    const filteredRequest = page.waitForRequest((request) => {
+      const url = new URL(request.url())
+      return url.pathname.endsWith('/api/metrics') && url.searchParams.get('type') === firstType
+    })
     await typeSelect.selectOption(firstType)
+    await filteredRequest
     const firstMeter = page.locator('.meter-list .list-group-item').first()
     await expect(firstMeter.locator('.badge')).toHaveText(firstType)
+    await expect(page.getByText(/Filters run on the server/)).toBeVisible()
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Metrics.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Metrics.test.js
@@ -4,11 +4,52 @@ import {ref} from 'vue'
 
 import Metrics from './Metrics.vue'
 
-function stubFetch(body) {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(() => Promise.resolve(new Response(JSON.stringify(body), {status: 200})))
-  )
+function meter(name, type = 'COUNTER') {
+  return {name, description: `${name} description`, baseUnit: null, type, availableTags: []}
+}
+
+function metricsReport(meters = [], overrides = {}) {
+  return {
+    metricsAvailable: true,
+    total: meters.length,
+    meters,
+    availableTypes: ['COUNTER', 'GAUGE'],
+    page: {
+      total: meters.length,
+      matched: meters.length,
+      offset: 0,
+      limit: 200,
+      returned: meters.length,
+      hasMore: false
+    },
+    ...overrides
+  }
+}
+
+function metricDetail(name, overrides = {}) {
+  return {
+    metricsAvailable: true,
+    name,
+    description: `${name} description`,
+    baseUnit: null,
+    type: 'COUNTER',
+    measurements: [{statistic: 'count', value: 3}],
+    availableTags: [],
+    samples: [{tags: [], measurements: [{statistic: 'count', value: 3}]}],
+    totalSamples: 1,
+    samplePage: {total: 1, matched: 1, offset: 0, limit: 100, returned: 1, hasMore: false},
+    samplesTruncated: false,
+    ...overrides
+  }
+}
+
+function stubFetch(handler) {
+  const fetchMock = vi.fn((input) => {
+    const body = handler(String(input))
+    return Promise.resolve(new Response(JSON.stringify(body), {status: 200}))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
 }
 
 function mountMetrics(platform) {
@@ -16,13 +57,14 @@ function mountMetrics(platform) {
   return mount(Metrics, {global})
 }
 
-describe('Metrics empty state', () => {
+describe('Metrics', () => {
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
   it('points Spring Boot users at Actuator or a MeterRegistry by default', async () => {
-    stubFetch({metricsAvailable: false})
+    stubFetch(() => metricsReport([], {metricsAvailable: false}))
     const wrapper = mountMetrics()
     await flushPromises()
     expect(wrapper.text()).toContain('Add Actuator or a MeterRegistry')
@@ -30,10 +72,159 @@ describe('Metrics empty state', () => {
   })
 
   it('points Quarkus users at a quarkus-micrometer registry', async () => {
-    stubFetch({metricsAvailable: false})
+    stubFetch(() => metricsReport([], {metricsAvailable: false}))
     const wrapper = mountMetrics('quarkus')
     await flushPromises()
     expect(wrapper.text()).toContain('quarkus-micrometer')
     expect(wrapper.text()).not.toContain('Add Actuator')
+  })
+
+  it('sends debounced search and type filters to the server', async () => {
+    vi.useFakeTimers()
+    const fetchMock = stubFetch((url) =>
+      url.includes('/detail') ? metricDetail('http.server.requests') : metricsReport([meter('http.server.requests')])
+    )
+    const wrapper = mountMetrics()
+    await flushPromises()
+
+    await wrapper.get('input[aria-label="Search meters"]').setValue('http')
+    await wrapper.get('select[aria-label="Filter meters by type"]').setValue('COUNTER')
+    vi.advanceTimersByTime(251)
+    await flushPromises()
+
+    const filteredRequest = fetchMock.mock.calls
+      .map(([input]) => String(input))
+      .filter((url) => url.includes('/metrics?'))
+      .at(-1)
+    const params = new URL(filteredRequest, 'http://localhost').searchParams
+    expect(params.get('q')).toBe('http')
+    expect(params.get('type')).toBe('COUNTER')
+    expect(params.get('offset')).toBe('0')
+    expect(params.get('limit')).toBe('200')
+  })
+
+  it('loads additional bounded meter pages', async () => {
+    const fetchMock = stubFetch((url) => {
+      if (url.includes('/detail')) return metricDetail('alpha')
+      const params = new URL(url, 'http://localhost').searchParams
+      if (params.get('offset') === '2') {
+        return metricsReport([meter('charlie')], {
+          total: 3,
+          page: {total: 3, matched: 3, offset: 2, limit: 200, returned: 1, hasMore: false}
+        })
+      }
+      return metricsReport([meter('alpha'), meter('bravo')], {
+        total: 3,
+        page: {total: 3, matched: 3, offset: 0, limit: 200, returned: 2, hasMore: true}
+      })
+    })
+    const wrapper = mountMetrics()
+    await flushPromises()
+
+    const loadMore = wrapper.findAll('button').find((button) => button.text() === 'Load next 1')
+    await loadMore.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.findAll('.meter-list .list-group-item')).toHaveLength(3)
+    expect(
+      fetchMock.mock.calls
+        .map(([input]) => String(input))
+        .some((url) => new URL(url, 'http://localhost').searchParams.get('offset') === '2')
+    ).toBe(true)
+    expect(wrapper.text()).toContain('3 shown · 3 matched · 3 total')
+  })
+
+  it('pages samples independently and reports the bounded range', async () => {
+    const fetchMock = stubFetch((url) => {
+      if (!url.includes('/detail')) return metricsReport([meter('http.server.requests')])
+      const params = new URL(url, 'http://localhost').searchParams
+      if (params.get('offset') === '100') {
+        return metricDetail('http.server.requests', {
+          samples: [{tags: [{key: 'route', value: 'last'}], measurements: [{statistic: 'count', value: 1}]}],
+          totalSamples: 101,
+          samplePage: {total: 101, matched: 101, offset: 100, limit: 100, returned: 1, hasMore: false},
+          samplesTruncated: true
+        })
+      }
+      return metricDetail('http.server.requests', {
+        totalSamples: 101,
+        samplePage: {total: 101, matched: 101, offset: 0, limit: 100, returned: 1, hasMore: true},
+        samplesTruncated: true
+      })
+    })
+    const wrapper = mountMetrics()
+    await flushPromises()
+
+    const next = wrapper.findAll('button').find((button) => button.text() === 'Next')
+    await next.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Showing 101–101 of 101')
+    expect(
+      fetchMock.mock.calls
+        .map(([input]) => String(input))
+        .some((url) => url.includes('/detail') && new URL(url, 'http://localhost').searchParams.get('offset') === '100')
+    ).toBe(true)
+  })
+
+  it('returns to the last valid sample page when live cardinality shrinks', async () => {
+    let secondPageRequests = 0
+    const fetchMock = stubFetch((url) => {
+      if (!url.includes('/detail')) return metricsReport([meter('http.server.requests')])
+      const params = new URL(url, 'http://localhost').searchParams
+      if (params.get('offset') === '100') {
+        secondPageRequests++
+        if (secondPageRequests === 1) {
+          return metricDetail('http.server.requests', {
+            totalSamples: 101,
+            samplePage: {total: 101, matched: 101, offset: 100, limit: 100, returned: 1, hasMore: false}
+          })
+        }
+        return metricDetail('http.server.requests', {
+          samples: [],
+          totalSamples: 50,
+          samplePage: {total: 50, matched: 50, offset: 50, limit: 100, returned: 0, hasMore: false},
+          samplesTruncated: true
+        })
+      }
+      return metricDetail('http.server.requests', {
+        totalSamples: 50,
+        samplePage: {total: 50, matched: 50, offset: 0, limit: 100, returned: 1, hasMore: false}
+      })
+    })
+    const wrapper = mountMetrics()
+    await flushPromises()
+
+    const next = wrapper.findAll('button').find((button) => button.text() === 'Next')
+    await next.trigger('click')
+    await flushPromises()
+    await wrapper.get('button[title="Refresh"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Showing 1–1 of 50')
+    expect(wrapper.text()).not.toContain('Showing 51–50')
+    expect(
+      fetchMock.mock.calls
+        .map(([input]) => String(input))
+        .filter((url) => url.includes('/detail'))
+        .some((url) => new URL(url, 'http://localhost').searchParams.get('offset') === '0')
+    ).toBe(true)
+  })
+
+  it('renders a clear empty state for server-side filters', async () => {
+    vi.useFakeTimers()
+    stubFetch(() =>
+      metricsReport([], {
+        total: 12,
+        page: {total: 12, matched: 0, offset: 0, limit: 200, returned: 0, hasMore: false}
+      })
+    )
+    const wrapper = mountMetrics()
+    await flushPromises()
+
+    await wrapper.get('input[aria-label="Search meters"]').setValue('missing')
+    vi.advanceTimersByTime(251)
+    await flushPromises()
+    expect(wrapper.text()).toContain('No meters match the current server-side filters')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Metrics.vue
+++ b/bootui-ui/src/main/frontend/src/views/Metrics.vue
@@ -1,14 +1,30 @@
 <script setup>
+import {computed, inject, onBeforeUnmount, ref, watch} from 'vue'
 import {getJson} from '../api.js'
-import {computed, inject, ref} from 'vue'
-import PanelHeader from './components/PanelHeader.vue'
-import PanelSkeleton from './components/PanelSkeleton.vue'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
+import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
+import ServerListFooter from './components/ServerListFooter.vue'
+
+const METER_PAGE_SIZE = 200
+const SAMPLE_PAGE_SIZE = 100
 
 const data = ref(null)
 const detail = ref(null)
 const error = ref(null)
+const detailError = ref(null)
+const search = ref('')
+const typeFilter = ref('')
+const selectedName = ref('')
+const selectedTags = ref([])
+const selectedStatistic = ref('')
+const sampleOffset = ref(0)
+const history = ref([])
+const lastUpdated = ref(null)
+const meterLoading = ref(false)
+const loadingMore = ref(false)
+const detailLoading = ref(false)
 
 const injectedPanels = inject('panels', null)
 const platform = computed(() => injectedPanels?.value?.platform ?? 'spring-boot')
@@ -18,31 +34,18 @@ const metricsUnavailableHelp = computed(() =>
     : 'Micrometer metrics are not available. Add Actuator or a MeterRegistry to browse live metrics.'
 )
 
-const detailError = ref(null)
-const search = ref('')
-const typeFilter = ref('')
-const selectedName = ref('')
-const selectedTags = ref([])
-const selectedStatistic = ref('')
-const history = ref([])
-const lastUpdated = ref(null)
-let loadingDetail = false
-
-const filteredMeters = computed(() => {
-  if (!data.value) return []
-  const q = search.value.trim().toLowerCase()
-  return data.value.meters.filter((meter) => {
-    const matchesSearch =
-      !q || meter.name.toLowerCase().includes(q) || (meter.description || '').toLowerCase().includes(q)
-    const matchesType = !typeFilter.value || meter.type === typeFilter.value
-    return matchesSearch && matchesType
-  })
-})
-
-const metricTypes = computed(() => {
-  if (!data.value) return []
-  return [...new Set(data.value.meters.map((meter) => meter.type).filter(Boolean))].sort()
-})
+const meters = computed(() => data.value?.meters ?? [])
+const meterPage = computed(() => data.value?.page ?? null)
+const meterTypes = computed(
+  () => data.value?.availableTypes ?? [...new Set(meters.value.map((meter) => meter.type).filter(Boolean))].sort()
+)
+const meterMatched = computed(() => meterPage.value?.matched ?? meters.value.length)
+const meterTotal = computed(() => meterPage.value?.total ?? data.value?.total ?? meters.value.length)
+const samplePage = computed(() => detail.value?.samplePage ?? null)
+const sampleStart = computed(() => (samplePage.value?.returned > 0 ? samplePage.value.offset + 1 : 0))
+const sampleEnd = computed(() =>
+  samplePage.value ? samplePage.value.offset + samplePage.value.returned : (detail.value?.samples?.length ?? 0)
+)
 
 const selectedMeasurement = computed(() => {
   if (!detail.value?.measurements?.length) return null
@@ -68,6 +71,10 @@ const chartPath = computed(() => {
     .join(' ')
 })
 
+let meterRequestId = 0
+let detailRequestId = 0
+let filterTimer = null
+
 function formatNumber(value) {
   if (value == null || Number.isNaN(value)) return 'N/A'
   if (Math.abs(value) >= 1000) return value.toLocaleString(undefined, {maximumFractionDigits: 1})
@@ -91,14 +98,16 @@ function resetSelection(name) {
   selectedName.value = name
   selectedTags.value = []
   selectedStatistic.value = ''
+  sampleOffset.value = 0
   detail.value = null
+  detailError.value = null
   resetHistory()
 }
 
 function selectMeter(name) {
   if (selectedName.value === name) return
   resetSelection(name)
-  loadDetail()
+  void loadDetail()
 }
 
 function toggleTag(key, value) {
@@ -107,8 +116,9 @@ function toggleTag(key, value) {
   selectedTags.value = exists
     ? selectedTags.value.filter((tag) => tag !== label)
     : [...selectedTags.value.filter((tag) => !tag.startsWith(`${key}:`)), label]
+  sampleOffset.value = 0
   resetHistory()
-  loadDetail()
+  void loadDetail()
 }
 
 function isTagSelected(key, value) {
@@ -117,8 +127,9 @@ function isTagSelected(key, value) {
 
 function clearTags() {
   selectedTags.value = []
+  sampleOffset.value = 0
   resetHistory()
-  loadDetail()
+  void loadDetail()
 }
 
 function changeStatistic(event) {
@@ -127,55 +138,149 @@ function changeStatistic(event) {
   appendHistoryPoint()
 }
 
-async function fetchMetrics() {
+function meterParams(offset, limit) {
+  const params = new URLSearchParams({offset: String(offset), limit: String(limit)})
+  const query = search.value.trim()
+  if (query) params.set('q', query)
+  if (typeFilter.value) params.set('type', typeFilter.value)
+  return params
+}
+
+async function fetchMetrics({append = false, reset = false} = {}) {
+  const requestId = ++meterRequestId
+  const offset = append ? meters.value.length : 0
+  const currentSize = reset ? 0 : meters.value.length
+  const limit = append ? METER_PAGE_SIZE : Math.max(METER_PAGE_SIZE, Math.min(currentSize, 1000))
+  const requestUrl = `api/metrics?${meterParams(offset, limit)}`
+
+  if (append) loadingMore.value = true
+  else meterLoading.value = true
+  error.value = null
+
   try {
-    data.value = await getJson('api/metrics')
-    error.value = null
-    if (!selectedName.value && data.value.meters.length) {
-      resetSelection(preferredInitialMeter(data.value.meters))
+    const response = await getJson(requestUrl)
+    if (requestId !== meterRequestId) return false
+
+    if (append) {
+      const combinedMeters = [...meters.value, ...(response.meters ?? [])]
+      data.value = {
+        ...response,
+        meters: combinedMeters,
+        page: response.page ? {...response.page, offset: 0, returned: combinedMeters.length} : response.page
+      }
+    } else {
+      data.value = response
     }
     return true
-  } catch (e) {
-    error.value = describeLoadError(e, 'Unable to load metrics')
+  } catch (exception) {
+    if (requestId === meterRequestId) {
+      error.value = describeLoadError(exception, 'Unable to load metrics')
+    }
     return false
+  } finally {
+    if (requestId === meterRequestId) {
+      meterLoading.value = false
+      loadingMore.value = false
+    }
   }
 }
 
-async function refreshMetrics() {
-  if (await fetchMetrics()) {
-    await loadDetail()
-  }
-}
-
-function preferredInitialMeter(meters) {
+function preferredInitialMeter(availableMeters) {
   return (
-    meters.find((meter) => meter.name === 'jvm.memory.used')?.name ||
-    meters.find((meter) => meter.name === 'process.uptime')?.name ||
-    meters[0].name
+    availableMeters.find((meter) => meter.name === 'jvm.memory.used')?.name ||
+    availableMeters.find((meter) => meter.name === 'process.uptime')?.name ||
+    availableMeters[0]?.name ||
+    ''
   )
 }
 
+function ensureSelection() {
+  if (!meters.value.length) {
+    if (selectedName.value) resetSelection('')
+    return
+  }
+  if (!meters.value.some((meter) => meter.name === selectedName.value)) {
+    resetSelection(preferredInitialMeter(meters.value))
+  }
+}
+
+async function refreshMetrics(options = {}) {
+  if (!(await fetchMetrics(options))) return
+  if (!data.value?.metricsAvailable) {
+    resetSelection('')
+    return
+  }
+  ensureSelection()
+  await loadDetail()
+}
+
+function scheduleFilterReload() {
+  meterRequestId++
+  detailRequestId++
+  if (filterTimer) clearTimeout(filterTimer)
+  meterLoading.value = true
+  filterTimer = setTimeout(() => {
+    filterTimer = null
+    void refreshMetrics({reset: true})
+  }, 250)
+}
+
+async function loadMoreMeters() {
+  await fetchMetrics({append: true})
+}
+
 async function loadDetail() {
-  if (!selectedName.value || loadingDetail) return
-  loadingDetail = true
+  if (!selectedName.value) return
+  const requestId = ++detailRequestId
+  detailLoading.value = true
+  detailError.value = null
+
   try {
-    const params = new URLSearchParams({name: selectedName.value})
+    const params = new URLSearchParams({
+      name: selectedName.value,
+      offset: String(sampleOffset.value),
+      limit: String(SAMPLE_PAGE_SIZE)
+    })
     for (const tag of selectedTags.value) {
       params.append('tag', tag)
     }
-    detail.value = await getJson(`api/metrics/detail?${params}`)
-    if (!detail.value.measurements.some((measurement) => measurement.statistic === selectedStatistic.value)) {
-      selectedStatistic.value = detail.value.measurements[0]?.statistic || ''
+    const response = await getJson(`api/metrics/detail?${params}`)
+    if (requestId !== detailRequestId) return
+
+    if (!response.samples?.length && response.totalSamples > 0 && sampleOffset.value > 0) {
+      sampleOffset.value = Math.floor((response.totalSamples - 1) / SAMPLE_PAGE_SIZE) * SAMPLE_PAGE_SIZE
+      return await loadDetail()
+    }
+
+    detail.value = response
+    sampleOffset.value = response.samplePage?.offset ?? 0
+    if (!response.measurements.some((measurement) => measurement.statistic === selectedStatistic.value)) {
+      selectedStatistic.value = response.measurements[0]?.statistic || ''
       resetHistory()
     }
     appendHistoryPoint()
     lastUpdated.value = new Date()
-    detailError.value = null
-  } catch (e) {
-    detailError.value = formatLoadError(e, 'Unable to load metric details')
+  } catch (exception) {
+    if (requestId === detailRequestId) {
+      detailError.value = formatLoadError(exception, 'Unable to load metric details')
+    }
   } finally {
-    loadingDetail = false
+    if (requestId === detailRequestId) {
+      detailLoading.value = false
+    }
   }
+}
+
+function previousSamples() {
+  if (!samplePage.value || samplePage.value.offset === 0 || detailLoading.value) return
+  sampleOffset.value = Math.max(0, samplePage.value.offset - samplePage.value.limit)
+  void loadDetail()
+}
+
+function nextSamples() {
+  if (!samplePage.value?.hasMore || detailLoading.value) return
+  sampleOffset.value = samplePage.value.offset + samplePage.value.limit
+  void loadDetail()
 }
 
 function appendHistoryPoint() {
@@ -183,7 +288,16 @@ function appendHistoryPoint() {
   history.value = [...history.value, {timestamp: Date.now(), value: selectedMeasurement.value.value}].slice(-60)
 }
 
+watch([search, typeFilter], scheduleFilterReload)
+
+onBeforeUnmount(() => {
+  meterRequestId++
+  detailRequestId++
+  if (filterTimer) clearTimeout(filterTimer)
+})
+
 const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh(refreshMetrics)
+const panelLoading = computed(() => loading.value || meterLoading.value || loadingMore.value || detailLoading.value)
 </script>
 
 <template>
@@ -192,7 +306,7 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
       icon="bi-activity"
       title="Metrics"
       subtitle="Browse meters, filter tag sets, and watch live values update automatically."
-      :loading="loading"
+      :loading="panelLoading"
       :error="error"
       :last-fetched="lastUpdated ? lastUpdated.getTime() : null"
       v-model:auto-refresh="autoRefresh"
@@ -208,26 +322,28 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
     <template v-else-if="data">
       <div class="row g-3">
         <div class="col-lg-4">
-          <div class="card h-100">
+          <div class="card h-100" :aria-busy="meterLoading">
             <div class="card-header">
               <div class="fw-semibold">Meters</div>
-              <div class="text-muted small">{{ filteredMeters.length }} of {{ data.total }} meters</div>
+              <div class="text-muted small" aria-live="polite">
+                {{ meters.length }} shown · {{ meterMatched }} matched · {{ meterTotal }} total
+              </div>
             </div>
             <div class="card-body border-bottom">
               <input
                 v-model="search"
                 aria-label="Search meters"
                 class="form-control form-control-sm mb-2"
-                placeholder="Search meters"
+                placeholder="Search names and descriptions"
               />
               <select v-model="typeFilter" aria-label="Filter meters by type" class="form-select form-select-sm">
                 <option value="">All meter types</option>
-                <option v-for="type in metricTypes" :key="type" :value="type">{{ type }}</option>
+                <option v-for="type in meterTypes" :key="type" :value="type">{{ type }}</option>
               </select>
             </div>
             <div class="list-group list-group-flush meter-list">
               <button
-                v-for="meter in filteredMeters"
+                v-for="meter in meters"
                 :key="meter.name"
                 :class="{active: meter.name === selectedName}"
                 class="list-group-item list-group-item-action"
@@ -240,6 +356,24 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
                 </div>
                 <div v-if="meter.description" class="small text-muted mt-1">{{ meter.description }}</div>
               </button>
+              <div v-if="!meters.length && meterLoading" class="p-3 text-muted small" role="status">
+                Updating meter list…
+              </div>
+              <div v-else-if="!meters.length && (search.trim() || typeFilter)" class="p-3 text-muted small">
+                No meters match the current server-side filters.
+              </div>
+              <div v-else-if="!meters.length" class="p-3 text-muted small">No meters are registered yet.</div>
+            </div>
+            <div v-if="meterPage" class="card-footer">
+              <ServerListFooter
+                :shown="meters.length"
+                :matched="meterMatched"
+                :total="meterTotal"
+                :page-size="METER_PAGE_SIZE"
+                :loading="loadingMore"
+                item-label="meters"
+                @load-more="loadMoreMeters"
+              />
             </div>
           </div>
         </div>
@@ -302,7 +436,12 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
           <div v-if="detail" class="card mb-3">
             <div class="card-header d-flex justify-content-between align-items-center">
               <span>Tag filters</span>
-              <button v-if="selectedTags.length" class="btn btn-sm btn-outline-secondary" @click="clearTags">
+              <button
+                v-if="selectedTags.length"
+                class="btn btn-sm btn-outline-secondary"
+                type="button"
+                @click="clearTags"
+              >
                 Clear filters
               </button>
             </div>
@@ -330,8 +469,13 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
             </div>
           </div>
 
-          <div v-if="detail" class="card">
-            <div class="card-header">Samples</div>
+          <div v-if="detail" class="card" :aria-busy="detailLoading">
+            <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+              <span>Samples</span>
+              <span class="text-muted small" aria-live="polite">
+                Showing {{ sampleStart }}–{{ sampleEnd }} of {{ detail.totalSamples }}
+              </span>
+            </div>
             <div class="table-responsive">
               <table class="table table-sm table-hover mb-0">
                 <thead class="table-light">
@@ -361,9 +505,34 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
                 </tbody>
               </table>
             </div>
+            <div
+              v-if="samplePage"
+              class="card-footer d-flex flex-wrap justify-content-between align-items-center gap-2"
+            >
+              <span class="text-muted small"> Responses are bounded to {{ SAMPLE_PAGE_SIZE }} samples per page. </span>
+              <div class="btn-group btn-group-sm" aria-label="Sample pages">
+                <button
+                  class="btn btn-outline-secondary"
+                  type="button"
+                  :disabled="samplePage.offset === 0 || detailLoading"
+                  @click="previousSamples"
+                >
+                  Previous
+                </button>
+                <button
+                  class="btn btn-outline-secondary"
+                  type="button"
+                  :disabled="!samplePage.hasMore || detailLoading"
+                  @click="nextSamples"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
           </div>
 
-          <div v-else class="text-muted">Select a meter to inspect live values.</div>
+          <div v-else-if="detailLoading" class="text-muted" role="status">Loading metric details…</div>
+          <div v-else-if="meters.length" class="text-muted">Select a meter to inspect live values.</div>
         </div>
       </div>
     </template>
@@ -413,7 +582,7 @@ const {autoRefresh, loading, initialLoading, load: loadMetrics} = useAutoRefresh
 }
 
 .chart-axis {
-  stroke: rgba(100, 116, 139, 0.35);
+  stroke: var(--bootui-border-alt);
   stroke-width: 0.5;
 }
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -701,8 +701,12 @@ GraalVM/CRaC get on Quarkus.
 
 ### Metrics
 
-The Metrics panel browses Micrometer meters exposed by Actuator. You can inspect meter descriptions, base units, tags,
-available measurements, and render a local live chart for a selected metric/tag combination.
+The Metrics panel browses Micrometer meters exposed by Actuator. You can search meter names/descriptions and filter by
+meter type on the server, inspect descriptions, base units, tags and available measurements, and render a local live chart
+for a selected metric/tag combination. Meter names are returned in deterministic 200-row pages (up to 1,000 per request),
+while a selected meter's concrete tagged samples use 100-row pages (also capped at 1,000). The UI reports the total,
+matching and displayed counts, provides load-more and sample Previous/Next controls, and keeps tag-value choices bounded to
+the first 100 sorted values per key with an explicit truncation badge.
 
 On Quarkus the panel is identical, served over Micrometer directly (Quarkus has no Actuator): it reads the live composite
 `MeterRegistry` when the application adds a `quarkus-micrometer` registry (for example

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1706,8 +1706,8 @@ Initial endpoints:
 | `/bootui/api/startup`                        | GET    | Startup timeline                                                                       |
 | `/bootui/api/threads`                        | GET    | Stable, paged live thread snapshot with state counts and deadlock info                 |
 | `/bootui/api/threads/download`               | POST   | Confirmation-gated raw text thread dump download                                       |
-| `/bootui/api/metrics`                        | GET    | Browseable Micrometer meter list                                                       |
-| `/bootui/api/metrics/detail`                 | GET    | Micrometer meter detail and live measurements                                          |
+| `/bootui/api/metrics`                        | GET    | Searchable/type-filtered Micrometer meter list, paged at 200 by default (1,000 maximum) |
+| `/bootui/api/metrics/detail`                 | GET    | Meter detail with tag filters and samples paged at 100 by default (1,000 maximum)       |
 | `/bootui/api/database-connection-pools/pools` | GET    | JDBC connection pool metadata                                                          |
 | `/bootui/api/database-connection-pools/pools/{name}/snapshot` | GET | Live connection pool utilization snapshot                                   |
 | `/bootui/api/vulnerabilities`                   | GET    | Runtime Maven dependency inventory without external scanning                           |


### PR DESCRIPTION
## What does this PR do?

Bounds the shared Metrics contract across Spring MVC/WebFlux and Quarkus with server-side meter filtering/paging, paged metric samples, deterministic ordering, canonical validation, and matching Vue pagination UX.

## Why is this change needed?

The Metrics panel previously materialized every meter, matching sample, and distinct tag value before the browser filtered it. High-cardinality registries could therefore produce unbounded server work and payloads.

The existing routes and fields remain intact. The additive contract introduces `availableTypes`/`page` on the meter list and `totalSamples`/`samplePage`/`samplesTruncated` on detail responses. Omitted parameters now use safe bounds: 200 meters and 100 samples, with a maximum requested page size of 1,000.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Focused validation:

- `./mvnw -B -ntp -pl bootui-spring-autoconfigure -am -Dtest=MetricsReportProviderTests,MetricsControllerTests -Dsurefire.failIfNoSpecifiedTests=false test`
- Quarkus Micrometer-present and Micrometer-absent integration tests
- Spring MVC, Spring WebFlux, and Quarkus shared API conformance suites
- `npm test -- --run src/views/Metrics.test.js`
- `npx playwright test tests/metrics.spec.js`
- Spotless and frontend/e2e Prettier checks

## Screenshots (UI changes)

N/A — this keeps the existing Metrics visual design and adds bounded list/sample paging controls and explicit count/empty/loading states.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed