### PR TITLE
Prepare 1.13.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to BootUI are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2026-08-07
+
+Patch release that restores accurate scanner scores with customized Jackson mappers and removes Quarkus split-package
+warnings during application augmentation.
+
+### Fixed
+
+- **Overview scanner scores no longer show a false `100 / Good` result when a Spring host application enables Jackson
+  polymorphic typing.** BootUI API responses now use a path-scoped clean Jackson 3 serializer on both Spring MVC and
+  WebFlux without changing host endpoint serialization, while malformed severity summaries surface as scanner errors
+  instead of silently receiving a perfect score (#724).
+- **Quarkus applications no longer report split-package warnings for BootUI runtime packages.** Same-package white-box
+  tests now live in the Quarkus runtime module instead of an integration-test application archive, keeping augmentation
+  output clean without changing runtime behavior (#719).
+
 ## [1.13.0] - 2026-08-06
 
 Feature release headlined by a **dependency graph mode for the Beans panel** on both Spring and Quarkus, alongside the
@@ -1352,7 +1367,9 @@ First tagged BootUI alpha. Highlights of the harden-all-visible-panels scope:
   request history, distributed tracing, multi-service orchestration, and live
   Docker Compose lifecycle control are intentionally out of scope for the alpha.
 
-[Unreleased]: https://github.com/jdubois/boot-ui/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/jdubois/boot-ui/compare/v1.13.1...HEAD
+[1.13.1]: https://github.com/jdubois/boot-ui/compare/v1.13.0...v1.13.1
+[1.13.0]: https://github.com/jdubois/boot-ui/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/jdubois/boot-ui/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/jdubois/boot-ui/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/jdubois/boot-ui/compare/v1.9.0...v1.10.0


### PR DESCRIPTION
## What does this PR do?

Documents the fixes included in BootUI 1.13.1 and updates the changelog comparison links for the new release.

## Why is this change needed?

The upcoming patch release needs accurate release notes for the scanner-score serialization fix and the Quarkus split-package warning fix. The existing comparison links also still stopped at 1.12.0.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [ ] Added or updated tests where applicable

The full Maven reactor passed with `./mvnw verify`; this PR changes documentation only.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed