### PR TITLE
fix: align Spring advisor with Boot 4.1

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/ActuatorExposure.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/ActuatorExposure.java
@@ -22,6 +22,7 @@ final class ActuatorExposure {
     private static final String EXCLUDE = "management.endpoints.web.exposure.exclude";
     private static final String ACCESS_DEFAULT = "management.endpoints.access.default";
     private static final String ACCESS_MAX = "management.endpoints.access.max-permitted";
+    private static final String ENABLED_BY_DEFAULT = "management.endpoints.enabled-by-default";
 
     private static final int ACCESS_NONE = 0;
     private static final int ACCESS_READ_ONLY = 1;
@@ -83,37 +84,52 @@ final class ActuatorExposure {
      * never when capped to read-only or disabled. The default ({@code access=none}) is not flagged.
      */
     static boolean shutdownAccessible(SpringContext context) {
-        if (!isWebExposed(context, "shutdown")) {
-            return false;
-        }
-        if (isPropertyFalse(context, "management.endpoint.shutdown.enabled")) {
-            return false;
-        }
-        String access = context.firstProperty("management.endpoint.shutdown.access", ACCESS_DEFAULT);
-        boolean unrestricted = "unrestricted".equalsIgnoreCase(access);
-        boolean legacyEnabled = context.isPropertyTrue("management.endpoint.shutdown.enabled");
-        boolean writable = unrestricted || legacyEnabled;
-        return writable && maxPermitted(context) >= ACCESS_UNRESTRICTED;
+        return isWebExposed(context, "shutdown")
+                && effectiveAccess(context, "shutdown", ACCESS_NONE) >= ACCESS_UNRESTRICTED;
     }
 
     /** True when the {@code heapdump} endpoint is web-exposed and at least readable (its default). */
     static boolean heapdumpAccessible(SpringContext context) {
-        if (isPropertyFalse(context, "management.endpoint.heapdump.enabled")) {
-            return false;
-        }
         return isReadable(context, "heapdump");
     }
 
     private static int effectiveAccess(SpringContext context, String id, int defaultRank) {
-        if (isPropertyFalse(context, "management.endpoint." + id + ".enabled")) {
+        String endpointAccess = context.firstProperty("management.endpoint." + id + ".access");
+        if (endpointAccess != null) {
+            return capped(context, rankOrDefault(endpointAccess, defaultRank));
+        }
+        String endpointEnabled = context.firstProperty("management.endpoint." + id + ".enabled");
+        if (endpointEnabled != null) {
+            return capped(context, enabledOrDefault(endpointEnabled, defaultRank));
+        }
+        String defaultAccess = context.firstProperty(ACCESS_DEFAULT);
+        if (defaultAccess != null) {
+            return capped(context, rankOrDefault(defaultAccess, defaultRank));
+        }
+        String enabledByDefault = context.firstProperty(ENABLED_BY_DEFAULT);
+        if (enabledByDefault != null) {
+            return capped(context, enabledOrDefault(enabledByDefault, defaultRank));
+        }
+        return capped(context, defaultRank);
+    }
+
+    private static int capped(SpringContext context, int access) {
+        return Math.min(access, maxPermitted(context));
+    }
+
+    private static int rankOrDefault(String access, int defaultRank) {
+        int rank = rank(access);
+        return rank >= 0 ? rank : defaultRank;
+    }
+
+    private static int enabledOrDefault(String enabled, int defaultRank) {
+        if ("true".equalsIgnoreCase(enabled)) {
+            return ACCESS_UNRESTRICTED;
+        }
+        if ("false".equalsIgnoreCase(enabled)) {
             return ACCESS_NONE;
         }
-        String access = context.firstProperty("management.endpoint." + id + ".access", ACCESS_DEFAULT);
-        int rank = access != null ? rank(access) : defaultRank;
-        if (rank < 0) {
-            rank = defaultRank;
-        }
-        return Math.min(rank, maxPermitted(context));
+        return defaultRank;
     }
 
     private static int maxPermitted(SpringContext context) {
@@ -132,11 +148,6 @@ final class ActuatorExposure {
             case "unrestricted" -> ACCESS_UNRESTRICTED;
             default -> -1;
         };
-    }
-
-    private static boolean isPropertyFalse(SpringContext context, String key) {
-        String value = context.firstProperty(key);
-        return value != null && "false".equalsIgnoreCase(value);
     }
 
     /** Binds the include/exclude property as a Set so comma strings and YAML lists both resolve. */

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringContext.java
@@ -23,12 +23,14 @@ record SpringContext(
         int beanDefinitionCount,
         List<BeanRef> objectMappers,
         List<BeanRef> taskExecutors,
+        boolean bootApplicationTaskExecutorPresent,
+        List<BeanRef> executors,
         List<BeanRef> dataSources,
         boolean pooledTaskExecutorPresent,
         boolean asyncEnabled,
         boolean devToolsPresent,
         boolean hikariDataSourcePresent,
-        boolean asyncConfigurerPresent,
+        boolean customAsyncConfigurerPresent,
         List<BeanRef> transactionManagers,
         boolean transactionManagementConfigurerPresent,
         List<BeanRef> restTemplates,
@@ -39,6 +41,7 @@ record SpringContext(
         boolean entityManagerFactoryPresent,
         boolean dispatcherServletPresent,
         boolean reactive,
+        boolean tomcatWebServerPresent,
         boolean webClientBeanPresent,
         int reactiveHandlerMethodCount,
         List<String> defaultPackageBeans,
@@ -47,6 +50,7 @@ record SpringContext(
     SpringContext {
         objectMappers = List.copyOf(objectMappers);
         taskExecutors = List.copyOf(taskExecutors);
+        executors = List.copyOf(executors);
         dataSources = List.copyOf(dataSources);
         transactionManagers = List.copyOf(transactionManagers);
         restTemplates = List.copyOf(restTemplates);
@@ -200,12 +204,14 @@ record SpringContext(
         private int beanDefinitionCount;
         private List<BeanRef> objectMappers = List.of();
         private List<BeanRef> taskExecutors = List.of();
+        private boolean bootApplicationTaskExecutorPresent;
+        private List<BeanRef> executors = List.of();
         private List<BeanRef> dataSources = List.of();
         private boolean pooledTaskExecutorPresent;
         private boolean asyncEnabled;
         private boolean devToolsPresent;
         private boolean hikariDataSourcePresent;
-        private boolean asyncConfigurerPresent;
+        private boolean customAsyncConfigurerPresent;
         private List<BeanRef> transactionManagers = List.of();
         private boolean transactionManagementConfigurerPresent;
         private List<BeanRef> restTemplates = List.of();
@@ -216,6 +222,7 @@ record SpringContext(
         private boolean entityManagerFactoryPresent;
         private boolean dispatcherServletPresent;
         private boolean reactive;
+        private boolean tomcatWebServerPresent;
         private boolean webClientBeanPresent;
         private int reactiveHandlerMethodCount;
         private List<String> defaultPackageBeans = List.of();
@@ -245,6 +252,16 @@ record SpringContext(
             return this;
         }
 
+        Builder bootApplicationTaskExecutorPresent(boolean value) {
+            this.bootApplicationTaskExecutorPresent = value;
+            return this;
+        }
+
+        Builder executors(List<BeanRef> value) {
+            this.executors = value;
+            return this;
+        }
+
         Builder dataSources(List<BeanRef> value) {
             this.dataSources = value;
             return this;
@@ -270,8 +287,8 @@ record SpringContext(
             return this;
         }
 
-        Builder asyncConfigurerPresent(boolean value) {
-            this.asyncConfigurerPresent = value;
+        Builder customAsyncConfigurerPresent(boolean value) {
+            this.customAsyncConfigurerPresent = value;
             return this;
         }
 
@@ -330,6 +347,11 @@ record SpringContext(
             return this;
         }
 
+        Builder tomcatWebServerPresent(boolean value) {
+            this.tomcatWebServerPresent = value;
+            return this;
+        }
+
         Builder webClientBeanPresent(boolean value) {
             this.webClientBeanPresent = value;
             return this;
@@ -357,12 +379,14 @@ record SpringContext(
                     beanDefinitionCount,
                     objectMappers,
                     taskExecutors,
+                    bootApplicationTaskExecutorPresent,
+                    executors,
                     dataSources,
                     pooledTaskExecutorPresent,
                     asyncEnabled,
                     devToolsPresent,
                     hikariDataSourcePresent,
-                    asyncConfigurerPresent,
+                    customAsyncConfigurerPresent,
                     transactionManagers,
                     transactionManagementConfigurerPresent,
                     restTemplates,
@@ -373,6 +397,7 @@ record SpringContext(
                     entityManagerFactoryPresent,
                     dispatcherServletPresent,
                     reactive,
+                    tomcatWebServerPresent,
                     webClientBeanPresent,
                     reactiveHandlerMethodCount,
                     defaultPackageBeans,

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringModel.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringModel.java
@@ -10,8 +10,14 @@ final class SpringModel {
 
     private SpringModel() {}
 
-    /** A managed bean of interest: its bean name and whether it is marked {@code @Primary}. */
-    record BeanRef(String name, boolean primary) {}
+    /** A managed bean of interest and candidate metadata available in the read-only snapshot. */
+    record BeanRef(
+            String name, boolean primary, boolean autowireCandidate, boolean fallback, boolean defaultCandidate) {
+
+        BeanRef(String name, boolean primary) {
+            this(name, primary, true, false, true);
+        }
+    }
 
     /** A {@code CacheManager} bean: its name and the resolved implementation class name (may be null). */
     record CacheManagerRef(String name, String className) {}
@@ -19,6 +25,28 @@ final class SpringModel {
     /** Counts the beans in {@code refs} that are marked primary. */
     static long primaryCount(List<BeanRef> refs) {
         return refs.stream().filter(BeanRef::primary).count();
+    }
+
+    /** Whether the primary, fallback, and default-candidate metadata resolves a single bean. */
+    static boolean hasResolvedCandidateMetadata(List<BeanRef> refs) {
+        List<BeanRef> candidates =
+                refs.stream().filter(BeanRef::autowireCandidate).toList();
+        if (candidates.size() < 2) {
+            return true;
+        }
+        long primaryCandidates = primaryCount(candidates);
+        if (primaryCandidates == 1) {
+            return true;
+        }
+        if (primaryCandidates > 1) {
+            return false;
+        }
+        long nonFallbackCandidates =
+                candidates.stream().filter(ref -> !ref.fallback()).count();
+        if (nonFallbackCandidates == 1) {
+            return true;
+        }
+        return candidates.stream().filter(BeanRef::defaultCandidate).count() == 1;
     }
 
     /** Whether any bean in {@code refs} carries the conventional name {@code names}. */

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
@@ -123,8 +123,9 @@ final class DuplicateObjectMapperRule extends AbstractSpringRule {
                 SpringCategory.BEAN_WIRING,
                 "LOW",
                 "Detects more than one Jackson JSON mapper bean (Jackson 2 ObjectMapper or the Jackson 3"
-                        + " JsonMapper that Spring Boot 4 auto-configures) with none marked @Primary, which can"
-                        + " lead to inconsistent JSON (de)serialization depending on which one is injected.",
+                        + " JsonMapper that Spring Boot 4 auto-configures) without primary/fallback/default"
+                        + " candidate selection, which can lead to inconsistent JSON"
+                        + " (de)serialization.",
                 "Keep a single primary JSON mapper. With Jackson 3 (the Spring Boot 4 default) customize the"
                         + " auto-configured mapper via a JsonMapperBuilderCustomizer, or mark one bean @Primary.",
                 "https://docs.spring.io/spring-boot/reference/features/json.html"));
@@ -133,9 +134,11 @@ final class DuplicateObjectMapperRule extends AbstractSpringRule {
     @Override
     SpringRuleResultDto evaluateRule(SpringContext context) {
         List<BeanRef> mappers = context.objectMappers();
-        if (mappers.size() > 1 && SpringModel.primaryCount(mappers) == 0) {
-            return violation(
-                    "Found " + mappers.size() + " JSON mapper beans and none is @Primary: " + names(mappers) + ".");
+        if (mappers.size() > 1 && !SpringModel.hasResolvedCandidateMetadata(mappers)) {
+            return violation("Found " + mappers.size()
+                    + " JSON mapper beans without primary/fallback/default-candidate selection: "
+                    + names(mappers)
+                    + ".");
         }
         return pass();
     }
@@ -149,10 +152,10 @@ final class AmbiguousTaskExecutorRule extends AbstractSpringRule {
                 "Multiple TaskExecutor beans need a primary",
                 SpringCategory.BEAN_WIRING,
                 "MEDIUM",
-                "Detects more than one TaskExecutor bean without a @Primary, so @Async and other"
-                        + " consumers may resolve an unexpected executor. A bean conventionally named"
-                        + " applicationTaskExecutor/taskExecutor, or an AsyncConfigurer, resolves the"
-                        + " ambiguity and suppresses this check.",
+                "Detects more than one TaskExecutor bean without primary/fallback/default-candidate selection,"
+                        + " so @Async and other consumers may resolve an unexpected executor. A bean"
+                        + " conventionally named applicationTaskExecutor/taskExecutor, or a custom AsyncConfigurer,"
+                        + " can resolve the ambiguity and suppresses this check.",
                 "Mark the intended executor @Primary, name it applicationTaskExecutor, implement"
                         + " AsyncConfigurer, or qualify each injection point with the executor bean name.",
                 "https://docs.spring.io/spring-framework/reference/integration/scheduling.html"));
@@ -162,11 +165,13 @@ final class AmbiguousTaskExecutorRule extends AbstractSpringRule {
     SpringRuleResultDto evaluateRule(SpringContext context) {
         List<BeanRef> executors = context.taskExecutors();
         if (executors.size() > 1
-                && SpringModel.primaryCount(executors) == 0
-                && !context.asyncConfigurerPresent()
+                && !SpringModel.hasResolvedCandidateMetadata(executors)
+                && !context.customAsyncConfigurerPresent()
                 && !SpringModel.hasName(executors, "applicationTaskExecutor", "taskExecutor")) {
-            return violation("Found " + executors.size() + " TaskExecutor beans and none is @Primary: "
-                    + names(executors) + ".");
+            return violation("Found " + executors.size()
+                    + " TaskExecutor beans without primary/fallback/default-candidate selection: "
+                    + names(executors)
+                    + ".");
         }
         return pass();
     }
@@ -180,8 +185,9 @@ final class AmbiguousDataSourceRule extends AbstractSpringRule {
                 "Multiple DataSource beans need a primary",
                 SpringCategory.BEAN_WIRING,
                 "MEDIUM",
-                "Detects more than one DataSource bean without a @Primary, which makes auto-configured"
-                        + " consumers (JPA, JdbcTemplate) fail or pick an unexpected source.",
+                "Detects more than one DataSource bean without primary/fallback/default-candidate selection,"
+                        + " which makes auto-configured consumers (JPA, JdbcTemplate) fail or pick an"
+                        + " unexpected source.",
                 "Mark the main DataSource @Primary and qualify any secondary DataSource explicitly.",
                 "https://docs.spring.io/spring-boot/reference/data/sql.html"));
     }
@@ -189,9 +195,11 @@ final class AmbiguousDataSourceRule extends AbstractSpringRule {
     @Override
     SpringRuleResultDto evaluateRule(SpringContext context) {
         List<BeanRef> dataSources = context.dataSources();
-        if (dataSources.size() > 1 && SpringModel.primaryCount(dataSources) == 0) {
-            return violation("Found " + dataSources.size() + " DataSource beans and none is @Primary: "
-                    + names(dataSources) + ".");
+        if (dataSources.size() > 1 && !SpringModel.hasResolvedCandidateMetadata(dataSources)) {
+            return violation("Found " + dataSources.size()
+                    + " DataSource beans without primary/fallback/default-candidate selection: "
+                    + names(dataSources)
+                    + ".");
         }
         return pass();
     }
@@ -205,8 +213,9 @@ final class AmbiguousTransactionManagerRule extends AbstractSpringRule {
                 "Multiple transaction managers need a primary",
                 SpringCategory.BEAN_WIRING,
                 "MEDIUM",
-                "Detects more than one PlatformTransactionManager bean without a @Primary, so @Transactional"
-                        + " methods may bind to an unexpected manager. A bean named transactionManager or a"
+                "Detects more than one PlatformTransactionManager bean without"
+                        + " primary/fallback/default-candidate selection, so @Transactional methods may bind to"
+                        + " an unexpected manager. A bean named transactionManager or a"
                         + " TransactionManagementConfigurer resolves the default and suppresses this check.",
                 "Mark the main transaction manager @Primary, name it transactionManager, implement"
                         + " TransactionManagementConfigurer, or set @Transactional(\"<name>\") on each usage.",
@@ -217,11 +226,13 @@ final class AmbiguousTransactionManagerRule extends AbstractSpringRule {
     SpringRuleResultDto evaluateRule(SpringContext context) {
         List<BeanRef> managers = context.transactionManagers();
         if (managers.size() > 1
-                && SpringModel.primaryCount(managers) == 0
+                && !SpringModel.hasResolvedCandidateMetadata(managers)
                 && !context.transactionManagementConfigurerPresent()
                 && !SpringModel.hasName(managers, "transactionManager")) {
-            return violation("Found " + managers.size() + " PlatformTransactionManager beans and none is @Primary: "
-                    + names(managers) + ".");
+            return violation("Found " + managers.size()
+                    + " PlatformTransactionManager beans without primary/fallback/default-candidate selection: "
+                    + names(managers)
+                    + ".");
         }
         return pass();
     }
@@ -345,10 +356,10 @@ final class DebugOrTraceLoggingRule extends AbstractSpringRule {
                 "Disable global debug or trace logging",
                 SpringCategory.CONFIGURATION,
                 "LOW",
-                "Detects debug=true or trace=true, which switch on verbose auto-configuration logging"
-                        + " and can leak internal details or slow down the application. Raised to MEDIUM when a"
-                        + " production-like profile is active, since the performance and data-leak cost of"
-                        + " verbose logging is highest there.",
+                "Detects debug=true, trace=true, or broad root/web/sql/Spring/Hibernate loggers at"
+                        + " DEBUG/TRACE/ALL, which can leak internal details or slow down the application."
+                        + " Raised to MEDIUM when a production-like profile is active, since the performance"
+                        + " and data-leak cost of verbose logging is highest there.",
                 "Remove the debug/trace flags and configure logging levels per package instead.",
                 "https://docs.spring.io/spring-boot/reference/features/logging.html"));
     }
@@ -695,7 +706,8 @@ final class VirtualThreadsAvailableRule extends AbstractSpringRule {
                 "The JVM supports virtual threads (Java 21+) but spring.threads.virtual.enabled is not"
                         + " set. Blocking workloads — request-per-thread web handlers, and blocking @Async /"
                         + " @Scheduled work on either the servlet or WebFlux stack — can often scale further on"
-                        + " virtual threads. An opportunity to evaluate, not a defect.",
+                        + " virtual threads. On WebFlux, this applies only to explicitly offloaded blocking"
+                        + " work. An opportunity to evaluate, not a defect.",
                 "Consider spring.threads.virtual.enabled=true after verifying that blocking code paths do"
                         + " not hold synchronized monitors that would pin carrier threads.",
                 "https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html"));
@@ -711,7 +723,7 @@ final class VirtualThreadsAvailableRule extends AbstractSpringRule {
                 return violation("Virtual threads are supported but spring.threads.virtual.enabled is not true."
                         + " On WebFlux this only benefits blocking work still offloaded to a thread pool (@Async,"
                         + " @Scheduled, or Schedulers.boundedElastic()-backed calls) — the reactive HTTP path"
-                        + " itself already runs non-blocking on Reactor Netty's event loop and is unaffected.");
+                        + " itself is non-blocking and does not directly benefit.");
             }
             return violation("Virtual threads are supported but spring.threads.virtual.enabled is not true.");
         }
@@ -762,10 +774,10 @@ final class AsyncWithoutCustomExecutorRule extends AbstractSpringRule {
                 SpringCategory.PERFORMANCE,
                 "MEDIUM",
                 "@EnableAsync is active but the application either defines no TaskExecutor bean at all,"
-                        + " or relies solely on Spring Boot's auto-configured 'applicationTaskExecutor' left"
-                        + " at its default pool settings — a bounded ThreadPoolTaskExecutor with a core pool"
-                        + " size of 8 and an effectively unbounded queue — sized for a generic default, not"
-                        + " this application's actual @Async workload.",
+                        + " or uses Spring Boot's auto-configured 'applicationTaskExecutor' left at its default"
+                        + " pool settings — a bounded ThreadPoolTaskExecutor with a core pool size of 8 and an"
+                        + " effectively unbounded queue — sized for a generic default, not this application's"
+                        + " actual @Async workload.",
                 "Define a dedicated executor sized for the workload, or explicitly review and set"
                         + " spring.task.execution.pool.core-size / max-size instead of relying on the"
                         + " unreviewed default, or enable spring.threads.virtual.enabled so @Async work is"
@@ -778,23 +790,21 @@ final class AsyncWithoutCustomExecutorRule extends AbstractSpringRule {
         if (!context.asyncEnabled() || context.isVirtualThreadsEnabled()) {
             return pass();
         }
-        List<BeanRef> executors = context.taskExecutors();
-        if (executors.isEmpty()) {
+        List<BeanRef> taskExecutors = context.taskExecutors();
+        if (taskExecutors.isEmpty() && !SpringModel.hasName(context.executors(), "taskExecutor")) {
             // Rare in practice: TaskExecutionAutoConfiguration always registers a default TaskExecutor
             // bean unless it was explicitly excluded, so this branch only fires when that
             // auto-configuration itself is absent — the one case where @Async genuinely falls back to
             // an unbounded SimpleAsyncTaskExecutor (one new platform thread per task).
-            return violation("@EnableAsync is active with no TaskExecutor bean at all, so @Async uses the"
-                    + " unbounded SimpleAsyncTaskExecutor (a new platform thread per task).");
+            return violation("@EnableAsync is active with no TaskExecutor and no Executor named taskExecutor, so"
+                    + " @Async uses the unbounded SimpleAsyncTaskExecutor (a new platform thread per task).");
         }
-        boolean onlyBootDefault = executors.size() == 1 && SpringModel.hasName(executors, DEFAULT_TASK_EXECUTOR_BEAN);
         boolean poolSizeReviewed = context.hasProperty("spring.task.execution.pool.core-size")
                 || context.hasProperty("spring.task.execution.pool.max-size");
-        if (onlyBootDefault && !poolSizeReviewed) {
-            return violation("@EnableAsync is active but the only TaskExecutor is Boot's auto-configured"
-                    + " 'applicationTaskExecutor' left at its default size (core pool size 8, unbounded"
-                    + " queue); this single pool backs every @Async method and has not been reviewed for"
-                    + " this workload.");
+        if (context.bootApplicationTaskExecutorPresent() && !poolSizeReviewed) {
+            return violation("@EnableAsync is active and Boot's auto-configured 'applicationTaskExecutor' is"
+                    + " left at its default size (core pool size 8, unbounded queue); this pool backs every"
+                    + " @Async method and has not been reviewed for this workload.");
         }
         return pass();
     }
@@ -870,9 +880,9 @@ final class UnboundedAsyncQueueRule extends AbstractSpringRule {
                 "Bound the @Async executor queue",
                 SpringCategory.PERFORMANCE,
                 "LOW",
-                "@EnableAsync is active and spring.task.execution.pool.queue-capacity is not set, so the"
-                        + " auto-configured task executor uses an effectively unbounded queue that can hide a"
-                        + " backlog and grow heap usage under load.",
+                "@EnableAsync uses Boot's auto-configured applicationTaskExecutor and"
+                        + " spring.task.execution.pool.queue-capacity is not set, so that executor uses an"
+                        + " effectively unbounded queue that can hide a backlog and grow heap usage under load.",
                 "Set spring.task.execution.pool.queue-capacity (and a matching max pool size) to a bounded"
                         + " value, or enable virtual threads so async work is not pooled.",
                 "https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html"));
@@ -881,6 +891,9 @@ final class UnboundedAsyncQueueRule extends AbstractSpringRule {
     @Override
     SpringRuleResultDto evaluateRule(SpringContext context) {
         if (!context.asyncEnabled() || context.isVirtualThreadsEnabled()) {
+            return pass();
+        }
+        if (!context.bootApplicationTaskExecutorPresent()) {
             return pass();
         }
         if (!context.hasProperty("spring.task.execution.pool.queue-capacity")) {
@@ -1193,24 +1206,23 @@ final class RedundantTomcatThreadsRule extends AbstractSpringRule {
                 "Tomcat thread cap is redundant with virtual threads",
                 SpringCategory.WEB,
                 "LOW",
-                "Virtual threads are enabled but server.tomcat.threads.max is set explicitly. With virtual"
-                        + " threads handling requests, a small platform-thread cap can needlessly limit"
-                        + " concurrency, while a large one has little effect.",
-                "Remove server.tomcat.threads.max when running on virtual threads, or confirm the cap is a"
-                        + " deliberate back-pressure limit.",
+                "An embedded Tomcat application enables virtual threads but also sets"
+                        + " server.tomcat.threads.max. Spring Boot replaces Tomcat's protocol-handler executor"
+                        + " with a virtual-thread executor, making the thread cap ineffective.",
+                "Remove server.tomcat.threads.max when running on virtual threads because it no longer"
+                        + " controls Tomcat request concurrency.",
                 "https://docs.spring.io/spring-boot/reference/web/servlet.html"));
     }
 
     @Override
     SpringRuleResultDto evaluateRule(SpringContext context) {
-        if (context.reactive()) {
-            // WebFlux uses Reactor Netty's event-loop group, not a Tomcat servlet thread pool, so
-            // server.tomcat.threads.max has no effect on this application at all.
-            return skipped("This is a WebFlux application; server.tomcat.threads.max does not apply.");
+        if (!context.tomcatWebServerPresent()) {
+            return skipped(
+                    "The application is not using embedded Tomcat, so server.tomcat.threads.max does not apply.");
         }
         if (context.isVirtualThreadsEnabled() && context.hasProperty("server.tomcat.threads.max")) {
-            return violation("Virtual threads are enabled but server.tomcat.threads.max is set, which can cap"
-                    + " request concurrency unnecessarily.");
+            return violation("Virtual threads are enabled but server.tomcat.threads.max is set, even though"
+                    + " Spring Boot's virtual-thread executor makes that cap ineffective.");
         }
         return pass();
     }
@@ -1565,11 +1577,11 @@ final class ReactiveHandlerWithBlockingDatasourceRule extends AbstractSpringRule
                 SpringCategory.REACTIVE,
                 "INFO",
                 "This is a WebFlux application with Mono/Flux-returning handler methods, and a blocking JDBC"
-                        + " DataSource is also configured. WebFlux runs on a small, fixed Reactor Netty event-loop"
-                        + " group; a blocking JDBC call made directly inside a reactive chain (instead of offloaded"
-                        + " to a bounded scheduler) stalls that event loop and can starve every other in-flight"
-                        + " request. This check cannot see inside method bodies, so it cannot tell whether"
-                        + " offloading is already done correctly — treat it as a prompt to verify, not a finding.",
+                        + " DataSource is also configured. A blocking JDBC call made directly inside a reactive"
+                        + " chain (instead of offloaded to a bounded scheduler) can block request processing and"
+                        + " reduce concurrent capacity. This check cannot see inside method bodies, so it cannot"
+                        + " tell whether offloading is already done correctly — treat it as a prompt to verify,"
+                        + " not a finding.",
                 "Offload blocking database calls, for example with"
                         + " Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic()), or migrate to a"
                         + " reactive driver such as R2DBC; verify this per endpoint.",
@@ -1586,8 +1598,8 @@ final class ReactiveHandlerWithBlockingDatasourceRule extends AbstractSpringRule
         }
         return violation(context.reactiveHandlerMethodCount() + " reactive (Mono/Flux) handler method(s) found"
                 + " alongside " + context.dataSources().size() + " blocking JDBC DataSource bean(s); verify"
-                + " blocking calls are offloaded to a bounded scheduler rather than invoked directly on the"
-                + " event loop.");
+                + " blocking calls are offloaded to a bounded scheduler rather than invoked directly in the"
+                + " reactive request pipeline.");
     }
 }
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScanner.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Controller;
@@ -47,11 +48,15 @@ final class SpringScanner {
     private static final String OBJECT_MAPPER_TYPE = "com.fasterxml.jackson.databind.ObjectMapper";
     private static final String JACKSON3_OBJECT_MAPPER_TYPE = "tools.jackson.databind.ObjectMapper";
     private static final String TASK_EXECUTOR_TYPE = "org.springframework.core.task.TaskExecutor";
+    private static final String EXECUTOR_TYPE = "java.util.concurrent.Executor";
     private static final String POOLED_TASK_EXECUTOR_TYPE =
             "org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor";
     private static final String DATA_SOURCE_TYPE = "javax.sql.DataSource";
     private static final String HIKARI_DATA_SOURCE_TYPE = "com.zaxxer.hikari.HikariDataSource";
     private static final String ASYNC_CONFIGURER_TYPE = "org.springframework.scheduling.annotation.AsyncConfigurer";
+    private static final String BOOT_ASYNC_CONFIGURER_BEAN = "applicationTaskExecutorAsyncConfigurer";
+    private static final String BOOT_TASK_EXECUTOR_CONFIGURATION =
+            "org.springframework.boot.autoconfigure.task.TaskExecutorConfigurations$TaskExecutorConfiguration";
     private static final String TRANSACTION_MANAGER_TYPE = "org.springframework.transaction.PlatformTransactionManager";
     private static final String TRANSACTION_MANAGEMENT_CONFIGURER_TYPE =
             "org.springframework.transaction.annotation.TransactionManagementConfigurer";
@@ -61,6 +66,10 @@ final class SpringScanner {
     private static final String ENTITY_MANAGER_FACTORY_TYPE = "jakarta.persistence.EntityManagerFactory";
     private static final String DISPATCHER_SERVLET_TYPE = "org.springframework.web.servlet.DispatcherServlet";
     private static final String WEB_CLIENT_TYPE = "org.springframework.web.reactive.function.client.WebClient";
+    private static final String TOMCAT_SERVLET_WEB_SERVER_FACTORY_TYPE =
+            "org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory";
+    private static final String TOMCAT_REACTIVE_WEB_SERVER_FACTORY_TYPE =
+            "org.springframework.boot.tomcat.reactive.TomcatReactiveWebServerFactory";
 
     // Matched by string type name (via ClassUtils.isPresent/forName), never a direct import: reactor-core
     // is pulled in only by the optional spring-boot-starter-webflux dependency, so a servlet-only consumer
@@ -72,10 +81,10 @@ final class SpringScanner {
 
     private static final String FLUX_TYPE = "reactor.core.publisher.Flux";
     private static final String ASYNC_PROCESSOR_BEAN =
-            "org.springframework.context.annotation.internalAsyncAnnotationProcessor";
+            "org.springframework.scheduling.config.internalAsyncAnnotationProcessor";
     private static final String CACHE_ADVISOR_BEAN = "org.springframework.cache.config.internalCacheAdvisor";
     private static final String SCHEDULED_PROCESSOR_BEAN =
-            "org.springframework.context.annotation.internalScheduledAnnotationProcessor";
+            "org.springframework.scheduling.config.internalScheduledAnnotationProcessor";
     private static final String DEVTOOLS_MARKER = "org.springframework.boot.devtools.restart.Restarter";
 
     /** Hard cap on the number of default-package bean names collected, to keep the scan bounded. */
@@ -290,6 +299,8 @@ final class SpringScanner {
                 beansOfType(beanFactory, OBJECT_MAPPER_TYPE, classLoader),
                 beansOfType(beanFactory, JACKSON3_OBJECT_MAPPER_TYPE, classLoader));
         List<BeanRef> taskExecutors = beansOfType(beanFactory, TASK_EXECUTOR_TYPE, classLoader);
+        boolean bootApplicationTaskExecutorPresent = bootApplicationTaskExecutorPresent(beanFactory);
+        List<BeanRef> executors = beansOfType(beanFactory, EXECUTOR_TYPE, classLoader);
         List<BeanRef> dataSources = beansOfType(beanFactory, DATA_SOURCE_TYPE, classLoader);
         boolean pooledExecutor = !beansOfType(beanFactory, POOLED_TASK_EXECUTOR_TYPE, classLoader)
                 .isEmpty();
@@ -300,8 +311,10 @@ final class SpringScanner {
         boolean devToolsPresent = ClassUtils.isPresent(DEVTOOLS_MARKER, classLoader);
         int beanCount = beanFactory != null ? beanFactory.getBeanDefinitionCount() : 0;
 
-        boolean asyncConfigurerPresent =
-                !beansOfType(beanFactory, ASYNC_CONFIGURER_TYPE, classLoader).isEmpty();
+        List<BeanRef> asyncConfigurers = beansOfType(beanFactory, ASYNC_CONFIGURER_TYPE, classLoader);
+        // Boot wraps a custom AsyncConfigurer under its original bean name; its own fallback uses this name.
+        boolean customAsyncConfigurerPresent =
+                asyncConfigurers.stream().anyMatch(configurer -> !BOOT_ASYNC_CONFIGURER_BEAN.equals(configurer.name()));
         List<BeanRef> transactionManagers = beansOfType(beanFactory, TRANSACTION_MANAGER_TYPE, classLoader);
         boolean transactionManagementConfigurerPresent = !beansOfType(
                         beanFactory, TRANSACTION_MANAGEMENT_CONFIGURER_TYPE, classLoader)
@@ -318,6 +331,10 @@ final class SpringScanner {
                 !beansOfType(beanFactory, DISPATCHER_SERVLET_TYPE, classLoader).isEmpty();
         boolean webClientBeanPresent =
                 !beansOfType(beanFactory, WEB_CLIENT_TYPE, classLoader).isEmpty();
+        boolean tomcatWebServerPresent = !beansOfType(beanFactory, TOMCAT_SERVLET_WEB_SERVER_FACTORY_TYPE, classLoader)
+                        .isEmpty()
+                || !beansOfType(beanFactory, TOMCAT_REACTIVE_WEB_SERVER_FACTORY_TYPE, classLoader)
+                        .isEmpty();
         int reactiveHandlerMethodCount = reactiveHandlerMethodCount(beanFactory, classLoader);
         List<String> defaultPackageBeans = defaultPackageBeans(beanFactory);
         List<String> mutableSingletonFields = mutableSingletonFields(beanFactory);
@@ -327,12 +344,14 @@ final class SpringScanner {
                 .beanDefinitionCount(beanCount)
                 .objectMappers(objectMappers)
                 .taskExecutors(taskExecutors)
+                .bootApplicationTaskExecutorPresent(bootApplicationTaskExecutorPresent)
+                .executors(executors)
                 .dataSources(dataSources)
                 .pooledTaskExecutorPresent(pooledExecutor)
                 .asyncEnabled(asyncEnabled)
                 .devToolsPresent(devToolsPresent)
                 .hikariDataSourcePresent(hikariPresent)
-                .asyncConfigurerPresent(asyncConfigurerPresent)
+                .customAsyncConfigurerPresent(customAsyncConfigurerPresent)
                 .transactionManagers(transactionManagers)
                 .transactionManagementConfigurerPresent(transactionManagementConfigurerPresent)
                 .restTemplates(restTemplates)
@@ -343,6 +362,7 @@ final class SpringScanner {
                 .entityManagerFactoryPresent(entityManagerFactoryPresent)
                 .dispatcherServletPresent(dispatcherServletPresent)
                 .reactive(reactive)
+                .tomcatWebServerPresent(tomcatWebServerPresent)
                 .webClientBeanPresent(webClientBeanPresent)
                 .reactiveHandlerMethodCount(reactiveHandlerMethodCount)
                 .defaultPackageBeans(defaultPackageBeans)
@@ -583,16 +603,40 @@ final class SpringScanner {
         }
         List<BeanRef> refs = new ArrayList<>();
         for (String name : names) {
-            refs.add(new BeanRef(name, isPrimary(beanFactory, name)));
+            refs.add(beanRef(beanFactory, name));
         }
         return refs;
     }
 
-    private static boolean isPrimary(ConfigurableListableBeanFactory beanFactory, String name) {
+    private static BeanRef beanRef(ConfigurableListableBeanFactory beanFactory, String name) {
         try {
             BeanDefinition definition = beanFactory.getBeanDefinition(name);
-            return definition.isPrimary();
-        } catch (RuntimeException ex) {
+            boolean defaultCandidate = !(definition instanceof AbstractBeanDefinition abstractDefinition)
+                    || abstractDefinition.isDefaultCandidate();
+            return new BeanRef(
+                    name,
+                    definition.isPrimary(),
+                    definition.isAutowireCandidate(),
+                    definition.isFallback(),
+                    defaultCandidate);
+        } catch (RuntimeException | LinkageError ex) {
+            return new BeanRef(name, false);
+        }
+    }
+
+    private static boolean bootApplicationTaskExecutorPresent(ConfigurableListableBeanFactory beanFactory) {
+        if (beanFactory == null || !beanFactory.containsBeanDefinition("applicationTaskExecutor")) {
+            return false;
+        }
+        try {
+            BeanDefinition definition = beanFactory.getBeanDefinition("applicationTaskExecutor");
+            if (!BOOT_TASK_EXECUTOR_CONFIGURATION.equals(definition.getFactoryBeanName())) {
+                return false;
+            }
+            String methodName = definition.getFactoryMethodName();
+            return "applicationTaskExecutor".equals(methodName)
+                    || "applicationTaskExecutorVirtualThreads".equals(methodName);
+        } catch (RuntimeException | LinkageError ex) {
             return false;
         }
     }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
@@ -20,6 +20,18 @@ class SpringRulesTests {
         return SpringContext.builder(environment).beanDefinitionCount(50);
     }
 
+    private static BeanRef fallbackCandidate(String name) {
+        return new BeanRef(name, false, true, true, true);
+    }
+
+    private static BeanRef nonAutowireCandidate(String name) {
+        return new BeanRef(name, false, false, false, true);
+    }
+
+    private static BeanRef nonDefaultCandidate(String name) {
+        return new BeanRef(name, false, true, false, false);
+    }
+
     // ── SPRING-WEB-002: only flag explicit server.shutdown=immediate ──────────────
 
     @Test
@@ -91,10 +103,50 @@ class SpringRulesTests {
                 .isEqualTo("PASS");
         assertThat(rule.evaluate(context(env())
                                 .taskExecutors(two)
-                                .asyncConfigurerPresent(true)
+                                .customAsyncConfigurerPresent(true)
                                 .build())
                         .status())
                 .isEqualTo("PASS");
+    }
+
+    @Test
+    void beanAmbiguityRulesHonorFrameworkCandidateMetadata() {
+        List<BeanRef> ambiguous = List.of(new BeanRef("first", false), new BeanRef("second", false));
+        List<BeanRef> preferredAndFallback = List.of(new BeanRef("preferred", false), fallbackCandidate("fallback"));
+
+        assertThat(new AmbiguousDataSourceRule()
+                        .evaluate(context(env()).dataSources(ambiguous).build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(new DuplicateObjectMapperRule()
+                        .evaluate(context(env())
+                                .objectMappers(preferredAndFallback)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(new AmbiguousTaskExecutorRule()
+                        .evaluate(context(env())
+                                .taskExecutors(preferredAndFallback)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(new AmbiguousDataSourceRule()
+                        .evaluate(
+                                context(env()).dataSources(preferredAndFallback).build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(new AmbiguousTransactionManagerRule()
+                        .evaluate(context(env())
+                                .transactionManagers(preferredAndFallback)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(SpringModel.hasResolvedCandidateMetadata(
+                        List.of(new BeanRef("default", false), nonDefaultCandidate("restricted"))))
+                .isTrue();
+        assertThat(SpringModel.hasResolvedCandidateMetadata(
+                        List.of(new BeanRef("eligible", false), nonAutowireCandidate("internal"))))
+                .isTrue();
     }
 
     // ── SPRING-PERF-003: @Async left on the unreviewed Boot-default executor ──────
@@ -127,20 +179,40 @@ class SpringRulesTests {
         assertThat(rule.evaluate(context(env())
                                 .asyncEnabled(true)
                                 .taskExecutors(bootDefaultOnly)
+                                .bootApplicationTaskExecutorPresent(true)
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env())
+                                .asyncEnabled(true)
+                                .taskExecutors(List.of(
+                                        new BeanRef("applicationTaskExecutor", false),
+                                        new BeanRef("taskScheduler", false)))
+                                .bootApplicationTaskExecutorPresent(true)
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+
+        // Spring Framework also accepts an Executor (not necessarily a TaskExecutor) named taskExecutor.
+        assertThat(rule.evaluate(context(env())
+                                .asyncEnabled(true)
+                                .executors(List.of(new BeanRef("taskExecutor", false)))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
 
         // Reviewing the pool size (core-size or max-size) suppresses the finding.
         assertThat(rule.evaluate(context(env().withProperty("spring.task.execution.pool.core-size", "16"))
                                 .asyncEnabled(true)
                                 .taskExecutors(bootDefaultOnly)
+                                .bootApplicationTaskExecutorPresent(true)
                                 .build())
                         .status())
                 .isEqualTo("PASS");
         assertThat(rule.evaluate(context(env().withProperty("spring.task.execution.pool.max-size", "32"))
                                 .asyncEnabled(true)
                                 .taskExecutors(bootDefaultOnly)
+                                .bootApplicationTaskExecutorPresent(true)
                                 .build())
                         .status())
                 .isEqualTo("PASS");
@@ -332,6 +404,38 @@ class SpringRulesTests {
         assertThat(rule.evaluate(context(env()).build()).status()).isEqualTo("PASS");
     }
 
+    @Test
+    void lazyInitializationIsSuggestedOnlyForLargeEagerContexts() {
+        LazyInitializationDisabledRule rule = new LazyInitializationDisabledRule();
+
+        assertThat(rule.evaluate(context(env()).beanDefinitionCount(300).build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(rule.evaluate(context(env()).beanDefinitionCount(301).build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.main.lazy-initialization", "true"))
+                                .beanDefinitionCount(301)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+    }
+
+    @Test
+    void pooledExecutorIsFlaggedWhenVirtualThreadsAreEnabled() {
+        VirtualThreadsOverriddenByPoolRule rule = new VirtualThreadsOverriddenByPoolRule();
+
+        assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true"))
+                                .pooledTaskExecutorPresent(true)
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true"))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+    }
+
     // ── SPRING-PERF-005 / 006 ────────────────────────────────────────────────────
 
     @Test
@@ -355,10 +459,33 @@ class SpringRulesTests {
                 .isEqualTo("PASS");
 
         UnboundedAsyncQueueRule async = new UnboundedAsyncQueueRule();
-        assertThat(async.evaluate(context(env()).asyncEnabled(true).build()).status())
+        List<BeanRef> bootDefaultOnly = List.of(new BeanRef("applicationTaskExecutor", false));
+        assertThat(async.evaluate(context(env())
+                                .asyncEnabled(true)
+                                .taskExecutors(bootDefaultOnly)
+                                .bootApplicationTaskExecutorPresent(true)
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(async.evaluate(context(env())
+                                .asyncEnabled(true)
+                                .taskExecutors(List.of(
+                                        new BeanRef("applicationTaskExecutor", false),
+                                        new BeanRef("taskScheduler", false)))
+                                .bootApplicationTaskExecutorPresent(true)
+                                .build())
+                        .status())
                 .isEqualTo("VIOLATION");
         assertThat(async.evaluate(context(env().withProperty("spring.task.execution.pool.queue-capacity", "100"))
                                 .asyncEnabled(true)
+                                .taskExecutors(bootDefaultOnly)
+                                .bootApplicationTaskExecutorPresent(true)
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(async.evaluate(context(env())
+                                .asyncEnabled(true)
+                                .taskExecutors(List.of(new BeanRef("reportingExecutor", false)))
                                 .build())
                         .status())
                 .isEqualTo("PASS");
@@ -622,29 +749,29 @@ class SpringRulesTests {
     // ── SPRING-WEB-007 ───────────────────────────────────────────────────────────
 
     @Test
-    void tomcatThreadCapRedundantWithVirtualThreads() {
+    void tomcatThreadCapRequiresAnEmbeddedTomcatServer() {
         RedundantTomcatThreadsRule rule = new RedundantTomcatThreadsRule();
 
         assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true")
                                         .withProperty("server.tomcat.threads.max", "200"))
+                                .tomcatWebServerPresent(true)
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
         assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true"))
+                                .tomcatWebServerPresent(true)
                                 .build())
                         .status())
                 .isEqualTo("PASS");
-    }
-
-    @Test
-    void tomcatThreadCapSkippedOnReactiveApplications() {
-        RedundantTomcatThreadsRule rule = new RedundantTomcatThreadsRule();
-
-        // WebFlux has no Tomcat servlet thread pool at all, so the rule is inapplicable regardless of
-        // virtual threads / server.tomcat.threads.max.
         assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true")
                                         .withProperty("server.tomcat.threads.max", "200"))
                                 .reactive(true)
+                                .tomcatWebServerPresent(true)
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        assertThat(rule.evaluate(context(env().withProperty("spring.threads.virtual.enabled", "true")
+                                        .withProperty("server.tomcat.threads.max", "200"))
                                 .build())
                         .status())
                 .isEqualTo("SKIPPED");
@@ -730,6 +857,17 @@ class SpringRulesTests {
                                 .build())
                         .status())
                 .isEqualTo("PASS");
+        assertThat(rule.evaluate(context(env().withProperty("management.endpoints.web.exposure.include", "env")
+                                        .withProperty("management.endpoints.enabled-by-default", "false"))
+                                .build())
+                        .status())
+                .isEqualTo("PASS");
+        assertThat(rule.evaluate(context(env().withProperty("management.endpoints.web.exposure.include", "env")
+                                        .withProperty("management.endpoints.access.default", "none")
+                                        .withProperty("management.endpoint.env.enabled", "true"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
     }
 
     // ── SPRING-MGMT-003: show-values / show-details = always ─────────────────────
@@ -780,6 +918,12 @@ class SpringRulesTests {
         // Boot 4 access model.
         assertThat(rule.evaluate(context(env().withProperty("management.endpoints.web.exposure.include", "shutdown")
                                         .withProperty("management.endpoint.shutdown.access", "unrestricted"))
+                                .build())
+                        .status())
+                .isEqualTo("VIOLATION");
+        // The still-supported global legacy setting also raises shutdown's default access.
+        assertThat(rule.evaluate(context(env().withProperty("management.endpoints.web.exposure.include", "shutdown")
+                                        .withProperty("management.endpoints.enabled-by-default", "true"))
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
@@ -930,7 +1074,7 @@ class SpringRulesTests {
     }
 
     @Test
-    void virtualThreadsAvailableMentionsEventLoopOnlyWhenReactive() {
+    void virtualThreadsAvailableMentionsWebFluxOnlyWhenReactive() {
         VirtualThreadsAvailableRule rule = new VirtualThreadsAvailableRule();
 
         SpringRuleResultDto servletResult =
@@ -942,6 +1086,7 @@ class SpringRulesTests {
                 context(env()).virtualThreadsSupported(true).reactive(true).build());
         assertThat(reactiveResult.status()).isEqualTo("VIOLATION");
         assertThat(reactiveResult.sampleViolations().get(0)).contains("WebFlux");
+        assertThat(reactiveResult.sampleViolations().get(0)).doesNotContain("Reactor Netty");
     }
 
     // ── Reactive-only "learn more" links stay accurate per adapter ────────────────
@@ -1026,6 +1171,7 @@ class SpringRulesTests {
                                 .build())
                         .status())
                 .isEqualTo("VIOLATION");
+        assertThat(rule.definition().description()).doesNotContain("Reactor Netty");
     }
 
     // ── SPRING-REACTIVE-002: codec in-memory buffer limit ─────────────────────────

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScannerTests.java
@@ -12,12 +12,26 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.tomcat.reactive.TomcatReactiveWebServerFactory;
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 class SpringScannerTests {
 
     private static final int RULE_COUNT = 41;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-06T10:00:00Z"), ZoneOffset.UTC);
+    private final ApplicationContextRunner taskRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(TaskExecutionAutoConfiguration.class));
 
     @Test
     void initialReportIsNotScanned() {
@@ -105,6 +119,58 @@ class SpringScannerTests {
     }
 
     @Test
+    void scannerDetectsTomcatFactoriesAcrossWebStacks() {
+        assertTomcatFactoryTriggersThreadCapRule(TomcatServletWebServerFactory.class, false);
+        assertTomcatFactoryTriggersThreadCapRule(TomcatReactiveWebServerFactory.class, true);
+    }
+
+    @Test
+    void scannerRecognizesBootAndExceptionOnlyAsyncConfigurers() {
+        taskRunner.withUserConfiguration(AsyncEnabledConfiguration.class).run(context -> {
+            assertThat(context.getBeanFactory()
+                            .containsBeanDefinition(
+                                    "org.springframework.scheduling.config.internalAsyncAnnotationProcessor"))
+                    .isTrue();
+            assertThat(context).hasBean("applicationTaskExecutor");
+            SpringReport report =
+                    new SpringScanner(context.getBeanFactory(), context.getEnvironment(), false, CLOCK).scan();
+
+            assertThat(report.results())
+                    .extracting(SpringRuleResultDto::id)
+                    .contains("SPRING-PERF-003", "SPRING-PERF-006");
+        });
+        taskRunner
+                .withUserConfiguration(ExceptionOnlyAsyncConfigurerConfiguration.class)
+                .run(context -> {
+                    SpringReport report =
+                            new SpringScanner(context.getBeanFactory(), context.getEnvironment(), false, CLOCK).scan();
+
+                    assertThat(report.results())
+                            .extracting(SpringRuleResultDto::id)
+                            .contains("SPRING-PERF-003", "SPRING-PERF-006");
+                });
+    }
+
+    @Test
+    void scannerRecognizesSchedulingAnnotationProcessor() {
+        new ApplicationContextRunner()
+                .withUserConfiguration(SchedulingEnabledConfiguration.class)
+                .run(context -> {
+                    assertThat(
+                                    context.getBeanFactory()
+                                            .containsBeanDefinition(
+                                                    "org.springframework.scheduling.config.internalScheduledAnnotationProcessor"))
+                            .isTrue();
+                    SpringReport report =
+                            new SpringScanner(context.getBeanFactory(), context.getEnvironment(), false, CLOCK).scan();
+
+                    assertThat(report.results())
+                            .extracting(SpringRuleResultDto::id)
+                            .contains("SPRING-PERF-005");
+                });
+    }
+
+    @Test
     void applyDismissalsReturnsTheSameReportWhenNothingIsDismissed() {
         SpringScanner scanner = new SpringScanner(findingContext(), CLOCK);
         SpringReport report = scanner.scan();
@@ -166,6 +232,18 @@ class SpringScannerTests {
                 .build();
     }
 
+    private static void assertTomcatFactoryTriggersThreadCapRule(Class<?> factoryType, boolean reactive) {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerBeanDefinition("webServerFactory", new RootBeanDefinition(factoryType));
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.threads.virtual.enabled", "true")
+                .withProperty("server.tomcat.threads.max", "200");
+
+        SpringReport report = new SpringScanner(beanFactory, environment, reactive, CLOCK).scan();
+
+        assertThat(report.results()).extracting(SpringRuleResultDto::id).contains("SPRING-WEB-007");
+    }
+
     @Test
     void analysisErrorsKeepsOnlyErrorResultsSortedById() {
         SpringRuleResultDto pass = result("SPRING-T-001", SpringRuleSupport.PASS);
@@ -194,4 +272,22 @@ class SpringScannerTests {
                 "recommendation",
                 "https://example.com");
     }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableAsync
+    static class AsyncEnabledConfiguration {}
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableAsync
+    static class ExceptionOnlyAsyncConfigurerConfiguration {
+
+        @Bean
+        AsyncConfigurer exceptionOnlyAsyncConfigurer() {
+            return new AsyncConfigurer() {};
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableScheduling
+    static class SchedulingEnabledConfiguration {}
 }

--- a/docs/SPRING-CHECKS.md
+++ b/docs/SPRING-CHECKS.md
@@ -1,12 +1,12 @@
 # Spring Advisor checks
 
-The Spring panel runs a fixed, on-demand ruleset against the host application's **running Spring application context** and `Environment`. It takes a read-only snapshot of selected bean groups (Jackson `ObjectMapper`s, `TaskExecutor`s, `DataSource`s) and feature flags, then evaluates a curated set of configuration and best-practice checks. It never mutates the context, intercepts live traffic, or surfaces secrets.
+The Spring panel runs a fixed, on-demand ruleset against the host application's **running Spring application context** and `Environment`. It takes a read-only snapshot of selected bean groups (Jackson `ObjectMapper`s, `Executor`s/`TaskExecutor`s, `DataSource`s) and feature flags, then evaluates a curated set of configuration and best-practice checks. It never mutates the context, intercepts live traffic, or surfaces secrets.
 
 Because the advisor runs inside the *started* application, it focuses on "started but suboptimal" states: settings that let the app boot yet deviate from production best practices. Conditions that would prevent startup entirely are out of scope. The checks are heuristic review prompts; the right remediation still depends on the application's requirements and deployment topology.
 
 This advisor is complementary to the **Architecture** panel: Architecture statically analyzes compiled bytecode with ArchUnit, whereas the Spring Advisor inspects the live, wired runtime context.
 
-The same ruleset runs on both the servlet (Spring MVC) and reactive (Spring WebFlux) adapters; the advisor detects which one is running (the same reactive-context check the panel-availability code uses) and adjusts a handful of rules accordingly: SPRING-WEB-007 does not apply to WebFlux at all (no Tomcat thread pool exists to cap), SPRING-WEB-005 also treats a `WebClient` bean as an HTTP client needing timeouts, SPRING-PERF-001's virtual-threads guidance is worded for whichever stack is running, and four rules (SPRING-WEB-001, -003, -004, -006) link their "Learn more" reference at the reactive web docs instead of the servlet ones when running on WebFlux. Two additional rules, SPRING-REACTIVE-001 and SPRING-REACTIVE-002, only evaluate (are not `SKIPPED`) on a WebFlux application; see the [Reactive](#reactive-webflux-only) section.
+The same ruleset runs on both the servlet (Spring MVC) and reactive (Spring WebFlux) adapters; the advisor detects which one is running (the same reactive-context check the panel-availability code uses) and adjusts a handful of rules accordingly: SPRING-WEB-007 evaluates only when the active embedded server is Tomcat, whether servlet or reactive, SPRING-WEB-005 also treats a `WebClient` bean as an HTTP client needing timeouts, SPRING-PERF-001's virtual-threads guidance is worded for whichever stack is running, and four rules (SPRING-WEB-001, -003, -004, -006) link their "Learn more" reference at the reactive web docs instead of the servlet ones when running on WebFlux. Two additional rules, SPRING-REACTIVE-001 and SPRING-REACTIVE-002, only evaluate (are not `SKIPPED`) on a WebFlux application; see the [Reactive](#reactive-webflux-only) section.
 
 ## Availability and bounds
 
@@ -41,28 +41,28 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-WIRING-003 - Avoid multiple JSON mapper beans
 
 - **Severity**: LOW
-- **Detects**: Detects more than one Jackson JSON mapper bean (Jackson 2 ObjectMapper or the Jackson 3 JsonMapper that Spring Boot 4 auto-configures) with none marked @Primary, which can lead to inconsistent JSON (de)serialization depending on which one is injected.
+- **Detects**: Detects more than one Jackson JSON mapper bean (Jackson 2 ObjectMapper or the Jackson 3 JsonMapper that Spring Boot 4 auto-configures) without a `@Primary`, single non-`@Fallback`, or single default candidate. Qualifier and priority resolution remain application-specific review concerns.
 - **Recommendation**: Keep a single primary JSON mapper. With Jackson 3 (the Spring Boot 4 default) customize the auto-configured mapper via a JsonMapperBuilderCustomizer, or mark one bean @Primary.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/json.html>
 
 ### SPRING-WIRING-004 - Multiple TaskExecutor beans need a primary
 
 - **Severity**: MEDIUM
-- **Detects**: Detects more than one TaskExecutor bean without a @Primary, so @Async and other consumers may resolve an unexpected executor. A bean conventionally named applicationTaskExecutor/taskExecutor, or an AsyncConfigurer, resolves the ambiguity and suppresses this check.
+- **Detects**: Detects more than one TaskExecutor bean without a `@Primary`, single non-`@Fallback`, or single default candidate, so @Async and other consumers may resolve an unexpected executor. A bean conventionally named applicationTaskExecutor/taskExecutor, or a custom AsyncConfigurer, can resolve the ambiguity and suppresses this check.
 - **Recommendation**: Mark the intended executor @Primary, name it applicationTaskExecutor, implement AsyncConfigurer, or qualify each injection point with the executor bean name.
 - **Learn more**: <https://docs.spring.io/spring-framework/reference/integration/scheduling.html>
 
 ### SPRING-WIRING-005 - Multiple DataSource beans need a primary
 
 - **Severity**: MEDIUM
-- **Detects**: Detects more than one DataSource bean without a @Primary, which makes auto-configured consumers (JPA, JdbcTemplate) fail or pick an unexpected source.
+- **Detects**: Detects more than one DataSource bean without a `@Primary`, single non-`@Fallback`, or single default candidate, which makes auto-configured consumers (JPA, JdbcTemplate) fail or pick an unexpected source.
 - **Recommendation**: Mark the main DataSource @Primary and qualify any secondary DataSource explicitly.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html>
 
 ### SPRING-WIRING-006 - Multiple transaction managers need a primary
 
 - **Severity**: MEDIUM
-- **Detects**: Detects more than one PlatformTransactionManager bean without a @Primary, so @Transactional methods may bind to an unexpected manager. A bean named transactionManager or a TransactionManagementConfigurer resolves the default and suppresses this check.
+- **Detects**: Detects more than one PlatformTransactionManager bean without a `@Primary`, single non-`@Fallback`, or single default candidate, so @Transactional methods may bind to an unexpected manager. A bean named transactionManager or a TransactionManagementConfigurer resolves the default and suppresses this check.
 - **Recommendation**: Mark the main transaction manager @Primary, name it transactionManager, implement TransactionManagementConfigurer, or set `@Transactional("<name>")` on each usage.
 - **Learn more**: <https://docs.spring.io/spring-framework/reference/data-access/transaction.html>
 
@@ -80,7 +80,7 @@ The panel is always available (a Spring application context always exists). Bean
 - **Recommendation**: Move these classes into a named package (for example com.example.app) so component scanning is bounded to your application's packages.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/using/structuring-your-code.html>
 
-### SPRING-WIRING-009 - Avoid mutable public fields on singleton beans
+### SPRING-WIRING-009 - Avoid public mutable fields on singleton beans
 
 - **Severity**: MEDIUM
 - **Detects**: Detects a public, non-final, non-static field on a singleton-scoped application bean that is not an injection point (not annotated @Autowired, @Value, @Qualifier, @Inject, @Resource, @PersistenceContext, or @PersistenceUnit). Because the default bean scope is a shared singleton, such a field is effectively unsynchronized mutable global state: any caller can reassign it, and concurrent requests reading and writing it race without a memory barrier.
@@ -159,7 +159,7 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-PERF-001 - Consider enabling virtual threads
 
 - **Severity**: INFO
-- **Detects**: The JVM supports virtual threads (Java 21+) but spring.threads.virtual.enabled is not set. Blocking workloads - request-per-thread web handlers, and blocking @Async/@Scheduled work on either the servlet or WebFlux stack - can often scale further on virtual threads - an opportunity to evaluate, not a defect. On a WebFlux application, the finding message clarifies that the benefit applies only to blocking work still offloaded to a thread pool (@Async, @Scheduled, or `Schedulers.boundedElastic()`), since the reactive HTTP path itself already runs non-blocking on Reactor Netty's event loop.
+- **Detects**: The JVM supports virtual threads (Java 21+) but spring.threads.virtual.enabled is not set. Blocking workloads - request-per-thread web handlers, and blocking @Async/@Scheduled work on either the servlet or WebFlux stack - can often scale further on virtual threads - an opportunity to evaluate, not a defect. On a WebFlux application, the finding message clarifies that the benefit applies only to blocking work still offloaded to a thread pool (@Async, @Scheduled, or `Schedulers.boundedElastic()`), because the reactive HTTP path is already non-blocking.
 - **Recommendation**: Consider spring.threads.virtual.enabled=true after verifying that blocking code paths do not hold synchronized monitors that would pin carrier threads.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html>
 
@@ -173,7 +173,7 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-PERF-003 - @Async should use a reviewed executor
 
 - **Severity**: MEDIUM
-- **Detects**: @EnableAsync is active and virtual threads are not enabled, and either (a) no TaskExecutor bean exists at all - rare, since Spring Boot auto-configures one, but when it happens @Async falls back to the unbounded SimpleAsyncTaskExecutor (a new platform thread per task) - or (b) the only TaskExecutor is Spring Boot's auto-configured `applicationTaskExecutor` left at its default settings (a bounded ThreadPoolTaskExecutor with a core pool size of 8 and an effectively unbounded queue) with neither spring.task.execution.pool.core-size nor .max-size customized, so a generic default - not a size chosen for this application's @Async workload - backs every @Async method unreviewed.
+- **Detects**: @EnableAsync is active and virtual threads are not enabled. The rule then detects either (a) no TaskExecutor and no Executor named `taskExecutor` - rare, since Spring Boot auto-configures one, but when it happens @Async falls back to the unbounded SimpleAsyncTaskExecutor (a new platform thread per task) - or (b) Spring Boot's auto-configured `applicationTaskExecutor` is left at its default settings (a bounded ThreadPoolTaskExecutor with a core pool size of 8 and an effectively unbounded queue) with neither spring.task.execution.pool.core-size nor .max-size customized, so a generic default - not a size chosen for this application's @Async workload - backs every @Async method unreviewed. If a custom AsyncConfigurer supplies another executor, verify that executor's settings directly before dismissing the prompt.
 - **Recommendation**: Define a dedicated executor sized for the workload, or explicitly review and set spring.task.execution.pool.core-size / max-size instead of relying on the unreviewed default, or enable spring.threads.virtual.enabled so @Async work is not pooled at all.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html>
 
@@ -194,7 +194,7 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-PERF-006 - Bound the @Async executor queue
 
 - **Severity**: LOW
-- **Detects**: @EnableAsync is active and spring.task.execution.pool.queue-capacity is not set, so the auto-configured task executor uses an effectively unbounded queue that can hide a backlog and grow heap usage under load.
+- **Detects**: @EnableAsync uses Spring Boot's auto-configured `applicationTaskExecutor` and spring.task.execution.pool.queue-capacity is not set, so that executor uses an effectively unbounded queue that can hide a backlog and grow heap usage under load. If a custom AsyncConfigurer supplies another executor, verify that executor's queue before dismissing the prompt.
 - **Recommendation**: Set spring.task.execution.pool.queue-capacity (and a matching max pool size) to a bounded value, or enable virtual threads so async work is not pooled.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/features/task-execution-and-scheduling.html>
 
@@ -252,8 +252,8 @@ The panel is always available (a Spring application context always exists). Bean
 ### SPRING-WEB-007 - Tomcat thread cap is redundant with virtual threads
 
 - **Severity**: LOW
-- **Detects**: Virtual threads are enabled but server.tomcat.threads.max is set explicitly. With virtual threads handling requests, a small platform-thread cap can needlessly limit concurrency, while a large one has little effect. On a WebFlux application this rule is always `SKIPPED`: WebFlux runs on Reactor Netty's event-loop group, not a Tomcat servlet thread pool, so server.tomcat.threads.max has no effect there at all.
-- **Recommendation**: Remove server.tomcat.threads.max when running on virtual threads, or confirm the cap is a deliberate back-pressure limit.
+- **Detects**: The active embedded server is Tomcat, virtual threads are enabled, and server.tomcat.threads.max is set explicitly. Spring Boot replaces Tomcat's protocol-handler executor with a virtual-thread executor, making the thread cap ineffective on either servlet or reactive Tomcat. The rule is `SKIPPED` for a non-Tomcat server such as Reactor Netty or Jetty.
+- **Recommendation**: Remove server.tomcat.threads.max when running on virtual threads because it no longer controls Tomcat request concurrency.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/web/servlet.html>
 
 ## Data and persistence
@@ -265,7 +265,7 @@ The panel is always available (a Spring application context always exists). Bean
 - **Recommendation**: Set spring.jpa.open-in-view=false and load the associations each request needs explicitly (fetch joins, entity graphs, or DTO projections).
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.jpa-and-spring-data.open-entity-manager-in-view>
 
-### SPRING-DATA-001 - Do not run production on an in-memory database
+### SPRING-DATA-001 - Avoid an in-memory database in production
 
 - **Severity**: MEDIUM
 - **Detects**: A production-like profile is active while spring.datasource.url points at an in-process, in-memory database (an H2 jdbc:h2:mem: or HSQLDB jdbc:hsqldb:mem: URL, or a Derby jdbc:derby:memory: URL). These engines keep their data only in the JVM heap of a single instance: a restart, redeploy, or crash silently discards everything, and the data is invisible to any other instance in a multi-instance deployment. A file-backed embedded URL (for example jdbc:h2:file:) is not flagged.
@@ -280,6 +280,8 @@ The panel is always available (a Spring application context always exists). Bean
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.r2dbc.embedded>
 
 ## Actuator and management
+
+The access-aware rules resolve Spring Boot 4 endpoint-specific and global `access` settings, their `max-permitted` cap, and the still-supported deprecated `enabled` settings in the same precedence order as Boot.
 
 ### SPRING-MGMT-001 - Avoid exposing all Actuator endpoints
 
@@ -316,7 +318,7 @@ Both rules in this category are `SKIPPED` unconditionally on a servlet (Spring M
 ### SPRING-REACTIVE-001 - Reactive endpoints alongside a blocking JDBC datasource
 
 - **Severity**: INFO
-- **Detects**: This is a WebFlux application with Mono/Flux-returning handler methods, and a blocking JDBC DataSource is also configured. WebFlux runs on a small, fixed Reactor Netty event-loop group; a blocking JDBC call made directly inside a reactive chain (instead of offloaded to a bounded scheduler) stalls that event loop and can starve every other in-flight request. Modeled after the Quarkus advisor's QA-RX-001, but deliberately coarser: this reflection-only scanner cannot see inside a handler method's body, so it cannot tell whether offloading is already done correctly. It is an app-level prompt to verify, not a per-endpoint finding.
+- **Detects**: This is a WebFlux application with Mono/Flux-returning handler methods, and a blocking JDBC DataSource is also configured. A blocking JDBC call made directly inside a reactive chain (instead of offloaded to a bounded scheduler) can block request processing and reduce concurrent capacity. Modeled after the Quarkus advisor's QA-RX-001, but deliberately coarser: this reflection-only scanner cannot see inside a handler method's body, so it cannot tell whether offloading is already done correctly. It is an app-level prompt to verify, not a per-endpoint finding.
 - **Recommendation**: Offload blocking database calls, for example with `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())`, or migrate to a reactive driver such as R2DBC; verify this per endpoint.
 - **Learn more**: <https://docs.spring.io/spring-framework/reference/web/webflux/reactive-spring.html>
 

--- a/docs/WEBFLUX-SUPPORT.md
+++ b/docs/WEBFLUX-SUPPORT.md
@@ -129,8 +129,8 @@ accidentally inherit the Reactor Netty event loop.
 
 [^spring-advisor-reactive]: The `SpringController` wiring itself needed no adapter change, but the ruleset it runs
     (`SpringScanner`/`SpringRules`) is reactive-aware internally: it detects a WebFlux `ReactiveWebApplicationContext`
-    the same way `PanelsController.isReactive()` does, skips a servlet-only rule that does not apply
-    (`SPRING-WEB-007`, Tomcat thread cap), also matches `WebClient` beans for the HTTP-client-timeout rule
+    the same way `PanelsController.isReactive()` does, checks the active embedded server before evaluating
+    `SPRING-WEB-007` (the Tomcat thread cap, including reactive Tomcat), also matches `WebClient` beans for the HTTP-client-timeout rule
     (`SPRING-WEB-005`), points four rules' "Learn more" links at the reactive docs page instead of the servlet one,
     and adds two WebFlux-only rules (`SPRING-REACTIVE-001`, `SPRING-REACTIVE-002`) that are otherwise `SKIPPED`. See
     `docs/SPRING-CHECKS.md`.


### PR DESCRIPTION
## Summary

- Align Spring Framework 7 annotation-processor discovery, candidate metadata, and Boot-managed async executor detection.
- Correct Boot 4.1 Actuator access precedence and only evaluate the Tomcat virtual-thread rule when embedded Tomcat is actually active, including reactive Tomcat.
- Keep MVC/WebFlux guidance stack-neutral where WebFlux can run on non-Netty servers, with focused rule and real-context regression coverage.
- Synchronize the Spring and WebFlux support documentation with the revised advisor behavior.

## Evidence

The changes are grounded in Spring Boot 4.1.0 and Spring Framework 7 source for task execution, endpoint access, Tomcat virtual-thread customization, and candidate selection.

## Validation

- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:check`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-spring-autoconfigure -am -Dtest=SpringRulesTests,SpringScannerTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -T 1C -B -ntp -Dmaven.repo.local=.m2 -Pcoverage clean install`

## Advisor audit protocol

- Independent reviewers: Claude Opus 5 (max, long context), GPT-5.6 Terra (max, long context), and Gemini 3.1 Pro (high, long context), all against the same frozen `main` snapshot.
- Evidence process: official Spring Boot 4.1 / Spring Framework 7 documentation and source plus comparable open-source guidance were researched before rule evaluation.
- Decision process: existing rules were classified as KEEP, MODIFY, REMOVE, or SPLIT; only source-backed, deterministic MVC/WebFlux behavior was accepted and speculative candidates were deferred.
- Delivery policy: focused and full validation plus hosted CI are required; known limitations remain documented and auto-merge is disabled.