### PR TITLE
Harden Vulnerabilities advisor data handling

### DIFF
--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyVulnerabilityDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyVulnerabilityDto.java
@@ -6,10 +6,9 @@ import java.util.List;
  * One vulnerability advisory affecting a dependency.
  *
  * <p>{@code fixAvailable} is derived from comparing the dependency's currently-resolved version against
- * {@code fixedVersions}: {@code true} when at least one fixed version is newer, {@code false} when
- * {@code fixedVersions} is empty (the advisory was fetched successfully but no fix has been published
- * upstream yet) &mdash; it exists so the UI can render an explicit "no fix yet" state instead of leaving an
- * empty {@code fixedVersions} list ambiguous between "checked, no fix" and "unknown".
+ * {@code fixedVersions}: {@code true} when at least one reported fixed version is newer. A false value means
+ * only that OSV reported no newer fixed-version candidate; it does not prove that the installed version is
+ * unaffected, because OSV's package/version query already matched it as vulnerable.
  *
  * <p>{@code epssScore}/{@code epssPercentile} are FIRST.org <a href="https://www.first.org/epss/">EPSS</a>
  * (Exploit Prediction Scoring System) figures for a CVE-aliased advisory: the modeled probability (0-1)

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScore.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScore.java
@@ -113,8 +113,8 @@ final class CvssV3BaseScore {
     /**
      * Parses the {@code Metric:Value} segments of a vector string into a map, requiring the
      * {@code CVSS:3.0/} or {@code CVSS:3.1/} prefix. Returns {@code null} for any structurally invalid
-     * vector: missing/wrong prefix, or a segment without exactly one non-edge {@code :}. Duplicate metric
-     * keys keep the last occurrence, matching how the reference calculator behaves.
+     * vector: missing/wrong prefix, a segment without exactly one non-edge {@code :}, or a duplicate metric
+     * key (which the CVSS v3.1 specification forbids).
      */
     private static Map<String, String> parseMetrics(String vector) {
         if (vector == null) {
@@ -134,10 +134,13 @@ final class CvssV3BaseScore {
                 continue;
             }
             int separator = segment.indexOf(':');
-            if (separator <= 0 || separator == segment.length() - 1) {
+            if (separator <= 0 || separator == segment.length() - 1 || segment.indexOf(':', separator + 1) >= 0) {
                 return null;
             }
-            metrics.put(segment.substring(0, separator), segment.substring(separator + 1));
+            String metric = segment.substring(0, separator);
+            if (metrics.putIfAbsent(metric, segment.substring(separator + 1)) != null) {
+                return null;
+            }
         }
         return metrics;
     }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
@@ -5,6 +5,8 @@ import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencyScanStatusDto;
 import io.github.jdubois.bootui.core.dto.DependencySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -12,19 +14,33 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 public final class DependencyReports {
 
     private static final List<String> VULNERABILITY_SEVERITIES =
-            List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN");
+            List.of("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN", "NONE");
+
+    /**
+     * FIRST's public EPSS API documents a 2,000-character maximum for the comma-separated {@code cve}
+     * parameter.
+     */
+    public static final int EPSS_CVE_PARAMETER_MAX_LENGTH = 2000;
+
+    private static final Pattern CVE_ID = Pattern.compile("CVE-[0-9]{4}-[0-9]{4,}");
 
     private static final Comparator<String> ALPHABETIC =
             Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER.thenComparing(Comparator.naturalOrder()));
 
+    private static final Comparator<String> MAVEN_VERSION_ORDER = (left, right) -> {
+        Integer compared = MavenVersionComparator.compare(left, right);
+        return compared != null && compared != 0 ? compared : ALPHABETIC.compare(left, right);
+    };
+
     private static final Comparator<DependencyDto> DEPENDENCY_ORDER = Comparator.comparingInt(
                     (DependencyDto dependency) -> severityRank(dependency.highestSeverity()))
             .thenComparing(DependencyDto::packageName, ALPHABETIC)
-            .thenComparing(DependencyDto::version, ALPHABETIC);
+            .thenComparing(DependencyDto::version, MAVEN_VERSION_ORDER);
 
     /**
      * Not-yet-reviewed vulnerabilities sort first (by severity, then id); dismissed vulnerabilities always
@@ -34,7 +50,7 @@ public final class DependencyReports {
     public static final Comparator<DependencyVulnerabilityDto> VULNERABILITY_ORDER = Comparator.comparing(
                     DependencyVulnerabilityDto::dismissed)
             .thenComparingInt((DependencyVulnerabilityDto v) -> severityRank(v.severity()))
-            .thenComparing(DependencyVulnerabilityDto::id);
+            .thenComparing(DependencyVulnerabilityDto::id, ALPHABETIC);
 
     private DependencyReports() {}
 
@@ -132,6 +148,9 @@ public final class DependencyReports {
     }
 
     public static String normalizeSeverity(double score) {
+        if (!Double.isFinite(score) || score < 0.0d || score > 10.0d) {
+            return "UNKNOWN";
+        }
         if (score >= 9.0d) {
             return "CRITICAL";
         }
@@ -141,37 +160,31 @@ public final class DependencyReports {
         if (score >= 4.0d) {
             return "MEDIUM";
         }
-        return "LOW";
+        return score > 0.0d ? "LOW" : "NONE";
     }
 
     /**
-     * Parses a supported OSV {@code severity[].score} value into a numeric Base Score.
+     * Parses a supported OSV severity entry into a numeric Base Score.
      *
-     * <p>Per the <a href="https://ossf.github.io/osv-schema/">OSV schema</a>, {@code score} is a CVSS
-     * vector string for {@code CVSS_V2}/{@code CVSS_V3}/{@code CVSS_V4} severity types. This method computes
-     * only prefixed CVSS v3.0/v3.1 vectors via {@link CvssV3BaseScore}; the unprefixed CVSS v2 notation and
-     * CVSS v4 vectors are left to the caller's database-specific severity fallback. A bare numeric string,
-     * although not a CVSS value in the OSV schema, is accepted defensively.
+     * <p>Per the <a href="https://ossf.github.io/osv-schema/">OSV schema</a>, {@code type} identifies how
+     * {@code score} must be interpreted. This method computes only {@code CVSS_V3} entries carrying a
+     * prefixed CVSS v3.0/v3.1 vector via {@link CvssV3BaseScore}; CVSS v2/v4 and provider-specific score
+     * types are left to the caller's database-specific severity fallback.
      *
-     * @return the Base Score, or {@code null} if it can't be determined from {@code value}
+     * @return the Base Score, or {@code null} if it can't be determined from {@code type}/{@code value}
+     */
+    public static Double parseScore(String type, String value) {
+        if (!"CVSS_V3".equals(type) || value == null) {
+            return null;
+        }
+        return CvssV3BaseScore.baseScore(value);
+    }
+
+    /**
+     * Compatibility overload for callers that already know they have a {@code CVSS_V3} entry.
      */
     public static Double parseScore(String value) {
-        if (value == null) {
-            return null;
-        }
-        if (value.startsWith("CVSS:3.0/") || value.startsWith("CVSS:3.1/")) {
-            return CvssV3BaseScore.baseScore(value);
-        }
-        if (value.startsWith("CVSS:")) {
-            // CVSS v4.0 (and any future major version): no closed-form Base Score equation exists; not
-            // computed here. Falls through to null so callers keep the database_specific.severity label.
-            return null;
-        }
-        try {
-            return Double.parseDouble(value);
-        } catch (NumberFormatException ex) {
-            return null;
-        }
+        return parseScore("CVSS_V3", value);
     }
 
     /**
@@ -204,6 +217,7 @@ public final class DependencyReports {
         }
         List<DependencyDto> marked = report.dependencies().stream()
                 .map(dependency -> markDismissals(dependency, dismissedIds))
+                .sorted(DEPENDENCY_ORDER)
                 .toList();
         int vulnerable = (int) marked.stream()
                 .filter(dependency -> dependency.vulnerabilityCount() > 0)
@@ -247,9 +261,10 @@ public final class DependencyReports {
      * Whether at least one of {@code fixedVersions} is newer than {@code currentVersion}, using the
      * lightweight {@link MavenVersionComparator} (BootUI takes no dependency on Maven's own
      * {@code ComparableVersion}). Backs {@link DependencyVulnerabilityDto#fixAvailable()}, which lets the UI
-     * distinguish a reported fixed-version upgrade target from an advisory without a {@code fixed} event.
-     * The latter does not prove that no fix exists: OSV ranges may instead close with {@code last_affected},
-     * which identifies the final vulnerable version without naming the first non-vulnerable version.
+     * distinguish a newer reported fixed-version upgrade target from an advisory without one. A false
+     * result means only that OSV reported no fixed event newer than the current version; it does not prove
+     * that the current dependency is unaffected, because OSV already matched it as vulnerable and ranges may
+     * be reintroduced or branch-specific.
      *
      * <p>An inconclusive per-version comparison (blank/unparseable input) is treated as "a fix is
      * available": OSV positively reported a {@code fixed} event for this advisory, so failing to parse the
@@ -294,23 +309,79 @@ public final class DependencyReports {
     }
 
     /**
-     * Every distinct {@code CVE-*} alias referenced by any vulnerability across {@code dependencies},
-     * preserving first-seen order. Feeds an adapter's batched FIRST.org EPSS lookup (one request per scan,
-     * mirroring the OSV batch query) &mdash; EPSS is scored only per-CVE, so non-CVE aliases (bare
-     * {@code GHSA-*}/{@code OSV-*} ids with no CVE cross-reference) are not included.
+     * Every distinct canonical CVE id referenced by any vulnerability across {@code dependencies},
+     * preserving first-seen order. The advisory's own id is considered before its aliases because OSV
+     * records may themselves be CVE records.
      */
     public static List<String> cveAliases(List<DependencyDto> dependencies) {
         Set<String> ids = new LinkedHashSet<>();
         for (DependencyDto dependency : dependencies) {
             for (DependencyVulnerabilityDto vulnerability : dependency.vulnerabilities()) {
-                for (String alias : vulnerability.aliases()) {
-                    if (alias != null && alias.startsWith("CVE-")) {
-                        ids.add(alias);
-                    }
-                }
+                ids.addAll(cveIds(vulnerability));
             }
         }
         return List.copyOf(ids);
+    }
+
+    /**
+     * Splits canonical CVE ids into deterministic chunks whose comma-separated {@code cve} parameter never
+     * exceeds FIRST.org's documented {@value #EPSS_CVE_PARAMETER_MAX_LENGTH}-character maximum.
+     */
+    public static List<List<String>> epssCveChunks(List<String> cveIds) {
+        if (cveIds == null || cveIds.isEmpty()) {
+            return List.of();
+        }
+        List<List<String>> chunks = new ArrayList<>();
+        List<String> chunk = new ArrayList<>();
+        int chunkLength = 0;
+        Set<String> seen = new LinkedHashSet<>();
+        for (String value : cveIds) {
+            String cveId = canonicalCveId(value);
+            if (cveId == null || !seen.add(cveId) || cveId.length() > EPSS_CVE_PARAMETER_MAX_LENGTH) {
+                continue;
+            }
+            int addedLength = cveId.length() + (chunk.isEmpty() ? 0 : 1);
+            if (!chunk.isEmpty() && chunkLength + addedLength > EPSS_CVE_PARAMETER_MAX_LENGTH) {
+                chunks.add(List.copyOf(chunk));
+                chunk.clear();
+                chunkLength = 0;
+                addedLength = cveId.length();
+            }
+            chunk.add(cveId);
+            chunkLength += addedLength;
+        }
+        if (!chunk.isEmpty()) {
+            chunks.add(List.copyOf(chunk));
+        }
+        return List.copyOf(chunks);
+    }
+
+    /**
+     * Returns a canonical uppercase CVE id, or {@code null} for malformed input.
+     */
+    public static String canonicalCveId(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        return CVE_ID.matcher(normalized).matches() ? normalized : null;
+    }
+
+    /**
+     * De-duplicates and orders reported Maven fixed-version candidates using Maven version semantics,
+     * falling back to stable lexical ordering when comparison is inconclusive.
+     */
+    public static List<String> orderFixedVersions(Collection<String> versions, int limit) {
+        if (versions == null || versions.isEmpty() || limit <= 0) {
+            return List.of();
+        }
+        return versions.stream()
+                .filter(version -> version != null && !version.isBlank())
+                .map(String::trim)
+                .distinct()
+                .sorted(MAVEN_VERSION_ORDER)
+                .limit(limit)
+                .toList();
     }
 
     /**
@@ -349,12 +420,29 @@ public final class DependencyReports {
 
     private static DependencyVulnerabilityDto applyEpssScore(
             DependencyVulnerabilityDto vulnerability, Map<String, EpssScore> epssByCve) {
-        for (String alias : vulnerability.aliases()) {
-            EpssScore epssScore = epssByCve.get(alias);
+        for (String cveId : cveIds(vulnerability)) {
+            EpssScore epssScore = epssByCve.get(cveId);
             if (epssScore != null) {
                 return vulnerability.withEpss(epssScore.probability(), epssScore.percentile());
             }
         }
         return vulnerability;
+    }
+
+    private static List<String> cveIds(DependencyVulnerabilityDto vulnerability) {
+        Set<String> ids = new LinkedHashSet<>();
+        String ownId = canonicalCveId(vulnerability.id());
+        if (ownId != null) {
+            ids.add(ownId);
+        }
+        if (vulnerability.aliases() != null) {
+            for (String alias : vulnerability.aliases()) {
+                String cveId = canonicalCveId(alias);
+                if (cveId != null) {
+                    ids.add(cveId);
+                }
+            }
+        }
+        return List.copyOf(ids);
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScoreTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/CvssV3BaseScoreTests.java
@@ -108,4 +108,16 @@ class CvssV3BaseScoreTests {
         assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/GARBAGE/PR:N/UI:N/S:U/C:H/I:H/A:H"))
                 .isNull();
     }
+
+    @Test
+    void returnsNullWhenAMetricAppearsMoreThanOnce() {
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"))
+                .isNull();
+    }
+
+    @Test
+    void returnsNullWhenASegmentContainsMoreThanOneColon() {
+        assertThat(CvssV3BaseScore.baseScore("CVSS:3.1/AV:N:EXTRA/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"))
+                .isNull();
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
@@ -6,7 +6,9 @@ import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -146,15 +148,26 @@ class DependencyReportsTests {
     }
 
     @Test
+    void normalizeSeverityScoreUsesTheOfficialCvssBands() {
+        assertThat(DependencyReports.normalizeSeverity(0.0d)).isEqualTo("NONE");
+        assertThat(DependencyReports.normalizeSeverity(0.1d)).isEqualTo("LOW");
+        assertThat(DependencyReports.normalizeSeverity(4.0d)).isEqualTo("MEDIUM");
+        assertThat(DependencyReports.normalizeSeverity(7.0d)).isEqualTo("HIGH");
+        assertThat(DependencyReports.normalizeSeverity(9.0d)).isEqualTo("CRITICAL");
+        assertThat(DependencyReports.normalizeSeverity(Double.NaN)).isEqualTo("UNKNOWN");
+        assertThat(DependencyReports.normalizeSeverity(10.1d)).isEqualTo("UNKNOWN");
+    }
+
+    @Test
     void parseScoreComputesTheBaseScoreForARealCvssV31Vector() {
         // CVE-2021-44228 "Log4Shell" -- NVD-published Base Score 10.0.
-        assertThat(DependencyReports.parseScore("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"))
+        assertThat(DependencyReports.parseScore("CVSS_V3", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"))
                 .isEqualTo(10.0d);
     }
 
     @Test
     void parseScoreSupportsTheCvss30Prefix() {
-        assertThat(DependencyReports.parseScore("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"))
+        assertThat(DependencyReports.parseScore("CVSS_V3", "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"))
                 .isEqualTo(9.8d);
     }
 
@@ -162,19 +175,23 @@ class DependencyReportsTests {
     void parseScoreReturnsNullForACvss40VectorRatherThanGuessing() {
         // No closed-form v4.0 Base Score equation exists (see CvssV3BaseScore's class Javadoc); callers
         // fall back to the database_specific.severity label for these advisories.
-        assertThat(DependencyReports.parseScore("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N"))
+        assertThat(DependencyReports.parseScore(
+                        "CVSS_V4", "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N"))
                 .isNull();
     }
 
     @Test
-    void parseScoreFallsBackToABareNumericStringForNonCvssValues() {
-        assertThat(DependencyReports.parseScore("7.5")).isEqualTo(7.5d);
+    void parseScoreDoesNotInterpretOtherSeverityTypesAsCvssV3() {
+        assertThat(DependencyReports.parseScore("Ubuntu", "7.5")).isNull();
+        assertThat(DependencyReports.parseScore("CVSS_V2", "7.5")).isNull();
+        assertThat(DependencyReports.parseScore("CVSS_V3", "7.5")).isNull();
     }
 
     @Test
     void parseScoreReturnsNullForAnUnparseableOrMissingValue() {
-        assertThat(DependencyReports.parseScore("not-a-score")).isNull();
-        assertThat(DependencyReports.parseScore(null)).isNull();
+        assertThat(DependencyReports.parseScore("CVSS_V3", "not-a-score")).isNull();
+        assertThat(DependencyReports.parseScore("CVSS_V3", null)).isNull();
+        assertThat(DependencyReports.parseScore(null, "CVSS:3.1/AV:N")).isNull();
     }
 
     @Test
@@ -262,6 +279,20 @@ class DependencyReportsTests {
     }
 
     @Test
+    void applyDismissalsReordersDependenciesUsingTheirRecomputedSeverity() {
+        DependencyDto critical = vulnerableDependency("org.example", "critical", "1.0.0", "CRITICAL");
+        DependencyDto high = vulnerableDependency("org.example", "high", "1.0.0", "HIGH");
+        DependenciesReport report = DependencyReports.report(true, "SCANNED", "done", 1L, 2, List.of(high, critical));
+
+        DependenciesReport updated = DependencyReports.applyDismissals(
+                report, Set.of(DependencyReports.dismissalKey("V-critical", "org.example:critical")));
+
+        assertThat(updated.dependencies())
+                .extracting(DependencyDto::packageName)
+                .containsExactly("org.example:high", "org.example:critical");
+    }
+
+    @Test
     void scanCandidatesDeduplicatesPackageVersionsBeforeApplyingTheLimit() {
         DependencyDto first = dependency("org.example", "first", "1.0.0");
         DependencyDto duplicate = dependency("org.example", "first", "1.0.0");
@@ -271,5 +302,58 @@ class DependencyReportsTests {
                 .containsExactly(first, second);
         assertThat(DependencyReports.scanCandidateCount(List.of(first, duplicate, second)))
                 .isEqualTo(2);
+    }
+
+    @Test
+    void cveAliasesIncludesTheAdvisoryIdAndRejectsMalformedAliases() {
+        DependencyVulnerabilityDto vulnerability = new DependencyVulnerabilityDto(
+                "cve-2024-1234",
+                null,
+                null,
+                "HIGH",
+                null,
+                List.of("CVE-2024-5678", "CVE-2024-5678", "CVE-2024-12&bad"),
+                List.of(),
+                List.of());
+        DependencyDto dependency = new DependencyDto(
+                "org.example", "lib", "1.0.0", "org.example:lib", "test", 1, "HIGH", List.of(vulnerability));
+
+        assertThat(DependencyReports.cveAliases(List.of(dependency))).containsExactly("CVE-2024-1234", "CVE-2024-5678");
+    }
+
+    @Test
+    void epssCveChunksRespectFirstsCharacterLimitWithoutDroppingIds() {
+        List<String> ids = new ArrayList<>();
+        for (int i = 1000; i < 1300; i++) {
+            ids.add("CVE-2024-" + i);
+        }
+
+        List<List<String>> chunks = DependencyReports.epssCveChunks(ids);
+
+        assertThat(chunks).hasSizeGreaterThan(1);
+        assertThat(chunks)
+                .allSatisfy(chunk -> assertThat(String.join(",", chunk))
+                        .hasSizeLessThanOrEqualTo(DependencyReports.EPSS_CVE_PARAMETER_MAX_LENGTH));
+        assertThat(chunks.stream().flatMap(List::stream).toList()).containsExactlyElementsOf(ids);
+    }
+
+    @Test
+    void applyEpssScoresMatchesACveAdvisoryWithoutRequiringAnAlias() {
+        DependencyVulnerabilityDto vulnerability = new DependencyVulnerabilityDto(
+                "CVE-2024-1234", null, null, "HIGH", null, List.of(), List.of(), List.of());
+        DependencyDto dependency = new DependencyDto(
+                "org.example", "lib", "1.0.0", "org.example:lib", "test", 1, "HIGH", List.of(vulnerability));
+
+        List<DependencyDto> enriched = DependencyReports.applyEpssScores(
+                List.of(dependency), Map.of("CVE-2024-1234", new EpssScore(0.25d, 0.75d)));
+
+        assertThat(enriched.get(0).vulnerabilities().get(0).epssScore()).isEqualTo(0.25d);
+        assertThat(enriched.get(0).vulnerabilities().get(0).epssPercentile()).isEqualTo(0.75d);
+    }
+
+    @Test
+    void orderFixedVersionsUsesMavenSemanticsAndStableDeduplication() {
+        assertThat(DependencyReports.orderFixedVersions(List.of("1.0-sp1", "1.0", "1.0-rc1", "1.0", "2.0"), 4))
+                .containsExactly("1.0-rc1", "1.0", "1.0-sp1", "2.0");
     }
 }

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/OsvStubTestResource.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/OsvStubTestResource.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.quarkus.it;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
@@ -26,6 +27,8 @@ public class OsvStubTestResource implements QuarkusTestResourceLifecycleManager 
 
     static final String ADVISORY_ID = "GHSA-it-vuln-0001";
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private HttpServer server;
 
     @Override
@@ -38,7 +41,10 @@ public class OsvStubTestResource implements QuarkusTestResourceLifecycleManager 
         // Only the first queried package is reported vulnerable; the remainder come back clean.
         server.createContext(
                 "/v1/querybatch",
-                exchange -> respond(exchange, 200, "{\"results\":[{\"vulns\":[{\"id\":\"" + ADVISORY_ID + "\"}]}]}"));
+                exchange -> respond(
+                        exchange,
+                        200,
+                        queryBatchResponse(exchange.getRequestBody().readAllBytes())));
         server.createContext(
                 "/v1/vulns/",
                 exchange -> respond(
@@ -56,6 +62,18 @@ public class OsvStubTestResource implements QuarkusTestResourceLifecycleManager 
         return Map.of(
                 "bootui.vulnerabilities.osv-base-uri",
                 "http://127.0.0.1:" + server.getAddress().getPort());
+    }
+
+    private static String queryBatchResponse(byte[] requestBody) throws IOException {
+        int queryCount = OBJECT_MAPPER.readTree(requestBody).path("queries").size();
+        StringBuilder response = new StringBuilder("{\"results\":[");
+        for (int i = 0; i < queryCount; i++) {
+            if (i > 0) {
+                response.append(',');
+            }
+            response.append(i == 0 ? "{\"vulns\":[{\"id\":\"" + ADVISORY_ID + "\"}]}" : "{}");
+        }
+        return response.append("]}").toString();
     }
 
     @Override

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
@@ -68,14 +68,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
      */
     private static final int MAX_QUERY_BATCH_PAGES = 20;
 
-    /**
-     * Maximum CVE ids per FIRST.org EPSS request. EPSS's own {@code limit} query parameter caps how many
-     * rows come back in one response (default 100, independent of how many CVEs were queried) -- each
-     * request pins {@code limit} to the chunk size so nothing is silently dropped, while chunking keeps
-     * the query string a reasonable length and matches the default {@code maxAdvisories}, keeping the
-     * common case to one request.
-     */
-    private static final int EPSS_CHUNK_SIZE = 200;
+    private static final int MAX_ALIASES = 20;
 
     /**
      * Bound on how many {@code GET /v1/vulns/{id}} advisory-detail requests run concurrently. OSV.dev
@@ -170,6 +163,9 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 continue;
             }
             for (JsonNode range : ranges) {
+                if ("GIT".equals(text(range, "type"))) {
+                    continue;
+                }
                 JsonNode events = range.path("events");
                 if (!events.isArray()) {
                     continue;
@@ -182,19 +178,22 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 }
             }
         }
-        return versions.stream().limit(10).toList();
+        return DependencyReports.orderFixedVersions(versions, 10);
     }
 
     private static List<String> stringArray(JsonNode node) {
-        List<String> values = new ArrayList<>();
+        Set<String> values = new LinkedHashSet<>();
         if (node.isArray()) {
             for (JsonNode value : node) {
-                if (!value.isNull()) {
-                    values.add(value.asText());
+                if (value.isTextual()) {
+                    String text = value.asText();
+                    if (text != null && !text.isBlank()) {
+                        values.add(text);
+                    }
                 }
             }
         }
-        return values;
+        return values.stream().limit(MAX_ALIASES).toList();
     }
 
     private static Set<String> uniqueIds(Map<String, List<String>> vulnerabilityIds) {
@@ -209,7 +208,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
     private static String text(JsonNode node, String fieldName) {
         JsonNode value = node.get(fieldName);
-        if (value == null || value.isNull()) {
+        if (value == null || !value.isTextual()) {
             return null;
         }
         String text = value.asText();
@@ -227,8 +226,9 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
     }
 
-    private static String scanMessage(boolean limited, boolean paginationTruncated, int failedFetches) {
-        if (!limited && !paginationTruncated && failedFetches == 0) {
+    private static String scanMessage(
+            boolean limited, boolean paginationTruncated, int failedPackages, int failedFetches) {
+        if (!limited && !paginationTruncated && failedPackages == 0 && failedFetches == 0) {
             return "Scan completed against OSV.dev.";
         }
         List<String> reasons = new ArrayList<>();
@@ -237,6 +237,12 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
         if (paginationTruncated) {
             reasons.add("some advisories were paginated and not fully fetched");
+        }
+        if (failedPackages > 0) {
+            reasons.add(failedPackages
+                    + (failedPackages == 1
+                            ? " package query was not completed"
+                            : " package queries were not completed"));
         }
         if (failedFetches > 0) {
             reasons.add(failedFetches + (failedFetches == 1 ? " advisory fetch failed" : " advisory fetches failed"));
@@ -248,34 +254,44 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     public DependenciesReport scan(List<DependencyDto> dependencies) {
         long scannedAt = Instant.now().toEpochMilli();
         List<DependencyDto> packages = DependencyReports.scanCandidates(dependencies, settings.maxPackages());
+        int packagesScanned = 0;
         if (packages.isEmpty()) {
             return DependencyReports.report(
                     true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
         }
         try {
             QueryBatchResult queryResult = queryBatch(packages);
+            packagesScanned = queryResult.packagesScanned();
             Map<String, List<String>> vulnerabilityIds = queryResult.idsByPackage();
             VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
             List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
             enriched = applyEpss(enriched);
             boolean limited = packages.size() < DependencyReports.scanCandidateCount(dependencies)
                     || uniqueIds(vulnerabilityIds).size() > Math.max(1, settings.maxAdvisories());
-            String status =
-                    limited || queryResult.paginationTruncated() || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";
+            String status = limited
+                            || queryResult.paginationTruncated()
+                            || queryResult.failedPackages() > 0
+                            || fetched.failedFetches() > 0
+                    ? "PARTIAL"
+                    : "SCANNED";
             return DependencyReports.report(
                     true,
                     status,
-                    scanMessage(limited, queryResult.paginationTruncated(), fetched.failedFetches()),
+                    scanMessage(
+                            limited,
+                            queryResult.paginationTruncated(),
+                            queryResult.failedPackages(),
+                            fetched.failedFetches()),
                     scannedAt,
-                    packages.size(),
+                    packagesScanned,
                     enriched);
         } catch (IOException ex) {
             return DependencyReports.report(
-                    true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
+                    true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packagesScanned, dependencies);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             return DependencyReports.report(
-                    true, "ERROR", "OSV scan was interrupted", scannedAt, packages.size(), dependencies);
+                    true, "ERROR", "OSV scan was interrupted", scannedAt, packagesScanned, dependencies);
         }
     }
 
@@ -285,7 +301,11 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
      * {@link #MAX_QUERY_BATCH_PAGES} (which the scan reports as {@code PARTIAL} rather than presenting an
      * incomplete result set as complete).
      */
-    private record QueryBatchResult(Map<String, List<String>> idsByPackage, boolean paginationTruncated) {}
+    private record QueryBatchResult(
+            Map<String, List<String>> idsByPackage,
+            boolean paginationTruncated,
+            int packagesScanned,
+            int failedPackages) {}
 
     /** One outstanding OSV query awaiting a further page of results. */
     private record PendingQuery(DependencyDto dependency, String pageToken) {}
@@ -293,14 +313,25 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private QueryBatchResult queryBatch(List<DependencyDto> dependencies) throws IOException, InterruptedException {
         Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
         boolean paginationTruncated = false;
+        int packagesScanned = 0;
+        int failedPackages = 0;
         for (int start = 0; start < dependencies.size(); start += MAX_QUERYBATCH_SIZE) {
             List<DependencyDto> chunk =
                     dependencies.subList(start, Math.min(dependencies.size(), start + MAX_QUERYBATCH_SIZE));
-            QueryBatchResult chunkResult = queryBatchChunk(chunk);
-            idsByPackage.putAll(chunkResult.idsByPackage());
-            paginationTruncated = paginationTruncated || chunkResult.paginationTruncated();
+            try {
+                QueryBatchResult chunkResult = queryBatchChunk(chunk);
+                idsByPackage.putAll(chunkResult.idsByPackage());
+                paginationTruncated = paginationTruncated || chunkResult.paginationTruncated();
+                packagesScanned += chunkResult.packagesScanned();
+            } catch (IOException ex) {
+                if (packagesScanned == 0) {
+                    throw ex;
+                }
+                failedPackages = dependencies.size() - start;
+                break;
+            }
         }
-        return new QueryBatchResult(idsByPackage, paginationTruncated);
+        return new QueryBatchResult(idsByPackage, paginationTruncated, packagesScanned, failedPackages);
     }
 
     /**
@@ -348,7 +379,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             pending = nextPending;
             page++;
         }
-        return new QueryBatchResult(idsByPackage, paginationTruncated);
+        return new QueryBatchResult(idsByPackage, paginationTruncated, dependencies.size(), 0);
     }
 
     private JsonNode queryBatchRequest(List<PendingQuery> pending) throws IOException, InterruptedException {
@@ -374,7 +405,36 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             throw new IOException("OSV query returned HTTP " + response.statusCode());
         }
-        return objectMapper.readTree(response.body()).path("results");
+        JsonNode root = objectMapper.readTree(response.body());
+        JsonNode results = root == null ? null : root.get("results");
+        if (root == null || !root.isObject() || results == null || !results.isArray()) {
+            throw new IOException("OSV querybatch response did not contain a results array");
+        }
+        if (results.size() != pending.size()) {
+            throw new IOException(
+                    "OSV querybatch returned " + results.size() + " results for " + pending.size() + " queries");
+        }
+        for (JsonNode result : results) {
+            if (!result.isObject()) {
+                throw new IOException("OSV querybatch returned a non-object result");
+            }
+            JsonNode vulns = result.get("vulns");
+            if (vulns != null && !vulns.isArray()) {
+                throw new IOException("OSV querybatch returned a non-array vulns field");
+            }
+            if (vulns != null) {
+                for (JsonNode vulnerability : vulns) {
+                    if (!vulnerability.isObject() || text(vulnerability, "id") == null) {
+                        throw new IOException("OSV querybatch returned a vulnerability without a non-blank id");
+                    }
+                }
+            }
+            JsonNode pageToken = result.get("next_page_token");
+            if (pageToken != null && !pageToken.isNull() && !pageToken.isTextual()) {
+                throw new IOException("OSV querybatch returned a non-string next_page_token");
+            }
+        }
+        return results;
     }
 
     /**
@@ -387,6 +447,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private VulnerabilityFetchResult fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
             throws InterruptedException {
         List<String> ids = uniqueIds(vulnerabilityIds).stream()
+                .sorted()
                 .limit(Math.max(1, settings.maxAdvisories()))
                 .toList();
         if (ids.isEmpty()) {
@@ -400,7 +461,9 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             }
             Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
             int failedFetches = 0;
-            for (Future<JsonNode> future : futures) {
+            for (int i = 0; i < futures.size(); i++) {
+                String expectedId = ids.get(i);
+                Future<JsonNode> future = futures.get(i);
                 JsonNode vulnerability;
                 try {
                     vulnerability = future.get();
@@ -418,15 +481,17 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     failedFetches++;
                     continue;
                 }
-                if (isWithdrawn(vulnerability)) {
-                    // A withdrawn OSV record is no longer considered a valid finding; OSV does not filter
-                    // these out of query results itself, so consumers must.
+                String vulnerabilityId = text(vulnerability, "id");
+                if (!expectedId.equals(vulnerabilityId)) {
+                    failedFetches++;
                     continue;
                 }
-                String vulnerabilityId = text(vulnerability, "id");
-                if (vulnerabilityId != null) {
-                    vulnerabilities.put(vulnerabilityId, vulnerability);
+                if (isWithdrawn(vulnerability)) {
+                    // POST queries exclude withdrawn records, but GET /v1/vulns/{id} returns them; keep this
+                    // detail-stage check so a withdrawn advisory never becomes a finding.
+                    continue;
                 }
+                vulnerabilities.put(expectedId, vulnerability);
             }
             return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
         } finally {
@@ -465,7 +530,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private record VulnerabilityFetchResult(Map<String, JsonNode> vulnerabilities, int failedFetches) {}
 
     private URI vulnerabilityUri(String id) {
-        String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8);
+        String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8).replace("+", "%20");
         return baseUri.resolve("/v1/vulns/" + encoded);
     }
 
@@ -493,6 +558,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         for (DependencyDto dependency : dependencies) {
             List<DependencyVulnerabilityDto> dependencyVulnerabilities =
                     vulnerabilityIds.getOrDefault(key(dependency), List.of()).stream()
+                            .distinct()
                             .map(vulnerabilities::get)
                             .filter(vulnerability -> vulnerability != null)
                             .map(vulnerability -> vulnerability(vulnerability, dependency))
@@ -558,24 +624,23 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         if (severities == null || !severities.isArray()) {
             return null;
         }
+        Double highest = null;
         for (JsonNode severityNode : severities) {
-            String value = text(severityNode, "score");
-            Double parsed = DependencyReports.parseScore(value);
-            if (parsed != null) {
-                return new Severity(DependencyReports.normalizeSeverity(parsed), parsed);
+            Double parsed = DependencyReports.parseScore(text(severityNode, "type"), text(severityNode, "score"));
+            if (parsed != null && (highest == null || parsed > highest)) {
+                highest = parsed;
             }
         }
-        return null;
+        return highest == null ? null : new Severity(DependencyReports.normalizeSeverity(highest), highest);
     }
 
     private record Severity(String label, Double score) {}
 
     /**
-     * Enriches CVE-aliased vulnerabilities with FIRST.org EPSS exploit-probability scores, one batched
-     * request per distinct CVE set per scan (mirroring the existing OSV batch-query pattern). EPSS is a
-     * best-effort secondary signal layered on top of the OSV-derived results: any failure (disabled,
-     * network error, malformed response) leaves the affected vulnerabilities without EPSS fields and never
-     * changes the scan's status or message -- only OSV outcomes do that.
+     * Enriches CVE-linked vulnerabilities with FIRST.org EPSS exploit-probability scores using one or more
+     * requests bounded by FIRST's documented 2,000-character {@code cve} parameter limit. EPSS is a
+     * best-effort secondary signal: any failure leaves the affected vulnerabilities without EPSS fields
+     * and never changes the scan's status or message -- only OSV outcomes do that.
      */
     private List<DependencyDto> applyEpss(List<DependencyDto> dependencies) {
         if (!settings.epssEnabled()) {
@@ -591,14 +656,13 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
     private Map<String, EpssScore> fetchEpssScores(List<String> cveIds) {
         Map<String, EpssScore> scores = new LinkedHashMap<>();
-        for (int start = 0; start < cveIds.size(); start += EPSS_CHUNK_SIZE) {
-            List<String> chunk = cveIds.subList(start, Math.min(cveIds.size(), start + EPSS_CHUNK_SIZE));
+        for (List<String> chunk : DependencyReports.epssCveChunks(cveIds)) {
             try {
                 scores.putAll(fetchEpssChunk(chunk));
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 break;
-            } catch (IOException ex) {
+            } catch (IOException | IllegalArgumentException ex) {
                 // EPSS is a best-effort enrichment on top of the OSV scan; stop trying further chunks but
                 // keep whatever scores were already fetched rather than failing the scan. (Jackson 2's
                 // JsonProcessingException already extends IOException.)
@@ -621,16 +685,24 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
         JsonNode data = objectMapper.readTree(response.body()).path("data");
         Map<String, EpssScore> scores = new LinkedHashMap<>();
+        Set<String> requested = new LinkedHashSet<>(cveIds);
         if (data.isArray()) {
             for (JsonNode entry : data) {
-                String cve = text(entry, "cve");
+                String cve = DependencyReports.canonicalCveId(text(entry, "cve"));
                 Double probability = parseDouble(text(entry, "epss"));
                 Double percentile = parseDouble(text(entry, "percentile"));
-                if (cve != null && probability != null && percentile != null) {
+                if (cve != null
+                        && requested.contains(cve)
+                        && validProbability(probability)
+                        && validProbability(percentile)) {
                     scores.put(cve, new EpssScore(probability, percentile));
                 }
             }
         }
         return scores;
+    }
+
+    private static boolean validProbability(Double value) {
+        return value != null && Double.isFinite(value) && value >= 0.0d && value <= 1.0d;
     }
 }

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
@@ -10,6 +10,7 @@ import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -262,6 +263,54 @@ class OsvVulnerabilityScannerTest {
     }
 
     @Test
+    void reportsErrorWhenQuerybatchResultsDoNotMatchTheQueries() {
+        handle("/v1/querybatch", "{\"results\":[{}]}");
+
+        DependenciesReport report = scanner(250, 200)
+                .scan(List.of(dependency("org.acme", "first", "1.0.0"), dependency("org.acme", "second", "1.0.0")));
+
+        assertThat(report.status()).isEqualTo("ERROR");
+        assertThat(report.scan().packagesScanned()).isZero();
+        assertThat(report.scan().message()).contains("1 results for 2 queries");
+        assertThat(report.dependencies()).hasSize(2);
+    }
+
+    @Test
+    void reportsErrorWhenQuerybatchContainsAVulnerabilityWithoutAnId() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{}]}]}");
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        assertThat(report.status()).isEqualTo("ERROR");
+        assertThat(report.scan().packagesScanned()).isZero();
+        assertThat(report.scan().message()).contains("vulnerability without a non-blank id");
+        assertThat(report.dependencies()).hasSize(1);
+    }
+
+    @Test
+    void deduplicatesRepeatedIdsAndRejectsMismatchedAdvisoryDetails() {
+        AtomicInteger duplicateFetches = new AtomicInteger();
+        handle(
+                "/v1/querybatch",
+                "{\"results\":[{\"vulns\":["
+                        + "{\"id\":\"V-DUPLICATE\"},{\"id\":\"V-DUPLICATE\"},{\"id\":\"V-MISMATCH\"}]}]}");
+        server.createContext("/v1/vulns/V-DUPLICATE", exchange -> {
+            duplicateFetches.incrementAndGet();
+            respond(exchange, 200, "{\"id\":\"V-DUPLICATE\",\"database_specific\":{\"severity\":\"HIGH\"}}");
+        });
+        handle("/v1/vulns/V-MISMATCH", "{\"id\":\"V-OTHER\",\"database_specific\":{\"severity\":\"CRITICAL\"}}");
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        assertThat(report.status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains("1 advisory fetch failed");
+        assertThat(duplicateFetches).hasValue(1);
+        assertThat(report.dependencies().get(0).vulnerabilities())
+                .extracting(DependencyVulnerabilityDto::id)
+                .containsExactly("V-DUPLICATE");
+    }
+
+    @Test
     void reportsErrorAndPreservesInventoryOnRequestTimeout() {
         server.createContext("/v1/querybatch", exchange -> {
             try {
@@ -370,6 +419,28 @@ class OsvVulnerabilityScannerTest {
                 report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.score()).isNull();
         assertThat(vulnerability.severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void usesOnlyTypedCvssV3EntriesAndChoosesTheHighestScore() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-typed-severity\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-typed-severity",
+                "{\"id\":\"GHSA-typed-severity\",\"severity\":["
+                        + "{\"type\":\"Ubuntu\",\"score\":\"9.9\"},"
+                        + "{\"type\":\"CVSS_V2\",\"score\":\"10.0\"},"
+                        + "{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N\"},"
+                        + "{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"}]}");
+
+        DependencyVulnerabilityDto vulnerability = scanner(250, 200)
+                .scan(List.of(dependency("org.acme", "widget", "1.0.0")))
+                .dependencies()
+                .get(0)
+                .vulnerabilities()
+                .get(0);
+
+        assertThat(vulnerability.score()).isEqualTo(9.8d);
+        assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
     }
 
     @Test
@@ -544,6 +615,27 @@ class OsvVulnerabilityScannerTest {
     }
 
     @Test
+    void preservesCompletedQueryChunksWhenALaterChunkFails() {
+        String firstResults = "{\"results\":[" + "{},".repeat(999) + "{}]}";
+        server.createContext("/v1/querybatch", exchange -> {
+            int call = queryBatchCalls.incrementAndGet();
+            respond(exchange, call == 1 ? 200 : 503, call == 1 ? firstResults : "unavailable");
+        });
+        List<DependencyDto> dependencies = new ArrayList<>();
+        for (int i = 0; i < 1001; i++) {
+            dependencies.add(dependency("org.acme", "widget" + i, "1.0.0"));
+        }
+
+        DependenciesReport report = scanner(1001, 200).scan(dependencies);
+
+        assertThat(queryBatchCalls).hasValue(2);
+        assertThat(report.status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().packagesScanned()).isEqualTo(1000);
+        assertThat(report.scan().message()).contains("1 package query was not completed");
+        assertThat(report.dependencies()).hasSize(1001);
+    }
+
+    @Test
     void epssEnrichesCveAliasedVulnerabilityWithProbabilityAndPercentile() {
         handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-epss\"}]}]}");
         handle(
@@ -563,6 +655,41 @@ class OsvVulnerabilityScannerTest {
                 report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.epssScore()).isEqualTo(0.9445d);
         assertThat(vulnerability.epssPercentile()).isEqualTo(0.9999d);
+    }
+
+    @Test
+    void epssUsesCveRecordIdsAndSplitsRequestsAtTheDocumentedCharacterLimit() {
+        String longCveOne = "CVE-2024-" + "1".repeat(1200);
+        String longCveTwo = "CVE-2024-" + "2".repeat(1200);
+        handle(
+                "/v1/querybatch",
+                "{\"results\":[{\"vulns\":[{\"id\":\"CVE-2024-1234\"},{\"id\":\"GHSA-long-cves\"}]}]}");
+        handle("/v1/vulns/CVE-2024-1234", "{\"id\":\"CVE-2024-1234\",\"database_specific\":{\"severity\":\"HIGH\"}}");
+        handle(
+                "/v1/vulns/GHSA-long-cves",
+                "{\"id\":\"GHSA-long-cves\",\"aliases\":[\"" + longCveOne + "\",\"" + longCveTwo
+                        + "\"],\"database_specific\":{\"severity\":\"LOW\"}}");
+        AtomicInteger epssCalls = new AtomicInteger();
+        server.createContext("/data/v1/epss", exchange -> {
+            epssCalls.incrementAndGet();
+            String cveParameter =
+                    exchange.getRequestURI().getRawQuery().split("&", 2)[0].substring("cve=".length());
+            assertThat(cveParameter).hasSizeLessThanOrEqualTo(DependencyReports.EPSS_CVE_PARAMETER_MAX_LENGTH);
+            respond(
+                    exchange,
+                    200,
+                    "{\"data\":[{\"cve\":\"CVE-2024-1234\",\"epss\":\"0.125\",\"percentile\":\"0.75\"}]}");
+        });
+
+        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+
+        assertThat(epssCalls).hasValue(2);
+        DependencyVulnerabilityDto cveFinding = report.dependencies().get(0).vulnerabilities().stream()
+                .filter(vulnerability -> "CVE-2024-1234".equals(vulnerability.id()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(cveFinding.epssScore()).isEqualTo(0.125d);
+        assertThat(cveFinding.epssPercentile()).isEqualTo(0.75d);
     }
 
     @Test
@@ -620,6 +747,28 @@ class OsvVulnerabilityScannerTest {
                 report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.fixedVersions()).isEmpty();
         assertThat(vulnerability.fixAvailable()).isFalse();
+    }
+
+    @Test
+    void ignoresGitCommitFixesAndOrdersMavenFixedVersions() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"GHSA-range-types\"}]}]}");
+        handle(
+                "/v1/vulns/GHSA-range-types",
+                "{\"id\":\"GHSA-range-types\",\"database_specific\":{\"severity\":\"HIGH\"},"
+                        + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"},"
+                        + "\"ranges\":["
+                        + "{\"type\":\"GIT\",\"events\":[{\"fixed\":\"abcdef123456\"}]},"
+                        + "{\"type\":\"ECOSYSTEM\",\"events\":[{\"fixed\":\"1.0-sp1\"},{\"fixed\":\"1.0-rc1\"},{\"fixed\":\"1.0\"}]}"
+                        + "]}]}");
+
+        DependencyVulnerabilityDto vulnerability = scanner(250, 200)
+                .scan(List.of(dependency("org.acme", "widget", "0.9")))
+                .dependencies()
+                .get(0)
+                .vulnerabilities()
+                .get(0);
+
+        assertThat(vulnerability.fixedVersions()).containsExactly("1.0-rc1", "1.0", "1.0-sp1");
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
@@ -24,6 +24,8 @@ final class DependencyCatalog implements DependencyProvider {
 
     private static final String MAVEN_PROPERTIES_PATTERN = "classpath*:META-INF/maven/*/*/pom.properties";
 
+    private static final System.Logger LOGGER = System.getLogger(DependencyCatalog.class.getName());
+
     private final ResourcePatternResolver resolver;
 
     DependencyCatalog() {
@@ -55,7 +57,11 @@ final class DependencyCatalog implements DependencyProvider {
         try {
             return resolver.getResources(MAVEN_PROPERTIES_PATTERN);
         } catch (IOException ex) {
-            throw new IllegalStateException("Could not inspect classpath Maven metadata", ex);
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "Could not inspect classpath Maven metadata; continuing with java.class.path: {0}",
+                    ex.getMessage());
+            return new Resource[0];
         }
     }
 
@@ -64,7 +70,12 @@ final class DependencyCatalog implements DependencyProvider {
         try (InputStream input = resource.getInputStream()) {
             properties.load(input);
         } catch (IOException ex) {
-            throw new IllegalStateException("Could not read Maven metadata from " + resource.getDescription(), ex);
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "Could not read Maven metadata from {0}; skipping it: {1}",
+                    resource.getDescription(),
+                    ex.getMessage());
+            return null;
         }
         String groupId = BlankStrings.blankToNullTrimmed(properties.getProperty("groupId"));
         String artifactId = BlankStrings.blankToNullTrimmed(properties.getProperty("artifactId"));
@@ -100,7 +111,11 @@ final class DependencyCatalog implements DependencyProvider {
         String artifactId = artifactPath.getFileName().toString();
         String version = versionPath.getFileName().toString();
         String fileName = jar.getFileName().toString();
-        if (!fileName.startsWith(artifactId + "-" + version) || !fileName.endsWith(".jar")) {
+        String expectedBaseName = artifactId + "-" + version;
+        boolean mainArtifact = fileName.equals(expectedBaseName + ".jar");
+        boolean classifiedArtifact =
+                fileName.startsWith(expectedBaseName + "-") && fileName.length() > expectedBaseName.length() + 5;
+        if ((!mainArtifact && !classifiedArtifact) || !fileName.endsWith(".jar")) {
             return null;
         }
         DependencyDto pomDependency = dependencyFromAdjacentPom(versionPath, artifactId, version);

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -39,14 +39,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
      */
     private static final int MAX_QUERY_BATCH_PAGES = 20;
 
-    /**
-     * Maximum CVE ids per FIRST.org EPSS request. EPSS's own {@code limit} query parameter caps how many
-     * rows come back in one response (default 100, independent of how many CVEs were queried) -- each
-     * request pins {@code limit} to the chunk size so nothing is silently dropped, while chunking keeps
-     * the query string a reasonable length and matches the default {@code maxAdvisories}, keeping the
-     * common case to one request.
-     */
-    private static final int EPSS_CHUNK_SIZE = 200;
+    private static final int MAX_ALIASES = 20;
 
     /**
      * Bound on how many {@code GET /v1/vulns/{id}} advisory-detail requests run concurrently. OSV.dev
@@ -148,6 +141,9 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 continue;
             }
             for (JsonNode range : ranges) {
+                if ("GIT".equals(text(range, "type"))) {
+                    continue;
+                }
                 JsonNode events = range.path("events");
                 if (!events.isArray()) {
                     continue;
@@ -160,19 +156,22 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 }
             }
         }
-        return versions.stream().limit(10).toList();
+        return DependencyReports.orderFixedVersions(versions, 10);
     }
 
     private static List<String> stringArray(JsonNode node) {
-        List<String> values = new ArrayList<>();
+        Set<String> values = new LinkedHashSet<>();
         if (node.isArray()) {
             for (JsonNode value : node) {
-                if (!value.isNull()) {
-                    values.add(value.asString());
+                if (value.isString()) {
+                    String text = value.asString();
+                    if (text != null && !text.isBlank()) {
+                        values.add(text);
+                    }
                 }
             }
         }
-        return values;
+        return values.stream().limit(MAX_ALIASES).toList();
     }
 
     private static Set<String> uniqueIds(Map<String, List<String>> vulnerabilityIds) {
@@ -187,7 +186,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
     private static String text(JsonNode node, String fieldName) {
         JsonNode value = node.get(fieldName);
-        if (value == null || value.isNull()) {
+        if (value == null || !value.isString()) {
             return null;
         }
         String text = value.asString();
@@ -205,8 +204,9 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
     }
 
-    private static String scanMessage(boolean limited, boolean paginationTruncated, int failedFetches) {
-        if (!limited && !paginationTruncated && failedFetches == 0) {
+    private static String scanMessage(
+            boolean limited, boolean paginationTruncated, int failedPackages, int failedFetches) {
+        if (!limited && !paginationTruncated && failedPackages == 0 && failedFetches == 0) {
             return "Scan completed against OSV.dev.";
         }
         List<String> reasons = new ArrayList<>();
@@ -215,6 +215,12 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
         if (paginationTruncated) {
             reasons.add("some advisories were paginated and not fully fetched");
+        }
+        if (failedPackages > 0) {
+            reasons.add(failedPackages
+                    + (failedPackages == 1
+                            ? " package query was not completed"
+                            : " package queries were not completed"));
         }
         if (failedFetches > 0) {
             reasons.add(failedFetches + (failedFetches == 1 ? " advisory fetch failed" : " advisory fetches failed"));
@@ -226,34 +232,44 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     public DependenciesReport scan(List<DependencyDto> dependencies) {
         long scannedAt = Instant.now().toEpochMilli();
         List<DependencyDto> packages = DependencyReports.scanCandidates(dependencies, properties.getMaxPackages());
+        int packagesScanned = 0;
         if (packages.isEmpty()) {
             return DependencyReports.report(
                     true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
         }
         try {
             QueryBatchResult queryResult = queryBatch(packages);
+            packagesScanned = queryResult.packagesScanned();
             Map<String, List<String>> vulnerabilityIds = queryResult.idsByPackage();
             VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
             List<DependencyDto> enriched = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
             enriched = applyEpss(enriched);
             boolean limited = packages.size() < DependencyReports.scanCandidateCount(dependencies)
                     || uniqueIds(vulnerabilityIds).size() > Math.max(1, properties.getMaxAdvisories());
-            String status =
-                    limited || queryResult.paginationTruncated() || fetched.failedFetches() > 0 ? "PARTIAL" : "SCANNED";
+            String status = limited
+                            || queryResult.paginationTruncated()
+                            || queryResult.failedPackages() > 0
+                            || fetched.failedFetches() > 0
+                    ? "PARTIAL"
+                    : "SCANNED";
             return DependencyReports.report(
                     true,
                     status,
-                    scanMessage(limited, queryResult.paginationTruncated(), fetched.failedFetches()),
+                    scanMessage(
+                            limited,
+                            queryResult.paginationTruncated(),
+                            queryResult.failedPackages(),
+                            fetched.failedFetches()),
                     scannedAt,
-                    packages.size(),
+                    packagesScanned,
                     enriched);
         } catch (IOException | JacksonException ex) {
             return DependencyReports.report(
-                    true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packages.size(), dependencies);
+                    true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packagesScanned, dependencies);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             return DependencyReports.report(
-                    true, "ERROR", "OSV scan was interrupted", scannedAt, packages.size(), dependencies);
+                    true, "ERROR", "OSV scan was interrupted", scannedAt, packagesScanned, dependencies);
         }
     }
 
@@ -263,7 +279,11 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
      * {@link #MAX_QUERY_BATCH_PAGES} (which the scan reports as {@code PARTIAL} rather than presenting an
      * incomplete result set as complete).
      */
-    private record QueryBatchResult(Map<String, List<String>> idsByPackage, boolean paginationTruncated) {}
+    private record QueryBatchResult(
+            Map<String, List<String>> idsByPackage,
+            boolean paginationTruncated,
+            int packagesScanned,
+            int failedPackages) {}
 
     /** One outstanding OSV query awaiting a further page of results. */
     private record PendingQuery(DependencyDto dependency, String pageToken) {}
@@ -271,14 +291,25 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private QueryBatchResult queryBatch(List<DependencyDto> dependencies) throws IOException, InterruptedException {
         Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
         boolean paginationTruncated = false;
+        int packagesScanned = 0;
+        int failedPackages = 0;
         for (int start = 0; start < dependencies.size(); start += MAX_QUERYBATCH_SIZE) {
             List<DependencyDto> chunk =
                     dependencies.subList(start, Math.min(dependencies.size(), start + MAX_QUERYBATCH_SIZE));
-            QueryBatchResult chunkResult = queryBatchChunk(chunk);
-            idsByPackage.putAll(chunkResult.idsByPackage());
-            paginationTruncated = paginationTruncated || chunkResult.paginationTruncated();
+            try {
+                QueryBatchResult chunkResult = queryBatchChunk(chunk);
+                idsByPackage.putAll(chunkResult.idsByPackage());
+                paginationTruncated = paginationTruncated || chunkResult.paginationTruncated();
+                packagesScanned += chunkResult.packagesScanned();
+            } catch (IOException | JacksonException ex) {
+                if (packagesScanned == 0) {
+                    throw ex;
+                }
+                failedPackages = dependencies.size() - start;
+                break;
+            }
         }
-        return new QueryBatchResult(idsByPackage, paginationTruncated);
+        return new QueryBatchResult(idsByPackage, paginationTruncated, packagesScanned, failedPackages);
     }
 
     /**
@@ -326,7 +357,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             pending = nextPending;
             page++;
         }
-        return new QueryBatchResult(idsByPackage, paginationTruncated);
+        return new QueryBatchResult(idsByPackage, paginationTruncated, dependencies.size(), 0);
     }
 
     private JsonNode queryBatchRequest(List<PendingQuery> pending) throws IOException, InterruptedException {
@@ -352,7 +383,36 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             throw new IOException("OSV query returned HTTP " + response.statusCode());
         }
-        return objectMapper.readTree(response.body()).path("results");
+        JsonNode root = objectMapper.readTree(response.body());
+        JsonNode results = root == null ? null : root.get("results");
+        if (root == null || !root.isObject() || results == null || !results.isArray()) {
+            throw new IOException("OSV querybatch response did not contain a results array");
+        }
+        if (results.size() != pending.size()) {
+            throw new IOException(
+                    "OSV querybatch returned " + results.size() + " results for " + pending.size() + " queries");
+        }
+        for (JsonNode result : results) {
+            if (!result.isObject()) {
+                throw new IOException("OSV querybatch returned a non-object result");
+            }
+            JsonNode vulns = result.get("vulns");
+            if (vulns != null && !vulns.isArray()) {
+                throw new IOException("OSV querybatch returned a non-array vulns field");
+            }
+            if (vulns != null) {
+                for (JsonNode vulnerability : vulns) {
+                    if (!vulnerability.isObject() || text(vulnerability, "id") == null) {
+                        throw new IOException("OSV querybatch returned a vulnerability without a non-blank id");
+                    }
+                }
+            }
+            JsonNode pageToken = result.get("next_page_token");
+            if (pageToken != null && !pageToken.isNull() && !pageToken.isString()) {
+                throw new IOException("OSV querybatch returned a non-string next_page_token");
+            }
+        }
+        return results;
     }
 
     /**
@@ -365,6 +425,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private VulnerabilityFetchResult fetchVulnerabilities(Map<String, List<String>> vulnerabilityIds)
             throws InterruptedException {
         List<String> ids = uniqueIds(vulnerabilityIds).stream()
+                .sorted()
                 .limit(Math.max(1, properties.getMaxAdvisories()))
                 .toList();
         if (ids.isEmpty()) {
@@ -378,7 +439,9 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             }
             Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
             int failedFetches = 0;
-            for (Future<JsonNode> future : futures) {
+            for (int i = 0; i < futures.size(); i++) {
+                String expectedId = ids.get(i);
+                Future<JsonNode> future = futures.get(i);
                 JsonNode vulnerability;
                 try {
                     vulnerability = future.get();
@@ -395,15 +458,17 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     failedFetches++;
                     continue;
                 }
-                if (isWithdrawn(vulnerability)) {
-                    // A withdrawn OSV record is no longer considered a valid finding; OSV does not filter
-                    // these out of query results itself, so consumers must.
+                String vulnerabilityId = text(vulnerability, "id");
+                if (!expectedId.equals(vulnerabilityId)) {
+                    failedFetches++;
                     continue;
                 }
-                String vulnerabilityId = text(vulnerability, "id");
-                if (vulnerabilityId != null) {
-                    vulnerabilities.put(vulnerabilityId, vulnerability);
+                if (isWithdrawn(vulnerability)) {
+                    // POST queries exclude withdrawn records, but GET /v1/vulns/{id} returns them; keep this
+                    // detail-stage check so a withdrawn advisory never becomes a finding.
+                    continue;
                 }
+                vulnerabilities.put(expectedId, vulnerability);
             }
             return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
         } finally {
@@ -442,7 +507,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private record VulnerabilityFetchResult(Map<String, JsonNode> vulnerabilities, int failedFetches) {}
 
     private URI vulnerabilityUri(String id) {
-        String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8);
+        String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8).replace("+", "%20");
         return baseUri.resolve("/v1/vulns/" + encoded);
     }
 
@@ -470,6 +535,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         for (DependencyDto dependency : dependencies) {
             List<DependencyVulnerabilityDto> dependencyVulnerabilities =
                     vulnerabilityIds.getOrDefault(key(dependency), List.of()).stream()
+                            .distinct()
                             .map(vulnerabilities::get)
                             .filter(vulnerability -> vulnerability != null)
                             .map(vulnerability -> vulnerability(vulnerability, dependency))
@@ -535,24 +601,23 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         if (severities == null || !severities.isArray()) {
             return null;
         }
+        Double highest = null;
         for (JsonNode severityNode : severities) {
-            String value = text(severityNode, "score");
-            Double parsed = DependencyReports.parseScore(value);
-            if (parsed != null) {
-                return new Severity(DependencyReports.normalizeSeverity(parsed), parsed);
+            Double parsed = DependencyReports.parseScore(text(severityNode, "type"), text(severityNode, "score"));
+            if (parsed != null && (highest == null || parsed > highest)) {
+                highest = parsed;
             }
         }
-        return null;
+        return highest == null ? null : new Severity(DependencyReports.normalizeSeverity(highest), highest);
     }
 
     private record Severity(String label, Double score) {}
 
     /**
-     * Enriches CVE-aliased vulnerabilities with FIRST.org EPSS exploit-probability scores, one batched
-     * request per distinct CVE set per scan (mirroring the existing OSV batch-query pattern). EPSS is a
-     * best-effort secondary signal layered on top of the OSV-derived results: any failure (disabled,
-     * network error, malformed response) leaves the affected vulnerabilities without EPSS fields and never
-     * changes the scan's status or message -- only OSV outcomes do that.
+     * Enriches CVE-linked vulnerabilities with FIRST.org EPSS exploit-probability scores using one or more
+     * requests bounded by FIRST's documented 2,000-character {@code cve} parameter limit. EPSS is a
+     * best-effort secondary signal: any failure leaves the affected vulnerabilities without EPSS fields
+     * and never changes the scan's status or message -- only OSV outcomes do that.
      */
     private List<DependencyDto> applyEpss(List<DependencyDto> dependencies) {
         if (!properties.isEpssEnabled()) {
@@ -568,14 +633,13 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
 
     private Map<String, EpssScore> fetchEpssScores(List<String> cveIds) {
         Map<String, EpssScore> scores = new LinkedHashMap<>();
-        for (int start = 0; start < cveIds.size(); start += EPSS_CHUNK_SIZE) {
-            List<String> chunk = cveIds.subList(start, Math.min(cveIds.size(), start + EPSS_CHUNK_SIZE));
+        for (List<String> chunk : DependencyReports.epssCveChunks(cveIds)) {
             try {
                 scores.putAll(fetchEpssChunk(chunk));
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 break;
-            } catch (IOException | JacksonException ex) {
+            } catch (IOException | JacksonException | IllegalArgumentException ex) {
                 // EPSS is a best-effort enrichment on top of the OSV scan; stop trying further chunks but
                 // keep whatever scores were already fetched rather than failing the scan.
                 break;
@@ -597,16 +661,24 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         }
         JsonNode data = objectMapper.readTree(response.body()).path("data");
         Map<String, EpssScore> scores = new LinkedHashMap<>();
+        Set<String> requested = new LinkedHashSet<>(cveIds);
         if (data.isArray()) {
             for (JsonNode entry : data) {
-                String cve = text(entry, "cve");
+                String cve = DependencyReports.canonicalCveId(text(entry, "cve"));
                 Double probability = parseDouble(text(entry, "epss"));
                 Double percentile = parseDouble(text(entry, "percentile"));
-                if (cve != null && probability != null && percentile != null) {
+                if (cve != null
+                        && requested.contains(cve)
+                        && validProbability(probability)
+                        && validProbability(percentile)) {
                     scores.put(cve, new EpssScore(probability, percentile));
                 }
             }
         }
         return scores;
+    }
+
+    private static boolean validProbability(Double value) {
+        return value != null && Double.isFinite(value) && value >= 0.0d && value <= 1.0d;
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -96,6 +99,39 @@ class DependencyCatalogTests {
         assertThat(withClassPath(jar.toString())).isEmpty();
     }
 
+    @Test
+    void skipsUnreadableMavenMetadataWithoutDiscardingReadableEntries() {
+        Resource readable = new ByteArrayResource(
+                "groupId=com.acme\nartifactId=widget\nversion=1.2.3\n".getBytes(StandardCharsets.UTF_8));
+        Resource unreadable = new ByteArrayResource(new byte[0]) {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                throw new IOException("unreadable");
+            }
+
+            @Override
+            public String getDescription() {
+                return "unreadable pom.properties";
+            }
+        };
+        ResourcePatternResolver resolver = resolver(readable, unreadable);
+
+        List<DependencyDto> dependencies = new DependencyCatalog(resolver).dependencies();
+
+        assertThat(dependencies)
+                .extracting(DependencyDto::packageName, DependencyDto::version)
+                .contains(org.assertj.core.api.Assertions.tuple("com.acme:widget", "1.2.3"));
+    }
+
+    @Test
+    void rejectsJarNamesWhoseVersionOnlySharesAStringPrefix() throws Exception {
+        Path versionDirectory = tempDir.resolve("repository/org/example/widget/1.0");
+        Files.createDirectories(versionDirectory);
+        Path wrongVersionJar = Files.createFile(versionDirectory.resolve("widget-1.0.1.jar"));
+
+        assertThat(withClassPath(wrongVersionJar.toString())).isEmpty();
+    }
+
     private List<DependencyDto> withClassPath(String classPath) {
         String previousClassPath = System.getProperty("java.class.path");
         try {
@@ -108,5 +144,24 @@ class DependencyCatalogTests {
                 System.setProperty("java.class.path", previousClassPath);
             }
         }
+    }
+
+    private static ResourcePatternResolver resolver(Resource... resources) {
+        return new ResourcePatternResolver() {
+            @Override
+            public Resource[] getResources(String locationPattern) {
+                return resources;
+            }
+
+            @Override
+            public Resource getResource(String location) {
+                return new ByteArrayResource(new byte[0]);
+            }
+
+            @Override
+            public ClassLoader getClassLoader() {
+                return DependencyCatalogTests.class.getClassLoader();
+            }
+        };
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -6,6 +6,7 @@ import com.sun.net.httpserver.HttpServer;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -207,6 +208,110 @@ class OsvVulnerabilityScannerTests {
     }
 
     @Test
+    void reportsErrorWhenQuerybatchResultsDoNotMatchTheQueries() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = "{\"results\":[{}]}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(
+                List.of(dependency("org.example", "first", "1.0.0"), dependency("org.example", "second", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("ERROR");
+        assertThat(report.scan().packagesScanned()).isZero();
+        assertThat(report.scan().message()).contains("1 results for 2 queries");
+        assertThat(report.dependencies()).hasSize(2);
+    }
+
+    @Test
+    void reportsErrorWhenQuerybatchContainsAVulnerabilityWithoutAnId() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = "{\"results\":[{\"vulns\":[{}]}]}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("ERROR");
+        assertThat(report.scan().packagesScanned()).isZero();
+        assertThat(report.scan().message()).contains("vulnerability without a non-blank id");
+        assertThat(report.dependencies()).hasSize(1);
+    }
+
+    @Test
+    void deduplicatesRepeatedIdsAndRejectsMismatchedAdvisoryDetails() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        AtomicInteger duplicateFetches = new AtomicInteger();
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                    {"results":[{"vulns":[
+                      {"id":"V-DUPLICATE"},{"id":"V-DUPLICATE"},{"id":"V-MISMATCH"}
+                    ]}]}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/V-DUPLICATE", exchange -> {
+            duplicateFetches.incrementAndGet();
+            byte[] body = """
+                    {"id":"V-DUPLICATE","database_specific":{"severity":"HIGH"}}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/V-MISMATCH", exchange -> {
+            byte[] body = """
+                    {"id":"V-OTHER","database_specific":{"severity":"CRITICAL"}}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().message()).contains("1 advisory fetch failed");
+        assertThat(duplicateFetches).hasValue(1);
+        assertThat(report.dependencies().get(0).vulnerabilities())
+                .extracting("id")
+                .containsExactly("V-DUPLICATE");
+    }
+
+    @Test
     void singleArgConstructorUsesConfiguredOsvBaseUri() {
         BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
 
@@ -304,6 +409,53 @@ class OsvVulnerabilityScannerTests {
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.score()).isNull();
         assertThat(vulnerability.severity()).isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void usesOnlyTypedCvssV3EntriesAndChoosesTheHighestScore() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                    {"results":[{"vulns":[{"id":"GHSA-TYPED-SEVERITY"}]}]}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-TYPED-SEVERITY", exchange -> {
+            byte[] body = """
+                    {
+                      "id":"GHSA-TYPED-SEVERITY",
+                      "severity":[
+                        {"type":"Ubuntu","score":"9.9"},
+                        {"type":"CVSS_V2","score":"10.0"},
+                        {"type":"CVSS_V3","score":"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"},
+                        {"type":"CVSS_V3","score":"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}
+                      ]
+                    }
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        var vulnerability = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")))
+                .dependencies()
+                .get(0)
+                .vulnerabilities()
+                .get(0);
+
+        assertThat(vulnerability.score()).isEqualTo(9.8d);
+        assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
     }
 
     @Test
@@ -667,6 +819,48 @@ class OsvVulnerabilityScannerTests {
     }
 
     @Test
+    void preservesCompletedQueryChunksWhenALaterChunkFails() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        AtomicInteger calls = new AtomicInteger();
+        String firstResults = "{\"results\":[" + "{},".repeat(999) + "{}]}";
+        server.createContext("/v1/querybatch", exchange -> {
+            int call = calls.incrementAndGet();
+            if (call == 1) {
+                byte[] body = firstResults.getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, body.length);
+                exchange.getResponseBody().write(body);
+            } else {
+                byte[] body = "unavailable".getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(503, body.length);
+                exchange.getResponseBody().write(body);
+            }
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(5));
+        properties.setMaxPackages(1001);
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+        List<DependencyDto> dependencies = new ArrayList<>();
+        for (int i = 0; i < 1001; i++) {
+            dependencies.add(dependency("org.example", "sample" + i, "1.0.0"));
+        }
+
+        DependenciesReport report = scanner.scan(dependencies);
+
+        assertThat(calls).hasValue(2);
+        assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().packagesScanned()).isEqualTo(1000);
+        assertThat(report.scan().message()).contains("1 package query was not completed");
+        assertThat(report.dependencies()).hasSize(1001);
+    }
+
+    @Test
     void epssEnrichesCveAliasedVulnerabilityWithProbabilityAndPercentile() throws Exception {
         server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
         server.createContext("/v1/querybatch", exchange -> {
@@ -713,6 +907,63 @@ class OsvVulnerabilityScannerTests {
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.epssScore()).isEqualTo(0.9445d);
         assertThat(vulnerability.epssPercentile()).isEqualTo(0.9999d);
+    }
+
+    @Test
+    void epssUsesCveRecordIdsAndSplitsRequestsAtTheDocumentedCharacterLimit() throws Exception {
+        String longCveOne = "CVE-2024-" + "1".repeat(1200);
+        String longCveTwo = "CVE-2024-" + "2".repeat(1200);
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                    {"results":[{"vulns":[{"id":"CVE-2024-1234"},{"id":"GHSA-LONG-CVES"}]}]}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        registerAdvisory("CVE-2024-1234", "HIGH");
+        server.createContext("/v1/vulns/GHSA-LONG-CVES", exchange -> {
+            byte[] body = ("{\"id\":\"GHSA-LONG-CVES\",\"aliases\":[\"" + longCveOne + "\",\"" + longCveTwo
+                            + "\"],\"database_specific\":{\"severity\":\"LOW\"}}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        AtomicInteger epssCalls = new AtomicInteger();
+        server.createContext("/data/v1/epss", exchange -> {
+            epssCalls.incrementAndGet();
+            String cveParameter =
+                    exchange.getRequestURI().getRawQuery().split("&", 2)[0].substring("cve=".length());
+            assertThat(cveParameter).hasSizeLessThanOrEqualTo(DependencyReports.EPSS_CVE_PARAMETER_MAX_LENGTH);
+            byte[] body = """
+                    {"data":[{"cve":"CVE-2024-1234","epss":"0.125","percentile":"0.75"}]}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        properties.setEpssBaseUri("http://localhost:" + server.getAddress().getPort());
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+
+        assertThat(epssCalls).hasValue(2);
+        var cveFinding = report.dependencies().get(0).vulnerabilities().stream()
+                .filter(vulnerability -> "CVE-2024-1234".equals(vulnerability.id()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(cveFinding.epssScore()).isEqualTo(0.125d);
+        assertThat(cveFinding.epssPercentile()).isEqualTo(0.75d);
     }
 
     @Test
@@ -856,6 +1107,54 @@ class OsvVulnerabilityScannerTests {
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.fixedVersions()).isEmpty();
         assertThat(vulnerability.fixAvailable()).isFalse();
+    }
+
+    @Test
+    void ignoresGitCommitFixesAndOrdersMavenFixedVersions() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/v1/querybatch", exchange -> {
+            byte[] body = """
+                    {"results":[{"vulns":[{"id":"GHSA-RANGE-TYPES"}]}]}
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.createContext("/v1/vulns/GHSA-RANGE-TYPES", exchange -> {
+            byte[] body = """
+                    {
+                      "id":"GHSA-RANGE-TYPES",
+                      "database_specific":{"severity":"HIGH"},
+                      "affected":[{
+                        "package":{"ecosystem":"Maven","name":"org.example:sample"},
+                        "ranges":[
+                          {"type":"GIT","events":[{"fixed":"abcdef123456"}]},
+                          {"type":"ECOSYSTEM","events":[{"fixed":"1.0-sp1"},{"fixed":"1.0-rc1"},{"fixed":"1.0"}]}
+                        ]
+                      }]
+                    }
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
+        server.start();
+
+        BootUiProperties.Vulnerabilities properties = new BootUiProperties.Vulnerabilities();
+        properties.setRequestTimeout(Duration.ofSeconds(2));
+        OsvVulnerabilityScanner scanner = new OsvVulnerabilityScanner(
+                properties,
+                HttpClient.newHttpClient(),
+                new ObjectMapper(),
+                URI.create("http://localhost:" + server.getAddress().getPort()));
+
+        var vulnerability = scanner.scan(List.of(dependency("org.example", "sample", "0.9")))
+                .dependencies()
+                .get(0)
+                .vulnerabilities()
+                .get(0);
+
+        assertThat(vulnerability.fixedVersions()).containsExactly("1.0-rc1", "1.0", "1.0-sp1");
     }
 
     @Test

--- a/bootui-spring-sample-app/e2e/tests/vulnerabilities.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/vulnerabilities.spec.js
@@ -149,7 +149,8 @@ function vulnerability(id, severity, summary, fixedVersion, aliases = [], fixAva
     // Every call site here uses a fixedVersion strictly newer than the mocked dependency's current
     // version, i.e. a genuine upgrade target -- so fixAvailable defaults to true, matching what the
     // real DependencyReports.fixAvailable() derivation would compute for these fixtures. Override it
-    // explicitly for a scenario that should render "already on a fixed version" or "No fix published yet".
+    // explicitly for a scenario that should render "No newer fixed version reported by OSV" or
+    // "No fixed version reported by OSV".
     fixAvailable
   }
 }

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/SpringVulnerabilitiesIntegrationTest.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/SpringVulnerabilitiesIntegrationTest.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.sample;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
@@ -38,6 +39,7 @@ class SpringVulnerabilitiesIntegrationTest {
     private static final String ADVISORY_ID = "GHSA-spring-it-0001";
     private static final Path DISMISSALS_FILE = Path.of("target/vulnerabilities-it/boot-ui.yml");
     private static final AtomicInteger QUERY_CALLS = new AtomicInteger();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static HttpServer osv;
 
     @LocalServerPort
@@ -165,7 +167,7 @@ class SpringVulnerabilitiesIntegrationTest {
             osv = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
             osv.createContext("/v1/querybatch", exchange -> {
                 QUERY_CALLS.incrementAndGet();
-                respond(exchange, "{\"results\":[{\"vulns\":[{\"id\":\"" + ADVISORY_ID + "\"}]}]}");
+                respond(exchange, queryBatchResponse(exchange.getRequestBody().readAllBytes()));
             });
             osv.createContext(
                     "/v1/vulns/",
@@ -178,6 +180,18 @@ class SpringVulnerabilitiesIntegrationTest {
         } catch (IOException ex) {
             throw new IllegalStateException("Could not start the OSV stub", ex);
         }
+    }
+
+    private static String queryBatchResponse(byte[] requestBody) throws IOException {
+        int queryCount = OBJECT_MAPPER.readTree(requestBody).path("queries").size();
+        StringBuilder response = new StringBuilder("{\"results\":[");
+        for (int i = 0; i < queryCount; i++) {
+            if (i > 0) {
+                response.append(',');
+            }
+            response.append(i == 0 ? "{\"vulns\":[{\"id\":\"" + ADVISORY_ID + "\"}]}" : "{}");
+        }
+        return response.append("]}").toString();
     }
 
     private static void respond(HttpExchange exchange, String body) throws IOException {

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
@@ -34,7 +34,11 @@ function dependency(packageName, version, vulnerabilities, highestSeverity) {
   }
 }
 
-function report(dependencies, vulnerable = dependencies.filter((d) => d.vulnerabilityCount > 0).length) {
+function report(
+  dependencies,
+  vulnerable = dependencies.filter((d) => d.vulnerabilityCount > 0).length,
+  status = 'SCANNED'
+) {
   return {
     scanningEnabled: true,
     total: dependencies.length,
@@ -47,7 +51,7 @@ function report(dependencies, vulnerable = dependencies.filter((d) => d.vulnerab
     ],
     scan: {
       scanner: 'OSV.dev',
-      status: 'SCANNED',
+      status,
       message: 'Scan completed against OSV.dev.',
       scannedAt: 1_700_000_000_000,
       packagesScanned: dependencies.length,
@@ -65,7 +69,7 @@ function report(dependencies, vulnerable = dependencies.filter((d) => d.vulnerab
  * re-fetching after a dismiss/restore, so each test supplies the *next* report reflecting the
  * expected server-side effect.
  */
-async function mountWithReports(reports) {
+async function mountWithReports(reports, props = {}) {
   let callIndex = 0
   const fetchMock = vi.fn((input, init) => {
     const url = typeof input === 'string' ? input : input.toString()
@@ -82,7 +86,7 @@ async function mountWithReports(reports) {
   })
   vi.stubGlobal('fetch', fetchMock)
 
-  const wrapper = mount(Vulnerabilities)
+  const wrapper = mount(Vulnerabilities, {props})
   await flushPromises()
   return {wrapper, fetchMock}
 }
@@ -131,6 +135,18 @@ describe('Vulnerabilities', () => {
     const {wrapper} = await mountWithReports([report([clean])])
 
     expect(wrapper.text()).toContain('None found')
+  })
+
+  it('does not claim a dependency is clean before or during an incomplete scan', async () => {
+    const dependencyWithoutFindings = dependency('org.example:unknown', '1.0.0', [], 'NONE')
+    const {wrapper: notScanned} = await mountWithReports([report([dependencyWithoutFindings], 0, 'NOT_SCANNED')])
+
+    expect(notScanned.text()).toContain('Not scanned')
+    expect(notScanned.text()).not.toContain('None found')
+
+    const {wrapper: partial} = await mountWithReports([report([dependencyWithoutFindings], 0, 'PARTIAL')])
+    expect(partial.text()).toContain('No finding in partial result')
+    expect(partial.text()).not.toContain('None found')
   })
 
   it('keeps a dismissed-only dependency out of "None found" so it can still be restored', async () => {
@@ -215,6 +231,22 @@ describe('Vulnerabilities', () => {
     expect(wrapper.text()).toContain('Dismiss')
   })
 
+  it('disables vulnerability dismissal when the panel is read-only', async () => {
+    const active = dependency(
+      'org.example:sample',
+      '1.0.0',
+      [vulnerability('GHSA-active-0001', 'CRITICAL', false)],
+      'CRITICAL'
+    )
+    const {wrapper, fetchMock} = await mountWithReports([report([active])], {
+      panel: {readOnly: true, readOnlyReason: 'Disabled by policy.'}
+    })
+
+    const dismissButton = wrapper.find('button.btn-outline-secondary')
+    expect(dismissButton.attributes('disabled')).toBeDefined()
+    expect(fetchMock.mock.calls.filter(([url]) => String(url).startsWith('api/dismissed-rules/'))).toHaveLength(0)
+  })
+
   it('renders the numeric CVSS base score next to the severity badge', async () => {
     const scored = dependency(
       'org.example:scored',
@@ -297,7 +329,7 @@ describe('Vulnerabilities', () => {
     expect(wrapper.text()).not.toContain('No fixed version reported by OSV')
   })
 
-  it('shows "already on a fixed version" when fixedVersions is non-empty but fixAvailable is false', async () => {
+  it('does not claim the installed dependency is fixed when OSV still matched it as vulnerable', async () => {
     const alreadyFixed = dependency(
       'org.example:already-fixed',
       '2.0.0',
@@ -306,7 +338,8 @@ describe('Vulnerabilities', () => {
     )
     const {wrapper} = await mountWithReports([report([alreadyFixed])])
 
-    expect(wrapper.text()).toContain('already on a fixed version')
+    expect(wrapper.text()).toContain('No newer fixed version reported by OSV (reported: 1.5.0)')
+    expect(wrapper.text()).not.toContain('already on a fixed version')
     expect(wrapper.text()).not.toContain('No fixed version reported by OSV')
   })
 

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -84,8 +84,20 @@ function dismissalKey(vulnerabilityId, packageName) {
 }
 
 function toggleDismiss(dependency, vulnerability) {
+  if (readOnly.value) {
+    showReadOnlyMessage()
+    return
+  }
   const key = dismissalKey(vulnerability.id, dependency.packageName)
   return vulnerability.dismissed ? restore(key) : dismiss(key)
+}
+
+function emptyAdvisoryText() {
+  const status = data.value?.scan?.status
+  if (status === 'NOT_SCANNED' || status === 'DISABLED') return 'Not scanned'
+  if (status === 'ERROR') return 'Unknown (scan failed)'
+  if (status === 'PARTIAL') return 'No finding in partial result'
+  return 'None found'
 }
 
 const filteredDependencies = computed(() => {
@@ -343,7 +355,9 @@ onMounted(loadDependencies)
                   </span>
                 </td>
                 <td>
-                  <span v-if="dependency.vulnerabilities.length === 0" class="text-muted">None found</span>
+                  <span v-if="dependency.vulnerabilities.length === 0" class="text-muted">
+                    {{ emptyAdvisoryText() }}
+                  </span>
                   <div v-else class="vulnerability-list">
                     <div
                       v-for="vulnerability in sortedVulnerabilities(dependency.vulnerabilities)"
@@ -381,12 +395,13 @@ onMounted(loadDependencies)
                           fixed in {{ vulnerability.fixedVersions.join(', ') }}
                         </span>
                         <span v-else-if="vulnerability.fixedVersions.length" class="small text-muted">
-                          already on a fixed version (&ge; {{ vulnerability.fixedVersions.join(', ') }})
+                          No newer fixed version reported by OSV (reported:
+                          {{ vulnerability.fixedVersions.join(', ') }})
                         </span>
                         <span v-else class="small text-muted fst-italic">No fixed version reported by OSV</span>
                         <span v-if="vulnerability.dismissed" class="badge text-bg-light border">Dismissed</span>
                         <button
-                          :disabled="dismissLoading"
+                          :disabled="dismissLoading || readOnly"
                           :title="vulnerability.dismissed ? 'Restore this vulnerability' : 'Dismiss this vulnerability'"
                           class="btn btn-sm btn-outline-secondary ms-auto"
                           type="button"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -580,20 +580,22 @@ vulnerable dependencies from the running project's dependency set during the loc
 ordered by severity first (dismissed findings sink to the bottom regardless of severity), with dependencies and
 advisories alphabetized within the same severity.
 
-Severity is derived from [OSV.dev](https://osv.dev/)'s `severity[]` entries, whose `score` field is a CVSS vector string
-for `CVSS_V3`/`CVSS_V4` types (for example `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`), never a bare number. Per the
+Severity is derived from [OSV.dev](https://osv.dev/)'s `severity[]` entries, whose `type` identifies how its `score`
+must be interpreted. BootUI computes only `CVSS_V3` entries carrying a CVSS v3.0/v3.1 vector (for example
+`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`); it never treats a bare number or another provider's scale as CVSS. Per the
 [OSV schema](https://ossf.github.io/osv-schema/#severity), a package-level `affected[].severity` entry — when present for
 the specific dependency being scored — takes priority over the advisory's top-level `severity[]` (the schema states the
 two are mutually exclusive, and some advisories only carry severity at the package level), so the scanner looks there
-first before falling back to the top-level array. A CVSS v3.0/v3.1 vector (from either level) is parsed into a real
-numeric Base Score using the formula from the
+first before falling back to the top-level array. When an array contains multiple valid CVSS v3 entries, the highest
+Base Score is used conservatively. A CVSS v3.0/v3.1 vector is parsed using the formula from the
 [FIRST.org CVSS v3.1 specification](https://www.first.org/cvss/v3-1/specification-document); CVSS v4.0 has no
 closed-form Base Score equation (its MacroVector lookup table is a much larger undertaking), and BootUI's calculator is
 intentionally v3-specific rather than implementing the separate CVSS v2 formula, so both fall back to the advisory's
 `database_specific.severity` label (`CRITICAL`/`HIGH`/`MODERATE`/`LOW`, normalized to BootUI's `MEDIUM` label) when no
-v3 score is present at either level. An advisory with neither a parseable CVSS v3 score nor a `database_specific` label
-renders as `UNKNOWN` rather than being silently dropped. Advisories carrying a `withdrawn` timestamp are excluded from
-results entirely, since OSV does not filter withdrawn records out of its API responses itself. A single advisory detail
+v3 score is present at either level. CVSS `0.0` is reported as `NONE`, matching FIRST's qualitative scale. An advisory
+with neither a parseable CVSS v3 score nor a `database_specific` label renders as `UNKNOWN` rather than being silently
+dropped. Advisories carrying a `withdrawn` timestamp are excluded from results. OSV omits withdrawn records from POST
+query responses but returns them from `GET /v1/vulns/{id}`, so the scanner keeps a defensive detail-stage check. A single advisory detail
 fetch that fails (network hiccup, rate limiting) no longer aborts the whole scan: it is counted and the scan degrades to
 `PARTIAL`, keeping every advisory that *did* fetch successfully instead of discarding the whole result. Advisory detail
 fetches (`GET /v1/vulns/{id}`) run with a small bounded concurrency (up to 10 at a time) rather than one at a time, so a
@@ -607,12 +609,19 @@ limit so a pathological advisory can't loop the scan forever (degrading to `PART
 pagination is exhausted, rather than silently truncating). Independently, OSV also enforces a hard limit of 1,000
 queries per `/v1/querybatch` request; the scanner partitions the (already `max-packages`-bounded) package list into
 batches of at most 1,000 before querying, so configuring `max-packages` above 1,000 no longer causes OSV to reject the
-whole batch with an HTTP 400.
+whole batch with an HTTP 400. Every successful response must contain exactly one structurally valid result per query,
+and every reported vulnerability reference must carry a non-blank id. Missing, short, or malformed result arrays fail
+visibly instead of being interpreted as a clean scan. Repeated advisory
+ids are fetched/reported once per dependency, and a detail response whose id does not match the requested advisory is
+counted as a failed fetch. If a later query chunk fails after an earlier chunk completed, the completed results are
+preserved as `PARTIAL` and `packagesScanned` reports only the completed package queries.
 
-Each advisory whose `aliases` includes a `CVE-*` id is additionally enriched with
+Each advisory whose own id or `aliases` includes a canonical `CVE-*` id is additionally enriched with
 [EPSS](https://www.first.org/epss/) (Exploit Prediction Scoring System) data from FIRST.org's free, unauthenticated API
-— one batched `GET /data/v1/epss?cve=...` request per scan, alongside the OSV calls, following the same
-"network call only on the user-initiated scan action" pattern. EPSS reports the modeled probability that a CVE will be
+— one or more batched `GET /data/v1/epss?cve=...` requests per scan, each respecting FIRST's documented 2,000-character
+maximum for the comma-separated `cve` parameter, alongside the OSV calls and following the same "network call only on
+the user-initiated scan action" pattern. Returned ids must belong to the request and probability/percentile values must
+be finite numbers from 0 to 1. EPSS reports the modeled probability that a CVE will be
 exploited in the wild in the next 30 days, plus the percentile that probability ranks against every other scored CVE —
 a likelihood-of-exploitation signal that deliberately complements (rather than replaces) CVSS's severity-if-exploited
 score, and is rendered as a secondary badge next to the severity/CVSS badge (for example "2.3% EPSS", with a tooltip
@@ -621,10 +630,12 @@ spelling out the percentile). EPSS lookups can be disabled independently of OSV 
 the OSV results — it simply omits the badge for that scan.
 
 Each advisory also carries a derived `fixAvailable` boolean, computed by comparing the dependency's currently-resolved
-version against the advisory's `fixedVersions` with Maven `ComparableVersion` qualifier ordering, including
-alpha/beta/milestone/RC/SNAPSHOT/release/service-pack semantics. This lets the UI distinguish a genuine upgrade target
-("fixed in `x.y.z`") from a dependency already at or above every fixed version OSV reported. When OSV reports no
-`fixed` event, the UI says only "No fixed version reported by OSV": under the OSV 1.8 schema a range may instead close
+version against the advisory's Maven fixed-version candidates with `ComparableVersion` qualifier ordering, including
+alpha/beta/milestone/RC/SNAPSHOT/release/service-pack semantics. Git commit hashes from `GIT` ranges are not presented as
+Maven upgrades, and candidates are de-duplicated and sorted using Maven semantics. The UI renders a newer candidate as
+"fixed in `x.y.z`"; if every reported candidate is at or below the installed version, it says only that OSV reported no
+newer fixed version, never that the installed dependency is fixed when OSV just matched it as affected. When OSV reports no
+`fixed` event, the UI says only "No fixed version reported by OSV": under the OSV schema a range may instead close
 with a mutually exclusive `last_affected` event, which identifies the final vulnerable version without naming the first
 non-vulnerable version, so absence of `fixedVersions` is not proof that no fix exists.
 
@@ -635,7 +646,9 @@ vulnerability is scoped to one dependency, it is keyed by `<vulnerability id>::<
 `GHSA-xxxx-xxxx-xxxx::org.example:sample`) rather than a bare rule id, so dismissing a finding for one dependency never
 accidentally hides the same advisory id reported against a different dependency, and a dismissal survives a
 patch-version bump of the still-vulnerable dependency. Dismissed vulnerabilities stay visible (dimmed, with a
-_Restore_ button) rather than disappearing, and are excluded from the per-dependency and panel-level vulnerable counts.
+_Restore_ button) rather than disappearing, are excluded from the per-dependency and panel-level vulnerable counts, and
+trigger a fresh deterministic dependency ordering from the recomputed active severity. Dismiss/restore controls are
+disabled when the Vulnerabilities panel is read-only.
 
 On Quarkus the panel is identical, listing the local inventory first and contacting OSV.dev only on the user-initiated
 scan, over the same report contract, the same CVSS/withdrawn/partial-failure handling, the same pagination/batch-
@@ -643,7 +656,10 @@ chunking, the same EPSS enrichment, and the same dismiss/restore workflow. The o
 discovery: the Spring adapter scans the classpath for `META-INF/maven/*/pom.properties`, which is unreliable under the
 Quarkus runtime classloader. For JARs without embedded metadata, Spring also reads an adjacent Maven POM (including in
 nonstandard local-repository paths), and only falls back to path-derived coordinates when a literal `repository`
-directory makes the group path unambiguous; it never guesses a group id from an arbitrary cache path. The Quarkus
+directory makes the group path unambiguous; it never guesses a group id from an arbitrary cache path. Unreadable
+individual `pom.properties` resources are logged and skipped instead of failing the complete inventory, and classpath
+JAR filenames must match the resolved artifact/version exactly (with an optional classifier) rather than merely sharing
+a version prefix. The Quarkus
 inventory is captured at build time from the application's resolved runtime
 dependency model and read back at runtime (mirroring the Architecture panel's build-time base-package discovery). The
 OSV and EPSS lookups are identical, and `bootui.vulnerabilities.osv-enabled=false` /

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -695,31 +695,45 @@ Features:
 - Provide an explicit "Scan with OSV.dev" action that sends Maven package names and versions to OSV.dev.
 - Show scan status, vulnerable dependency count, advisory count, severity breakdown, advisory links, aliases, and fixed
   versions when available.
-- Derive severity from a real CVSS v3.0/v3.1 Base Score computed from the advisory's CVSS vector (per the FIRST.org
-  specification) when present, preferring a package-level `affected[].severity` entry matching the scanned dependency
-  over the advisory's top-level `severity[]` (the OSV schema states the two are mutually exclusive), falling back to
-  the advisory's `database_specific` severity label when no CVSS vector is present at either level; render `UNKNOWN`
-  only when none of these is available, never silently drop the finding.
+- Derive severity only from OSV entries explicitly typed `CVSS_V3` and carrying a valid CVSS v3.0/v3.1 vector (per the
+  FIRST.org specification), choosing the highest valid v3 Base Score when multiple entries exist. Prefer a
+  package-level `affected[].severity` entry matching the scanned dependency over the advisory's top-level
+  `severity[]` (the OSV schema states the two are mutually exclusive), falling back to the advisory's
+  `database_specific` severity label when no supported vector is present; render CVSS `0.0` as `NONE` and `UNKNOWN`
+  only when no supported score/label is available. Never reinterpret bare numbers, CVSS v2/v4, or provider-specific
+  scales as CVSS v3, and never silently drop the finding.
 - Exclude advisories marked `withdrawn` by OSV from results and counts.
 - Follow OSV `/v1/querybatch` pagination (`next_page_token`) until every query is exhausted or a bounded page-count
-  safety limit is hit, and partition the outgoing package list into batches of at most 1,000 queries (OSV's documented
-  hard limit per request), merging every page/batch back into one result set.
+  safety limit is hit, and partition the outgoing package list into batches of at most 1,000 queries (the OSV server
+  implementation's hard limit), merging every page/batch back into one result set. Validate that every response
+  contains exactly one structurally valid result per submitted query; never reinterpret a missing/short/malformed
+  response as an empty result. Require every returned vulnerability reference to be an object with a non-blank id.
+  Preserve completed chunks as `PARTIAL` if a later chunk fails and report only completed package queries in
+  `packagesScanned`.
 - Fetch distinct advisory details (`GET /v1/vulns/{id}`) with a small bounded concurrency (up to 10 at a time) instead of
-  one at a time, so scans against a dependency tree with many distinct advisories stay responsive.
-- Enrich each CVE-aliased advisory with FIRST.org [EPSS](https://www.first.org/epss/) exploit-probability data
-  (probability + percentile) in one batched request per scan, alongside the OSV calls; EPSS is a likelihood-of-
+  one at a time, so scans against a dependency tree with many distinct advisories stay responsive. De-duplicate repeated
+  ids per dependency and require each detail response id to match the requested id; mismatch/missing-id responses count
+  as failed fetches. Keep the detail-stage withdrawn check because POST queries omit withdrawn records while
+  `GET /v1/vulns/{id}` can return them.
+- Enrich each advisory linked to a canonical CVE through either its own id or an alias with FIRST.org
+  [EPSS](https://www.first.org/epss/) exploit-probability data (probability + percentile) in one or more batched requests
+  per scan, each respecting FIRST's 2,000-character maximum for the comma-separated `cve` parameter, alongside the OSV calls; EPSS is a likelihood-of-
   exploitation signal that deliberately complements, rather than replaces, the CVSS severity-if-exploited score. EPSS
-  lookups can be disabled independently of OSV scanning, and a failed/unreachable EPSS request never fails the scan or
-  discards the underlying OSV results — it just omits the EPSS figures.
+  responses may enrich only CVEs requested in that chunk and must contain finite probability/percentile values from
+  0 to 1. Lookups can be disabled independently of OSV scanning, and a failed/unreachable EPSS request never fails the
+  scan or discards the underlying OSV results — it just omits the EPSS figures.
 - Derive an explicit `fixAvailable` signal per advisory by comparing the dependency's currently-resolved version
-  against the advisory's `fixedVersions` using Maven `ComparableVersion` qualifier semantics. An empty list means only
+  against the advisory's non-`GIT` `fixedVersions` using Maven `ComparableVersion` qualifier semantics; de-duplicate and
+  order candidates using those same semantics. A false signal means only that OSV reported no candidate newer than the
+  installed version, not that the installed dependency is unaffected. An empty list means only
   that OSV reported no `fixed` event: a range may instead end with `last_affected`, which names the final vulnerable
   version but does not identify the first non-vulnerable upgrade target. The UI must not conflate that state with proof
   that no fix exists.
 - Support disabling OSV scans with `bootui.vulnerabilities.osv-enabled=false`.
 - Allow dismissing/restoring an individual vulnerability finding for a specific dependency, excluding it from the
   vulnerable count and severity rollups until restored, consistent with the dismiss/restore workflow shared by every
-  other advisor.
+  other advisor. Recompute dependency ordering from active severity after every dismissal change, and disable the
+  Vulnerabilities panel's dismissal controls under panel read-only policy.
 
 Acceptance criteria:
 
@@ -729,6 +743,9 @@ Acceptance criteria:
   inventory; a failure fetching one advisory's details does not discard advisories that were already fetched
   successfully, degrading the scan to a partial-success status instead of an outright error.
 - Scan size is bounded by configuration so large classpaths remain responsive.
+- Initial/error/partial UI states must not label an empty advisory list as a clean "None found" result.
+- An unreadable Spring `pom.properties` resource is logged and skipped without discarding readable inventory entries;
+  Quarkus continues to use its build-time resolved runtime dependency model and fails soft on malformed entries.
 
 Known limitation: the dependency inventory on both adapters is coordinate-based (one resolved JAR = one artifact
 coordinate). A vulnerable library relocated/repackaged inside a shaded or uber JAR has no `pom.properties`/build-time


### PR DESCRIPTION
## Summary

Hardens the Vulnerabilities advisor against malformed or partial upstream data while keeping scans explicit, bounded, local-first, and behaviorally identical across Spring MVC, Spring WebFlux, and Quarkus.

- validates OSV query envelopes, positional result cardinality, vulnerability ids, advisory-detail identity, pagination tokens, and withdrawn detail records
- preserves completed query chunks as truthful partial results and reports only completed package queries
- interprets only typed CVSS v3 vectors, handles the official `NONE` band, and keeps unsupported CVSS v2/v4/provider scales on the documented fallback path
- canonicalizes CVE identities and splits EPSS lookups at FIRST's 2,000-character parameter limit while validating returned ids and probability bounds
- filters Git commits from Maven upgrade suggestions, orders fixes with Maven semantics, and removes the incorrect "already fixed" claim
- isolates unreadable Spring inventory metadata, tightens JAR coordinate matching, recomputes dismissal ordering, and aligns read-only/empty UI states

## Research and decisions

The audit used public primary sources:

- [OSV schema](https://ossf.github.io/osv-schema/)
- [OSV querybatch API](https://google.github.io/osv.dev/post-v1-querybatch/)
- [OSV withdrawn-record FAQ](https://google.github.io/osv.dev/faq/)
- [FIRST EPSS API](https://api.first.org/epss/)
- [FIRST CVSS v3.1 specification](https://www.first.org/cvss/v3-1/specification-document)
- [FIRST CVSS v4.0 specification](https://www.first.org/cvss/v4.0/specification-document)
- [Maven 3.9.16 `ComparableVersion`](https://maven.apache.org/ref/3.9.16/maven-artifact/xref/org/apache/maven/artifact/versioning/ComparableVersion.html)
- comparable behavior in [OSV-Scanner](https://google.github.io/osv-scanner/configuration/) and [Trivy](https://trivy.dev/latest/docs/scanner/vulnerability/)

| Classification | Decision |
| --- | --- |
| **KEEP** | Explicit user-triggered scans; network-free inventory/render; local-only safety; existing request timeouts, response-body bounds, package/advisory/page limits, bounded advisory concurrency, single-flight scan caching, and OSV-owned affected-range evaluation. |
| **MODIFY** | Fail closed on malformed OSV envelopes; retain completed chunks on later failure; require matching advisory ids; use schema-typed CVSS v3; canonicalize/bound EPSS; apply Maven ordering to reported fixes; recompute dismissal ordering; isolate unreadable Spring inventory entries. |
| **REMOVE** | Untyped/numeric severity interpretation, Git hashes presented as Maven fixes, the one-request EPSS assumption, the incorrect withdrawn-response rationale, and UI copy claiming an OSV-matched installed version is already fixed. |
| **NEW** | CVE-record-id EPSS enrichment, deterministic EPSS character-budget chunks, strict positional/result-id edge coverage, partial-batch parity tests, and honest unscanned/error/partial empty states. |

No repository code, credentials, or secrets were sent to external research services.

## Dependency inventory and platform parity

The shared engine owns CVSS, CVE/EPSS, Maven-version, aggregation, ordering, and dismissal policy. Spring and Quarkus retain thin JSON/HTTP adapters with mirrored behavior; their only intentional differences remain Jackson 3 vs Jackson 2 and native configuration types.

Spring continues to discover runtime Maven metadata and classpath JARs, but one unreadable `pom.properties` no longer discards the inventory, resolver failure falls back to `java.class.path`, and filename matching rejects version-prefix collisions. Quarkus keeps its build-time resolved runtime dependency model and existing fail-soft behavior.

Both real-boot OSV fixtures now return one positional result per submitted package, matching the upstream querybatch contract.

## Tests

Local checks:

- engine CVSS/report/version/EPSS/dismissal and Spring dependency-inventory tests
- Spring OSV scanner suite: 30 tests
- Quarkus OSV scanner suite: 33 tests
- Spring and Quarkus real-boot Vulnerabilities integration suites: 5 tests
- complete frontend unit suite: 692 tests
- Spring Vulnerabilities Playwright flow
- Maven Spotless and all frontend/E2E Prettier checks

Hosted checks:

- full Java 17 build, coverage gates, frontend tests, and Spring browser suites
- Quarkus Java 17 end-to-end browser suite
- Java 21 and Java 25 focused compatibility suites
- CodeQL (Java/Kotlin and JavaScript/TypeScript), documentation build, and dependency submission

## Limitations

- CVSS v4 scoring remains deferred until a vetted implementation can be validated against FIRST reference vectors; v4 continues to use the advisory database-severity fallback.
- BootUI does not reimplement OSV affected-range membership; it compares only OSV-reported Maven fixed candidates for presentation.
- Alias-component advisory collapsing, alias-aware dismissal migration/reason/expiry, per-dependency coverage DTOs, cached-report export, aggregate text budgets, and EPSS as-of dates remain separate contract/design work.
- Coordinate inventories cannot identify libraries relocated inside shaded or uber JARs without resolvable metadata.

## Advisor audit protocol

- Independent reviewers: Claude Opus 5 (max, long context), GPT-5.6 Terra (max, long context), and Gemini 3.1 Pro (high, long context), all against the same frozen `main` snapshot.
- Evidence and decisions: official OSV, FIRST, Maven sources and comparable scanners were researched before the KEEP/MODIFY/REMOVE/NEW synthesis above.
- Acceptance policy: only bounded, deterministic, platform-parity changes were accepted; deferred contract work remains explicit.
- Delivery policy: focused/full validation and hosted CI are required; auto-merge is disabled.