### PR TITLE
Prevent invalid release version jumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Release version to prepare, for example 1.0.0. Leave empty to publish the selected tagged ref.
+        description: Next major, minor, or patch version to prepare. Leave empty to publish the selected tagged ref.
         required: false
         type: string
         default: ''
@@ -82,13 +82,31 @@ jobs:
           SOURCE_BRANCH="$GITHUB_REF_NAME"
           SOURCE_SHA="$GITHUB_SHA"
 
-          if [[ -z "$VERSION" || "$VERSION" == *[[:space:]]* || "$VERSION" == */* ]]; then
-            echo "::error::Invalid release version: $RELEASE_VERSION"
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Invalid release version '$RELEASE_VERSION': expected a stable major.minor.patch version"
             exit 2
           fi
 
-          if [[ "$VERSION" == *-SNAPSHOT ]]; then
-            echo "::error::Refusing to prepare a snapshot release: $VERSION"
+          LATEST_TAG="$(
+            git tag --list 'v*' |
+              grep -E '^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' |
+              sort -V |
+              tail -n 1 ||
+              true
+          )"
+          if [[ -z "$LATEST_TAG" ]]; then
+            echo "::error::Cannot determine the latest stable release tag"
+            exit 1
+          fi
+
+          LATEST_VERSION="${LATEST_TAG#v}"
+          IFS=. read -r LATEST_MAJOR LATEST_MINOR LATEST_PATCH <<< "$LATEST_VERSION"
+          NEXT_PATCH="$LATEST_MAJOR.$LATEST_MINOR.$((LATEST_PATCH + 1))"
+          NEXT_MINOR="$LATEST_MAJOR.$((LATEST_MINOR + 1)).0"
+          NEXT_MAJOR="$((LATEST_MAJOR + 1)).0.0"
+
+          if [[ "$VERSION" != "$NEXT_PATCH" && "$VERSION" != "$NEXT_MINOR" && "$VERSION" != "$NEXT_MAJOR" ]]; then
+            echo "::error::Invalid release version '$VERSION'. Latest release is $LATEST_TAG; expected $NEXT_PATCH (patch), $NEXT_MINOR (minor), or $NEXT_MAJOR (major)."
             exit 2
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,14 +284,16 @@ to stage for manual publishing instead.
 
 To prepare and publish a release, run the **Release** GitHub Actions workflow
 from the branch you want to release, usually `main`, and enter the target version
-without the leading `v`, for example `1.0.0`. The workflow updates all Maven
-module versions and refreshes the documentation dependency examples in the working
-tree and optionally verifies with the `release` Maven profile. Before any Maven
-Central upload, it commits those exact contents, creates a GPG-signed annotated
-`v1.0.0` tag, and atomically pushes the source branch plus tag. If the source branch
-advanced during preparation, the workflow aborts; it never rebases released
-contents. The selected branch must allow `github-actions[bot]` to push the release
-commit and tag.
+without the leading `v`. The target must be exactly the next patch, minor, or major
+version after the latest stable release tag. For example, after `v1.13.1`, the
+workflow accepts only `1.13.2`, `1.14.0`, or `2.0.0`. The workflow updates all
+Maven module versions and refreshes the documentation dependency examples in the
+working tree and optionally verifies with the `release` Maven profile. Before any
+Maven Central upload, it commits those exact contents, creates a GPG-signed
+annotated version tag, and atomically pushes the source branch plus tag. If the
+source branch advanced during preparation, the workflow aborts; it never rebases
+released contents. The selected branch must allow
+`github-actions[bot]` to push the release commit and tag.
 
 The workflow then resolves the remote tag to its peeled commit SHA, checks out that
 SHA in detached state, rechecks the Maven/npm/tag identity, and publishes exactly


### PR DESCRIPTION
## What does this PR do?

Validates manually dispatched release versions before changing files or publishing artifacts. The requested version must be exactly the next patch, minor, or major increment from the latest stable release tag.

## Why is this change needed?

A mistyped release version can publish immutable Maven Central coordinates. Restricting releases to the three valid successors prevents accidental regressions and skipped versions such as `1.3.1` after `1.13.0`.

Closes #

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Started `bootui-spring-sample-app` and verified `/bootui` loads and the change works end-to-end
- [x] Added or updated tests where applicable

Validated the workflow YAML and exercised accepted and rejected version cases against latest tag `v1.13.1`.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed