### PR TITLE
Harden MVC Spring Security advisor detection

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
@@ -38,6 +38,7 @@ record SecurityContext(
         boolean hideUserNotFoundExceptionsDisabled,
         List<String> opaqueTokenIntrospectorTypes,
         boolean generatedUserDetailsManagerPresent,
+        boolean securityDebugFilterPresent,
         Environment environment) {
     SecurityContext {
         chains = List.copyOf(chains);
@@ -46,6 +47,41 @@ record SecurityContext(
         jwtDecoderTypes = List.copyOf(jwtDecoderTypes);
         oauth2TokenValidatorTypes = List.copyOf(oauth2TokenValidatorTypes);
         opaqueTokenIntrospectorTypes = List.copyOf(opaqueTokenIntrospectorTypes);
+    }
+
+    SecurityContext(
+            List<FilterChainModel> chains,
+            List<PasswordEncoderModel> passwordEncoders,
+            List<CorsConfigModel> corsConfigs,
+            boolean corsSourcePresent,
+            List<String> jwtDecoderTypes,
+            boolean methodSecurityEnabled,
+            boolean globalMethodSecurityLegacyPresent,
+            boolean methodSecurityAnnotationsPresent,
+            boolean customCorsSourcePresent,
+            List<String> oauth2TokenValidatorTypes,
+            boolean strictHttpFirewallWeakened,
+            boolean hideUserNotFoundExceptionsDisabled,
+            List<String> opaqueTokenIntrospectorTypes,
+            boolean generatedUserDetailsManagerPresent,
+            Environment environment) {
+        this(
+                chains,
+                passwordEncoders,
+                corsConfigs,
+                corsSourcePresent,
+                jwtDecoderTypes,
+                methodSecurityEnabled,
+                globalMethodSecurityLegacyPresent,
+                methodSecurityAnnotationsPresent,
+                customCorsSourcePresent,
+                oauth2TokenValidatorTypes,
+                strictHttpFirewallWeakened,
+                hideUserNotFoundExceptionsDisabled,
+                opaqueTokenIntrospectorTypes,
+                generatedUserDetailsManagerPresent,
+                false,
+                environment);
     }
 
     /** The fully-qualified type names of the discovered {@code PasswordEncoder} beans. */

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
@@ -16,9 +16,9 @@ final class SecurityModel {
     /**
      * One {@code SecurityFilterChain} and the salient, read-only facts the advisor needs about it.
      *
-     * @param permitsAllAnonymous best-effort result of simulating an anonymous request through the
-     *     chain's authorization manager ({@code TRUE} when fully public, {@code null} when it could
-     *     not be determined)
+     * @param permitsAllAnonymous best-effort result of simulating a bounded set of anonymous requests
+     *     across common paths and HTTP methods through the chain's authorization manager ({@code
+     *     TRUE} when every probe is granted, {@code null} when it could not be determined)
      * @param sessionFixationDisabled {@code TRUE} when the session-management strategy was detected
      *     to skip session-fixation protection, {@code null} when it could not be determined
      * @param headerWriterNames simple class names of the {@code HeaderWriter}s installed by the
@@ -36,7 +36,8 @@ final class SecurityModel {
      * @param authorizationRuleShadowed {@code TRUE} when an earlier, broader {@code
      *     authorizeHttpRequests} matcher in this chain shadows a later, narrower one (so the later
      *     rule can never take effect), {@code FALSE} when no shadowing was detected, {@code null}
-     *     when the chain's {@code AuthorizationManager} could not be introspected
+     *     when the chain's {@code AuthorizationManager} was absent, wrapped by an unrecognized
+     *     implementation, or could not be introspected
      * @param rememberMeKeyLength the length of the configured remember-me signing key, when a
      *     {@code RememberMeAuthenticationFilter} is present and its key could be read, {@code null}
      *     otherwise. Only the length is retained -- never the key itself -- so a short/predictable

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
@@ -264,13 +264,16 @@ final class FormLoginWithoutTlsRule extends AbstractSecurityRule {
                         "Form login should run only over HTTPS",
                         SecurityCategory.AUTHENTICATION,
                         "HIGH",
-                        "Detects an interactive form-login chain while no server-side TLS, HTTPS redirect, or forwarded-header strategy is configured. Submitting credentials over HTTP exposes them to passive network observers and active interception.",
-                        "Enforce HTTPS via server.ssl.* (or a forwarded-headers strategy when TLS terminates upstream) for every formLogin() chain.",
+                        "Detects an interactive form-login chain while a production profile is active and no server-side TLS, HTTPS redirect, or forwarded-header strategy is configured. Submitting credentials over HTTP exposes them to passive network observers and active interception.",
+                        "Enforce HTTPS via server.ssl.* (or a forwarded-headers strategy when TLS terminates upstream) for every production formLogin() chain.",
                         "https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#transmit-passwords-only-over-tls-or-other-strong-transport"));
     }
 
     @Override
     SecurityRuleResultDto evaluateRule(SecurityContext context) {
+        if (!context.isProductionProfileActive()) {
+            return pass();
+        }
         List<String> details = new ArrayList<>();
         for (FilterChainModel chain : context.chains()) {
             if (chain.hasFilter("UsernamePasswordAuthenticationFilter") && !context.isTlsConfiguredFor(chain)) {
@@ -379,7 +382,7 @@ final class PermitAllCatchAllRule extends AbstractSecurityRule {
                 "Avoid blanket permitAll authorization",
                 SecurityCategory.AUTHORIZATION,
                 "HIGH",
-                "Detects a chain whose authorization grants every request to anonymous callers (permitAll catch-all).",
+                "Detects a catch-all chain whose authorization grants every bounded anonymous path/method probe.",
                 "Restrict sensitive paths and finish with anyRequest().authenticated(); keep permitAll only for genuinely public endpoints.",
                 "https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html"));
     }
@@ -408,7 +411,7 @@ final class EffectivelyDisabledSecurityRule extends AbstractSecurityRule {
                 "Application security should not be effectively disabled",
                 SecurityCategory.AUTHORIZATION,
                 "HIGH",
-                "Detects when every filter chain permits all requests anonymously and no chain requires authentication.",
+                "Detects when every determinable filter chain grants every bounded anonymous path/method probe and none requires authentication.",
                 "Define authorization rules that require authentication for non-public endpoints instead of leaving the app fully open.",
                 "https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html"));
     }
@@ -487,6 +490,10 @@ final class AuthorizationRuleShadowedRule extends AbstractSecurityRule {
                         chain.describe()
                                 + " registers a broader matcher before a narrower one in its authorizeHttpRequests rules; the narrower rule is unreachable.");
             }
+        }
+        if (details.isEmpty()
+                && context.chains().stream().noneMatch(chain -> chain.authorizationRuleShadowed() != null)) {
+            return skipped("Authorization matcher order could not be inspected for any filter chain.");
         }
         return violation(details);
     }
@@ -666,8 +673,8 @@ final class SessionTimeoutRule extends AbstractSecurityRule {
                 "An explicit session timeout should be configured",
                 SecurityCategory.SESSION,
                 "INFO",
-                "Detects that server.servlet.session.timeout is unset, leaving the container's default timeout.",
-                "Set server.servlet.session.timeout to a bounded value appropriate for the application's risk profile.",
+                "Detects that server.servlet.session.timeout is unset, which uses Spring Boot's 30-minute default.",
+                "Confirm that the 30-minute default suits the application's risk profile or set server.servlet.session.timeout explicitly.",
                 "https://docs.spring.io/spring-boot/reference/web/servlet.html"));
     }
 
@@ -1142,7 +1149,7 @@ final class CorsNotInSecurityChainRule extends AbstractSecurityRule {
                 "CORS should be wired through the security filter chain",
                 SecurityCategory.CORS,
                 "INFO",
-                "Detects a CorsConfigurationSource bean while no filter chain installs a CorsFilter.",
+                "Detects an application CorsConfigurationSource bean while no filter chain installs Spring's CorsFilter or PreFlightRequestFilter.",
                 "Enable .cors(...) on the HttpSecurity so preflight handling is consistent with the security chain rather than MVC-only.",
                 "https://docs.spring.io/spring-security/reference/servlet/integrations/cors.html"));
     }
@@ -1152,12 +1159,14 @@ final class CorsNotInSecurityChainRule extends AbstractSecurityRule {
         if (!context.corsSourcePresent()) {
             return pass();
         }
-        boolean anyCorsFilter = context.chains().stream().anyMatch(chain -> chain.hasFilter("CorsFilter"));
+        boolean anyCorsFilter = context.chains().stream()
+                .anyMatch(chain -> chain.hasFilter("CorsFilter") || chain.hasFilter("PreFlightRequestFilter"));
         if (anyCorsFilter) {
             return pass();
         }
-        return violation(List.of(
-                "A CorsConfigurationSource bean is present but no security filter chain installs a CorsFilter."));
+        return violation(
+                List.of(
+                        "A CorsConfigurationSource bean is present but no security filter chain installs CorsFilter or PreFlightRequestFilter."));
     }
 }
 
@@ -1270,7 +1279,7 @@ final class LegacyGlobalMethodSecurityRule extends AbstractSecurityRule {
                 "Replace @EnableGlobalMethodSecurity with @EnableMethodSecurity",
                 SecurityCategory.METHOD_SECURITY,
                 "LOW",
-                "Detects the legacy @EnableGlobalMethodSecurity configuration removed/deprecated in Spring Security 6+.",
+                "Detects @EnableGlobalMethodSecurity, deprecated since Spring Security 6 and still present in Spring Security 7.",
                 "Migrate to @EnableMethodSecurity, which enables @PreAuthorize/@PostAuthorize by default and uses the modern AuthorizationManager API.",
                 "https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html"));
     }
@@ -1385,9 +1394,8 @@ final class HealthDetailsExposureRule extends AbstractSecurityRule {
                         "HIGH",
                         "Detects management.endpoint.health.show-details=always or show-components=always, either of"
                                 + " which leaks infrastructure/component details (disk space, database, custom health"
-                                + " indicators, dependency versions) to anonymous callers. Spring Boot's own default"
-                                + " for both properties is 'never' (not 'when-authorized', which was the default"
-                                + " prior to Spring Boot 3.0).",
+                                + " indicators, dependency versions) to anonymous callers. Spring Boot's default for"
+                                + " both properties is 'never'.",
                         "Leave show-details/show-components at 'never' (the default), or set them to 'when-authorized'"
                                 + " and require authentication for the health endpoint.",
                         "https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.health.show-details"));
@@ -1655,15 +1663,16 @@ final class SecurityDebugRule extends AbstractSecurityRule {
                 "Spring Security debug mode should be off",
                 SecurityCategory.CONFIGURATION,
                 "MEDIUM",
-                "Detects spring.security.debug=true (or a DebugFilter), which logs filter chains and request details.",
+                "Detects Spring Security's DebugFilter, installed by @EnableWebSecurity(debug = true), which logs filter chains and request details.",
                 "Disable security debug mode outside local development; it leaks configuration and request information.",
                 "https://docs.spring.io/spring-security/reference/servlet/configuration/java.html"));
     }
 
     @Override
     SecurityRuleResultDto evaluateRule(SecurityContext context) {
-        boolean debugFilter = context.chains().stream().anyMatch(chain -> chain.hasFilterContaining("DebugFilter"));
-        if (context.isPropertyTrue("spring.security.debug") || debugFilter) {
+        boolean debugFilterPresent = context.securityDebugFilterPresent()
+                || context.chains().stream().anyMatch(chain -> chain.hasFilter("DebugFilter"));
+        if (debugFilterPresent) {
             String suffix = context.isProductionProfileActive() ? " while a production profile is active" : "";
             return violation(List.of("Spring Security debug mode is enabled" + suffix + "."));
         }
@@ -1808,7 +1817,7 @@ final class SecurityDebugLoggingProductionRule extends AbstractSecurityRule {
                 "Spring Security framework logging should not run at DEBUG/TRACE in production",
                 SecurityCategory.CONFIGURATION,
                 "MEDIUM",
-                "Detects logging.level.org.springframework.security=DEBUG (or TRACE) while a production profile is active, which logs filter chain decisions, header values, and request/response details. Distinct from spring.security.debug (SEC-CONFIG-001), Spring Security's own dedicated debug filter.",
+                "Detects logging.level.org.springframework.security=DEBUG (or TRACE) while a production profile is active, which logs filter chain decisions, header values, and request/response details. Distinct from @EnableWebSecurity(debug = true), which SEC-CONFIG-001 detects through Spring Security's dedicated debug filter.",
                 "Keep org.springframework.security logging at INFO or WARN in production; reserve DEBUG/TRACE for local troubleshooting.",
                 "https://docs.spring.io/spring-boot/reference/features/logging.html#features.logging.log-levels"));
     }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -43,6 +43,7 @@ import org.springframework.security.web.access.intercept.RequestMatcherDelegatin
 import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter;
+import org.springframework.security.web.debug.DebugFilter;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
@@ -56,8 +57,8 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
  *
  * <p>The scanner reads the registered {@code SecurityFilterChain} beans and related security beans,
  * builds a read-only model, and runs a curated registry of static best-practice checks. It never
- * intercepts live requests beyond simulating an anonymous authorization decision against an in-memory
- * stub, and never surfaces credentials, keys, or session identifiers.</p>
+ * intercepts live requests beyond simulating bounded anonymous authorization decisions against
+ * in-memory stubs, and never surfaces credentials, keys, or session identifiers.</p>
  */
 final class SecurityScanner {
 
@@ -68,6 +69,25 @@ final class SecurityScanner {
                     + "validated against the application's threat model.";
     private static final List<String> SEVERITIES = List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
     private static final int MAX_BEAN_SCAN = 5000;
+    private static final List<AuthorizationProbe> AUTHORIZATION_PROBES = List.of(
+            new AuthorizationProbe("GET", "/"),
+            new AuthorizationProbe("GET", "/login"),
+            new AuthorizationProbe("GET", "/admin"),
+            new AuthorizationProbe("GET", "/api"),
+            new AuthorizationProbe("GET", "/actuator/env"),
+            new AuthorizationProbe("GET", "/bootui-authz-probe-8f3c1d20"),
+            new AuthorizationProbe("HEAD", "/bootui-authz-probe-8f3c1d20"),
+            new AuthorizationProbe("POST", "/bootui-authz-probe-8f3c1d20"),
+            new AuthorizationProbe("PUT", "/bootui-authz-probe-8f3c1d20"),
+            new AuthorizationProbe("PATCH", "/bootui-authz-probe-8f3c1d20"),
+            new AuthorizationProbe("DELETE", "/bootui-authz-probe-8f3c1d20"),
+            new AuthorizationProbe("OPTIONS", "/bootui-authz-probe-8f3c1d20"));
+    private static final String SPRING_SECURITY_FILTER_CHAIN_BEAN_NAME = "springSecurityFilterChain";
+    private static final String MVC_HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME = "mvcHandlerMappingIntrospector";
+    private static final String MVC_HANDLER_MAPPING_INTROSPECTOR_CLASS_NAME =
+            "org.springframework.web.servlet.handler.HandlerMappingIntrospector";
+    private static final String OBSERVATION_AUTHORIZATION_MANAGER_CLASS_NAME =
+            "org.springframework.security.authorization.ObservationAuthorizationManager";
 
     private static final Comparator<SecurityRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(
                     (SecurityRuleResultDto result) -> severityRank(result.severity()))
@@ -226,11 +246,27 @@ final class SecurityScanner {
             ObjectProvider<FilterChainProxy> filterChainProxies,
             ObjectProvider<ListableBeanFactory> beanFactories,
             Environment environment) {
+        ListableBeanFactory beanFactory;
+        try {
+            beanFactory = beanFactories.getIfAvailable();
+        } catch (RuntimeException | LinkageError ex) {
+            return SecurityDiscovery.empty(safeMessage(ex));
+        }
         FilterChainProxy proxy;
         try {
             proxy = filterChainProxies.getIfAvailable();
         } catch (RuntimeException | LinkageError ex) {
             return SecurityDiscovery.empty(safeMessage(ex));
+        }
+        boolean securityDebugFilterPresent = false;
+        if (proxy == null && beanFactory != null && beanFactory.containsBean(SPRING_SECURITY_FILTER_CHAIN_BEAN_NAME)) {
+            Object securityFilter = beanFactory.getBean(SPRING_SECURITY_FILTER_CHAIN_BEAN_NAME);
+            if (securityFilter instanceof FilterChainProxy filterChainProxy) {
+                proxy = filterChainProxy;
+            } else if (securityFilter instanceof DebugFilter debugFilter) {
+                proxy = debugFilter.getFilterChainProxy();
+                securityDebugFilterPresent = true;
+            }
         }
         if (proxy == null) {
             return SecurityDiscovery.empty("No Spring Security FilterChainProxy is available.");
@@ -251,7 +287,6 @@ final class SecurityScanner {
             errors.add("Filter chains: " + safeMessage(ex));
         }
 
-        ListableBeanFactory beanFactory = beanFactories.getIfAvailable();
         List<PasswordEncoderModel> passwordEncoders = discoverPasswordEncoders(beanFactory);
         List<String> jwtDecoderTypes = beanTypeNames(beanFactory, "org.springframework.security.oauth2.jwt.JwtDecoder");
         List<String> oauth2TokenValidatorTypes =
@@ -293,6 +328,7 @@ final class SecurityScanner {
                 hideUserNotFoundExceptionsDisabled,
                 opaqueTokenIntrospectorTypes,
                 generatedUserDetailsManagerPresent,
+                securityDebugFilterPresent,
                 environment);
         return new SecurityDiscovery(context, errors);
     }
@@ -338,15 +374,25 @@ final class SecurityScanner {
         if (manager == null) {
             return null;
         }
-        try {
-            Authentication anonymous = new AnonymousAuthenticationToken(
-                    "bootui-advisor", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
-            HttpServletRequest request = simulatedRequest();
-            AuthorizationResult result = manager.authorize(() -> anonymous, request);
-            return result != null && result.isGranted();
-        } catch (RuntimeException | LinkageError ex) {
+        AuthorizationManager<HttpServletRequest> unwrappedManager = unwrapObservationAuthorizationManager(manager);
+        if (unwrappedManager == null) {
             return null;
         }
+        Authentication anonymous = new AnonymousAuthenticationToken(
+                "bootui-advisor", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+        boolean indeterminate = false;
+        for (AuthorizationProbe probe : AUTHORIZATION_PROBES) {
+            try {
+                AuthorizationResult result =
+                        unwrappedManager.authorize(() -> anonymous, simulatedRequest(probe.method(), probe.path()));
+                if (result == null || !result.isGranted()) {
+                    return Boolean.FALSE;
+                }
+            } catch (RuntimeException | LinkageError ex) {
+                indeterminate = true;
+            }
+        }
+        return indeterminate ? null : Boolean.TRUE;
     }
 
     private static AuthorizationManager<HttpServletRequest> authorizationManager(List<Filter> filters) {
@@ -371,31 +417,30 @@ final class SecurityScanner {
     private static final Pattern UNCONDITIONAL_CATCH_ALL_PATTERN = Pattern.compile("\\[/\\*\\*]");
 
     /**
-     * {@code true} when {@code null} (indeterminate -- the chain's {@code AuthorizationManager} could
-     * not be introspected), {@code true} when an earlier, broader {@code authorizeHttpRequests}
-     * matcher shadows a later, narrower one (so the later rule can never take effect since Spring
-     * Security's {@code RequestMatcherDelegatingAuthorizationManager} evaluates matchers in
-     * declaration order and returns on the first match), {@code false} when no such shadowing was
-     * detected. Only an unconditional, method-agnostic catch-all matcher (Spring Security's
-     * {@code AnyRequestMatcher}, or an explicit {@code "/**"} pattern with no HTTP-method
-     * restriction) is treated as shadowing -- a method-scoped catch-all such as
-     * {@code requestMatchers(HttpMethod.GET, "/**")} is deliberately not flagged, since it only
-     * shadows requests using that one method and determining general matcher subsumption across
-     * methods and path patterns is out of scope for this bounded, low-false-positive check.
+     * {@code null} when the chain's {@code AuthorizationManager} could not be introspected, {@code
+     * true} when an earlier, broader {@code authorizeHttpRequests} matcher shadows a later, narrower
+     * one, or {@code false} when no such shadowing was detected. Only an unconditional,
+     * method-agnostic catch-all matcher is treated as shadowing.
      */
     private static Boolean detectAuthorizationRuleShadowed(AuthorizationManager<HttpServletRequest> manager) {
-        if (!(manager instanceof RequestMatcherDelegatingAuthorizationManager)) {
+        AuthorizationManager<HttpServletRequest> unwrappedManager = unwrapObservationAuthorizationManager(manager);
+        if (!(unwrappedManager instanceof RequestMatcherDelegatingAuthorizationManager)) {
             return null;
         }
-        Object mappingsField = readField(manager, "mappings");
-        if (!(mappingsField instanceof List<?> mappings) || mappings.size() < 2) {
+        Object mappingsField = readField(unwrappedManager, "mappings");
+        if (!(mappingsField instanceof List<?> mappings)) {
+            return null;
+        }
+        if (mappings.size() < 2) {
             return false;
         }
         // The last entry is allowed to be a catch-all (it is the final fallback rule and shadows
         // nothing after it), so only entries before it are checked.
         for (int i = 0; i < mappings.size() - 1; i++) {
-            if (mappings.get(i) instanceof RequestMatcherEntry<?> matcherEntry
-                    && isUnconditionalCatchAllMatcher(matcherEntry.getRequestMatcher())) {
+            if (!(mappings.get(i) instanceof RequestMatcherEntry<?> matcherEntry)) {
+                return null;
+            }
+            if (isUnconditionalCatchAllMatcher(matcherEntry.getRequestMatcher())) {
                 return true;
             }
         }
@@ -557,8 +602,14 @@ final class SecurityScanner {
         if (sources.isEmpty()) {
             return NO_CORS_SOURCES;
         }
+        boolean sourcePresent = false;
         boolean customSourcePresent = false;
-        for (CorsConfigurationSource source : sources.values()) {
+        for (Map.Entry<String, CorsConfigurationSource> sourceEntry : sources.entrySet()) {
+            CorsConfigurationSource source = sourceEntry.getValue();
+            if (isMvcHandlerMappingIntrospector(sourceEntry.getKey(), source)) {
+                continue;
+            }
+            sourcePresent = true;
             if (source instanceof UrlBasedCorsConfigurationSource urlSource) {
                 try {
                     Map<String, CorsConfiguration> configurations = urlSource.getCorsConfigurations();
@@ -582,7 +633,7 @@ final class SecurityScanner {
                 customSourcePresent = true;
             }
         }
-        return new CorsDiscoveryResult(true, customSourcePresent);
+        return sourcePresent ? new CorsDiscoveryResult(true, customSourcePresent) : NO_CORS_SOURCES;
     }
 
     private static boolean discoverMethodSecurityAnnotations(ListableBeanFactory beanFactory) {
@@ -756,18 +807,50 @@ final class SecurityScanner {
         return null;
     }
 
-    private static HttpServletRequest simulatedRequest() {
+    @SuppressWarnings("unchecked")
+    private static AuthorizationManager<HttpServletRequest> unwrapObservationAuthorizationManager(
+            AuthorizationManager<HttpServletRequest> manager) {
+        AuthorizationManager<?> current = manager;
+        for (int depth = 0;
+                depth < 8
+                        && current != null
+                        && OBSERVATION_AUTHORIZATION_MANAGER_CLASS_NAME.equals(
+                                current.getClass().getName());
+                depth++) {
+            Object delegate = readField(current, "delegate");
+            if (!(delegate instanceof AuthorizationManager<?> authorizationManager) || delegate == current) {
+                return null;
+            }
+            current = authorizationManager;
+        }
+        if (current == null
+                || OBSERVATION_AUTHORIZATION_MANAGER_CLASS_NAME.equals(
+                        current.getClass().getName())) {
+            return null;
+        }
+        return (AuthorizationManager<HttpServletRequest>) current;
+    }
+
+    private static boolean isMvcHandlerMappingIntrospector(String beanName, CorsConfigurationSource source) {
+        if (MVC_HANDLER_MAPPING_INTROSPECTOR_BEAN_NAME.equals(beanName)) {
+            return true;
+        }
+        Class<?> introspectorType = classForName(MVC_HANDLER_MAPPING_INTROSPECTOR_CLASS_NAME);
+        return introspectorType != null && introspectorType.isInstance(source);
+    }
+
+    private static HttpServletRequest simulatedRequest(String requestMethod, String requestPath) {
         InvocationHandler handler = (proxy, method, args) -> {
             String name = method.getName();
             return switch (name) {
-                case "getMethod" -> "GET";
-                case "getServletPath", "getRequestURI", "getPathInfo" -> "/";
+                case "getMethod" -> requestMethod;
+                case "getServletPath", "getRequestURI", "getPathInfo" -> requestPath;
                 case "getContextPath" -> "";
                 case "getScheme" -> "http";
                 case "getProtocol" -> "HTTP/1.1";
                 case "getServerName", "getRemoteHost", "getLocalName" -> "localhost";
                 case "getRemoteAddr", "getLocalAddr" -> "127.0.0.1";
-                case "getRequestURL" -> new StringBuffer("http://localhost/");
+                case "getRequestURL" -> new StringBuffer("http://localhost" + requestPath);
                 default -> defaultValue(method);
             };
         };
@@ -912,6 +995,8 @@ final class SecurityScanner {
     private static boolean isViolation(SecurityRuleResultDto result) {
         return SecurityRuleSupport.VIOLATION.equals(result.status());
     }
+
+    private record AuthorizationProbe(String method, String path) {}
 
     private record SecurityDiscovery(SecurityContext context, List<String> errors) {
 

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityDocumentationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityDocumentationTests.java
@@ -1,0 +1,60 @@
+package io.github.jdubois.bootui.autoconfigure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class SecurityDocumentationTests {
+
+    private static final Pattern SERVLET_RULE_HEADING = Pattern.compile("(?m)^### (SEC-(?!RXF-)[A-Z0-9-]+) - ");
+
+    @Test
+    void servletCatalogDocumentsEveryActiveRuleWithMatchingSeverity() throws IOException {
+        String documentation = Files.readString(securityChecksDocumentation());
+        Set<String> documentedRuleIds = new LinkedHashSet<>();
+        Matcher headings = SERVLET_RULE_HEADING.matcher(documentation);
+        while (headings.find()) {
+            documentedRuleIds.add(headings.group(1));
+        }
+
+        Set<String> activeRuleIds = new LinkedHashSet<>();
+        for (SecurityRule rule : SecurityRuleRegistry.activeRules()) {
+            SecurityRuleDefinition definition = rule.definition();
+            activeRuleIds.add(definition.id());
+
+            String heading = "### " + definition.id() + " - ";
+            int sectionStart = documentation.indexOf(heading);
+            assertThat(sectionStart)
+                    .as("documentation heading for %s", definition.id())
+                    .isNotNegative();
+            int nextSection = documentation.indexOf("\n### ", sectionStart + heading.length());
+            String section =
+                    documentation.substring(sectionStart, nextSection < 0 ? documentation.length() : nextSection);
+            assertThat(section)
+                    .as("documented severity for %s", definition.id())
+                    .contains("- **Severity**: " + definition.severity());
+        }
+
+        assertThat(documentedRuleIds).containsExactlyInAnyOrderElementsOf(activeRuleIds);
+    }
+
+    private static Path securityChecksDocumentation() {
+        Path workingDirectory = Path.of("").toAbsolutePath();
+        for (Path candidate : new Path[] {
+            workingDirectory.resolve("docs/SECURITY-CHECKS.md"),
+            workingDirectory.resolve("../docs/SECURITY-CHECKS.md").normalize()
+        }) {
+            if (Files.isRegularFile(candidate)) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("docs/SECURITY-CHECKS.md could not be located from " + workingDirectory);
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
@@ -105,9 +105,11 @@ class SecurityRulesTests {
                 chain("PathPattern [/api/**]", List.of("HttpsRedirectFilter", "AuthorizationFilter"));
         FilterChainModel formChain =
                 chain("PathPattern [/**]", List.of("UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
 
         SecurityRuleResultDto result =
-                new FormLoginWithoutTlsRule().evaluate(context(List.of(apiChain, formChain), new MockEnvironment()));
+                new FormLoginWithoutTlsRule().evaluate(context(List.of(apiChain, formChain), environment));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
     }
@@ -117,8 +119,10 @@ class SecurityRulesTests {
         FilterChainModel formChain = chain(
                 "PathPattern [/**]",
                 List.of("HttpsRedirectFilter", "UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
 
-        SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(singleChain(formChain));
+        SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(context(List.of(formChain), environment));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
@@ -592,6 +596,18 @@ class SecurityRulesTests {
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.SKIPPED);
     }
 
+    @Test
+    void corsSourcePassesWhenSpringSecurityInstallsPreFlightRequestFilter() {
+        FilterChainModel chain = chain("any request", List.of("PreFlightRequestFilter", "AuthorizationFilter"));
+        CorsConfigModel cors =
+                new CorsConfigModel("/**", List.of("https://example.com"), List.of(), List.of("GET"), List.of(), false);
+        SecurityContext context = context(List.of(chain), List.of(), List.of(cors), List.of(), new MockEnvironment());
+
+        SecurityRuleResultDto result = new CorsNotInSecurityChainRule().evaluate(context);
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
     // --- SEC-AUTHZ-002 / 003: stop over-claiming blanket permitAll --------------------------
 
     @Test
@@ -706,12 +722,12 @@ class SecurityRulesTests {
     }
 
     @Test
-    void authorizationRuleShadowedPassesWhenTheAuthorizationManagerCouldNotBeIntrospected() {
+    void authorizationRuleShadowedIsSkippedWhenTheAuthorizationManagerCouldNotBeIntrospected() {
         FilterChainModel chain = chain("any request", List.of("AuthorizationFilter"));
 
         SecurityRuleResultDto result = new AuthorizationRuleShadowedRule().evaluate(singleChain(chain));
 
-        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.SKIPPED);
     }
 
     // --- SEC-CSRF-001: Spring Security 6 form-login statefulness ----------------------------
@@ -888,11 +904,13 @@ class SecurityRulesTests {
     // --- SEC-AUTH-010: form login requires TLS -----------------------------------------------
 
     @Test
-    void formLoginWithoutTlsFires() {
+    void formLoginWithoutTlsFiresInProduction() {
         FilterChainModel chain =
                 chain("any request", List.of("UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+        MockEnvironment environment = new MockEnvironment();
+        environment.setActiveProfiles("prod");
 
-        SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(singleChain(chain));
+        SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(context(List.of(chain), environment));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
         assertThat(result.severity()).isEqualTo("HIGH");
@@ -901,10 +919,21 @@ class SecurityRulesTests {
     @Test
     void formLoginWithTlsPasses() {
         MockEnvironment environment = new MockEnvironment().withProperty("server.ssl.enabled", "true");
+        environment.setActiveProfiles("prod");
         FilterChainModel chain =
                 chain("any request", List.of("UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
 
         SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void formLoginWithoutTlsIsIgnoredOutsideProduction() {
+        FilterChainModel chain =
+                chain("any request", List.of("UsernamePasswordAuthenticationFilter", "AuthorizationFilter"));
+
+        SecurityRuleResultDto result = new FormLoginWithoutTlsRule().evaluate(singleChain(chain));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
@@ -1050,6 +1079,25 @@ class SecurityRulesTests {
         SecurityContext context = context(new MockEnvironment(), List.of(), false, false, List.of(), false);
 
         SecurityRuleResultDto result = new StrictHttpFirewallWeakenedRule().evaluate(context);
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-CONFIG-001: @EnableWebSecurity debug filter ------------------------------------
+
+    @Test
+    void securityDebugFilterFires() {
+        SecurityRuleResultDto result =
+                new SecurityDebugRule().evaluate(contextWithSecurityDebug(true, new MockEnvironment()));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void unsupportedSpringSecurityDebugPropertyDoesNotFire() {
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.security.debug", "true");
+
+        SecurityRuleResultDto result = new SecurityDebugRule().evaluate(contextWithSecurityDebug(false, environment));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
     }
@@ -1644,6 +1692,27 @@ class SecurityRulesTests {
                 false,
                 opaqueTokenIntrospectorTypes,
                 false,
+                environment);
+    }
+
+    private static SecurityContext contextWithSecurityDebug(
+            boolean securityDebugFilterPresent, Environment environment) {
+        return new SecurityContext(
+                List.of(),
+                List.of(),
+                List.of(),
+                false,
+                List.of(),
+                false,
+                false,
+                false,
+                false,
+                List.of(),
+                false,
+                false,
+                List.of(),
+                false,
+                securityDebugFilterPresent,
                 environment);
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -1,25 +1,48 @@
 package io.github.jdubois.bootui.autoconfigure.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.CorsConfigModel;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.FilterChainModel;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.PasswordEncoderModel;
 import io.github.jdubois.bootui.core.dto.SecurityReport;
 import io.github.jdubois.bootui.core.dto.SecurityRuleResultDto;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import jakarta.servlet.http.HttpServletRequest;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.ObservationAuthorizationManager;
+import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+import org.springframework.security.web.access.intercept.RequestMatcherDelegatingAuthorizationManager;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.debug.DebugFilter;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 class SecurityScannerTests {
 
@@ -42,7 +65,6 @@ class SecurityScannerTests {
                 List.of());
         MockEnvironment environment = new MockEnvironment()
                 .withProperty("management.endpoints.web.exposure.include", "*")
-                .withProperty("spring.security.debug", "true")
                 .withProperty("spring.security.user.name", "admin")
                 .withProperty("spring.security.user.password", "admin");
         SecurityContext context = new SecurityContext(
@@ -60,6 +82,7 @@ class SecurityScannerTests {
                 false,
                 List.of(),
                 false,
+                true,
                 environment);
         SecurityScanner scanner = new SecurityScanner(context, CLOCK);
 
@@ -301,6 +324,127 @@ class SecurityScannerTests {
     }
 
     @Test
+    void blanketPermitAllRequiresEveryBoundedPathProbeToBeGranted() {
+        AuthorizationManager<HttpServletRequest> publicResourcesOnly =
+                RequestMatcherDelegatingAuthorizationManager.builder()
+                        .requestMatchers(
+                                PathPatternRequestMatcher.pathPattern("/"),
+                                PathPatternRequestMatcher.pathPattern("/login"),
+                                PathPatternRequestMatcher.pathPattern("/css/**"))
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated()
+                        .build();
+
+        SecurityReport report = scannerFor(filterChainProxy(publicResourcesOnly), new DefaultListableBeanFactory())
+                .scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-AUTHZ-002");
+    }
+
+    @Test
+    void blanketPermitAllRequiresEveryBoundedHttpMethodProbeToBeGranted() {
+        AuthorizationManager<HttpServletRequest> getOnly = RequestMatcherDelegatingAuthorizationManager.builder()
+                .requestMatchers(PathPatternRequestMatcher.pathPattern(HttpMethod.GET, "/**"))
+                .permitAll()
+                .anyRequest()
+                .authenticated()
+                .build();
+
+        SecurityReport report = scannerFor(filterChainProxy(getOnly), new DefaultListableBeanFactory())
+                .scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-AUTHZ-002");
+    }
+
+    @Test
+    void blanketPermitAllFiresWhenEveryBoundedProbeIsGranted() {
+        AuthorizationManager<HttpServletRequest> permitAll = RequestMatcherDelegatingAuthorizationManager.builder()
+                .anyRequest()
+                .permitAll()
+                .build();
+
+        SecurityReport report = scannerFor(filterChainProxy(permitAll), new DefaultListableBeanFactory())
+                .scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-AUTHZ-002");
+    }
+
+    @Test
+    void observationAuthorizationManagerIsUnwrappedWithoutEmittingSyntheticObservations() {
+        AtomicInteger observationsStarted = new AtomicInteger();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        observationRegistry.observationConfig().observationHandler(new ObservationHandler<Observation.Context>() {
+            @Override
+            public void onStart(Observation.Context context) {
+                observationsStarted.incrementAndGet();
+            }
+
+            @Override
+            public boolean supportsContext(Observation.Context context) {
+                return true;
+            }
+        });
+        AuthorizationManager<RequestAuthorizationContext> permitAll =
+                (authentication, context) -> new AuthorizationDecision(true);
+        RequestMatcherDelegatingAuthorizationManager delegate = RequestMatcherDelegatingAuthorizationManager.builder()
+                .add(new DescribedRequestMatcher("PathPattern [/**]", true), permitAll)
+                .add(new DescribedRequestMatcher("PathPattern [/admin/**]", false), permitAll)
+                .build();
+        AuthorizationManager<HttpServletRequest> observed =
+                new ObservationAuthorizationManager<>(observationRegistry, delegate);
+
+        SecurityReport report = scannerFor(filterChainProxy(observed), new DefaultListableBeanFactory())
+                .scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-AUTHZ-005");
+        assertThat(observationsStarted).hasValue(0);
+    }
+
+    @Test
+    void debugFilterKeepsTheAdvisorAvailableAndProducesTheDebugFinding() {
+        AuthorizationManager<HttpServletRequest> denyAll =
+                (authentication, request) -> new AuthorizationDecision(false);
+        FilterChainProxy proxy = filterChainProxy(denyAll);
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton("springSecurityFilterChain", new DebugFilter(proxy));
+
+        SecurityReport report = scannerFor(null, beanFactory).scan();
+
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
+        assertThat(report.filterChainsAnalyzed()).isEqualTo(1);
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-CONFIG-001");
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void mvcHandlerMappingIntrospectorIsNotTreatedAsApplicationCorsConfiguration() {
+        AuthorizationManager<HttpServletRequest> denyAll =
+                (authentication, request) -> new AuthorizationDecision(false);
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton("mvcHandlerMappingIntrospector", new HandlerMappingIntrospector());
+
+        SecurityReport report =
+                scannerFor(filterChainProxy(denyAll), beanFactory).scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-CORS-003");
+    }
+
+    @Test
+    void applicationCorsConfigurationStillRequiresSecurityChainIntegration() {
+        AuthorizationManager<HttpServletRequest> denyAll =
+                (authentication, request) -> new AuthorizationDecision(false);
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        CorsConfigurationSource applicationCorsSource = request -> null;
+        beanFactory.registerSingleton("corsConfigurationSource", applicationCorsSource);
+
+        SecurityReport report =
+                scannerFor(filterChainProxy(denyAll), beanFactory).scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-CORS-003");
+    }
+
+    @Test
     void initialReportDoesNotInspectConfigurationBeforeExplicitScan() {
         FilterChainModel chain =
                 new FilterChainModel(0, "any request", List.of("AuthorizationFilter"), null, null, List.of());
@@ -450,6 +594,22 @@ class SecurityScannerTests {
         return new MockEnvironment();
     }
 
+    private static FilterChainProxy filterChainProxy(AuthorizationManager<HttpServletRequest> authorizationManager) {
+        return new FilterChainProxy(new DefaultSecurityFilterChain(
+                AnyRequestMatcher.INSTANCE,
+                new UsernamePasswordAuthenticationFilter(),
+                new AuthorizationFilter(authorizationManager)));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static SecurityScanner scannerFor(FilterChainProxy proxy, ListableBeanFactory beanFactory) {
+        ObjectProvider<FilterChainProxy> filterChains = mock(ObjectProvider.class);
+        ObjectProvider<ListableBeanFactory> beanFactories = mock(ObjectProvider.class);
+        when(filterChains.getIfAvailable()).thenReturn(proxy);
+        when(beanFactories.getIfAvailable()).thenReturn(beanFactory);
+        return new SecurityScanner(filterChains, beanFactories, new MockEnvironment(), CLOCK);
+    }
+
     private static SecurityContext hardenedContext(List<PasswordEncoderModel> encoders, MockEnvironment environment) {
         return new SecurityContext(
                 List.of(hardenedChain()),
@@ -587,6 +747,19 @@ class SecurityScannerTests {
         @Override
         SecurityRuleResultDto evaluateRule(SecurityContext context) {
             return skipped("Not applicable in this context.");
+        }
+    }
+
+    private record DescribedRequestMatcher(String description, boolean matches) implements RequestMatcher {
+
+        @Override
+        public boolean matches(HttpServletRequest request) {
+            return matches;
+        }
+
+        @Override
+        public String toString() {
+            return description;
         }
     }
 

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -1,10 +1,10 @@
 # Spring Security Advisor checks
 
 The Security panel runs a fixed, on-demand ruleset against the host application's Spring Security configuration.
-It introspects the registered `SecurityFilterChain` beans and their filter lists, simulates an anonymous authorization
-decision, and inspects security-relevant beans (`PasswordEncoder`, `CorsConfigurationSource`, `JwtDecoder`) and
-`Environment` properties. It never intercepts live traffic, exposes credentials, keys, or session identifiers, or modifies
-the security configuration.
+It introspects the registered `SecurityFilterChain` beans and their filter lists, simulates a bounded set of anonymous
+authorization decisions across common paths and HTTP methods, and inspects security-relevant beans (`PasswordEncoder`,
+`CorsConfigurationSource`, `JwtDecoder`) and `Environment` properties. It never intercepts live traffic, exposes
+credentials, keys, or session identifiers, or modifies the security configuration.
 
 The checks are heuristic review prompts. They highlight common Spring Security hardening gaps, but the right remediation
 still depends on the application's threat model and deployment topology.
@@ -46,7 +46,7 @@ includes up to a handful of sample details plus a remediation link.
 
 ### SEC-AUTH-002 - Password encoder should not use a weak or legacy algorithm
 
-- **Severity**: MEDIUM
+- **Severity**: HIGH
 - **Detects**: Detects deprecated encoders based on MD5/SHA or the legacy StandardPasswordEncoder.
 - **Recommendation**: Migrate to bcrypt, Argon2, or PBKDF2 via a DelegatingPasswordEncoder so hashes upgrade over time.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/features/authentication/password-storage.html>
@@ -103,8 +103,8 @@ includes up to a handful of sample details plus a remediation link.
 ### SEC-AUTH-010 - Form login should run only over HTTPS
 
 - **Severity**: HIGH
-- **Detects**: Detects an interactive form-login chain while no server-side TLS, HTTPS redirect, or forwarded-header strategy is configured. Passwords submitted over HTTP are visible to passive network observers and active intermediaries.
-- **Recommendation**: Enforce HTTPS via server.ssl.* (or a forwarded-headers strategy when TLS terminates upstream) for every formLogin() chain.
+- **Detects**: Detects an interactive form-login chain while a production-like profile is active and no server-side TLS, HTTPS redirect, or forwarded-header strategy is configured. Passwords submitted over HTTP are visible to passive network observers and active intermediaries.
+- **Recommendation**: Enforce HTTPS via server.ssl.* (or a forwarded-headers strategy when TLS terminates upstream) for every production formLogin() chain.
 - **Learn more**: <https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#transmit-passwords-only-over-tls-or-other-strong-transport>
 
 ## Authorization
@@ -119,14 +119,14 @@ includes up to a handful of sample details plus a remediation link.
 ### SEC-AUTHZ-002 - Avoid blanket permitAll authorization
 
 - **Severity**: HIGH
-- **Detects**: Detects a chain whose authorization grants every request to anonymous callers (permitAll catch-all).
+- **Detects**: Detects a catch-all chain whose authorization grants every request in a bounded anonymous probe set spanning common application paths, an unmatched sentinel path, and common HTTP methods. This is a heuristic, not a proof over the application's entire request space.
 - **Recommendation**: Restrict sensitive paths and finish with anyRequest().authenticated(); keep permitAll only for genuinely public endpoints.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html>
 
 ### SEC-AUTHZ-003 - Application security should not be effectively disabled
 
 - **Severity**: HIGH
-- **Detects**: Detects when every filter chain permits all requests anonymously and no chain requires authentication.
+- **Detects**: Detects when every determinable filter chain grants the bounded anonymous probe set and no chain installs a real authentication mechanism. Chains whose authorization manager cannot be evaluated remain indeterminate.
 - **Recommendation**: Define authorization rules that require authentication for non-public endpoints instead of leaving the app fully open.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html>
 
@@ -140,7 +140,7 @@ includes up to a handful of sample details plus a remediation link.
 ### SEC-AUTHZ-005 - Broader authorizeHttpRequests matchers should not shadow narrower ones
 
 - **Severity**: HIGH
-- **Detects**: Detects an unconditional, method-agnostic catch-all matcher (e.g. requestMatchers("/**")) registered before a narrower matcher in the same chain's authorizeHttpRequests rules. Requests are matched in declaration order and Spring Security does not guard against this (unlike anyRequest(), a plain requestMatchers("/**") does not block further rules from being added after it), so the narrower, later rule can never take effect.
+- **Detects**: Detects an unconditional, method-agnostic catch-all matcher (e.g. requestMatchers("/**")) registered before a narrower matcher in the same chain's authorizeHttpRequests rules. Requests are matched in declaration order and Spring Security does not guard against this (unlike anyRequest(), a plain requestMatchers("/**") does not block further rules from being added after it), so the narrower, later rule can never take effect. The rule renders **SKIPPED** when BootUI cannot unwrap or introspect the authorization manager.
 - **Recommendation**: Register narrower matchers (e.g. requestMatchers("/admin/**").hasRole("ADMIN")) before the broader catch-all, or replace the catch-all with anyRequest() so later requestMatchers additions are rejected at startup instead of silently ignored.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authorization/authorize-http-requests.html>
 
@@ -193,8 +193,8 @@ includes up to a handful of sample details plus a remediation link.
 ### SEC-SESSION-005 - An explicit session timeout should be configured
 
 - **Severity**: INFO
-- **Detects**: Detects that server.servlet.session.timeout is unset, leaving the container's default timeout.
-- **Recommendation**: Set server.servlet.session.timeout to a bounded value appropriate for the application's risk profile.
+- **Detects**: Detects that server.servlet.session.timeout is unset, which uses Spring Boot's documented 30-minute default.
+- **Recommendation**: Confirm that 30 minutes is a suitable bound for the application's risk profile, or set server.servlet.session.timeout explicitly.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/servlet.html>
 
 ### SEC-SESSION-006 - Bearer-token authentication chains should be stateless
@@ -302,7 +302,8 @@ includes up to a handful of sample details plus a remediation link.
 A custom `CorsConfigurationSource` bean (one BootUI cannot introspect for `CorsConfiguration` objects) is indeterminate,
 not automatically hardened: SEC-CORS-001, SEC-CORS-002, SEC-CORS-004, and SEC-CORS-006 render **SKIPPED** rather than a
 silent pass whenever such a bean is present and no introspectable `CorsConfiguration` already produced a finding, so a
-custom source is never misreported as verified-safe.
+custom source is never misreported as verified-safe. Spring MVC's built-in `mvcHandlerMappingIntrospector` is framework
+infrastructure rather than an application CORS policy and is excluded from this bean inventory.
 
 ### SEC-CORS-001 - CORS should not allow all origins
 
@@ -321,7 +322,7 @@ custom source is never misreported as verified-safe.
 ### SEC-CORS-003 - CORS should be wired through the security filter chain
 
 - **Severity**: INFO
-- **Detects**: Detects a CorsConfigurationSource bean while no filter chain installs a CorsFilter.
+- **Detects**: Detects an application CorsConfigurationSource bean while no filter chain installs Spring's `CorsFilter` or `PreFlightRequestFilter`.
 - **Recommendation**: Enable .cors(...) on the HttpSecurity so preflight handling is consistent with the security chain rather than MVC-only.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/integrations/cors.html>
 
@@ -351,7 +352,7 @@ custom source is never misreported as verified-safe.
 ### SEC-METHOD-002 - Replace @EnableGlobalMethodSecurity with @EnableMethodSecurity
 
 - **Severity**: LOW
-- **Detects**: Detects the legacy @EnableGlobalMethodSecurity configuration removed/deprecated in Spring Security 6+.
+- **Detects**: Detects the legacy @EnableGlobalMethodSecurity configuration, deprecated since Spring Security 6 and still present in Spring Security 7.
 - **Recommendation**: Migrate to @EnableMethodSecurity, which enables @PreAuthorize/@PostAuthorize by default and uses the modern AuthorizationManager API.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html>
 
@@ -381,7 +382,7 @@ custom source is never misreported as verified-safe.
 ### SEC-ACT-004 - Actuator health details/components should not be exposed unconditionally
 
 - **Severity**: HIGH
-- **Detects**: Detects management.endpoint.health.show-details=always or show-components=always, either of which leaks infrastructure/component details (disk space, database, custom health indicators, dependency versions) to anonymous callers. Spring Boot's own default for both properties is 'never' (not 'when-authorized', which was the default prior to Spring Boot 3.0).
+- **Detects**: Detects management.endpoint.health.show-details=always or show-components=always, either of which leaks infrastructure/component details (disk space, database, custom health indicators, dependency versions) to anonymous callers. Spring Boot's default for both properties is 'never'.
 - **Recommendation**: Leave show-details/show-components at 'never' (the default), or set them to 'when-authorized' and require authentication for the health endpoint.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.health.show-details>
 
@@ -441,7 +442,7 @@ custom source is never misreported as verified-safe.
 ### SEC-CONFIG-001 - Spring Security debug mode should be off
 
 - **Severity**: MEDIUM
-- **Detects**: Detects spring.security.debug=true (or a DebugFilter), which logs filter chains and request details.
+- **Detects**: Detects Spring Security's top-level `DebugFilter`, which is installed by `@EnableWebSecurity(debug = true)` and logs filter chains and request details. `spring.security.debug` is not a Spring Boot property and is not treated as a signal.
 - **Recommendation**: Disable security debug mode outside local development; it leaks configuration and request information.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/configuration/java.html>
 
@@ -483,7 +484,7 @@ custom source is never misreported as verified-safe.
 ### SEC-CONFIG-009 - Spring Security framework logging should not run at DEBUG/TRACE in production
 
 - **Severity**: MEDIUM
-- **Detects**: Detects logging.level.org.springframework.security=DEBUG (or TRACE) while a production profile is active, which logs filter chain decisions, header values, and request/response details. Distinct from spring.security.debug (SEC-CONFIG-001), Spring Security's own dedicated debug filter.
+- **Detects**: Detects logging.level.org.springframework.security=DEBUG (or TRACE) while a production profile is active, which logs filter chain decisions, header values, and request/response details. Distinct from `@EnableWebSecurity(debug = true)`, which SEC-CONFIG-001 detects through Spring Security's dedicated debug filter.
 - **Recommendation**: Keep org.springframework.security logging at INFO or WARN in production; reserve DEBUG/TRACE for local troubleshooting.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/logging.html#features.logging.log-levels>
 


### PR DESCRIPTION
## What does this PR do?

Audits all 61 servlet Spring Security Advisor rules against Java 17, Spring Boot 4.1, and Spring Security 7.1, then fixes demonstrable detection defects without changing any rule ID, severity, public DTO, or reactive/Quarkus behavior.

## Why is this change needed?

Several current servlet checks produce false positives or silently miss findings against current framework internals:

- SEC-AUTHZ-002/003 infer blanket `permitAll` from only anonymous `GET /`, so a normal public-home/login configuration is misclassified.
- Spring observability wraps the request authorization manager, hiding SEC-AUTHZ-005 and causing synthetic scan observations.
- `@EnableWebSecurity(debug = true)` wraps the top-level `FilterChainProxy` in `DebugFilter`, which currently disables the entire advisor; `spring.security.debug` is not a Spring Boot property.
- MVC's infrastructure `mvcHandlerMappingIntrospector` implements `CorsConfigurationSource`, producing SEC-CORS-003 false positives and indeterminate CORS results in ordinary MVC applications.
- Spring Security 7.1 can install `PreFlightRequestFilter` instead of `CorsFilter`.
- SEC-AUTH-010 reports normal local form-login development as a HIGH finding despite the production gate already used by SEC-AUTH-007.

## Independent research audit

Exactly three independent read-only audits examined the same immutable base snapshot (`d98836f0158b8b25d290252500b90a2b73371f9e`) before implementation:

| Audit | Configuration | Result |
|---|---|---|
| Claude Opus 5 | max effort, long context | 37 KEEP, 22 MODIFY, 1 SPLIT, 1 replace-in-place; identified the authorization, observation, debug-wrapper, and MVC CORS defects accepted here. |
| GPT-5.6 Terra | max effort, long context | Strict runtime-evidence position: 51 REMOVE, 9 MODIFY, 1 SPLIT; highlighted the risk of treating unavailable runtime evidence as a safe PASS. |
| Gemini 3.1 Pro | high effort, long context | Audited all 61 and proposed a 62-rule catalog through one split plus severity changes. |

The audits disagreed sharply on removals and severity changes. Because security removals/reductions require unusually strong primary evidence, this PR accepts only reproducible correctness fixes and factual copy corrections. It preserves the 61-rule catalog and every existing severity.

Primary evidence included Spring Security's current [`RequestMatcherDelegatingAuthorizationManager`](https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/access/intercept/RequestMatcherDelegatingAuthorizationManager.java), [`ObservationAuthorizationManager`](https://github.com/spring-projects/spring-security/blob/main/core/src/main/java/org/springframework/security/authorization/ObservationAuthorizationManager.java), [`WebSecurity`](https://github.com/spring-projects/spring-security/blob/main/config/src/main/java/org/springframework/security/config/annotation/web/builders/WebSecurity.java), [`DebugFilter`](https://github.com/spring-projects/spring-security/blob/main/web/src/main/java/org/springframework/security/web/debug/DebugFilter.java), and [`CorsConfigurer`](https://github.com/spring-projects/spring-security/blob/main/config/src/main/java/org/springframework/security/config/annotation/web/configurers/CorsConfigurer.java); Spring Boot's [`SecurityProperties`](https://github.com/spring-projects/spring-boot/blob/main/module/spring-boot-security/src/main/java/org/springframework/boot/security/autoconfigure/SecurityProperties.java), servlet [`Session`](https://github.com/spring-projects/spring-boot/blob/main/module/spring-boot-web-server/src/main/java/org/springframework/boot/web/server/servlet/Session.java), and [Actuator health documentation](https://docs.spring.io/spring-boot/reference/actuator/endpoints.html); Spring Security's [`EnableGlobalMethodSecurity`](https://github.com/spring-projects/spring-security/blob/main/config/src/main/java/org/springframework/security/config/annotation/method/configuration/EnableGlobalMethodSecurity.java); and [OWASP transport guidance](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#transmit-passwords-only-over-tls-or-other-strong-transport). Comparable [Semgrep](https://github.com/semgrep/semgrep-rules/blob/develop/java/spring/security/audit/spring-csrf-disabled.yaml), [CodeQL](https://codeql.github.com/codeql-query-help/java/java-spring-disabled-csrf-protection/), and [OpenRewrite](https://docs.openrewrite.org/recipes/java/spring/security6) analyzers were used only as secondary calibration.

## Conservative decision matrix

| Area | Final decision | Implementation |
|---|---|---|
| SEC-AUTHZ-002/003 | MODIFY | Probe representative public/sensitive/unmatched paths plus common HTTP methods; a definite denial prevents blanket-open classification, while evaluation errors remain indeterminate. |
| SEC-AUTHZ-005 | MODIFY | Boundedly unwrap `ObservationAuthorizationManager`; inspect its delegate without emitting synthetic Micrometer observations; opaque/unreadable mappings return SKIPPED. |
| SEC-CONFIG-001 | REPLACE predicate in place | Recover `FilterChainProxy` from the named top-level `DebugFilter` and record the actual filter; ignore unsupported `spring.security.debug`. |
| SEC-CORS-003 and CORS discovery | MODIFY | Exclude MVC's infrastructure introspector, preserve opaque custom sources as indeterminate, and accept `CorsFilter` or `PreFlightRequestFilter`. |
| SEC-AUTH-010 | MODIFY | Apply the existing production-profile gate used by the HTTP Basic TLS check. |
| AUTH-002, SESSION-005, METHOD-002, ACT-004, CONFIG-009 | COPY/DOCS | Correct severity parity, Boot's 30-minute session default, current deprecation status, unsupported historical default copy, and debug-mode terminology. |
| Proposed removals, splits, additions, or severity changes | REJECT/DEFER | No rule churn without stronger cross-audit primary evidence and reliable runtime detection. |

Deferred proposals include CORS severity reduction, BCrypt/HSTS/SameSite severity changes or removals, Actuator splits, new session/header rules, broad deletion of environment/runtime checks, reactive rule changes, and GraalVM reflection-hint work.

## Complete servlet inventory

| Final disposition | Rule IDs | Count |
|---|---|---:|
| Behavior modified | `SEC-AUTH-010`, `SEC-AUTHZ-002`, `SEC-AUTHZ-003`, `SEC-AUTHZ-005`, `SEC-CORS-003`, `SEC-CONFIG-001` | 6 |
| Guidance/parity corrected | `SEC-AUTH-002`, `SEC-SESSION-005`, `SEC-METHOD-002`, `SEC-ACT-004`, `SEC-CONFIG-009` | 5 |
| Kept unchanged after audit | `SEC-AUTH-001`, `SEC-AUTH-003`, `SEC-AUTH-004`, `SEC-AUTH-005`, `SEC-AUTH-006`, `SEC-AUTH-007`, `SEC-AUTH-008`, `SEC-AUTH-009`; `SEC-AUTHZ-001`, `SEC-AUTHZ-004`; `SEC-CSRF-001`, `SEC-CSRF-002`; `SEC-SESSION-001`, `SEC-SESSION-002`, `SEC-SESSION-003`, `SEC-SESSION-004`, `SEC-SESSION-006`, `SEC-SESSION-007`, `SEC-SESSION-008`, `SEC-SESSION-009`; `SEC-HEAD-001` through `SEC-HEAD-010`; `SEC-CORS-001`, `SEC-CORS-002`, `SEC-CORS-004`, `SEC-CORS-006`; `SEC-METHOD-001`; `SEC-ACT-001`, `SEC-ACT-002`, `SEC-ACT-003`, `SEC-ACT-005`, `SEC-ACT-006`, `SEC-ACT-007`; `SEC-OAUTH-001` through `SEC-OAUTH-004`; `SEC-CONFIG-002`, `SEC-CONFIG-005`, `SEC-CONFIG-006`, `SEC-CONFIG-007`, `SEC-CONFIG-008` | 50 |
| **Total active servlet catalog** | No IDs added, retired, or renumbered | **61** |

A new documentation-parity test now requires every active servlet ID to have a matching documented severity.

## Platform behavior

This is intentionally servlet/MVC-only. The internal scanner context gains a debug-filter observation, but the framework-neutral DTO/JSON contract is unchanged. Spring WebFlux keeps its existing 25-rule reactive catalog and Quarkus keeps its native catalog. Shared UI behavior and panel availability remain unchanged except that MVC debug mode no longer incorrectly makes the advisor unavailable.

## Limitations

- Anonymous authorization probing remains a bounded heuristic, not proof over every application request; the unmatched sentinel and method coverage reduce false positives materially.
- Custom or inaccessible authorization-manager wrappers remain SKIPPED rather than being reported safe.
- Excluding `mvcHandlerMappingIntrospector` avoids an always-present infrastructure false positive, but BootUI cannot infer a pure MVC CORS policy from that opaque infrastructure bean alone.
- Reflection-backed observation unwrapping can remain indeterminate under restrictive/native runtimes; native reflection hints are deliberately out of scope.
- Production-profile detection retains the project's existing profile-name heuristic.

## How was it tested?

- [x] `./mvnw -T 1C -B -ntp -Pcoverage clean install` passes locally on Java 17 (all 31 reactor modules)
- [x] Focused advisor suite: 145 tests across scanner, rules, and documentation parity
- [x] Ran the affected Spring MVC and Spring WebFlux conformance/tests
- [x] Started the MVC and WebFlux sample apps and verified `/bootui` on ports 8080 and 8081
- [x] Spring MVC Playwright: 150 passed, 6 skipped
- [x] Spring WebFlux Playwright: 8 passed
- [x] Custom-path Playwright: 13 passed, 1 skipped
- [x] Java Spotless, frontend formatting, Spring e2e formatting, Quarkus e2e formatting, workflow-reference, and release-integrity checks pass
- [x] Hosted Build (Java 17), Java 21/25 compatibility, CodeQL, documentation, and Quarkus end-to-end jobs pass
- [x] Added deterministic positive, negative, boundary, observation-side-effect, debug-wrapper, CORS-infrastructure, and docs-parity tests

## Screenshots (UI changes)

N/A — no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` updated when behaviour changes
- [x] Public API kept backward compatible
- [x] No secrets, tokens, or local paths committed