### PR TITLE
fix: refine Quarkus application advisor checks

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppChecks.java
@@ -15,7 +15,7 @@ import java.util.List;
 final class QuarkusAppChecks {
 
     private static final String VIOLATION = "VIOLATION";
-    private static final int RULE_COUNT = 20;
+    private static final int RULE_COUNT = 19;
     private static final String GUIDE = "https://quarkus.io/guides/cdi-reference";
     private static final String CONFIG_GUIDE = "https://quarkus.io/guides/config-reference";
     private static final String REACTIVE_GUIDE = "https://quarkus.io/guides/getting-started-reactive";
@@ -97,10 +97,11 @@ final class QuarkusAppChecks {
                     "Reactive endpoints with a blocking JDBC datasource",
                     "Reactive",
                     "HIGH",
-                    "Endpoint(s) return Uni/Multi/CompletionStage/CompletableFuture/Publisher (run on the I/O"
-                            + " event loop), lack a @Blocking or @Transactional guard on the method or resource"
-                            + " class, and a blocking JDBC datasource is configured; a JDBC call on the event loop"
-                            + " stalls it and can throw BlockingOperationNotAllowedException at runtime.",
+                    "Endpoint(s) return Uni/Multi/RestMulti/CompletionStage/CompletableFuture/Flow.Publisher/"
+                            + "Publisher (run on the I/O event loop), lack a @Blocking or @Transactional guard on"
+                            + " the method or resource class, and a blocking JDBC datasource is configured; a JDBC"
+                            + " call on the event loop stalls it and can throw BlockingOperationNotAllowedException"
+                            + " at runtime.",
                     s.reactiveEndpointsWithoutBlockingCount(),
                     List.of(s.reactiveEndpointsWithoutBlockingCount()
                             + " reactive endpoint(s) without @Blocking/@Transactional, JDBC datasource present"),
@@ -264,9 +265,8 @@ final class QuarkusAppChecks {
                     "Graceful shutdown grace period zeroed",
                     "Web",
                     "MEDIUM",
-                    "quarkus.shutdown.timeout or quarkus.http.shutdown.timeout is explicitly set to 0, disabling"
-                            + " the graceful-shutdown grace period; in-flight requests are dropped instead of"
-                            + " being allowed to complete on SIGTERM.",
+                    "quarkus.shutdown.timeout is explicitly set to 0, disabling the graceful-shutdown grace period;"
+                            + " in-flight requests are dropped instead of being allowed to complete on SIGTERM.",
                     1,
                     List.of("shutdown timeout=0"),
                     "Remove the override (or set a positive duration) so in-flight requests can drain before"
@@ -279,9 +279,9 @@ final class QuarkusAppChecks {
                     "Graceful shutdown timeout never configured",
                     "Web",
                     "INFO",
-                    "Neither quarkus.shutdown.timeout nor quarkus.http.shutdown.timeout is set. Quarkus's"
-                            + " graceful shutdown is opt-in: with no timeout configured, the application exits"
-                            + " immediately on SIGTERM instead of draining in-flight requests.",
+                    "quarkus.shutdown.timeout is not set. Quarkus's graceful shutdown is opt-in: with no timeout"
+                            + " configured, the application exits immediately on SIGTERM instead of draining"
+                            + " in-flight requests.",
                     1,
                     List.of("no shutdown timeout configured"),
                     "Set quarkus.shutdown.timeout to a positive duration (e.g. 10s) so in-flight requests can"
@@ -305,21 +305,6 @@ final class QuarkusAppChecks {
                             + " appropriate for the remote service.",
                     REST_CLIENT_GUIDE));
         }
-        if (s.endpointCount() > 0 && s.virtualThreadEndpointCount() == 0 && s.jdkMajorVersion() >= 21) {
-            v.add(rule(
-                    "QA-PERF-001",
-                    "No virtual-thread adoption",
-                    "Performance",
-                    "INFO",
-                    "The app declares " + s.endpointCount() + " JAX-RS endpoint(s) but none use"
-                            + " @RunOnVirtualThread. If any perform blocking I/O (JDBC, file access, blocking"
-                            + " REST calls), running them on virtual threads can improve throughput without"
-                            + " sizing a worker thread pool.",
-                    s.endpointCount(),
-                    List.of(s.endpointCount() + " JAX-RS endpoint(s), 0 @RunOnVirtualThread"),
-                    "Annotate blocking I/O-bound endpoint methods (or the resource class) with @RunOnVirtualThread.",
-                    VIRTUAL_THREADS_GUIDE));
-        }
         if (s.virtualThreadSynchronizedCount() > 0 && s.jdkMajorVersion() >= 21 && s.jdkMajorVersion() < 24) {
             v.add(rule(
                     "QA-PERF-002",
@@ -327,9 +312,10 @@ final class QuarkusAppChecks {
                     "Performance",
                     "HIGH",
                     s.virtualThreadSynchronizedCount() + " @RunOnVirtualThread method(s) are also declared"
-                            + " synchronized. On JDK " + s.jdkMajorVersion() + " (21-23), entering a synchronized"
-                            + " method pins the carrier thread instead of yielding it, defeating the scalability"
-                            + " benefit of virtual threads; JEP 491 removes this pinning starting in JDK 24.",
+                            + " synchronized. On JDK " + s.jdkMajorVersion()
+                            + " (21-23), a blocking operation inside a synchronized method pins the carrier thread"
+                            + " instead of yielding it, defeating the scalability benefit of virtual threads; JEP"
+                            + " 491 removes this pinning starting in JDK 24.",
                     s.virtualThreadSynchronizedCount(),
                     List.of(s.virtualThreadSynchronizedCount() + " @RunOnVirtualThread synchronized method(s), JDK "
                             + s.jdkMajorVersion()),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusAppSnapshot.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/QuarkusAppSnapshot.java
@@ -21,10 +21,10 @@ import java.util.List;
  * @param configPropertyCount number of {@code @ConfigProperty} injection sites
  * @param endpointCount discovered JAX-RS endpoint methods
  * @param defaultScopeResourceCount JAX-RS resources with no explicit CDI scope
- * @param reactiveEndpointCount endpoints returning {@code Uni}/{@code Multi}
- * @param reactiveEndpointsWithoutBlockingCount reactive ({@code Uni}/{@code Multi}) endpoints whose method and
- *     declaring class both lack {@code @Blocking} — the exact endpoints QA-RX-001 should flag, correlated
- *     per-endpoint rather than against the app's total {@code @Blocking} count
+ * @param reactiveEndpointCount endpoints whose return type Quarkus REST dispatches as non-blocking
+ * @param reactiveEndpointsWithoutBlockingCount reactive endpoints whose method and declaring class both lack a
+ *     blocking guard — the exact endpoints QA-RX-001 should flag, correlated per-endpoint rather than against the
+ *     app's total {@code @Blocking} count
  * @param blockingAnnotationCount {@code @Blocking} sites
  * @param scheduledCount {@code @Scheduled} methods
  * @param activeProfiles the SmallRye active profiles
@@ -32,7 +32,7 @@ import java.util.List;
  * @param prodDevServicesEnabled whether a {@code %prod.*devservices.enabled=true} key is present
  * @param nativeBuild whether the snapshot was taken during a native build
  * @param configMappingCount number of {@code @ConfigMapping} interfaces (type-safe config groups)
- * @param jdbcDatasourcePresent whether a JDBC datasource (db-kind or jdbc url) is configured
+ * @param jdbcDatasourcePresent whether Quarkus's Agroal (JDBC datasource) capability was captured at build time
  * @param prodSchemaGeneration effective {@code %prod} Hibernate schema strategy (normalised, may be empty)
  * @param prodDbKind the {@code %prod.quarkus.datasource.db-kind} value (may be empty)
  * @param prodJdbcUrlInMemory whether a {@code %prod} JDBC url points at an in-memory database
@@ -46,7 +46,6 @@ import java.util.List;
  * @param restClientTimeoutZeroOrExcessive whether a global or per-client REST client connect/read timeout is
  *     explicitly set to {@code 0} (disabled) or to an excessively high value — Quarkus REST clients already
  *     default to a 15s connect-timeout/30s read-timeout, so merely leaving the timeout unset is not flagged
- * @param virtualThreadEndpointCount {@code @RunOnVirtualThread} sites (methods or classes)
  * @param virtualThreadSynchronizedCount {@code @RunOnVirtualThread} sites that are also {@code synchronized}
  *     (a class-level {@code @RunOnVirtualThread} counts every {@code synchronized} method in that class)
  * @param jdkMajorVersion the build JDK's major version (0 if undetermined)
@@ -55,8 +54,8 @@ import java.util.List;
  * @param legacySchemaGenerationPropertyUsed whether the deprecated {@code quarkus.hibernate-orm.database.generation}
  *     property (or a profile/named-persistence-unit variant) is used instead of the current
  *     {@code quarkus.hibernate-orm.schema-management.strategy}
- * @param shutdownTimeoutConfigured whether {@code quarkus.shutdown.timeout} or
- *     {@code quarkus.http.shutdown.timeout} is set at all (to any value, including {@code 0})
+ * @param shutdownTimeoutConfigured whether {@code quarkus.shutdown.timeout} is set at all (to any value,
+ *     including {@code 0})
  * @param datasourceMaxSizeConfigured whether {@code quarkus.datasource.jdbc.max-size} is explicitly set
  *     (globally or via a {@code %prod} override)
  */
@@ -90,7 +89,6 @@ public record QuarkusAppSnapshot(
         boolean shutdownTimeoutZeroed,
         boolean restClientsRegistered,
         boolean restClientTimeoutZeroOrExcessive,
-        int virtualThreadEndpointCount,
         int virtualThreadSynchronizedCount,
         int jdkMajorVersion,
         List<String> mutableSingletonFields,

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
@@ -18,7 +18,7 @@ class QuarkusAppScannerTest {
 
     /**
      * Mutable builder whose defaults describe a clean Quarkus app that fires zero rules, so each test can flip
-     * exactly the fields under test. Mirrors the 36-field {@link QuarkusAppSnapshot} positional record.
+     * exactly the fields under test. Mirrors the 35-field {@link QuarkusAppSnapshot} positional record.
      */
     private static final class Snap {
         // CDI / beans (beanCount = applicationScoped + singleton + requestScoped + dependentScoped = 4)
@@ -62,8 +62,7 @@ class QuarkusAppScannerTest {
         boolean shutdownTimeoutConfigured = true;
         boolean restClientsRegistered = false;
         boolean restClientTimeoutZeroOrExcessive = false;
-        // Performance / virtual threads (jdkMajorVersion=21 + 1 adopting endpoint is a clean modern baseline)
-        int virtualThreadEndpoints = 1;
+        // Performance / virtual threads
         int virtualThreadSynchronized = 0;
         int jdkMajorVersion = 21;
 
@@ -98,7 +97,6 @@ class QuarkusAppScannerTest {
                     shutdownTimeoutZeroed,
                     restClientsRegistered,
                     restClientTimeoutZeroOrExcessive,
-                    virtualThreadEndpoints,
                     virtualThreadSynchronized,
                     jdkMajorVersion,
                     mutableSingletonFields,
@@ -426,32 +424,6 @@ class QuarkusAppScannerTest {
     }
 
     @Test
-    void noVirtualThreadAdoptionIsFlagged() {
-        Snap s = new Snap();
-        s.virtualThreadEndpoints = 0;
-        SpringReport r = scan(s);
-        assertThat(find(r, "QA-PERF-001").severity()).isEqualTo("INFO");
-    }
-
-    @Test
-    void virtualThreadAdoptionSuppressesPerf001() {
-        Snap s = new Snap();
-        s.virtualThreadEndpoints = 1;
-        SpringReport r = scan(s);
-        assertThat(find(r, "QA-PERF-001")).isNull();
-    }
-
-    @Test
-    void oldJdkDoesNotFlagPerf001() {
-        // Virtual threads are not a mainstream concern before JDK 21; the rule intentionally does not fire.
-        Snap s = new Snap();
-        s.virtualThreadEndpoints = 0;
-        s.jdkMajorVersion = 17;
-        SpringReport r = scan(s);
-        assertThat(find(r, "QA-PERF-001")).isNull();
-    }
-
-    @Test
     void virtualThreadSynchronizedPinningIsFlagged() {
         Snap s = new Snap();
         s.virtualThreadSynchronized = 1;
@@ -482,7 +454,7 @@ class QuarkusAppScannerTest {
     @Test
     void rulesEvaluatedMatchesTotalRuleCount() {
         SpringReport r = scan(new Snap());
-        assertThat(r.scan().rulesEvaluated()).isEqualTo(20);
+        assertThat(r.scan().rulesEvaluated()).isEqualTo(19);
     }
 
     @Test

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -566,6 +566,10 @@ class BootUiQuarkusProcessor {
         runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(key, Integer.toString(value)));
     }
 
+    static boolean hasJdbcDatasource(Capabilities capabilities) {
+        return capabilities.isPresent(Capability.AGROAL);
+    }
+
     private static final DotName APPLICATION_SCOPED =
             DotName.createSimple("jakarta.enterprise.context.ApplicationScoped");
     private static final DotName SINGLETON = DotName.createSimple("jakarta.inject.Singleton");
@@ -604,39 +608,61 @@ class BootUiQuarkusProcessor {
             "jakarta.ws.rs.HEAD",
             "jakarta.ws.rs.OPTIONS");
 
+    /**
+     * Quarkus REST automatically makes a resource request scoped when it uses one of these parameter field
+     * annotations, including annotations on a superclass. This mirrors Quarkus 3.33's
+     * {@code ANNOTATIONS_REQUIRING_FIELD_INJECTION} set.
+     */
+    private static final Set<DotName> REQUEST_SCOPE_FIELD_INJECTION_ANNOTATIONS = Set.of(
+            DotName.createSimple("jakarta.ws.rs.PathParam"),
+            DotName.createSimple("jakarta.ws.rs.QueryParam"),
+            DotName.createSimple("jakarta.ws.rs.HeaderParam"),
+            DotName.createSimple("jakarta.ws.rs.FormParam"),
+            DotName.createSimple("jakarta.ws.rs.MatrixParam"),
+            DotName.createSimple("jakarta.ws.rs.CookieParam"),
+            DotName.createSimple("org.jboss.resteasy.reactive.RestPath"),
+            DotName.createSimple("org.jboss.resteasy.reactive.RestQuery"),
+            DotName.createSimple("org.jboss.resteasy.reactive.RestHeader"),
+            DotName.createSimple("org.jboss.resteasy.reactive.RestForm"),
+            DotName.createSimple("org.jboss.resteasy.reactive.RestMatrix"),
+            DotName.createSimple("org.jboss.resteasy.reactive.RestCookie"),
+            DotName.createSimple("jakarta.ws.rs.BeanParam"));
+
     private static final DotName PRODUCES = DotName.createSimple("jakarta.ws.rs.Produces");
     private static final DotName CONSUMES = DotName.createSimple("jakarta.ws.rs.Consumes");
 
     /**
      * Captures build-time idiom counts for the Quarkus-native application advisor: CDI scope annotation counts,
      * {@code @ConfigProperty} sites, {@code @ConfigMapping} interfaces, JAX-RS resources without an explicit scope,
-     * reactive ({@code Uni}/{@code Multi}/{@code CompletionStage}/{@code CompletableFuture}/{@code Publisher})
-     * endpoints without a {@code @Blocking} or {@code @Transactional} guard (Quarkus REST dispatches either
-     * annotation to a worker thread, so both count as a guard for QA-RX-001), shared mutable fields on
-     * {@code @ApplicationScoped} beans (QA-CDI-001) and on {@code @Singleton} beans (QA-CDI-003, excluding
-     * injected fields in both cases), public mutable fields on JAX-RS resources excluding those explicitly
-     * {@code @RequestScoped} (QA-CDI-002 — a fresh instance per request has no shared-state risk),
+     * reactive ({@code Uni}/{@code Multi}/{@code RestMulti}/{@code CompletionStage}/{@code CompletableFuture}/
+     * {@code Flow.Publisher}/{@code Publisher}) endpoints without a {@code @Blocking} or {@code @Transactional}
+     * guard (Quarkus REST dispatches either annotation to a worker thread, so both count as a guard for QA-RX-001),
+     * shared mutable fields on {@code @ApplicationScoped} beans (QA-CDI-001) and on {@code @Singleton} beans
+     * (QA-CDI-003, excluding injected fields in both cases), public mutable fields on JAX-RS resources excluding
+     * those explicitly or automatically {@code @RequestScoped} (QA-CDI-002 — a fresh instance per request has no
+     * shared-state risk),
      * {@code @RegisterRestClient} interfaces (QA-WEB-003), {@code @Scheduled} method count (QA-SCH-001, reusing
-     * {@link #scanScheduledTasks(IndexView)}), and the JEP-491 virtual-thread-pinning correlation
-     * (QA-PERF-001/QA-PERF-002): {@code @RunOnVirtualThread} sites — method or class level, per the docs; a
-     * class-level annotation makes every method in that class run on a virtual thread — total vs. the subset
-     * that are also declared {@code synchronized}, plus the build JDK's major version (the
-     * pinning-on-{@code synchronized} bug is fixed in JDK 24). Note the {@code synchronized}-count only sees the
-     * method-level modifier — Jandex does not index {@code synchronized(lock) { … }} blocks inside a method
-     * body, so this is a real but incomplete signal. Emitted as runtime config defaults the advisor reads.
-     * Dev/test only — skipped in {@link LaunchMode#NORMAL}.
+     * {@link #scanScheduledTasks(IndexView)}), the Agroal capability (QA-RX-001/QA-DB-001), and JEP-491
+     * virtual-thread-pinning correlation (QA-PERF-002): {@code @RunOnVirtualThread} sites that are also declared
+     * {@code synchronized}, plus the build JDK's major version. The {@code synchronized}-count only sees the
+     * method-level modifier — Jandex does not index {@code synchronized(lock) { … }} blocks inside a method body,
+     * so this is a real but incomplete signal. Emitted as runtime config defaults the advisor reads. Dev/test
+     * only — skipped in {@link LaunchMode#NORMAL}.
      */
     @BuildStep
     void registerAppIdioms(
             LaunchModeBuildItem launchMode,
             BeanArchiveIndexBuildItem beanArchiveIndex,
             ApplicationIndexBuildItem applicationIndex,
+            Capabilities capabilities,
             BuildProducer<RunTimeConfigurationDefaultBuildItem> runtimeDefaults) {
         if (launchMode.getLaunchMode() == LaunchMode.NORMAL) {
             return;
         }
         IndexView app = applicationIndex.getIndex();
         IndexView beans = beanArchiveIndex.getIndex();
+        runtimeDefaults.produce(new RunTimeConfigurationDefaultBuildItem(
+                "bootui.internal.app.jdbc-datasource", Boolean.toString(hasJdbcDatasource(capabilities))));
         emit(runtimeDefaults, "bootui.internal.app.application-scoped", classAnnotations(app, APPLICATION_SCOPED));
         emit(runtimeDefaults, "bootui.internal.app.singleton", classAnnotations(app, SINGLETON));
         emit(runtimeDefaults, "bootui.internal.app.request-scoped", classAnnotations(app, REQUEST_SCOPED));
@@ -680,7 +706,6 @@ class BootUiQuarkusProcessor {
         emit(runtimeDefaults, "bootui.internal.app.reactive-endpoints-without-blocking", reactiveWithoutBlocking);
 
         int defaultScopeResources = 0;
-        List<String> publicResourceFields = new ArrayList<>();
         for (AnnotationInstance ann : app.getAnnotations(PATH)) {
             if (ann.target() == null || ann.target().kind() != AnnotationTarget.Kind.CLASS) {
                 continue;
@@ -692,19 +717,8 @@ class BootUiQuarkusProcessor {
                     && cls.declaredAnnotation(DEPENDENT) == null) {
                 defaultScopeResources++;
             }
-            if (cls.declaredAnnotation(REQUEST_SCOPED) != null) {
-                // A fresh instance per request carries no shared-mutable-state risk (QA-CDI-002).
-                continue;
-            }
-            for (FieldInfo f : cls.fields()) {
-                boolean isPublic = (f.flags() & 0x0001) != 0;
-                boolean isFinal = (f.flags() & 0x0010) != 0;
-                boolean isStatic = (f.flags() & 0x0008) != 0;
-                if (isPublic && !isStatic && !isFinal) {
-                    publicResourceFields.add(cls.simpleName() + "." + f.name());
-                }
-            }
         }
+        List<String> publicResourceFields = publicResourceFieldsOf(app);
         List<String> mutableFields = mutableFieldsOf(app, APPLICATION_SCOPED);
         List<String> mutableSingletonFields = mutableFieldsOf(app, SINGLETON);
         emit(runtimeDefaults, "bootui.internal.app.default-scope-resources", defaultScopeResources);
@@ -727,12 +741,8 @@ class BootUiQuarkusProcessor {
                 "bootui.internal.app.scheduled",
                 scanScheduledTasks(beans).size());
 
-        VirtualThreadCounts virtualThreadCounts = virtualThreadSitesOf(app);
-        emit(runtimeDefaults, "bootui.internal.app.virtual-thread-endpoints", virtualThreadCounts.sites());
-        emit(
-                runtimeDefaults,
-                "bootui.internal.app.virtual-thread-synchronized",
-                virtualThreadCounts.synchronizedSites());
+        int virtualThreadSynchronized = virtualThreadSynchronizedSitesOf(app);
+        emit(runtimeDefaults, "bootui.internal.app.virtual-thread-synchronized", virtualThreadSynchronized);
         emit(
                 runtimeDefaults,
                 "bootui.internal.app.jdk-major-version",
@@ -740,27 +750,21 @@ class BootUiQuarkusProcessor {
     }
 
     /**
-     * Number of {@code @RunOnVirtualThread} sites — method or class level — and, of those, how many
-     * synchronized methods run on a virtual thread as a result. A class-level annotation counts as a single
-     * site (matching {@code virtualThreadEndpointCount}'s "sites (methods or classes)" contract) but scans
-     * every method it covers for the {@code synchronized} modifier, since the annotation makes all of them
-     * run on a virtual thread (QA-PERF-001/QA-PERF-002).
+     * Number of synchronized methods that run on a virtual thread due to a method- or class-level
+     * {@code @RunOnVirtualThread} annotation. A class-level annotation scans every method it covers.
      */
-    static VirtualThreadCounts virtualThreadSitesOf(IndexView app) {
-        int sites = 0;
+    static int virtualThreadSynchronizedSitesOf(IndexView app) {
         int synchronizedSites = 0;
         for (AnnotationInstance ann : app.getAnnotations(RUN_ON_VIRTUAL_THREAD)) {
             if (ann.target() == null) {
                 continue;
             }
             if (ann.target().kind() == AnnotationTarget.Kind.METHOD) {
-                sites++;
                 MethodInfo method = ann.target().asMethod();
                 if ((method.flags() & ACC_SYNCHRONIZED) != 0) {
                     synchronizedSites++;
                 }
             } else if (ann.target().kind() == AnnotationTarget.Kind.CLASS) {
-                sites++;
                 for (MethodInfo method : ann.target().asClass().methods()) {
                     if ((method.flags() & ACC_SYNCHRONIZED) != 0) {
                         synchronizedSites++;
@@ -768,11 +772,52 @@ class BootUiQuarkusProcessor {
                 }
             }
         }
-        return new VirtualThreadCounts(sites, synchronizedSites);
+        return synchronizedSites;
     }
 
-    /** Result of {@link #virtualThreadSitesOf(IndexView)}. */
-    record VirtualThreadCounts(int sites, int synchronizedSites) {}
+    static List<String> publicResourceFieldsOf(IndexView app) {
+        List<String> publicResourceFields = new ArrayList<>();
+        for (AnnotationInstance ann : app.getAnnotations(PATH)) {
+            if (ann.target() == null || ann.target().kind() != AnnotationTarget.Kind.CLASS) {
+                continue;
+            }
+            ClassInfo resource = ann.target().asClass();
+            if (isRequestScopedRestResource(resource, app)) {
+                continue;
+            }
+            for (FieldInfo field : resource.fields()) {
+                boolean isPublic = (field.flags() & 0x0001) != 0;
+                boolean isFinal = (field.flags() & 0x0010) != 0;
+                boolean isStatic = (field.flags() & 0x0008) != 0;
+                if (isPublic && !isStatic && !isFinal) {
+                    publicResourceFields.add(resource.simpleName() + "." + field.name());
+                }
+            }
+        }
+        return publicResourceFields;
+    }
+
+    private static boolean isRequestScopedRestResource(ClassInfo resource, IndexView app) {
+        if (resource.declaredAnnotation(REQUEST_SCOPED) != null) {
+            return true;
+        }
+        ClassInfo current = resource;
+        while (current != null) {
+            for (FieldInfo field : current.fields()) {
+                for (DotName annotation : REQUEST_SCOPE_FIELD_INJECTION_ANNOTATIONS) {
+                    if (field.hasAnnotation(annotation)) {
+                        return true;
+                    }
+                }
+            }
+            DotName parent = current.superName();
+            if (parent == null || parent.toString().equals("java.lang.Object")) {
+                return false;
+            }
+            current = app.getClassByName(parent);
+        }
+        return false;
+    }
 
     /**
      * Mutable, non-static, non-injected fields on every class annotated {@code scopeAnnotation}.
@@ -846,8 +891,10 @@ class BootUiQuarkusProcessor {
         String name = returnType.name().toString();
         return name.equals("io.smallrye.mutiny.Uni")
                 || name.equals("io.smallrye.mutiny.Multi")
+                || name.equals("org.jboss.resteasy.reactive.RestMulti")
                 || name.equals("java.util.concurrent.CompletionStage")
                 || name.equals("java.util.concurrent.CompletableFuture")
+                || name.equals("java.util.concurrent.Flow$Publisher")
                 || name.equals("org.reactivestreams.Publisher");
     }
 

--- a/bootui-quarkus-deployment/src/test/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessorAppIdiomsTest.java
+++ b/bootui-quarkus-deployment/src/test/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessorAppIdiomsTest.java
@@ -2,13 +2,21 @@ package io.github.jdubois.bootui.quarkus.deployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.Capability;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
@@ -21,8 +29,9 @@ import org.reactivestreams.Publisher;
  * Unit tests for the pure Jandex-index-processing helpers behind the Quarkus application advisor's
  * build-time idiom counts: {@link BootUiQuarkusProcessor#isReactive(Type)} (QA-RX-001),
  * {@link BootUiQuarkusProcessor#mutableFieldsOf(org.jboss.jandex.IndexView, DotName)} (QA-CDI-001/QA-CDI-003),
- * {@link BootUiQuarkusProcessor#classAnnotations(org.jboss.jandex.IndexView, DotName)}, and
- * {@link BootUiQuarkusProcessor#virtualThreadSitesOf(org.jboss.jandex.IndexView)} (QA-PERF-001/QA-PERF-002).
+ * {@link BootUiQuarkusProcessor#classAnnotations(org.jboss.jandex.IndexView, DotName)},
+ * {@link BootUiQuarkusProcessor#publicResourceFieldsOf(org.jboss.jandex.IndexView)}, and
+ * {@link BootUiQuarkusProcessor#virtualThreadSynchronizedSitesOf(org.jboss.jandex.IndexView)} (QA-PERF-002).
  *
  * <p>These build a real Jandex index from the small fixture classes below (compiled by Maven, indexed via
  * {@link Indexer#indexClass(Class)}) so the assertions exercise the exact bytecode-level annotation/flag
@@ -65,6 +74,10 @@ class BootUiQuarkusProcessorAppIdiomsTest {
                 .isTrue();
         assertThat(BootUiQuarkusProcessor.isReactive(classType(Publisher.class.getName())))
                 .isTrue();
+        assertThat(BootUiQuarkusProcessor.isReactive(classType("org.jboss.resteasy.reactive.RestMulti")))
+                .isTrue();
+        assertThat(BootUiQuarkusProcessor.isReactive(classType(Flow.Publisher.class.getName())))
+                .isTrue();
     }
 
     @Test
@@ -72,6 +85,14 @@ class BootUiQuarkusProcessorAppIdiomsTest {
         assertThat(BootUiQuarkusProcessor.isReactive(classType("java.lang.String")))
                 .isFalse();
         assertThat(BootUiQuarkusProcessor.isReactive(null)).isFalse();
+    }
+
+    @Test
+    void hasJdbcDatasourceUsesTheAgroalCapability() {
+        assertThat(BootUiQuarkusProcessor.hasJdbcDatasource(new Capabilities(Set.of(Capability.AGROAL))))
+                .isTrue();
+        assertThat(BootUiQuarkusProcessor.hasJdbcDatasource(new Capabilities(Set.of())))
+                .isFalse();
     }
 
     private static Type classType(String fqcn) {
@@ -115,7 +136,22 @@ class BootUiQuarkusProcessorAppIdiomsTest {
         assertThat(BootUiQuarkusProcessor.mutableFieldsOf(index, SINGLETON)).isEmpty();
     }
 
-    // ---- classAnnotations / virtualThreadSitesOf (QA-PERF-001 / QA-PERF-002) ----
+    // ---- publicResourceFieldsOf (QA-CDI-002) ----
+
+    @Test
+    void publicResourceFieldsOfExcludesResourcesQuarkusMakesRequestScopedForFieldInjection() throws IOException {
+        Index index = indexOf(
+                DefaultScopeResource.class,
+                FieldParameterResource.class,
+                ContextResource.class,
+                FieldParameterBase.class,
+                InheritedFieldParameterResource.class);
+
+        assertThat(BootUiQuarkusProcessor.publicResourceFieldsOf(index))
+                .containsExactlyInAnyOrder("DefaultScopeResource.cachedResult", "ContextResource.lastRequestId");
+    }
+
+    // ---- classAnnotations / virtualThreadSynchronizedSitesOf (QA-PERF-002) ----
 
     @Test
     void classAnnotationsCountsOnlyClassLevelTargetsNotMethodLevel() throws IOException {
@@ -127,35 +163,32 @@ class BootUiQuarkusProcessorAppIdiomsTest {
     }
 
     @Test
-    void virtualThreadSitesOfCountsClassLevelAsOneSiteButScansAllItsMethodsForSynchronized() throws IOException {
+    void virtualThreadSynchronizedSitesOfScansAllMethodsCoveredByClassLevelAnnotation() throws IOException {
         Index index = indexOf(ClassLevelVirtualThreadBean.class);
 
-        BootUiQuarkusProcessor.VirtualThreadCounts counts = BootUiQuarkusProcessor.virtualThreadSitesOf(index);
+        int synchronizedSites = BootUiQuarkusProcessor.virtualThreadSynchronizedSitesOf(index);
 
-        assertThat(counts.sites()).isEqualTo(1);
-        assertThat(counts.synchronizedSites())
+        assertThat(synchronizedSites)
                 .as("the class-level annotation makes synchronizedMethod run on a virtual thread too")
                 .isEqualTo(1);
     }
 
     @Test
-    void virtualThreadSitesOfCountsEachMethodLevelSiteIndividually() throws IOException {
+    void virtualThreadSynchronizedSitesOfCountsSynchronizedMethodLevelAnnotations() throws IOException {
         Index index = indexOf(MethodLevelVirtualThreadBean.class);
 
-        BootUiQuarkusProcessor.VirtualThreadCounts counts = BootUiQuarkusProcessor.virtualThreadSitesOf(index);
+        int synchronizedSites = BootUiQuarkusProcessor.virtualThreadSynchronizedSitesOf(index);
 
-        assertThat(counts.sites()).isEqualTo(2);
-        assertThat(counts.synchronizedSites()).isEqualTo(1);
+        assertThat(synchronizedSites).isEqualTo(1);
     }
 
     @Test
-    void virtualThreadSitesOfCombinesClassAndMethodLevelSites() throws IOException {
+    void virtualThreadSynchronizedSitesOfCombinesClassAndMethodLevelAnnotations() throws IOException {
         Index index = indexOf(ClassLevelVirtualThreadBean.class, MethodLevelVirtualThreadBean.class);
 
-        BootUiQuarkusProcessor.VirtualThreadCounts counts = BootUiQuarkusProcessor.virtualThreadSitesOf(index);
+        int synchronizedSites = BootUiQuarkusProcessor.virtualThreadSynchronizedSitesOf(index);
 
-        assertThat(counts.sites()).isEqualTo(3);
-        assertThat(counts.synchronizedSites()).isEqualTo(2);
+        assertThat(synchronizedSites).isEqualTo(2);
     }
 
     // ---- Fixtures ----
@@ -183,6 +216,35 @@ class BootUiQuarkusProcessorAppIdiomsTest {
 
     static class PlainBean {
         public String publicMutableField;
+    }
+
+    @Path("/default-scope")
+    static class DefaultScopeResource {
+        public String cachedResult;
+    }
+
+    @Path("/field-parameter")
+    static class FieldParameterResource {
+        @QueryParam("query")
+        public String query;
+    }
+
+    @Path("/context")
+    static class ContextResource {
+        @Context
+        UriInfo uriInfo;
+
+        public String lastRequestId;
+    }
+
+    static class FieldParameterBase {
+        @QueryParam("query")
+        String query;
+    }
+
+    @Path("/inherited-field-parameter")
+    static class InheritedFieldParameterResource extends FieldParameterBase {
+        public String cachedResult;
     }
 
     @io.smallrye.common.annotation.RunOnVirtualThread

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/quarkusapp/QuarkusAppSnapshotProviderImpl.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/quarkusapp/QuarkusAppSnapshotProviderImpl.java
@@ -34,7 +34,7 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
     static final String CONFIG_MAPPING_KEY = "bootui.internal.app.config-mapping";
     static final String PUBLIC_RESOURCE_FIELDS_KEY = "bootui.internal.app.public-resource-fields";
     static final String REST_CLIENTS_KEY = "bootui.internal.app.rest-clients";
-    static final String VIRTUAL_THREAD_ENDPOINTS_KEY = "bootui.internal.app.virtual-thread-endpoints";
+    static final String JDBC_DATASOURCE_KEY = "bootui.internal.app.jdbc-datasource";
     static final String VIRTUAL_THREAD_SYNCHRONIZED_KEY = "bootui.internal.app.virtual-thread-synchronized";
     static final String JDK_MAJOR_VERSION_KEY = "bootui.internal.app.jdk-major-version";
 
@@ -81,7 +81,7 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
                 prodDevServices,
                 false,
                 count(CONFIG_MAPPING_KEY),
-                jdbcDatasourcePresent(),
+                bool(JDBC_DATASOURCE_KEY),
                 prodSchemaGeneration(),
                 str("%prod.quarkus.datasource.db-kind", "").toLowerCase(),
                 prodJdbcUrlInMemory(),
@@ -93,7 +93,6 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
                 shutdownTimeoutZeroed(),
                 count(REST_CLIENTS_KEY) > 0,
                 restClientTimeoutZeroOrExcessive(),
-                count(VIRTUAL_THREAD_ENDPOINTS_KEY),
                 count(VIRTUAL_THREAD_SYNCHRONIZED_KEY),
                 count(JDK_MAJOR_VERSION_KEY),
                 strList(MUTABLE_SINGLETON_FIELDS_KEY),
@@ -108,11 +107,11 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
     }
 
     private boolean shutdownTimeoutZeroed() {
-        return isZero("quarkus.shutdown.timeout") || isZero("quarkus.http.shutdown.timeout");
+        return isZero("quarkus.shutdown.timeout");
     }
 
     private boolean shutdownTimeoutConfigured() {
-        return has("quarkus.shutdown.timeout") || has("quarkus.http.shutdown.timeout");
+        return has("quarkus.shutdown.timeout");
     }
 
     private boolean isZero(String key) {
@@ -127,8 +126,7 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
      */
     private boolean restClientTimeoutZeroOrExcessive() {
         for (String name : config.getPropertyNames()) {
-            if (name.startsWith("quarkus.rest-client")
-                    && (name.endsWith("connect-timeout") || name.endsWith("read-timeout"))) {
+            if (isRestClientConnectOrReadTimeout(name)) {
                 Long ms = config.getOptionalValue(name, Long.class).orElse(null);
                 if (ms != null && (ms == 0L || ms > EXCESSIVE_REST_CLIENT_TIMEOUT_MS)) {
                     return true;
@@ -138,11 +136,9 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
         return false;
     }
 
-    private boolean jdbcDatasourcePresent() {
-        return has("quarkus.datasource.db-kind")
-                || has("quarkus.datasource.jdbc.url")
-                || has("%prod.quarkus.datasource.db-kind")
-                || has("%prod.quarkus.datasource.jdbc.url");
+    private static boolean isRestClientConnectOrReadTimeout(String propertyName) {
+        return propertyName.startsWith("quarkus.rest-client.")
+                && (propertyName.endsWith(".connect-timeout") || propertyName.endsWith(".read-timeout"));
     }
 
     private String prodSchemaGeneration() {
@@ -163,18 +159,22 @@ public class QuarkusAppSnapshotProviderImpl implements QuarkusAppSnapshotProvide
     }
 
     /**
-     * QA-CFG-004: {@code quarkus.hibernate-orm.database.generation} is {@code @Deprecated(forRemoval = true)}
-     * as of Quarkus 3.22, in favour of {@code quarkus.hibernate-orm.schema-management.strategy}. Matches any
-     * profile (bare, {@code %prod.}/{@code %dev.}/…) or named-persistence-unit variant, since the property
-     * name — not just its {@code %prod} use — is what is being flagged as legacy.
+     * QA-CFG-004: detects the legacy {@code quarkus.hibernate-orm.database.generation} namespace, including
+     * profile and named-persistence-unit variants, rather than unrelated vendor properties with a matching suffix.
      */
     private boolean legacySchemaGenerationPropertyUsed() {
         for (String name : config.getPropertyNames()) {
-            if (name.endsWith("database.generation")) {
+            if (isLegacySchemaGenerationProperty(name)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private static boolean isLegacySchemaGenerationProperty(String propertyName) {
+        int profileSeparator = propertyName.startsWith("%") ? propertyName.indexOf('.') : -1;
+        String unprofiledName = profileSeparator >= 0 ? propertyName.substring(profileSeparator + 1) : propertyName;
+        return unprofiledName.startsWith("quarkus.hibernate-orm.") && unprofiledName.endsWith(".database.generation");
     }
 
     /** QA-DB-001: the default (unnamed) datasource's own max pool size, checked bare or under {@code %prod}. */

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/quarkusapp/QuarkusAppSnapshotProviderImplTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/quarkusapp/QuarkusAppSnapshotProviderImplTest.java
@@ -1,0 +1,65 @@
+package io.github.jdubois.bootui.quarkus.quarkusapp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.spi.QuarkusAppSnapshot;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class QuarkusAppSnapshotProviderImplTest {
+
+    @Test
+    void recognizesJdbcDatasourcesOnlyFromTheBuildTimeAgroalFlag() {
+        QuarkusAppSnapshot reactive = snapshot(Map.of("quarkus.datasource.db-kind", "postgresql"));
+        QuarkusAppSnapshot jdbc = snapshot(Map.of(
+                "quarkus.datasource.db-kind",
+                "postgresql",
+                QuarkusAppSnapshotProviderImpl.JDBC_DATASOURCE_KEY,
+                "true"));
+
+        assertThat(reactive.jdbcDatasourcePresent()).isFalse();
+        assertThat(jdbc.jdbcDatasourcePresent()).isTrue();
+    }
+
+    @Test
+    void ignoresUnrelatedSchemaGenerationProperties() {
+        QuarkusAppSnapshot unrelated = snapshot(Map.of("vendor.database.generation", "update"));
+        QuarkusAppSnapshot legacy =
+                snapshot(Map.of("%prod.quarkus.hibernate-orm.\"orders\".database.generation", "update"));
+
+        assertThat(unrelated.legacySchemaGenerationPropertyUsed()).isFalse();
+        assertThat(legacy.legacySchemaGenerationPropertyUsed()).isTrue();
+    }
+
+    @Test
+    void recognizesOnlyTheQuarkusShutdownTimeout() {
+        QuarkusAppSnapshot obsoleteHttpKey = snapshot(Map.of("quarkus.http.shutdown.timeout", "PT0S"));
+        QuarkusAppSnapshot zeroed = snapshot(Map.of("quarkus.shutdown.timeout", "PT0S"));
+        QuarkusAppSnapshot configured = snapshot(Map.of("quarkus.shutdown.timeout", "PT10S"));
+
+        assertThat(obsoleteHttpKey.shutdownTimeoutZeroed()).isFalse();
+        assertThat(obsoleteHttpKey.shutdownTimeoutConfigured()).isFalse();
+        assertThat(zeroed.shutdownTimeoutZeroed()).isTrue();
+        assertThat(zeroed.shutdownTimeoutConfigured()).isTrue();
+        assertThat(configured.shutdownTimeoutZeroed()).isFalse();
+        assertThat(configured.shutdownTimeoutConfigured()).isTrue();
+    }
+
+    @Test
+    void ignoresProxyConnectTimeoutWhenInspectingClientTimeouts() {
+        QuarkusAppSnapshot proxyTimeout = snapshot(Map.of("quarkus.rest-client.proxy-connect-timeout", "10s"));
+        QuarkusAppSnapshot disabledTimeout = snapshot(Map.of("quarkus.rest-client.connect-timeout", "0"));
+
+        assertThat(proxyTimeout.restClientTimeoutZeroOrExcessive()).isFalse();
+        assertThat(disabledTimeout.restClientTimeoutZeroOrExcessive()).isTrue();
+    }
+
+    private static QuarkusAppSnapshot snapshot(Map<String, String> properties) {
+        var config = new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(properties, "test", 1000))
+                .build();
+        return new QuarkusAppSnapshotProviderImpl(config).snapshot();
+    }
+}

--- a/docs/QUARKUS-ADVISOR-CHECKS.md
+++ b/docs/QUARKUS-ADVISOR-CHECKS.md
@@ -3,10 +3,11 @@
 The Spring advisor panel, on Quarkus, runs a fixed, on-demand ruleset against the host application's
 **Quarkus idioms** — not the Spring application context. It reads build-time counts of CDI scope
 annotations, `@ConfigProperty` injection sites, `@ConfigMapping` interfaces, JAX-RS endpoints, reactive
-(`Uni`/`Multi`/`CompletionStage`/`CompletableFuture`/`Publisher`) signatures, `@Blocking`/`@Transactional`
-sites, `@Scheduled` methods, `@RegisterRestClient` interfaces, `@RunOnVirtualThread` (method- or class-level)
-/`synchronized` combinations, the build JDK version, public mutable fields on JAX-RS resources (excluding
-`@RequestScoped` ones), and shared mutable fields on `@ApplicationScoped` and `@Singleton` beans, plus
+(`Uni`/`Multi`/`RestMulti`/`CompletionStage`/`CompletableFuture`/`Flow.Publisher`/Reactive Streams `Publisher`)
+signatures, `@Blocking`/`@Transactional` sites, `@Scheduled` methods, `@RegisterRestClient` interfaces,
+`@RunOnVirtualThread`/`synchronized` combinations, the build JDK version, public mutable fields on JAX-RS
+resources (excluding resources that Quarkus scopes per request), and shared mutable fields on
+`@ApplicationScoped` and `@Singleton` beans, plus
 active/`%prod.` profile keys (Hibernate schema strategy, the legacy `database.generation` property, datasource
 kind/URL/pool size, SQL logging, log level, Dev Services, clustered scheduler) and HTTP settings (response
 compression, graceful-shutdown timeout presence/value, REST client timeouts) from MicroProfile config. It
@@ -44,9 +45,11 @@ or expose an immutable value, or move per-request state to a `@RequestScoped` be
 ### QA-CDI-002 - Public mutable field on a JAX-RS resource (MEDIUM)
 JAX-RS resources default to `@Singleton`, so a public non-final (non-static) field is process-wide shared
 mutable state accessed concurrently across requests. A resource explicitly annotated `@RequestScoped` gets a
-fresh instance per request and carries no shared-state risk, so it is excluded from this scan. Make the field
-`private final`, inject it, or move per-request state to a `@RequestScoped` bean. (Private fields set in
-`@PostConstruct`, e.g. injected Micrometer meters, are not flagged.)
+fresh instance per request and carries no shared-state risk. Quarkus REST also automatically scopes resources
+with JAX-RS parameter fields (for example `@QueryParam` or `@RestQuery`, including inherited fields) per
+request; both cases are excluded from this scan. Make the field `private final`, inject it, or move per-request
+state to a `@RequestScoped` bean.
+(Private fields set in `@PostConstruct`, e.g. injected Micrometer meters, are not flagged.)
 
 ### QA-CDI-003 - Shared mutable state on a @Singleton bean (MEDIUM)
 `@Singleton` beans are a single instance shared across threads, exactly like `@ApplicationScoped` — the same
@@ -78,16 +81,18 @@ accepts the same values: `none`/`create`/`drop-and-create`/`drop`/`update`/`vali
 ## Reactive
 
 ### QA-RX-001 - Reactive endpoints with a blocking JDBC datasource (HIGH)
-One or more endpoints return `Uni`/`Multi`/`CompletionStage`/`CompletableFuture`/`Publisher` (run on the I/O
-event loop), and neither the method nor its declaring resource class carries a `@Blocking` or `@Transactional`
-guard (Quarkus REST dispatches a `@Transactional` method to a worker thread just like `@Blocking` — see the
-[latest stable REST execution-model guide](https://quarkus.io/guides/rest#execution-model-blocking-non-blocking)),
-while a blocking JDBC datasource is configured; a JDBC call on the event loop stalls it and throws
+One or more endpoints return `Uni`/`Multi`/`RestMulti`/`CompletionStage`/`CompletableFuture`/
+`Flow.Publisher`/Reactive Streams `Publisher` (run on the I/O event loop), and neither the method nor its
+declaring resource class carries a `@Blocking` or `@Transactional` guard (Quarkus REST dispatches a
+`@Transactional` method to a worker thread just like `@Blocking` — see the [latest stable REST
+execution-model guide](https://quarkus.io/guides/rest#execution-model-blocking-non-blocking)), while Quarkus's
+Agroal JDBC capability is present; a JDBC call on the event loop stalls it and throws
 `BlockingOperationNotAllowedException` at runtime. This is one of the most common and severe Quarkus
 production footguns, hence HIGH rather than an informational note. Annotate blocking work with `@Blocking`
 (or make the method `@Transactional`), or use a reactive datasource client. (Only raised when a JDBC
-datasource is present, so fully-reactive apps are not flagged. The check is correlated per endpoint — an
-unrelated guard elsewhere in the app does not suppress a finding on a genuinely unguarded reactive endpoint.)
+datasource capability is present, so a fully reactive datasource configuration is not flagged. The check is
+correlated per endpoint — an unrelated guard elsewhere in the app does not suppress a finding on a genuinely
+unguarded reactive endpoint.)
 
 ## Scheduling
 
@@ -134,8 +139,8 @@ externalised (env vars, Secrets/ConfigMaps); otherwise prod shares dev defaults 
 ## Database
 
 ### QA-DB-001 - JDBC datasource without an explicit pool size (LOW)
-A JDBC datasource is configured, but `quarkus.datasource.jdbc.max-size` is never set. Agroal (Quarkus's
-connection pool) defaults to a max pool size of 50. Under high concurrency — especially with virtual threads
+A JDBC datasource capability is present, but `quarkus.datasource.jdbc.max-size` is never set. Agroal
+(Quarkus's connection pool) defaults to a max pool size of 50. Under high concurrency — especially with virtual threads
 increasing request parallelism — the default pool can become a bottleneck or exhaust the database's own
 connection limit. Set `quarkus.datasource.jdbc.max-size` (with a `%prod` override if it should differ from
 dev) to a value sized for the target database and expected concurrency.
@@ -148,9 +153,9 @@ dev) to a value sized for the target database and expected concurrency.
 `quarkus.http.enable-compression=true` (tune `quarkus.http.compress-media-types` if needed).
 
 ### QA-WEB-002 - Graceful shutdown grace period zeroed (MEDIUM)
-`quarkus.shutdown.timeout` or `quarkus.http.shutdown.timeout` is explicitly set to `0`, disabling the
-graceful-shutdown grace period; in-flight requests are dropped instead of being allowed to complete on
-`SIGTERM`. Remove the override (or set a positive duration) so in-flight requests can drain before shutdown.
+`quarkus.shutdown.timeout` is explicitly set to `0`, disabling the graceful-shutdown grace period; in-flight
+requests are dropped instead of being allowed to complete on `SIGTERM`. Remove the override (or set a positive
+duration) so in-flight requests can drain before shutdown.
 
 ### QA-WEB-003 - REST client connect/read timeout disabled or excessive (MEDIUM)
 A connect-timeout or read-timeout for a `@RegisterRestClient` interface is explicitly set to `0` (no timeout)
@@ -162,29 +167,23 @@ override to keep Quarkus's 15s/30s defaults, or set a specific, bounded timeout 
 service.
 
 ### QA-WEB-004 - Graceful shutdown timeout never configured (INFO)
-Neither `quarkus.shutdown.timeout` nor `quarkus.http.shutdown.timeout` is set anywhere. Quarkus's graceful
-shutdown is opt-in and disabled by default — with no timeout configured at all, the application exits
-immediately on `SIGTERM` instead of draining in-flight requests. Because this is Quarkus's documented default,
-it is informational rather than a configuration error. This is distinct from QA-WEB-002 (which fires
-only when the timeout is explicitly disabled via `=0`); the two are mutually exclusive; see the
-[lifecycle guide](https://quarkus.io/guides/lifecycle#graceful-shutdown). Set `quarkus.shutdown.timeout` to a
-positive duration (e.g. `10s`) so in-flight requests can drain before shutdown.
+`quarkus.shutdown.timeout` is not set anywhere. Quarkus's graceful shutdown is opt-in and disabled by default
+— with no timeout configured at all, the application exits immediately on `SIGTERM` instead of draining
+in-flight requests. Because this is Quarkus's documented default, it is informational rather than a
+configuration error. This is distinct from QA-WEB-002 (which fires only when the timeout is explicitly
+disabled via `=0`); the two are mutually exclusive; see the
+[lifecycle guide](https://quarkus.io/guides/lifecycle#graceful-shutdown). Set
+`quarkus.shutdown.timeout` to a positive duration (e.g. `10s`) so in-flight requests can drain before
+shutdown.
 
 ## Performance
-
-### QA-PERF-001 - No virtual-thread adoption (INFO)
-The app declares JAX-RS endpoint(s) but none use `@RunOnVirtualThread` at the method or class level (checked
-only from JDK 21, when virtual threads became stable/mainstream). If any endpoint performs blocking I/O
-(JDBC, file access, blocking REST calls), running it on a virtual thread can improve throughput without
-sizing a worker thread pool. Annotate blocking I/O-bound endpoint methods (or the resource class) with
-`@RunOnVirtualThread`.
 
 ### QA-PERF-002 - Virtual-thread pinning via synchronized (HIGH)
 **Quarkus/JDK-specific — no Spring equivalent.** One or more methods that run on a virtual thread — via a
 method-level `@RunOnVirtualThread`, or because their declaring class carries a class-level
 `@RunOnVirtualThread` (which makes every method in that class run on a virtual thread) — are also declared
-`synchronized`. On JDK 21-23, entering a `synchronized` method or block pins the carrier thread instead of
-yielding it, defeating the scalability benefit of virtual threads under load; [JEP
+`synchronized`. On JDK 21-23, a blocking operation inside a `synchronized` method or block pins the carrier
+thread instead of yielding it, defeating the scalability benefit of virtual threads under load; [JEP
 491](https://openjdk.org/jeps/491) removes this pinning starting in JDK 24. Replace `synchronized` with a
 `java.util.concurrent.locks.ReentrantLock`, or upgrade to JDK 24+. (Detected via the method's `synchronized`
 modifier; a `synchronized(lock) { }` block inside an otherwise-unsynchronized method is not visible to this


### PR DESCRIPTION
## Summary

- Capture `Capability.AGROAL` at Quarkus build time so QA-RX-001 and QA-DB-001 do not mistake reactive-only datasource configuration for JDBC.
- Match Quarkus REST scope promotion exactly for parameter-field injection, including inherited fields, while retaining QA-CDI-002 for singleton resources using `@Context`.
- Recognize `RestMulti` and `Flow.Publisher`, remove the noisy optional virtual-thread adoption prompt, and retain the bounded synchronized-pinning check.
- Correct Quarkus configuration parsing: use only `quarkus.shutdown.timeout`, ignore `proxy-connect-timeout` when inspecting numeric REST client timeouts, and restrict legacy schema-generation detection to the Hibernate namespace.

## Evidence

The changes are verified against Quarkus 3.33.3.1 source:

- `Capability.AGROAL` denotes a datasource connection-pool implementation.
- RESTEasy Reactive uses `ANNOTATIONS_REQUIRING_FIELD_INJECTION` to promote resources with parameter fields to `@RequestScoped`; the implementation and regression tests mirror that exact 13-annotation set.
- RESTEasy Reactive dispatches `RestMulti` and `Flow.Publisher` as asynchronous return types.
- `ShutdownConfig` exposes `quarkus.shutdown.*`, while REST client `proxy-connect-timeout` is a `Duration`, not a numeric connect timeout.

## Validation

- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:check`
- Focused Quarkus advisor tests (engine, runtime snapshot provider, and deployment capture)
- Quarkus sample-app CI build stage and E2E formatting check
- Full coverage reactor attempted twice on local JDK 26: all affected Quarkus modules passed; unrelated Spring/WebFlux and OpenTelemetry timing failures each passed on isolated serial retry. GitHub CI runs the Java 17 baseline.

## Advisor audit protocol

- Independent reviewers: Claude Opus 5 (max, long context), GPT-5.6 Terra (max, long context), and Gemini 3.1 Pro (high, long context), all against the same frozen `main` snapshot.
- Evidence process: official Quarkus 3.33 LTS documentation/source and comparable open-source guidance were researched before evaluating existing rules.
- Decision process: rules were classified as KEEP, MODIFY, REMOVE, or SPLIT; only source-backed and deterministic changes were accepted. The noisy virtual-thread non-adoption rule was removed, while speculative or context-dependent candidates were deferred.
- Delivery policy: focused and full validation plus hosted CI are required; limitations remain explicit and auto-merge is disabled.