### PR TITLE
Fix Hibernate advisor evidence and Quarkus mappings

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateContext.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateContext.java
@@ -142,17 +142,8 @@ record HibernateContext(
         return hibernateVersion.display();
     }
 
-    boolean isHibernateEnhancementEnabled() {
-        return isPropertyTrue(
-                        "spring.jpa.properties.hibernate.enhancer.enableLazyInitialization",
-                        "hibernate.enhancer.enableLazyInitialization")
-                || isPropertyTrue(
-                        "spring.jpa.properties.hibernate.bytecode.enhancer.enableLazyInitialization",
-                        "hibernate.bytecode.enhancer.enableLazyInitialization");
-    }
-
     boolean isHibernateEnhancementEnabled(HibernateEntityModel entity) {
-        return isHibernateEnhancementEnabled() || entity.isBytecodeEnhanced();
+        return isPropertyTrue(HibernateScanner.BYTECODE_ENHANCEMENT_VERIFIED_PROPERTY) || entity.isBytecodeEnhanced();
     }
 
     boolean isOpenInViewApplicable() {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
@@ -39,7 +39,6 @@ final class HibernateRuleRegistry {
             new BigDecimalPrecisionRule(),
             new LegacyDateTimeRule(),
             new ManyToOneOptionalRule(),
-            new LazyOneToOneEnhancementRule(),
             new NonOwningOneToOneEnhancementRule(),
             new MissingForeignKeyIndexRule(),
             new LegacyWhereAnnotationRule(),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
@@ -3,6 +3,8 @@ package io.github.jdubois.bootui.engine.hibernate;
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -441,8 +443,8 @@ final class ManyToManyListRule extends AbstractHibernateRule {
                         "Many-to-many associations should use Set semantics",
                         HibernateCategory.MAPPING,
                         "MEDIUM",
-                        "Detects @ManyToMany associations declared as List, which can trigger delete-and-reinsert DML.",
-                        "Use Set for many-to-many associations, or model the join table as an entity when it has business meaning.",
+                        "Detects @ManyToMany associations declared as List. Their link-table lifecycle remains less efficient than a bidirectional one-to-many, even when @OrderColumn persists the list order.",
+                        "Use Set when ordering is not domain-significant. When order or link attributes matter, model the join table as an entity instead.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#associations-many-to-many"));
     }
 
@@ -452,7 +454,13 @@ final class ManyToManyListRule extends AbstractHibernateRule {
         for (HibernateEntityModel entity : context.entities()) {
             for (HibernateAttributeModel attribute : entity.attributes()) {
                 if (attribute.isManyToMany() && attribute.isListAttribute()) {
-                    details.add(attribute.description() + " is @ManyToMany and declared as a List.");
+                    String ordering = attribute.hasOrderColumn()
+                            ? " with @OrderColumn; preserve the order only when it is domain-significant."
+                            : " without @OrderColumn.";
+                    details.add(attribute.description()
+                            + " is @ManyToMany and declared as a List"
+                            + ordering
+                            + " Consider a link entity when link lifecycle or attributes matter.");
                 }
             }
         }
@@ -1123,8 +1131,8 @@ final class QueryCacheRegionFactoryRule extends AbstractHibernateRule {
                         "Query cache requires a second-level cache provider",
                         HibernateCategory.CONFIGURATION,
                         "HIGH",
-                        "Detects hibernate.cache.use_query_cache=true without a second-level cache provider.",
-                        "Disable query caching or configure a second-level cache region factory and cache the entities returned by cacheable entity queries.",
+                        "Detects hibernate.cache.use_query_cache=true without an effective second-level cache provider.",
+                        "Disable query caching or configure an effective second-level cache region factory and cache the entities returned by cacheable entity queries.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#caching-query"));
     }
 
@@ -1140,7 +1148,7 @@ final class QueryCacheRegionFactoryRule extends AbstractHibernateRule {
                 "spring.jpa.properties.hibernate.cache.use_second_level_cache",
                 "hibernate.cache.use_second_level_cache");
         if (regionFactory == null || secondLevelCacheDisabled) {
-            return violation(List.of("Query cache is enabled without a configured second-level cache region factory."));
+            return violation(List.of("Query cache is enabled without an effective second-level cache region factory."));
         }
         return pass();
     }
@@ -1155,8 +1163,8 @@ final class CacheableWithoutCacheStrategyRule extends AbstractHibernateRule {
                         "Cacheable entities should declare an explicit cache strategy",
                         HibernateCategory.CONFIGURATION,
                         "MEDIUM",
-                        "Detects JPA @Cacheable entities without Hibernate @Cache when second-level caching appears configured.",
-                        "Add an explicit Hibernate cache concurrency strategy or remove @Cacheable if the entity should not use the second-level cache.",
+                        "Detects JPA @Cacheable entities without Hibernate @Cache or hibernate.cache.default_cache_concurrency_strategy when second-level caching appears configured.",
+                        "Add an explicit Hibernate cache concurrency strategy, configure a valid default cache concurrency strategy, or remove @Cacheable if the entity should not use the second-level cache.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#caching"));
     }
 
@@ -1170,13 +1178,27 @@ final class CacheableWithoutCacheStrategyRule extends AbstractHibernateRule {
                         "hibernate.cache.use_second_level_cache")) {
             return skipped("Second-level caching is not configured.");
         }
+        boolean hasDefaultCacheStrategy = hasDefaultCacheStrategy(context);
         List<String> details = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
-            if (entity.isJpaCacheable() && !entity.hasHibernateCacheAnnotation()) {
+            if (entity.isJpaCacheable() && !entity.hasHibernateCacheAnnotation() && !hasDefaultCacheStrategy) {
                 details.add(entity.name() + " uses @Cacheable without an explicit Hibernate @Cache strategy.");
             }
         }
         return violation(details);
+    }
+
+    private boolean hasDefaultCacheStrategy(HibernateContext context) {
+        String value = context.firstProperty(
+                "spring.jpa.properties.hibernate.cache.default_cache_concurrency_strategy",
+                "hibernate.cache.default_cache_concurrency_strategy");
+        if (value == null) {
+            return false;
+        }
+        return switch (value.trim().toUpperCase(Locale.ROOT).replace('-', '_')) {
+            case "READ_ONLY", "NONSTRICT_READ_WRITE", "READ_WRITE", "TRANSACTIONAL" -> true;
+            default -> false;
+        };
     }
 }
 
@@ -1527,9 +1549,9 @@ final class FinalEntityRule extends AbstractHibernateRule {
                 "HIB-MAP-011",
                 "Entity classes should not be final",
                 HibernateCategory.MAPPING,
-                "HIGH",
-                "Detects @Entity classes declared as final, which prevents Hibernate from creating runtime proxies for lazy associations.",
-                "Remove the final modifier from entities (and avoid Kotlin classes without `open`) so lazy to-one associations and bytecode enhancement work correctly.",
+                "INFO",
+                "Detects final entity classes that are not proven bytecode-enhanced. Final entities are not Jakarta-portable and cannot use subclass proxies for lazy to-one associations.",
+                "Prefer non-final entities (and `open` Kotlin entities) when lazy subclass proxies are needed. Bytecode-enhanced entities are exempt.",
                 "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#entity"));
     }
 
@@ -1537,8 +1559,10 @@ final class FinalEntityRule extends AbstractHibernateRule {
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
         List<String> details = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
-            if (entity.isFinalClass()) {
-                details.add(entity.name() + " is declared final.");
+            if (entity.isFinalClass() && !context.isHibernateEnhancementEnabled(entity)) {
+                details.add(
+                        entity.name()
+                                + " is declared final and is not proven bytecode-enhanced, so Hibernate cannot create subclass proxies for lazy to-one associations.");
             }
         }
         return violation(details);
@@ -1709,51 +1733,6 @@ final class ManyToOneOptionalRule extends AbstractHibernateRule {
     }
 }
 
-final class LazyOneToOneEnhancementRule extends AbstractHibernateRule {
-
-    LazyOneToOneEnhancementRule() {
-        super(
-                new HibernateRuleDefinition(
-                        "HIB-MAP-017",
-                        "Lazy owning @OneToOne requires bytecode enhancement",
-                        HibernateCategory.MAPPING,
-                        "INFO",
-                        "Detects optional owning @OneToOne associations declared LAZY without Hibernate bytecode enhancement enabled, so Hibernate silently fetches them eagerly.",
-                        "Enable hibernate.bytecode.enhancer.enableLazyInitialization (and configure the enhancement plugin), or switch the relation to @MapsId so the existing foreign key drives loading.",
-                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#BytecodeEnhancement-lazy-loading"));
-    }
-
-    @Override
-    HibernateRuleResultDto evaluateRule(HibernateContext context) {
-        if (context.isHibernateEnhancementEnabled()) {
-            return pass();
-        }
-        List<String> details = new ArrayList<>();
-        for (HibernateEntityModel entity : context.entities()) {
-            for (HibernateAttributeModel attribute : entity.attributes()) {
-                Annotation oneToOne = attribute.oneToOneAnnotation();
-                if (oneToOne == null) {
-                    continue;
-                }
-                String mappedBy = attribute.annotationStringValue(oneToOne, "mappedBy");
-                if (mappedBy != null && !mappedBy.isBlank()) {
-                    continue;
-                }
-                if (attribute.hasMapsId()) {
-                    continue;
-                }
-                String fetch = attribute.annotationValueName(oneToOne, "fetch");
-                Boolean optional = attribute.annotationBooleanValue(oneToOne, "optional");
-                if ("LAZY".equals(fetch) && !Boolean.FALSE.equals(optional)) {
-                    details.add(attribute.description()
-                            + " is a lazy owning @OneToOne but bytecode enhancement is disabled.");
-                }
-            }
-        }
-        return violation(details);
-    }
-}
-
 final class EqualsHashCodeAssociationsRule extends AbstractHibernateRule {
 
     EqualsHashCodeAssociationsRule() {
@@ -1855,11 +1834,11 @@ final class ModifyingClearAutomaticallyRule extends AbstractHibernateRule {
     ModifyingClearAutomaticallyRule() {
         super(new HibernateRuleDefinition(
                 "HIB-QUERY-001",
-                "@Modifying queries should clear or flush the persistence context",
+                "@Modifying bulk queries should clear stale persistence context",
                 HibernateCategory.QUERY,
-                "HIGH",
-                "Detects Spring Data @Modifying queries that do not set clearAutomatically or flushAutomatically, so the persistence context can hold stale entities after the bulk update or delete.",
-                "Set @Modifying(clearAutomatically=true) (and flushAutomatically=true when pending changes must be applied first), or evict affected entities before issuing the bulk statement.",
+                "INFO",
+                "Detects Spring Data @Modifying queries that do not set clearAutomatically, so the persistence context can hold stale entities after the bulk update or delete. flushAutomatically synchronizes pending changes before the query but does not clear those stale entities afterward.",
+                "Set @Modifying(clearAutomatically=true), or explicitly evict affected entities after the bulk statement. Set flushAutomatically=true as well when pending changes must be applied first.",
                 "https://docs.spring.io/spring-data/jpa/reference/jpa/query-methods.html#jpa.modifying-queries"));
     }
 
@@ -1874,8 +1853,11 @@ final class ModifyingClearAutomaticallyRule extends AbstractHibernateRule {
                 if (!method.modifying()) {
                     continue;
                 }
-                if (!method.modifyingClearsAutomatically() && !method.modifyingFlushesAutomatically()) {
-                    details.add(method.description() + " is @Modifying without clearAutomatically/flushAutomatically.");
+                if (!method.modifyingClearsAutomatically()) {
+                    String flushDetail = method.modifyingFlushesAutomatically()
+                            ? " flushAutomatically=true does not clear stale managed entities."
+                            : "";
+                    details.add(method.description() + " is @Modifying without clearAutomatically." + flushDetail);
                 }
             }
         }
@@ -1919,11 +1901,11 @@ final class NativePagedQueryCountRule extends AbstractHibernateRule {
     NativePagedQueryCountRule() {
         super(new HibernateRuleDefinition(
                 "HIB-QUERY-003",
-                "Native paged @Query must declare countQuery",
+                "Native Page queries should review count derivation",
                 HibernateCategory.QUERY,
-                "HIGH",
-                "Detects native @Query methods with a Pageable parameter or Page<> return type that do not declare countQuery, leaving Spring Data unable to derive a correct COUNT statement.",
-                "Add countQuery=... to the @Query so paging can compute totals; without it Spring Data either fails to start or executes a wrong COUNT.",
+                "INFO",
+                "Detects native @Query methods returning Page without an explicit countQuery. Spring Data can derive counts for some simple native SQL, but complex queries may require an explicit count query or JSqlParser.",
+                "Review the generated count query. Add countQuery=... when Spring Data cannot derive a correct count, especially for complex native SQL.",
                 "https://docs.spring.io/spring-data/jpa/reference/jpa/query-methods.html#jpa.query-methods.at-query"));
     }
 
@@ -1938,7 +1920,7 @@ final class NativePagedQueryCountRule extends AbstractHibernateRule {
                 if (!method.nativeQuery() || !method.hasQuery()) {
                     continue;
                 }
-                if (!method.hasPageableParameter() && !method.returnsPage()) {
+                if (!method.returnsPage()) {
                     continue;
                 }
                 if (!method.hasCountQuery()) {
@@ -2062,11 +2044,11 @@ final class DeferDatasourceInitializationRule extends AbstractHibernateRule {
     DeferDatasourceInitializationRule() {
         super(new HibernateRuleDefinition(
                 "HIB-CONFIG-015",
-                "spring.jpa.defer-datasource-initialization is only safe with embedded DDL flows",
+                "Deferred script initialization should have an intentional order",
                 HibernateCategory.CONFIGURATION,
-                "MEDIUM",
-                "Detects spring.jpa.defer-datasource-initialization=true while ddl-auto is none/validate; the setting is meaningful only when Hibernate generates the schema (create/create-drop/update).",
-                "Combine defer-datasource-initialization=true with ddl-auto=create or create-drop, or remove it when relying on Flyway/Liquibase so data.sql is loaded by the migration tool instead.",
+                "INFO",
+                "Detects spring.jpa.defer-datasource-initialization=true, which moves script-based datasource initialization until after JPA initialization.",
+                "Verify that script-based initialization has the intended owner and order. This setting is valid with schema validation or externally managed schemas when scripts intentionally seed an existing schema.",
                 "https://docs.spring.io/spring-boot/reference/data/sql.html#data.sql.datasource.initialization"));
     }
 
@@ -2079,18 +2061,11 @@ final class DeferDatasourceInitializationRule extends AbstractHibernateRule {
                 "spring.jpa.hibernate.ddl-auto",
                 "spring.jpa.properties.hibernate.hbm2ddl.auto",
                 "hibernate.hbm2ddl.auto");
-        if (ddlAuto == null) {
-            return skipped(
-                    "ddl-auto is not set; for an embedded database Spring Boot defaults to create-drop, which makes defer-datasource-initialization meaningful, so this cannot be flagged without knowing the datasource.");
-        }
-        String normalized = ddlAuto.toLowerCase(Locale.ROOT);
-        if (normalized.equals("create") || normalized.equals("create-drop") || normalized.equals("update")) {
-            return pass();
-        }
-        return violation(
-                List.of(
-                        "spring.jpa.defer-datasource-initialization=true while ddl-auto=" + ddlAuto
-                                + "; Hibernate does not generate the schema, so the property has no effect and data.sql must be loaded by your migration tool."));
+        String detail = "spring.jpa.defer-datasource-initialization=true defers script-based datasource initialization"
+                + " until after JPA initialization"
+                + (ddlAuto == null ? "." : " (ddl-auto=" + ddlAuto + ").")
+                + " Verify that this ordering is intentional.";
+        return violation(HibernateRuleSupport.INFO, detail);
     }
 }
 
@@ -2100,11 +2075,11 @@ final class CacheAssociationCoverageRule extends AbstractHibernateRule {
         super(
                 new HibernateRuleDefinition(
                         "HIB-CACHE-001",
-                        "Cached entities should also cache their associations",
+                        "Cached entity association coverage should be reviewed",
                         HibernateCategory.CACHING,
-                        "MEDIUM",
-                        "Detects entities annotated with @Cacheable or Hibernate @Cache whose associations do not declare @Cache themselves; loading a cached aggregate then re-hits the database for every uncached association.",
-                        "Annotate the associated entities (or the association attributes) with @org.hibernate.annotations.Cache so the second-level cache covers the whole graph; otherwise the cache yields little benefit.",
+                        "INFO",
+                        "Detects cached entities whose associations target uncached entities. Association coverage is a workload-specific second-level-cache optimization, not a correctness requirement.",
+                        "Measure cache hit rates and access patterns before caching associated entities or collection roles. Leave mutable or low-hit targets uncached when that better fits the workload.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#caching-entity"));
     }
 
@@ -2252,8 +2227,8 @@ final class FormatSqlInProductionRule extends AbstractHibernateRule {
                         "Disable SQL formatting in production",
                         HibernateCategory.CONFIGURATION,
                         "LOW",
-                        "Detects hibernate.format_sql=true while a production profile is active.",
-                        "Disable hibernate.format_sql in production profiles to save CPU and memory, as formatting occurs even when SQL logging is off.",
+                        "Detects hibernate.format_sql=true while SQL logging is enabled in a production profile.",
+                        "Disable hibernate.format_sql when verbose SQL logging is enabled in production to avoid formatting every logged statement.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#configurations-logging"));
     }
 
@@ -2262,8 +2237,10 @@ final class FormatSqlInProductionRule extends AbstractHibernateRule {
         if (!context.isProductionProfileActive()) {
             return pass();
         }
-        if (context.isPropertyTrue("spring.jpa.properties.hibernate.format_sql", "hibernate.format_sql")) {
-            return violation(List.of("hibernate.format_sql is enabled while a production profile is active."));
+        if (context.isPropertyTrue("spring.jpa.properties.hibernate.format_sql", "hibernate.format_sql")
+                && context.isSqlLoggingEnabled()) {
+            return violation(
+                    List.of("hibernate.format_sql and SQL logging are enabled while a production profile is active."));
         }
         return pass();
     }
@@ -2311,11 +2288,11 @@ final class NonOwningOneToOneEnhancementRule extends AbstractHibernateRule {
 
     @Override
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
-        if (context.isHibernateEnhancementEnabled()) {
-            return pass();
-        }
         List<String> details = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
+            if (context.isHibernateEnhancementEnabled(entity)) {
+                continue;
+            }
             for (HibernateAttributeModel attribute : entity.attributes()) {
                 java.lang.annotation.Annotation oneToOne = attribute.oneToOneAnnotation();
                 if (oneToOne == null) {
@@ -2389,6 +2366,9 @@ final class MissingForeignKeyIndexRule extends AbstractHibernateRule {
     }
 
     private boolean isOwningToOne(HibernateAttributeModel attribute) {
+        if (attribute.hasMapsId()) {
+            return false;
+        }
         if (attribute.manyToOneAnnotation() != null) {
             return true;
         }
@@ -2562,7 +2542,7 @@ final class AssignedIdPersistableRule extends AbstractHibernateRule {
                         "Assigned IDs should implement Persistable",
                         HibernateCategory.ENTITY_DESIGN,
                         "MEDIUM",
-                        "Detects entities with assigned identifiers and no @Version that do not implement org.springframework.data.domain.Persistable.",
+                        "Detects Spring Data repository domain entities with assigned identifiers and no @Version that do not implement org.springframework.data.domain.Persistable.",
                         "Implement Persistable<ID> and manage the isNew() flag manually so Spring Data avoids a SELECT before every insert.",
                         "https://docs.spring.io/spring-data/jpa/reference/jpa/entity-persistence.html#jpa.entity-persistence.saving-entities.strategies"));
     }
@@ -2572,12 +2552,19 @@ final class AssignedIdPersistableRule extends AbstractHibernateRule {
         // The concern is specific to Spring Data JPA's generic save(): it inspects the id/version to guess whether
         // an entity is new. Quarkus/Panache calls entityManager.persist() directly and has no such ambiguity, so
         // without Spring Data Commons on the classpath there is nothing to recommend implementing Persistable for.
-        if (!HibernateRuleModelSupport.isSpringDataPersistableAvailable()) {
+        if (!HibernateRuleModelSupport.isSpringDataPersistableAvailable()
+                || context.repositories().isEmpty()) {
             return skipped(
-                    "Spring Data Commons was not detected; this check only applies to Spring Data JPA repositories.");
+                    "No Spring Data repository metadata was detected; this check only applies to Spring Data JPA repository domain types.");
         }
+        Set<Class<?>> repositoryDomainTypes = context.repositories().stream()
+                .map(HibernateRepositoryModel::domainType)
+                .collect(java.util.stream.Collectors.toSet());
         List<String> details = new ArrayList<>();
         for (HibernateEntityModel entity : context.entities()) {
+            if (entity.javaType() == null || !repositoryDomainTypes.contains(entity.javaType())) {
+                continue;
+            }
             boolean hasGeneratedId = entity.attributes().stream().anyMatch(a -> a.generatedValueAnnotation() != null);
             boolean hasVersion = entity.hasVersionAttribute();
             if (hasGeneratedId || hasVersion) {
@@ -2917,8 +2904,8 @@ final class CompositeIdentifierContractRule extends AbstractHibernateRule {
                         "Composite identifier classes must satisfy the JPA contract",
                         HibernateCategory.IDENTIFIERS,
                         "HIGH",
-                        "Detects @EmbeddedId / @IdClass primary-key classes that are not Serializable, lack a public no-arg constructor, or do not override both equals and hashCode. JPA and Hibernate require all four for a composite identifier class to work correctly.",
-                        "Make the composite identifier class implement Serializable, declare a public no-arg constructor, and override both equals and hashCode over every identifier field; violating any of these can silently break entity equality, second-level caching, and collection lookups.",
+                        "Detects @EmbeddedId / @IdClass primary-key classes that are not Serializable, lack a public or protected no-arg constructor (unless declared as a record), or do not override both equals and hashCode.",
+                        "Make a non-record composite identifier class implement Serializable, declare a public or protected no-arg constructor, and override both equals and hashCode over every identifier field.",
                         "https://docs.hibernate.org/orm/current/userguide/html_single/Hibernate_User_Guide.html#identifiers-composite"));
     }
 
@@ -2950,8 +2937,8 @@ final class CompositeIdentifierContractRule extends AbstractHibernateRule {
         if (!Serializable.class.isAssignableFrom(idClass)) {
             problems.add("not Serializable");
         }
-        if (!hasPublicNoArgConstructor(idClass)) {
-            problems.add("no public no-arg ctor");
+        if (!idClass.isRecord() && !hasPublicOrProtectedNoArgConstructor(idClass)) {
+            problems.add("no public/protected no-arg ctor");
         }
         if (!overrides(idClass, "equals", Object.class)) {
             problems.add("no equals() override");
@@ -2967,12 +2954,11 @@ final class CompositeIdentifierContractRule extends AbstractHibernateRule {
         }
     }
 
-    private static boolean hasPublicNoArgConstructor(Class<?> type) {
+    private static boolean hasPublicOrProtectedNoArgConstructor(Class<?> type) {
         try {
-            // getConstructor() (as opposed to getDeclaredConstructor()) only ever returns public constructors,
-            // so success alone already proves the "public no-arg constructor" requirement.
-            type.getConstructor();
-            return true;
+            Constructor<?> constructor = type.getDeclaredConstructor();
+            int modifiers = constructor.getModifiers();
+            return Modifier.isPublic(modifiers) || Modifier.isProtected(modifiers);
         } catch (NoSuchMethodException ex) {
             return false;
         }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateScanner.java
@@ -24,6 +24,8 @@ import java.util.function.Supplier;
 public final class HibernateScanner {
 
     public static final String OPEN_IN_VIEW_APPLICABLE_PROPERTY = "bootui.internal.hibernate.open-in-view-applicable";
+    public static final String BYTECODE_ENHANCEMENT_VERIFIED_PROPERTY =
+            "bootui.internal.hibernate.bytecode-enhancement-verified";
 
     private static final String ANALYZER = "BootUI Hibernate Advisor";
     private static final String DISCLAIMER =

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
 import jakarta.persistence.Basic;
+import jakarta.persistence.Cacheable;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -20,6 +21,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.OrderBy;
@@ -40,6 +42,7 @@ import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Where;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Persistable;
 
 class HibernateRulesTests {
@@ -82,6 +85,30 @@ class HibernateRulesTests {
                 false,
                 false,
                 parameterTypes);
+    }
+
+    private static HibernateRepositoryMethodModel repositoryMethod(
+            String name,
+            Class<?> returnType,
+            String query,
+            boolean nativeQuery,
+            boolean hasPageableParameter,
+            boolean modifying,
+            boolean clearAutomatically,
+            boolean flushAutomatically) {
+        return new HibernateRepositoryMethodModel(
+                "com.example.Repo",
+                name,
+                Object.class,
+                returnType,
+                query,
+                nativeQuery,
+                null,
+                hasPageableParameter,
+                modifying,
+                clearAutomatically,
+                flushAutomatically,
+                List.of());
     }
 
     // --- HIB-ID-006 ---------------------------------------------------------
@@ -336,13 +363,13 @@ class HibernateRulesTests {
     }
 
     @Test
-    void lobLazyFetchRuleRecommendsLazyWhenEnhancementIsEnabled() {
+    void lobLazyFetchRuleDoesNotTrustAnUnverifiedEnhancementSetting() {
         TestEnvironment environment =
                 new TestEnvironment().withProperty("hibernate.enhancer.enableLazyInitialization", "true");
 
         HibernateRuleResultDto result = new LobLazyFetchRule().evaluate(context(environment, EagerLobEntity.class));
 
-        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
     @Test
@@ -356,9 +383,30 @@ class HibernateRulesTests {
     }
 
     @Test
-    void lazyBasicRulePassesWhenEnhancementIsEnabled() {
+    void lobLazyFetchRuleRecommendsLazyWhenAnAdapterVerifiesEnhancement() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty(HibernateScanner.BYTECODE_ENHANCEMENT_VERIFIED_PROPERTY, "true");
+
+        HibernateRuleResultDto result = new LobLazyFetchRule().evaluate(context(environment, EagerLobEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void lazyBasicRuleDoesNotTrustAnUnverifiedEnhancementSetting() {
         TestEnvironment environment =
                 new TestEnvironment().withProperty("hibernate.enhancer.enableLazyInitialization", "true");
+
+        HibernateRuleResultDto result =
+                new LazyBasicWithoutEnhancementRule().evaluate(context(environment, LazyLobEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void lazyBasicRulePassesWhenAnAdapterVerifiesEnhancement() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty(HibernateScanner.BYTECODE_ENHANCEMENT_VERIFIED_PROPERTY, "true");
 
         HibernateRuleResultDto result =
                 new LazyBasicWithoutEnhancementRule().evaluate(context(environment, LazyLobEntity.class));
@@ -456,20 +504,101 @@ class HibernateRulesTests {
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
+    // --- HIB-CONFIG-011 -----------------------------------------------------
+
+    @Test
+    void cacheableWithoutCacheStrategyRuleHonorsConfiguredDefaultStrategy() {
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty("hibernate.cache.use_second_level_cache", "true")
+                .withProperty("hibernate.cache.default_cache_concurrency_strategy", "read-write");
+
+        HibernateRuleResultDto result = new CacheableWithoutCacheStrategyRule()
+                .evaluate(context(environment, CacheableDefaultStrategyEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    // --- HIB-QUERY-001 ------------------------------------------------------
+
+    @Test
+    void modifyingRuleFlagsFlushWithoutClearAutomatically() {
+        HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                "com.example.Repo",
+                Object.class,
+                List.of(repositoryMethod(
+                        "updateAll", int.class, "update Entity e set e.value = 1", false, false, true, false, true)));
+
+        HibernateRuleResultDto result =
+                new ModifyingClearAutomaticallyRule().evaluate(context(new TestEnvironment(), List.of(repository)));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("flushAutomatically=true does not clear"));
+    }
+
+    @Test
+    void modifyingRulePassesWhenClearAutomaticallyIsEnabled() {
+        HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                "com.example.Repo",
+                Object.class,
+                List.of(repositoryMethod(
+                        "updateAll", int.class, "update Entity e set e.value = 1", false, false, true, true, false)));
+
+        HibernateRuleResultDto result =
+                new ModifyingClearAutomaticallyRule().evaluate(context(new TestEnvironment(), List.of(repository)));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    // --- HIB-QUERY-003 ------------------------------------------------------
+
+    @Test
+    void nativePageQueryWithoutCountQueryIsAnInformationalReview() {
+        HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                "com.example.Repo",
+                Object.class,
+                List.of(repositoryMethod(
+                        "findPage", Page.class, "select * from entity_table", true, true, false, false, false)));
+
+        HibernateRuleResultDto result =
+                new NativePagedQueryCountRule().evaluate(context(new TestEnvironment(), List.of(repository)));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+    }
+
+    @Test
+    void nativeListQueryWithPageableDoesNotRequireCountQuery() {
+        HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                "com.example.Repo",
+                Object.class,
+                List.of(repositoryMethod(
+                        "findSlice", List.class, "select * from entity_table", true, true, false, false, false)));
+
+        HibernateRuleResultDto result =
+                new NativePagedQueryCountRule().evaluate(context(new TestEnvironment(), List.of(repository)));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
     // --- HIB-CONFIG-015 -----------------------------------------------------
 
     @Test
-    void deferDatasourceInitializationRuleSkipsWhenDdlAutoUnset() {
+    void deferDatasourceInitializationRuleReportsOrderingWhenDdlAutoIsUnset() {
         TestEnvironment environment =
                 new TestEnvironment().withProperty("spring.jpa.defer-datasource-initialization", "true");
 
         HibernateRuleResultDto result = new DeferDatasourceInitializationRule().evaluate(context(environment));
 
-        assertThat(result.status()).isEqualTo(HibernateRuleSupport.SKIPPED);
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("after JPA initialization"));
     }
 
     @Test
-    void deferDatasourceInitializationRuleViolatesForValidate() {
+    void deferDatasourceInitializationRuleDoesNotClaimValidateMakesItIneffective() {
         TestEnvironment environment = new TestEnvironment()
                 .withProperty("spring.jpa.defer-datasource-initialization", "true")
                 .withProperty("spring.jpa.hibernate.ddl-auto", "validate");
@@ -477,17 +606,44 @@ class HibernateRulesTests {
         HibernateRuleResultDto result = new DeferDatasourceInitializationRule().evaluate(context(environment));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+        assertThat(result.sampleViolations()).noneMatch(sample -> sample.contains("has no effect"));
     }
 
     @Test
-    void deferDatasourceInitializationRulePassesForCreate() {
+    void deferDatasourceInitializationRuleReportsOrderingForCreate() {
         TestEnvironment environment = new TestEnvironment()
                 .withProperty("spring.jpa.defer-datasource-initialization", "true")
                 .withProperty("spring.jpa.hibernate.ddl-auto", "create");
 
         HibernateRuleResultDto result = new DeferDatasourceInitializationRule().evaluate(context(environment));
 
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+    }
+
+    // --- HIB-CONFIG-017 -----------------------------------------------------
+
+    @Test
+    void formatSqlInProductionRulePassesWhenSqlLoggingIsOff() {
+        TestEnvironment environment = new TestEnvironment().withProperty("hibernate.format_sql", "true");
+        environment.setActiveProfiles("prod");
+
+        HibernateRuleResultDto result = new FormatSqlInProductionRule().evaluate(context(environment));
+
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void formatSqlInProductionRuleFlagsFormattedSqlWhenLoggingIsEnabled() {
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty("hibernate.format_sql", "true")
+                .withProperty("hibernate.show_sql", "true");
+        environment.setActiveProfiles("prod");
+
+        HibernateRuleResultDto result = new FormatSqlInProductionRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
     }
 
     // --- HIB-MAP-006 --------------------------------------------------------
@@ -508,6 +664,52 @@ class HibernateRulesTests {
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
         assertThat(result.severity()).isEqualTo(HibernateRuleSupport.LOW);
+    }
+
+    // --- HIB-MAP-002 --------------------------------------------------------
+
+    @Test
+    void manyToManyListRuleRetainsOrderedListsAsAnAdvisory() {
+        HibernateRuleResultDto result =
+                new ManyToManyListRule().evaluate(context(new TestEnvironment(), OrderedManyToManyEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("@OrderColumn"));
+    }
+
+    // --- HIB-MAP-011 / HIB-MAP-018 -----------------------------------------
+
+    @Test
+    void finalEntityRulePassesWhenAnAdapterVerifiesEnhancement() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty(HibernateScanner.BYTECODE_ENHANCEMENT_VERIFIED_PROPERTY, "true");
+
+        HibernateRuleResultDto result = new FinalEntityRule().evaluate(context(environment, FinalEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void nonOwningOneToOneRuleDoesNotTrustAnUnverifiedEnhancementSetting() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty("hibernate.enhancer.enableLazyInitialization", "true");
+
+        HibernateRuleResultDto result =
+                new NonOwningOneToOneEnhancementRule().evaluate(context(environment, InverseOneToOneEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void nonOwningOneToOneRulePassesWhenAnAdapterVerifiesEnhancement() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty(HibernateScanner.BYTECODE_ENHANCEMENT_VERIFIED_PROPERTY, "true");
+
+        HibernateRuleResultDto result =
+                new NonOwningOneToOneEnhancementRule().evaluate(context(environment, InverseOneToOneEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
     // --- HIB-MAP-019 --------------------------------------------------------
@@ -557,6 +759,16 @@ class HibernateRulesTests {
 
         HibernateRuleResultDto result =
                 new MissingForeignKeyIndexRule().evaluate(context(environment, ImplicitJoinColumnEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void missingForeignKeyIndexRuleSkipsSharedPrimaryKeyAssociations() {
+        TestEnvironment environment = new TestEnvironment().withProperty("hibernate.hbm2ddl.auto", "create");
+
+        HibernateRuleResultDto result =
+                new MissingForeignKeyIndexRule().evaluate(context(environment, SharedPrimaryKeyEntity.class));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
@@ -851,11 +1063,10 @@ class HibernateRulesTests {
 
     @Test
     void assignedIdPersistableRuleFlagsAssignedIdWithoutPersistable() {
-        // Spring Data Commons' real Persistable interface is on this module's test classpath, so
-        // isSpringDataPersistableAvailable() is always true here; the "Spring Data absent" skip branch is not
-        // reachable from this module (matching the AiFrameworkDetector classpath-presence precedent).
-        HibernateRuleResultDto result =
-                new AssignedIdPersistableRule().evaluate(context(new TestEnvironment(), AssignedIdEntity.class));
+        HibernateRepositoryModel repository =
+                new HibernateRepositoryModel("com.example.Repo", AssignedIdEntity.class, List.of());
+        HibernateRuleResultDto result = new AssignedIdPersistableRule()
+                .evaluate(context(new TestEnvironment(), List.of(repository), AssignedIdEntity.class));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
         assertThat(result.sampleViolations())
@@ -864,18 +1075,30 @@ class HibernateRulesTests {
 
     @Test
     void assignedIdPersistableRulePassesWhenEntityImplementsPersistable() {
+        HibernateRepositoryModel repository =
+                new HibernateRepositoryModel("com.example.Repo", PersistableAssignedIdEntity.class, List.of());
         HibernateRuleResultDto result = new AssignedIdPersistableRule()
-                .evaluate(context(new TestEnvironment(), PersistableAssignedIdEntity.class));
+                .evaluate(context(new TestEnvironment(), List.of(repository), PersistableAssignedIdEntity.class));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
     @Test
     void assignedIdPersistableRulePassesForGeneratedIdentifiers() {
-        HibernateRuleResultDto result =
-                new AssignedIdPersistableRule().evaluate(context(new TestEnvironment(), IdentityEntity.class));
+        HibernateRepositoryModel repository =
+                new HibernateRepositoryModel("com.example.Repo", IdentityEntity.class, List.of());
+        HibernateRuleResultDto result = new AssignedIdPersistableRule()
+                .evaluate(context(new TestEnvironment(), List.of(repository), IdentityEntity.class));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void assignedIdPersistableRuleSkipsEntitiesWithoutRepositoryMetadata() {
+        HibernateRuleResultDto result =
+                new AssignedIdPersistableRule().evaluate(context(new TestEnvironment(), AssignedIdEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.SKIPPED);
     }
 
     @Test
@@ -903,7 +1126,7 @@ class HibernateRulesTests {
         assertThat(result.sampleViolations())
                 .anySatisfy(sample -> assertThat(sample)
                         .contains("not Serializable")
-                        .contains("no public no-arg ctor")
+                        .contains("no public/protected no-arg ctor")
                         .contains("no equals() override")
                         .contains("no hashCode() override"));
     }
@@ -912,6 +1135,22 @@ class HibernateRulesTests {
     void compositeIdentifierContractRulePassesForWellFormedIdClass() {
         HibernateRuleResultDto result = new CompositeIdentifierContractRule()
                 .evaluate(context(new TestEnvironment(), WellFormedIdClassEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void compositeIdentifierContractRuleAcceptsProtectedNoArgConstructor() {
+        HibernateRuleResultDto result = new CompositeIdentifierContractRule()
+                .evaluate(context(new TestEnvironment(), ProtectedConstructorEmbeddedIdEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void compositeIdentifierContractRuleAcceptsRecordPrimaryKeys() {
+        HibernateRuleResultDto result = new CompositeIdentifierContractRule()
+                .evaluate(context(new TestEnvironment(), RecordEmbeddedIdEntity.class));
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
@@ -1116,6 +1355,31 @@ class HibernateRulesTests {
     }
 
     @Entity
+    static class InverseOneToOneEntity {
+        @Id
+        Long id;
+
+        @OneToOne(mappedBy = "owner", fetch = FetchType.LAZY)
+        Child child;
+    }
+
+    @Entity
+    static class OrderedManyToManyEntity {
+        @Id
+        Long id;
+
+        @ManyToMany
+        @OrderColumn(name = "child_order")
+        List<Child> children;
+    }
+
+    @Entity
+    static final class FinalEntity {
+        @Id
+        Long id;
+    }
+
+    @Entity
     static class EagerLobEntity {
         @Id
         Long id;
@@ -1171,6 +1435,17 @@ class HibernateRulesTests {
     }
 
     @Entity
+    static class SharedPrimaryKeyEntity {
+        @Id
+        Long id;
+
+        @OneToOne
+        @MapsId
+        @JoinColumn(name = "id")
+        Child child;
+    }
+
+    @Entity
     static class ImplicitJoinColumnEntity {
         @Id
         Long id;
@@ -1198,6 +1473,13 @@ class HibernateRulesTests {
     @Immutable
     @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
     static class ImmutableReadOnlyCacheEntity {
+        @Id
+        Long id;
+    }
+
+    @Entity
+    @Cacheable
+    static class CacheableDefaultStrategyEntity {
         @Id
         Long id;
     }
@@ -1360,6 +1642,37 @@ class HibernateRulesTests {
     static class WellFormedEmbeddedIdEntity {
         @EmbeddedId
         WellFormedEmbeddedIdKey id;
+    }
+
+    /** A protected no-arg constructor is valid for a non-record composite primary-key class. */
+    static class ProtectedConstructorEmbeddedIdKey implements Serializable {
+        private Long value;
+
+        protected ProtectedConstructorEmbeddedIdKey() {}
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof ProtectedConstructorEmbeddedIdKey key && java.util.Objects.equals(value, key.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(value);
+        }
+    }
+
+    @Entity
+    static class ProtectedConstructorEmbeddedIdEntity {
+        @EmbeddedId
+        ProtectedConstructorEmbeddedIdKey id;
+    }
+
+    record RecordEmbeddedIdKey(Long orderId, Long lineNumber) implements Serializable {}
+
+    @Entity
+    static class RecordEmbeddedIdEntity {
+        @EmbeddedId
+        RecordEmbeddedIdKey id;
     }
 
     /** Composite identifier class violating every part of the JPA contract HIB-ID-007 checks. */

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
@@ -53,10 +53,11 @@ import org.hibernate.annotations.NotFoundAction;
 import org.hibernate.annotations.OptimisticLockType;
 import org.hibernate.annotations.OptimisticLocking;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 
 class HibernateScannerTests {
 
-    private static final int RULE_COUNT = 73;
+    private static final int RULE_COUNT = 72;
     private static final String AFFECTED_HIBERNATE_VERSION = "7.3.9.Final";
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 
@@ -182,7 +183,7 @@ class HibernateScannerTests {
                                 "com.example.ProblemOrderRepository",
                                 "findPageNative",
                                 ProblemOrder.class,
-                                List.class,
+                                Page.class,
                                 "select * from problem_order where status = ?",
                                 true,
                                 null,
@@ -261,7 +262,6 @@ class HibernateScannerTests {
                         "HIB-MAP-014",
                         "HIB-MAP-015",
                         "HIB-MAP-016",
-                        "HIB-MAP-017",
                         "HIB-ENTITY-002",
                         "HIB-ENTITY-003",
                         "HIB-ENTITY-004",

--- a/bootui-quarkus-integration-tests/hibernate/src/main/resources/application.properties
+++ b/bootui-quarkus-integration-tests/hibernate/src/main/resources/application.properties
@@ -12,9 +12,11 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:hibdemo;DB_CLOSE_DELAY=-1
 # the JPA value vocabulary, so drop-and-create is mapped to the engine's risky create-drop value.
 quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 
-# Exercises three more QuarkusHibernatePropertyLookup aliases end to end against a real SmallRye Config: without
-# them, HIB-FETCH-002/HIB-CONFIG-007/HIB-CONFIG-013 would false-positive on every Quarkus scan even though these
-# are correctly configured using the native Quarkus property name.
+# Exercises five more QuarkusHibernatePropertyLookup aliases end to end against a real SmallRye Config: without
+# them, HIB-FETCH-002/HIB-CONFIG-006/HIB-CONFIG-007/HIB-CONFIG-010/HIB-CONFIG-013 would false-positive on every
+# Quarkus scan even though these are correctly configured using the native Quarkus property name.
 quarkus.hibernate-orm.fetch.batch-size=16
 quarkus.hibernate-orm.statistics=true
 quarkus.hibernate-orm.jdbc.timezone=UTC
+quarkus.hibernate-orm.log.queries-slower-than-ms=25
+quarkus.hibernate-orm.second-level-caching-enabled=true

--- a/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHibernateAdvisorTest.java
+++ b/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHibernateAdvisorTest.java
@@ -24,8 +24,9 @@ import org.junit.jupiter.api.Test;
  * that a known annotation-driven advisory fires against the deliberately-imperfect {@link org.acme.hibdemo.Product}
  * entity, and — crucially — that the Spring-only Open-Session-in-View rule {@code HIB-CONFIG-001} stays inert,
  * proving {@code QuarkusHibernatePropertyLookup}'s OSIV neutralization works against a live SmallRye Config. It
- * also proves three more {@code QuarkusHibernatePropertyLookup} aliases end to end (batch fetching, statistics,
- * JDBC time zone — see {@code application.properties}): {@code HIB-FETCH-002}/{@code HIB-CONFIG-007}/
+ * also proves five more {@code QuarkusHibernatePropertyLookup} aliases end to end (batch fetching, slow-query
+ * logging, statistics, second-level caching, JDBC time zone — see {@code application.properties}):
+ * {@code HIB-FETCH-002}/{@code HIB-CONFIG-006}/{@code HIB-CONFIG-007}/{@code HIB-CONFIG-010}/
  * {@code HIB-CONFIG-013} would each false-positive on every Quarkus scan without them.</p>
  */
 @QuarkusTest
@@ -102,6 +103,14 @@ class BootUiQuarkusHibernateAdvisorTest {
                 .as("quarkus.hibernate-orm.statistics=true must be read back as hibernate.generate_statistics, so"
                         + " HIB-CONFIG-007 does not false-positive")
                 .doesNotContain("HIB-CONFIG-007");
+        assertThat(violationIds)
+                .as("quarkus.hibernate-orm.log.queries-slower-than-ms=25 must be read back as Hibernate's"
+                        + " slow-query threshold, so HIB-CONFIG-006 does not false-positive")
+                .doesNotContain("HIB-CONFIG-006");
+        assertThat(violationIds)
+                .as("Quarkus-managed second-level caching must satisfy HIB-CONFIG-010 without requiring an"
+                        + " unsupported explicit Hibernate region-factory property")
+                .doesNotContain("HIB-CONFIG-010");
         assertThat(violationIds)
                 .as("quarkus.hibernate-orm.jdbc.timezone=UTC must be read back as hibernate.jdbc.time_zone, so"
                         + " HIB-CONFIG-013 does not false-positive")

--- a/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest.java
+++ b/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest.java
@@ -21,9 +21,8 @@ import org.junit.jupiter.api.Test;
 /**
  * Live-runtime spike (HIB-CONFIG-005, see docs/HIBERNATE-CHECKS.md) proving that Quarkus' generic
  * {@code quarkus.hibernate-orm.unsupported-properties."..."} escape hatch — the fallback
- * {@code QuarkusHibernatePropertyLookup} uses for {@code hibernate.order_inserts}/{@code hibernate.order_updates},
- * which have no first-class {@code quarkus.hibernate-orm.*} equivalent — actually reaches vanilla Hibernate ORM's
- * own bootstrapped {@link org.hibernate.boot.spi.SessionFactoryOptions}, not just that BootUI's own property
+ * {@code QuarkusHibernatePropertyLookup} uses for native Hibernate settings — actually reaches vanilla Hibernate
+ * ORM's own bootstrapped {@link org.hibernate.boot.spi.SessionFactoryOptions}, not just that BootUI's own property
  * lookup reads the SmallRye Config value back. Bytecode inspection of the shipped
  * {@code quarkus-hibernate-orm-deployment} jar already showed {@code FastBootMetadataBuilder} merges
  * {@code unsupported-properties} verbatim into Hibernate's build-time settings; this test is the corroborating
@@ -72,7 +71,7 @@ class BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest {
         }
         assertThat(violationIds)
                 .as("hibernate.order_inserts/order_updates reached via the unsupported-properties passthrough"
-                        + " (with batching also configured via quarkus.hibernate-orm.jdbc.statement-batch-size)"
+                        + " (with hibernate.jdbc.batch_size also configured through that passthrough)"
                         + " must be read back so HIB-CONFIG-005 does not false-positive")
                 .doesNotContain("HIB-CONFIG-005");
     }
@@ -81,7 +80,7 @@ class BootUiQuarkusUnsupportedPropertiesPassthroughSpikeTest {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
-                    "quarkus.hibernate-orm.jdbc.statement-batch-size",
+                    "quarkus.hibernate-orm.unsupported-properties.\"hibernate.jdbc.batch_size\"",
                     "25",
                     "quarkus.hibernate-orm.unsupported-properties.\"hibernate.order_inserts\"",
                     "true",

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookup.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookup.java
@@ -2,7 +2,6 @@ package io.github.jdubois.bootui.quarkus.hibernate;
 
 import io.github.jdubois.bootui.engine.hibernate.HibernateScanner;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import org.eclipse.microprofile.config.Config;
 
@@ -26,18 +25,18 @@ import org.eclipse.microprofile.config.Config;
  *       {@code spring.jpa.open-in-view} resolves to {@code "false"} (its effective state). Without this the
  *       {@code HIB-CONFIG-001} rule — which treats an <em>absent</em> value as Spring Boot's web default of
  *       {@code true} — would render a hard false-positive on every Quarkus scan.</li>
- *   <li><strong>Reports Hibernate bytecode enhancement as always enabled</strong>: Quarkus enhances every entity
+ *   <li><strong>Reports Quarkus bytecode enhancement as adapter-verified</strong>: Quarkus enhances every entity
  *       at build time unconditionally (see {@code HibernateOrmProcessor.enhancerDomainObjects()}, an ungated
- *       build step) — there is no {@code quarkus.hibernate-orm.enhancement.*} switch to turn it off. The engine's
- *       {@code HIB-MAP-017}/{@code HIB-MAP-018} rules read the enable-lazy-initialization keys above to decide
- *       whether the enhancer is active; without this mapping they would read {@code null} (falsy) and flag every
- *       lazy/non-owning {@code @OneToOne} as a false positive on every Quarkus scan.</li>
- *   <li><strong>Maps batch fetching, JDBC time zone, statistics, IN-clause padding, pagination-over-collection
- *       and second-level/query caching</strong> to their real {@code quarkus.hibernate-orm.*} equivalents (all
- *       confirmed by decompiling the {@code quarkus-hibernate-orm}/{@code -deployment} 3.33.2.1 jars — see the
- *       per-alias notes on {@link #KEY_ALIASES}). Before this mapping existed, {@code HIB-FETCH-002} and
- *       {@code HIB-CONFIG-007}/{@code -009}/{@code -010}/{@code -011}/{@code -013}/{@code -016} could never
- *       observe an operator's setting on Quarkus, no matter which native property name they used.</li>
+ *       build step) — there is no {@code quarkus.hibernate-orm.enhancement.*} switch to turn it off. The engine
+ *       consumes this internal adapter fact separately from ordinary Hibernate enhancement settings, which request
+ *       enhancement features but do not prove that application classes were transformed.</li>
+ *   <li><strong>Maps batch fetching, slow-query logging, JDBC time zone, statistics, IN-clause padding,
+ *       pagination-over-collection and second-level/query caching</strong> to their real
+ *       {@code quarkus.hibernate-orm.*} equivalents (all confirmed by decompiling the
+ *       {@code quarkus-hibernate-orm}/{@code -deployment} 3.33.2.1 jars — see the per-alias notes on
+ *       {@link #KEY_ALIASES}). Before this mapping existed, {@code HIB-FETCH-002} and
+ *       {@code HIB-CONFIG-006}/{@code -007}/{@code -009}/{@code -010}/{@code -011}/{@code -013}/{@code -016}
+ *       could never observe an operator's setting on Quarkus, no matter which native property name they used.</li>
  *   <li><strong>Reads the Quarkus-native {@code quarkus.hibernate-orm.log.bind-parameters} convenience
  *       flag</strong> (and its deprecated {@code .bind-param} alias) as the synthetic {@code "trace"} value of
  *       the neutral {@code logging.level.org.hibernate.orm.jdbc.bind} key, matching Hibernate's own
@@ -45,13 +44,14 @@ import org.eclipse.microprofile.config.Config;
  *       {@code Logger.isTraceEnabled()} — so {@code HIB-CONFIG-018} sees bind-parameter logging as enabled
  *       however the operator configured it.</li>
  *   <li><strong>Falls back to the {@code quarkus.hibernate-orm.unsupported-properties."..."} escape
- *       hatch</strong> for any {@code hibernate.*} key with no first-class Quarkus config option. Decompiling
- *       {@code FastBootMetadataBuilder#createBuildTimeSettings} confirms Quarkus merges this map verbatim into
- *       Hibernate's real bootstrap settings, so a key set this way genuinely reaches Hibernate (unlike a bare,
- *       un-namespaced property in {@code application.properties}, which Quarkus never forwards). This is how an
- *       operator's {@code hibernate.order_inserts}/{@code order_updates} (HIB-CONFIG-005) or
- *       {@code hibernate.cache.region.factory_class} (HIB-CONFIG-010) setting can be read back even though
- *       Quarkus has no dedicated config property for either — see {@link #unsupportedPropertiesFallback}.</li>
+ *       hatch</strong> when a {@code hibernate.*} key has no first-class Quarkus config option or its first-class
+ *       equivalent is unset. Decompiling {@code FastBootMetadataBuilder#createBuildTimeSettings} confirms Quarkus
+ *       merges this map verbatim into Hibernate's real bootstrap settings, so a key set this way genuinely reaches
+ *       Hibernate (unlike a bare, un-namespaced property in {@code application.properties}, which Quarkus never
+ *       forwards). This is how an operator's {@code hibernate.order_inserts}/{@code order_updates}
+ *       (HIB-CONFIG-005), {@code hibernate.jdbc.batch_size}, or
+ *       {@code hibernate.cache.region.factory_class} (HIB-CONFIG-010) setting can be read back — see
+ *       {@link #unsupportedPropertiesFallback}.</li>
  * </ul>
  *
  * <p>Every other engine key falls through to a raw MicroProfile Config read, which returns {@code null} for
@@ -77,16 +77,6 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
 
     private static final String OPEN_IN_VIEW_KEY = "spring.jpa.open-in-view";
 
-    // The engine's HibernateContext.isHibernateEnhancementEnabled() ORs these four keys together to decide
-    // whether Hibernate bytecode enhancement is active. Quarkus enhances every entity unconditionally at build
-    // time (HibernateOrmProcessor.enhancerDomainObjects() is an ungated @BuildStep) and exposes no config
-    // property to disable it, so all four report "true" regardless of what (if anything) is actually set.
-    private static final Set<String> ENHANCEMENT_ENABLED_KEYS = Set.of(
-            "spring.jpa.properties.hibernate.enhancer.enableLazyInitialization",
-            "hibernate.enhancer.enableLazyInitialization",
-            "spring.jpa.properties.hibernate.bytecode.enhancer.enableLazyInitialization",
-            "hibernate.bytecode.enhancer.enableLazyInitialization");
-
     // The engine's HibernateContext exposes bind-parameter-value logging as the neutral property key
     // "logging.level.org.hibernate.orm.jdbc.bind", checked for a "trace" value (Hibernate's own
     // JdbcBindingLogging only ever logs bound values when Logger.isTraceEnabled()). Quarkus offers a
@@ -100,9 +90,9 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
 
     private static final String LEGACY_BIND_PARAM_PROPERTY = "quarkus.hibernate-orm.log.bind-param";
 
-    // Hibernate property keys have no first-class quarkus.hibernate-orm.* option but ARE genuinely readable
-    // if an operator sets them through Quarkus' generic "unsupported properties" escape hatch, which
-    // FastBootMetadataBuilder merges verbatim into Hibernate's real bootstrap settings
+    // Hibernate property keys are genuinely readable if an operator sets them through Quarkus' generic
+    // "unsupported properties" escape hatch, which FastBootMetadataBuilder merges verbatim into Hibernate's real
+    // bootstrap settings. This is also a fallback when the corresponding first-class Quarkus key is unset.
     // (RecordedConfig.getQuarkusConfigUnsupportedProperties() -> Map.putAll(...), confirmed by decompiling
     // quarkus-hibernate-orm-3.33.2.1.jar). unsupportedPropertiesFallback() below tries this for any
     // otherwise-unmapped hibernate.* key.
@@ -117,6 +107,10 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
     // "query-cache-enabled" property in Quarkus (verified against the generated config-doc model — only
     // second-level-caching-enabled exists).
     private static final String SECOND_LEVEL_CACHING_KEY = "quarkus.hibernate-orm.second-level-caching-enabled";
+
+    private static final String REGION_FACTORY_KEY = "hibernate.cache.region.factory_class";
+
+    private static final String QUARKUS_MANAGED_REGION_FACTORY = "quarkus-managed";
 
     // Engine key -> quarkus.hibernate-orm.* equivalent. Every mapping below is verified against the actual
     // quarkus-hibernate-orm{,-deployment} 3.33.2.1 jars (bytecode disassembly plus the generated
@@ -153,6 +147,16 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
             Map.entry(
                     "spring.jpa.properties.hibernate.query.in_clause_parameter_padding",
                     "quarkus.hibernate-orm.query.in-clause-parameter-padding"),
+            Map.entry(
+                    "hibernate.session.events.log.LOG_QUERIES_SLOWER_THAN_MS",
+                    "quarkus.hibernate-orm.log.queries-slower-than-ms"),
+            Map.entry(
+                    "spring.jpa.properties.hibernate.session.events.log.LOG_QUERIES_SLOWER_THAN_MS",
+                    "quarkus.hibernate-orm.log.queries-slower-than-ms"),
+            Map.entry("hibernate.log_slow_query", "quarkus.hibernate-orm.log.queries-slower-than-ms"),
+            Map.entry(
+                    "spring.jpa.properties.hibernate.log_slow_query",
+                    "quarkus.hibernate-orm.log.queries-slower-than-ms"),
             Map.entry("hibernate.cache.use_query_cache", SECOND_LEVEL_CACHING_KEY),
             Map.entry("spring.jpa.properties.hibernate.cache.use_query_cache", SECOND_LEVEL_CACHING_KEY),
             Map.entry("hibernate.cache.use_second_level_cache", SECOND_LEVEL_CACHING_KEY),
@@ -169,16 +173,25 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
         if (HibernateScanner.OPEN_IN_VIEW_APPLICABLE_PROPERTY.equals(key)) {
             return "false";
         }
+        if (HibernateScanner.BYTECODE_ENHANCEMENT_VERIFIED_PROPERTY.equals(key)) {
+            return "true";
+        }
         if (OPEN_IN_VIEW_KEY.equals(key)) {
             // Quarkus has no Open-Session-in-View; report its effective state so HIB-CONFIG-001 passes
             // rather than assuming Spring Boot's enabled-by-default.
             return "false";
         }
-        if (ENHANCEMENT_ENABLED_KEYS.contains(key)) {
-            return "true";
-        }
         if (BIND_PARAMETER_LOGGING_KEY.equals(key)) {
             return isBindParameterLoggingEnabled() ? "trace" : raw(key);
+        }
+        if (isRegionFactoryKey(key)) {
+            String configured = raw(key);
+            if (configured == null) {
+                configured = unsupportedPropertiesFallback(key);
+            }
+            return configured != null
+                    ? configured
+                    : isSecondLevelCachingEnabled() ? QUARKUS_MANAGED_REGION_FACTORY : null;
         }
         String quarkusKey = KEY_ALIASES.get(key);
         if (SCHEMA_STRATEGY_KEY.equals(quarkusKey)) {
@@ -186,7 +199,8 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
             return "drop-and-create".equalsIgnoreCase(value) ? "create-drop" : value;
         }
         if (quarkusKey != null) {
-            return raw(quarkusKey);
+            String value = raw(quarkusKey);
+            return value != null ? value : unsupportedPropertiesFallback(key);
         }
         String direct = raw(key);
         return direct != null ? direct : unsupportedPropertiesFallback(key);
@@ -212,9 +226,18 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
                 || "true".equalsIgnoreCase(raw(LEGACY_BIND_PARAM_PROPERTY));
     }
 
+    private boolean isRegionFactoryKey(String key) {
+        return REGION_FACTORY_KEY.equals(key) || (SPRING_JPA_PROPERTIES_PREFIX + REGION_FACTORY_KEY).equals(key);
+    }
+
+    private boolean isSecondLevelCachingEnabled() {
+        return "true".equalsIgnoreCase(raw(SECOND_LEVEL_CACHING_KEY));
+    }
+
     /**
      * Falls back to Quarkus' generic {@code quarkus.hibernate-orm.unsupported-properties."..."} escape hatch
-     * for a native Hibernate property key with no first-class {@code quarkus.hibernate-orm.*} option. Only
+     * for a native Hibernate property key. This is used for keys with no first-class
+     * {@code quarkus.hibernate-orm.*} option and as a fallback when an equivalent native key is unset. It only
      * applies to keys that are (once any {@code spring.jpa.properties.} prefix is stripped) a bare
      * {@code hibernate.*} property, since that is the only key shape this passthrough can plausibly carry.
      */

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookupTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookupTest.java
@@ -91,19 +91,15 @@ class QuarkusHibernatePropertyLookupTest {
     }
 
     @Test
-    void reportsHibernateBytecodeEnhancementAsAlwaysEnabledRegardlessOfConfig() {
+    void reportsHibernateBytecodeEnhancementAsAdapterVerifiedRegardlessOfConfig() {
         // Quarkus enhances every entity unconditionally at build time (HibernateOrmProcessor's
-        // enhancerDomainObjects() build step is ungated) and has no config switch to disable it, so
-        // HIB-MAP-017/HIB-MAP-018 must see these keys as "true" even when nothing at all is configured.
+        // enhancerDomainObjects() build step is ungated) and has no config switch to disable it. This is an
+        // adapter fact, not a synthetic value for ordinary Hibernate enhancement settings.
         QuarkusHibernatePropertyLookup lookup = lookup(Map.of());
 
-        assertThat(lookup.apply("spring.jpa.properties.hibernate.enhancer.enableLazyInitialization"))
+        assertThat(lookup.apply(HibernateScanner.BYTECODE_ENHANCEMENT_VERIFIED_PROPERTY))
                 .isEqualTo("true");
-        assertThat(lookup.apply("hibernate.enhancer.enableLazyInitialization")).isEqualTo("true");
-        assertThat(lookup.apply("spring.jpa.properties.hibernate.bytecode.enhancer.enableLazyInitialization"))
-                .isEqualTo("true");
-        assertThat(lookup.apply("hibernate.bytecode.enhancer.enableLazyInitialization"))
-                .isEqualTo("true");
+        assertThat(lookup.apply("hibernate.enhancer.enableLazyInitialization")).isNull();
     }
 
     @Test
@@ -180,6 +176,17 @@ class QuarkusHibernatePropertyLookupTest {
     }
 
     @Test
+    void mapsSlowQueryThresholdToItsQuarkusEquivalent() {
+        QuarkusHibernatePropertyLookup lookup =
+                lookup(Map.of("quarkus.hibernate-orm.log.queries-slower-than-ms", "25"));
+
+        assertThat(lookup.apply("hibernate.session.events.log.LOG_QUERIES_SLOWER_THAN_MS"))
+                .isEqualTo("25");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.log_slow_query"))
+                .isEqualTo("25");
+    }
+
+    @Test
     void mapsBothCacheFlagsToTheUnifiedSecondLevelCachingToggle() {
         // HIB-CONFIG-010/HIB-CONFIG-011. Quarkus has a SINGLE quarkus.hibernate-orm.second-level-caching-enabled
         // toggle, not one property per Hibernate cache setting: decompiling HibernateProcessorUtil's
@@ -196,6 +203,16 @@ class QuarkusHibernatePropertyLookupTest {
         assertThat(lookup.apply("hibernate.cache.use_second_level_cache")).isEqualTo("false");
         assertThat(lookup.apply("spring.jpa.properties.hibernate.cache.use_second_level_cache"))
                 .isEqualTo("false");
+    }
+
+    @Test
+    void exposesQuarkusManagedRegionFactoryWhenSecondLevelCachingIsEnabled() {
+        QuarkusHibernatePropertyLookup lookup =
+                lookup(Map.of("quarkus.hibernate-orm.second-level-caching-enabled", "true"));
+
+        assertThat(lookup.apply("hibernate.cache.region.factory_class")).isEqualTo("quarkus-managed");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.cache.region.factory_class"))
+                .isEqualTo("quarkus-managed");
     }
 
     @Test
@@ -244,6 +261,19 @@ class QuarkusHibernatePropertyLookupTest {
                 .isEqualTo("true");
         assertThat(lookup.apply("hibernate.cache.region.factory_class"))
                 .isEqualTo("org.hibernate.cache.jcache.internal.JCacheRegionFactory");
+    }
+
+    @Test
+    void fallsBackToUnsupportedPropertiesWhenAnAliasedNativeKeyIsUnset() {
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of(
+                "quarkus.hibernate-orm.unsupported-properties.\"hibernate.jdbc.batch_size\"",
+                "25",
+                "quarkus.hibernate-orm.unsupported-properties.\"hibernate.jdbc.time_zone\"",
+                "UTC"));
+
+        assertThat(lookup.apply("hibernate.jdbc.batch_size")).isEqualTo("25");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.jdbc.time_zone"))
+                .isEqualTo("UTC");
     }
 
     @Test

--- a/bootui-spring-sample-app/e2e/tests/hibernate.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/hibernate.spec.js
@@ -45,11 +45,11 @@ test.describe('Hibernate Advisor view', () => {
     await expect(
       page.getByText(/SampleAuditEntry#amount is a BigDecimal column without explicit precision/)
     ).toBeVisible()
-    await expect(page.getByText('@Modifying queries should clear or flush the persistence context')).toBeVisible()
+    await expect(page.getByText('@Modifying bulk queries should clear stale persistence context')).toBeVisible()
     await expect(
       page.getByText(/SampleOrderRepository#markAllAs is @Modifying without clearAutomatically/)
     ).toBeVisible()
-    await expect(page.getByText('Native paged @Query must declare countQuery')).toBeVisible()
+    await expect(page.getByText('Native Page queries should review count derivation')).toBeVisible()
     await expect(page.getByText(/SampleOrderRepository#findPageNative/)).toBeVisible()
     await expect(page.getByRole('link', {name: 'Learn more'}).first()).toBeVisible()
   })

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrderRepository.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/advisor/hibernate/SampleOrderRepository.java
@@ -39,8 +39,7 @@ public interface SampleOrderRepository extends JpaRepository<SampleOrder, Long> 
     @Query("update SampleOrder o set o.status = :status")
     int markAllAs(SampleOrderStatus status);
 
-    // Intentionally a native paged @Query without countQuery to trigger HIB-QUERY-003 (Spring Data cannot derive
-    // COUNT).
+    // Intentionally a native Page query without countQuery to trigger HIB-QUERY-003's count-derivation review.
     @Query(value = "select * from sample_advisor_orders where status = :status", nativeQuery = true)
     Page<SampleOrder> findPageNative(String status, Pageable pageable);
 

--- a/bootui-ui/src/main/frontend/src/accessibility.test.js
+++ b/bootui-ui/src/main/frontend/src/accessibility.test.js
@@ -253,7 +253,7 @@ describe('frontend accessibility', () => {
     })
 
     expect(unnamedControls).toEqual([])
-  })
+  }, 20_000)
 
   it.each([
     ['placeholder-only controls', '<input placeholder="Filter items">'],

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -100,8 +100,9 @@ includes up to a handful of sample mapped members plus a remediation link.
   `@Basic(fetch = FetchType.LAZY)`.
 - **Enhancement requirement**: Hibernate ORM 7 requires bytecode enhancement to honor lazy basic attributes. This rule
   deliberately does not recommend `@Basic(fetch = LAZY)` when enhancement is unavailable; HIB-FETCH-007 instead reports
-  existing ineffective lazy-basic declarations. Quarkus enhances entities at build time, while Spring applications must
-  configure enhancement explicitly.
+  existing ineffective lazy-basic declarations. The advisor relies on transformed-class evidence or an adapter-verified
+  platform capability; an ordinary Hibernate enhancement setting alone does not prove that application classes were
+  transformed. Quarkus provides that verified capability at build time.
 
 ### HIB-FETCH-006 - Collection associations should not declare @Fetch(JOIN)
 
@@ -211,13 +212,12 @@ includes up to a handful of sample mapped members plus a remediation link.
 
 - **Severity**: HIGH
 - **Inspects**: `@EmbeddedId` attribute types and `@IdClass` values (including inherited from a superclass).
-- **Fires when**: the composite identifier class is not `Serializable`, has no public no-arg constructor, or does not
-  override both `equals` and `hashCode`.
-- **Why it matters**: JPA and Hibernate require all four for a composite identifier class to work correctly - this is a
-  pure, deterministic contract check with essentially zero false-positive risk. Violating any of these can silently
-  break entity equality, second-level caching, and collection lookups.
-- **Recommendation**: make the composite identifier class implement `Serializable`, declare a public no-arg constructor,
-  and override both `equals` and `hashCode` over every identifier field.
+- **Fires when**: the composite identifier class is not `Serializable`; a non-record class has no public or protected
+  no-arg constructor; or the class does not override both `equals` and `hashCode`.
+- **Why it matters**: a composite identifier needs stable equality and a construction path that JPA can use. A record
+  supplies its canonical constructor and generated equality methods, so it is exempt from the no-arg-constructor check.
+- **Recommendation**: make the composite identifier class implement `Serializable`. For a non-record class, declare a
+  public or protected no-arg constructor and override both `equals` and `hashCode` over every identifier field.
 - **Quarkus/Panache**: applies identically - this check inspects only the identifier class via reflection, with no
   framework-specific behavior.
 
@@ -239,8 +239,10 @@ includes up to a handful of sample mapped members plus a remediation link.
 - **Severity**: MEDIUM
 - **Inspects**: `@ManyToMany` mappings and their Java collection type.
 - **Fires when**: a many-to-many association is declared as `List`.
-- **Why it matters**: list-backed many-to-many mappings can force delete-and-reinsert behavior for join-table rows.
-- **Recommendation**: use `Set`, or model the join table as an entity when it has attributes or business meaning.
+- **Why it matters**: a many-to-many link table is not owned by either entity like a child foreign key is. A `List` adds
+  ordering and lifecycle complexity even when `@OrderColumn` persists that order.
+- **Recommendation**: use `Set` when ordering is not domain-significant. When link order or attributes matter, model the
+  link table as an entity instead.
 
 ### HIB-MAP-003 - Enum attributes should declare an explicit storage strategy
 
@@ -324,12 +326,13 @@ includes up to a handful of sample mapped members plus a remediation link.
 
 ### HIB-MAP-011 - Entity classes should not be final
 
-- **Severity**: HIGH
-- **Inspects**: `@Entity` classes for the `final` modifier.
-- **Fires when**: an entity is declared `final`.
-- **Why it matters**: Hibernate cannot create runtime proxies for lazy associations or bytecode-enhanced state when the
-  class is final.
-- **Recommendation**: remove the `final` modifier from entities (and avoid Kotlin classes without `open`).
+- **Severity**: INFO
+- **Inspects**: `@Entity` classes for the `final` modifier and their bytecode-enhancement state.
+- **Fires when**: an entity is declared `final` and is not proven bytecode-enhanced.
+- **Why it matters**: final entities are not Jakarta-portable and cannot use subclass proxies for lazy to-one associations.
+  Bytecode enhancement is a valid alternative and is not itself blocked by a final declaration.
+- **Recommendation**: prefer non-final entities (and `open` Kotlin entities) when lazy subclass proxies are needed.
+  Bytecode-enhanced entities are exempt.
 
 ### HIB-MAP-012 - SINGLE_TABLE inheritance should declare @DiscriminatorColumn
 
@@ -344,7 +347,9 @@ includes up to a handful of sample mapped members plus a remediation link.
 
 - **Severity**: INFO
 - **Inspects**: persistent `String` attributes (excluding identifiers and `@Lob` fields).
-- **Fires when**: there is no `@Column(length=...)` and no `columnDefinition`.
+- **Fires when**: there is no `@Column` mapping and no `columnDefinition`. Reflection cannot distinguish
+  `@Column(length = 255)` from the annotation's default length, so an existing `@Column` is treated as an explicit
+  mapping.
 - **Why it matters**: generated DDL defaults to 255 characters, which can clash with domain expectations or database
   constraints.
 - **Recommendation**: set `@Column(length=...)` to match the domain, or use `@Lob`/`columnDefinition` for free-text
@@ -376,30 +381,17 @@ includes up to a handful of sample mapped members plus a remediation link.
   issue to discriminate between null and a real proxy.
 - **Recommendation**: set `@ManyToOne(optional=false)` whenever the join column is non-nullable.
 
-### HIB-MAP-017 - Lazy owning @OneToOne requires bytecode enhancement
-
-- **Severity**: INFO
-- **Inspects**: optional owning `@OneToOne` associations.
-- **Fires when**: the association is `FetchType.LAZY`, `optional` is not `false`, no `@MapsId` is declared, and Hibernate
-  bytecode enhancement is not enabled.
-- **Why it matters**: Hibernate cannot proxy the missing-or-present discriminator on the owning side without the
-  enhancer, so it silently fetches the association eagerly.
-- **Recommendation**: enable `hibernate.bytecode.enhancer.enableLazyInitialization` (and configure the enhancement
-  plugin), or switch to `@MapsId` so the existing foreign key drives loading.
-- **Quarkus**: bytecode enhancement is always considered enabled. Quarkus enhances every Hibernate ORM entity's
-  bytecode unconditionally at build time (there is no `quarkus.hibernate-orm.enhancement.*` opt-out), so this check
-  never fires there.
-
 ### HIB-MAP-018 - Non-owning @OneToOne triggers N+1 queries
 
 - **Severity**: HIGH
-- **Inspects**: non-owning (`mappedBy`) `@OneToOne` associations and whether Hibernate bytecode enhancement is enabled.
-- **Fires when**: bytecode enhancement is disabled and an entity declares a non-owning `@OneToOne` association.
+- **Inspects**: non-owning (`mappedBy`) `@OneToOne` associations and whether the declaring entity is bytecode enhanced.
+- **Fires when**: bytecode enhancement is not proven and an entity declares a non-owning `@OneToOne` association.
 - **Why it matters**: without bytecode enhancement Hibernate cannot create a lazy proxy for a non-owning `@OneToOne`, so
   it loads the association eagerly with an extra query per parent row — the classic N+1 pattern.
 - **Recommendation**: enable bytecode enhancement, or replace the bidirectional `@OneToOne` with a shared primary key
   (`@MapsId`) and a unidirectional mapping.
-- **Quarkus**: bytecode enhancement is always considered enabled (see HIB-MAP-017), so this check never fires there.
+- **Quarkus**: bytecode enhancement is verified by the adapter's unconditional build-time entity enhancement, so this
+  check never fires there.
 
 ### HIB-MAP-019 - Missing foreign key indexes
 
@@ -416,6 +408,8 @@ includes up to a handful of sample mapped members plus a remediation link.
   schema with Flyway/Liquibase, ensure the index exists in your migrations.
 - **Noise controls**: inferred join-column names are skipped because a physical naming strategy can rewrite them, and
   migration-managed schemas are skipped because JPA annotations cannot prove whether the migration created an index.
+  Shared-primary-key `@MapsId` associations are also skipped because the join column is already the primary-key access
+  path.
 
 ### HIB-MAP-020 - Unidirectional @OneToMany with @JoinColumn issues extra UPDATE statements
 
@@ -438,6 +432,8 @@ includes up to a handful of sample mapped members plus a remediation link.
   migrated before or during an ORM 7 upgrade.
 - **Recommendation**: use `@SQLRestriction` / `@SQLJoinTableRestriction`, or Hibernate's `@SoftDelete` for supported
   soft-delete mappings.
+- **Runtime scope**: this check is most useful while scanning an ORM 6.x application before migration. On ORM 7 the
+  removed annotation types prevent a compatible mapping from starting, rather than yielding a live advisory finding.
 
 ### HIB-MAP-022 - Explicit ordinal enum mappings should be reviewed
 
@@ -527,15 +523,17 @@ includes up to a handful of sample mapped members plus a remediation link.
 ### HIB-ENTITY-007 - Assigned IDs should implement Persistable
 
 - **Severity**: MEDIUM
-- **Inspects**: entities with assigned identifiers (lacking `@GeneratedValue`) and no `@Version` attribute.
-- **Fires when**: the entity does not implement `org.springframework.data.domain.Persistable`.
+- **Inspects**: Spring Data repository domain entities with assigned identifiers (lacking `@GeneratedValue`) and no
+  `@Version` attribute.
+- **Fires when**: a discovered Spring Data repository domain entity does not implement
+  `org.springframework.data.domain.Persistable`.
 - **Why it matters**: when using assigned identifiers such as a natural key or application-created UUID, Spring Data cannot
   determine whether the entity is new or detached because the ID is already populated. It assumes the entity might exist
   and issues a `SELECT` before `INSERT`.
 - **Recommendation**: implement `Persistable<ID>` and manage the `isNew()` flag manually, for example via a `@Transient`
   flag set after loading or defaulting to true, so Spring Data avoids the unnecessary `SELECT` before every insert.
-- **Quarkus**: skipped entirely (whole-rule) when `spring-data-commons` is not on the classpath. The concern is specific
-  to Spring Data's repository `save()` merge-vs-persist decision; Panache's own `persist()`/`persistAndFlush()` always
+- **Quarkus**: skipped entirely because no Spring Data repository metadata is available. The concern is specific to
+  Spring Data's repository `save()` merge-vs-persist decision; Panache's own `persist()`/`persistAndFlush()` always
   issues an `INSERT` and never probes existence first, so there is nothing to recommend on a Quarkus/Panache app.
 
 ### HIB-ENTITY-008 - Mutable entities should declare @Version for optimistic locking
@@ -573,13 +571,17 @@ runtime repository/query metadata with enough fidelity to evaluate these rules r
 Quarkus rather than guessing from Panache method names or generated bytecode. Mapping, identifier, fetching, configuration,
 and caching rules still run on Quarkus against the live JPA metamodel.
 
-### HIB-QUERY-001 - @Modifying queries should clear or flush the persistence context
+The JPQL checks deliberately use bounded, heuristic parsing rather than a full JPQL parser. Queries with nested aliases,
+subqueries, or multiple roots may be skipped rather than inferred incorrectly.
 
-- **Severity**: HIGH
+### HIB-QUERY-001 - @Modifying bulk queries should clear stale persistence context
+
+- **Severity**: INFO
 - **Inspects**: Spring Data JPA `@Modifying` annotations on repository methods.
-- **Fires when**: a `@Modifying` method does not set `clearAutomatically` or `flushAutomatically`.
+- **Fires when**: a `@Modifying` method does not set `clearAutomatically`.
 - **Why it matters**: the persistence context can hold stale entities after a bulk update or delete, leading to
-  hard-to-diagnose data inconsistencies.
+  hard-to-diagnose data inconsistencies. `flushAutomatically` only synchronizes pending changes before the bulk query;
+  it does not evict the stale managed entities afterward.
 - **Recommendation**: set `@Modifying(clearAutomatically=true)` (and `flushAutomatically=true` when pending changes must
   be applied first), or evict affected entities explicitly before issuing the bulk statement.
 
@@ -593,14 +595,15 @@ and caching rules still run on Quarkus against the live JPA metamodel.
 - **Recommendation**: annotate the caller with `@Transactional(readOnly = true)`, consume the stream inside a
   try-with-resources block, and close it before the transaction ends; otherwise prefer `Page<>` or a bounded `List<>`.
 
-### HIB-QUERY-003 - Native paged @Query must declare countQuery
+### HIB-QUERY-003 - Native Page queries should review count derivation
 
-- **Severity**: HIGH
-- **Inspects**: Spring Data `@Query(nativeQuery=true)` methods with `Pageable` or returning `Page<>`.
+- **Severity**: INFO
+- **Inspects**: Spring Data `@Query(nativeQuery=true)` methods returning `Page<>`.
 - **Fires when**: `countQuery` is missing.
-- **Why it matters**: Spring Data cannot derive a correct COUNT statement from a native query, so paging either fails to
-  start or executes the wrong COUNT.
-- **Recommendation**: add `countQuery = "..."` to the `@Query` so paging can compute totals reliably.
+- **Why it matters**: Spring Data can derive a count query for some simple native SQL, but complex SQL can require an
+  explicit count query or JSqlParser support.
+- **Recommendation**: review the generated count query. Add `countQuery = "..."` when Spring Data cannot derive a correct
+  count, especially for complex native SQL.
 
 ### HIB-QUERY-004 - Derived deleteBy methods load entities before deletion
 
@@ -682,6 +685,8 @@ and caching rules still run on Quarkus against the live JPA metamodel.
 - **Fires when**: the property is absent or non-positive.
 - **Why it matters**: write-heavy code otherwise sends insert/update/delete statements one at a time.
 - **Recommendation**: set a bounded batch size, such as 25, and tune it with representative workloads.
+- **Quarkus**: `quarkus.hibernate-orm.jdbc.statement-batch-size` has no native default, so an unset value leaves
+  Hibernate batching disabled and this INFO prompt remains applicable.
 
 ### HIB-CONFIG-005 - JDBC batching should order inserts and updates
 
@@ -705,6 +710,8 @@ and caching rules still run on Quarkus against the live JPA metamodel.
 - **Fires when**: no positive threshold is configured.
 - **Why it matters**: a local slow-query threshold helps spot expensive SQL before it reaches shared environments.
 - **Recommendation**: configure a bounded threshold in development and staging profiles.
+- **Quarkus**: the neutral Hibernate threshold keys map to
+  `quarkus.hibernate-orm.log.queries-slower-than-ms`, so a native Quarkus threshold is recognized.
 
 ### HIB-CONFIG-007 - Hibernate statistics should be enabled when tuning
 
@@ -749,22 +756,23 @@ and caching rules still run on Quarkus against the live JPA metamodel.
 - **Fires when**: query cache is enabled without a configured second-level cache provider, or when second-level cache is
   explicitly disabled.
 - **Why it matters**: query caching depends on the second-level cache infrastructure and proper entity caching.
-- **Recommendation**: disable query caching or configure a region factory and cache entities returned by cacheable entity
-  queries.
+- **Recommendation**: disable query caching or configure an effective region factory and cache entities returned by
+  cacheable entity queries.
 - **Quarkus**: `hibernate.cache.use_query_cache` maps to `quarkus.hibernate-orm.second-level-caching-enabled` via
   `QuarkusHibernatePropertyLookup` — Quarkus exposes a single unified toggle for second-level/query caching, not a
   separate query-cache property, so both the query-cache and second-level-cache reads resolve to the same Quarkus
-  setting. `hibernate.cache.region.factory_class` has no first-class Quarkus equivalent but is still reachable via
-  the `unsupported-properties` fallback if explicitly configured.
+  setting. When enabled, Quarkus supplies its integrated second-level cache implementation even though it does not
+  expose a `hibernate.cache.region.factory_class` property.
 
 ### HIB-CONFIG-011 - Cacheable entities should declare an explicit cache strategy
 
 - **Severity**: MEDIUM
 - **Inspects**: entity-level `@Cacheable` and Hibernate `@Cache` when second-level caching appears configured.
-- **Fires when**: an entity is JPA-cacheable but does not declare an explicit Hibernate cache strategy.
+- **Fires when**: an entity is JPA-cacheable but does not declare an explicit Hibernate cache strategy or a valid
+  `hibernate.cache.default_cache_concurrency_strategy` is not configured.
 - **Why it matters**: cache concurrency behavior should be explicit for cached entities.
-- **Recommendation**: add a Hibernate cache concurrency strategy, or remove `@Cacheable` when the entity should not use the
-  second-level cache.
+- **Recommendation**: add a Hibernate cache concurrency strategy, configure a valid default cache concurrency strategy,
+  or remove `@Cacheable` when the entity should not use the second-level cache.
 - **Quarkus**: `hibernate.cache.use_second_level_cache` maps to the same
   `quarkus.hibernate-orm.second-level-caching-enabled` toggle as HIB-CONFIG-010, so the precondition check for
   "second-level caching appears configured" is read correctly on Quarkus too.
@@ -814,17 +822,16 @@ and caching rules still run on Quarkus against the live JPA metamodel.
   and lacks the resilience and monitoring of a production pool.
 - **Recommendation**: remove the property and rely on Spring Boot's managed `DataSource` (HikariCP by default).
 
-### HIB-CONFIG-015 - spring.jpa.defer-datasource-initialization is only safe with embedded DDL flows
+### HIB-CONFIG-015 - Deferred script initialization should have an intentional order
 
-- **Severity**: MEDIUM
+- **Severity**: INFO
 - **Inspects**: `spring.jpa.defer-datasource-initialization` and `spring.jpa.hibernate.ddl-auto`.
-- **Fires when**: deferred initialization is enabled while `ddl-auto` is explicitly set to a value other than `create`,
-  `create-drop`, or `update`. If `ddl-auto` is unset, the check is skipped because embedded-database defaults can still
-  make deferred initialization meaningful.
-- **Why it matters**: the property is meaningful only when Hibernate creates or updates the schema; otherwise `data.sql`
-  is never executed by that flow and the configuration is misleading.
-- **Recommendation**: combine deferred initialization with `ddl-auto=create`/`create-drop`, or remove it and load seed
-  data through your migration tool (Flyway, Liquibase).
+- **Fires when**: deferred initialization is enabled.
+- **Why it matters**: the property moves script-based datasource initialization until after JPA initialization. That can
+  be intentional with schema validation or externally managed schemas, but the initialization owner and ordering should
+  be explicit.
+- **Recommendation**: verify that script-based initialization has the intended owner and order. Do not infer that scripts
+  are ineffective solely because Hibernate validates or does not generate the schema.
 
 ### HIB-CONFIG-016 - Fail on pagination over collection fetch
 
@@ -849,12 +856,13 @@ and caching rules still run on Quarkus against the live JPA metamodel.
 ### HIB-CONFIG-017 - Disable SQL formatting in production
 
 - **Severity**: LOW
-- **Inspects**: the `hibernate.format_sql` property and the active Spring profiles.
-- **Fires when**: a production profile is active and `hibernate.format_sql` is `true`.
-- **Why it matters**: pretty-printing SQL adds CPU and memory overhead, and Hibernate formats the statements even when SQL
-  logging is disabled, so it is wasted work in production.
-- **Recommendation**: disable `hibernate.format_sql` in production profiles and keep it enabled only for local development
-  where readable SQL helps.
+- **Inspects**: the `hibernate.format_sql` property, SQL-logging state, and active Spring profiles.
+- **Fires when**: a production profile is active, `hibernate.format_sql` is `true`, and SQL logging is enabled.
+- **Why it matters**: Hibernate formats a statement only when it logs that statement. Formatting every verbose SQL log
+  line adds avoidable CPU and allocation work in production.
+- **Recommendation**: disable `hibernate.format_sql` when verbose SQL logging is enabled in production.
+- **Quarkus**: `quarkus.hibernate-orm.log.format-sql` defaults to `true`, but it is inert unless
+  `quarkus.hibernate-orm.log.sql` or an equivalent Hibernate SQL logger is enabled.
 
 ### HIB-CONFIG-018 - Bind-parameter logging should be off in production
 
@@ -872,15 +880,16 @@ and caching rules still run on Quarkus against the live JPA metamodel.
 
 ## Caching
 
-### HIB-CACHE-001 - Cached entities should also cache their associations
+### HIB-CACHE-001 - Cached entity association coverage should be reviewed
 
-- **Severity**: MEDIUM
+- **Severity**: INFO
 - **Inspects**: entities annotated with `@Cacheable` or Hibernate `@Cache` and the entities they associate with.
 - **Fires when**: an association on a cached entity targets another entity that is itself uncached.
-- **Why it matters**: loading the aggregate from the cache still hits the database for every uncached association,
-  defeating much of the cache's value.
-- **Recommendation**: annotate the associated entities (or the association attributes) with
-  `@org.hibernate.annotations.Cache` so the second-level cache covers the whole graph.
+- **Why it matters**: loading a cached aggregate can still query an uncached target, but caching target entities and
+  caching collection roles have different semantics and costs. The right coverage depends on real hit rates, mutability,
+  and access patterns.
+- **Recommendation**: measure cache hit rates and access patterns before caching associated entities or collection roles.
+  Leave mutable or low-hit targets uncached when that better fits the workload.
 
 ### HIB-CACHE-002 - READ_ONLY cache strategy on writable entities is unsafe
 


### PR DESCRIPTION
## Summary

- Audit the 73-rule Hibernate/JPA advisor baseline against Hibernate ORM 7, Jakarta Persistence, Spring Data JPA, Quarkus 3.33, and comparable analyzer guidance. Retire the unsupported owning lazy `@OneToOne` check, leaving 72 evidence-backed active rules.
- Require transformed-class or adapter-verified evidence for enhancement-sensitive checks; make final entities advisory only when enhancement is not proven.
- Correct JPA and Spring Data rule semantics for composite identifiers, `@Modifying` persistence contexts, native `Page` count derivation, assigned-id repository scope, deferred initialization, and second-level-cache guidance.
- Align Quarkus property lookup with native slow-query configuration, integrated second-level caching, and `unsupported-properties` fallback for absent first-class aliases.
- Refresh the complete rule catalog, Spring browser expectations, focused engine/adaptor tests, and Quarkus integration fixtures.

## Evidence-backed audit outcomes

| Area | Result |
| --- | --- |
| Fetching and enhancement | Stop treating configuration flags as proof of class enhancement; retain Quarkus build-time verification. |
| Mapping and identifiers | Remove the inverted owning-one-to-one finding; accept protected no-arg constructors and record composite keys; avoid shared-primary-key index noise. |
| Repository queries | Make stale-context and native count derivation checks actionable INFO reviews instead of absolute claims. |
| Configuration and cache | Gate SQL formatting on SQL logging, recognize default cache strategies, and treat cache-association coverage as workload-dependent. |
| Platform mapping | Recognize Quarkus slow-query logging and managed L2 cache; honor valid unsupported-property fallback values. |

## Validation

- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:apply`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:check`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 verify`
- Focused Hibernate engine, Quarkus property-lookup, and Spring metamodel wiring tests
- `bootui-spring-sample-app/e2e`: `npm run format`, `npm run format:check`, and `npm test -- tests/hibernate.spec.js`

The local runtime uses JDK 26, so the JDK-17-to-21-gated Quarkus Hibernate ORM integration module is excluded from the local reactor; its unit fixtures are covered locally and CI exercises that module on its supported JDK.

## Advisor audit protocol

- Independent reviewers: Claude Opus 5 (max, long context), GPT-5.6 Terra (max, long context), and Gemini 3.1 Pro (high, long context), all against the same frozen `main` snapshot. Gemini produced no additional actionable findings.
- Evidence process: Hibernate ORM 7, Jakarta Persistence, Spring Data JPA, and Quarkus 3.33 primary sources plus comparable analyzer guidance were researched first.
- Decision process: all existing rules were classified as KEEP, MODIFY, REMOVE, or SPLIT; unsupported HIB-MAP-017 was removed and only reliably observable additions or corrections were accepted.
- Delivery policy: focused/full validation and hosted CI are required; workload-dependent guidance and remaining limitations are explicit and auto-merge is disabled.