### PR TITLE
fix(ui): harden responsive and reduced-motion behavior

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/responsive-accessibility.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/responsive-accessibility.spec.js
@@ -1,0 +1,103 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+async function useTwoHundredPercentText(page) {
+  await page.addStyleTag({content: 'html { font-size: 200% !important; }'})
+}
+
+async function expectOwnedHorizontalOverflow(page, tableSelector) {
+  await expect(page.locator(tableSelector).first()).toBeVisible()
+  const layout = await page.evaluate((selector) => {
+    const documentScroller = document.scrollingElement
+    const workspace = document.querySelector('.bootui-workspace')
+    const table = document.querySelector(selector)
+    const scrollRegion = table?.closest('.table-responsive')
+    if (!documentScroller || !workspace || !table || !scrollRegion)
+      throw new Error(`Missing layout node for ${selector}`)
+
+    return {
+      documentOverflows: documentScroller.scrollWidth > documentScroller.clientWidth + 1,
+      workspaceOverflows: workspace.scrollWidth > workspace.clientWidth + 1,
+      tableOverflowX: getComputedStyle(scrollRegion).overflowX,
+      tableScrolls: scrollRegion.scrollWidth > scrollRegion.clientWidth + 1
+    }
+  }, tableSelector)
+
+  expect(layout.documentOverflows).toBe(false)
+  expect(layout.workspaceOverflows).toBe(false)
+  expect(layout.tableOverflowX).toBe('auto')
+  expect(layout.tableScrolls).toBe(true)
+}
+
+async function expectMobileTarget(page, locator) {
+  const bounds = await locator.boundingBox()
+  if (!bounds) throw new Error('Expected a visible mobile interaction target')
+  expect(bounds.width).toBeGreaterThanOrEqual(44)
+  expect(bounds.height).toBeGreaterThanOrEqual(44)
+}
+
+test.describe('responsive accessibility', () => {
+  test.use({viewport: {width: 320, height: 720}})
+
+  test('keeps Flyway tables and actions reachable at 320px with 200% text', async ({openView, page}) => {
+    await openView('flyway', 'Flyway migrations')
+    await useTwoHundredPercentText(page)
+
+    await expectOwnedHorizontalOverflow(page, '.flyway-migrations-table')
+    await expectMobileTarget(page, page.getByRole('button', {name: 'Migrate'}).first())
+  })
+
+  test('keeps Liquibase tables and actions reachable at 320px with 200% text', async ({openView, page}) => {
+    await openView('liquibase', 'Liquibase change sets')
+    await useTwoHundredPercentText(page)
+
+    await expectOwnedHorizontalOverflow(page, '.liquibase-changesets-table')
+    await expectMobileTarget(page, page.getByRole('button', {name: 'Update'}).first())
+  })
+
+  test('keeps Spring Data methods and repository controls reachable at 320px with 200% text', async ({
+    openView,
+    page
+  }) => {
+    await openView('data', 'Spring Data repositories')
+    await useTwoHundredPercentText(page)
+
+    const repository = page.locator('.list-group-item-action', {hasText: 'ProductRepository'})
+    await expectMobileTarget(page, repository)
+    await repository.click()
+    await expect(page.locator('.data-methods-table')).toBeVisible()
+    await expectOwnedHorizontalOverflow(page, '.data-methods-table')
+  })
+
+  test('selectively removes motion while leaving busy and progress state visible', async ({page}) => {
+    await page.emulateMedia({reducedMotion: 'reduce'})
+    await page.goto('/bootui/')
+
+    const motion = await page.evaluate(() => {
+      const spinner = document.createElement('span')
+      spinner.className = 'spinner-border'
+      spinner.setAttribute('aria-hidden', 'true')
+      const progress = document.createElement('div')
+      progress.className = 'progress-bar'
+      progress.style.width = '60%'
+      document.body.append(spinner, progress)
+
+      const sidebar = document.querySelector('.bootui-sidebar')
+      return {
+        reduced: matchMedia('(prefers-reduced-motion: reduce)').matches,
+        sidebarTransition: sidebar ? getComputedStyle(sidebar).transitionDuration : null,
+        spinnerAnimation: getComputedStyle(spinner).animationName,
+        progressTransition: getComputedStyle(progress).transitionDuration,
+        progressWidth: getComputedStyle(progress).width
+      }
+    })
+
+    expect(motion).toMatchObject({
+      reduced: true,
+      sidebarTransition: '0s',
+      spinnerAnimation: 'none',
+      progressTransition: '0s'
+    })
+    expect(Number.parseFloat(motion.progressWidth)).toBeGreaterThan(0)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1339,6 +1339,22 @@ function onGlobalKeydown(e) {
   transition: width 500ms ease;
 }
 
+:global(.bootui-table-scroll) {
+  max-width: 100%;
+  overscroll-behavior-inline: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+:global(.bootui-data-table) {
+  min-width: var(--bootui-table-min-width, 42rem);
+}
+
+:global(.bootui-break-anywhere) {
+  overflow-wrap: anywhere;
+  white-space: normal;
+  word-break: break-word;
+}
+
 .bootui-shell {
   color: var(--bootui-text);
   display: flex;
@@ -1803,6 +1819,7 @@ function onGlobalKeydown(e) {
   flex-direction: column;
   height: 100vh;
   min-width: 0;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 
@@ -2000,8 +2017,19 @@ function onGlobalKeydown(e) {
 
 @media (max-width: 575.98px) {
   .topbar {
+    align-items: stretch;
+    flex-direction: column;
     padding-left: 1rem;
     padding-right: 1rem;
+  }
+
+  .topbar-actions {
+    justify-content: flex-start;
+  }
+
+  .topbar-title,
+  .topbar-subtitle {
+    overflow-wrap: anywhere;
   }
 
   .content-stage,
@@ -2009,16 +2037,67 @@ function onGlobalKeydown(e) {
     padding-left: 1rem;
     padding-right: 1rem;
   }
+
+  :global(button),
+  :global(a.btn),
+  :global(summary),
+  :global(.form-control-sm),
+  :global(.form-select-sm) {
+    min-block-size: 44px;
+    min-inline-size: 44px;
+  }
+
+  :global(.form-check-input) {
+    min-block-size: 44px;
+    min-inline-size: 44px;
+    margin-top: 0;
+  }
+
+  :global(.form-check) {
+    min-block-size: 44px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
+  :global(html) {
     scroll-behavior: auto !important;
-    transition-duration: 0.01ms !important;
+  }
+
+  .bootui-sidebar,
+  .bootui-sidebar--drawer,
+  .bootui-nav-backdrop,
+  .flyout-fade-enter-active,
+  .flyout-fade-leave-active,
+  .page-slide-enter-active,
+  .page-slide-leave-active,
+  .brand-card,
+  .contribute-card,
+  .bootui-nav-link,
+  .bootui-nav-group__toggle,
+  .sidebar-toggle,
+  .nav-hamburger,
+  .cp-trigger,
+  .theme-toggle,
+  :global(.card),
+  :global(.btn),
+  :global(.progress-bar),
+  :global(.spinner-border),
+  :global(.spinner-grow),
+  :global(.spin) {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  .page-slide-enter-from,
+  .page-slide-leave-to,
+  .flyout-fade-enter-from,
+  .flyout-fade-leave-to,
+  .brand-card:hover,
+  .contribute-card:hover,
+  .bootui-nav-link:hover,
+  .bootui-nav-group__toggle:hover,
+  .bootui-nav-group__toggle.active {
+    transform: none;
   }
 }
 

--- a/bootui-ui/src/main/frontend/src/responsiveMotion.test.js
+++ b/bootui-ui/src/main/frontend/src/responsiveMotion.test.js
@@ -1,0 +1,90 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {parse as parseTemplate} from '@vue/compiler-dom'
+import {parse as parseSfc} from '@vue/compiler-sfc'
+import {describe, expect, it} from 'vitest'
+
+const sourceRoot = path.dirname(fileURLToPath(import.meta.url))
+
+function vueFiles(directory) {
+  return fs.readdirSync(directory, {withFileTypes: true}).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) return vueFiles(entryPath)
+    return entry.name.endsWith('.vue') ? [entryPath] : []
+  })
+}
+
+function staticClasses(node) {
+  const classAttribute = node.props?.find((property) => property.type === 6 && property.name === 'class')
+  return new Set(classAttribute?.value?.content.split(/\s+/).filter(Boolean) ?? [])
+}
+
+function uncontainedTables(template, lineOffset = 0) {
+  const issues = []
+  const ast = parseTemplate(template)
+
+  function visit(node, ancestors = []) {
+    if (node.type === 1) {
+      if (node.tag === 'table' && !ancestors.some((ancestor) => staticClasses(ancestor).has('table-responsive'))) {
+        issues.push(`line ${lineOffset + node.loc.start.line}: table has no responsive scroll container`)
+      }
+      node.children.forEach((child) => visit(child, [...ancestors, node]))
+      return
+    }
+    node.children?.forEach((child) => visit(child, ancestors))
+  }
+
+  visit(ast)
+  return issues
+}
+
+function cssBlock(source, header) {
+  const headerIndex = source.indexOf(header)
+  const openingBrace = source.indexOf('{', headerIndex)
+  if (headerIndex < 0 || openingBrace < 0) return null
+
+  let depth = 0
+  for (let index = openingBrace; index < source.length; index += 1) {
+    if (source[index] === '{') depth += 1
+    if (source[index] === '}') depth -= 1
+    if (depth === 0) return source.slice(headerIndex, index + 1)
+  }
+  return null
+}
+
+describe('responsive and motion contracts', () => {
+  it('contains every data table in an owned responsive scroll region', () => {
+    const issues = vueFiles(sourceRoot).flatMap((file) => {
+      const {descriptor} = parseSfc(fs.readFileSync(file, 'utf8'), {filename: file})
+      if (!descriptor.template) return []
+      return uncontainedTables(descriptor.template.content, descriptor.template.loc.start.line - 1).map(
+        (issue) => `${path.relative(sourceRoot, file)}:${issue}`
+      )
+    })
+
+    expect(issues).toEqual([])
+  })
+
+  it('uses selective reduced-motion rules instead of blanket near-zero timings', () => {
+    const sources = vueFiles(sourceRoot).map((file) => fs.readFileSync(file, 'utf8'))
+    const combined = sources.join('\n')
+    const appSource = fs.readFileSync(path.join(sourceRoot, 'App.vue'), 'utf8')
+
+    expect(combined).not.toMatch(/0\.0*1ms/)
+    expect(appSource).not.toMatch(/\*\s*,\s*\*::before\s*,\s*\*::after/)
+    expect(appSource).toContain(':global(.spinner-border)')
+    expect(appSource).toContain(':global(.progress-bar)')
+    expect(appSource).toContain('scroll-behavior: auto !important')
+  })
+
+  it('keeps desktop density while defining mobile-only 44px interaction targets', () => {
+    const appSource = fs.readFileSync(path.join(sourceRoot, 'App.vue'), 'utf8')
+    const mobileRules = cssBlock(appSource, '@media (max-width: 575.98px)')
+
+    expect(mobileRules).not.toBeNull()
+    expect(mobileRules).toContain('min-block-size: 44px')
+    expect(mobileRules).toContain('min-inline-size: 44px')
+    expect(appSource.replace(mobileRules, '')).not.toContain('44px')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -1383,6 +1383,13 @@ watch(
   z-index: 1;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .activity-tooltip {
+    transform: translateX(-50%);
+    transition: none;
+  }
+}
+
 .session-row-target:focus-visible {
   outline-offset: -3px;
 }

--- a/bootui-ui/src/main/frontend/src/views/Data.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Data.test.js
@@ -24,6 +24,26 @@ function repositoriesReport() {
   }
 }
 
+function repositoryDetail() {
+  return {
+    repositoryInterface: 'com.example.UserRepository',
+    storeModule: 'JPA',
+    domainType: 'com.example.User',
+    idType: 'java.lang.Long',
+    beanName: 'userRepository',
+    customImplementation: null,
+    methods: [
+      {
+        origin: 'ANNOTATED',
+        signature: 'findUsersWithAnIntentionallyLongMethodSignature(java.lang.String)',
+        query: 'select user from User user where user.displayName = :displayName',
+        namedQuery: null,
+        nativeQuery: false
+      }
+    ]
+  }
+}
+
 describe('Data', () => {
   let wrapper
 
@@ -66,5 +86,23 @@ describe('Data', () => {
     expect(wrapper.text()).not.toContain('not on the classpath')
     expect(wrapper.text()).toContain('UserRepository')
     expect(wrapper.text()).toContain('1 / 1 repositories')
+  })
+
+  it('contains long repository method values in a responsive table', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse(repositoriesReport()))
+        .mockResolvedValueOnce(jsonResponse(repositoryDetail()))
+    )
+
+    wrapper = mount(Data)
+    await flushPromises()
+    await wrapper.get('.list-group-item-action').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('.table-responsive.bootui-table-scroll .data-methods-table').exists()).toBe(true)
+    expect(wrapper.findAll('.data-methods-table .bootui-break-anywhere')).toHaveLength(2)
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Data.vue
+++ b/bootui-ui/src/main/frontend/src/views/Data.vue
@@ -136,10 +136,10 @@ onMounted(load)
               type="button"
               @click="open(r)"
             >
-              <div class="d-flex justify-content-between align-items-start">
-                <div>
+              <div class="d-flex justify-content-between align-items-start gap-2">
+                <div class="repository-summary">
                   <div>
-                    <strong>{{ shortName(r.repositoryInterface) }}</strong>
+                    <strong class="bootui-break-anywhere">{{ shortName(r.repositoryInterface) }}</strong>
                   </div>
                   <div class="small text-muted">
                     {{ shortName(r.domainType) }}
@@ -164,7 +164,7 @@ onMounted(load)
             <div class="card-body">
               <h5 class="card-title mb-1">{{ shortName(detail.repositoryInterface) }}</h5>
               <div class="text-muted small mb-3">
-                <code>{{ detail.repositoryInterface }}</code>
+                <code class="bootui-break-anywhere">{{ detail.repositoryInterface }}</code>
               </div>
               <dl class="row mb-3 small">
                 <dt class="col-sm-3">Store module</dt>
@@ -173,20 +173,20 @@ onMounted(load)
                 </dd>
                 <dt class="col-sm-3">Domain type</dt>
                 <dd class="col-sm-9">
-                  <code>{{ detail.domainType }}</code>
+                  <code class="bootui-break-anywhere">{{ detail.domainType }}</code>
                 </dd>
                 <dt class="col-sm-3">ID type</dt>
                 <dd class="col-sm-9">
-                  <code>{{ detail.idType }}</code>
+                  <code class="bootui-break-anywhere">{{ detail.idType }}</code>
                 </dd>
                 <dt class="col-sm-3">Bean name</dt>
                 <dd class="col-sm-9">
-                  <code>{{ detail.beanName }}</code>
+                  <code class="bootui-break-anywhere">{{ detail.beanName }}</code>
                 </dd>
                 <template v-if="detail.customImplementation">
                   <dt class="col-sm-3">Base class</dt>
                   <dd class="col-sm-9">
-                    <code>{{ detail.customImplementation }}</code>
+                    <code class="bootui-break-anywhere">{{ detail.customImplementation }}</code>
                   </dd>
                 </template>
               </dl>
@@ -194,31 +194,35 @@ onMounted(load)
               <h6 class="mb-2">
                 Methods <span class="badge bg-secondary">{{ detail.methods.length }}</span>
               </h6>
-              <table class="table table-sm table-hover">
-                <thead>
-                  <tr>
-                    <th style="width: 110px">Origin</th>
-                    <th>Signature</th>
-                    <th>Query</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="m in detail.methods" :key="m.signature">
-                    <td>
-                      <span :class="originClass(m.origin)" class="badge">{{ m.origin }}</span>
-                    </td>
-                    <td>
-                      <code>{{ m.signature }}</code>
-                    </td>
-                    <td>
-                      <code v-if="m.query" class="small">{{ m.query }}</code>
-                      <span v-else-if="m.namedQuery" class="small text-muted">named: {{ m.namedQuery }}</span>
-                      <span v-else class="text-muted small">—</span>
-                      <span v-if="m.nativeQuery" class="badge bg-warning text-dark ms-1">native</span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              <div class="table-responsive bootui-table-scroll">
+                <table class="table table-sm table-hover bootui-data-table data-methods-table">
+                  <thead>
+                    <tr>
+                      <th style="width: 110px">Origin</th>
+                      <th>Signature</th>
+                      <th>Query</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="m in detail.methods" :key="m.signature">
+                      <td>
+                        <span :class="originClass(m.origin)" class="badge">{{ m.origin }}</span>
+                      </td>
+                      <td>
+                        <code class="bootui-break-anywhere">{{ m.signature }}</code>
+                      </td>
+                      <td>
+                        <code v-if="m.query" class="small bootui-break-anywhere">{{ m.query }}</code>
+                        <span v-else-if="m.namedQuery" class="small text-muted bootui-break-anywhere"
+                          >named: {{ m.namedQuery }}</span
+                        >
+                        <span v-else class="text-muted small">—</span>
+                        <span v-if="m.nativeQuery" class="badge bg-warning text-dark ms-1">native</span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
         </div>
@@ -226,3 +230,13 @@ onMounted(load)
     </template>
   </div>
 </template>
+
+<style scoped>
+.repository-summary {
+  min-width: 0;
+}
+
+.data-methods-table {
+  --bootui-table-min-width: 42rem;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -364,16 +364,18 @@ async function responseMessage(res) {
               <div v-if="detailEntries(selected).length === 0" class="text-muted small">
                 No connection detail values exposed.
               </div>
-              <table v-else class="table table-sm">
-                <tbody>
-                  <tr v-for="[key, value] in detailEntries(selected)" :key="key">
-                    <th class="text-nowrap small">{{ key }}</th>
-                    <td>
-                      <code>{{ value ?? '—' }}</code>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              <div v-else class="table-responsive bootui-table-scroll">
+                <table class="table table-sm">
+                  <tbody>
+                    <tr v-for="[key, value] in detailEntries(selected)" :key="key">
+                      <th class="text-nowrap small">{{ key }}</th>
+                      <td>
+                        <code>{{ value ?? '—' }}</code>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
 
               <template v-if="logs">
                 <div class="d-flex justify-content-between align-items-center mt-3">

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -308,4 +308,10 @@ onUnmounted(clearReconnectTimer)
     transform: rotate(360deg);
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .spin {
+    animation: none;
+  }
+}
 </style>

--- a/bootui-ui/src/main/frontend/src/views/Flyway.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Flyway.test.js
@@ -76,5 +76,7 @@ describe('Flyway', () => {
     expect(wrapper.text()).not.toContain('not on the classpath')
     expect(wrapper.text()).toContain('migration(s) across')
     expect(wrapper.text()).toContain('V1__init.sql')
+    expect(wrapper.get('.table-responsive.bootui-table-scroll .flyway-migrations-table').exists()).toBe(true)
+    expect(wrapper.get('code.bootui-break-anywhere').text()).toBe('dataSource')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Flyway.vue
+++ b/bootui-ui/src/main/frontend/src/views/Flyway.vue
@@ -148,11 +148,11 @@ onMounted(load)
       </div>
 
       <div v-for="db in databases" :key="db.name" class="card mb-3">
-        <div class="card-header d-flex justify-content-between align-items-center">
+        <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <span>
-            <i class="bi bi-database me-1"></i><code>{{ db.name }}</code>
+            <i class="bi bi-database me-1"></i><code class="bootui-break-anywhere">{{ db.name }}</code>
           </span>
-          <span class="small">
+          <span class="small d-flex flex-wrap align-items-center gap-1">
             <span class="me-2"
               >Current: <strong>{{ db.currentVersion || '—' }}</strong></span
             >
@@ -187,39 +187,47 @@ onMounted(load)
           </div>
         </div>
         <div class="card-body p-0">
-          <table class="table table-sm table-hover mb-0">
-            <thead>
-              <tr>
-                <th style="width: 110px">Version</th>
-                <th>Description</th>
-                <th>Type</th>
-                <th>State</th>
-                <th>Installed on</th>
-                <th class="text-end">Exec (ms)</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="m in db.migrations" :key="(m.version || '') + m.script">
-                <td>
-                  <code>{{ m.version || '—' }}</code>
-                </td>
-                <td>
-                  {{ m.description }}
-                  <div class="small text-muted">
-                    <code>{{ m.script }}</code>
-                  </div>
-                </td>
-                <td>{{ m.type }}</td>
-                <td>
-                  <span :class="stateClass(m.state)" class="badge">{{ m.state }}</span>
-                </td>
-                <td class="small">{{ m.installedOn || '—' }}</td>
-                <td class="text-end small">{{ m.executionTime != null ? m.executionTime : '—' }}</td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="table-responsive bootui-table-scroll">
+            <table class="table table-sm table-hover mb-0 bootui-data-table flyway-migrations-table">
+              <thead>
+                <tr>
+                  <th style="width: 110px">Version</th>
+                  <th>Description</th>
+                  <th>Type</th>
+                  <th>State</th>
+                  <th>Installed on</th>
+                  <th class="text-end">Exec (ms)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="m in db.migrations" :key="(m.version || '') + m.script">
+                  <td>
+                    <code>{{ m.version || '—' }}</code>
+                  </td>
+                  <td>
+                    {{ m.description }}
+                    <div class="small text-muted">
+                      <code class="bootui-break-anywhere">{{ m.script }}</code>
+                    </div>
+                  </td>
+                  <td>{{ m.type }}</td>
+                  <td>
+                    <span :class="stateClass(m.state)" class="badge">{{ m.state }}</span>
+                  </td>
+                  <td class="small">{{ m.installedOn || '—' }}</td>
+                  <td class="text-end small">{{ m.executionTime != null ? m.executionTime : '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </template>
   </div>
 </template>
+
+<style scoped>
+.flyway-migrations-table {
+  --bootui-table-min-width: 44rem;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.vue
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.vue
@@ -339,35 +339,37 @@ onBeforeUnmount(() => {
                 <div class="fw-semibold text-body">No classes match the current filter</div>
                 <div>Clear the class prefix filter or turn off the smart filter to show matching classes.</div>
               </div>
-              <table v-else class="table table-sm align-middle mb-0">
-                <thead>
-                  <tr>
-                    <th scope="col" class="text-end">#</th>
-                    <th scope="col">Class</th>
-                    <th scope="col" class="text-end">Instances</th>
-                    <th scope="col" class="w-25">{{ smartFilter === 'big-objects' ? 'Per object' : 'Retained' }}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="entry in report.topClasses" :key="entry.rank">
-                    <td class="text-end text-muted">{{ entry.rank }}</td>
-                    <td class="font-monospace text-break">{{ entry.className }}</td>
-                    <td class="text-end">{{ formatNumber(entry.instances) }}</td>
-                    <td>
-                      <div class="d-flex align-items-center gap-2">
-                        <div
-                          class="progress flex-grow-1"
-                          role="img"
-                          :aria-label="`${entry.className}: ${barLabel(entry)}`"
-                        >
-                          <div class="progress-bar text-bg-primary" :style="{width: classWidth(entry)}"></div>
+              <div v-else class="table-responsive bootui-table-scroll">
+                <table class="table table-sm align-middle mb-0 bootui-data-table heap-histogram-table">
+                  <thead>
+                    <tr>
+                      <th scope="col" class="text-end">#</th>
+                      <th scope="col">Class</th>
+                      <th scope="col" class="text-end">Instances</th>
+                      <th scope="col" class="w-25">{{ smartFilter === 'big-objects' ? 'Per object' : 'Retained' }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="entry in report.topClasses" :key="entry.rank">
+                      <td class="text-end text-muted">{{ entry.rank }}</td>
+                      <td class="font-monospace text-break">{{ entry.className }}</td>
+                      <td class="text-end">{{ formatNumber(entry.instances) }}</td>
+                      <td>
+                        <div class="d-flex align-items-center gap-2">
+                          <div
+                            class="progress flex-grow-1"
+                            role="img"
+                            :aria-label="`${entry.className}: ${barLabel(entry)}`"
+                          >
+                            <div class="progress-bar text-bg-primary" :style="{width: classWidth(entry)}"></div>
+                          </div>
+                          <span class="small text-muted text-nowrap">{{ barLabel(entry) }}</span>
                         </div>
-                        <span class="small text-muted text-nowrap">{{ barLabel(entry) }}</span>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
           </div>
         </div>
@@ -450,3 +452,9 @@ onBeforeUnmount(() => {
     </template>
   </div>
 </template>
+
+<style scoped>
+.heap-histogram-table {
+  --bootui-table-min-width: 38rem;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/Liquibase.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Liquibase.test.js
@@ -74,6 +74,12 @@ describe('Liquibase', () => {
     expect(wrapper.text()).not.toContain('not on the classpath')
     expect(wrapper.text()).toContain('change set(s) across')
     expect(wrapper.text()).toContain('create-users')
+    expect(wrapper.get('.table-responsive.bootui-table-scroll .liquibase-changesets-table').exists()).toBe(true)
+    expect(wrapper.findAll('code.bootui-break-anywhere').map((node) => node.text())).toEqual([
+      'dataSource',
+      'create-users',
+      'db/changelog.xml'
+    ])
   })
 
   it('shows Quarkus-specific copy when Liquibase is not configured on Quarkus', async () => {

--- a/bootui-ui/src/main/frontend/src/views/Liquibase.vue
+++ b/bootui-ui/src/main/frontend/src/views/Liquibase.vue
@@ -155,11 +155,11 @@ onMounted(load)
       </div>
 
       <div v-for="db in databases" :key="db.name" class="card mb-3">
-        <div class="card-header d-flex justify-content-between align-items-center">
+        <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <span>
-            <i class="bi bi-database me-1"></i><code>{{ db.name }}</code>
+            <i class="bi bi-database me-1"></i><code class="bootui-break-anywhere">{{ db.name }}</code>
           </span>
-          <span>
+          <span class="d-flex flex-wrap align-items-center gap-1">
             <span class="badge bg-success me-1">{{ db.applied }} applied</span>
             <span v-if="db.pending > 0" class="badge bg-warning text-dark">{{ db.pending }} pending</span>
           </span>
@@ -181,38 +181,46 @@ onMounted(load)
           </div>
         </div>
         <div class="card-body p-0">
-          <table class="table table-sm table-hover mb-0">
-            <thead>
-              <tr>
-                <th style="width: 60px">#</th>
-                <th>Id</th>
-                <th>Author</th>
-                <th>Change log</th>
-                <th>Exec type</th>
-                <th>Executed</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr v-for="c in db.changeSets" :key="c.changeLog + '-' + c.id + '-' + c.author + '-' + c.execType">
-                <td class="small text-muted">{{ c.orderExecuted != null ? c.orderExecuted : '—' }}</td>
-                <td>
-                  <code>{{ c.id }}</code>
-                  <span v-if="c.tag" class="badge bg-primary ms-1">{{ c.tag }}</span>
-                  <div v-if="c.description" class="small text-muted">{{ c.description }}</div>
-                </td>
-                <td class="small">{{ c.author }}</td>
-                <td class="small">
-                  <code>{{ c.changeLog }}</code>
-                </td>
-                <td>
-                  <span :class="execClass(c.execType)" class="badge">{{ c.execType }}</span>
-                </td>
-                <td class="small">{{ c.dateExecuted || '—' }}</td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="table-responsive bootui-table-scroll">
+            <table class="table table-sm table-hover mb-0 bootui-data-table liquibase-changesets-table">
+              <thead>
+                <tr>
+                  <th style="width: 60px">#</th>
+                  <th>Id</th>
+                  <th>Author</th>
+                  <th>Change log</th>
+                  <th>Exec type</th>
+                  <th>Executed</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="c in db.changeSets" :key="c.changeLog + '-' + c.id + '-' + c.author + '-' + c.execType">
+                  <td class="small text-muted">{{ c.orderExecuted != null ? c.orderExecuted : '—' }}</td>
+                  <td>
+                    <code class="bootui-break-anywhere">{{ c.id }}</code>
+                    <span v-if="c.tag" class="badge bg-primary ms-1">{{ c.tag }}</span>
+                    <div v-if="c.description" class="small text-muted">{{ c.description }}</div>
+                  </td>
+                  <td class="small">{{ c.author }}</td>
+                  <td class="small">
+                    <code class="bootui-break-anywhere">{{ c.changeLog }}</code>
+                  </td>
+                  <td>
+                    <span :class="execClass(c.execType)" class="badge">{{ c.execType }}</span>
+                  </td>
+                  <td class="small">{{ c.dateExecuted || '—' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </template>
   </div>
 </template>
+
+<style scoped>
+.liquibase-changesets-table {
+  --bootui-table-min-width: 48rem;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -570,14 +570,4 @@ onActivated(refreshScores)
 .scanner-score--secondary {
   color: var(--bootui-text-muted);
 }
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-}
 </style>

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.test.js
@@ -30,6 +30,22 @@ describe('PanelHeader', () => {
     wrapper.unmount()
   })
 
+  it('communicates refresh activity when reduced motion leaves the icon static', () => {
+    const wrapper = mount(PanelHeader, {
+      props: {
+        title: 'Health',
+        loading: true,
+        onRefresh: vi.fn()
+      }
+    })
+
+    const refresh = wrapper.get('button[title="Refresh"]')
+    expect(refresh.attributes('aria-busy')).toBe('true')
+    expect(refresh.attributes('aria-label')).toBe('Refreshing panel')
+
+    wrapper.unmount()
+  })
+
   it('renders shared auto-refresh controls and emits auto-refresh updates', async () => {
     const onUpdateAutoRefresh = vi.fn()
     const wrapper = mount(PanelHeader, {

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
@@ -85,6 +85,8 @@ onBeforeUnmount(stopRelativeTimer)
       />
       <button
         v-if="hasRefresh"
+        :aria-busy="loading || undefined"
+        :aria-label="loading ? 'Refreshing panel' : 'Refresh panel'"
         :disabled="loading"
         class="btn btn-outline-secondary btn-sm"
         title="Refresh"
@@ -148,5 +150,11 @@ onBeforeUnmount(stopRelativeTimer)
 .spin {
   animation: spin 900ms linear infinite;
   display: inline-block;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spin {
+    animation: none;
+  }
 }
 </style>

--- a/bootui-ui/src/main/frontend/src/views/components/PanelSkeleton.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelSkeleton.vue
@@ -39,4 +39,11 @@ defineProps({
   height: 1.4rem;
   width: 40%;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-line {
+    animation: none;
+    background-position: 50% 0;
+  }
+}
 </style>

--- a/bootui-ui/src/main/frontend/src/views/components/SpinnerButton.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/SpinnerButton.test.js
@@ -16,6 +16,7 @@ describe('SpinnerButton', () => {
     const wrapper = mount(SpinnerButton, {
       props: {loading: true, label: 'Run checks', loadingLabel: 'Running...'}
     })
+    expect(wrapper.get('button').attributes('aria-busy')).toBe('true')
     expect(wrapper.find('.spinner-border').exists()).toBe(true)
     expect(wrapper.text()).toBe('Running...')
   })

--- a/bootui-ui/src/main/frontend/src/views/components/SpinnerButton.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/SpinnerButton.vue
@@ -14,7 +14,7 @@ defineProps({
 </script>
 
 <template>
-  <button type="button">
+  <button :aria-busy="loading || undefined" type="button">
     <span v-if="loading" aria-hidden="true" :class="['spinner-border spinner-border-sm', spinnerClass]"></span>
     <i v-else-if="icon" :class="['bi', icon, 'me-1']"></i>
     <slot>{{ loading && loadingLabel !== null ? loadingLabel : label }}</slot>


### PR DESCRIPTION
## Summary
- stack B6 on #722 and contain every frontend data table in an owned responsive scroll region
- add reusable dense-table and long-identifier wrapping utilities, including Flyway, Liquibase, Spring Data, Dev Services, and Heap Dump gaps
- enforce mobile-only 44x44 interaction targets and reflow the top bar at phone widths without changing desktop density
- replace blanket 0.01ms motion suppression with selective reduced-motion rules that keep static busy, progress, and state communication visible

## Responsive audit
- audited all 45 table instances across 33 views/components; the regression test now requires every literal table to have a responsive ancestor
- verified Flyway, Liquibase, and Spring Data at 320 CSS px with 200% text scaling: no document/workspace horizontal overflow, table content remains independently scrollable, and primary controls remain at least 44x44
- long scripts, change-log paths, repository types, signatures, and queries wrap deliberately instead of forcing page width

## Validation
- Impeccable detector: no findings on changed targets
- full Vitest: 83 files, 645 tests passed
- packaged Spring sample UI: Maven install passed
- affected Playwright: app shell/mobile/table panel coverage passed; dedicated responsive/reduced-motion suite 4/4 passed
- frontend and e2e Prettier checks passed