### PR TITLE
Document remote access security and adapter workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,11 +14,22 @@ body:
       placeholder: "0.1.0-SNAPSHOT"
     validations:
       required: true
-  - type: input
-    id: spring-boot-version
+  - type: dropdown
+    id: adapter
     attributes:
-      label: Spring Boot version
-      placeholder: "4.0.6"
+      label: BootUI adapter
+      options:
+        - Spring MVC
+        - Spring WebFlux
+        - Quarkus
+    validations:
+      required: true
+  - type: input
+    id: framework-version
+    attributes:
+      label: Spring Boot or Quarkus version
+      description: Use the framework version for the selected adapter.
+      placeholder: "Spring Boot 4.1.0 or Quarkus 3.33.3.1"
     validations:
       required: true
   - type: input
@@ -56,11 +67,11 @@ body:
     id: repro
     attributes:
       label: Steps to reproduce
-      description: Provide a minimal repro. A pom.xml snippet and the active profiles are usually enough.
+      description: Provide a minimal repro. Include the relevant starter/extension, configuration, and active profile or launch mode.
       placeholder: |
-        1. Add `bootui-spring-boot-starter` to a Spring Boot 4 project
-        2. Run with `--spring.profiles.active=dev`
-        3. Open http://localhost:8080/bootui
+        1. Add the Spring MVC starter, Spring WebFlux starter, or Quarkus extension
+        2. Run with a local Spring profile or in Quarkus dev mode
+        3. Open the configured BootUI path
         4. ...
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,19 @@ name: Feature request
 description: Suggest an idea for BootUI
 labels: [ enhancement, triage ]
 body:
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Target platform
+      description: Select every adapter this request should cover.
+      multiple: true
+      options:
+        - Spring MVC
+        - Spring WebFlux
+        - Quarkus
+        - Shared engine or UI (all adapters)
+    validations:
+      required: true
   - type: textarea
     id: problem
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,9 @@ Closes #
 ## How was it tested?
 
 - [ ] `./mvnw clean install` passes locally
-- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
+- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
+- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
+- [ ] Ran the affected Playwright suite(s) for browser-facing changes
 - [ ] Added or updated tests where applicable
 
 ## Screenshots (UI changes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,10 @@ participating you are expected to uphold this code.
 - **Node.js 24+** and npm 11+ are downloaded automatically by the
   `frontend-maven-plugin` when you run the build. You do not need to install
   Node manually.
-- **Spring Boot 4.0+** is targeted. BootUI does not support Spring Boot 3.x.
+- **Framework targets**. The Spring MVC and WebFlux adapters target Spring Boot
+  4.0+; the Quarkus adapter targets the LTS version declared by
+  `quarkus.platform.version` in the root `pom.xml`. BootUI does not support
+  Spring Boot 3.x.
 
 ## Project layout
 
@@ -78,10 +81,18 @@ is not baked into `.mvn/maven.config` — add it to your own shell alias or a pe
 as `-Dmaven.repo.local`; see "Parallel worktrees" in `.github/copilot-instructions.md`). CI always
 builds with `-T 1C`.
 
-To rebuild only the backend (useful while iterating on Java code):
+For an adapter-focused Java iteration, select the corresponding sample or
+integration-test module and let Maven build its dependencies:
 
 ```bash
-./mvnw -pl bootui-core,bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-sample-app -am install
+# Spring MVC
+./mvnw -B -ntp -pl bootui-spring-sample-app -am install
+
+# Spring WebFlux
+./mvnw -B -ntp -pl bootui-spring-webflux-sample-app -am install
+
+# Quarkus extension plus Docker-free integration suites
+./mvnw -B -ntp -pl bootui-quarkus-integration-tests -am install
 ```
 
 ## Testing
@@ -100,6 +111,20 @@ npm install
 npm test
 ```
 
+The shared HTTP contract has one adapter-specific runner per platform. After
+installing the reactor dependencies, run the affected conformance class:
+
+```bash
+# Spring MVC
+./mvnw -B -ntp -pl bootui-spring-sample-app test -Dtest=SpringApiConformanceTest
+
+# Spring WebFlux
+./mvnw -B -ntp -pl bootui-spring-webflux-sample-app test -Dtest=WebFluxApiConformanceTest
+
+# Quarkus
+./mvnw -B -ntp -pl bootui-quarkus-integration-tests/base test -Dtest=BootUiQuarkusApiConformanceTest
+```
+
 ### Panel metadata workflow
 
 Backend panel metadata (`id`, manifest title/order, action capability, and guarded
@@ -114,17 +139,23 @@ manifests, and the directly related docs. When moving a sidebar entry, update
 that the backend catalog, UI routes, conformance manifests, and
 `docs/FEATURES.md` stay aligned.
 
-Run the browser end-to-end suite when you change the UI, browser-facing API responses, or sample-app behavior:
+Run the browser end-to-end suite for every affected adapter when you change the
+UI, browser-facing API responses, or sample-app behavior:
 
 ```bash
-cd bootui-spring-sample-app/e2e
-npm install
-npx playwright install chromium
-npm test
+# Spring MVC and WebFlux share one Playwright project
+(cd bootui-spring-sample-app/e2e && npm ci && npx playwright install chromium)
+(cd bootui-spring-sample-app/e2e && npm test)
+(cd bootui-spring-sample-app/e2e && npm run test:webflux)
+
+# Quarkus (requires JDK 17, 21, or 25 and Docker/Podman for Dev Services)
+(cd bootui-quarkus-sample-app/e2e && npm ci && npx playwright install chromium)
+(cd bootui-quarkus-sample-app/e2e && npm test)
 ```
 
-Playwright can start the sample app automatically. If you already have the sample app running on port 8080, it will
-reuse that server.
+Playwright starts the relevant sample app automatically and reuses an existing
+server on port `8080` (Spring MVC), `8081` (Spring WebFlux), or `8082`
+(Quarkus).
 
 ## Formatting
 
@@ -140,6 +171,16 @@ Use Prettier for the Vue app and Playwright tests:
 ```bash
 (cd bootui-ui/src/main/frontend && npm run format)
 (cd bootui-spring-sample-app/e2e && npm run format)
+(cd bootui-quarkus-sample-app/e2e && npm run format)
+```
+
+Before pushing, run the matching checks:
+
+```bash
+./mvnw -B -ntp spotless:check
+(cd bootui-ui/src/main/frontend && npm run format:check)
+(cd bootui-spring-sample-app/e2e && npm run format:check)
+(cd bootui-quarkus-sample-app/e2e && npm run format:check)
 ```
 
 ## GitHub Actions dependencies
@@ -170,11 +211,17 @@ bash .github/scripts/check-action-references.sh
 
 ## Run the sample app
 
-```bash
-./mvnw -pl bootui-spring-sample-app spring-boot:run -Dspring-boot.run.profiles=dev
-```
+Build the selected adapter first (see the adapter-focused commands above), then
+run its sample without `-am`:
 
-Then open <http://localhost:8080/bootui>.
+| Adapter | Command | Console |
+| ------- | ------- | ------- |
+| Spring MVC | `./mvnw -pl bootui-spring-sample-app spring-boot:run` | <http://localhost:8080/bootui> |
+| Spring WebFlux | `./mvnw -pl bootui-spring-webflux-sample-app spring-boot:run` | <http://localhost:8081/bootui> |
+| Quarkus | `./mvnw -pl bootui-quarkus-sample-app quarkus:dev` | <http://localhost:8082/bootui> |
+
+The Quarkus sample requires JDK 17, 21, or 25 for augmentation and uses Dev
+Services, so Docker or Podman must be available.
 
 ## Front-end development
 
@@ -296,9 +343,10 @@ bash .github/scripts/check-release-integrity.sh
    GitHub username (e.g. `jdubois/improve-config-ui`).
 3. Keep PRs small and focused. Update `docs/` whenever public behaviour
    changes.
-4. Run `./mvnw clean install` before pushing.
-5. Run the Playwright end-to-end suite when you change the UI, browser-facing
-   API responses, or sample-app behavior.
+4. Run `./mvnw -B -ntp clean install` before pushing.
+5. Run the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance and
+   Playwright commands when you change the UI, browser-facing API responses, or
+   sample-app behavior.
 6. Use the pull request template — it links to the verifications we expect.
 
 ## Reporting bugs and security issues

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,19 +25,93 @@ provide a fix or mitigation within thirty days for high-severity issues.
 
 ## Threat model and intended use
 
-BootUI is a **local developer console**. By design it:
+BootUI is a **local developer console**, not an application authentication
+system. Spring MVC and Spring WebFlux activate it in `AUTO` mode only for the
+configured local profiles or when DevTools is present, unless
+`bootui.enabled=ON` explicitly forces activation. The Quarkus extension wires
+the console only in development and test launch modes; its API is absent and
+its static shell is suppressed in a normal production launch.
 
-- activates only on the `dev` / `local` profile, when DevTools is on the
-  classpath, or when explicitly enabled with `bootui.enabled=ON`;
-- exposes its endpoints on the loopback interface only — non-loopback
-  requests are rejected unless `bootui.allow-non-localhost=true` is set, or the
-  source falls within a range configured in `bootui.trusted-proxies` (a narrow
-  opt-in for local Docker-bridge callers that still enforces the `Host`
-  allow-list and cross-site write protection, and should be scoped to trusted
-  local/dev networks);
-- masks values for property keys that look like secrets (`password`, `token`,
-  `secret`, `key`, …) — controlled by `bootui.expose-values`, which defaults to
-  `MASKED`.
+BootUI uses the host application's HTTP listener. It does not separately bind
+the console to a loopback interface. Instead, every adapter applies the same
+request-time safety and authentication policy described below.
+
+### Request filter and authentication model
+
+For Spring MVC, Spring WebFlux, and Quarkus, BootUI evaluates requests in this
+order:
+
+1. Security headers are attached to the BootUI response.
+2. `LocalhostGuard` protects the entire configured UI and API surface.
+3. Bearer/cookie authentication protects the configured API surface.
+4. Per-panel enabled/read-only policy is applied before an API handler runs.
+
+Spring MVC implements this with servlet filters ordered at
+`Integer.MIN_VALUE` through `Integer.MIN_VALUE + 3`; WebFlux uses the same
+relative order with `WebFilter`; Quarkus uses Vert.x route-filter priorities
+`1000` (guard), `975` (authentication), and `950` (panel policy). The Spring
+Security integration deliberately permits BootUI routes in its own
+highest-precedence chain: it is the BootUI filters above, not the host
+application's login, that enforce this boundary.
+
+Unless `bootui.allow-non-localhost=true`, `LocalhostGuard` applies these checks
+in order:
+
+1. The raw TCP peer must be loopback, in a CIDR listed by
+   `bootui.trusted-proxies`, or an auto-detected container gateway trusted by
+   `bootui.trust-container-gateway`. Forwarded client-address headers are not
+   consulted.
+2. A present `Host` header must use a built-in loopback name or a hostname in
+   `bootui.allowed-hosts`.
+3. A state-changing request is rejected when `Sec-Fetch-Site` is `cross-site`,
+   or when a present `Origin` has a different host. The comparison intentionally
+   ignores scheme and port; requests with neither header are not rejected by
+   this check.
+
+`bootui.allowed-hosts` does not trust a source address. Conversely,
+`bootui.trusted-proxies` and `bootui.trust-container-gateway` treat the matching
+raw peer as trusted: those callers remain authentication-free, but the `Host`
+and cross-site-write checks still apply. Scope these trust mechanisms to
+controlled local/development networks.
+
+`bootui.allow-non-localhost=true` is a broader escape hatch. It bypasses all
+three `LocalhostGuard` checks, but it does **not** mark the peer as trusted.
+The static SPA may load, while every `/bootui/api/**` request from that peer
+must present either the configured/generated token as
+`Authorization: Bearer <token>` or the BootUI session cookie. Authentication
+runs before panel policy, so an unauthenticated API caller receives `401`
+without learning panel availability.
+
+### Token generation and browser cookie exchange
+
+`bootui.authentication.token` is used verbatim when configured. When it is
+blank, BootUI generates a 256-bit URL-safe token for the lifetime of that
+application process. A generated token is logged once at startup when any
+remote-access option is configured (`allow-non-localhost`, trusted CIDRs, or
+container-gateway trust); a configured token is never logged. Keep configured
+tokens in an environment-backed secret rather than source control, and treat
+startup logs containing a generated token as credentials.
+
+The unlock screen sends the token once in a bearer-authenticated
+`POST <api-path>/auth/session`. After the guard and token checks pass, an
+untrusted remote caller receives `204` plus a `BOOTUI_SESSION` cookie containing
+the same token. The cookie is `HttpOnly`, `SameSite=Strict`, and scoped to the
+configured API path including the application's context/root path. It is marked
+`Secure` only when the adapter sees the request as HTTPS. Trusted loopback,
+CIDR, and container-gateway callers do not receive or need this cookie.
+
+Use end-to-end HTTPS for remote access. Bearer credentials and a cookie without
+the `Secure` attribute can be intercepted over plain HTTP. When TLS terminates
+at a development proxy, configure the host framework/proxy so the backend
+correctly recognizes the original HTTPS scheme before relying on the cookie's
+`Secure` attribute. BootUI does not provide token rotation, login throttling,
+or user-level authorization.
+
+### Data exposure
+
+BootUI masks values for property keys that look like secrets (`password`,
+`token`, `secret`, `key`, …). This is controlled by `bootui.expose-values`,
+which defaults to `MASKED`.
 
 ### Local agent session panels (Copilot and Claude Code)
 
@@ -80,9 +154,17 @@ In-scope security issues include:
 - A way to access BootUI endpoints from a non-loopback origin when
   `bootui.allow-non-localhost=false` and `bootui.trusted-proxies` is empty.
 - A way to bypass the `Host` allow-list (DNS-rebinding) or cross-site write
-  (CSRF) protections for a caller trusted only via `bootui.trusted-proxies`.
-- A configuration that causes BootUI to activate when neither the `dev`
-  profile is active, DevTools is present, nor `bootui.enabled=ON`.
+  protections while `LocalhostGuard` is enabled.
+- A way for a peer admitted only by `bootui.allow-non-localhost=true` to access
+  a BootUI API without the correct bearer token or session cookie.
+- A way for an untrusted caller to exchange an invalid token for a
+  `BOOTUI_SESSION` cookie, or to bypass authentication through filter ordering.
+- Trusting a client-supplied forwarded address instead of the raw TCP peer.
+- Disclosure of a configured token, or disclosure of a generated token outside
+  the intentional startup log and authenticated session-cookie exchange.
+- A configuration that activates a Spring adapter without a configured enabled
+  profile, DevTools, or `bootui.enabled=ON`, or that wires the Quarkus API in a
+  normal production launch.
 - Secret values leaked in API responses despite default masking.
 - Stored XSS or RCE against the bundled Vue UI.
 - Path traversal through the runtime overrides file store, or through the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -142,8 +142,8 @@ returns the source JSON for one event on demand. It is:
   (Copilot enables it by default; Claude Code disables it by default because its
   logs can contain prompts and outputs);
 - automatically disabled when `bootui.expose-values=METADATA_ONLY`;
-- subject to the standard loopback-only filter applied to every BootUI
-  endpoint.
+- subject to the standard `LocalhostGuard` and API authentication policy
+  applied to every BootUI endpoint.
 
 **BootUI must never be enabled in production.** Issues that require running
 BootUI in a production-like setting (publicly exposed, with security


### PR DESCRIPTION
## Summary

- document the enforced remote-access threat model across Spring MVC, Spring WebFlux, and Quarkus, including guard/auth/panel ordering, trusted-source semantics, bearer generation, browser cookie exchange, HTTPS expectations, and in-scope bypasses
- make contributor build, conformance, formatter, smoke, and Playwright guidance adapter-specific without changing the source-first release flow from the stacked base
- add MVC/WebFlux/Quarkus context to issue forms and remove the Spring-MVC-only PR checklist item

## Evidence

Claims were checked against `LocalhostGuard`, `ApiTokenAuthenticator`, the MVC/WebFlux authentication and localhost filters, the Quarkus safety/authentication filters, adapter filter registrations/priorities, startup token logging, and the SPA unlock flow.

## Validation

- `./mvnw -B -ntp spotless:apply`
- `./mvnw -B -ntp spotless:check`
- parsed all issue-form YAML with Ruby/Psych
- resolved all documented Maven module selectors
- `bash .github/scripts/check-release-integrity.sh`
- `git diff --check`

Stacked on #723 (`jdubois-release-integrity-local`).