### PR TITLE
feat(ui): recover platform-aware navigation

### DIFF
--- a/bootui-spring-sample-app/e2e/tests-custom-path/custom-path.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-custom-path/custom-path.spec.js
@@ -32,6 +32,16 @@ test('loads the SPA and assets only from the configured path', async ({page, req
   await expect(page).toHaveURL(/\/host\/$/)
 })
 
+test('recovers from an unknown hash without losing the configured mount', async ({page}) => {
+  await page.goto(`${UI_PATH}/#/missing-panel`)
+
+  await expect(page.getByRole('heading', {name: 'Page not found'})).toBeVisible()
+  await expect(page).toHaveURL(new RegExp(`${UI_PATH}/#/missing-panel$`))
+
+  await page.getByRole('link', {name: 'Go to Overview'}).click()
+  await expect(page).toHaveURL(new RegExp(`${UI_PATH}/#/overview$`))
+})
+
 test('uses the configured API path for queries, SSE, and security', async ({page, request}) => {
   const threads = await request.get(`${API_PATH}/threads?offset=0&limit=1`)
   expect(threads.ok()).toBeTruthy()

--- a/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
@@ -229,6 +229,22 @@ test.describe('BootUI app shell', () => {
     await expect(page.locator('main.content-stage')).toBeFocused()
   })
 
+  test('unknown hashes provide accessible recovery without leaving the mounted console', async ({page}) => {
+    await page.goto('/bootui/#/missing-panel')
+
+    await expect(page.getByRole('heading', {name: 'Page not found'})).toBeVisible()
+    await expect(page).toHaveTitle('Not Found · bootui-sample · BootUI')
+
+    await page.getByRole('button', {name: 'Search panels'}).click()
+    const palette = page.getByRole('dialog', {name: 'Command palette'})
+    await expect(palette.getByRole('combobox', {name: 'Search panels'})).toBeFocused()
+    await page.keyboard.press('Escape')
+
+    await page.getByRole('link', {name: 'Go to Overview'}).click()
+    await expect(page).toHaveURL(/\/bootui\/#\/overview$/)
+    await expect(page).toHaveTitle('Overview · bootui-sample · BootUI')
+  })
+
   test('mobile command palette restores shortcut focus on cancel', async ({page}) => {
     await page.setViewportSize({width: 390, height: 844})
     await page.goto('/bootui/')

--- a/bootui-ui/src/main/frontend/src/App.test.js
+++ b/bootui-ui/src/main/frontend/src/App.test.js
@@ -9,7 +9,7 @@ const namedRoutes = routes.filter((route) => route.name && route.meta?.title)
 const NARROW_QUERY = '(max-width: 991.98px)'
 
 function shellRoutes() {
-  return routes.map((route) => (route.redirect ? route : {...route, component: TestPanel}))
+  return routes.map((route) => (route.redirect || !route.name ? route : {...route, component: TestPanel}))
 }
 
 function jsonResponse(body) {
@@ -132,7 +132,7 @@ async function mountApp(initialPath = '/overview', options = {}) {
       plugins: [router],
       stubs: {
         CommandPalette: options.stubCommandPalette === false ? false : true,
-        RouterView: {template: '<div />'}
+        RouterView: options.stubRouterView === false ? false : {template: '<div />'}
       }
     }
   })
@@ -366,6 +366,52 @@ describe('App command palette', () => {
     expect(router.currentRoute.value.name).toBe('architecture')
     expect(wrapper.find('[aria-label="Command palette"]').exists()).toBe(false)
     expect(document.activeElement).toBe(wrapper.find('main').element)
+  })
+})
+
+describe('App route recovery and document title', () => {
+  beforeEach(() => {
+    stubLocalStorage()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    restoreLocalStorage()
+    document.body.innerHTML = ''
+    document.title = ''
+  })
+
+  it('updates the title from the active platform route and existing overview application name', async () => {
+    mockShellFetch('quarkus')
+    const {router} = await mountApp('/spring')
+
+    expect(document.title).toBe('Quarkus · bootui-sample · BootUI')
+
+    await router.push('/beans')
+    await flushPromises()
+    expect(document.title).toBe('Beans · bootui-sample · BootUI')
+  })
+
+  it('renders the catch-all route and recovers through overview or command search', async () => {
+    mockShellFetch()
+    const {router, wrapper} = await mountApp('/missing-panel', {
+      stubCommandPalette: false,
+      stubRouterView: false
+    })
+
+    expect(wrapper.get('#not-found-title').text()).toBe('Page not found')
+    expect(document.title).toBe('Not Found · bootui-sample · BootUI')
+
+    await wrapper.get('.not-found-actions a').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.name).toBe('overview')
+
+    await router.push('/still-missing')
+    await flushPromises()
+    await wrapper.get('.not-found-actions button').trigger('click')
+    await flushPromises()
+    expect(wrapper.get('[aria-label="Command palette"]').exists()).toBe(true)
+    expect(document.activeElement).toBe(wrapper.get('.cp-input').element)
   })
 })
 

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -12,6 +12,15 @@ import {
   THEME_STORAGE_KEY
 } from './utils/theme.js'
 import {describeLoadError} from './utils/loadError.js'
+import {
+  buildDocumentTitle,
+  createPanelLookup,
+  panelDisabledReason,
+  resolveRouteTitle,
+  routeAvailabilityLabel as routeAccessibleLabel,
+  routeStatusIcon as panelStatusIcon,
+  routeUnavailable as isRouteUnavailable
+} from './utils/panelNavigation.js'
 import {recordRecentPanel} from './utils/recentPanels.js'
 import {safeLocalStorage} from './utils/safeStorage.js'
 import CommandPalette from './views/components/CommandPalette.vue'
@@ -76,6 +85,7 @@ const themeToggleText = computed(() => `${darkTheme.value ? 'Light' : 'Dark'} mo
 
 provide('overview', overview)
 provide('panels', panels)
+provide('openCommandPalette', openCommandPalette)
 
 async function openCommandPalette(event) {
   if (commandPaletteOpen.value || mobileDrawerOpen.value) return
@@ -259,7 +269,7 @@ function loadExpandedGroups() {
 }
 
 const expandedGroups = reactive(loadExpandedGroups())
-const panelLookup = computed(() => new Map((panels.value?.panels ?? []).map((panel) => [panel.id, panel])))
+const panelLookup = computed(() => createPanelLookup(panels.value))
 const activeRoute = computed(() => routes.find((r) => r.name === route.name))
 const activePanel = computed(() => (route.name ? panelLookup.value.get(route.name) : null))
 const activePanelDisabled = computed(() => activePanel.value?.enabled === false)
@@ -277,6 +287,7 @@ const activePanelUnavailableReason = computed(() => {
 const activePanelReadOnly = computed(() => activePanel.value?.readOnly === true && !activePanelUnavailable.value)
 const activePanelReadOnlyReason = computed(() => activePanel.value?.readOnlyReason || 'This panel is read-only.')
 const applicationTitle = computed(() => overview.value?.applicationName || 'application')
+const browserTitle = computed(() => buildDocumentTitle(route, panels.value?.platform, overview.value?.applicationName))
 const runtimeSummary = computed(() => {
   if (shellServerUnreachable.value) return 'The application is not responding. Restart it and retry.'
   if (shellError.value && !overview.value) return 'Unable to load BootUI runtime details.'
@@ -334,8 +345,7 @@ const footerText = computed(() =>
 )
 const githubProjectUrl = 'https://github.com/jdubois/boot-ui'
 function navTitle(r) {
-  const platform = panels.value?.platform
-  return r.meta?.titleByPlatform?.[platform] || r.meta?.title
+  return resolveRouteTitle(r, panels.value?.platform)
 }
 const navigationSections = computed(() => {
   const sections = [
@@ -438,47 +448,16 @@ async function authenticate() {
   }
 }
 
-function panelForRoute(r) {
-  return panelLookup.value.get(r.name)
-}
-
 function routeUnavailable(r) {
-  const panel = panelForRoute(r)
-  return panel?.enabled === false || panel?.available === false
-}
-
-function routeReadOnly(r) {
-  const panel = panelForRoute(r)
-  return panel?.readOnly === true && !routeUnavailable(r)
+  return isRouteUnavailable(r, panelLookup.value)
 }
 
 function routeStatusIcon(r) {
-  if (routeUnavailable(r)) {
-    return 'bi-slash-circle'
-  }
-  if (routeReadOnly(r)) {
-    return 'bi-lock'
-  }
-  return null
-}
-
-function panelDisabledReason(panel) {
-  return `Panel is disabled via bootui.panels.${panel?.id || 'panel'}.enabled=false`
+  return panelStatusIcon(r, panelLookup.value)
 }
 
 function routeAvailabilityLabel(r) {
-  const panel = panelForRoute(r)
-  const title = navTitle(r)
-  if (panel?.enabled === false) {
-    return `${title} - disabled: ${panelDisabledReason(panel)}`
-  }
-  if (panel?.available === false) {
-    return `${title} - unavailable: ${panel.unavailableReason || 'required support is unavailable'}`
-  }
-  if (panel?.readOnly === true) {
-    return `${title} - read-only: ${panel.readOnlyReason || 'mutating actions are disabled'}`
-  }
-  return title
+  return routeAccessibleLabel(r, panelLookup.value, panels.value?.platform)
 }
 
 function groupDomId(group) {
@@ -562,6 +541,14 @@ watch(
     safeLocalStorage.setJson(EXPANDED_GROUPS_STORAGE_KEY, groups)
   },
   {deep: true}
+)
+
+watch(
+  browserTitle,
+  (title) => {
+    document.title = title
+  },
+  {immediate: true}
 )
 
 onMounted(() => {

--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -49,6 +49,7 @@ const Email = () => import('./views/Email.vue')
 const Kafka = () => import('./views/Kafka.vue')
 const RabbitMQ = () => import('./views/RabbitMQ.vue')
 const Jms = () => import('./views/Jms.vue')
+const NotFound = () => import('./views/NotFound.vue')
 
 export const groups = {
   overview: 'overview',
@@ -864,5 +865,10 @@ export const routes = [
   {path: '/memory-advisor', redirect: '/memory'},
   {path: '/security-advisor', redirect: '/security'},
   {path: '/profiles', redirect: '/profile-diff'},
-  {path: '/spring-cache', redirect: '/cache'}
+  {path: '/spring-cache', redirect: '/cache'},
+  {
+    path: '/:pathMatch(.*)*',
+    component: NotFound,
+    meta: {title: 'Not Found'}
+  }
 ]

--- a/bootui-ui/src/main/frontend/src/routes.test.js
+++ b/bootui-ui/src/main/frontend/src/routes.test.js
@@ -219,6 +219,14 @@ function findRepositoryRoot(startDirectory) {
 }
 
 describe('routes', () => {
+  it('keeps the final catch-all route outside the panel catalog', () => {
+    const catchAll = routes.at(-1)
+
+    expect(catchAll.path).toBe('/:pathMatch(.*)*')
+    expect(catchAll.name).toBeUndefined()
+    expect(catchAll.meta.title).toBe('Not Found')
+  })
+
   it('keeps the sidebar order aligned with the documented feature order', () => {
     expect(namedRoutes.map((route) => route.meta.title)).toEqual([
       'Overview',

--- a/bootui-ui/src/main/frontend/src/utils/panelNavigation.js
+++ b/bootui-ui/src/main/frontend/src/utils/panelNavigation.js
@@ -1,0 +1,79 @@
+export const UNAVAILABLE_GROUP_LABEL = 'Disabled / unavailable'
+
+export function createPanelLookup(manifest) {
+  return new Map((manifest?.panels ?? []).map((panel) => [panel.id, panel]))
+}
+
+export function resolveRouteTitle(route, platform) {
+  return route?.meta?.titleByPlatform?.[platform] || route?.meta?.title || null
+}
+
+export function panelForRoute(route, panelLookup) {
+  return route?.name ? panelLookup.get(route.name) : null
+}
+
+export function panelDisabledReason(panel) {
+  return `Panel is disabled via bootui.panels.${panel?.id || 'panel'}.enabled=false`
+}
+
+export function routePanelState(route, panelLookup) {
+  const panel = panelForRoute(route, panelLookup)
+  if (panel?.enabled === false) {
+    return {
+      icon: 'bi-slash-circle',
+      kind: 'disabled',
+      label: 'Disabled',
+      reason: panelDisabledReason(panel)
+    }
+  }
+  if (panel?.available === false) {
+    return {
+      icon: 'bi-slash-circle',
+      kind: 'unavailable',
+      label: 'Unavailable',
+      reason: panel.unavailableReason || 'required support is unavailable'
+    }
+  }
+  if (panel?.readOnly === true) {
+    return {
+      icon: 'bi-lock',
+      kind: 'read-only',
+      label: 'Read-only',
+      reason: panel.readOnlyReason || 'mutating actions are disabled'
+    }
+  }
+  return null
+}
+
+export function routeUnavailable(route, panelLookup) {
+  const kind = routePanelState(route, panelLookup)?.kind
+  return kind === 'disabled' || kind === 'unavailable'
+}
+
+export function routeReadOnly(route, panelLookup) {
+  return routePanelState(route, panelLookup)?.kind === 'read-only'
+}
+
+export function routeStatusIcon(route, panelLookup) {
+  return routePanelState(route, panelLookup)?.icon ?? null
+}
+
+export function routeAvailabilityLabel(route, panelLookup, platform) {
+  const title = resolveRouteTitle(route, platform) || 'Panel'
+  const state = routePanelState(route, panelLookup)
+  return state ? `${title} - ${state.kind}: ${state.reason}` : title
+}
+
+export function routeNavigationGroup(route, panelLookup) {
+  return routeUnavailable(route, panelLookup) ? UNAVAILABLE_GROUP_LABEL : route.meta?.group
+}
+
+export function buildDocumentTitle(route, platform, applicationName) {
+  const panelTitle = cleanLabel(resolveRouteTitle(route, platform), 'BootUI')
+  const applicationTitle = cleanLabel(applicationName, 'Application')
+  return `${panelTitle} · ${applicationTitle} · BootUI`
+}
+
+function cleanLabel(value, fallback) {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback
+}

--- a/bootui-ui/src/main/frontend/src/utils/panelNavigation.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/panelNavigation.test.js
@@ -1,0 +1,52 @@
+import {describe, expect, it} from 'vitest'
+
+import {
+  buildDocumentTitle,
+  createPanelLookup,
+  resolveRouteTitle,
+  routeAvailabilityLabel,
+  routeNavigationGroup,
+  routePanelState,
+  routeUnavailable
+} from './panelNavigation.js'
+
+const springRoute = {
+  name: 'spring',
+  meta: {
+    group: 'advisors',
+    title: 'Spring',
+    titleByPlatform: {quarkus: 'Quarkus'}
+  }
+}
+
+describe('panel navigation', () => {
+  it('resolves platform-aware labels and browser titles with safe fallbacks', () => {
+    expect(resolveRouteTitle(springRoute, 'spring-boot')).toBe('Spring')
+    expect(resolveRouteTitle(springRoute, 'quarkus')).toBe('Quarkus')
+    expect(buildDocumentTitle(springRoute, 'quarkus', 'orders')).toBe('Quarkus · orders · BootUI')
+    expect(buildDocumentTitle({}, null, '  ')).toBe('BootUI · Application · BootUI')
+  })
+
+  it('moves disabled and unavailable panels into the same explicit group used by the sidebar', () => {
+    const lookup = createPanelLookup({
+      panels: [
+        {
+          id: 'spring',
+          available: true,
+          enabled: false
+        }
+      ]
+    })
+
+    expect(routeUnavailable(springRoute, lookup)).toBe(true)
+    expect(routeNavigationGroup(springRoute, lookup)).toBe('Disabled / unavailable')
+    expect(routePanelState(springRoute, lookup)).toMatchObject({
+      kind: 'disabled',
+      label: 'Disabled',
+      icon: 'bi-slash-circle'
+    })
+    expect(routeAvailabilityLabel(springRoute, lookup, 'quarkus')).toBe(
+      'Quarkus - disabled: Panel is disabled via bootui.panels.spring.enabled=false'
+    )
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/NotFound.test.js
+++ b/bootui-ui/src/main/frontend/src/views/NotFound.test.js
@@ -1,0 +1,27 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it, vi} from 'vitest'
+
+import NotFound from './NotFound.vue'
+
+describe('NotFound', () => {
+  it('offers overview and command-search recovery actions', async () => {
+    const openCommandPalette = vi.fn()
+    const wrapper = mount(NotFound, {
+      global: {
+        provide: {openCommandPalette},
+        stubs: {
+          RouterLink: {
+            props: ['to'],
+            template: '<a :href="to"><slot /></a>'
+          }
+        }
+      }
+    })
+
+    expect(wrapper.get('h2').text()).toBe('Page not found')
+    expect(wrapper.get('a').attributes('href')).toBe('/overview')
+
+    await wrapper.get('button').trigger('click')
+    expect(openCommandPalette).toHaveBeenCalledOnce()
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/NotFound.vue
+++ b/bootui-ui/src/main/frontend/src/views/NotFound.vue
@@ -1,0 +1,70 @@
+<script setup>
+import {inject} from 'vue'
+
+const openCommandPalette = inject('openCommandPalette', null)
+
+function openSearch(event) {
+  openCommandPalette?.(event)
+}
+</script>
+
+<template>
+  <section class="not-found-state" aria-labelledby="not-found-title">
+    <span class="not-found-icon fs-5" aria-hidden="true"><i class="bi bi-signpost-split"></i></span>
+    <div>
+      <h2 id="not-found-title">Page not found</h2>
+      <p class="text-muted mb-0">
+        This BootUI panel does not exist. Return to the overview or search for another panel.
+      </p>
+    </div>
+    <div class="not-found-actions">
+      <router-link class="btn btn-primary" to="/overview">Go to Overview</router-link>
+      <button class="btn btn-outline-secondary" type="button" @click="openSearch">
+        <i class="bi bi-search me-1" aria-hidden="true"></i>
+        Search panels
+      </button>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.not-found-state {
+  align-items: flex-start;
+  background: var(--bootui-surface);
+  border: 1px solid var(--bootui-border);
+  border-radius: var(--bootui-radius-lg);
+  box-shadow: var(--bootui-shadow-sm);
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.not-found-icon {
+  align-items: center;
+  background: var(--bootui-nav-group-bg);
+  border-radius: var(--bootui-radius-md);
+  color: var(--bootui-text-muted);
+  display: inline-flex;
+  height: 2.75rem;
+  justify-content: center;
+  width: 2.75rem;
+}
+
+.not-found-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  grid-column: 2;
+}
+
+@media (max-width: 575.98px) {
+  .not-found-state {
+    grid-template-columns: 1fr;
+  }
+
+  .not-found-actions {
+    grid-column: 1;
+  }
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.test.js
@@ -1,8 +1,10 @@
 import {flushPromises, mount} from '@vue/test-utils'
 import {createMemoryHistory, createRouter} from 'vue-router'
+import {ref} from 'vue'
 import {afterEach, describe, expect, it, vi} from 'vitest'
 
 import {routes} from '../../routes.js'
+import {safeLocalStorage} from '../../utils/safeStorage.js'
 import CommandPalette from './CommandPalette.vue'
 
 const namedRoutes = routes.filter((route) => route.name && route.meta?.title)
@@ -18,7 +20,8 @@ async function mountPalette(options = {}) {
   const wrapper = mount(CommandPalette, {
     attachTo: options.attachTo,
     global: {
-      plugins: [router]
+      plugins: [router],
+      provide: options.panels ? {panels: ref(options.panels)} : {}
     }
   })
 
@@ -34,6 +37,7 @@ async function setQuery(wrapper, value) {
 describe('CommandPalette', () => {
   afterEach(() => {
     document.body.innerHTML = ''
+    vi.restoreAllMocks()
   })
 
   it('lists every navigable panel before filtering', async () => {
@@ -91,6 +95,59 @@ describe('CommandPalette', () => {
     expect(titles[0]).toBe('Spring')
     expect(titles).toContain('Beans')
     expect(titles.indexOf('Spring')).toBeLessThan(titles.indexOf('Beans'))
+  })
+
+  it('uses the manifest platform for the shared application-advisor label and search', async () => {
+    const {wrapper} = await mountPalette({
+      panels: {
+        platform: 'quarkus',
+        panels: namedRoutes.map((route) => ({id: route.name, available: true, enabled: true}))
+      }
+    })
+
+    await setQuery(wrapper, 'quarkus')
+
+    expect(wrapper.findAll('.cp-item-title').map((item) => item.text())).toContain('Quarkus')
+    expect(wrapper.findAll('.cp-item-title').map((item) => item.text())).not.toContain('Spring')
+  })
+
+  it('keeps unavailable panels discoverable in the explicit sidebar-equivalent group', async () => {
+    const {wrapper} = await mountPalette({
+      panels: {
+        platform: 'spring-boot',
+        panels: [
+          {
+            id: 'ai',
+            available: false,
+            enabled: true,
+            unavailableReason: 'AI support is not installed'
+          }
+        ]
+      }
+    })
+
+    await setQuery(wrapper, 'AI Framework')
+
+    const result = wrapper.get('[role="option"]')
+    expect(result.classes()).toContain('cp-item--unavailable')
+    expect(result.get('.cp-item-group').text()).toBe('Disabled / unavailable')
+    expect(result.attributes('aria-label')).toBe('AI Framework - unavailable: AI support is not installed')
+    expect(result.get('.cp-item-status').attributes('title')).toBe('Unavailable')
+  })
+
+  it('keeps unavailable recent panels first without losing their status', async () => {
+    vi.spyOn(safeLocalStorage, 'getJson').mockReturnValue(['ai'])
+    const {wrapper} = await mountPalette({
+      panels: {
+        platform: 'spring-boot',
+        panels: [{id: 'ai', available: false, enabled: true}]
+      }
+    })
+
+    const firstResult = wrapper.get('[role="option"]')
+    expect(firstResult.get('.cp-item-title').text()).toBe('AI Framework')
+    expect(firstResult.find('.cp-item-recent').exists()).toBe(true)
+    expect(firstResult.classes()).toContain('cp-item--unavailable')
   })
 
   it('navigates with a number key while browsing the unfiltered list', async () => {

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
@@ -1,11 +1,19 @@
 <script setup>
-import {computed, nextTick, ref, watch} from 'vue'
+import {computed, inject, nextTick, ref, watch} from 'vue'
 import {useRouter} from 'vue-router'
 import {routes} from '../../routes.js'
+import {
+  createPanelLookup,
+  resolveRouteTitle,
+  routeAvailabilityLabel,
+  routeNavigationGroup,
+  routePanelState
+} from '../../utils/panelNavigation.js'
 import {loadRecentPanels} from '../../utils/recentPanels.js'
 
 const emit = defineEmits(['close'])
 const router = useRouter()
+const panels = inject('panels', ref(null))
 const query = ref('')
 const backdropEl = ref(null)
 const inputEl = ref(null)
@@ -14,10 +22,17 @@ const inputId = 'bootui-command-palette-input'
 const listboxId = 'bootui-command-palette-listbox'
 
 const searchableRoutes = routes.filter((r) => r.name && r.meta?.title)
-const recentRouteList = loadRecentPanels()
-  .map((name) => searchableRoutes.find((r) => r.name === name))
-  .filter(Boolean)
-const recentNames = new Set(recentRouteList.map((r) => r.name))
+const recentPanelNames = loadRecentPanels()
+const panelLookup = computed(() => createPanelLookup(panels.value))
+const platform = computed(() => panels.value?.platform)
+const recentRouteList = computed(() =>
+  recentPanelNames.map((name) => searchableRoutes.find((r) => r.name === name)).filter(Boolean)
+)
+const recentNames = computed(() => new Set(recentRouteList.value.map((r) => r.name)))
+
+function routeTitle(route) {
+  return resolveRouteTitle(route, platform.value)
+}
 
 function keywordMatch(keywords, needle) {
   // Match on word prefixes within a keyword rather than arbitrary substrings,
@@ -26,7 +41,7 @@ function keywordMatch(keywords, needle) {
 }
 
 function score(route, q) {
-  const title = (route.meta.title || '').toLowerCase()
+  const title = (routeTitle(route) || '').toLowerCase()
   const group = (route.meta.group || '').toLowerCase()
   const shortcut = (route.meta.shortcut || '').toLowerCase()
   const keywords = (route.meta.keywords || []).map((k) => k.toLowerCase())
@@ -40,14 +55,14 @@ function score(route, q) {
   return 0
 }
 
-const showRecent = computed(() => !query.value.trim() && recentRouteList.length > 0)
+const showRecent = computed(() => !query.value.trim() && recentRouteList.value.length > 0)
 
 const results = computed(() => {
   const q = query.value.trim()
   if (!q) {
-    if (!recentRouteList.length) return searchableRoutes
-    const rest = searchableRoutes.filter((r) => !recentNames.has(r.name))
-    return [...recentRouteList, ...rest]
+    if (!recentRouteList.value.length) return searchableRoutes
+    const rest = searchableRoutes.filter((r) => !recentNames.value.has(r.name))
+    return [...recentRouteList.value, ...rest]
   }
   return searchableRoutes
     .map((r) => ({route: r, score: score(r, q)}))
@@ -57,7 +72,19 @@ const results = computed(() => {
 })
 
 function isRecent(route) {
-  return showRecent.value && recentNames.has(route.name)
+  return showRecent.value && recentNames.value.has(route.name)
+}
+
+function panelState(route) {
+  return routePanelState(route, panelLookup.value)
+}
+
+function routeLabel(route) {
+  return routeAvailabilityLabel(route, panelLookup.value, platform.value)
+}
+
+function routeGroup(route) {
+  return routeNavigationGroup(route, panelLookup.value)
 }
 
 watch(results, (currentResults) => {
@@ -200,7 +227,11 @@ defineExpose({focusInput})
           :id="optionId(r)"
           :key="r.name"
           :aria-selected="i === activeIndex"
-          :class="{active: i === activeIndex}"
+          :aria-label="routeLabel(r)"
+          :class="{
+            active: i === activeIndex,
+            'cp-item--unavailable': ['disabled', 'unavailable'].includes(panelState(r)?.kind)
+          }"
           class="cp-item"
           :data-option-index="i"
           role="option"
@@ -210,15 +241,22 @@ defineExpose({focusInput})
         >
           <span v-if="i < 9 && !query.trim()" class="cp-item-num">{{ i + 1 }}</span>
           <i :class="['bi', r.meta.icon, 'cp-item-icon']"></i>
-          <span class="cp-item-title">{{ r.meta.title }}</span>
+          <span class="cp-item-title">{{ routeTitle(r) }}</span>
           <i
             v-if="isRecent(r)"
             class="bi bi-clock-history cp-item-recent"
             title="Recently viewed"
             aria-hidden="true"
           ></i>
+          <i
+            v-if="panelState(r)"
+            :class="['bi', panelState(r).icon, 'cp-item-status']"
+            :title="panelState(r).label"
+            aria-hidden="true"
+          ></i>
+          <span v-if="panelState(r)" class="visually-hidden">({{ panelState(r).label }})</span>
           <span v-if="r.meta.shortcut" class="cp-item-shortcut">{{ r.meta.shortcut }}</span>
-          <span class="cp-item-group">{{ r.meta.group }}</span>
+          <span class="cp-item-group">{{ routeGroup(r) }}</span>
         </li>
       </ul>
       <div v-if="!results.length" class="cp-empty">No panels match "{{ query }}"</div>
@@ -373,6 +411,17 @@ defineExpose({focusInput})
   color: var(--bootui-green, #198754);
   flex-shrink: 0;
   font-size: 0.85rem;
+}
+
+.cp-item-status {
+  color: var(--bootui-text-subtle, #5b6b80);
+  flex-shrink: 0;
+  font-size: 0.85rem;
+}
+
+.cp-item--unavailable .cp-item-title {
+  color: var(--bootui-text-subtle, #5b6b80);
+  font-style: italic;
 }
 
 .cp-section-label {


### PR DESCRIPTION
## Summary

- make command search use the injected panel manifest, platform-aware labels, and the sidebar's explicit disabled/unavailable policy
- add reactive `Panel · Application · BootUI` document titles without another request
- add a final hash-router Not Found view with Overview and command-search recovery, including custom mounts

## Stack

- Based on #721 (`jdubois-ui-accessibility-a3`)

## Validation

- 645 Vitest tests
- packaged Spring sample build with isolated Maven repository
- 13 app-shell Playwright tests
- custom-path unknown-hash Playwright coverage
- frontend and e2e Prettier checks