### PR TITLE
Deepen cross-runtime API conformance

### DIFF
--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
@@ -6,6 +6,10 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.ActionContract;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.JsonType;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.ReadContract;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,10 +36,10 @@ import org.junit.jupiter.api.Test;
  * {@link #baseUrl()}, and (optionally) overrides {@link #expectedPanelsResource()} to declare the
  * panel manifest its platform ships.
  *
- * <p>The assertions here are deliberately framework-neutral: they verify the panel manifest contract
- * and that every panel the manifest reports as available answers its primary GET with JSON, plus the
- * transport-level CSRF defense. Fine-grained per-endpoint payloads stay covered by each adapter's own
- * unit/controller tests; this suite locks the cross-adapter contract.
+ * <p>The assertions here are deliberately framework-neutral: they verify the panel manifest, apply
+ * maintainable DTO-family shape and semantic contracts to every available panel, exercise canonical
+ * action outcomes, and pin the transport safety floor. Runtime values may vary; field types, null/empty
+ * semantics, masking, stable statuses, and error bodies may not.
  */
 public abstract class AbstractBootUiApiConformanceTest {
 
@@ -71,68 +75,6 @@ public abstract class AbstractBootUiApiConformanceTest {
     private static final Pattern BUILT_ASSET =
             Pattern.compile("(?:src|href)=\"\\./(assets/[^\"]+-[A-Za-z0-9_-]{8,}\\.[^\"]+)\"");
 
-    /**
-     * Panels whose primary data lives at a plain {@code GET /bootui/api/<id>} and must answer 200 with
-     * JSON whenever the manifest reports them available and enabled. Scan-first and action-capable panels
-     * remain safe to include because their root GETs only return the current report/state; this inventory
-     * never invokes a scan, network call, file capture, or other mutation.
-     */
-    private static final Set<String> DATA_PANEL_ROOT_GETS = Set.of(
-            "overview",
-            "health",
-            "metrics",
-            "live-memory",
-            "jvm-tuning",
-            "heap-dump",
-            "threads",
-            "memory",
-            "startup",
-            "graalvm",
-            "config",
-            "profile-diff",
-            "loggers",
-            "beans",
-            "conditions",
-            "spring-security",
-            "scheduled",
-            "hibernate",
-            "security",
-            "pentesting",
-            "spring",
-            "cache",
-            "exceptions",
-            "http-exchanges",
-            "security-logs",
-            "http-sessions",
-            "traces",
-            "architecture",
-            "rest-api",
-            "vulnerabilities",
-            "dev-services",
-            "devtools",
-            "github",
-            "crac",
-            "sql-trace",
-            "rest-client-trace",
-            "mcp-server",
-            "email",
-            "kafka",
-            "rabbitmq",
-            "jms",
-            "activity");
-
-    /** Panels whose primary data lives at a nested path instead of the root {@code GET /bootui/api/<id>}. */
-    private static final Map<String, String> NESTED_GET_PATHS = Map.ofEntries(
-            Map.entry("data", "/bootui/api/data/repositories"),
-            Map.entry("ai", "/bootui/api/ai/overview"),
-            Map.entry("log-tail", "/bootui/api/log-tail/recent"),
-            Map.entry("mappings", "/bootui/api/mappings/flat"),
-            Map.entry("copilot", "/bootui/api/copilot/dashboard"),
-            Map.entry("claude-code", "/bootui/api/claude-code/dashboard"),
-            Map.entry("flyway", "/bootui/api/flyway/migrations"),
-            Map.entry("liquibase", "/bootui/api/liquibase/changesets"),
-            Map.entry("database-connection-pools", "/bootui/api/database-connection-pools/pools"));
-
     /** Panels that intentionally have no safe GET because their API is an action form. */
     private static final Set<String> ACTION_ONLY_PANELS = Set.of("http-probe");
 
@@ -141,8 +83,8 @@ public abstract class AbstractBootUiApiConformanceTest {
      * path is the well-known action endpoint for the confirmation gate test.
      */
     private static final Map<String, String> CONFIRMATION_ACTION_PATHS = Map.of(
-            "flyway", "/bootui/api/flyway/migrate",
-            "liquibase", "/bootui/api/liquibase/update");
+            "flyway", "/flyway/migrate",
+            "liquibase", "/liquibase/update");
 
     /** Base URL of the booted app under test, e.g. {@code http://localhost:54321} (no trailing slash). */
     protected abstract String baseUrl();
@@ -152,16 +94,52 @@ public abstract class AbstractBootUiApiConformanceTest {
         return DEFAULT_EXPECTED_PANELS;
     }
 
+    /** Runtime adapter exercised by this concrete consumer. */
+    protected Runtime runtime() {
+        return Runtime.SPRING_MVC;
+    }
+
+    /** Registry action-capable panels that intentionally expose no write route on this runtime. */
+    protected Set<String> actionlessPanels() {
+        return Set.of();
+    }
+
+    /**
+     * Available panels whose configured-path transport is supplied by a pending sibling adapter change.
+     * Concrete custom-mount consumers may exclude only those known transport gaps.
+     */
+    protected Set<String> unsupportedReadContracts() {
+        return Set.of();
+    }
+
+    /** Browser-visible UI mount, including any host application root path. */
+    protected String uiPath() {
+        return "/bootui";
+    }
+
+    /** Browser-visible API mount, including any host application root path. */
+    protected String apiPath() {
+        return "/bootui/api";
+    }
+
     private BootUiHttpProbe probe() {
         return new BootUiHttpProbe(baseUrl());
+    }
+
+    private String api(String relativePath) {
+        return apiPath() + relativePath;
+    }
+
+    private String ui(String relativePath) {
+        return uiPath() + relativePath;
     }
 
     @Test
     void panelsManifestMatchesExpectedContract() {
         List<ExpectedPanel> expected = loadExpectedPanels();
 
-        Response response = probe().get("/bootui/api/panels");
-        assertThat(response.status()).as("GET /bootui/api/panels status").isEqualTo(200);
+        Response response = probe().get(api("/panels"));
+        assertThat(response.status()).as("GET %s/panels status", apiPath()).isEqualTo(200);
         assertThat(response.isJson())
                 .as("GET /bootui/api/panels content-type (%s)", response.contentType())
                 .isTrue();
@@ -201,47 +179,51 @@ public abstract class AbstractBootUiApiConformanceTest {
     }
 
     @Test
-    void availablePanelsAnswerTheirPrimaryGet() {
-        Response manifest = probe().get("/bootui/api/panels");
-        assertThat(manifest.status()).as("GET /bootui/api/panels status").isEqualTo(200);
+    void availablePanelsMatchTheirDtoFamilyContracts() {
+        Response manifest = probe().get(api("/panels"));
+        assertThat(manifest.status()).as("GET %s/panels status", apiPath()).isEqualTo(200);
 
+        Map<String, ReadContract> contracts = BootUiApiContractCatalog.readsByPanel();
         List<String> failures = new ArrayList<>();
         for (JsonNode panel : manifest.json().get("panels")) {
             String id = panel.path("id").asText(null);
-            String path = DATA_PANEL_ROOT_GETS.contains(id) ? "/bootui/api/" + id : NESTED_GET_PATHS.get(id);
-            if (path == null
+            ReadContract contract = contracts.get(id);
+            if (contract == null
+                    || unsupportedReadContracts().contains(id)
                     || !panel.path("available").asBoolean(false)
                     || !panel.path("enabled").asBoolean(true)) {
                 continue;
             }
+            String path = api(contract.relativePath());
             Response response = probe().get(path);
             if (response.status() != 200) {
                 failures.add(id + " -> HTTP " + response.status());
             } else if (!response.isJson()) {
                 failures.add(id + " -> non-JSON content-type '" + response.contentType() + "'");
+            } else {
+                assertJsonContract(id, contract, response.json(), failures);
             }
         }
 
         if (!failures.isEmpty()) {
-            fail("Available panels whose primary GET regressed: " + failures);
+            fail("Available panel DTO contracts regressed: " + failures);
         }
     }
 
     @Test
     void endpointInventoryCoversEveryManifestPanel() {
-        JsonNode panels = probe().get("/bootui/api/panels").json().get("panels");
+        JsonNode panels = probe().get(api("/panels")).json().get("panels");
+        Map<String, ReadContract> contracts = BootUiApiContractCatalog.readsByPanel();
         List<String> missing = new ArrayList<>();
         panels.forEach(panel -> {
             String id = panel.path("id").asText(null);
-            if (!DATA_PANEL_ROOT_GETS.contains(id)
-                    && !NESTED_GET_PATHS.containsKey(id)
-                    && !ACTION_ONLY_PANELS.contains(id)) {
+            if (!contracts.containsKey(id) && !ACTION_ONLY_PANELS.contains(id)) {
                 missing.add(id);
             }
         });
 
         assertThat(missing)
-                .as("every manifest panel must declare its safe primary GET or be explicitly action-only")
+                .as("every manifest panel must declare a typed read contract or be explicitly action-only")
                 .isEmpty();
     }
 
@@ -261,8 +243,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         // is the black-box wire contract the SPA/e2e may key on, so a change to the constant must show up
         // here as a deliberate contract change rather than passing silently.
         Response rejected = probe().post(
-                        "/bootui/api/overview",
-                        Map.of("Origin", "http://evil.example.com", "Sec-Fetch-Site", "cross-site"));
+                        api("/overview"), Map.of("Origin", "http://evil.example.com", "Sec-Fetch-Site", "cross-site"));
         assertThat(rejected.status())
                 .as("cross-site POST to /bootui/api/overview must be rejected with 403")
                 .isEqualTo(403);
@@ -277,20 +258,20 @@ public abstract class AbstractBootUiApiConformanceTest {
 
     @Test
     void securityHeadersCoverShellAndHashedAssets() {
-        Response shell = probe().get("/bootui/");
-        assertThat(shell.status()).as("GET /bootui/ status").isEqualTo(200);
-        assertThat(shell.contentType()).as("GET /bootui/ content-type").containsIgnoringCase("text/html");
+        Response shell = probe().get(ui("/"));
+        assertThat(shell.status()).as("GET %s/ status", uiPath()).isEqualTo(200);
+        assertThat(shell.contentType()).as("GET %s/ content-type", uiPath()).containsIgnoringCase("text/html");
         assertSecurityHeaders(shell, NO_CACHE, true);
 
         Matcher asset = BUILT_ASSET.matcher(shell.body());
         assertThat(asset.find())
                 .as("packaged index.html must reference a content-hashed asset: %s", shell.body())
                 .isTrue();
-        Response builtAsset = probe().get("/bootui/" + asset.group(1));
+        Response builtAsset = probe().get(ui("/" + asset.group(1)));
         assertThat(builtAsset.status()).as("GET packaged hashed asset status").isEqualTo(200);
         assertSecurityHeaders(builtAsset, IMMUTABLE, false);
 
-        Response missingHashedAsset = probe().get("/bootui/assets/missing-C2x2BcDS.js");
+        Response missingHashedAsset = probe().get(ui("/assets/missing-C2x2BcDS.js"));
         assertThat(missingHashedAsset.status())
                 .as("GET missing hashed-looking asset status")
                 .isEqualTo(404);
@@ -299,21 +280,21 @@ public abstract class AbstractBootUiApiConformanceTest {
 
     @Test
     void securityHeadersCoverApiErrorsStreamsAndDownloads() {
-        Response api = probe().get("/bootui/api/overview");
+        Response api = probe().get(api("/overview"));
         assertThat(api.status()).as("GET overview status").isEqualTo(200);
         assertSecurityHeaders(api, NO_STORE, true);
 
-        Response error = probe().get("/bootui/api/this-route-does-not-exist");
+        Response error = probe().get(api("/this-route-does-not-exist"));
         assertThat(error.status()).as("unmatched BootUI API route status").isEqualTo(404);
         assertSecurityHeaders(error, NO_STORE, true);
 
-        Response stream = probe().getStreaming("/bootui/api/log-tail/stream");
+        Response stream = probe().getStreaming(api("/log-tail/stream"));
         assertThat(stream.status()).as("GET log-tail SSE stream status").isEqualTo(200);
         assertThat(stream.contentType()).as("GET log-tail SSE content-type").containsIgnoringCase("text/event-stream");
         assertSecurityHeaders(stream, NO_STORE, true);
 
         BootUiHttpProbe downloadProbe = probe();
-        Response download = downloadProbe.post("/bootui/api/threads/download", stateChangingHeaders(downloadProbe));
+        Response download = downloadProbe.post(api("/threads/download"), stateChangingHeaders(downloadProbe));
         assertThat(download.status()).as("POST thread-dump download status").isEqualTo(200);
         assertThat(download.headerValues("Content-Disposition"))
                 .as("download must have one attachment disposition")
@@ -330,7 +311,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         // it pins the fields the shell binds to, not their platform-varying values (so it asserts that
         // frameworkVersion is present, not its value, and never asserts the activation.localhostOnly
         // flag, which differs by platform).
-        Response response = probe().get("/bootui/api/overview");
+        Response response = probe().get(api("/overview"));
         assertThat(response.status()).as("GET /bootui/api/overview status").isEqualTo(200);
         assertThat(response.isJson())
                 .as("GET /bootui/api/overview content-type (%s)", response.contentType())
@@ -381,7 +362,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         String logger = "com.example.bootui.conformanceprobe";
         Map<String, String> headers = stateChangingHeaders(probe);
 
-        Response set = probe.request("POST", "/bootui/api/loggers/" + logger, headers, "{\"level\":\"DEBUG\"}");
+        Response set = probe.request("POST", api("/loggers/" + logger), headers, "{\"level\":\"DEBUG\"}");
         assertThat(set.status()).as("POST set-level status").isEqualTo(200);
         assertThat(set.isJson())
                 .as("POST set-level content-type (%s)", set.contentType())
@@ -395,7 +376,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                 .as("effective level after set")
                 .isEqualTo("DEBUG");
 
-        Response reset = probe.request("POST", "/bootui/api/loggers/" + logger, headers, "{\"level\":null}");
+        Response reset = probe.request("POST", api("/loggers/" + logger), headers, "{\"level\":null}");
         assertThat(reset.status()).as("POST reset-level status").isEqualTo(200);
         assertThat(isNull(reset.json().path("configuredLevel")))
                 .as("configured level must be null after a reset")
@@ -420,7 +401,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                 .as("conformance fixtures must set bootui.panels.copilot.enabled=false")
                 .isFalse();
 
-        Response response = probe().get("/bootui/api/" + disabledId);
+        Response response = probe().get(api("/" + disabledId));
         assertThat(response.status())
                 .as("GET /bootui/api/%s must be rejected with 403 when the panel is disabled", disabledId)
                 .isEqualTo(403);
@@ -457,7 +438,7 @@ public abstract class AbstractBootUiApiConformanceTest {
 
         BootUiHttpProbe probe = probe();
         Map<String, String> headers = stateChangingHeaders(probe);
-        Response response = probe.request("POST", "/bootui/api/heap-dump/capture", headers, "");
+        Response response = probe.request("POST", api("/heap-dump/capture"), headers, "");
         assertThat(response.status())
                 .as("POST /bootui/api/heap-dump/capture must be rejected with 403 when the panel is read-only")
                 .isEqualTo(403);
@@ -489,7 +470,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                 isPanelUsableInLiveManifest("architecture"), "architecture panel is not available in this environment");
 
         // 1. Initial GET – scan.status must be a string (typically NOT_SCANNED, but any status is valid).
-        Response initial = probe().get("/bootui/api/architecture");
+        Response initial = probe().get(api("/architecture"));
         assertThat(initial.status())
                 .as("GET /bootui/api/architecture initial status")
                 .isEqualTo(200);
@@ -503,7 +484,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         // 2. POST /scan – must return the fresh scan report; scannedAt proves the engine ran.
         BootUiHttpProbe probe = probe();
         Map<String, String> headers = stateChangingHeaders(probe);
-        Response scanResponse = probe.request("POST", "/bootui/api/architecture/scan", headers, "");
+        Response scanResponse = probe.request("POST", api("/architecture/scan"), headers, "");
         assertThat(scanResponse.status())
                 .as("POST /bootui/api/architecture/scan status")
                 .isEqualTo(200);
@@ -538,7 +519,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                     if (!start.await(10, TimeUnit.SECONDS)) {
                         throw new IllegalStateException("Timed out waiting to start concurrent architecture scans");
                     }
-                    return probe.request("POST", "/bootui/api/architecture/scan", headers, "");
+                    return probe.request("POST", api("/architecture/scan"), headers, "");
                 }));
             }
             assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
@@ -574,7 +555,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                                 "Operation 'architecture.scan' cannot start while 'architecture.scan' is in progress.");
             });
 
-            Response completed = probe.get("/bootui/api/architecture");
+            Response completed = probe.get(api("/architecture"));
             assertThat(completed.status()).isEqualTo(200);
             assertThat(completed.json().path("scan").path("scannedAt").isNumber())
                     .isTrue();
@@ -595,7 +576,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                 isPanelUsableInLiveManifest("vulnerabilities"),
                 "vulnerabilities panel is not available in this environment");
 
-        Response response = probe().get("/bootui/api/vulnerabilities");
+        Response response = probe().get(api("/vulnerabilities"));
         assertThat(response.status())
                 .as("GET /bootui/api/vulnerabilities status")
                 .isEqualTo(200);
@@ -630,7 +611,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         assumeTrue(isPanelUsableInLiveManifest("beans"), "beans panel is not available in this environment");
 
         // Root GET — shape contract.
-        Response root = probe().get("/bootui/api/beans");
+        Response root = probe().get(api("/beans"));
         assertThat(root.status()).as("GET /bootui/api/beans status").isEqualTo(200);
         assertThat(root.isJson()).as("GET /bootui/api/beans content-type").isTrue();
         JsonNode report = root.json();
@@ -645,14 +626,14 @@ public abstract class AbstractBootUiApiConformanceTest {
                 .isTrue();
 
         // Pagination: limit=1 must return at most 1 bean regardless of the total count.
-        Response limited = probe().get("/bootui/api/beans?limit=1");
+        Response limited = probe().get(api("/beans?limit=1"));
         assertThat(limited.status()).as("GET /bootui/api/beans?limit=1 status").isEqualTo(200);
         assertThat(limited.json().path("beans").size())
                 .as("GET /bootui/api/beans?limit=1 must return at most 1 bean")
                 .isLessThanOrEqualTo(1);
 
         // Query filter: a value that cannot match any bean name should return an empty page.
-        Response noMatch = probe().get("/bootui/api/beans?q=conformanceprobexyz123notabean");
+        Response noMatch = probe().get(api("/beans?q=conformanceprobexyz123notabean"));
         assertThat(noMatch.status())
                 .as("GET /bootui/api/beans?q=<nonexistent> status")
                 .isEqualTo(200);
@@ -673,7 +654,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         assumeTrue(isPanelUsableInLiveManifest("loggers"), "loggers panel is not available in this environment");
 
         // Root GET — shape contract.
-        Response root = probe().get("/bootui/api/loggers");
+        Response root = probe().get(api("/loggers"));
         assertThat(root.status()).as("GET /bootui/api/loggers status").isEqualTo(200);
         assertThat(root.isJson()).as("GET /bootui/api/loggers content-type").isTrue();
         JsonNode report = root.json();
@@ -685,7 +666,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                 .isTrue();
 
         // Pagination: limit=1 must return at most 1 logger.
-        Response limited = probe().get("/bootui/api/loggers?limit=1");
+        Response limited = probe().get(api("/loggers?limit=1"));
         assertThat(limited.status())
                 .as("GET /bootui/api/loggers?limit=1 status")
                 .isEqualTo(200);
@@ -694,7 +675,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                 .isLessThanOrEqualTo(1);
 
         // Query filter: a query that cannot match any logger name should return an empty page.
-        Response noMatch = probe().get("/bootui/api/loggers?q=conformanceprobexyz123notalogger");
+        Response noMatch = probe().get(api("/loggers?q=conformanceprobexyz123notalogger"));
         assertThat(noMatch.status())
                 .as("GET /bootui/api/loggers?q=<nonexistent> status")
                 .isEqualTo(200);
@@ -712,7 +693,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         assumeTrue(isPanelUsableInLiveManifest("traces"), "traces panel is not available in this environment");
 
         // 1. GET /traces — shape contract.
-        Response listResponse = probe().get("/bootui/api/traces");
+        Response listResponse = probe().get(api("/traces"));
         assertThat(listResponse.status()).as("GET /bootui/api/traces status").isEqualTo(200);
         assertThat(listResponse.isJson())
                 .as("GET /bootui/api/traces content-type")
@@ -728,7 +709,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         // 2. DELETE /traces — clears the buffer; must return 204 No Content with no body.
         BootUiHttpProbe probe = probe();
         Map<String, String> headers = stateChangingHeaders(probe);
-        Response clearResponse = probe.request("DELETE", "/bootui/api/traces", headers, null);
+        Response clearResponse = probe.request("DELETE", api("/traces"), headers, null);
         assertThat(clearResponse.status())
                 .as("DELETE /bootui/api/traces must return 204 No Content")
                 .isEqualTo(204);
@@ -737,46 +718,10 @@ public abstract class AbstractBootUiApiConformanceTest {
                 .isEmpty();
 
         // 3. GET /traces/{unknown} — must return 404 for an unrecognised trace id.
-        Response detailResponse = probe().get("/bootui/api/traces/conformance-probe-unknown-trace-id-xyz");
+        Response detailResponse = probe().get(api("/traces/conformance-probe-unknown-trace-id-xyz"));
         assertThat(detailResponse.status())
                 .as("GET /bootui/api/traces/{unknown} must return 404 for an unrecognised trace id")
                 .isEqualTo(404);
-    }
-
-    @Test
-    void nestedGetEndpointsReturnJsonForAvailablePanels() {
-        // Panels whose primary data lives at a sub-path (not /bootui/api/<id>) are excluded from
-        // availablePanelsAnswerTheirPrimaryGet(); this test covers their nested paths. Each panel is
-        // skipped when the live manifest reports it unavailable (capability not on the classpath, not
-        // configured, etc.) rather than failing, so the test remains green on any adapter combination.
-        JsonNode panelsArray = probe().get("/bootui/api/panels").json().get("panels");
-        Map<String, PanelState> panelStates = new java.util.LinkedHashMap<>();
-        if (panelsArray != null) {
-            panelsArray.forEach(panel -> panelStates.put(
-                    panel.path("id").asText(null),
-                    new PanelState(
-                            panel.path("available").asBoolean(false),
-                            panel.path("enabled").asBoolean(true))));
-        }
-
-        List<String> failures = new ArrayList<>();
-        for (Map.Entry<String, String> entry : NESTED_GET_PATHS.entrySet()) {
-            String panelId = entry.getKey();
-            String path = entry.getValue();
-            if (!panelStates.getOrDefault(panelId, PanelState.UNUSABLE).usable()) {
-                // Panel not available or explicitly disabled on this adapter / environment.
-                continue;
-            }
-            Response response = probe().get(path);
-            if (response.status() != 200) {
-                failures.add(panelId + " GET " + path + " -> HTTP " + response.status());
-            } else if (!response.isJson()) {
-                failures.add(panelId + " GET " + path + " -> non-JSON content-type '" + response.contentType() + "'");
-            }
-        }
-        if (!failures.isEmpty()) {
-            fail("Available panels' nested GET endpoints regressed: " + failures);
-        }
     }
 
     @Test
@@ -786,7 +731,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         // JSON body containing a "message" field — the canonical confirmation gate enforced by the shared
         // engine FlywayService / LiquibaseService. Both adapters must fire this gate identically.
         // Panels are skipped when unavailable (optional dependency not on the classpath).
-        JsonNode panelsArray = probe().get("/bootui/api/panels").json().get("panels");
+        JsonNode panelsArray = probe().get(api("/panels")).json().get("panels");
         Map<String, PanelState> panelStates = new java.util.LinkedHashMap<>();
         if (panelsArray != null) {
             panelsArray.forEach(panel -> panelStates.put(
@@ -807,7 +752,7 @@ public abstract class AbstractBootUiApiConformanceTest {
                 continue; // not available on this adapter / environment
             }
             // Send without confirm=true — the engine must return 400 before touching the database.
-            Response response = probe.request("POST", path, headers, "{}");
+            Response response = probe.request("POST", api(path), headers, "{}");
             if (response.status() != 400) {
                 failures.add(panelId + " POST " + path + " without confirm -> HTTP " + response.status()
                         + " (expected 400)");
@@ -825,6 +770,112 @@ public abstract class AbstractBootUiApiConformanceTest {
         }
     }
 
+    @Test
+    void unavailableActionTargetReturnsCanonicalNotFound() {
+        assumeTrue(isPanelUsableInLiveManifest("flyway"), "flyway panel is not available in this environment");
+
+        BootUiHttpProbe probe = probe();
+        Response response = probe.request(
+                "POST",
+                api("/flyway/migrate"),
+                stateChangingHeaders(probe),
+                "{\"beanName\":\"conformance-missing-flyway\",\"confirm\":true}");
+
+        assertThat(response.status()).as("unknown Flyway target status").isEqualTo(404);
+        assertThat(response.isJson()).as("unknown Flyway target content type").isTrue();
+        assertThat(response.json().path("status").asText()).isEqualTo("unavailable");
+        assertThat(response.json().path("message").asText())
+                .isEqualTo("No Flyway bean matched the requested datasource.");
+    }
+
+    @Test
+    void databaseBackedActivitySwitchRequiresConfirmationWhenCapable() {
+        assumeTrue(isPanelUsableInLiveManifest("activity"), "activity panel is not available in this environment");
+
+        JsonNode report = probe().get(api("/activity")).json();
+        JsonNode option = report.path("persistenceOption");
+        assumeTrue(option.isObject(), "activity persistence option is not exposed in this environment");
+        assumeTrue(
+                option.path("dataSourceAvailable").asBoolean(false),
+                "activity persistence cannot reuse a datasource in this environment");
+        assumeTrue(!option.path("active").asBoolean(false), "activity persistence is already active");
+
+        BootUiHttpProbe probe = probe();
+        Response response = probe.request(
+                "POST", api("/activity/use-existing-datasource"), stateChangingHeaders(probe), "{\"confirm\":false}");
+
+        assertThat(response.status())
+                .as("unconfirmed activity persistence switch status")
+                .isEqualTo(400);
+        assertThat(response.json().path("status").asText()).isEqualTo("blocked");
+        assertThat(response.json().path("message").asText())
+                .isEqualTo(
+                        "Action requires confirm=true because it creates a database table and starts writing to it.");
+    }
+
+    @Test
+    void devToolsRestartRequiresConfirmationWithoutSchedulingARestart() {
+        assumeTrue(runtime() != Runtime.QUARKUS, "DevTools restart is Spring-only");
+        assumeTrue(isPanelUsableInLiveManifest("devtools"), "devtools panel is not available in this environment");
+
+        BootUiHttpProbe probe = probe();
+        Response response =
+                probe.request("POST", api("/devtools/restart"), stateChangingHeaders(probe), "{\"confirm\":false}");
+
+        assertThat(response.status()).as("unconfirmed DevTools restart status").isEqualTo(400);
+        assertThat(response.json().path("action").asText()).isEqualTo("restart");
+        assertThat(response.json().path("status").asText()).isEqualTo("confirmation_required");
+        assertThat(response.json().path("message").asText()).isEqualTo("Restart requires explicit confirmation.");
+    }
+
+    @Test
+    void configSecretsAreMaskedBeforeSerialization() {
+        assumeTrue(isPanelUsableInLiveManifest("config"), "config panel is not available in this environment");
+
+        String key = "bootui.conformance.api-token";
+        String rawSecret = "conformance-raw-secret-value";
+        Response response = probe().get(api("/config?q=" + key + "&limit=10"));
+        assertThat(response.status()).as("masked config query status").isEqualTo(200);
+        assertThat(response.body()).as("raw secret must never be serialized").doesNotContain(rawSecret);
+
+        JsonNode matching = null;
+        for (JsonNode property : response.json().path("properties")) {
+            if (key.equals(property.path("name").asText())) {
+                matching = property;
+                break;
+            }
+        }
+        assertThat(matching)
+                .as("conformance secret property must be observable in the config inventory")
+                .isNotNull();
+        assertThat(matching.path("masked").asBoolean()).isTrue();
+        assertThat(matching.path("value").asText()).isEqualTo("******");
+    }
+
+    @Test
+    void actionCatalogCoversEveryAvailableActionPanelForThisRuntime() {
+        Map<String, JsonNode> livePanels = livePanelsById();
+        Set<String> expectedActionPanels = loadExpectedPanels().stream()
+                .filter(ExpectedPanel::actionCapable)
+                .map(ExpectedPanel::id)
+                .filter(id -> {
+                    JsonNode panel = livePanels.get(id);
+                    return panel != null
+                            && panel.path("available").asBoolean(false)
+                            && panel.path("enabled").asBoolean(true)
+                            && !actionlessPanels().contains(id);
+                })
+                .collect(java.util.stream.Collectors.toSet());
+        Set<String> cataloged = BootUiApiContractCatalog.actions(runtime()).stream()
+                .map(ActionContract::panelId)
+                .filter(java.util.Objects::nonNull)
+                .collect(java.util.stream.Collectors.toSet());
+
+        assertThat(cataloged)
+                .as("available action-capable panels must have a state-changing route in the runtime catalog")
+                .containsAll(expectedActionPanels);
+    }
+
     /**
      * Headers for a same-origin state-changing request, built exactly as the BootUI SPA does. A priming
      * GET lets the Spring adapter set its {@code XSRF-TOKEN} cookie, which Spring's SPA CSRF contract
@@ -835,7 +886,7 @@ public abstract class AbstractBootUiApiConformanceTest {
         Map<String, String> headers = new java.util.LinkedHashMap<>();
         headers.put("Content-Type", "application/json");
         headers.put("Origin", baseUrl());
-        probe.get("/bootui/api/overview");
+        probe.get(api("/overview"));
         probe.cookie("XSRF-TOKEN").ifPresent(token -> headers.put("X-XSRF-TOKEN", token));
         return headers;
     }
@@ -856,15 +907,6 @@ public abstract class AbstractBootUiApiConformanceTest {
                     .as("immutable assets must not carry a conflicting Pragma")
                     .isEmpty();
         }
-    }
-
-    private boolean loggersAvailable() {
-        for (JsonNode panel : probe().get("/bootui/api/panels").json().get("panels")) {
-            if ("loggers".equals(panel.path("id").asText(null))) {
-                return panel.path("available").asBoolean(false);
-            }
-        }
-        return false;
     }
 
     private void assertPanelShape(ExpectedPanel expectedPanel, JsonNode panel) {
@@ -913,13 +955,76 @@ public abstract class AbstractBootUiApiConformanceTest {
         }
     }
 
+    private void assertJsonContract(String panelId, ReadContract contract, JsonNode root, List<String> failures) {
+        if (!matchesType(root, contract.rootType())) {
+            failures.add(panelId + " -> root expected " + contract.rootType() + " but was " + root.getNodeType());
+            return;
+        }
+        for (Map.Entry<String, JsonType> field : contract.requiredFields().entrySet()) {
+            JsonNode value = at(root, field.getKey());
+            if (!matchesType(value, field.getValue())) {
+                failures.add(panelId + " -> $." + field.getKey() + " expected " + field.getValue() + " but was "
+                        + describe(value));
+            }
+        }
+        if (root.isObject() && root.has("available") && root.has("unavailableReason")) {
+            boolean available = root.path("available").asBoolean(false);
+            JsonNode reason = root.path("unavailableReason");
+            if (available && !isNull(reason)) {
+                failures.add(panelId + " -> unavailableReason must be null when available=true");
+            } else if (!available && !reason.isTextual()) {
+                failures.add(panelId + " -> unavailableReason must be a string when available=false");
+            }
+        }
+        if (root.isObject() && root.has("total")) {
+            int total = root.path("total").asInt();
+            if (total < 0) {
+                failures.add(panelId + " -> total must be non-negative");
+            }
+        }
+    }
+
+    private static JsonNode at(JsonNode root, String dottedPath) {
+        JsonNode current = root;
+        for (String segment : dottedPath.split("\\.")) {
+            current = current.path(segment);
+        }
+        return current;
+    }
+
+    private static boolean matchesType(JsonNode node, JsonType type) {
+        return switch (type) {
+            case STRING -> node.isTextual();
+            case BOOLEAN -> node.isBoolean();
+            case INTEGER -> node.isIntegralNumber();
+            case NUMBER -> node.isNumber();
+            case ARRAY -> node.isArray();
+            case OBJECT -> node.isObject();
+            case NULLABLE_STRING -> isNull(node) || node.isTextual();
+            case NULLABLE_OBJECT -> isNull(node) || node.isObject();
+        };
+    }
+
+    private static String describe(JsonNode node) {
+        return node == null || node.isMissingNode()
+                ? "missing"
+                : node.getNodeType().name();
+    }
+
+    private Map<String, JsonNode> livePanelsById() {
+        Map<String, JsonNode> panels = new java.util.LinkedHashMap<>();
+        JsonNode array = probe().get(api("/panels")).json().path("panels");
+        array.forEach(panel -> panels.put(panel.path("id").asText(), panel));
+        return panels;
+    }
+
     private static boolean isNull(JsonNode node) {
         return node == null || node.isNull() || node.isMissingNode();
     }
 
     /** Returns the live manifest entry for the named panel, or {@code null} if not found. */
     private JsonNode panelFromLiveManifest(String id) {
-        JsonNode panels = probe().get("/bootui/api/panels").json().get("panels");
+        JsonNode panels = probe().get(api("/panels")).json().get("panels");
         if (panels == null) {
             return null;
         }

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/BootUiApiContractCatalog.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/BootUiApiContractCatalog.java
@@ -299,10 +299,10 @@ public final class BootUiApiContractCatalog {
         all(actions, "rabbitmq.clear", "rabbitmq", "DELETE", "/rabbitmq");
         spring(actions, "jms.clear", "jms", "DELETE", "/jms");
 
-        infrastructure(actions, "dismissed-rules.dismiss", "POST", "/dismissed-rules/conformance-rule", ALL);
-        infrastructure(actions, "dismissed-rules.restore", "DELETE", "/dismissed-rules/conformance-rule", ALL);
-        infrastructure(actions, "mcp.bridge", "POST", "/mcp", ALL);
-        infrastructure(actions, "otlp.ingest", "POST", "/otlp/v1/traces", SPRING);
+        infrastructure(actions, "dismissed-rules.dismiss", "POST", "/dismissed-rules/conformance-rule", ALL, true);
+        infrastructure(actions, "dismissed-rules.restore", "DELETE", "/dismissed-rules/conformance-rule", ALL, true);
+        infrastructure(actions, "mcp.bridge", "POST", "/mcp", ALL, false);
+        infrastructure(actions, "otlp.ingest", "POST", "/otlp/v1/traces", SPRING, false);
         return List.copyOf(actions);
     }
 
@@ -433,24 +433,29 @@ public final class BootUiApiContractCatalog {
     }
 
     private static void all(List<ActionContract> actions, String id, String panelId, String method, String path) {
-        actions.add(new ActionContract(id, panelId, method, path, ALL));
+        actions.add(new ActionContract(id, panelId, method, path, ALL, true));
     }
 
     private static void spring(List<ActionContract> actions, String id, String panelId, String method, String path) {
-        actions.add(new ActionContract(id, panelId, method, path, SPRING));
+        actions.add(new ActionContract(id, panelId, method, path, SPRING, true));
     }
 
     private static void springMvc(List<ActionContract> actions, String id, String panelId, String method, String path) {
-        actions.add(new ActionContract(id, panelId, method, path, Set.of(Runtime.SPRING_MVC)));
+        actions.add(new ActionContract(id, panelId, method, path, Set.of(Runtime.SPRING_MVC), true));
     }
 
     private static void quarkus(List<ActionContract> actions, String id, String panelId, String method, String path) {
-        actions.add(new ActionContract(id, panelId, method, path, Set.of(Runtime.QUARKUS)));
+        actions.add(new ActionContract(id, panelId, method, path, Set.of(Runtime.QUARKUS), true));
     }
 
     private static void infrastructure(
-            List<ActionContract> actions, String id, String method, String path, Set<Runtime> runtimes) {
-        actions.add(new ActionContract(id, null, method, path, runtimes));
+            List<ActionContract> actions,
+            String id,
+            String method,
+            String path,
+            Set<Runtime> runtimes,
+            boolean blockedByGlobalReadOnly) {
+        actions.add(new ActionContract(id, null, method, path, runtimes, blockedByGlobalReadOnly));
     }
 
     public enum Runtime {
@@ -478,7 +483,13 @@ public final class BootUiApiContractCatalog {
         }
     }
 
-    public record ActionContract(String id, String panelId, String method, String relativePath, Set<Runtime> runtimes) {
+    public record ActionContract(
+            String id,
+            String panelId,
+            String method,
+            String relativePath,
+            Set<Runtime> runtimes,
+            boolean blockedByGlobalReadOnly) {
 
         public ActionContract {
             runtimes = Set.copyOf(runtimes);

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/BootUiApiContractCatalog.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/BootUiApiContractCatalog.java
@@ -1,0 +1,487 @@
+package io.github.jdubois.bootui.conformance;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Framework-neutral catalog of BootUI's black-box read and action contracts.
+ *
+ * <p>Read contracts intentionally describe stable DTO families and semantic fields rather than complete
+ * payload snapshots. Action contracts list every state-changing adapter route, including infrastructure
+ * writes that are deliberately outside panel read-only gating.
+ */
+public final class BootUiApiContractCatalog {
+
+    private static final Set<Runtime> SPRING = Set.of(Runtime.SPRING_MVC, Runtime.SPRING_WEBFLUX);
+    private static final Set<Runtime> ALL = Set.of(Runtime.SPRING_MVC, Runtime.SPRING_WEBFLUX, Runtime.QUARKUS);
+
+    private static final List<ReadContract> READS = List.of(
+            read(
+                    "overview",
+                    "/overview",
+                    fields(
+                            "applicationName", JsonType.STRING,
+                            "frameworkName", JsonType.STRING,
+                            "frameworkVersion", JsonType.NULLABLE_STRING,
+                            "javaVersion", JsonType.STRING,
+                            "activeProfiles", JsonType.ARRAY,
+                            "activation", JsonType.OBJECT)),
+            read(
+                    "health",
+                    "/health",
+                    fields(
+                            "status", JsonType.STRING,
+                            "components", JsonType.ARRAY,
+                            "available", JsonType.BOOLEAN,
+                            "unavailableReason", JsonType.NULLABLE_STRING,
+                            "setup", JsonType.ARRAY)),
+            capabilityList(
+                    "http-sessions",
+                    "/http-sessions",
+                    "sessions",
+                    "totalSessions",
+                    fields("actionEnabled", JsonType.BOOLEAN, "valueExposure", JsonType.STRING)),
+            inventory("metrics", "/metrics", "metricsAvailable", "meters"),
+            memory("live-memory", "/live-memory"),
+            memory("jvm-tuning", "/jvm-tuning"),
+            read(
+                    "heap-dump",
+                    "/heap-dump",
+                    fields(
+                            "hotspotAvailable", JsonType.BOOLEAN,
+                            "captureEnabled", JsonType.BOOLEAN,
+                            "dumpCount", JsonType.INTEGER,
+                            "dumps", JsonType.ARRAY,
+                            "topClasses", JsonType.ARRAY)),
+            pagedCapabilityList("threads", "/threads", "available", "threads", "totalThreads"),
+            advisor("memory", "/memory", "results"),
+            read("startup", "/startup", fields("steps", JsonType.ARRAY)),
+            advisor("graalvm", "/graalvm", "findings"),
+            inventory("scheduled", "/scheduled", "schedulingPresent", "tasks"),
+            pagedList(
+                    "config",
+                    "/config",
+                    "properties",
+                    fields(
+                            "activeProfiles", JsonType.ARRAY,
+                            "sources", JsonType.ARRAY,
+                            "propertySuggestions", JsonType.ARRAY,
+                            "overrideCount", JsonType.INTEGER)),
+            read(
+                    "profile-diff",
+                    "/profile-diff",
+                    fields("activeProfiles", JsonType.ARRAY, "profileSources", JsonType.ARRAY)),
+            pagedList("loggers", "/loggers", "loggers", fields("availableLevels", JsonType.ARRAY)),
+            pagedList("beans", "/beans", "beans", fields("total", JsonType.INTEGER)),
+            pagedList(
+                    "conditions",
+                    "/conditions",
+                    "positiveMatches",
+                    fields(
+                            "negativeMatches", JsonType.ARRAY,
+                            "unconditionalClasses", JsonType.ARRAY,
+                            "exclusions", JsonType.ARRAY,
+                            "counts", JsonType.OBJECT)),
+            pagedList("mappings", "/mappings/flat", "mappings", fields("total", JsonType.INTEGER)),
+            inventory("data", "/data/repositories", "springDataPresent", "repositories"),
+            inventory("flyway", "/flyway/migrations", "flywayPresent", "databases"),
+            inventory("liquibase", "/liquibase/changesets", "liquibasePresent", "databases"),
+            inventory("database-connection-pools", "/database-connection-pools/pools", "hikariPresent", "pools"),
+            advisor("hibernate", "/hibernate", "results"),
+            read(
+                    "cache",
+                    "/cache",
+                    fields(
+                            "cacheAvailable", JsonType.BOOLEAN,
+                            "clearEnabled", JsonType.BOOLEAN,
+                            "managerCount", JsonType.INTEGER,
+                            "cacheCount", JsonType.INTEGER,
+                            "managers", JsonType.ARRAY,
+                            "operations", JsonType.ARRAY,
+                            "warnings", JsonType.ARRAY)),
+            read(
+                    "spring-security",
+                    "/spring-security",
+                    fields(
+                            "springSecurityPresent", JsonType.BOOLEAN,
+                            "chains", JsonType.ARRAY,
+                            "auth", JsonType.OBJECT)),
+            advisor("security", "/security", "results"),
+            read(
+                    "security-logs",
+                    "/security-logs",
+                    fields(
+                            "auditEventsPresent", JsonType.BOOLEAN,
+                            "unavailableReason", JsonType.NULLABLE_STRING,
+                            "typeSummaries", JsonType.ARRAY,
+                            "events", JsonType.ARRAY,
+                            "page", JsonType.OBJECT)),
+            advisor("pentesting", "/pentesting", "findings"),
+            read(
+                    "ai",
+                    "/ai/overview",
+                    fields(
+                            "enabled", JsonType.BOOLEAN,
+                            "totalChats", JsonType.INTEGER,
+                            "tokensByModel", JsonType.OBJECT,
+                            "callsByModel", JsonType.OBJECT,
+                            "recent", JsonType.ARRAY)),
+            read(
+                    "traces",
+                    "/traces",
+                    fields(
+                            "enabled", JsonType.BOOLEAN,
+                            "retained", JsonType.INTEGER,
+                            "capacity", JsonType.INTEGER,
+                            "traces", JsonType.ARRAY)),
+            array("log-tail", "/log-tail/recent"),
+            capabilityList("exceptions", "/exceptions", "groups", "totalExceptions", Map.of()),
+            pagedList(
+                    "http-exchanges",
+                    "/http-exchanges",
+                    "exchanges",
+                    fields(
+                            "total", JsonType.INTEGER,
+                            "recorded", JsonType.INTEGER,
+                            "hiddenSelf", JsonType.INTEGER,
+                            "unavailableReason", JsonType.NULLABLE_STRING)),
+            advisor("architecture", "/architecture", "results"),
+            advisor("rest-api", "/rest-api", "results"),
+            read(
+                    "vulnerabilities",
+                    "/vulnerabilities",
+                    fields(
+                            "scanningEnabled", JsonType.BOOLEAN,
+                            "total", JsonType.INTEGER,
+                            "vulnerable", JsonType.INTEGER,
+                            "severityCounts", JsonType.ARRAY,
+                            "scan", JsonType.OBJECT,
+                            "dependencies", JsonType.ARRAY)),
+            read(
+                    "dev-services",
+                    "/dev-services",
+                    fields(
+                            "dockerComposePresent", JsonType.BOOLEAN,
+                            "testcontainersPresent", JsonType.BOOLEAN,
+                            "snapshotTimestamp", JsonType.NUMBER,
+                            "total", JsonType.INTEGER,
+                            "services", JsonType.ARRAY,
+                            "warnings", JsonType.ARRAY)),
+            read(
+                    "devtools",
+                    "/devtools",
+                    fields(
+                            "restartAvailable", JsonType.BOOLEAN,
+                            "restartUnavailableReason", JsonType.NULLABLE_STRING,
+                            "restartPending", JsonType.BOOLEAN,
+                            "liveReloadAvailable", JsonType.BOOLEAN,
+                            "liveReloadUnavailableReason", JsonType.NULLABLE_STRING)),
+            agent("copilot", "/copilot/dashboard"),
+            agent("claude-code", "/claude-code/dashboard"),
+            read(
+                    "github",
+                    "/github",
+                    fields(
+                            "available", JsonType.BOOLEAN,
+                            "unavailableReason", JsonType.NULLABLE_STRING,
+                            "connected", JsonType.BOOLEAN,
+                            "status", JsonType.STRING,
+                            "metrics", JsonType.ARRAY,
+                            "warnings", JsonType.ARRAY)),
+            advisor("spring", "/spring", "results"),
+            advisor("crac", "/crac", "findings"),
+            capture("sql-trace", "/sql-trace", "entries"),
+            capture("rest-client-trace", "/rest-client-trace", "entries"),
+            read(
+                    "mcp-server",
+                    "/mcp-server",
+                    fields(
+                            "enabled", JsonType.BOOLEAN,
+                            "configuredMode", JsonType.STRING,
+                            "overridden", JsonType.BOOLEAN,
+                            "endpoint", JsonType.STRING,
+                            "toolCount", JsonType.INTEGER,
+                            "tools", JsonType.ARRAY)),
+            read(
+                    "activity",
+                    "/activity",
+                    fields(
+                            "available", JsonType.BOOLEAN,
+                            "entries", JsonType.ARRAY,
+                            "typeCounts", JsonType.OBJECT,
+                            "sources", JsonType.ARRAY,
+                            "warnings", JsonType.ARRAY,
+                            "pageInfo", JsonType.NULLABLE_OBJECT,
+                            "persistenceOption", JsonType.NULLABLE_OBJECT)),
+            capabilityList("email", "/email", "messages", "total", fields("devTrapEnabled", JsonType.BOOLEAN)),
+            capture("kafka", "/kafka", "messages"),
+            capture("rabbitmq", "/rabbitmq", "messages"),
+            capture("jms", "/jms", "messages"));
+
+    private static final List<ActionContract> ACTIONS = buildActions();
+
+    private BootUiApiContractCatalog() {}
+
+    public static List<ReadContract> reads() {
+        return READS;
+    }
+
+    public static Map<String, ReadContract> readsByPanel() {
+        Map<String, ReadContract> contracts = new LinkedHashMap<>();
+        READS.forEach(contract -> contracts.put(contract.panelId(), contract));
+        return Map.copyOf(contracts);
+    }
+
+    public static List<ActionContract> actions() {
+        return ACTIONS;
+    }
+
+    public static List<ActionContract> actions(Runtime runtime) {
+        return ACTIONS.stream()
+                .filter(action -> action.runtimes().contains(runtime))
+                .toList();
+    }
+
+    private static List<ActionContract> buildActions() {
+        List<ActionContract> actions = new ArrayList<>();
+
+        springMvc(actions, "http-sessions.clear", "http-sessions", "POST", "/http-sessions/session-key/clear");
+        springMvc(
+                actions, "http-sessions.invalidate", "http-sessions", "POST", "/http-sessions/session-key/invalidate");
+        all(actions, "heap-dump.capture", "heap-dump", "POST", "/heap-dump/capture");
+        all(actions, "heap-dump.analyze", "heap-dump", "POST", "/heap-dump/analyze");
+        all(actions, "heap-dump.delete", "heap-dump", "POST", "/heap-dump/delete");
+        all(actions, "threads.download", "threads", "POST", "/threads/download");
+        all(actions, "memory.scan", "memory", "POST", "/memory/scan");
+        spring(actions, "graalvm.scan.cancel", "graalvm", "POST", "/graalvm/scan/cancel");
+        spring(actions, "graalvm.scan", "graalvm", "POST", "/graalvm/scan");
+        spring(actions, "graalvm.install", "graalvm", "POST", "/graalvm/install");
+        spring(actions, "graalvm.install-all", "graalvm", "POST", "/graalvm/install/all");
+        spring(actions, "graalvm.dockerfile.install", "graalvm", "POST", "/graalvm/dockerfile/install");
+        spring(actions, "config.override.put", "config", "POST", "/config/overrides");
+        spring(actions, "config.override.delete", "config", "DELETE", "/config/overrides/conformance.key");
+        all(actions, "loggers.level", "loggers", "POST", "/loggers/io.github.jdubois.bootui.conformance");
+        all(actions, "security.scan", "security", "POST", "/security/scan");
+        all(actions, "pentesting.scan", "pentesting", "POST", "/pentesting/scan");
+        all(actions, "hibernate.scan", "hibernate", "POST", "/hibernate/scan");
+        all(actions, "cache.clear", "cache", "POST", "/cache/clear");
+        all(actions, "traces.clear", "traces", "DELETE", "/traces");
+        all(actions, "exceptions.clear", "exceptions", "DELETE", "/exceptions");
+        all(actions, "exceptions.status", "exceptions", "POST", "/exceptions/conformance-unknown-fingerprint/status");
+        all(actions, "http-probe.execute", "http-probe", "POST", "/http-probe");
+        all(actions, "architecture.scan", "architecture", "POST", "/architecture/scan");
+        all(actions, "vulnerabilities.scan", "vulnerabilities", "POST", "/vulnerabilities/scan");
+        spring(actions, "devtools.livereload", "devtools", "POST", "/devtools/livereload");
+        spring(actions, "devtools.restart", "devtools", "POST", "/devtools/restart");
+        spring(actions, "dev-services.restart", "dev-services", "POST", "/dev-services/services/conformance/restart");
+        quarkus(actions, "dev-services.restart", "dev-services", "POST", "/dev-services/conformance/restart");
+        all(actions, "flyway.migrate", "flyway", "POST", "/flyway/migrate");
+        all(actions, "flyway.clean", "flyway", "POST", "/flyway/clean");
+        all(actions, "liquibase.update", "liquibase", "POST", "/liquibase/update");
+        all(actions, "github.refresh", "github", "POST", "/github/refresh");
+        all(actions, "rest-api.scan", "rest-api", "POST", "/rest-api/scan");
+        all(actions, "spring.scan", "spring", "POST", "/spring/scan");
+        spring(actions, "crac.scan", "crac", "POST", "/crac/scan");
+        spring(actions, "crac.dockerfile.install", "crac", "POST", "/crac/dockerfile/install");
+        spring(actions, "crac.entrypoint.install", "crac", "POST", "/crac/entrypoint/install");
+        spring(actions, "crac.install-all", "crac", "POST", "/crac/install/all");
+        all(actions, "sql-trace.clear", "sql-trace", "POST", "/sql-trace/clear");
+        all(actions, "sql-trace.recording", "sql-trace", "POST", "/sql-trace/recording");
+        all(actions, "rest-client-trace.clear", "rest-client-trace", "POST", "/rest-client-trace/clear");
+        all(actions, "rest-client-trace.recording", "rest-client-trace", "POST", "/rest-client-trace/recording");
+        all(actions, "mcp-server.toggle", "mcp-server", "POST", "/mcp-server/toggle");
+        all(actions, "activity.use-existing-datasource", "activity", "POST", "/activity/use-existing-datasource");
+        all(actions, "email.clear", "email", "DELETE", "/email");
+        all(actions, "kafka.clear", "kafka", "DELETE", "/kafka");
+        all(actions, "rabbitmq.clear", "rabbitmq", "DELETE", "/rabbitmq");
+        spring(actions, "jms.clear", "jms", "DELETE", "/jms");
+
+        infrastructure(actions, "dismissed-rules.dismiss", "POST", "/dismissed-rules/conformance-rule", ALL);
+        infrastructure(actions, "dismissed-rules.restore", "DELETE", "/dismissed-rules/conformance-rule", ALL);
+        infrastructure(actions, "mcp.bridge", "POST", "/mcp", ALL);
+        infrastructure(actions, "otlp.ingest", "POST", "/otlp/v1/traces", SPRING);
+        return List.copyOf(actions);
+    }
+
+    private static ReadContract read(String panelId, String path, Map<String, JsonType> fields) {
+        return new ReadContract(panelId, path, JsonType.OBJECT, fields);
+    }
+
+    private static ReadContract array(String panelId, String path) {
+        return new ReadContract(panelId, path, JsonType.ARRAY, Map.of());
+    }
+
+    private static ReadContract advisor(String panelId, String path, String resultField) {
+        return read(
+                panelId,
+                path,
+                fields(
+                        "localOnly",
+                        JsonType.BOOLEAN,
+                        "disclaimer",
+                        JsonType.STRING,
+                        "severityCounts",
+                        JsonType.ARRAY,
+                        "scan",
+                        JsonType.OBJECT,
+                        "scan.status",
+                        JsonType.STRING,
+                        resultField,
+                        JsonType.ARRAY));
+    }
+
+    private static ReadContract memory(String panelId, String path) {
+        return read(
+                panelId,
+                path,
+                fields(
+                        "heap", JsonType.OBJECT,
+                        "nonHeap", JsonType.OBJECT,
+                        "pools", JsonType.ARRAY,
+                        "jvmInputArguments", JsonType.ARRAY,
+                        "suggestedJvmOptions", JsonType.STRING,
+                        "calculation", JsonType.OBJECT));
+    }
+
+    private static ReadContract inventory(String panelId, String path, String availabilityField, String itemsField) {
+        return read(
+                panelId,
+                path,
+                fields(availabilityField, JsonType.BOOLEAN, "total", JsonType.INTEGER, itemsField, JsonType.ARRAY));
+    }
+
+    private static ReadContract capabilityList(
+            String panelId, String path, String itemsField, String totalField, Map<String, JsonType> additionalFields) {
+        Map<String, JsonType> required = new LinkedHashMap<>(fields(
+                "available",
+                JsonType.BOOLEAN,
+                "unavailableReason",
+                JsonType.NULLABLE_STRING,
+                totalField,
+                JsonType.NUMBER,
+                itemsField,
+                JsonType.ARRAY));
+        required.putAll(additionalFields);
+        return read(panelId, path, required);
+    }
+
+    private static ReadContract pagedCapabilityList(
+            String panelId, String path, String availabilityField, String itemsField, String totalField) {
+        return read(
+                panelId,
+                path,
+                fields(
+                        availabilityField,
+                        JsonType.BOOLEAN,
+                        "unavailableReason",
+                        JsonType.NULLABLE_STRING,
+                        totalField,
+                        JsonType.INTEGER,
+                        itemsField,
+                        JsonType.ARRAY,
+                        "page",
+                        JsonType.OBJECT));
+    }
+
+    private static ReadContract pagedList(
+            String panelId, String path, String itemsField, Map<String, JsonType> additionalFields) {
+        Map<String, JsonType> required =
+                new LinkedHashMap<>(fields(itemsField, JsonType.ARRAY, "page", JsonType.OBJECT));
+        required.putAll(additionalFields);
+        return read(panelId, path, required);
+    }
+
+    private static ReadContract capture(String panelId, String path, String itemsField) {
+        return read(
+                panelId,
+                path,
+                fields(
+                        "available",
+                        JsonType.BOOLEAN,
+                        "unavailableReason",
+                        JsonType.NULLABLE_STRING,
+                        "capturing",
+                        JsonType.BOOLEAN,
+                        "totalCaptured",
+                        JsonType.NUMBER,
+                        itemsField,
+                        JsonType.ARRAY));
+    }
+
+    private static ReadContract agent(String panelId, String path) {
+        return read(
+                panelId,
+                path,
+                fields(
+                        "available", JsonType.BOOLEAN,
+                        "unavailableReason", JsonType.NULLABLE_STRING,
+                        "sessionCount", JsonType.INTEGER,
+                        "eventCount", JsonType.INTEGER,
+                        "recentSessions", JsonType.ARRAY,
+                        "warnings", JsonType.ARRAY));
+    }
+
+    private static Map<String, JsonType> fields(Object... pairs) {
+        Map<String, JsonType> fields = new LinkedHashMap<>();
+        for (int index = 0; index < pairs.length; index += 2) {
+            fields.put((String) pairs[index], (JsonType) pairs[index + 1]);
+        }
+        return Map.copyOf(fields);
+    }
+
+    private static void all(List<ActionContract> actions, String id, String panelId, String method, String path) {
+        actions.add(new ActionContract(id, panelId, method, path, ALL));
+    }
+
+    private static void spring(List<ActionContract> actions, String id, String panelId, String method, String path) {
+        actions.add(new ActionContract(id, panelId, method, path, SPRING));
+    }
+
+    private static void springMvc(List<ActionContract> actions, String id, String panelId, String method, String path) {
+        actions.add(new ActionContract(id, panelId, method, path, Set.of(Runtime.SPRING_MVC)));
+    }
+
+    private static void quarkus(List<ActionContract> actions, String id, String panelId, String method, String path) {
+        actions.add(new ActionContract(id, panelId, method, path, Set.of(Runtime.QUARKUS)));
+    }
+
+    private static void infrastructure(
+            List<ActionContract> actions, String id, String method, String path, Set<Runtime> runtimes) {
+        actions.add(new ActionContract(id, null, method, path, runtimes));
+    }
+
+    public enum Runtime {
+        SPRING_MVC,
+        SPRING_WEBFLUX,
+        QUARKUS
+    }
+
+    public enum JsonType {
+        STRING,
+        BOOLEAN,
+        INTEGER,
+        NUMBER,
+        ARRAY,
+        OBJECT,
+        NULLABLE_STRING,
+        NULLABLE_OBJECT
+    }
+
+    public record ReadContract(
+            String panelId, String relativePath, JsonType rootType, Map<String, JsonType> requiredFields) {
+
+        public ReadContract {
+            requiredFields = Map.copyOf(requiredFields);
+        }
+    }
+
+    public record ActionContract(String id, String panelId, String method, String relativePath, Set<Runtime> runtimes) {
+
+        public ActionContract {
+            runtimes = Set.copyOf(runtimes);
+        }
+    }
+}

--- a/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
+++ b/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.jdubois.bootui.engine.panel.BootUiGlobalWritePolicy;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels.Panel;
 import java.io.IOException;
@@ -119,6 +120,12 @@ class BackendPanelCatalogConsistencyTest {
                         .filter(java.util.Objects::nonNull)
                         .collect(java.util.stream.Collectors.toSet()))
                 .containsExactlyInAnyOrderElementsOf(expectedActionPanels);
+
+        assertThat(actions)
+                .filteredOn(action -> action.panelId() == null && action.blockedByGlobalReadOnly())
+                .allSatisfy(action -> assertThat(BootUiGlobalWritePolicy.subjectFor(action.relativePath()))
+                        .as(action.id())
+                        .isPresent());
     }
 
     private static JsonNode loadJsonResource(String resource) {

--- a/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
+++ b/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
@@ -12,6 +12,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
@@ -74,6 +75,50 @@ class BackendPanelCatalogConsistencyTest {
                     .containsPattern(Pattern.compile(
                             "^" + Pattern.quote(headingPrefix + panel.title()) + "$", Pattern.MULTILINE));
         }
+    }
+
+    @Test
+    void readContractCatalogCoversEveryDataPanelExactlyOnce() {
+        Set<String> expected = BootUiPanels.all().stream()
+                .map(Panel::id)
+                .filter(id -> !BootUiPanels.HTTP_PROBE.equals(id))
+                .collect(java.util.stream.Collectors.toSet());
+
+        assertThat(BootUiApiContractCatalog.reads())
+                .extracting(BootUiApiContractCatalog.ReadContract::panelId)
+                .doesNotHaveDuplicates()
+                .containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    @Test
+    void actionContractCatalogIsUniqueAndResolvesThroughThePanelRegistry() {
+        List<BootUiApiContractCatalog.ActionContract> actions = BootUiApiContractCatalog.actions();
+
+        assertThat(actions)
+                .extracting(action -> action.method() + " " + action.relativePath() + " " + action.runtimes())
+                .doesNotHaveDuplicates();
+        assertThat(actions).allSatisfy(action -> {
+            assertThat(action.relativePath()).startsWith("/");
+            assertThat(action.method()).isIn("POST", "PUT", "PATCH", "DELETE");
+            assertThat(action.runtimes()).isNotEmpty();
+            if (action.panelId() != null) {
+                assertThat(BootUiPanels.byApiPath(action.relativePath()))
+                        .as(action.id())
+                        .get()
+                        .extracting(Panel::id)
+                        .isEqualTo(action.panelId());
+            }
+        });
+
+        Set<String> expectedActionPanels = BootUiPanels.all().stream()
+                .filter(Panel::actionCapable)
+                .map(Panel::id)
+                .collect(java.util.stream.Collectors.toSet());
+        assertThat(actions.stream()
+                        .map(BootUiApiContractCatalog.ActionContract::panelId)
+                        .filter(java.util.Objects::nonNull)
+                        .collect(java.util.stream.Collectors.toSet()))
+                .containsExactlyInAnyOrderElementsOf(expectedActionPanels);
     }
 
     private static JsonNode loadJsonResource(String resource) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/panel/BootUiGlobalWritePolicy.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/panel/BootUiGlobalWritePolicy.java
@@ -1,0 +1,25 @@
+package io.github.jdubois.bootui.engine.panel;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves non-panel API writes that are still governed by BootUI's global read-only policy.
+ */
+public final class BootUiGlobalWritePolicy {
+
+    private static final Map<String, String> SUBJECTS_BY_PREFIX = Map.of("/dismissed-rules", "dismissed-rules");
+
+    private BootUiGlobalWritePolicy() {}
+
+    public static Optional<String> subjectFor(String apiRelativePath) {
+        if (apiRelativePath == null) {
+            return Optional.empty();
+        }
+        return SUBJECTS_BY_PREFIX.entrySet().stream()
+                .filter(entry ->
+                        apiRelativePath.equals(entry.getKey()) || apiRelativePath.startsWith(entry.getKey() + "/"))
+                .map(Map.Entry::getValue)
+                .findFirst();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/panel/BootUiGlobalWritePolicyTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/panel/BootUiGlobalWritePolicyTests.java
@@ -1,0 +1,18 @@
+package io.github.jdubois.bootui.engine.panel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class BootUiGlobalWritePolicyTests {
+
+    @Test
+    void resolvesDismissedRuleWritesWithoutMatchingLookalikePaths() {
+        assertThat(BootUiGlobalWritePolicy.subjectFor("/dismissed-rules/rule-id"))
+                .contains("dismissed-rules");
+        assertThat(BootUiGlobalWritePolicy.subjectFor("/dismissed-rules-extra/rule-id"))
+                .isEmpty();
+        assertThat(BootUiGlobalWritePolicy.subjectFor("/mcp")).isEmpty();
+        assertThat(BootUiGlobalWritePolicy.subjectFor("/otlp/v1/traces")).isEmpty();
+    }
+}

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiCustomPathBootTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiCustomPathBootTest.java
@@ -2,6 +2,8 @@ package io.github.jdubois.bootui.quarkus.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.jdubois.bootui.conformance.AbstractBootUiApiConformanceTest;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
 import io.quarkus.test.common.http.TestHTTPResource;
@@ -10,13 +12,14 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import java.net.URL;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
 @TestProfile(BootUiCustomPathBootTest.CustomPathProfile.class)
-class BootUiCustomPathBootTest {
+class BootUiCustomPathBootTest extends AbstractBootUiApiConformanceTest {
 
     private static final Pattern ASSET = Pattern.compile("(?:src|href)=\"\\./(assets/[^\"]+)\"");
 
@@ -26,6 +29,36 @@ class BootUiCustomPathBootTest {
     private BootUiHttpProbe probe() {
         String serverRoot = baseUrl.getProtocol() + "://" + baseUrl.getHost() + ":" + baseUrl.getPort();
         return new BootUiHttpProbe(serverRoot);
+    }
+
+    @Override
+    protected String baseUrl() {
+        return baseUrl.getProtocol() + "://" + baseUrl.getHost() + ":" + baseUrl.getPort();
+    }
+
+    @Override
+    protected String expectedPanelsResource() {
+        return "/io/github/jdubois/bootui/conformance/expected-panels-quarkus.json";
+    }
+
+    @Override
+    protected Runtime runtime() {
+        return Runtime.QUARKUS;
+    }
+
+    @Override
+    protected Set<String> actionlessPanels() {
+        return Set.of("config");
+    }
+
+    @Override
+    protected String uiPath() {
+        return "/host/dev-console";
+    }
+
+    @Override
+    protected String apiPath() {
+        return "/host/internal/bootui-api";
     }
 
     @Test
@@ -94,7 +127,12 @@ class BootUiCustomPathBootTest {
             return Map.of(
                     "quarkus.http.root-path", "/host",
                     "bootui.path", "/dev-console/",
-                    "bootui.api-path", "/internal/bootui-api/");
+                    "bootui.api-path", "/internal/bootui-api/",
+                    "bootui.panels.copilot.enabled", "false",
+                    "bootui.panels.heap-dump.read-only", "true",
+                    "bootui.heap-dump.capture-enabled", "false",
+                    "bootui.claude-code.enabled", "OFF",
+                    "bootui.conformance.api-token", "conformance-raw-secret-value");
         }
     }
 }

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusApiConformanceTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusApiConformanceTest.java
@@ -1,12 +1,14 @@
 package io.github.jdubois.bootui.quarkus.it;
 
 import io.github.jdubois.bootui.conformance.AbstractBootUiApiConformanceTest;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import java.net.URL;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Runs the shared, framework-neutral {@link AbstractBootUiApiConformanceTest} contract against the
@@ -37,7 +39,8 @@ class BootUiQuarkusApiConformanceTest extends AbstractBootUiApiConformanceTest {
                     "bootui.panels.copilot.enabled", "false",
                     "bootui.panels.heap-dump.read-only", "true",
                     "bootui.heap-dump.capture-enabled", "false",
-                    "bootui.claude-code.enabled", "OFF");
+                    "bootui.claude-code.enabled", "OFF",
+                    "bootui.conformance.api-token", "conformance-raw-secret-value");
         }
     }
 
@@ -52,5 +55,15 @@ class BootUiQuarkusApiConformanceTest extends AbstractBootUiApiConformanceTest {
     @Override
     protected String expectedPanelsResource() {
         return "/io/github/jdubois/bootui/conformance/expected-panels-quarkus.json";
+    }
+
+    @Override
+    protected Runtime runtime() {
+        return Runtime.QUARKUS;
+    }
+
+    @Override
+    protected Set<String> actionlessPanels() {
+        return Set.of("config");
     }
 }

--- a/bootui-quarkus/pom.xml
+++ b/bootui-quarkus/pom.xml
@@ -264,6 +264,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-conformance</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessConfig.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessConfig.java
@@ -64,7 +64,7 @@ public final class QuarkusPanelAccessConfig {
         return "Panel is read-only via bootui.panels." + id + ".read-only=true";
     }
 
-    private boolean isGlobalReadOnly() {
+    boolean isGlobalReadOnly() {
         return booleanValue(GLOBAL_READ_ONLY_KEY, false);
     }
 

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilter.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.quarkus;
 
+import io.github.jdubois.bootui.engine.panel.BootUiGlobalWritePolicy;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels.Panel;
 import io.quarkus.vertx.http.runtime.filters.Filters;
@@ -66,6 +67,15 @@ public class QuarkusPanelAccessFilter {
             return;
         }
 
+        String method = rc.request().method().name();
+        if (!SAFE_METHODS.contains(method) && accessConfig.isGlobalReadOnly()) {
+            var globalSubject = BootUiGlobalWritePolicy.subjectFor(apiRelativePath);
+            if (globalSubject.isPresent()) {
+                writeBlockedResponse(rc, globalSubject.get(), accessConfig.panelReadOnlyReason(globalSubject.get()));
+                return;
+            }
+        }
+
         Panel panel = BootUiPanels.byApiPath(apiRelativePath).orElse(null);
         if (panel == null) {
             rc.next();
@@ -77,7 +87,6 @@ public class QuarkusPanelAccessFilter {
             return;
         }
 
-        String method = rc.request().method().name();
         if (panel.actionCapable() && !SAFE_METHODS.contains(method) && accessConfig.isPanelReadOnly(panel.id())) {
             writeBlockedResponse(rc, panel.id(), accessConfig.panelReadOnlyReason(panel.id()));
             return;

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilterTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilterTest.java
@@ -8,6 +8,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.ActionContract;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.smallrye.config.PropertiesConfigSource;
 import io.smallrye.config.SmallRyeConfigBuilder;
@@ -15,7 +18,7 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.microprofile.config.Config;
@@ -119,13 +122,15 @@ class QuarkusPanelAccessFilterTest {
 
     @Test
     void globalReadOnlyBlocksEveryQuarkusActionCapablePanelAction() {
-        Map<String, ActionRequest> actionRequestsByPanel = actionRequestsByPanel();
+        List<ActionContract> actions = BootUiApiContractCatalog.actions(Runtime.QUARKUS).stream()
+                .filter(action -> action.panelId() != null)
+                .toList();
 
         // Completeness self-check: every actionCapable panel in the shared registry must be triaged into
         // exactly one of the fixture map, the not-applicable-on-Quarkus set, or the no-write-path-yet set
         // (Config). This fails loudly if a new action-capable panel is added to the registry without being
         // triaged, instead of silently under-covering it.
-        assertThat(actionRequestsByPanel.keySet())
+        assertThat(actions.stream().map(ActionContract::panelId).collect(java.util.stream.Collectors.toSet()))
                 .containsExactlyInAnyOrderElementsOf(BootUiPanels.all().stream()
                         .filter(BootUiPanels.Panel::actionCapable)
                         .map(BootUiPanels.Panel::id)
@@ -134,14 +139,13 @@ class QuarkusPanelAccessFilterTest {
                         .toList());
 
         QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.read-only", "true"));
-        for (Map.Entry<String, ActionRequest> entry : actionRequestsByPanel.entrySet()) {
-            RoutingContext rc =
-                    mockRequest(entry.getValue().method(), entry.getValue().uri());
+        for (ActionContract action : actions) {
+            RoutingContext rc = mockRequest(action.method(), "/bootui/api" + action.relativePath());
             HttpServerResponse resp = rc.response();
 
             filter.handle(rc);
 
-            assertBlocked(resp, entry.getKey(), "BootUI is read-only via bootui.read-only=true");
+            assertBlocked(resp, action.panelId(), "BootUI is read-only via bootui.read-only=true");
         }
     }
 
@@ -236,7 +240,7 @@ class QuarkusPanelAccessFilterTest {
             Set.of(BootUiPanels.HTTP_SESSIONS, BootUiPanels.GRAALVM, BootUiPanels.DEVTOOLS, BootUiPanels.CRAC);
 
     /** Action-capable in the shared registry (Spring has a write path), but Quarkus has none yet. */
-    private static final Set<String> NO_WRITE_PATH_ON_QUARKUS_YET = Set.of(BootUiPanels.CONFIG);
+    private static final Set<String> NO_WRITE_PATH_ON_QUARKUS_YET = Set.of(BootUiPanels.CONFIG, BootUiPanels.JMS);
 
     private static QuarkusPanelAccessFilter newFilter(Map<String, String> properties) {
         return new QuarkusPanelAccessFilter(configOf(properties));
@@ -270,45 +274,4 @@ class QuarkusPanelAccessFilterTest {
                 .isEqualTo("{\"error\":\"BootUI panel access denied\",\"panel\":\"" + expectedPanelId
                         + "\",\"reason\":\"" + expectedReason + "\"}");
     }
-
-    /**
-     * The Quarkus-verified action-request fixture, one representative endpoint per real, available,
-     * action-capable Quarkus panel — the Quarkus analogue of Spring's {@code actionRequestsByPanel()},
-     * re-derived from the actual {@code @POST}/{@code @DELETE} JAX-RS resources rather than copied from
-     * Spring (paths can differ — e.g. Spring's {@code dev-services} path has an extra {@code services/}
-     * segment that the real Quarkus resource does not).
-     */
-    private static Map<String, ActionRequest> actionRequestsByPanel() {
-        Map<String, ActionRequest> requests = new LinkedHashMap<>();
-        requests.put("heap-dump", new ActionRequest("POST", "/bootui/api/heap-dump/capture"));
-        requests.put("threads", new ActionRequest("POST", "/bootui/api/threads/download"));
-        requests.put("memory", new ActionRequest("POST", "/bootui/api/memory/scan"));
-        requests.put("loggers", new ActionRequest("POST", "/bootui/api/loggers/io.github.jdubois.bootui"));
-        requests.put("security", new ActionRequest("POST", "/bootui/api/security/scan"));
-        requests.put("pentesting", new ActionRequest("POST", "/bootui/api/pentesting/scan"));
-        requests.put("hibernate", new ActionRequest("POST", "/bootui/api/hibernate/scan"));
-        requests.put("cache", new ActionRequest("POST", "/bootui/api/cache/clear"));
-        requests.put("kafka", new ActionRequest("DELETE", "/bootui/api/kafka"));
-        requests.put("rabbitmq", new ActionRequest("DELETE", "/bootui/api/rabbitmq"));
-        requests.put("jms", new ActionRequest("DELETE", "/bootui/api/jms"));
-        requests.put("traces", new ActionRequest("DELETE", "/bootui/api/traces"));
-        requests.put("exceptions", new ActionRequest("DELETE", "/bootui/api/exceptions"));
-        requests.put("http-probe", new ActionRequest("POST", "/bootui/api/http-probe"));
-        requests.put("architecture", new ActionRequest("POST", "/bootui/api/architecture/scan"));
-        requests.put("vulnerabilities", new ActionRequest("POST", "/bootui/api/vulnerabilities/scan"));
-        requests.put("dev-services", new ActionRequest("POST", "/bootui/api/dev-services/demo/restart"));
-        requests.put("flyway", new ActionRequest("POST", "/bootui/api/flyway/migrate"));
-        requests.put("liquibase", new ActionRequest("POST", "/bootui/api/liquibase/update"));
-        requests.put("github", new ActionRequest("POST", "/bootui/api/github/refresh"));
-        requests.put("rest-api", new ActionRequest("POST", "/bootui/api/rest-api/scan"));
-        requests.put("spring", new ActionRequest("POST", "/bootui/api/spring/scan"));
-        requests.put("sql-trace", new ActionRequest("POST", "/bootui/api/sql-trace/clear"));
-        requests.put("rest-client-trace", new ActionRequest("POST", "/bootui/api/rest-client-trace/recording"));
-        requests.put("email", new ActionRequest("DELETE", "/bootui/api/email"));
-        requests.put("mcp-server", new ActionRequest("POST", "/bootui/api/mcp-server/toggle"));
-        requests.put("activity", new ActionRequest("POST", "/bootui/api/activity/use-existing-datasource"));
-        return requests;
-    }
-
-    private record ActionRequest(String method, String uri) {}
 }

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilterTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusPanelAccessFilterTest.java
@@ -150,6 +150,24 @@ class QuarkusPanelAccessFilterTest {
     }
 
     @Test
+    void globalReadOnlyBlocksCatalogedNonPanelBrowserWrites() {
+        List<ActionContract> actions = BootUiApiContractCatalog.actions(Runtime.QUARKUS).stream()
+                .filter(action -> action.panelId() == null && action.blockedByGlobalReadOnly())
+                .toList();
+
+        assertThat(actions).isNotEmpty();
+        QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.read-only", "true"));
+        for (ActionContract action : actions) {
+            RoutingContext rc = mockRequest(action.method(), "/bootui/api" + action.relativePath());
+            HttpServerResponse resp = rc.response();
+
+            filter.handle(rc);
+
+            assertBlocked(resp, "dismissed-rules", "BootUI is read-only via bootui.read-only=true");
+        }
+    }
+
+    @Test
     void globalReadOnlyDoesNotBlockAPanelWithoutActions() {
         RoutingContext rc = mockRequest("GET", "/bootui/api/metrics");
         QuarkusPanelAccessFilter filter = newFilter(Map.of("bootui.read-only", "true"));

--- a/bootui-spring-autoconfigure/pom.xml
+++ b/bootui-spring-autoconfigure/pom.xml
@@ -194,6 +194,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.julien-dubois.bootui</groupId>
+            <artifactId>bootui-conformance</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
             <scope>test</scope>

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactivePanelAccessFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactivePanelAccessFilter.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.reactive;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.engine.panel.BootUiGlobalWritePolicy;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels.Panel;
 import java.util.Set;
@@ -44,6 +45,15 @@ public class ReactivePanelAccessFilter extends AbstractReactiveBootUiFilter impl
     protected Mono<Void> doFilterInternal(ServerWebExchange exchange, WebFilterChain chain) {
         ServerHttpRequest request = exchange.getRequest();
         String apiRelativePath = apiRelativePath(request);
+        String method = request.getMethod() != null ? request.getMethod().name() : "";
+        if (!SAFE_METHODS.contains(method) && properties.isReadOnly()) {
+            var globalSubject = BootUiGlobalWritePolicy.subjectFor(apiRelativePath);
+            if (globalSubject.isPresent()) {
+                return writeBlockedResponse(
+                        exchange, globalSubject.get(), properties.panelReadOnlyReason(globalSubject.get()));
+            }
+        }
+
         Panel panel = apiRelativePath != null
                 ? BootUiPanels.byApiPath(apiRelativePath).orElse(null)
                 : null;
@@ -55,7 +65,6 @@ public class ReactivePanelAccessFilter extends AbstractReactiveBootUiFilter impl
             return writeBlockedResponse(exchange, panel.id(), properties.panelDisabledReason(panel.id()));
         }
 
-        String method = request.getMethod() != null ? request.getMethod().name() : "";
         if (panel.actionCapable() && !SAFE_METHODS.contains(method) && properties.isPanelReadOnly(panel.id())) {
             return writeBlockedResponse(exchange, panel.id(), properties.panelReadOnlyReason(panel.id()));
         }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilter.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.safety;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.web.AbstractBootUiFilter;
+import io.github.jdubois.bootui.engine.panel.BootUiGlobalWritePolicy;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels.Panel;
 import jakarta.servlet.FilterChain;
@@ -31,6 +32,19 @@ public class PanelAccessFilter extends AbstractBootUiFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
         String apiRelativePath = apiRelativePath(request);
+        String method = request.getMethod();
+        if (!SAFE_METHODS.contains(method) && properties.isReadOnly()) {
+            var globalSubject = BootUiGlobalWritePolicy.subjectFor(apiRelativePath);
+            if (globalSubject.isPresent()) {
+                writeBlockedResponse(
+                        response,
+                        "BootUI panel access denied",
+                        globalSubject.get(),
+                        properties.panelReadOnlyReason(globalSubject.get()));
+                return;
+            }
+        }
+
         Panel panel = BootUiPanels.byApiPath(apiRelativePath).orElse(null);
         if (panel == null) {
             chain.doFilter(request, response);
@@ -43,9 +57,7 @@ public class PanelAccessFilter extends AbstractBootUiFilter {
             return;
         }
 
-        if (panel.actionCapable()
-                && !SAFE_METHODS.contains(request.getMethod())
-                && properties.isPanelReadOnly(panel.id())) {
+        if (panel.actionCapable() && !SAFE_METHODS.contains(method) && properties.isPanelReadOnly(panel.id())) {
             writeBlockedResponse(
                     response, "BootUI panel access denied", panel.id(), properties.panelReadOnlyReason(panel.id()));
             return;

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactivePanelAccessFilterTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactivePanelAccessFilterTests.java
@@ -3,10 +3,12 @@ package io.github.jdubois.bootui.autoconfigure.reactive;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.ActionContract;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import java.time.Duration;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
@@ -99,25 +101,25 @@ class ReactivePanelAccessFilterTests {
     @Test
     void globalReadOnlyBlocksActionCapablePanelActions() {
         properties.setReadOnly(true);
-        Map<String, ActionRequest> actionRequestsByPanel = actionRequestsByPanel();
+        List<ActionContract> actions = BootUiApiContractCatalog.actions(Runtime.SPRING_WEBFLUX).stream()
+                .filter(action -> action.panelId() != null)
+                .toList();
 
-        assertThat(actionRequestsByPanel.keySet())
-                .containsExactlyElementsOf(BootUiPanels.all().stream()
+        assertThat(actions.stream().map(ActionContract::panelId).collect(java.util.stream.Collectors.toSet()))
+                .containsExactlyInAnyOrderElementsOf(BootUiPanels.all().stream()
                         .filter(BootUiPanels.Panel::actionCapable)
                         .map(BootUiPanels.Panel::id)
+                        .filter(id -> !BootUiPanels.HTTP_SESSIONS.equals(id))
                         .toList());
-        for (Map.Entry<String, ActionRequest> entry : actionRequestsByPanel.entrySet()) {
-            MockServerWebExchange exchange =
-                    exchange(entry.getValue().method(), entry.getValue().uri());
+        for (ActionContract action : actions) {
+            MockServerWebExchange exchange = exchange(action.method(), "/bootui/api" + action.relativePath());
 
             filter.filter(exchange, OK_CHAIN).block(Duration.ofSeconds(5));
 
-            assertThat(exchange.getResponse().getStatusCode())
-                    .as(entry.getKey())
-                    .isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(exchange.getResponse().getStatusCode()).as(action.id()).isEqualTo(HttpStatus.FORBIDDEN);
             assertThat(bodyAsString(exchange))
-                    .as(entry.getKey())
-                    .contains("\"panel\":\"" + entry.getKey() + "\"")
+                    .as(action.id())
+                    .contains("\"panel\":\"" + action.panelId() + "\"")
                     .contains("bootui.read-only=true");
         }
     }
@@ -222,43 +224,4 @@ class ReactivePanelAccessFilterTests {
     private static String bodyAsString(MockServerWebExchange exchange) {
         return exchange.getResponse().getBodyAsString().block(Duration.ofSeconds(5));
     }
-
-    private Map<String, ActionRequest> actionRequestsByPanel() {
-        Map<String, ActionRequest> requests = new LinkedHashMap<>();
-        requests.put("http-sessions", new ActionRequest("POST", "/bootui/api/http-sessions/session-key/invalidate"));
-        requests.put("heap-dump", new ActionRequest("POST", "/bootui/api/heap-dump/capture"));
-        requests.put("threads", new ActionRequest("POST", "/bootui/api/threads/download"));
-        requests.put("memory", new ActionRequest("POST", "/bootui/api/memory/scan"));
-        requests.put("graalvm", new ActionRequest("POST", "/bootui/api/graalvm/scan"));
-        requests.put("config", new ActionRequest("POST", "/bootui/api/config/overrides"));
-        requests.put("loggers", new ActionRequest("POST", "/bootui/api/loggers/io.github.jdubois.bootui"));
-        requests.put("security", new ActionRequest("POST", "/bootui/api/security/scan"));
-        requests.put("pentesting", new ActionRequest("POST", "/bootui/api/pentesting/scan"));
-        requests.put("hibernate", new ActionRequest("POST", "/bootui/api/hibernate/scan"));
-        requests.put("cache", new ActionRequest("POST", "/bootui/api/cache/clear"));
-        requests.put("traces", new ActionRequest("DELETE", "/bootui/api/traces"));
-        requests.put("exceptions", new ActionRequest("DELETE", "/bootui/api/exceptions"));
-        requests.put("http-probe", new ActionRequest("POST", "/bootui/api/http-probe"));
-        requests.put("architecture", new ActionRequest("POST", "/bootui/api/architecture/scan"));
-        requests.put("vulnerabilities", new ActionRequest("POST", "/bootui/api/vulnerabilities/scan"));
-        requests.put("devtools", new ActionRequest("POST", "/bootui/api/devtools/restart"));
-        requests.put("dev-services", new ActionRequest("POST", "/bootui/api/dev-services/services/demo/restart"));
-        requests.put("flyway", new ActionRequest("POST", "/bootui/api/flyway/migrate"));
-        requests.put("liquibase", new ActionRequest("POST", "/bootui/api/liquibase/update"));
-        requests.put("github", new ActionRequest("POST", "/bootui/api/github/refresh"));
-        requests.put("rest-api", new ActionRequest("POST", "/bootui/api/rest-api/scan"));
-        requests.put("spring", new ActionRequest("POST", "/bootui/api/spring/scan"));
-        requests.put("crac", new ActionRequest("POST", "/bootui/api/crac/scan"));
-        requests.put("sql-trace", new ActionRequest("POST", "/bootui/api/sql-trace/clear"));
-        requests.put("rest-client-trace", new ActionRequest("POST", "/bootui/api/rest-client-trace/clear"));
-        requests.put("mcp-server", new ActionRequest("POST", "/bootui/api/mcp-server/toggle"));
-        requests.put("activity", new ActionRequest("POST", "/bootui/api/activity/use-existing-datasource"));
-        requests.put("email", new ActionRequest("DELETE", "/bootui/api/email"));
-        requests.put("kafka", new ActionRequest("DELETE", "/bootui/api/kafka"));
-        requests.put("rabbitmq", new ActionRequest("DELETE", "/bootui/api/rabbitmq"));
-        requests.put("jms", new ActionRequest("DELETE", "/bootui/api/jms"));
-        return requests;
-    }
-
-    private record ActionRequest(String method, String uri) {}
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactivePanelAccessFilterTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactivePanelAccessFilterTests.java
@@ -125,6 +125,27 @@ class ReactivePanelAccessFilterTests {
     }
 
     @Test
+    void globalReadOnlyBlocksCatalogedNonPanelBrowserWrites() {
+        properties.setReadOnly(true);
+        List<ActionContract> actions = BootUiApiContractCatalog.actions(Runtime.SPRING_WEBFLUX).stream()
+                .filter(action -> action.panelId() == null && action.blockedByGlobalReadOnly())
+                .toList();
+
+        assertThat(actions).isNotEmpty();
+        for (ActionContract action : actions) {
+            MockServerWebExchange exchange = exchange(action.method(), "/bootui/api" + action.relativePath());
+
+            filter.filter(exchange, OK_CHAIN).block(Duration.ofSeconds(5));
+
+            assertThat(exchange.getResponse().getStatusCode()).as(action.id()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(bodyAsString(exchange))
+                    .as(action.id())
+                    .contains("\"panel\":\"dismissed-rules\"")
+                    .contains("bootui.read-only=true");
+        }
+    }
+
+    @Test
     void perPanelReadOnlyBlocksPentestingScanAction() {
         properties.panel("pentesting").setReadOnly(true);
         MockServerWebExchange exchange = exchange("POST", "/bootui/api/pentesting/scan");

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilterTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilterTests.java
@@ -3,9 +3,11 @@ package io.github.jdubois.bootui.autoconfigure.safety;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.ActionContract;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockFilterChain;
@@ -89,24 +91,25 @@ class PanelAccessFilterTests {
     @Test
     void globalReadOnlyBlocksActionCapablePanelActions() throws Exception {
         properties.setReadOnly(true);
-        Map<String, ActionRequest> actionRequestsByPanel = actionRequestsByPanel();
+        List<ActionContract> actions = BootUiApiContractCatalog.actions(Runtime.SPRING_MVC).stream()
+                .filter(action -> action.panelId() != null)
+                .toList();
 
-        assertThat(actionRequestsByPanel.keySet())
-                .containsExactlyElementsOf(BootUiPanels.all().stream()
+        assertThat(actions.stream().map(ActionContract::panelId).collect(java.util.stream.Collectors.toSet()))
+                .containsExactlyInAnyOrderElementsOf(BootUiPanels.all().stream()
                         .filter(BootUiPanels.Panel::actionCapable)
                         .map(BootUiPanels.Panel::id)
                         .toList());
-        for (Map.Entry<String, ActionRequest> entry : actionRequestsByPanel.entrySet()) {
-            MockHttpServletRequest request =
-                    request(entry.getValue().method(), entry.getValue().uri());
+        for (ActionContract action : actions) {
+            MockHttpServletRequest request = request(action.method(), "/bootui/api" + action.relativePath());
             MockHttpServletResponse response = new MockHttpServletResponse();
 
             filter.doFilter(request, response, new MockFilterChain());
 
-            assertThat(response.getStatus()).as(entry.getKey()).isEqualTo(403);
+            assertThat(response.getStatus()).as(action.id()).isEqualTo(403);
             assertThat(response.getContentAsString())
-                    .as(entry.getKey())
-                    .contains("\"panel\":\"" + entry.getKey() + "\"")
+                    .as(action.id())
+                    .contains("\"panel\":\"" + action.panelId() + "\"")
                     .contains("bootui.read-only=true");
         }
     }
@@ -203,43 +206,4 @@ class PanelAccessFilterTests {
         request.setRequestURI(uri);
         return request;
     }
-
-    private Map<String, ActionRequest> actionRequestsByPanel() {
-        Map<String, ActionRequest> requests = new LinkedHashMap<>();
-        requests.put("http-sessions", new ActionRequest("POST", "/bootui/api/http-sessions/session-key/invalidate"));
-        requests.put("heap-dump", new ActionRequest("POST", "/bootui/api/heap-dump/capture"));
-        requests.put("threads", new ActionRequest("POST", "/bootui/api/threads/download"));
-        requests.put("memory", new ActionRequest("POST", "/bootui/api/memory/scan"));
-        requests.put("graalvm", new ActionRequest("POST", "/bootui/api/graalvm/scan"));
-        requests.put("config", new ActionRequest("POST", "/bootui/api/config/overrides"));
-        requests.put("loggers", new ActionRequest("POST", "/bootui/api/loggers/io.github.jdubois.bootui"));
-        requests.put("security", new ActionRequest("POST", "/bootui/api/security/scan"));
-        requests.put("pentesting", new ActionRequest("POST", "/bootui/api/pentesting/scan"));
-        requests.put("hibernate", new ActionRequest("POST", "/bootui/api/hibernate/scan"));
-        requests.put("cache", new ActionRequest("POST", "/bootui/api/cache/clear"));
-        requests.put("traces", new ActionRequest("DELETE", "/bootui/api/traces"));
-        requests.put("exceptions", new ActionRequest("DELETE", "/bootui/api/exceptions"));
-        requests.put("http-probe", new ActionRequest("POST", "/bootui/api/http-probe"));
-        requests.put("architecture", new ActionRequest("POST", "/bootui/api/architecture/scan"));
-        requests.put("vulnerabilities", new ActionRequest("POST", "/bootui/api/vulnerabilities/scan"));
-        requests.put("devtools", new ActionRequest("POST", "/bootui/api/devtools/restart"));
-        requests.put("dev-services", new ActionRequest("POST", "/bootui/api/dev-services/services/demo/restart"));
-        requests.put("flyway", new ActionRequest("POST", "/bootui/api/flyway/migrate"));
-        requests.put("liquibase", new ActionRequest("POST", "/bootui/api/liquibase/update"));
-        requests.put("github", new ActionRequest("POST", "/bootui/api/github/refresh"));
-        requests.put("rest-api", new ActionRequest("POST", "/bootui/api/rest-api/scan"));
-        requests.put("spring", new ActionRequest("POST", "/bootui/api/spring/scan"));
-        requests.put("crac", new ActionRequest("POST", "/bootui/api/crac/scan"));
-        requests.put("sql-trace", new ActionRequest("POST", "/bootui/api/sql-trace/clear"));
-        requests.put("rest-client-trace", new ActionRequest("POST", "/bootui/api/rest-client-trace/clear"));
-        requests.put("mcp-server", new ActionRequest("POST", "/bootui/api/mcp-server/toggle"));
-        requests.put("activity", new ActionRequest("POST", "/bootui/api/activity/use-existing-datasource"));
-        requests.put("email", new ActionRequest("DELETE", "/bootui/api/email"));
-        requests.put("kafka", new ActionRequest("DELETE", "/bootui/api/kafka"));
-        requests.put("rabbitmq", new ActionRequest("DELETE", "/bootui/api/rabbitmq"));
-        requests.put("jms", new ActionRequest("DELETE", "/bootui/api/jms"));
-        return requests;
-    }
-
-    private record ActionRequest(String method, String uri) {}
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilterTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilterTests.java
@@ -115,6 +115,28 @@ class PanelAccessFilterTests {
     }
 
     @Test
+    void globalReadOnlyBlocksCatalogedNonPanelBrowserWrites() throws Exception {
+        properties.setReadOnly(true);
+        List<ActionContract> actions = BootUiApiContractCatalog.actions(Runtime.SPRING_MVC).stream()
+                .filter(action -> action.panelId() == null && action.blockedByGlobalReadOnly())
+                .toList();
+
+        assertThat(actions).isNotEmpty();
+        for (ActionContract action : actions) {
+            MockHttpServletRequest request = request(action.method(), "/bootui/api" + action.relativePath());
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            filter.doFilter(request, response, new MockFilterChain());
+
+            assertThat(response.getStatus()).as(action.id()).isEqualTo(403);
+            assertThat(response.getContentAsString())
+                    .as(action.id())
+                    .contains("\"panel\":\"dismissed-rules\"")
+                    .contains("bootui.read-only=true");
+        }
+    }
+
+    @Test
     void perPanelReadOnlyBlocksPentestingScanAction() throws Exception {
         properties.panel("pentesting").setReadOnly(true);
         MockHttpServletRequest request = request("POST", "/bootui/api/pentesting/scan");

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiCustomPathIntegrationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiCustomPathIntegrationTests.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.sample;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.jdubois.bootui.conformance.AbstractBootUiApiConformanceTest;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
 import java.util.HashMap;
@@ -23,9 +24,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
             "bootui.path=/dev-console/",
             "bootui.api-path=/internal/bootui-api/",
             "bootui.show-banner=false",
-            "bootui.overrides-file=target/bootui-custom-path-test-overrides.properties"
+            "bootui.overrides-file=target/bootui-custom-path-test-overrides.properties",
+            "bootui.panels.copilot.enabled=false",
+            "bootui.panels.heap-dump.read-only=true",
+            "bootui.heap-dump.capture-enabled=false",
+            "bootui.claude-code.enabled=OFF",
+            "bootui.conformance.api-token=conformance-raw-secret-value"
         })
-class BootUiCustomPathIntegrationTests {
+class BootUiCustomPathIntegrationTests extends AbstractBootUiApiConformanceTest {
 
     private static final String UI_PATH = "/host/dev-console";
     private static final String API_PATH = "/host/internal/bootui-api";
@@ -36,6 +42,21 @@ class BootUiCustomPathIntegrationTests {
 
     private BootUiHttpProbe probe() {
         return new BootUiHttpProbe("http://localhost:" + port);
+    }
+
+    @Override
+    protected String baseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    @Override
+    protected String uiPath() {
+        return UI_PATH;
+    }
+
+    @Override
+    protected String apiPath() {
+        return API_PATH;
     }
 
     @Test

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/SpringApiConformanceTest.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/SpringApiConformanceTest.java
@@ -32,7 +32,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
             "bootui.panels.copilot.enabled=false",
             "bootui.panels.heap-dump.read-only=true",
             "bootui.heap-dump.capture-enabled=false",
-            "bootui.claude-code.enabled=OFF"
+            "bootui.claude-code.enabled=OFF",
+            "bootui.conformance.api-token=conformance-raw-secret-value"
         })
 class SpringApiConformanceTest extends AbstractBootUiApiConformanceTest {
 

--- a/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxApiConformanceTest.java
+++ b/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxApiConformanceTest.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.webfluxsample;
 
 import io.github.jdubois.bootui.conformance.AbstractBootUiApiConformanceTest;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -36,7 +37,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
             "bootui.panels.copilot.enabled=false",
             "bootui.panels.heap-dump.read-only=true",
             "bootui.heap-dump.capture-enabled=false",
-            "bootui.claude-code.enabled=OFF"
+            "bootui.claude-code.enabled=OFF",
+            "bootui.conformance.api-token=conformance-raw-secret-value"
         })
 class WebFluxApiConformanceTest extends AbstractBootUiApiConformanceTest {
 
@@ -51,5 +53,10 @@ class WebFluxApiConformanceTest extends AbstractBootUiApiConformanceTest {
     @Override
     protected String expectedPanelsResource() {
         return "/io/github/jdubois/bootui/conformance/expected-panels-webflux.json";
+    }
+
+    @Override
+    protected Runtime runtime() {
+        return Runtime.SPRING_WEBFLUX;
     }
 }

--- a/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxCustomPathIntegrationTest.java
+++ b/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxCustomPathIntegrationTest.java
@@ -2,10 +2,13 @@ package io.github.jdubois.bootui.webfluxsample;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.jdubois.bootui.conformance.AbstractBootUiApiConformanceTest;
+import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
@@ -22,9 +25,14 @@ import org.springframework.boot.test.web.server.LocalServerPort;
             "bootui.path=/dev-console/",
             "bootui.api-path=/internal/bootui-api/",
             "bootui.show-banner=false",
-            "bootui.overrides-file=target/bootui-custom-path-test-overrides.properties"
+            "bootui.overrides-file=target/bootui-custom-path-test-overrides.properties",
+            "bootui.panels.copilot.enabled=false",
+            "bootui.panels.heap-dump.read-only=true",
+            "bootui.heap-dump.capture-enabled=false",
+            "bootui.claude-code.enabled=OFF",
+            "bootui.conformance.api-token=conformance-raw-secret-value"
         })
-class WebFluxCustomPathIntegrationTest {
+class WebFluxCustomPathIntegrationTest extends AbstractBootUiApiConformanceTest {
 
     private static final String UI_PATH = "/host/dev-console";
     private static final String API_PATH = "/host/internal/bootui-api";
@@ -35,6 +43,38 @@ class WebFluxCustomPathIntegrationTest {
 
     private BootUiHttpProbe probe() {
         return new BootUiHttpProbe("http://localhost:" + port);
+    }
+
+    @Override
+    protected String baseUrl() {
+        return "http://localhost:" + port;
+    }
+
+    @Override
+    protected String expectedPanelsResource() {
+        return "/io/github/jdubois/bootui/conformance/expected-panels-webflux.json";
+    }
+
+    @Override
+    protected Runtime runtime() {
+        return Runtime.SPRING_WEBFLUX;
+    }
+
+    @Override
+    protected String uiPath() {
+        return UI_PATH;
+    }
+
+    @Override
+    protected String apiPath() {
+        return API_PATH;
+    }
+
+    @Override
+    protected Set<String> unsupportedReadContracts() {
+        // PR #726 moves these rebuilt reactive handlers behind the configured API path. Keep C1
+        // stacked only on #732 and consume that sibling fix when it lands instead of duplicating it.
+        return Set.of("rest-client-trace", "security", "spring-security");
     }
 
     @Test

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -2111,10 +2111,12 @@ Future compatibility:
   null/empty and availability semantics, pagination containers, scan-status fields, and observable secret masking while
   allowing runtime counts, timestamps, framework versions, and captured data to vary.
 - A central mutation catalog lists every panel action plus the MCP, dismissed-rules, and OTLP infrastructure writes.
-  Adapter access-filter tests consume that catalog so a newly cataloged route cannot silently bypass global read-only
-  policy. The live contract covers confirmation gates, canonical panel denial, missing targets, single-flight `409`
-  responses, and only deterministic repeatable successes; it never calls external services or invokes destructive,
-  heap-capture, or GC-heavy actions.
+  It classifies non-panel writes by global read-only applicability: dismissed-rule persistence is blocked, the MCP bridge
+  delegates authorization to its per-tool panel policy, and OTLP ingestion remains an observability transport. Adapter
+  access-filter tests consume that catalog so a browser mutation cannot silently bypass global read-only policy. The live
+  contract covers confirmation gates, canonical panel denial, missing targets, single-flight `409` responses, and only
+  deterministic repeatable successes; it never calls external services or invokes destructive, heap-capture, or
+  GC-heavy actions.
 - The same suite runs at the default mount and at independent custom UI/API mounts (including each runtime's host root
   path), so shell, assets, reads, streams, downloads, errors, and safe writes share one path contract.
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -2103,7 +2103,22 @@ Future compatibility:
 - Newer panels work against the sample app or degrade cleanly when optional infrastructure is absent.
 - Production profile disables BootUI.
 
-### 9.4 Browser/UI tests
+### 9.4 Cross-runtime API conformance
+
+- `bootui-conformance` runs one black-box HTTP contract against Spring MVC, Spring WebFlux, and Quarkus.
+- Golden panel fixtures continue to pin panel ids, titles, ordering, and action-capable metadata.
+- Available data panels are checked through a central DTO-family catalog. The contract asserts stable field types,
+  null/empty and availability semantics, pagination containers, scan-status fields, and observable secret masking while
+  allowing runtime counts, timestamps, framework versions, and captured data to vary.
+- A central mutation catalog lists every panel action plus the MCP, dismissed-rules, and OTLP infrastructure writes.
+  Adapter access-filter tests consume that catalog so a newly cataloged route cannot silently bypass global read-only
+  policy. The live contract covers confirmation gates, canonical panel denial, missing targets, single-flight `409`
+  responses, and only deterministic repeatable successes; it never calls external services or invokes destructive,
+  heap-capture, or GC-heavy actions.
+- The same suite runs at the default mount and at independent custom UI/API mounts (including each runtime's host root
+  path), so shell, assets, reads, streams, downloads, errors, and safe writes share one path contract.
+
+### 9.5 Browser/UI tests
 
 - Playwright smoke tests for all visible panels in `bootui-spring-sample-app/e2e`.
 - Search and filter behavior.


### PR DESCRIPTION
## Summary

- replace generic available-panel `200 + JSON` checks with a central DTO-family contract catalog covering every data panel, stable field types, availability/null/empty semantics, pagination, scan statuses, and observable secret masking
- centralize every BootUI mutating route by runtime and reuse that catalog in MVC, WebFlux, and Quarkus read-only filter tests
- expand live action semantics for confirmation-required, canonical read-only/disabled denial, missing targets, safe repeatable success, and #732 single-flight `409` conflicts
- run the shared conformance contract at both default and custom UI/API mounts for MVC, WebFlux, and Quarkus
- document the conformance methodology in the specification

## Stack

- **Base:** #732 (`jdubois-scanner-single-flight`)
- #726 custom-path reactive handler fixes are consumed as a documented capability exclusion until that sibling lands; no implementation is duplicated
- #727 Metrics contract changes are not copied or cherry-picked

## Validation

- `./mvnw -B -ntp -pl bootui-spring-sample-app,bootui-spring-webflux-sample-app,bootui-quarkus-integration-tests/base -am test`
- `./mvnw -B -ntp -pl bootui-engine,bootui-spring-autoconfigure -am test -Dtest=EngineBoundaryArchitectureTests,SpiBoundaryArchitectureTests,BootUiArchitectureTests -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw -B -ntp spotless:check`

No UI behavior changed, so no browser suite was required.