### PR TITLE
Audit JVM tuning advisor recommendations

### DIFF
--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/KubernetesMemoryRecommendationDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/KubernetesMemoryRecommendationDto.java
@@ -3,8 +3,9 @@ package io.github.jdubois.bootui.core.dto;
 import java.util.List;
 
 /**
- * Kubernetes resource recommendation derived from the JVM memory
- * calculator and the current runtime snapshot.
+ * Kubernetes resource recommendation derived from the JVM memory calculator and the current runtime
+ * snapshot. {@code qosClass} is only definitive when the emitted memory settings determine the answer:
+ * equal memory request/limit values report that Pod QoS still depends on CPU settings.
  */
 public record KubernetesMemoryRecommendationDto(
         long requestMemoryBytes,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MemoryCalculationDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MemoryCalculationDto.java
@@ -5,9 +5,10 @@ package io.github.jdubois.bootui.core.dto;
  *
  * <p>Computed by partitioning a target container memory budget into JVM regions:
  * {@code heap = totalMemory − headRoom − directMemory − metaspace − codeCache − stack×threads}.
- * Mirrors the formula in {@code paketo-buildpacks/libjvm/calc/calculator.go} with one
- * adaptation: we use the live loaded-class count from {@link java.lang.management.ClassLoadingMXBean}
- * with a safety factor instead of the buildpack's build-time JAR-entry estimate.
+ * Mirrors the formula in {@code paketo-buildpacks/libjvm/calc/calculator.go} with live-observation
+ * adaptations: the live loaded-class count replaces the buildpack's build-time JAR-entry estimate,
+ * direct memory is raised to at least current direct-buffer usage, and virtual-thread detection does
+ * not reduce the conservative platform-thread stack reserve.
  */
 public record MemoryCalculationDto(
         long totalMemoryBytes,

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCalculator.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCalculator.java
@@ -325,7 +325,7 @@ final class MemoryCalculator {
 
         StringBuilder sb = new StringBuilder(256);
         sb.append("-Xms").append(heapMb).append("m");
-        sb.append("-Xmx").append(heapMb).append("m");
+        sb.append(" -Xmx").append(heapMb).append("m");
         sb.append(" -XX:MaxMetaspaceSize=").append(metaMb).append("m");
         sb.append(" -XX:ReservedCodeCacheSize=").append(ccMb).append("m");
         sb.append(" -Xss").append(stackKb).append("k");

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCalculator.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCalculator.java
@@ -1,7 +1,7 @@
 package io.github.jdubois.bootui.engine.memory;
 
 import io.github.jdubois.bootui.core.dto.MemoryCalculationDto;
-import java.util.Locale;
+import java.math.BigDecimal;
 
 /**
  * Paketo {@code libjvm}-style JVM memory calculator.
@@ -13,8 +13,8 @@ import java.util.Locale;
  * </pre>
  *
  * <p>The formula and the default region sizes mirror
- * {@code paketo-buildpacks/libjvm/calc/calculator.go}. We deviate from the
- * buildpack on two points because BootUI has access to a live JVM:
+ * {@code paketo-buildpacks/libjvm/calc/calculator.go}. We adapt the
+ * buildpack model where BootUI has live JVM observations:
  *
  * <ul>
  *   <li><b>Loaded class count</b> comes from
@@ -24,10 +24,14 @@ import java.util.Locale;
  *       not applied. We do apply a {@link #META_SAFETY_FACTOR} on top of the
  *       observed count to account for lazy class loading after the user
  *       opens the panel.</li>
- *   <li><b>Default thread count</b> is {@code max(liveThreads, 250)} for
- *       platform threads and {@code max(liveThreads, 80)} when Spring
- *       virtual threads are enabled, so a freshly-started small app doesn't
- *       under-reserve stack memory.</li>
+ *   <li><b>Direct memory</b> keeps libjvm's 10 MiB fallback, but is raised to
+ *       at least the currently observed direct-buffer usage. The generated
+ *       options deliberately do not hard-cap direct memory because a live
+ *       snapshot cannot predict future Netty/NIO demand.</li>
+ *   <li><b>Default thread count</b> is {@code max(liveThreads, 250)}. Virtual
+ *       threads do not reduce this platform-thread reserve or {@code -Xss}:
+ *       their stacks are heap-backed, while carrier and helper platform
+ *       threads still use native stacks.</li>
  * </ul>
  *
  * <p>This class is pure (no Spring, no JMX); the controller resolves all
@@ -35,27 +39,23 @@ import java.util.Locale;
  */
 final class MemoryCalculator {
 
+    private static final long MEBIBYTE = 1024L * 1024L;
+
     /**
-     * libjvm: {@code DefaultDirectMemory = 10 * Mebi}.
+     * libjvm: {@code DefaultDirectMemory = 10 * Mebi}. This is a modeling
+     * fallback, not a universally safe hard cap.
      */
-    static final long DIRECT_MEMORY_BYTES = 10L * 1024 * 1024;
+    static final long DIRECT_MEMORY_BYTES = 10L * MEBIBYTE;
 
     /**
      * libjvm: {@code DefaultReservedCodeCache = 240 * Mebi}.
      */
-    static final long CODE_CACHE_BYTES = 240L * 1024 * 1024;
+    static final long CODE_CACHE_BYTES = 240L * MEBIBYTE;
 
     /**
      * libjvm: {@code DefaultStack = 1 * Mebi}.
      */
-    static final long STACK_BYTES_PER_THREAD = 1L * 1024 * 1024;
-
-    /**
-     * Smaller platform-thread stacks for virtual-thread deployments. The JVM
-     * still needs carrier/platform thread stacks, but the request-concurrency
-     * model no longer reserves one native stack per request.
-     */
-    static final long VIRTUAL_THREAD_STACK_BYTES_PER_THREAD = 512L * 1024;
+    static final long STACK_BYTES_PER_THREAD = MEBIBYTE;
 
     /**
      * libjvm: {@code ClassOverhead = 14_000_000} (decimal MB, not MiB).
@@ -69,9 +69,9 @@ final class MemoryCalculator {
 
     /**
      * Safety factor on observed loaded-class count, used to size metaspace.
-     * The live count is a snapshot; Spring lazily loads many classes
-     * (devtools, JDBC drivers, error paths, JSON serializers …) after the
-     * panel is first opened. 1.25× gives a forgiving but not wasteful cap.
+     * The live count is a snapshot and applications can load more classes
+     * after the panel opens. This is an explicit BootUI heuristic, not a JVM
+     * ergonomic guarantee.
      */
     static final double META_SAFETY_FACTOR = 1.25;
 
@@ -80,44 +80,23 @@ final class MemoryCalculator {
      */
     static final int DEFAULT_THREAD_COUNT_FLOOR = 250;
 
-    /**
-     * Conservative carrier/platform-thread floor when Spring virtual threads are
-     * enabled. It leaves room for Tomcat acceptors, GC/JIT/helper threads,
-     * scheduler/database workers, and carrier threads without assuming a
-     * 200-thread servlet request pool.
-     */
-    static final int VIRTUAL_THREAD_COUNT_FLOOR = 80;
-
     static final int MIN_THREAD_COUNT = 1;
     static final int MAX_THREAD_COUNT = 10_000;
     static final int MIN_HEAD_ROOM_PERCENT = 0;
-    static final int MAX_HEAD_ROOM_PERCENT = 90;
-    static final long MIN_TOTAL_MEMORY_BYTES = 128L * 1024 * 1024;
-    static final long MAX_TOTAL_MEMORY_BYTES = 64L * 1024 * 1024 * 1024;
-
-    private static final long GC_FLIP_HEAP_BYTES = 4L * 1024 * 1024 * 1024;
-
-    private final JdkVersion jdkVersion;
-
-    MemoryCalculator() {
-        this(JdkVersion.current());
-    }
-
-    MemoryCalculator(JdkVersion jdkVersion) {
-        this.jdkVersion = jdkVersion;
-    }
+    static final int MAX_HEAD_ROOM_PERCENT = 30;
+    static final long MIN_TOTAL_MEMORY_BYTES = 128L * MEBIBYTE;
+    static final long MAX_TOTAL_MEMORY_BYTES = 64L * 1024 * MEBIBYTE;
 
     static int defaultThreadCount(int liveThreadCount) {
-        return defaultThreadCount(liveThreadCount, false);
+        return Math.max(liveThreadCount, DEFAULT_THREAD_COUNT_FLOOR);
     }
 
-    static int defaultThreadCount(int liveThreadCount, boolean virtualThreadsEnabled) {
-        int floor = virtualThreadsEnabled ? VIRTUAL_THREAD_COUNT_FLOOR : DEFAULT_THREAD_COUNT_FLOOR;
-        return Math.max(liveThreadCount, floor);
+    private static long bytesToMiBFloor(long bytes) {
+        return Math.max(0, bytes / MEBIBYTE);
     }
 
-    private static long bytesToMb(long bytes) {
-        return Math.max(0, Math.round(bytes / (1024.0 * 1024.0)));
+    private static long bytesToMiBCeil(long bytes) {
+        return Math.max(0, (bytes + MEBIBYTE - 1) / MEBIBYTE);
     }
 
     private static long roundUpTo(long value, long multiple) {
@@ -188,6 +167,28 @@ final class MemoryCalculator {
             int liveLoadedClassCount,
             boolean virtualThreadsEnabled,
             String virtualThreadsProperty) {
+        return calculate(
+                totalMemoryBytes,
+                threadCount,
+                loadedClasses,
+                headRoomPercent,
+                liveThreadCount,
+                liveLoadedClassCount,
+                virtualThreadsEnabled,
+                virtualThreadsProperty,
+                0);
+    }
+
+    MemoryCalculationDto calculate(
+            long totalMemoryBytes,
+            int threadCount,
+            int loadedClasses,
+            int headRoomPercent,
+            int liveThreadCount,
+            int liveLoadedClassCount,
+            boolean virtualThreadsEnabled,
+            String virtualThreadsProperty,
+            long observedDirectMemoryBytes) {
 
         long clampedTotal = clamp(totalMemoryBytes, MIN_TOTAL_MEMORY_BYTES, MAX_TOTAL_MEMORY_BYTES);
         int clampedThreads = (int) clamp(threadCount, MIN_THREAD_COUNT, MAX_THREAD_COUNT);
@@ -195,23 +196,25 @@ final class MemoryCalculator {
         int clampedClasses = Math.max(loadedClasses, 0);
 
         long metaspaceBytes = computeMetaspaceBytes(clampedClasses);
-        long stackBytesPerThread = stackBytesPerThread(virtualThreadsEnabled);
+        long directMemoryBytes = computeDirectMemoryBytes(observedDirectMemoryBytes);
+        long stackBytesPerThread = STACK_BYTES_PER_THREAD;
         long stackBytesTotal = stackBytesPerThread * (long) clampedThreads;
-        long fixedRegionsBytes = DIRECT_MEMORY_BYTES + metaspaceBytes + CODE_CACHE_BYTES + stackBytesTotal;
+        long fixedRegionsBytes = directMemoryBytes + metaspaceBytes + CODE_CACHE_BYTES + stackBytesTotal;
         long headRoomBytes = (long) ((clampedHeadRoom / 100.0) * clampedTotal);
         long heapBytes = clampedTotal - headRoomBytes - fixedRegionsBytes;
 
-        if (heapBytes <= 0) {
+        if (heapBytes < MEBIBYTE) {
             String message = String.format(
-                    "No room for heap: fixed regions (%d MB) + headroom (%d MB) >= total (%d MB). "
+                    "No room for a renderable heap: fixed regions (%d MiB) + headroom (%d MiB) "
+                            + "leave less than 1 MiB from the %d MiB total. "
                             + "Try a larger total memory, fewer threads, or lower headroom.",
-                    bytesToMb(fixedRegionsBytes), bytesToMb(headRoomBytes), bytesToMb(clampedTotal));
+                    bytesToMiBCeil(fixedRegionsBytes), bytesToMiBCeil(headRoomBytes), bytesToMiBCeil(clampedTotal));
             return new MemoryCalculationDto(
                     clampedTotal,
                     0,
                     metaspaceBytes,
                     CODE_CACHE_BYTES,
-                    DIRECT_MEMORY_BYTES,
+                    directMemoryBytes,
                     stackBytesPerThread,
                     stackBytesTotal,
                     headRoomBytes,
@@ -228,15 +231,14 @@ final class MemoryCalculator {
                     message);
         }
 
-        String jvmOptions =
-                buildJvmOptions(heapBytes, metaspaceBytes, CODE_CACHE_BYTES, DIRECT_MEMORY_BYTES, stackBytesPerThread);
+        String jvmOptions = buildJvmOptions(heapBytes, metaspaceBytes, CODE_CACHE_BYTES, stackBytesPerThread);
 
         return new MemoryCalculationDto(
                 clampedTotal,
                 heapBytes,
                 metaspaceBytes,
                 CODE_CACHE_BYTES,
-                DIRECT_MEMORY_BYTES,
+                directMemoryBytes,
                 stackBytesPerThread,
                 stackBytesTotal,
                 headRoomBytes,
@@ -256,44 +258,38 @@ final class MemoryCalculator {
     /**
      * Pick a sensible default {@code totalMemoryBytes} that is independent of
      * the host machine's RAM. We size to roughly 1.5× the app's observed
-     * footprint, with a floor sized to fit all fixed regions plus 128 MB of
+     * footprint, with a floor sized to fit all fixed regions plus 128 MiB of
      * heap, and a hard upper clamp of 2 GiB so a 32 GB Mac doesn't poison
      * the recommendation. The user can move the value freely afterwards.
      */
     long defaultTotalMemoryBytes(
             long heapCommittedBytes, long nonHeapCommittedBytes, int threadCount, int loadedClasses) {
-        return defaultTotalMemoryBytes(heapCommittedBytes, nonHeapCommittedBytes, threadCount, loadedClasses, false);
-    }
-
-    long defaultTotalMemoryBytes(
-            long heapCommittedBytes,
-            long nonHeapCommittedBytes,
-            int threadCount,
-            int loadedClasses,
-            boolean virtualThreadsEnabled) {
-
-        int safeThreads =
-                Math.max(threadCount, virtualThreadsEnabled ? VIRTUAL_THREAD_COUNT_FLOOR : DEFAULT_THREAD_COUNT_FLOOR);
+        int safeThreads = Math.max(threadCount, DEFAULT_THREAD_COUNT_FLOOR);
         long fixed = DIRECT_MEMORY_BYTES
                 + computeMetaspaceBytes(loadedClasses)
                 + CODE_CACHE_BYTES
-                + stackBytesPerThread(virtualThreadsEnabled) * (long) safeThreads;
-        long floor = fixed + 128L * 1024 * 1024;
+                + STACK_BYTES_PER_THREAD * (long) safeThreads;
+        long floor = fixed + 128L * MEBIBYTE;
 
         long useful = heapCommittedBytes + Math.max(0, nonHeapCommittedBytes);
         useful = useful + (useful / 2); // ×1.5 footprint
 
         long picked = Math.max(floor, useful);
-        picked = roundUpTo(picked, 64L * 1024 * 1024);
+        picked = roundUpTo(picked, 64L * MEBIBYTE);
 
-        long min = 384L * 1024 * 1024;
-        long max = 2048L * 1024 * 1024;
+        long min = 384L * MEBIBYTE;
+        long max = 2048L * MEBIBYTE;
         return clamp(picked, min, max);
     }
 
     private long computeMetaspaceBytes(int loadedClasses) {
         double withFactor = (META_BASE_BYTES + META_PER_CLASS_BYTES * (double) loadedClasses) * META_SAFETY_FACTOR;
-        return (long) Math.ceil(withFactor);
+        return roundUpTo((long) Math.ceil(withFactor), MEBIBYTE);
+    }
+
+    private static long computeDirectMemoryBytes(long observedDirectMemoryBytes) {
+        long boundedObserved = clamp(observedDirectMemoryBytes, 0, MAX_TOTAL_MEMORY_BYTES);
+        return Math.max(DIRECT_MEMORY_BYTES, roundUpTo(boundedObserved, MEBIBYTE));
     }
 
     String buildKubernetesJvmOptions(
@@ -303,98 +299,36 @@ final class MemoryCalculator {
         }
 
         StringBuilder sb = new StringBuilder(256);
-        sb.append("-XX:+UseContainerSupport");
-        sb.append(" -XX:MaxRAMPercentage=").append(formatPercentage(maxRamPercentage));
+        sb.append("-XX:MaxRAMPercentage=").append(formatPercentage(maxRamPercentage));
+        sb.append(" -XX:MinRAMPercentage=").append(formatPercentage(maxRamPercentage));
         sb.append(" -XX:InitialRAMPercentage=").append(formatPercentage(initialRamPercentage));
         sb.append(" -XX:MaxMetaspaceSize=")
-                .append(bytesToMb(calculation.metaspaceBytes()))
+                .append(bytesToMiBCeil(calculation.metaspaceBytes()))
                 .append("m");
         sb.append(" -XX:ReservedCodeCacheSize=")
-                .append(bytesToMb(calculation.codeCacheBytes()))
-                .append("m");
-        sb.append(" -XX:MaxDirectMemorySize=")
-                .append(bytesToMb(calculation.directMemoryBytes()))
+                .append(bytesToMiBCeil(calculation.codeCacheBytes()))
                 .append("m");
         sb.append(" -Xss").append(calculation.stackBytesPerThread() / 1024).append("k");
-        appendCommonOptions(sb, calculation.heapBytes());
         return sb.toString();
     }
 
-    private static long stackBytesPerThread(boolean virtualThreadsEnabled) {
-        return virtualThreadsEnabled ? VIRTUAL_THREAD_STACK_BYTES_PER_THREAD : STACK_BYTES_PER_THREAD;
-    }
-
     private static String formatPercentage(double percentage) {
-        return String.format(Locale.ROOT, "%.1f", percentage);
+        return BigDecimal.valueOf(percentage).stripTrailingZeros().toPlainString();
     }
 
-    private String buildJvmOptions(
-            long heapBytes,
-            long metaspaceBytes,
-            long codeCacheBytes,
-            long directMemoryBytes,
-            long stackBytesPerThread) {
+    private String buildJvmOptions(long heapBytes, long metaspaceBytes, long codeCacheBytes, long stackBytesPerThread) {
 
-        long heapMb = bytesToMb(heapBytes);
-        long metaMb = bytesToMb(metaspaceBytes);
-        long ccMb = bytesToMb(codeCacheBytes);
-        long dmMb = bytesToMb(directMemoryBytes);
+        long heapMb = bytesToMiBFloor(heapBytes);
+        long metaMb = bytesToMiBCeil(metaspaceBytes);
+        long ccMb = bytesToMiBCeil(codeCacheBytes);
         long stackKb = stackBytesPerThread / 1024;
 
         StringBuilder sb = new StringBuilder(256);
         sb.append("-Xms").append(heapMb).append("m");
-        sb.append(" -Xmx").append(heapMb).append("m");
+        sb.append("-Xmx").append(heapMb).append("m");
         sb.append(" -XX:MaxMetaspaceSize=").append(metaMb).append("m");
         sb.append(" -XX:ReservedCodeCacheSize=").append(ccMb).append("m");
-        sb.append(" -XX:MaxDirectMemorySize=").append(dmMb).append("m");
         sb.append(" -Xss").append(stackKb).append("k");
-        sb.append(" -XX:+AlwaysPreTouch");
-        appendCommonOptions(sb, heapBytes);
         return sb.toString();
-    }
-
-    private void appendCommonOptions(StringBuilder sb, long heapBytes) {
-        boolean usesZgc = heapBytes >= GC_FLIP_HEAP_BYTES;
-        if (usesZgc) {
-            sb.append(" -XX:+UseZGC");
-            // JEP 439 (JDK 21) added generational ZGC as an experimental opt-in; JEP 474 (JDK 23)
-            // made it the default and deprecated the flag (a warning is printed if it is set
-            // explicitly); JEP 490 (JDK 24) obsoletes it further, and later releases stop
-            // recognizing it altogether, causing the JVM to refuse to start. So the flag is only
-            // useful on 21/22.
-            if (jdkVersion.feature() >= 21 && jdkVersion.feature() < 23) {
-                sb.append(" -XX:+ZGenerational");
-            }
-        } else {
-            sb.append(" -XX:+UseG1GC");
-        }
-        // G1 has supported string deduplication since JDK 8u20 (JEP 192); ZGC only gained support
-        // in JDK 18. Setting it with ZGC on an older JDK is not fatal, but the JVM disables it with
-        // a startup warning ("String Deduplication disabled: not supported by selected GC"), so skip
-        // it there rather than emit a flag that silently does nothing.
-        if (!usesZgc || jdkVersion.feature() >= 18) {
-            sb.append(" -XX:+UseStringDeduplication");
-        }
-        if (jdkVersion.feature() >= 25) {
-            sb.append(" -XX:+UseCompactObjectHeaders");
-        }
-        sb.append(" -XX:+ExitOnOutOfMemoryError");
-        sb.append(" -XX:+HeapDumpOnOutOfMemoryError");
-        sb.append(" -XX:HeapDumpPath=/tmp");
-    }
-
-    /**
-     * Indirection over {@link Runtime#version()} so tests can pin the feature
-     * version and verify JDK-gated options (e.g. {@code UseCompactObjectHeaders}
-     * which became a product flag in JDK 25 / JEP 519 and is rejected on
-     * earlier JDKs).
-     */
-    @FunctionalInterface
-    interface JdkVersion {
-        static JdkVersion current() {
-            return () -> Runtime.version().feature();
-        }
-
-        int feature();
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryKubernetesSizer.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryKubernetesSizer.java
@@ -3,16 +3,13 @@ package io.github.jdubois.bootui.engine.memory;
 import io.github.jdubois.bootui.core.dto.KubernetesMemoryRecommendationDto;
 import io.github.jdubois.bootui.core.dto.MemoryCalculationDto;
 import io.github.jdubois.bootui.spi.HealthProbeManifest;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 final class MemoryKubernetesSizer {
 
-    static final int RECOMMENDED_MIN_HEADROOM_PERCENT = 10;
-    static final int RECOMMENDED_MAX_HEADROOM_PERCENT = 15;
-    static final double MAX_HEAP_PERCENTAGE = 75.0;
-    static final double RECOMMENDED_MIN_HEAP_PERCENTAGE = 65.0;
+    static final int DEFAULT_HEADROOM_PERCENT = 10;
 
     private static final long MB = 1024L * 1024L;
     private static final long MIN_BURSTABLE_REQUEST_BYTES = 128L * MB;
@@ -29,6 +26,7 @@ final class MemoryKubernetesSizer {
             long directBufferMemoryUsedBytes,
             boolean nativeMemoryTrackingEnabled,
             Long detectedContainerLimitBytes,
+            Long detectedContainerCurrentUsageBytes,
             double maxRamPercentage,
             double initialRamPercentage,
             String javaToolOptions,
@@ -37,7 +35,10 @@ final class MemoryKubernetesSizer {
             HealthProbeManifest healthProbeManifest) {
 
         long currentSnapshotBytes = estimateCurrentSnapshotBytes(
-                calculation, heapCommittedBytes, nonHeapCommittedBytes, directBufferMemoryUsedBytes);
+                heapCommittedBytes,
+                nonHeapCommittedBytes,
+                directBufferMemoryUsedBytes,
+                detectedContainerCurrentUsageBytes);
         String detectedContainerLimitMemory =
                 detectedContainerLimitBytes == null ? null : formatMi(detectedContainerLimitBytes);
 
@@ -73,15 +74,14 @@ final class MemoryKubernetesSizer {
                 calculation,
                 nativeMemoryTrackingEnabled,
                 detectedContainerLimitBytes,
+                detectedContainerCurrentUsageBytes,
                 burstableRequestBytes,
                 limitBytes,
-                maxRamPercentage,
-                javaToolOptions,
                 burstableEnabled,
                 healthProbesEnabled,
                 healthProbeManifest);
-        String confidence = confidence(calculation, nativeMemoryTrackingEnabled, detectedContainerLimitBytes);
-        String qosClass = requestBytes < limitBytes ? "Burstable" : "Guaranteed";
+        String confidence = confidence(calculation, detectedContainerLimitBytes, detectedContainerCurrentUsageBytes);
+        String qosClass = requestBytes < limitBytes ? "Burstable" : "Depends on CPU";
         String yaml = buildYaml(
                 formatMi(requestBytes),
                 formatMi(limitBytes),
@@ -116,26 +116,34 @@ final class MemoryKubernetesSizer {
             return 0;
         }
         double calculated = calculation.heapBytes() * 100.0 / calculation.totalMemoryBytes();
-        return Math.max(1.0, Math.min(MAX_HEAP_PERCENTAGE, calculated));
+        double floored = Math.floor(calculated * 1000.0) / 1000.0;
+        return floored > 0 ? floored : calculated;
     }
 
     private static long estimateCurrentSnapshotBytes(
-            MemoryCalculationDto calculation,
             long heapCommittedBytes,
             long nonHeapCommittedBytes,
-            long directBufferMemoryUsedBytes) {
+            long directBufferMemoryUsedBytes,
+            Long detectedContainerCurrentUsageBytes) {
 
-        long liveStackBytes = calculation.stackBytesPerThread() * Math.max(0L, calculation.liveThreadCount());
-        return nonNegative(heapCommittedBytes)
-                + nonNegative(nonHeapCommittedBytes)
-                + nonNegative(directBufferMemoryUsedBytes)
-                + liveStackBytes;
+        if (detectedContainerCurrentUsageBytes != null) {
+            return nonNegative(detectedContainerCurrentUsageBytes);
+        }
+        long committedPools = saturatedAdd(nonNegative(heapCommittedBytes), nonNegative(nonHeapCommittedBytes));
+        return saturatedAdd(committedPools, nonNegative(directBufferMemoryUsedBytes));
     }
 
     private static long estimateBurstableRequestBytes(long limitBytes, long currentSnapshotBytes) {
         long marginBytes =
                 Math.max(MIN_SNAPSHOT_MARGIN_BYTES, Math.round(currentSnapshotBytes * SNAPSHOT_MARGIN_FACTOR));
-        long rounded = roundUpTo(Math.max(MIN_BURSTABLE_REQUEST_BYTES, currentSnapshotBytes + marginBytes));
+        long snapshotWithMargin = currentSnapshotBytes > Long.MAX_VALUE - marginBytes
+                ? Long.MAX_VALUE
+                : currentSnapshotBytes + marginBytes;
+        long requestWithFloor = Math.max(MIN_BURSTABLE_REQUEST_BYTES, snapshotWithMargin);
+        if (requestWithFloor >= limitBytes) {
+            return limitBytes;
+        }
+        long rounded = roundUpTo(requestWithFloor);
         return Math.min(limitBytes, rounded);
     }
 
@@ -143,28 +151,38 @@ final class MemoryKubernetesSizer {
             MemoryCalculationDto calculation,
             boolean nativeMemoryTrackingEnabled,
             Long detectedContainerLimitBytes,
+            Long detectedContainerCurrentUsageBytes,
             long burstableRequestBytes,
             long limitBytes,
-            double maxRamPercentage,
-            String javaToolOptions,
             boolean burstableEnabled,
             boolean healthProbesEnabled,
             HealthProbeManifest healthProbeManifest) {
 
         List<String> warnings = new ArrayList<>();
-        warnings.add(garbageCollectorWarning(javaToolOptions));
-        if (burstableEnabled) {
+        boolean memoryRequestBelowLimit = burstableEnabled && burstableRequestBytes < limitBytes;
+        if (memoryRequestBelowLimit) {
             warnings.add(
-                    "Burstable mode lowers requests.memory below limits.memory; use it only in clusters that intentionally overcommit memory.");
+                    "Because requests.memory is below limits.memory, this container prevents the Pod from receiving Guaranteed QoS.");
         } else {
             warnings.add(
-                    "Request equals limit for Kubernetes Guaranteed QoS; enable burstable mode only in clusters that intentionally overcommit memory.");
+                    "Memory request equals memory limit. Kubernetes Guaranteed QoS additionally requires equal, non-zero CPU request and limit for every container in the Pod.");
+            if (burstableEnabled) {
+                warnings.add(
+                        "Burstable mode did not lower requests.memory because the current snapshot plus its safety margin reaches the selected limit.");
+            }
         }
         if (!healthProbesEnabled) {
             warnings.add(healthProbeManifest.probesOmittedWarning());
+        } else {
+            warnings.add(
+                    "Health probes use the framework's default paths and the named container port \"http\"; verify both against custom application or management-server settings.");
         }
         warnings.add(
-                "JAVA_TOOL_OPTIONS uses MaxRAMPercentage/InitialRAMPercentage so the heap follows the container memory limit; fixed metaspace, code cache, direct memory, and stack caps must still fit if you shrink the pod.");
+                "JAVA_TOOL_OPTIONS uses MaxRAMPercentage, MinRAMPercentage, and InitialRAMPercentage so HotSpot follows the container limit across small and regular heaps. Metaspace, code cache, and thread-stack caps remain fixed.");
+        warnings.add(
+                "Direct memory is modeled at "
+                        + formatMi(calculation.directMemoryBytes())
+                        + " from the 10 MiB fallback and current direct-buffer usage, but is intentionally not hard-capped; validate Netty/NIO demand under representative load.");
         if (detectedContainerLimitBytes != null && detectedContainerLimitBytes.longValue() != limitBytes) {
             warnings.add("Detected cgroup memory limit is "
                     + formatMi(detectedContainerLimitBytes)
@@ -172,66 +190,41 @@ final class MemoryKubernetesSizer {
                     + formatMi(limitBytes)
                     + "; update the total memory input if you want the manifest to match the live container limit.");
         }
-        if (calculation.headRoomPercent() < RECOMMENDED_MIN_HEADROOM_PERCENT) {
-            warnings.add("Headroom below "
-                    + RECOMMENDED_MIN_HEADROOM_PERCENT
-                    + "% leaves little room for native allocations; Kubernetes deployments usually start at "
-                    + RECOMMENDED_MIN_HEADROOM_PERCENT
-                    + "-"
-                    + RECOMMENDED_MAX_HEADROOM_PERCENT
-                    + "% unless measured otherwise.");
-        }
         if (!nativeMemoryTrackingEnabled) {
+            warnings.add("Native Memory Tracking is not enabled; this model cannot attribute all native JVM memory.");
+        } else {
             warnings.add(
-                    "Native Memory Tracking is not enabled, so native overhead is estimated from JVM pools and runtime defaults.");
+                    "Native Memory Tracking is enabled, but BootUI does not consume its output; confidence remains model-based.");
         }
         if (calculation.threadCount() < calculation.liveThreadCount()) {
             warnings.add(
                     "Thread budget is below the current live thread count; increase it before applying these limits.");
         }
-        double calculatedHeapPercentage = calculation.heapBytes() * 100.0 / limitBytes;
-        if (calculatedHeapPercentage > MAX_HEAP_PERCENTAGE) {
-            warnings.add("Kubernetes heap sizing is capped at "
-                    + formatPercentage(MAX_HEAP_PERCENTAGE)
-                    + "% of the container limit to leave room for native memory.");
-        } else if (maxRamPercentage < RECOMMENDED_MIN_HEAP_PERCENTAGE) {
-            warnings.add(
-                    "Heap is "
-                            + formatPercentage(maxRamPercentage)
-                            + "% of the container limit because fixed non-heap and thread-stack reservations are high for this memory size.");
-        }
         if (burstableRequestBytes < limitBytes) {
-            warnings.add(
-                    "The burstable request is based on the current committed-memory snapshot and can be too low after warmup.");
+            if (detectedContainerCurrentUsageBytes != null) {
+                warnings.add(
+                        "The burstable request starts from the current cgroup memory.current snapshot and can still be too low after warmup or a workload change.");
+            } else {
+                warnings.add(
+                        "cgroup memory.current is unavailable, so the burstable request falls back to committed JVM pools plus observed direct buffers and can be too low after warmup.");
+            }
         }
         return warnings;
     }
 
-    private static String garbageCollectorWarning(String javaToolOptions) {
-        if (javaToolOptions != null && javaToolOptions.contains("-XX:+UseZGC")) {
-            String mode = javaToolOptions.contains("-XX:+ZGenerational") ? " with generational mode" : "";
-            return "Garbage collector: ZGC"
-                    + mode
-                    + " is selected for calculated heaps of 4 GiB or more to prioritize low pause times.";
-        }
-        if (javaToolOptions != null && javaToolOptions.contains("-XX:+UseG1GC")) {
-            return "Garbage collector: G1GC is selected for calculated heaps below 4 GiB; the advisor switches to ZGC for larger heaps.";
-        }
-        return "Garbage collector: unavailable until the JVM options can be calculated.";
-    }
-
     private static String confidence(
-            MemoryCalculationDto calculation, boolean nativeMemoryTrackingEnabled, Long detectedContainerLimitBytes) {
+            MemoryCalculationDto calculation,
+            Long detectedContainerLimitBytes,
+            Long detectedContainerCurrentUsageBytes) {
         if (!calculation.valid()) {
             return "Low";
         }
         if (detectedContainerLimitBytes != null
                 && detectedContainerLimitBytes.longValue() == calculation.totalMemoryBytes()
-                && nativeMemoryTrackingEnabled
-                && calculation.headRoomPercent() >= RECOMMENDED_MIN_HEADROOM_PERCENT) {
-            return "High";
+                && detectedContainerCurrentUsageBytes != null) {
+            return "Medium";
         }
-        return "Medium";
+        return "Low";
     }
 
     private static String buildYaml(
@@ -240,7 +233,6 @@ final class MemoryKubernetesSizer {
             String javaToolOptions,
             boolean healthProbesEnabled,
             HealthProbeManifest healthProbeManifest) {
-        String escapedJvmOptions = javaToolOptions.replace("\\", "\\\\").replace("\"", "\\\"");
         StringBuilder yaml = new StringBuilder(512);
         yaml.append("resources:\n")
                 .append("  requests:\n")
@@ -255,7 +247,7 @@ final class MemoryKubernetesSizer {
                 .append("  - name: JAVA_TOOL_OPTIONS\n")
                 .append("    value: >-\n")
                 .append("      ")
-                .append(escapedJvmOptions);
+                .append(javaToolOptions);
         if (healthProbesEnabled) {
             // Terminate the JAVA_TOOL_OPTIONS value line before the (optional) enabling env entry or the
             // probe stanzas, so frameworks without an enabling env var (e.g. Quarkus) still yield valid YAML.
@@ -272,7 +264,7 @@ final class MemoryKubernetesSizer {
                     .append("    path: ")
                     .append(healthProbeManifest.startupPath())
                     .append("\n")
-                    .append("    port: 8080\n")
+                    .append("    port: http\n")
                     .append("  failureThreshold: 30\n")
                     .append("  periodSeconds: 10\n")
                     .append("readinessProbe:\n")
@@ -280,7 +272,7 @@ final class MemoryKubernetesSizer {
                     .append("    path: ")
                     .append(healthProbeManifest.readinessPath())
                     .append("\n")
-                    .append("    port: 8080\n")
+                    .append("    port: http\n")
                     .append("  periodSeconds: 10\n")
                     .append("  timeoutSeconds: 5\n")
                     .append("  failureThreshold: 3\n")
@@ -289,7 +281,7 @@ final class MemoryKubernetesSizer {
                     .append("    path: ")
                     .append(healthProbeManifest.livenessPath())
                     .append("\n")
-                    .append("    port: 8080\n")
+                    .append("    port: http\n")
                     .append("  periodSeconds: 15\n")
                     .append("  timeoutSeconds: 5\n")
                     .append("  failureThreshold: 3");
@@ -299,6 +291,10 @@ final class MemoryKubernetesSizer {
 
     private static long nonNegative(long value) {
         return Math.max(0, value);
+    }
+
+    private static long saturatedAdd(long left, long right) {
+        return left > Long.MAX_VALUE - right ? Long.MAX_VALUE : left + right;
     }
 
     private static long roundUpTo(long value) {
@@ -314,6 +310,6 @@ final class MemoryKubernetesSizer {
     }
 
     private static String formatPercentage(double percentage) {
-        return String.format(Locale.ROOT, "%.1f", percentage);
+        return BigDecimal.valueOf(percentage).stripTrailingZeros().toPlainString();
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryReportProvider.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryReportProvider.java
@@ -15,6 +15,8 @@ import java.util.OptionalLong;
  */
 public class MemoryReportProvider {
 
+    private static final long MEBIBYTE = 1024L * 1024L;
+
     private final MemoryCalculator calculator;
     private final ContainerMemoryLimitDetector containerMemoryLimitDetector;
     private final MemoryRuntimeConfig runtimeConfig;
@@ -73,22 +75,20 @@ public class MemoryReportProvider {
         int liveThreads = threadBean.getThreadCount();
         int liveClasses = classBean.getLoadedClassCount();
         OptionalLong detectedContainerMemoryLimit = containerMemoryLimitDetector.detectLimit();
+        OptionalLong detectedContainerCurrentUsage = containerMemoryLimitDetector.detectCurrentUsage();
+        long directBufferMemoryUsedBytes = directBufferMemoryUsedBytes();
         boolean resolvedVirtualThreadsEnabled = resolveVirtualThreadsEnabled();
         boolean resolvedKubernetesBurstableEnabled = kubernetesBurstableEnabled != null && kubernetesBurstableEnabled;
         boolean resolvedKubernetesActuatorEnabled = resolveKubernetesActuatorEnabled(kubernetesActuatorEnabled);
-        int defaultThreadCount = MemoryCalculator.defaultThreadCount(liveThreads, resolvedVirtualThreadsEnabled);
+        int defaultThreadCount = MemoryCalculator.defaultThreadCount(liveThreads);
 
         long resolvedTotalBytes = totalMemoryMb != null
-                ? totalMemoryMb * 1024L * 1024L
+                ? totalMemoryBytes(totalMemoryMb)
                 : detectedContainerMemoryLimit.orElseGet(() -> calculator.defaultTotalMemoryBytes(
-                        heapUsage.getCommitted(),
-                        nonHeapUsage.getCommitted(),
-                        defaultThreadCount,
-                        liveClasses,
-                        resolvedVirtualThreadsEnabled));
+                        heapUsage.getCommitted(), nonHeapUsage.getCommitted(), defaultThreadCount, liveClasses));
         int resolvedThreads = threadCount != null ? threadCount : defaultThreadCount;
         int resolvedHeadRoom =
-                headRoomPercent != null ? headRoomPercent : MemoryKubernetesSizer.RECOMMENDED_MIN_HEADROOM_PERCENT;
+                headRoomPercent != null ? headRoomPercent : MemoryKubernetesSizer.DEFAULT_HEADROOM_PERCENT;
 
         MemoryCalculationDto calculation = calculator.calculate(
                 resolvedTotalBytes,
@@ -98,9 +98,12 @@ public class MemoryReportProvider {
                 liveThreads,
                 liveClasses,
                 resolvedVirtualThreadsEnabled,
-                runtimeConfig.virtualThreadsProperty());
+                runtimeConfig.virtualThreadsProperty(),
+                directBufferMemoryUsedBytes);
         Long detectedContainerMemoryLimitBytes =
                 detectedContainerMemoryLimit.isPresent() ? detectedContainerMemoryLimit.getAsLong() : null;
+        Long detectedContainerCurrentUsageBytes =
+                detectedContainerCurrentUsage.isPresent() ? detectedContainerCurrentUsage.getAsLong() : null;
         double maxRamPercentage = MemoryKubernetesSizer.heapPercentage(calculation);
         double initialRamPercentage = maxRamPercentage;
         String kubernetesJvmOptions =
@@ -109,9 +112,10 @@ public class MemoryReportProvider {
                 calculation,
                 heapUsage.getCommitted(),
                 nonHeapUsage.getCommitted(),
-                directBufferMemoryUsedBytes(),
+                directBufferMemoryUsedBytes,
                 nativeMemoryTrackingEnabled(inputArgs),
                 detectedContainerMemoryLimitBytes,
+                detectedContainerCurrentUsageBytes,
                 maxRamPercentage,
                 initialRamPercentage,
                 kubernetesJvmOptions,
@@ -120,6 +124,13 @@ public class MemoryReportProvider {
                 runtimeConfig.healthProbeManifest());
 
         return new LiveMemoryReport(heap, nonHeap, pools, inputArgs, calculation.jvmOptions(), calculation, kubernetes);
+    }
+
+    private long totalMemoryBytes(long requestedMebibytes) {
+        long minimumMebibytes = MemoryCalculator.MIN_TOTAL_MEMORY_BYTES / MEBIBYTE;
+        long maximumMebibytes = MemoryCalculator.MAX_TOTAL_MEMORY_BYTES / MEBIBYTE;
+        long clampedMebibytes = Math.max(minimumMebibytes, Math.min(maximumMebibytes, requestedMebibytes));
+        return clampedMebibytes * MEBIBYTE;
     }
 
     private boolean resolveVirtualThreadsEnabled() {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/HealthProbeManifest.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/HealthProbeManifest.java
@@ -2,8 +2,10 @@ package io.github.jdubois.bootui.spi;
 
 /**
  * Framework-neutral description of how an application exposes its Kubernetes health-probe HTTP
- * endpoints. The engine uses this to render the Live Memory / JVM Tuning Kubernetes manifest without
- * hardcoding any one framework's URLs, enabling switch, or advisory copy.
+ * endpoints. The engine uses this to render the Live Memory / JVM Tuning Kubernetes fragment without
+ * hardcoding any one framework's default URLs, enabling switch, or advisory copy. The fragment uses the
+ * named container port {@code http}; callers must verify that name and these default paths against
+ * custom application or management-server configuration.
  *
  * <p>{@code enablingEnvVar} is nullable: Spring Boot turns its Actuator Kubernetes probe groups on with
  * an environment variable ({@code MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED}), whereas Quarkus/SmallRye
@@ -30,7 +32,7 @@ public record HealthProbeManifest(
             "/actuator/health/liveness",
             "/actuator/health/readiness",
             "MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED",
-            "Spring Boot Actuator probes are omitted from the snippet; enabling them is recommended so Kubernetes can restart or drain unhealthy pods.");
+            "Spring Boot Actuator probes are omitted from the snippet; add verified startup, readiness, and liveness probes for the deployment.");
 
     /**
      * Quarkus SmallRye Health endpoints. SmallRye serves a dedicated startup endpoint
@@ -41,5 +43,5 @@ public record HealthProbeManifest(
             "/q/health/live",
             "/q/health/ready",
             null,
-            "Kubernetes liveness/readiness health probes are omitted from the snippet; enabling them is recommended so Kubernetes can restart or drain unhealthy pods.");
+            "Kubernetes health probes are omitted from the snippet; add verified startup, readiness, and liveness probes for the deployment.");
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/MemoryRuntimeConfig.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/spi/MemoryRuntimeConfig.java
@@ -5,9 +5,9 @@ package io.github.jdubois.bootui.spi;
  * framework-neutral semantic questions rather than raw configuration property names.
  *
  * <p>This is the seam behind the memory report: the engine asks <em>whether</em> virtual threads are
- * enabled (which changes per-thread stack sizing) and <em>whether</em> Kubernetes liveness/readiness
- * health probes are exposed (which changes the generated manifest), but <em>how</em> those facts are
- * derived is a per-framework detail. The Spring Boot adapter resolves them from
+ * enabled (for explanatory context, not a speculative stack discount) and <em>whether</em> Kubernetes
+ * liveness/readiness health probes are exposed (which changes the generated manifest), but
+ * <em>how</em> those facts are derived is a per-framework detail. The Spring Boot adapter resolves them from
  * {@code spring.threads.virtual.enabled} and the {@code management.endpoint.health.*} chain; a Quarkus
  * adapter would resolve them from its own equivalents (e.g. SmallRye Health). Both are read <em>live</em>
  * on every report so a runtime override is honored.

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCalculatorTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCalculatorTests.java
@@ -3,41 +3,33 @@ package io.github.jdubois.bootui.engine.memory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.MemoryCalculationDto;
-import io.github.jdubois.bootui.engine.memory.MemoryCalculator.JdkVersion;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the Paketo {@code libjvm}-style {@link MemoryCalculator}.
  *
- * <p>Verifies the partition formula, libjvm-equivalent constants, and the JDK version gating that
- * controls {@code -XX:+UseCompactObjectHeaders}, {@code -XX:+ZGenerational}, and
- * {@code -XX:+UseStringDeduplication}.
+ * <p>Verifies the partition formula, live-observation adaptations, rendered-budget boundaries, and the
+ * intentionally small Java 17+ option surface.
  */
 class MemoryCalculatorTests {
 
     private static final long MB = 1024L * 1024L;
 
-    private static final JdkVersion JDK_25 = () -> 25;
-    private static final JdkVersion JDK_24 = () -> 24;
-    private static final JdkVersion JDK_23 = () -> 23;
-    private static final JdkVersion JDK_22 = () -> 22;
-    private static final JdkVersion JDK_21 = () -> 21;
-    private static final JdkVersion JDK_18 = () -> 18;
-    private static final JdkVersion JDK_17 = () -> 17;
+    private final MemoryCalculator calculator = new MemoryCalculator();
 
     @Test
-    void heapIsTotalMinusFixedRegionsAndHeadroom() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+    void heapIsTotalMinusAlignedFixedRegionsAndHeadroom() {
+        MemoryCalculationDto result = calculator.calculate(1024 * MB, 250, 10_000, 0, 42, 10_000);
 
-        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 10_000, 0, 42, 10_000);
-
-        long expectedMetaspace =
-                (long) Math.ceil((14_000_000L + 5_800L * 10_000L) * MemoryCalculator.META_SAFETY_FACTOR);
+        long rawMetaspace = (long) Math.ceil((14_000_000L + 5_800L * 10_000L) * MemoryCalculator.META_SAFETY_FACTOR);
+        long expectedMetaspace = roundUpToMiB(rawMetaspace);
         long expectedFixed = MemoryCalculator.DIRECT_MEMORY_BYTES
                 + expectedMetaspace
                 + MemoryCalculator.CODE_CACHE_BYTES
                 + MemoryCalculator.STACK_BYTES_PER_THREAD * 250L;
-        long expectedHeap = 1024 * MB - 0 - expectedFixed;
+        long expectedHeap = 1024 * MB - expectedFixed;
 
         assertThat(result.valid()).isTrue();
         assertThat(result.error()).isNull();
@@ -57,24 +49,21 @@ class MemoryCalculatorTests {
     }
 
     @Test
-    void metaspaceAppliesSafetyFactorOnLiveClassCount() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+    void metaspaceAppliesSafetyFactorAndRoundsUpToAMebibyte() {
+        MemoryCalculationDto baseline = calculator.calculate(1024 * MB, 250, 0, 0, 1, 0);
+        long expectedBaseline = roundUpToMiB((long) Math.ceil(14_000_000L * MemoryCalculator.META_SAFETY_FACTOR));
+        assertThat(baseline.metaspaceBytes()).isEqualTo(expectedBaseline);
 
-        MemoryCalculationDto a = calc.calculate(1024 * MB, 250, 0, 0, 1, 0);
-        long expectedBaseline = (long) Math.ceil(14_000_000L * MemoryCalculator.META_SAFETY_FACTOR);
-        assertThat(a.metaspaceBytes()).isEqualTo(expectedBaseline);
-
-        MemoryCalculationDto b = calc.calculate(1024 * MB, 250, 1_000, 0, 1, 1_000);
-        long expected1k = (long) Math.ceil((14_000_000L + 5_800L * 1_000L) * MemoryCalculator.META_SAFETY_FACTOR);
-        assertThat(b.metaspaceBytes()).isEqualTo(expected1k);
+        MemoryCalculationDto oneThousandClasses = calculator.calculate(1024 * MB, 250, 1_000, 0, 1, 1_000);
+        long expected =
+                roundUpToMiB((long) Math.ceil((14_000_000L + 5_800L * 1_000L) * MemoryCalculator.META_SAFETY_FACTOR));
+        assertThat(oneThousandClasses.metaspaceBytes()).isEqualTo(expected);
     }
 
     @Test
-    void headRoomReducesAvailableHeap() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-
-        MemoryCalculationDto noHeadroom = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
-        MemoryCalculationDto withHeadroom = calc.calculate(1024 * MB, 250, 5_000, 10, 1, 5_000);
+    void headroomReducesAvailableHeap() {
+        MemoryCalculationDto noHeadroom = calculator.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+        MemoryCalculationDto withHeadroom = calculator.calculate(1024 * MB, 250, 5_000, 10, 1, 5_000);
 
         long expectedHeadroom = (long) ((10 / 100.0) * (1024 * MB));
         assertThat(withHeadroom.headRoomBytes()).isEqualTo(expectedHeadroom);
@@ -83,210 +72,144 @@ class MemoryCalculatorTests {
     }
 
     @Test
-    void gcFlagFlipsToZgcAt4GiBHeap() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+    void bareMetalOptionsContainOnlyTheModeledMemorySettings() {
+        MemoryCalculationDto result = calculator.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
 
-        MemoryCalculationDto small = calc.calculate(1024 * MB, 250, 1_000, 0, 1, 1_000);
-        MemoryCalculationDto large = calc.calculate(8L * 1024 * MB, 250, 1_000, 0, 1, 1_000);
-
-        assertThat(small.jvmOptions()).contains("-XX:+UseG1GC").doesNotContain("-XX:+UseZGC");
-        assertThat(large.jvmOptions()).contains("-XX:+UseZGC").doesNotContain("-XX:+UseG1GC");
-    }
-
-    @Test
-    void jvmOptionsSetXmsEqualToXmx() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
-
-        long heapMb = Math.round(result.heapBytes() / (double) MB);
-        assertThat(result.jvmOptions()).contains("-Xms" + heapMb + "m").contains("-Xmx" + heapMb + "m");
-    }
-
-    @Test
-    void bareMetalOptionsPreTouchTheFixedHeap() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
-
-        assertThat(result.jvmOptions()).contains("-XX:+AlwaysPreTouch");
-    }
-
-    @Test
-    void jvmOptionsExpressStackInKilobytes() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
-
-        assertThat(result.jvmOptions()).contains("-Xss1024k");
-    }
-
-    @Test
-    void jvmOptionsExpressFixedRegionsInMegabytes() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
-
-        long metaMb = Math.round(result.metaspaceBytes() / (double) MB);
         assertThat(result.jvmOptions())
-                .contains("-XX:ReservedCodeCacheSize=240m")
-                .contains("-XX:MaxDirectMemorySize=10m")
-                .contains("-XX:MaxMetaspaceSize=" + metaMb + "m");
+                .contains("-Xms", "-Xmx", "-XX:MaxMetaspaceSize=", "-XX:ReservedCodeCacheSize=240m", "-Xss1024k")
+                .doesNotContain(
+                        "-XX:MaxDirectMemorySize=",
+                        "-XX:+AlwaysPreTouch",
+                        "-XX:+UseG1GC",
+                        "-XX:+UseZGC",
+                        "-XX:+UseStringDeduplication",
+                        "-XX:+UseCompactObjectHeaders",
+                        "-XX:+ExitOnOutOfMemoryError",
+                        "-XX:+HeapDumpOnOutOfMemoryError",
+                        "-XX:HeapDumpPath=");
     }
 
     @Test
-    void compactObjectHeadersOnlyOnJdk25OrNewer() {
-        MemoryCalculator on25 = new MemoryCalculator(JDK_25);
-        MemoryCalculator on24 = new MemoryCalculator(JDK_24);
+    void renderedOptionsStayWithinTheModeledBudget() {
+        MemoryCalculationDto result = calculator.calculate(1024 * MB, 250, 5_001, 7, 40, 5_001);
 
-        MemoryCalculationDto result25 = on25.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
-        MemoryCalculationDto result24 = on24.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
+        long renderedHeap = optionMebibytes(result.jvmOptions(), "-Xmx") * MB;
+        long renderedMetaspace = optionMebibytes(result.jvmOptions(), "-XX:MaxMetaspaceSize=") * MB;
+        long renderedTotal = renderedHeap
+                + renderedMetaspace
+                + result.codeCacheBytes()
+                + result.directMemoryBytes()
+                + result.stackBytesTotal()
+                + result.headRoomBytes();
 
-        assertThat(result25.jvmOptions()).contains("-XX:+UseCompactObjectHeaders");
-        assertThat(result24.jvmOptions()).doesNotContain("-XX:+UseCompactObjectHeaders");
+        assertThat(renderedHeap).isLessThanOrEqualTo(result.heapBytes());
+        assertThat(renderedMetaspace).isGreaterThanOrEqualTo(result.metaspaceBytes());
+        assertThat(renderedTotal).isLessThanOrEqualTo(result.totalMemoryBytes());
     }
 
     @Test
-    void zGenerationalFlagOnlyAppliedOnJdk21And22() {
-        long largeHeap = 8L * 1024 * MB; // flips GC selection to ZGC
+    void observedDirectMemoryRaisesTheModelWithoutCreatingAHardCap() {
+        long observedDirectMemory = 33 * MB + 1;
 
-        MemoryCalculationDto on21 = new MemoryCalculator(JDK_21).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
-        MemoryCalculationDto on22 = new MemoryCalculator(JDK_22).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
-        MemoryCalculationDto on23 = new MemoryCalculator(JDK_23).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
-        MemoryCalculationDto on24 = new MemoryCalculator(JDK_24).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
-        MemoryCalculationDto on25 = new MemoryCalculator(JDK_25).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+        MemoryCalculationDto result = calculator.calculate(
+                2048 * MB, 250, 5_000, 10, 40, 5_000, false, "spring.threads.virtual.enabled", observedDirectMemory);
 
-        // JEP 439 (JDK 21) shipped generational ZGC as an experimental opt-in flag.
-        assertThat(on21.jvmOptions()).contains("-XX:+ZGenerational");
-        assertThat(on22.jvmOptions()).contains("-XX:+ZGenerational");
-        // JEP 474 (JDK 23) makes generational ZGC the default and deprecates the explicit flag
-        // (printing a warning if set); JEP 490 (JDK 24) obsoletes it further, and later releases
-        // stop recognizing it altogether, causing the JVM to refuse to start. It must never be
-        // emitted from JDK 23 onward.
-        assertThat(on23.jvmOptions()).doesNotContain("-XX:+ZGenerational");
-        assertThat(on24.jvmOptions()).doesNotContain("-XX:+ZGenerational");
-        assertThat(on25.jvmOptions()).doesNotContain("-XX:+ZGenerational");
+        assertThat(result.directMemoryBytes()).isEqualTo(34 * MB);
+        assertThat(result.jvmOptions()).doesNotContain("-XX:MaxDirectMemorySize=");
     }
 
     @Test
-    void stringDeduplicationSkippedForZgcBeforeJdk18() {
-        long largeHeap = 8L * 1024 * MB; // flips GC selection to ZGC
+    void kubernetesOptionsCoverSmallHeapErgonomicsWithoutChoosingACollector() {
+        MemoryCalculationDto result = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
 
-        MemoryCalculationDto on17 = new MemoryCalculator(JDK_17).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
-        MemoryCalculationDto on18 = new MemoryCalculator(JDK_18).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
-        MemoryCalculationDto on21 = new MemoryCalculator(JDK_21).calculate(largeHeap, 250, 1_000, 0, 1, 1_000);
+        String options = calculator.buildKubernetesJvmOptions(result, 42.125, 42.125);
 
-        // ZGC did not support string deduplication until JDK 18. On JDK 17 the JVM would print a
-        // startup warning ("String Deduplication disabled: not supported by selected GC") and
-        // silently disable it anyway, so the flag must be omitted rather than emitted uselessly.
-        assertThat(on17.jvmOptions()).contains("-XX:+UseZGC").doesNotContain("-XX:+UseStringDeduplication");
-        assertThat(on18.jvmOptions()).contains("-XX:+UseZGC").contains("-XX:+UseStringDeduplication");
-        assertThat(on21.jvmOptions()).contains("-XX:+UseZGC").contains("-XX:+UseStringDeduplication");
+        assertThat(options)
+                .contains(
+                        "-XX:MaxRAMPercentage=42.125",
+                        "-XX:MinRAMPercentage=42.125",
+                        "-XX:InitialRAMPercentage=42.125",
+                        "-XX:MaxMetaspaceSize=",
+                        "-XX:ReservedCodeCacheSize=240m",
+                        "-Xss1024k")
+                .doesNotContain(
+                        "-Xmx",
+                        "-Xms",
+                        "-XX:+UseContainerSupport",
+                        "-XX:MaxDirectMemorySize=",
+                        "-XX:+UseG1GC",
+                        "-XX:+UseZGC");
     }
 
     @Test
-    void stringDeduplicationAlwaysPresentForG1RegardlessOfJdkVersion() {
-        long smallHeap = 1024 * MB; // stays under the ZGC flip threshold, selects G1
+    void rejectsAPlanThatCannotRenderAtLeastOneMebibyteOfHeap() {
+        MemoryCalculationDto invalid = calculator.calculate(517 * MB, 250, 0, 0, 10, 0);
+        MemoryCalculationDto boundary = calculator.calculate(518 * MB, 250, 0, 0, 10, 0);
 
-        MemoryCalculationDto on17 = new MemoryCalculator(JDK_17).calculate(smallHeap, 250, 1_000, 0, 1, 1_000);
+        assertThat(invalid.valid()).isFalse();
+        assertThat(invalid.error()).contains("less than 1 MiB");
+        assertThat(invalid.heapBytes()).isZero();
+        assertThat(invalid.jvmOptions()).isEmpty();
 
-        // G1 has supported string deduplication since JDK 8u20 (JEP 192), so it is always present.
-        assertThat(on17.jvmOptions()).contains("-XX:+UseG1GC").contains("-XX:+UseStringDeduplication");
+        assertThat(boundary.valid()).isTrue();
+        assertThat(boundary.heapBytes()).isEqualTo(MB);
+        assertThat(boundary.jvmOptions()).contains("-Xms1m", "-Xmx1m");
     }
 
     @Test
-    void invalidWhenTotalMemoryLeavesNoRoomForHeap() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+    void clampsOutOfRangeInputsToTheUiContract() {
+        MemoryCalculationDto belowMinimum = calculator.calculate(-1, -1, -1, -50, 10, 0);
+        MemoryCalculationDto aboveMaximum =
+                calculator.calculate(Long.MAX_VALUE, Integer.MAX_VALUE, 10_000, 1_000, 10, 10_000);
 
-        MemoryCalculationDto result = calc.calculate(256 * MB, 5_000, 100_000, 0, 10, 100_000);
+        assertThat(belowMinimum.totalMemoryBytes()).isEqualTo(MemoryCalculator.MIN_TOTAL_MEMORY_BYTES);
+        assertThat(belowMinimum.threadCount()).isEqualTo(MemoryCalculator.MIN_THREAD_COUNT);
+        assertThat(belowMinimum.headRoomPercent()).isEqualTo(MemoryCalculator.MIN_HEAD_ROOM_PERCENT);
+        assertThat(belowMinimum.loadedClasses()).isZero();
 
-        assertThat(result.valid()).isFalse();
-        assertThat(result.error()).isNotNull().contains("No room for heap");
-        assertThat(result.heapBytes()).isZero();
-        assertThat(result.jvmOptions()).isEmpty();
+        assertThat(aboveMaximum.totalMemoryBytes()).isEqualTo(MemoryCalculator.MAX_TOTAL_MEMORY_BYTES);
+        assertThat(aboveMaximum.threadCount()).isEqualTo(MemoryCalculator.MAX_THREAD_COUNT);
+        assertThat(aboveMaximum.headRoomPercent()).isEqualTo(MemoryCalculator.MAX_HEAD_ROOM_PERCENT);
     }
 
     @Test
-    void clampsOutOfRangeInputs() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
+    void defaultTotalMemoryIsBoundedAndAlignedRegardlessOfHostFootprint() {
+        long onLargeHost = calculator.defaultTotalMemoryBytes(2L * 1024 * MB, 300L * MB, 40, 15_000);
+        long onTinyApp = calculator.defaultTotalMemoryBytes(32L * MB, 16L * MB, 10, 500);
 
-        MemoryCalculationDto result = calc.calculate(-1, -1, -1, -50, 10, 0);
-
-        assertThat(result.totalMemoryBytes()).isGreaterThanOrEqualTo(MemoryCalculator.MIN_TOTAL_MEMORY_BYTES);
-        assertThat(result.threadCount()).isGreaterThanOrEqualTo(MemoryCalculator.MIN_THREAD_COUNT);
-        assertThat(result.headRoomPercent()).isGreaterThanOrEqualTo(MemoryCalculator.MIN_HEAD_ROOM_PERCENT);
-        assertThat(result.loadedClasses()).isGreaterThanOrEqualTo(0);
+        assertThat(onLargeHost).isBetween(384L * MB, 2048L * MB);
+        assertThat(onTinyApp).isBetween(384L * MB, 2048L * MB);
+        assertThat(onLargeHost % (64L * MB)).isZero();
+        assertThat(onTinyApp % (64L * MB)).isZero();
     }
 
     @Test
-    void clampsOversizedInputs() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-
-        MemoryCalculationDto result = calc.calculate(Long.MAX_VALUE, Integer.MAX_VALUE, 10_000, 1_000, 10, 10_000);
-
-        assertThat(result.totalMemoryBytes()).isLessThanOrEqualTo(MemoryCalculator.MAX_TOTAL_MEMORY_BYTES);
-        assertThat(result.threadCount()).isLessThanOrEqualTo(MemoryCalculator.MAX_THREAD_COUNT);
-        assertThat(result.headRoomPercent()).isLessThanOrEqualTo(MemoryCalculator.MAX_HEAD_ROOM_PERCENT);
-    }
-
-    @Test
-    void defaultTotalMemoryIsClampedRegardlessOfHostFootprint() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-
-        long onLargeMac = calc.defaultTotalMemoryBytes(2L * 1024 * MB, 300L * MB, 40, 15_000);
-
-        long onTinyApp = calc.defaultTotalMemoryBytes(32L * MB, 16L * MB, 10, 500);
-
-        assertThat(onLargeMac).isLessThanOrEqualTo(2048L * MB);
-        assertThat(onLargeMac).isGreaterThanOrEqualTo(384L * MB);
-        assertThat(onTinyApp).isGreaterThanOrEqualTo(384L * MB);
-        assertThat(onTinyApp).isLessThanOrEqualTo(2048L * MB);
-    }
-
-    @Test
-    void defaultTotalMemoryIsAlignedTo64MbBoundary() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-
-        long result = calc.defaultTotalMemoryBytes(200L * MB, 100L * MB, 40, 10_000);
-
-        assertThat(result % (64L * MB)).isZero();
-    }
-
-    @Test
-    void defaultThreadCountFloorsAt250() {
+    void defaultThreadCountKeepsThePaketoPlatformThreadFloor() {
         assertThat(MemoryCalculator.defaultThreadCount(10)).isEqualTo(250);
         assertThat(MemoryCalculator.defaultThreadCount(250)).isEqualTo(250);
         assertThat(MemoryCalculator.defaultThreadCount(500)).isEqualTo(500);
     }
 
     @Test
-    void virtualThreadsReduceStackBudgetWithoutSettingSpringProperty() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-
-        MemoryCalculationDto platformThreads = calc.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000, false);
-        MemoryCalculationDto virtualThreads = calc.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000, true);
+    void virtualThreadDetectionDoesNotDiscountPlatformThreadStacks() {
+        MemoryCalculationDto platformThreads = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000, false);
+        MemoryCalculationDto virtualThreads = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000, true);
 
         assertThat(virtualThreads.virtualThreadsEnabled()).isTrue();
-        assertThat(virtualThreads.stackBytesPerThread())
-                .isEqualTo(MemoryCalculator.VIRTUAL_THREAD_STACK_BYTES_PER_THREAD);
-        assertThat(virtualThreads.stackBytesTotal()).isLessThan(platformThreads.stackBytesTotal());
-        assertThat(virtualThreads.heapBytes()).isGreaterThan(platformThreads.heapBytes());
-        assertThat(virtualThreads.jvmOptions()).contains("-Xss512k").doesNotContain("spring.threads.virtual.enabled");
-        assertThat(platformThreads.jvmOptions()).doesNotContain("spring.threads.virtual.enabled");
+        assertThat(virtualThreads.stackBytesPerThread()).isEqualTo(MemoryCalculator.STACK_BYTES_PER_THREAD);
+        assertThat(virtualThreads.stackBytesTotal()).isEqualTo(platformThreads.stackBytesTotal());
+        assertThat(virtualThreads.heapBytes()).isEqualTo(platformThreads.heapBytes());
+        assertThat(virtualThreads.jvmOptions()).contains("-Xss1024k").doesNotContain("spring.threads.virtual.enabled");
     }
 
-    @Test
-    void virtualThreadDefaultsUseSmallerPlatformThreadFloor() {
-        assertThat(MemoryCalculator.defaultThreadCount(10, true)).isEqualTo(80);
-        assertThat(MemoryCalculator.defaultThreadCount(80, true)).isEqualTo(80);
-        assertThat(MemoryCalculator.defaultThreadCount(120, true)).isEqualTo(120);
+    private static long roundUpToMiB(long bytes) {
+        return ((bytes + MB - 1) / MB) * MB;
     }
 
-    @Test
-    void jvmOptionsAlwaysIncludeOomSafetyAndStringDeduplication() {
-        MemoryCalculator calc = new MemoryCalculator(JDK_25);
-        MemoryCalculationDto result = calc.calculate(1024 * MB, 250, 5_000, 0, 1, 5_000);
-
-        assertThat(result.jvmOptions())
-                .contains("-XX:+UseStringDeduplication")
-                .contains("-XX:+ExitOnOutOfMemoryError")
-                .contains("-XX:+HeapDumpOnOutOfMemoryError")
-                .contains("-XX:HeapDumpPath=/tmp");
+    private static long optionMebibytes(String options, String optionPrefix) {
+        Matcher matcher =
+                Pattern.compile(Pattern.quote(optionPrefix) + "(\\d+)m").matcher(options);
+        assertThat(matcher.find()).as("option %s in %s", optionPrefix, options).isTrue();
+        return Long.parseLong(matcher.group(1));
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCalculatorTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCalculatorTests.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.engine.memory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.MemoryCalculationDto;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
@@ -90,6 +91,59 @@ class MemoryCalculatorTests {
     }
 
     @Test
+    void bareMetalOptionsAreSpaceSeparatedTokensAcrossRepresentativeInputs() {
+        // Regression test for a StringBuilder bug where "-Xms" and "-Xmx" were appended
+        // without a separating space, producing an unparseable token such as
+        // "-Xms369m-Xmx369m". containsExactly on the split tokens fails loudly if any two
+        // options are concatenated instead of separated by exactly one space.
+        long[][] representativeInputs = {
+            // {totalMemoryBytes, threadCount, loadedClasses, headRoomPercent, liveThreadCount, liveLoadedClasses}
+            {1024 * MB, 250, 5_000, 0, 1, 5_000},
+            {2048 * MB, 250, 5_000, 10, 40, 5_000},
+            {64L * 1024 * MB, 10_000, 200_000, 30, 5_000, 200_000},
+            {518 * MB, 250, 0, 0, 10, 0}, // boundary: smallest total that still renders a 1 MiB heap
+        };
+
+        for (long[] input : representativeInputs) {
+            MemoryCalculationDto result = calculator.calculate(
+                    input[0], (int) input[1], (int) input[2], (int) input[3], (int) input[4], (int) input[5]);
+
+            assertThat(result.valid()).as("input %s", (Object) input).isTrue();
+
+            long heapMb = result.heapBytes() / MB;
+            long metaMb = result.metaspaceBytes() / MB;
+
+            List<String> tokens = List.of(result.jvmOptions().split(" "));
+            assertThat(tokens)
+                    .as("tokens for input %s", (Object) input)
+                    .containsExactly(
+                            "-Xms" + heapMb + "m",
+                            "-Xmx" + heapMb + "m",
+                            "-XX:MaxMetaspaceSize=" + metaMb + "m",
+                            "-XX:ReservedCodeCacheSize=240m",
+                            "-Xss1024k");
+        }
+    }
+
+    @Test
+    void kubernetesOptionsAreSpaceSeparatedTokensWithoutConcatenation() {
+        MemoryCalculationDto result = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
+
+        String options = calculator.buildKubernetesJvmOptions(result, 42.125, 33.5);
+        long metaMb = result.metaspaceBytes() / MB;
+
+        List<String> tokens = List.of(options.split(" "));
+        assertThat(tokens)
+                .containsExactly(
+                        "-XX:MaxRAMPercentage=42.125",
+                        "-XX:MinRAMPercentage=42.125",
+                        "-XX:InitialRAMPercentage=33.5",
+                        "-XX:MaxMetaspaceSize=" + metaMb + "m",
+                        "-XX:ReservedCodeCacheSize=240m",
+                        "-Xss1024k");
+    }
+
+    @Test
     void renderedOptionsStayWithinTheModeledBudget() {
         MemoryCalculationDto result = calculator.calculate(1024 * MB, 250, 5_001, 7, 40, 5_001);
 
@@ -153,7 +207,9 @@ class MemoryCalculatorTests {
 
         assertThat(boundary.valid()).isTrue();
         assertThat(boundary.heapBytes()).isEqualTo(MB);
-        assertThat(boundary.jvmOptions()).contains("-Xms1m", "-Xmx1m");
+        // Exact token equality (not mere substring containment) so a missing separator between
+        // "-Xms1m" and "-Xmx1m" (e.g. a concatenated "-Xms1m-Xmx1m") fails this assertion.
+        assertThat(List.of(boundary.jvmOptions().split(" "))).contains("-Xms1m", "-Xmx1m");
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryKubernetesSizerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryKubernetesSizerTests.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.KubernetesMemoryRecommendationDto;
 import io.github.jdubois.bootui.core.dto.MemoryCalculationDto;
-import io.github.jdubois.bootui.engine.memory.MemoryCalculator.JdkVersion;
 import io.github.jdubois.bootui.spi.HealthProbeManifest;
 import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
@@ -12,91 +11,11 @@ import org.junit.jupiter.api.Test;
 class MemoryKubernetesSizerTests {
 
     private static final long MB = 1024L * 1024L;
-    private static final JdkVersion JDK_24 = () -> 24;
 
-    private final MemoryCalculator calculator = new MemoryCalculator(JDK_24);
-
-    @Test
-    void recommendsGuaranteedQosByDefault() {
-        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
-
-        KubernetesMemoryRecommendationDto recommendation =
-                recommend(calculation, 256 * MB, 128 * MB, 8 * MB, true, 1024 * MB);
-
-        assertThat(recommendation.requestMemoryBytes()).isEqualTo(1024 * MB);
-        assertThat(recommendation.limitMemoryBytes()).isEqualTo(1024 * MB);
-        assertThat(recommendation.requestMemory()).isEqualTo("1024Mi");
-        assertThat(recommendation.limitMemory()).isEqualTo("1024Mi");
-        assertThat(recommendation.qosClass()).isEqualTo("Guaranteed");
-        assertThat(recommendation.burstableEnabled()).isFalse();
-        assertThat(recommendation.healthProbesEnabled()).isTrue();
-        assertThat(recommendation.confidence()).isEqualTo("High");
-        assertThat(recommendation.detectedContainerLimitMemory()).isEqualTo("1024Mi");
-        assertThat(recommendation.maxRamPercentage()).isGreaterThan(0).isLessThanOrEqualTo(75.0);
-        assertThat(recommendation.warnings().get(0)).contains("Garbage collector: G1GC");
-        assertThat(recommendation.javaToolOptions())
-                .contains("-XX:+UseContainerSupport")
-                .contains("-XX:MaxRAMPercentage=")
-                .contains("-XX:InitialRAMPercentage=")
-                .doesNotContain("-Xmx")
-                .doesNotContain("-Xms");
-        assertThat(recommendation.yaml())
-                .startsWith("resources:\n  requests:\n    memory: \"1024Mi\"\n  limits:\n    memory: \"1024Mi\"")
-                .contains("JAVA_TOOL_OPTIONS")
-                .contains("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED")
-                .contains("startupProbe")
-                .contains("readinessProbe")
-                .contains("-XX:MaxRAMPercentage=")
-                .doesNotContain("-Xmx")
-                .doesNotContain("-Xms");
-    }
+    private final MemoryCalculator calculator = new MemoryCalculator();
 
     @Test
-    void burstableRequestUsesLiveSnapshotRatherThanFixedRegionCaps() {
-        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 10, 5_000);
-
-        KubernetesMemoryRecommendationDto recommendation = recommend(calculation, 64 * MB, 64 * MB, 0, false, null);
-
-        assertThat(recommendation.currentSnapshotBytes()).isEqualTo(138 * MB);
-        assertThat(recommendation.burstableRequestMemoryBytes()).isEqualTo(256 * MB);
-        assertThat(recommendation.burstableRequestMemory()).isEqualTo("256Mi");
-        assertThat(recommendation.requestMemoryBytes()).isEqualTo(1024 * MB);
-    }
-
-    @Test
-    void burstableModeUsesSnapshotRequestInYaml() {
-        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 10, 5_000);
-
-        KubernetesMemoryRecommendationDto recommendation =
-                recommend(calculation, 64 * MB, 64 * MB, 0, false, null, true, true);
-
-        assertThat(recommendation.burstableEnabled()).isTrue();
-        assertThat(recommendation.qosClass()).isEqualTo("Burstable");
-        assertThat(recommendation.requestMemoryBytes()).isEqualTo(256 * MB);
-        assertThat(recommendation.limitMemoryBytes()).isEqualTo(1024 * MB);
-        assertThat(recommendation.yaml())
-                .startsWith("resources:\n  requests:\n    memory: \"256Mi\"\n  limits:\n    memory: \"1024Mi\"");
-    }
-
-    @Test
-    void actuatorToggleControlsProbeSnippet() {
-        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
-
-        KubernetesMemoryRecommendationDto recommendation =
-                recommend(calculation, 256 * MB, 128 * MB, 8 * MB, true, null, false, false);
-
-        assertThat(recommendation.healthProbesEnabled()).isFalse();
-        assertThat(recommendation.yaml())
-                .doesNotContain("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED")
-                .doesNotContain("startupProbe")
-                .doesNotContain("readinessProbe")
-                .doesNotContain("livenessProbe");
-        assertThat(recommendation.warnings())
-                .anySatisfy(warning -> assertThat(warning).contains("Actuator probes are omitted"));
-    }
-
-    @Test
-    void quarkusManifestUsesSmallRyePathsAndOmitsEnablingEnvVar() {
+    void equalMemoryRequestAndLimitDoesNotClaimGuaranteedQos() {
         MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
 
         KubernetesMemoryRecommendationDto recommendation = recommend(
@@ -106,23 +25,151 @@ class MemoryKubernetesSizerTests {
                 8 * MB,
                 true,
                 1024 * MB,
+                512 * MB,
                 false,
                 true,
-                HealthProbeManifest.QUARKUS_SMALLRYE);
+                HealthProbeManifest.SPRING_ACTUATOR);
 
+        assertThat(recommendation.requestMemoryBytes()).isEqualTo(1024 * MB);
+        assertThat(recommendation.limitMemoryBytes()).isEqualTo(1024 * MB);
+        assertThat(recommendation.requestMemory()).isEqualTo("1024Mi");
+        assertThat(recommendation.limitMemory()).isEqualTo("1024Mi");
+        assertThat(recommendation.qosClass()).isEqualTo("Depends on CPU");
+        assertThat(recommendation.burstableEnabled()).isFalse();
         assertThat(recommendation.healthProbesEnabled()).isTrue();
+        assertThat(recommendation.confidence()).isEqualTo("Medium");
+        assertThat(recommendation.detectedContainerLimitMemory()).isEqualTo("1024Mi");
+        assertThat(recommendation.warnings())
+                .anySatisfy(warning ->
+                        assertThat(warning).contains("Guaranteed QoS").contains("CPU request and limit"));
+        assertThat(recommendation.javaToolOptions())
+                .contains("-XX:MaxRAMPercentage=", "-XX:MinRAMPercentage=", "-XX:InitialRAMPercentage=")
+                .doesNotContain(
+                        "-Xmx",
+                        "-Xms",
+                        "-XX:+UseContainerSupport",
+                        "-XX:MaxDirectMemorySize=",
+                        "-XX:+UseG1GC",
+                        "-XX:+UseZGC");
         assertThat(recommendation.yaml())
-                .doesNotContain("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED")
-                .doesNotContain("/actuator/health")
-                .contains("    path: /q/health/started\n")
-                .contains("    path: /q/health/ready\n")
-                .contains("    path: /q/health/live\n")
-                .contains("\nstartupProbe:\n")
-                .doesNotContain("\n\nstartupProbe");
+                .startsWith("resources:\n  requests:\n    memory: \"1024Mi\"\n  limits:\n    memory: \"1024Mi\"")
+                .contains(
+                        "JAVA_TOOL_OPTIONS",
+                        "MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED",
+                        "startupProbe",
+                        "readinessProbe",
+                        "    port: http\n",
+                        "-XX:MinRAMPercentage=")
+                .doesNotContain("-Xmx", "-Xms", "port: 8080");
     }
 
     @Test
-    void quarkusManifestOmittedProbesWarningIsFrameworkNeutral() {
+    void burstableRequestUsesCgroupCurrentWhenAvailable() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 10, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation,
+                64 * MB,
+                64 * MB,
+                0,
+                false,
+                1024 * MB,
+                200 * MB,
+                true,
+                true,
+                HealthProbeManifest.SPRING_ACTUATOR);
+
+        assertThat(recommendation.currentSnapshotBytes()).isEqualTo(200 * MB);
+        assertThat(recommendation.burstableRequestMemoryBytes()).isEqualTo(320 * MB);
+        assertThat(recommendation.requestMemoryBytes()).isEqualTo(320 * MB);
+        assertThat(recommendation.warnings())
+                .anySatisfy(warning -> assertThat(warning).contains("cgroup memory.current"));
+    }
+
+    @Test
+    void burstableRequestFallsBackToJvmPoolsWithoutTreatingStacksAsResident() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 10, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation, 64 * MB, 64 * MB, 0, false, null, null, true, true, HealthProbeManifest.SPRING_ACTUATOR);
+
+        assertThat(recommendation.currentSnapshotBytes()).isEqualTo(128 * MB);
+        assertThat(recommendation.burstableRequestMemoryBytes()).isEqualTo(192 * MB);
+        assertThat(recommendation.warnings())
+                .anySatisfy(warning -> assertThat(warning).contains("committed JVM pools"));
+    }
+
+    @Test
+    void lowerMemoryRequestIsTruthfullyClassifiedAsBurstable() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 10, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation,
+                64 * MB,
+                64 * MB,
+                0,
+                false,
+                1024 * MB,
+                200 * MB,
+                true,
+                true,
+                HealthProbeManifest.SPRING_ACTUATOR);
+
+        assertThat(recommendation.qosClass()).isEqualTo("Burstable");
+        assertThat(recommendation.yaml())
+                .startsWith("resources:\n  requests:\n    memory: \"320Mi\"\n  limits:\n    memory: \"1024Mi\"");
+        assertThat(recommendation.warnings())
+                .anySatisfy(warning -> assertThat(warning).contains("prevents the Pod from receiving Guaranteed QoS"));
+    }
+
+    @Test
+    void burstableModeKeepsTruthfulQosWhenTheSnapshotMarginReachesTheLimit() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 10, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation,
+                64 * MB,
+                64 * MB,
+                0,
+                false,
+                1024 * MB,
+                1000 * MB,
+                true,
+                true,
+                HealthProbeManifest.SPRING_ACTUATOR);
+
+        assertThat(recommendation.requestMemoryBytes()).isEqualTo(1024 * MB);
+        assertThat(recommendation.qosClass()).isEqualTo("Depends on CPU");
+        assertThat(recommendation.warnings())
+                .anySatisfy(warning -> assertThat(warning).contains("Burstable mode did not lower requests.memory"))
+                .noneSatisfy(warning ->
+                        assertThat(warning).contains("this container prevents the Pod from receiving Guaranteed QoS"));
+    }
+
+    @Test
+    void burstableFallbackSaturatesOverflowingSnapshotCountersAtTheLimit() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 10, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation,
+                Long.MAX_VALUE,
+                Long.MAX_VALUE,
+                Long.MAX_VALUE,
+                false,
+                null,
+                null,
+                true,
+                true,
+                HealthProbeManifest.SPRING_ACTUATOR);
+
+        assertThat(recommendation.currentSnapshotBytes()).isEqualTo(Long.MAX_VALUE);
+        assertThat(recommendation.burstableRequestMemoryBytes()).isEqualTo(1024 * MB);
+        assertThat(recommendation.requestMemoryBytes()).isEqualTo(1024 * MB);
+        assertThat(recommendation.qosClass()).isEqualTo("Depends on CPU");
+    }
+
+    @Test
+    void healthProbeToggleControlsTheSnippet() {
         MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
 
         KubernetesMemoryRecommendationDto recommendation = recommend(
@@ -132,23 +179,55 @@ class MemoryKubernetesSizerTests {
                 8 * MB,
                 true,
                 null,
+                null,
                 false,
                 false,
-                HealthProbeManifest.QUARKUS_SMALLRYE);
+                HealthProbeManifest.SPRING_ACTUATOR);
 
         assertThat(recommendation.healthProbesEnabled()).isFalse();
-        assertThat(recommendation.yaml()).doesNotContain("startupProbe");
+        assertThat(recommendation.yaml())
+                .doesNotContain(
+                        "MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED", "startupProbe", "readinessProbe", "livenessProbe");
         assertThat(recommendation.warnings())
-                .anySatisfy(warning -> assertThat(warning)
-                        .contains("Kubernetes liveness/readiness health probes are omitted")
-                        .doesNotContain("Spring Boot Actuator"));
+                .anySatisfy(warning -> assertThat(warning).contains("Actuator probes are omitted"));
+    }
+
+    @Test
+    void quarkusManifestUsesSmallRyeDefaultsAndANamedPort() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
+
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation,
+                256 * MB,
+                128 * MB,
+                8 * MB,
+                true,
+                1024 * MB,
+                512 * MB,
+                false,
+                true,
+                HealthProbeManifest.QUARKUS_SMALLRYE);
+
+        assertThat(recommendation.yaml())
+                .doesNotContain("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED", "/actuator/health", "port: 8080")
+                .contains(
+                        "    path: /q/health/started\n",
+                        "    path: /q/health/ready\n",
+                        "    path: /q/health/live\n",
+                        "    port: http\n",
+                        "\nstartupProbe:\n")
+                .doesNotContain("\n\nstartupProbe");
+        assertThat(recommendation.warnings())
+                .anySatisfy(warning ->
+                        assertThat(warning).contains("default paths").contains("named container port \"http\""));
     }
 
     @Test
     void reportsLowConfidenceAndNoYamlWhenCalculationIsInvalid() {
         MemoryCalculationDto calculation = calculator.calculate(256 * MB, 5_000, 100_000, 0, 10, 100_000);
 
-        KubernetesMemoryRecommendationDto recommendation = recommend(calculation, 64 * MB, 64 * MB, 0, false, null);
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation, 64 * MB, 64 * MB, 0, false, null, null, false, true, HealthProbeManifest.SPRING_ACTUATOR);
 
         assertThat(recommendation.confidence()).isEqualTo("Low");
         assertThat(recommendation.requestMemoryBytes()).isZero();
@@ -157,38 +236,62 @@ class MemoryKubernetesSizerTests {
     }
 
     @Test
-    void warnsWhenHeadroomIsBelowKubernetesRecommendation() {
-        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 0, 10, 5_000);
+    void modelConfidenceStaysLowWithoutMatchingCgroupObservations() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
 
-        KubernetesMemoryRecommendationDto recommendation = recommend(calculation, 64 * MB, 64 * MB, 0, true, null);
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation,
+                256 * MB,
+                128 * MB,
+                8 * MB,
+                true,
+                null,
+                null,
+                false,
+                true,
+                HealthProbeManifest.SPRING_ACTUATOR);
 
+        assertThat(recommendation.confidence()).isEqualTo("Low");
         assertThat(recommendation.warnings())
-                .anySatisfy(warning -> assertThat(warning).contains("Headroom below 10%"));
+                .anySatisfy(warning -> assertThat(warning).contains("does not consume its output"));
     }
 
     @Test
-    void virtualThreadsFlowIntoKubernetesJavaToolOptions() {
-        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000, true);
+    void heapPercentageFollowsTheRenderedModelInsteadOfAUniversalSeventyFivePercentCap() {
+        MemoryCalculationDto calculation = calculator.calculate(8L * 1024 * MB, 1, 0, 0, 1, 0);
 
-        KubernetesMemoryRecommendationDto recommendation =
-                recommend(calculation, 256 * MB, 128 * MB, 8 * MB, true, null);
+        double percentage = MemoryKubernetesSizer.heapPercentage(calculation);
 
-        assertThat(recommendation.javaToolOptions())
-                .contains("-Xss512k")
-                .doesNotContain("spring.threads.virtual.enabled")
-                .doesNotContain("-Xmx")
-                .doesNotContain("-Xms");
+        assertThat(percentage).isGreaterThan(75.0);
+        assertThat(calculator.buildKubernetesJvmOptions(calculation, percentage, percentage))
+                .contains("-XX:MaxRAMPercentage=" + percentage)
+                .contains("-XX:MinRAMPercentage=" + percentage);
     }
 
     @Test
-    void explainsZgcChoiceForLargeCalculatedHeaps() {
-        MemoryCalculationDto calculation = calculator.calculate(8 * 1024 * MB, 250, 5_000, 10, 40, 5_000);
+    void foldedYamlScalarPreservesQuotesAndBackslashesLiterally() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
+        String options = "-Dpath=C:\\tmp -Dmessage=\"hello world\"";
+        double percentage = MemoryKubernetesSizer.heapPercentage(calculation);
 
-        KubernetesMemoryRecommendationDto recommendation =
-                recommend(calculation, 256 * MB, 128 * MB, 8 * MB, true, null);
+        KubernetesMemoryRecommendationDto recommendation = MemoryKubernetesSizer.recommend(
+                calculation,
+                256 * MB,
+                128 * MB,
+                8 * MB,
+                false,
+                null,
+                null,
+                percentage,
+                percentage,
+                options,
+                false,
+                false,
+                HealthProbeManifest.SPRING_ACTUATOR);
 
-        assertThat(recommendation.javaToolOptions()).contains("-XX:+UseZGC");
-        assertThat(recommendation.warnings().get(0)).contains("Garbage collector: ZGC");
+        assertThat(recommendation.yaml())
+                .contains("      " + options)
+                .doesNotContain("C:\\\\tmp", "\\\"hello world\\\"");
     }
 
     @Test
@@ -209,6 +312,7 @@ class MemoryKubernetesSizerTests {
             long directBufferMemoryUsedBytes,
             boolean nativeMemoryTrackingEnabled,
             Long detectedContainerLimitBytes,
+            Long detectedContainerCurrentUsageBytes,
             boolean burstableEnabled,
             boolean healthProbesEnabled,
             HealthProbeManifest healthProbeManifest) {
@@ -221,61 +325,12 @@ class MemoryKubernetesSizerTests {
                 directBufferMemoryUsedBytes,
                 nativeMemoryTrackingEnabled,
                 detectedContainerLimitBytes,
+                detectedContainerCurrentUsageBytes,
                 maxRamPercentage,
                 maxRamPercentage,
                 javaToolOptions,
                 burstableEnabled,
                 healthProbesEnabled,
                 healthProbeManifest);
-    }
-
-    private KubernetesMemoryRecommendationDto recommend(
-            MemoryCalculationDto calculation,
-            long heapCommittedBytes,
-            long nonHeapCommittedBytes,
-            long directBufferMemoryUsedBytes,
-            boolean nativeMemoryTrackingEnabled,
-            Long detectedContainerLimitBytes) {
-        double maxRamPercentage = MemoryKubernetesSizer.heapPercentage(calculation);
-        String javaToolOptions = calculator.buildKubernetesJvmOptions(calculation, maxRamPercentage, maxRamPercentage);
-        return MemoryKubernetesSizer.recommend(
-                calculation,
-                heapCommittedBytes,
-                nonHeapCommittedBytes,
-                directBufferMemoryUsedBytes,
-                nativeMemoryTrackingEnabled,
-                detectedContainerLimitBytes,
-                maxRamPercentage,
-                maxRamPercentage,
-                javaToolOptions,
-                false,
-                true,
-                HealthProbeManifest.SPRING_ACTUATOR);
-    }
-
-    private KubernetesMemoryRecommendationDto recommend(
-            MemoryCalculationDto calculation,
-            long heapCommittedBytes,
-            long nonHeapCommittedBytes,
-            long directBufferMemoryUsedBytes,
-            boolean nativeMemoryTrackingEnabled,
-            Long detectedContainerLimitBytes,
-            boolean burstableEnabled,
-            boolean healthProbesEnabled) {
-        double maxRamPercentage = MemoryKubernetesSizer.heapPercentage(calculation);
-        String javaToolOptions = calculator.buildKubernetesJvmOptions(calculation, maxRamPercentage, maxRamPercentage);
-        return MemoryKubernetesSizer.recommend(
-                calculation,
-                heapCommittedBytes,
-                nonHeapCommittedBytes,
-                directBufferMemoryUsedBytes,
-                nativeMemoryTrackingEnabled,
-                detectedContainerLimitBytes,
-                maxRamPercentage,
-                maxRamPercentage,
-                javaToolOptions,
-                burstableEnabled,
-                healthProbesEnabled,
-                HealthProbeManifest.SPRING_ACTUATOR);
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryReportProviderTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryReportProviderTests.java
@@ -3,7 +3,6 @@ package io.github.jdubois.bootui.engine.memory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.LiveMemoryReport;
-import io.github.jdubois.bootui.engine.memory.MemoryCalculator.JdkVersion;
 import io.github.jdubois.bootui.spi.HealthProbeManifest;
 import io.github.jdubois.bootui.spi.MemoryRuntimeConfig;
 import org.junit.jupiter.api.Test;
@@ -12,17 +11,14 @@ import org.junit.jupiter.api.Test;
  * Behavior tests for {@link MemoryReportProvider}, the framework-neutral engine service shared by the
  * Live Memory and JVM Tuning panels.
  *
- * <p>Uses the package-private {@code MemoryCalculator(JdkVersion)} seam to pin the JDK version so that
- * JVM-option assertions are reproducible regardless of the host JDK, and a fake
- * {@link MemoryRuntimeConfig} to drive the virtual-threads / Kubernetes-health-probe inputs without a
- * framework. Live {@link java.lang.management.ManagementFactory} data is used for heap, non-heap and
- * pool readings — these are always non-negative in a running JVM, which is all these tests assert about
- * them. The pure formula assertions are covered by {@link MemoryCalculatorTests} and
- * {@link MemoryKubernetesSizerTests}.</p>
+ * <p>Uses a fake {@link MemoryRuntimeConfig} to drive the virtual-threads /
+ * Kubernetes-health-probe inputs without a framework. Live
+ * {@link java.lang.management.ManagementFactory} data is used for heap, non-heap and pool readings —
+ * these are always non-negative in a running JVM, which is all these tests assert about them. The pure
+ * formula assertions are covered by {@link MemoryCalculatorTests} and
+ * {@link MemoryKubernetesSizerTests}.
  */
 class MemoryReportProviderTests {
-
-    private static final JdkVersion JDK_25 = () -> 25;
 
     private static MemoryRuntimeConfig config(boolean virtualThreads, boolean healthProbes) {
         return new MemoryRuntimeConfig() {
@@ -49,12 +45,11 @@ class MemoryReportProviderTests {
     }
 
     private static MemoryReportProvider providerWithDefaults() {
-        return new MemoryReportProvider(new MemoryCalculator(JDK_25));
+        return new MemoryReportProvider(new MemoryCalculator());
     }
 
     private static MemoryReportProvider providerWithDisabledDetector(MemoryRuntimeConfig runtimeConfig) {
-        return new MemoryReportProvider(
-                new MemoryCalculator(JDK_25), ContainerMemoryLimitDetector.disabled(), runtimeConfig);
+        return new MemoryReportProvider(new MemoryCalculator(), ContainerMemoryLimitDetector.disabled(), runtimeConfig);
     }
 
     @Test
@@ -93,7 +88,13 @@ class MemoryReportProviderTests {
                 .contains("-Xmx")
                 .contains("-Xms")
                 .contains("-XX:MaxMetaspaceSize=")
-                .contains("-XX:+UseCompactObjectHeaders");
+                .contains("-XX:ReservedCodeCacheSize=")
+                .doesNotContain(
+                        "-XX:MaxDirectMemorySize=",
+                        "-XX:+UseG1GC",
+                        "-XX:+UseZGC",
+                        "-XX:+UseStringDeduplication",
+                        "-XX:+UseCompactObjectHeaders");
     }
 
     @Test
@@ -105,36 +106,40 @@ class MemoryReportProviderTests {
     }
 
     @Test
-    void kubernetesRecommendationReportsGuaranteedResources() {
+    void kubernetesRecommendationDoesNotInferPodQosFromMemoryAlone() {
         LiveMemoryReport report =
                 providerWithDisabledDetector(MemoryRuntimeConfig.DEFAULTS).buildReport(1024L, null, 10, null, null);
 
         long expectedBytes = 1024L * 1024L * 1024L;
         assertThat(report.kubernetes().requestMemoryBytes()).isEqualTo(expectedBytes);
         assertThat(report.kubernetes().limitMemoryBytes()).isEqualTo(expectedBytes);
-        assertThat(report.kubernetes().qosClass()).isEqualTo("Guaranteed");
+        assertThat(report.kubernetes().qosClass()).isEqualTo("Depends on CPU");
         assertThat(report.kubernetes().burstableEnabled()).isFalse();
         assertThat(report.kubernetes().healthProbesEnabled()).isTrue();
         assertThat(report.kubernetes().yaml())
                 .contains("resources:")
                 .contains("MaxRAMPercentage")
+                .contains("MinRAMPercentage")
                 .contains("startupProbe")
                 .contains("readinessProbe")
+                .contains("port: http")
                 .doesNotContain("-Xmx")
                 .doesNotContain("-Xms");
     }
 
     @Test
-    void detectedVirtualThreadsChangeStackSizing() {
+    void detectedVirtualThreadsDoNotDiscountPlatformThreadStacks() {
         LiveMemoryReport enabled =
                 providerWithDisabledDetector(config(true, true)).buildReport(1024L, 250, null, null, null);
         assertThat(enabled.calculation().virtualThreadsEnabled()).isTrue();
-        assertThat(enabled.calculation().stackBytesPerThread()).isEqualTo(512L * 1024L);
+        assertThat(enabled.calculation().stackBytesPerThread()).isEqualTo(1024L * 1024L);
 
         LiveMemoryReport disabled =
                 providerWithDisabledDetector(config(false, true)).buildReport(1024L, 250, null, null, null);
         assertThat(disabled.calculation().virtualThreadsEnabled()).isFalse();
         assertThat(disabled.calculation().stackBytesPerThread()).isEqualTo(1024L * 1024L);
+        assertThat(enabled.calculation().stackBytesTotal())
+                .isEqualTo(disabled.calculation().stackBytesTotal());
     }
 
     @Test
@@ -159,5 +164,16 @@ class MemoryReportProviderTests {
         assertThat(report.kubernetes().qosClass()).isEqualTo("Burstable");
         assertThat(report.kubernetes().limitMemory()).isEqualTo("4096Mi");
         assertThat(report.kubernetes().requestMemory()).isNotEqualTo("4096Mi");
+    }
+
+    @Test
+    void clampsTotalMemoryMebibytesBeforeMultiplication() {
+        LiveMemoryReport oversized = providerWithDisabledDetector(MemoryRuntimeConfig.DEFAULTS)
+                .buildReport(Long.MAX_VALUE, null, null, null, null);
+        LiveMemoryReport negative = providerWithDisabledDetector(MemoryRuntimeConfig.DEFAULTS)
+                .buildReport(Long.MIN_VALUE, null, null, null, null);
+
+        assertThat(oversized.calculation().totalMemoryBytes()).isEqualTo(MemoryCalculator.MAX_TOTAL_MEMORY_BYTES);
+        assertThat(negative.calculation().totalMemoryBytes()).isEqualTo(MemoryCalculator.MIN_TOTAL_MEMORY_BYTES);
     }
 }

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusJvmTuningResourceTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusJvmTuningResourceTest.java
@@ -87,7 +87,9 @@ class BootUiQuarkusJvmTuningResourceTest {
                 .as("forced-on probes must render the SmallRye startup/liveness/readiness paths")
                 .contains("/q/health/started")
                 .contains("/q/health/live")
-                .contains("/q/health/ready");
+                .contains("/q/health/ready")
+                .contains("port: http")
+                .doesNotContain("port: 8080");
         assertThat(yaml)
                 .as("Quarkus has no Spring Actuator enabling env var, so it must never appear")
                 .doesNotContain("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED")

--- a/bootui-quarkus-sample-app/e2e/tests/jvm-tuning.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/jvm-tuning.spec.js
@@ -33,23 +33,25 @@ test.describe('JVM Tuning view (Quarkus)', () => {
     const kubernetesYaml = kubernetesCard.locator('.options-box code')
     await expect(jvmOptionsCard).toBeVisible()
     await expect(kubernetesCard).toBeVisible()
-    await expect(kubernetesCard).toContainText('Guaranteed')
+    await expect(kubernetesCard).toContainText('Depends on CPU')
     await expect(kubernetesCard.locator('#kubernetesBurstableEnabled')).not.toBeChecked()
     // SmallRye Health is on the sample app's classpath, so
     // QuarkusMemoryRuntimeConfig.kubernetesHealthProbesEnabled() is true and the toggle starts checked.
     await expect(kubernetesCard.locator('#kubernetesActuatorEnabled')).toBeChecked()
     await expect(kubernetesYaml).toContainText('JAVA_TOOL_OPTIONS')
     await expect(kubernetesYaml).toContainText('MaxRAMPercentage')
+    await expect(kubernetesYaml).toContainText('MinRAMPercentage')
     // Quarkus renders SmallRye Health's own httpGet probe paths directly (no Spring Actuator
     // env-var toggle exists on this platform).
     await expect(kubernetesYaml).toContainText('startupProbe')
     await expect(kubernetesYaml).toContainText('readinessProbe')
     await expect(kubernetesYaml).toContainText('/q/health/ready')
     await expect(kubernetesYaml).toContainText('/q/health/live')
+    await expect(kubernetesYaml).toContainText('port: http')
     await expect(kubernetesYaml).not.toContainText('MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED')
     await expect(kubernetesYaml).not.toContainText('spring.threads.virtual.enabled=true')
     await expect(kubernetesYaml).not.toContainText('-Xmx')
-    await expect(kubernetesCard).toContainText('Garbage collector:')
+    await expect(kubernetesCard).not.toContainText('Garbage collector:')
     await expect(kubernetesCard).toContainText('Sizing notes')
 
     const optionsBlock = jvmOptionsCard.locator('.options-box code')
@@ -70,9 +72,9 @@ test.describe('JVM Tuning view (Quarkus)', () => {
     const actuatorToggle = kubernetesCard.locator('#kubernetesActuatorEnabled')
 
     await expect(kubernetesCard).toBeVisible()
-    const guaranteedYaml = await yamlBlock.innerText()
-    const guaranteedRequest = guaranteedYaml.match(/requests:\s+memory: "([^"]+)"/)?.[1]
-    expect(guaranteedRequest).toBeTruthy()
+    const equalRequestYaml = await yamlBlock.innerText()
+    const equalRequest = equalRequestYaml.match(/requests:\s+memory: "([^"]+)"/)?.[1]
+    expect(equalRequest).toBeTruthy()
 
     await burstableToggle.check()
     await expect
@@ -83,7 +85,7 @@ test.describe('JVM Tuning view (Quarkus)', () => {
         },
         {timeout: 5_000}
       )
-      .not.toBe(guaranteedRequest)
+      .not.toBe(equalRequest)
     await expect(kubernetesCard).toContainText('Burstable')
 
     // Unchecking the health-probes toggle removes SmallRye Health's startup/readiness/liveness

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LiveMemoryControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/LiveMemoryControllerTests.java
@@ -53,7 +53,7 @@ class LiveMemoryControllerTests {
                 true,
                 null);
         KubernetesMemoryRecommendationDto kubernetes = new KubernetesMemoryRecommendationDto(
-                0, 0, 0, 0, null, "", "", "", "", "", "Guaranteed", "", List.of(), "", 0, 0, "", false, true);
+                0, 0, 0, 0, null, "", "", "", "", "", "Depends on CPU", "", List.of(), "", 0, 0, "", false, true);
         return new LiveMemoryReport(heap, nonHeap, List.of(heap), List.of("-Xss"), "-Xmx", calculation, kubernetes);
     }
 
@@ -73,7 +73,7 @@ class LiveMemoryControllerTests {
                 .andExpect(jsonPath("$.heap.name").value("Heap"))
                 .andExpect(jsonPath("$.nonHeap.name").value("Non-Heap"))
                 .andExpect(jsonPath("$.calculation.threadCount").value(7))
-                .andExpect(jsonPath("$.kubernetes.qosClass").value("Guaranteed"));
+                .andExpect(jsonPath("$.kubernetes.qosClass").value("Depends on CPU"));
     }
 
     @Test
@@ -101,7 +101,7 @@ class LiveMemoryControllerTests {
         mvc.perform(get("/bootui/api/jvm-tuning").param("totalMemoryMb", "512").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.heap.name").value("Heap"))
-                .andExpect(jsonPath("$.kubernetes.qosClass").value("Guaranteed"));
+                .andExpect(jsonPath("$.kubernetes.qosClass").value("Depends on CPU"));
 
         verify(provider).buildReport(512L, null, null, null, null);
     }

--- a/bootui-spring-sample-app/e2e/tests/jvm-tuning.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/jvm-tuning.spec.js
@@ -26,21 +26,23 @@ test.describe('JVM Tuning view', () => {
     const kubernetesYaml = kubernetesCard.locator('.options-box code')
     await expect(virtualThreadsStatus).toBeVisible()
     await expect(virtualThreadsStatus).toContainText('Virtual threads enabled')
-    await expect(virtualThreadsStatus).toContainText('positive for performance')
+    await expect(virtualThreadsStatus).toContainText('conservative platform-thread reserve')
     await expect(virtualThreadsStatus).toHaveClass(/alert-info/)
     await expect(page.locator('#virtualThreadsEnabled')).toHaveCount(0)
     await expect(jvmOptionsCard).toBeVisible()
     await expect(kubernetesCard).toBeVisible()
-    await expect(kubernetesCard).toContainText('Guaranteed')
+    await expect(kubernetesCard).toContainText('Depends on CPU')
     await expect(kubernetesCard.locator('#kubernetesBurstableEnabled')).not.toBeChecked()
     await expect(kubernetesCard.locator('#kubernetesActuatorEnabled')).toBeChecked()
     await expect(kubernetesYaml).toContainText('JAVA_TOOL_OPTIONS')
     await expect(kubernetesYaml).toContainText('MaxRAMPercentage')
+    await expect(kubernetesYaml).toContainText('MinRAMPercentage')
+    await expect(kubernetesYaml).toContainText('port: http')
     await expect(kubernetesYaml).toContainText('MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED')
     await expect(kubernetesYaml).toContainText('readinessProbe')
     await expect(kubernetesYaml).not.toContainText('spring.threads.virtual.enabled=true')
     await expect(kubernetesYaml).not.toContainText('-Xmx')
-    await expect(kubernetesCard).toContainText('Garbage collector:')
+    await expect(kubernetesCard).not.toContainText('Garbage collector:')
     await expect(kubernetesCard).toContainText('Sizing notes')
 
     const optionsBlock = jvmOptionsCard.locator('.options-box code')
@@ -61,9 +63,9 @@ test.describe('JVM Tuning view', () => {
     const actuatorToggle = kubernetesCard.locator('#kubernetesActuatorEnabled')
 
     await expect(kubernetesCard).toBeVisible()
-    const guaranteedYaml = await yamlBlock.innerText()
-    const guaranteedRequest = guaranteedYaml.match(/requests:\s+memory: "([^"]+)"/)?.[1]
-    expect(guaranteedRequest).toBeTruthy()
+    const equalRequestYaml = await yamlBlock.innerText()
+    const equalRequest = equalRequestYaml.match(/requests:\s+memory: "([^"]+)"/)?.[1]
+    expect(equalRequest).toBeTruthy()
 
     await burstableToggle.check()
     await expect
@@ -74,7 +76,7 @@ test.describe('JVM Tuning view', () => {
         },
         {timeout: 5_000}
       )
-      .not.toBe(guaranteedRequest)
+      .not.toBe(equalRequest)
     await expect(kubernetesCard).toContainText('Burstable')
 
     await actuatorToggle.uncheck()

--- a/bootui-ui/src/main/frontend/src/views/JvmTuning.test.js
+++ b/bootui-ui/src/main/frontend/src/views/JvmTuning.test.js
@@ -12,9 +12,8 @@ function memoryReport({
   kubernetesActuatorEnabled = true
 } = {}) {
   const requestMemory = kubernetesBurstableEnabled ? '512Mi' : '1024Mi'
-  const qosClass = kubernetesBurstableEnabled ? 'Burstable' : 'Guaranteed'
-  const javaToolOptions =
-    '-XX:+UseContainerSupport -XX:MaxRAMPercentage=62.5 -XX:InitialRAMPercentage=62.5 -XX:+UseG1GC'
+  const qosClass = kubernetesBurstableEnabled ? 'Burstable' : 'Depends on CPU'
+  const javaToolOptions = '-XX:MaxRAMPercentage=62.5 -XX:MinRAMPercentage=62.5 -XX:InitialRAMPercentage=62.5'
   const probeYaml = kubernetesActuatorEnabled
     ? '\n' +
       '  - name: MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED\n' +
@@ -22,7 +21,7 @@ function memoryReport({
       'startupProbe:\n' +
       '  httpGet:\n' +
       '    path: /actuator/health/liveness\n' +
-      '    port: 8080'
+      '    port: http'
     : ''
 
   return {
@@ -30,15 +29,15 @@ function memoryReport({
     nonHeap: {name: 'Non-Heap', usedBytes: 64 * MB, committedBytes: 128 * MB, maxBytes: -1, usedPercent: 50},
     pools: [{name: 'G1 Eden Space', usedBytes: 32 * MB, committedBytes: 64 * MB, maxBytes: 128 * MB, usedPercent: 25}],
     jvmInputArguments: [],
-    suggestedJvmOptions: '-Xms512m -Xmx512m -XX:+UseG1GC',
+    suggestedJvmOptions: '-Xms512m -Xmx512m -XX:MaxMetaspaceSize=64m',
     calculation: {
       totalMemoryBytes: 1024 * MB,
       heapBytes: 512 * MB,
       metaspaceBytes: 64 * MB,
       codeCacheBytes: 240 * MB,
       directMemoryBytes: 10 * MB,
-      stackBytesPerThread: virtualThreadsEnabled ? MB / 2 : MB,
-      stackBytesTotal: virtualThreadsEnabled ? 125 * MB : 250 * MB,
+      stackBytesPerThread: MB,
+      stackBytesTotal: 250 * MB,
       headRoomBytes: 102 * MB,
       fixedRegionsBytes: 564 * MB,
       threadCount: 250,
@@ -48,7 +47,7 @@ function memoryReport({
       headRoomPercent: 10,
       virtualThreadsEnabled,
       virtualThreadsProperty,
-      jvmOptions: '-Xms512m -Xmx512m -XX:+UseG1GC',
+      jvmOptions: '-Xms512m -Xmx512m -XX:MaxMetaspaceSize=64m',
       valid: true,
       error: null
     },
@@ -64,10 +63,10 @@ function memoryReport({
       currentSnapshotMemory: '432Mi',
       detectedContainerLimitMemory: '1024Mi',
       qosClass,
-      confidence: 'High',
+      confidence: 'Medium',
       warnings: [
-        'Garbage collector: G1GC is selected for calculated heaps below 4 GiB; the advisor switches to ZGC for larger heaps.',
-        'Request equals limit for Kubernetes Guaranteed QoS.'
+        'Memory request equals memory limit. Kubernetes Guaranteed QoS additionally requires equal, non-zero CPU request and limit for every container in the Pod.',
+        'Direct memory is modeled from the current direct-buffer usage and is intentionally not hard-capped.'
       ],
       yaml:
         'resources:\n' +
@@ -130,27 +129,28 @@ describe('JvmTuning', () => {
     })
     expect(panelPositions).toEqual([...panelPositions].sort((a, b) => a - b))
     expect(renderedText).toContain('1024Mi')
-    expect(renderedText).toContain('Guaranteed')
+    expect(renderedText).toContain('Depends on CPU')
     expect(renderedText).not.toContain('Burstable alternative')
-    expect(renderedText).toContain('High confidence')
-    expect(renderedText).toContain('Request equals limit')
-    expect(renderedText).toContain('Garbage collector: G1GC')
+    expect(renderedText).toContain('Medium model confidence')
+    expect(renderedText).toContain('CPU request and limit')
+    expect(renderedText).not.toContain('Garbage collector:')
     expect(wrapper.find('.alert-info').text()).toContain('Sizing notes')
     expect(renderedText.indexOf('Deployment snippet')).toBeLessThan(renderedText.indexOf('Sizing notes'))
-    expect(renderedText.indexOf('Garbage collector: G1GC')).toBeLessThan(renderedText.indexOf('Request equals limit'))
     expect(renderedText).toContain('Burstable resources')
     expect(renderedText).toContain('Kubernetes health probes')
     const virtualThreadsStatus = wrapper.find('.virtual-threads-status')
     expect(virtualThreadsStatus.classes()).toContain('alert-warning')
     expect(virtualThreadsStatus.text()).toContain('Virtual threads not enabled')
-    expect(virtualThreadsStatus.text()).toContain('improve throughput')
+    expect(virtualThreadsStatus.text()).toContain('representative load')
     const optionsText = wrapper
       .findAll('.options-box code')
       .map((node) => node.text())
       .join('\n')
     expect(optionsText).toContain('JAVA_TOOL_OPTIONS')
     expect(optionsText).toContain('MaxRAMPercentage=62.5')
+    expect(optionsText).toContain('MinRAMPercentage=62.5')
     expect(optionsText).not.toContain('spring.threads.virtual.enabled=true')
+    expect(renderedText).toContain('62.5%')
     expect(optionsText).toContain('MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED')
     expect(wrapper.html()).not.toContain('value: &quot;-Xms512m')
     expect(wrapper.find('#virtualThreadsEnabled').exists()).toBe(false)
@@ -168,14 +168,25 @@ describe('JvmTuning', () => {
     const virtualThreadsStatus = wrapper.find('.virtual-threads-status')
     expect(virtualThreadsStatus.classes()).toContain('alert-info')
     expect(virtualThreadsStatus.text()).toContain('Virtual threads enabled')
-    expect(virtualThreadsStatus.text()).toContain('positive for performance')
+    expect(virtualThreadsStatus.text()).toContain('conservative platform-thread reserve')
     expect(wrapper.find('#virtualThreadsEnabled').exists()).toBe(false)
-    expect(wrapper.text()).toContain('virtual-thread mode uses')
+    expect(wrapper.text()).toContain('1024 KiB per platform thread')
     const optionsText = wrapper
       .findAll('.options-box code')
       .map((node) => node.text())
       .join('\n')
     expect(optionsText).not.toContain('spring.threads.virtual.enabled=true')
+  })
+
+  it('preserves sub-percent heap precision', async () => {
+    const report = memoryReport()
+    report.kubernetes.maxRamPercentage = 0.781
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(report)))
+
+    wrapper = mount(JvmTuning)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('0.781%')
   })
 
   it('hides the virtual-threads advisory when no app-wide switch exists (Quarkus)', async () => {
@@ -208,6 +219,20 @@ describe('JvmTuning', () => {
     expect(wrapper.find('#kubernetesBurstableEnabled').element.checked).toBe(true)
     expect(wrapper.find('#kubernetesActuatorEnabled').element.checked).toBe(false)
     expect(wrapper.text()).toContain('Burstable')
+  })
+
+  it('keeps equal-request wording when burstable sizing reaches the limit', async () => {
+    const report = memoryReport({kubernetesBurstableEnabled: true})
+    report.kubernetes.requestMemoryBytes = report.kubernetes.limitMemoryBytes
+    report.kubernetes.requestMemory = report.kubernetes.limitMemory
+    report.kubernetes.qosClass = 'Depends on CPU'
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(report)))
+
+    wrapper = mount(JvmTuning)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Memory request equals limit')
+    expect(wrapper.text()).toContain('CPU settings also required')
   })
 
   it('reloads recommendations when Kubernetes toggles are changed', async () => {

--- a/bootui-ui/src/main/frontend/src/views/JvmTuning.vue
+++ b/bootui-ui/src/main/frontend/src/views/JvmTuning.vue
@@ -24,6 +24,10 @@ const {copiedKey, copyToClipboard} = useCopyToClipboard(2000)
 
 const virtualThreadsProperty = computed(() => data.value?.calculation?.virtualThreadsProperty ?? null)
 const virtualThreadsActive = computed(() => data.value?.calculation?.virtualThreadsEnabled === true)
+const kubernetesRequestBelowLimit = computed(() => {
+  const recommendation = data.value?.kubernetes
+  return recommendation ? recommendation.requestMemoryBytes < recommendation.limitMemoryBytes : false
+})
 
 const breakdown = computed(() => {
   const c = data.value?.calculation
@@ -59,6 +63,13 @@ async function copyKubernetesYaml() {
   if (data.value?.kubernetes?.yaml) {
     await copyToClipboard(data.value.kubernetes.yaml, 'kubernetes-yaml')
   }
+}
+
+function formatPercentage(value) {
+  if (value == null) return '—'
+  return `${Number(value)
+    .toFixed(3)
+    .replace(/\.?0+$/, '')}%`
 }
 </script>
 
@@ -103,21 +114,21 @@ async function copyKubernetesYaml() {
             <div class="fw-semibold mb-1">Virtual threads {{ virtualThreadsActive ? 'enabled' : 'not enabled' }}</div>
             <template v-if="virtualThreadsActive">
               <p class="small mb-2">
-                This application is running with <code>{{ virtualThreadsProperty }}=true</code>. That is positive for
-                performance because the application can use virtual threads for web requests and supported task
-                executors, reducing platform-thread pressure during blocking work.
+                This application is running with <code>{{ virtualThreadsProperty }}=true</code>. Virtual threads
+                decouple blocking-request concurrency from the platform-thread count, but the calculator keeps a
+                conservative platform-thread reserve and 1 MiB stacks because carrier and JVM helper threads still use
+                native stacks.
               </p>
             </template>
             <template v-else>
               <p class="small mb-2">
-                <code>{{ virtualThreadsProperty }}=true</code> is not active for this application. On Java 21+, enabling
-                it in application configuration is recommended for services that handle blocking web requests or
-                supported task-executor work because it can improve throughput and latency under concurrent blocking
-                workloads.
+                <code>{{ virtualThreadsProperty }}=true</code> is not active for this application. On Java 21+, consider
+                virtual threads for services dominated by blocking request or task-executor work, then verify
+                throughput, pinning, and memory under representative load.
               </p>
               <p class="small mb-0">
-                BootUI keeps the JVM and Kubernetes snippets in platform-thread mode until the running application
-                enables virtual threads.
+                BootUI always uses the conservative platform-thread sizing model and never adds this application
+                property to generated JVM options.
               </p>
             </template>
           </div>
@@ -131,15 +142,15 @@ async function copyKubernetesYaml() {
         </div>
         <div class="card-body">
           <p class="text-muted small mb-3">
-            For a dedicated server or VM, heap is fixed after subtracting metaspace (sized from currently loaded classes
-            × 1.25 safety factor), code cache, direct memory, platform-thread stacks, and headroom from your target JVM
-            process memory.
+            For a dedicated server or VM, heap is fixed after subtracting modeled metaspace (currently loaded classes ×
+            1.25), code cache, direct memory, platform-thread stacks, and operator-selected headroom. Direct memory uses
+            the Paketo 10 MiB fallback or the current observed usage, whichever is larger.
           </p>
 
           <div class="row g-3 mb-3">
             <div class="col-md-5">
               <label class="form-label small fw-semibold" for="jvm-target-memory">
-                Target JVM process memory (MB)
+                Target JVM process memory (MiB)
               </label>
               <div class="input-group input-group-sm">
                 <button aria-label="Decrease" class="btn btn-outline-secondary" type="button" @click="stepTotal(-64)">
@@ -157,7 +168,7 @@ async function copyKubernetesYaml() {
                 <button aria-label="Increase" class="btn btn-outline-secondary" type="button" @click="stepTotal(64)">
                   +
                 </button>
-                <span class="input-group-text">MB</span>
+                <span class="input-group-text">MiB</span>
               </div>
             </div>
             <div class="col-md-4">
@@ -214,10 +225,8 @@ async function copyKubernetesYaml() {
             </div>
             <div class="small text-muted">
               Currently {{ data.calculation.liveLoadedClassCount.toLocaleString() }} classes loaded · metaspace sized
-              for {{ data.calculation.loadedClasses.toLocaleString() }} classes × 1.25 safety factor
-              <span v-if="data.calculation.virtualThreadsEnabled">
-                · virtual-thread mode uses {{ data.calculation.stackBytesPerThread / 1024 }} KB platform-thread stacks
-              </span>
+              for {{ data.calculation.loadedClasses.toLocaleString() }} classes × 1.25 safety factor ·
+              {{ data.calculation.stackBytesPerThread / 1024 }} KiB per platform thread
             </div>
           </template>
         </div>
@@ -238,16 +247,17 @@ async function copyKubernetesYaml() {
         </div>
         <div class="card-body">
           <p class="text-muted small mb-2">
-            Generated from your calculator inputs for a dedicated host. <code>-Xms == -Xmx</code> fixes heap size for
-            predictable startup and runtime latency; GC is picked automatically (G1 below 4 GB, ZGC above).
+            Generated as a starting point for a dedicated host. <code>-Xms == -Xmx</code> fixes the modeled heap; the
+            running JVM's collector stays unchanged, and workload-specific GC, string deduplication, compact-header,
+            direct-memory-cap, pre-touch, and OOM policy flags are intentionally omitted.
           </p>
           <pre
             :class="{'opacity-50': data.calculation && !data.calculation.valid}"
             class="bg-dark text-light rounded p-3 mb-0 options-box"
           ><code>{{ data.suggestedJvmOptions || '—' }}</code></pre>
           <div class="mt-2">
-            <span class="badge text-bg-secondary me-1"><i class="bi bi-shield-check me-1"></i>OOM protection</span>
-            <span class="badge text-bg-secondary me-1"><i class="bi bi-gear me-1"></i>GC tuned</span>
+            <span class="badge text-bg-secondary me-1"><i class="bi bi-calculator me-1"></i>Sizing model</span>
+            <span class="badge text-bg-secondary me-1"><i class="bi bi-gear me-1"></i>Collector unchanged</span>
             <span class="badge text-bg-secondary me-1"><i class="bi bi-memory me-1"></i>Fixed heap</span>
           </div>
         </div>
@@ -257,16 +267,16 @@ async function copyKubernetesYaml() {
         <div class="card-header bg-success text-white d-flex justify-content-between align-items-center">
           <span><i class="bi bi-box-seam me-2"></i>Kubernetes calculator</span>
           <span :class="['badge', confidenceBadgeClass(data.kubernetes.confidence)]">
-            {{ data.kubernetes.confidence }} confidence
+            {{ data.kubernetes.confidence }} model confidence
           </span>
         </div>
         <div class="card-body">
           <p class="text-muted small mb-3">
             Uses the calculator total as the hard Kubernetes memory limit. By default, the generated manifest sets
-            <code>requests.memory == limits.memory</code> for Guaranteed QoS; the Burstable toggle lowers only the
-            request. The JVM uses <code>MaxRAMPercentage</code>/<code>InitialRAMPercentage</code> instead of fixed
-            <code>-Xmx</code>/<code>-Xms</code>, so heap tracks the container memory limit when an operator resizes the
-            pod.
+            <code>requests.memory == limits.memory</code>; Kubernetes only assigns Guaranteed QoS when every container
+            also has equal, non-zero CPU request and limit. The Burstable toggle lowers only the memory request. HotSpot
+            uses <code>MaxRAMPercentage</code>/<code>MinRAMPercentage</code>/<code>InitialRAMPercentage</code> instead
+            of fixed <code>-Xmx</code>/<code>-Xms</code>.
           </p>
 
           <div class="row g-3 mb-3">
@@ -276,9 +286,9 @@ async function copyKubernetesYaml() {
                   <div>
                     <div class="fw-semibold">Burstable resources</div>
                     <div class="text-muted small">
-                      Off by default. When enabled, the snippet lowers <code>requests.memory</code> to the current
-                      snapshot-based request while keeping the same limit. Use only when your cluster intentionally
-                      overcommits memory.
+                      Off by default. When enabled, the snippet attempts to lower <code>requests.memory</code> to the
+                      current snapshot-based request while keeping the same limit. Use only when your cluster
+                      intentionally overcommits memory.
                     </div>
                   </div>
                   <div class="form-check form-switch mb-0 flex-shrink-0">
@@ -301,8 +311,9 @@ async function copyKubernetesYaml() {
                   <div>
                     <div class="fw-semibold">Kubernetes health probes</div>
                     <div class="text-muted small">
-                      Initialized from the current health configuration. Recommended so Kubernetes can use startup,
-                      readiness, and liveness checks; the snippet below uses this application's health endpoints.
+                      Initialized from the current health capability. The fragment uses framework-default paths and the
+                      named container port <code>http</code>; verify both when application or management settings
+                      differ.
                     </div>
                   </div>
                   <div class="form-check form-switch mb-0 flex-shrink-0">
@@ -333,7 +344,7 @@ async function copyKubernetesYaml() {
                 <div class="text-muted small">Request memory</div>
                 <div class="fs-5 fw-semibold">{{ data.kubernetes.requestMemory || '—' }}</div>
                 <div class="text-muted small">
-                  {{ kubernetesBurstableEnabled ? 'Burstable scheduling request' : 'Guaranteed scheduling request' }}
+                  {{ kubernetesRequestBelowLimit ? 'Burstable scheduling request' : 'Memory request equals limit' }}
                 </div>
               </div>
             </div>
@@ -347,28 +358,24 @@ async function copyKubernetesYaml() {
             <div class="col-md">
               <div class="border rounded p-3 h-100">
                 <div class="text-muted small">Heap percentage</div>
-                <div class="fs-5 fw-semibold">
-                  {{
-                    data.kubernetes.maxRamPercentage != null ? data.kubernetes.maxRamPercentage.toFixed(1) + '%' : '—'
-                  }}
-                </div>
-                <div class="text-muted small">MaxRAMPercentage</div>
+                <div class="fs-5 fw-semibold">{{ formatPercentage(data.kubernetes.maxRamPercentage) }}</div>
+                <div class="text-muted small">Max/Min RAM percentage</div>
               </div>
             </div>
             <div class="col-md">
               <div class="border rounded p-3 h-100">
-                <div class="text-muted small">QoS class</div>
+                <div class="text-muted small">Pod QoS</div>
                 <div class="fs-5 fw-semibold">{{ data.kubernetes.qosClass }}</div>
                 <div class="text-muted small">
-                  {{ kubernetesBurstableEnabled ? 'Opt-in mode' : 'Recommended default' }}
+                  {{ kubernetesRequestBelowLimit ? 'Determined by memory settings' : 'CPU settings also required' }}
                 </div>
               </div>
             </div>
             <div class="col-md">
               <div class="border rounded p-3 h-100">
-                <div class="text-muted small">Current snapshot</div>
+                <div class="text-muted small">Observed baseline</div>
                 <div class="fs-5 fw-semibold">{{ data.kubernetes.currentSnapshotMemory }}</div>
-                <div class="text-muted small">Committed JVM memory + live platform stacks</div>
+                <div class="text-muted small">cgroup total when available; JVM-pool fallback otherwise</div>
               </div>
             </div>
           </div>

--- a/bootui-ui/src/main/frontend/src/views/LiveMemory.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveMemory.test.js
@@ -14,7 +14,7 @@ function memoryReport() {
     nonHeap: {name: 'Non-Heap', usedBytes: 64 * MB, committedBytes: 128 * MB, maxBytes: -1, usedPercent: 50},
     pools: [{name: 'G1 Eden Space', usedBytes: 32 * MB, committedBytes: 64 * MB, maxBytes: 128 * MB, usedPercent: 25}],
     jvmInputArguments: [],
-    suggestedJvmOptions: '-Xms512m -Xmx512m -XX:+UseG1GC',
+    suggestedJvmOptions: '-Xms512m -Xmx512m -XX:MaxMetaspaceSize=64m',
     calculation: {
       totalMemoryBytes: 1024 * MB,
       heapBytes: 512 * MB,
@@ -30,7 +30,7 @@ function memoryReport() {
       liveThreadCount: 40,
       liveLoadedClassCount: 5000,
       headRoomPercent: 10,
-      jvmOptions: '-Xms512m -Xmx512m -XX:+UseG1GC',
+      jvmOptions: '-Xms512m -Xmx512m -XX:MaxMetaspaceSize=64m',
       valid: true,
       error: null
     },
@@ -45,9 +45,9 @@ function memoryReport() {
       burstableRequestMemory: '512Mi',
       currentSnapshotMemory: '432Mi',
       detectedContainerLimitMemory: '1024Mi',
-      qosClass: 'Guaranteed',
-      confidence: 'High',
-      warnings: ['Request equals limit for Kubernetes Guaranteed QoS.'],
+      qosClass: 'Depends on CPU',
+      confidence: 'Low',
+      warnings: ['Kubernetes Guaranteed QoS also requires matching CPU resources.'],
       yaml:
         'resources:\n' +
         '  requests:\n' +
@@ -56,7 +56,8 @@ function memoryReport() {
         '    memory: "1024Mi"\n' +
         'env:\n' +
         '  - name: JAVA_TOOL_OPTIONS\n' +
-        '    value: "-Xms512m -Xmx512m -XX:+UseG1GC"'
+        '    value: >-\n' +
+        '      -XX:MaxRAMPercentage=50 -XX:MinRAMPercentage=50 -XX:InitialRAMPercentage=50'
     }
   }
 }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -727,18 +727,23 @@ JVM sizing controls mixed into the view.
 
 The JVM Tuning panel uses the same live JVM context to review current JVM input arguments, explain
 `spring.threads.virtual.enabled=true`, and run JVM sizing calculators for both dedicated hosts and Kubernetes. It detects
-whether Spring virtual threads are enabled in the current application, shows an information or warning bubble, and feeds
-that detected state into platform-thread stack budgets and heap sizing recommendations without adding the Spring property
-to generated JVM or Kubernetes snippets.
+whether Spring virtual threads are enabled in the current application and shows an information or warning bubble, but
+does not infer a smaller native-stack budget from that signal or add the Spring property to generated snippets.
 
 The bare-metal calculator partitions a target JVM process memory budget into heap, metaspace, code cache, direct memory,
-thread stacks, and headroom, then turns that plan into copyable JVM options with fixed `-Xms` and `-Xmx` values. The
-Kubernetes calculator keeps `requests.memory == limits.memory` for Guaranteed QoS by default, but can switch to a
-snapshot-based Burstable request when the operator intentionally overcommits memory. Its `JAVA_TOOL_OPTIONS` uses
-`-XX:MaxRAMPercentage` and `-XX:InitialRAMPercentage` instead of fixed heap sizes so the JVM heap follows the container
-memory limit when an operator resizes the pod. A Kubernetes health probes toggle initializes from the current health
-probe configuration and, when enabled, adds startup/readiness/liveness probe YAML plus the health-probes property. Fixed
-non-heap caps remain visible in the snippet and sizing notes because they still need to fit inside any smaller limit.
+thread stacks, and headroom, then turns that plan into copyable JVM options with fixed `-Xms` and `-Xmx` values. It keeps
+the current collector and omits workload-specific GC, direct-memory-cap, pre-touch, compact-header, string-deduplication,
+and out-of-memory policy flags.
+
+The Kubernetes calculator sets equal memory request and limit values by default but labels Pod QoS `Depends on CPU`,
+because Kubernetes also requires matching non-zero CPU resources on every container for Guaranteed QoS. Operators can
+instead attempt a lower, snapshot-based Burstable request. `JAVA_TOOL_OPTIONS` uses `-XX:MaxRAMPercentage`,
+`-XX:MinRAMPercentage`, and `-XX:InitialRAMPercentage` instead of fixed heap sizes. A health-probes toggle initializes
+from the current framework capability and adds framework-default startup/readiness/liveness paths on the named container
+port `http`; those paths and the port name must be verified against deployment configuration.
+
+See [JVM-TUNING-CHECKS.md](JVM-TUNING-CHECKS.md) for the behavior inventory, evidence ledger, cross-platform details,
+and model limitations.
 
 > **Not available in GraalVM native images.** JVM heap, GC, and flag tuning does not apply to a native executable;
 > the panel is automatically hidden when the application is detected to be running as a native image.

--- a/docs/JVM-TUNING-CHECKS.md
+++ b/docs/JVM-TUNING-CHECKS.md
@@ -1,0 +1,136 @@
+# JVM Tuning Advisor Model
+
+The JVM Tuning panel is a deterministic memory-budget calculator, not an automatic performance tuner. It turns live,
+local JVM observations and operator inputs into a reviewable starting point. It does not modify the running process,
+select a garbage collector, inspect application traffic, or claim that a snapshot predicts peak production demand.
+
+This document records the evidence and decisions behind the shared engine used by Spring MVC, Spring WebFlux, and
+Quarkus. The compatibility baseline is Java 17 through Java 26, Spring Boot 4.1, and Quarkus 3.33 LTS.
+
+## Evidence ledger
+
+| Source | Evidence used |
+| ------ | ------------- |
+| [Spring Boot 4.1 system requirements](https://docs.spring.io/spring-boot/system-requirements.html) | Spring Boot 4.1 requires Java 17 and supports Java through 26, defining the generated-option compatibility range. |
+| [Oracle JDK 17 `java` launcher](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html) and [JDK 26 launcher](https://docs.oracle.com/en/java/javase/26/docs/specs/man/java.html) | Defines `-Xms`, `-Xmx`, `-Xss`, container support, RAM-percentage, metaspace, code-cache, GC, pre-touch, and OOM options across the supported range. `MinRAMPercentage` governs maximum-heap ergonomics for small heaps, so it must accompany `MaxRAMPercentage`. `UseContainerSupport` is Linux-only and already defaults to true where supported, so a portable snippet must not force it. |
+| [Paketo Java memory calculator reference](https://paketo.io/docs/reference/java-reference/#memory-calculator) and [`libjvm` calculator source](https://github.com/paketo-buildpacks/libjvm/blob/main/calc/calculator.go) | Supplies the partition formula and the 10 MiB direct-memory, 240 MiB code-cache, 1 MiB stack, and 250-thread modeling defaults. |
+| [`ClassLoadingMXBean`](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/ClassLoadingMXBean.html) and [`BufferPoolMXBean`](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/BufferPoolMXBean.html) | Provide observable current loaded-class count and estimated direct-buffer memory usage. Both are snapshots, not peak forecasts. |
+| [JEP 444: Virtual Threads](https://openjdk.org/jeps/444) | Virtual threads are not tied one-to-one to OS threads and are mounted on carrier platform threads. Their presence does not provide an observable, deterministic replacement for a platform-thread native-stack budget. |
+| [Oracle GC ergonomics guidance](https://docs.oracle.com/en/java/javase/17/gctuning/ergonomics.html) | GC sizing and pause/throughput choices are competing workload goals; heap size alone is not sufficient evidence for changing collectors or enabling pre-touch. |
+| [JEP 439](https://openjdk.org/jeps/439) and [JEP 474](https://openjdk.org/jeps/474) | Generational ZGC availability and defaults changed after Java 17, so emitting `ZGenerational` cannot be portable across the supported range. |
+| [JEP 450: Compact Object Headers](https://openjdk.org/jeps/450) | Compact headers entered as a disabled experimental feature after Java 17 and require workload validation, so the advisor cannot enable them generically. |
+| [Kubernetes resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) and [Pod QoS classes](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/) | Memory limits are hard OOM boundaries; requests drive scheduling. Guaranteed QoS requires equal, non-zero CPU and memory requests and limits for every container, not memory equality alone. |
+| [Linux cgroup v2 memory controller](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files) | `memory.current` is the current total memory attributed to a cgroup and `memory.max` is its hard limit. |
+| [Oracle Native Memory Tracking](https://docs.oracle.com/en/java/javase/17/vm/native-memory-tracking.html) | NMT is off by default, requires `jcmd` output to use, and tracks JVM/HotSpot memory rather than all user-native allocations. Detecting its startup flag alone is not stronger sizing evidence. |
+| [Kubernetes probe configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#use-a-named-port) | HTTP probes may refer to a named container port, avoiding a framework-specific hard-coded port number. |
+| [Spring Boot Kubernetes probes](https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.kubernetes-probes) and [Quarkus 3.33 SmallRye Health](https://quarkus.io/version/3.33/guides/smallrye-health) | Supplies framework-default health capabilities and paths. Both frameworks allow configuration that can move those endpoints or their port. |
+
+## Memory model
+
+The calculator keeps the Paketo-style partition:
+
+```text
+heap = total process budget
+     - operator-selected headroom
+     - modeled direct memory
+     - modeled metaspace
+     - reserved code cache
+     - (platform-thread budget × stack size)
+```
+
+The current inputs and bounds are:
+
+| Input or region | Current behavior |
+| --------------- | ---------------- |
+| Total process budget | Operator input clamped to 128 MiB–64 GiB before byte conversion. The initial host default is an explicit BootUI heuristic, approximately 1.5 times committed heap plus non-heap, rounded to 64 MiB and clamped to 384 MiB–2 GiB. |
+| Headroom | Operator-selected 0%–30%; default 10%. It covers unmodeled native/process overhead but is not a measured guarantee. |
+| Direct memory | Greater of Paketo's 10 MiB fallback and current `java.nio` direct-buffer memory, rounded up to MiB. It is modeled but not hard-capped. |
+| Metaspace | `(14,000,000 + 5,800 × current loaded classes) × 1.25`, rounded up to MiB. The constants follow Paketo; 1.25 is an explicit BootUI allowance for later class loading. |
+| Code cache | 240 MiB, following the comparable Paketo model. |
+| Platform-thread stacks | 1 MiB times the operator budget. The initial budget is `max(current live threads, 250)` for every runtime, including applications using virtual threads. |
+| Heap | Exact remaining bytes in the report; generated MiB options round down so rendering never exceeds the modeled budget. A plan with less than 1 MiB of renderable heap is invalid. |
+
+### Generated option inventory
+
+For a valid dedicated-host plan, the advisor emits only:
+
+```text
+-Xms<heapMiB>m
+-Xmx<heapMiB>m
+-XX:MaxMetaspaceSize=<metaspaceMiB>m
+-XX:ReservedCodeCacheSize=240m
+-Xss1024k
+```
+
+For Kubernetes, fixed heap flags are replaced with:
+
+```text
+-XX:MaxRAMPercentage=<calculated>
+-XX:MinRAMPercentage=<calculated>
+-XX:InitialRAMPercentage=<calculated>
+-XX:MaxMetaspaceSize=<metaspaceMiB>m
+-XX:ReservedCodeCacheSize=240m
+-Xss1024k
+```
+
+The heap percentage is the modeled heap divided by the memory limit, floored to three decimal places. There is no
+universal 75% cap: fixed regions and selected headroom have already been subtracted.
+
+## Kubernetes behavior
+
+- The hard memory limit is the calculator total.
+- The default memory request equals that limit. The panel reports QoS as `Depends on CPU`; it cannot see or safely invent
+  the CPU settings and resources of every container in the final Pod.
+- Burstable mode attempts to lower the request using `current snapshot + max(15%, 64 MiB)`, rounded up to 64 MiB,
+  floored at 128 MiB, and capped by the limit. If the result reaches the limit, memory request and limit stay equal and
+  QoS remains `Depends on CPU`. This is explicitly a starting heuristic.
+- `memory.current` (or the cgroup v1 current-usage file) is preferred for the snapshot. When unavailable, the fallback is
+  committed heap + committed non-heap + observed direct buffers. Reserved stack address space is not added to resident
+  memory.
+- Confidence is `Medium` only when both cgroup limit and current usage are available and the detected limit matches the
+  selected total. Every other valid model is `Low`; the advisor does not claim high confidence from NMT merely being
+  enabled.
+- Generated health probes use framework-default paths and the named container port `http`. The fragment assumes the
+  surrounding container declares that port name. Custom application paths, management interfaces, and ports must be
+  reconciled by the operator.
+
+## Decision inventory
+
+| Decision | Result | Rationale |
+| -------- | ------ | --------- |
+| Paketo partition and fixed-region defaults | **KEEP** | Established, deterministic baseline with transparent arithmetic. |
+| Live class count with 1.25 allowance | **KEEP** | Observable input plus an explicit, testable heuristic. |
+| Metaspace and rendered-cap rounding | **MODIFY** | Caps round up; heap rounds down, preventing snippets from under-allocating caps or exceeding the plan. |
+| Direct-memory region | **MODIFY** | Raise the model to observed direct-buffer usage, but do not convert a transient observation into a hard cap. |
+| Virtual-thread stack discount | **REMOVE** | The previous 80-thread/512 KiB assumption was not derivable from `ThreadMXBean` or the virtual-thread scheduler. |
+| Automatic G1/ZGC selection and `ZGenerational` | **REMOVE** | Heap size alone does not establish pause/throughput goals, and flag behavior varies inside the supported JDK range. |
+| String deduplication, compact headers, and pre-touch | **REMOVE** | Workload- or JDK-specific choices cannot be inferred from this snapshot. |
+| Direct-memory cap and OOM exit/dump policy | **REMOVE** | Future native demand, restart policy, dump storage, and sensitive-data handling are deployment decisions. |
+| Kubernetes 75% heap ceiling | **REMOVE** | It double-counted native safety after fixed regions and headroom were already subtracted. |
+| `MinRAMPercentage` | **ADD** | Keeps the calculated maximum-heap percentage effective for HotSpot's small-heap path. |
+| Explicit `UseContainerSupport` | **REMOVE** | The option is Linux-only and already enabled by default where supported; omitting it keeps the fragment valid on other container platforms. |
+| cgroup current usage | **ADD** | More complete current container observation than summing selected JVM pools. |
+| Guaranteed QoS claim | **MODIFY** | Memory equality is necessary but not sufficient; CPU and all Pod containers also determine QoS. |
+| Hard-coded probe port 8080 | **MODIFY** | A named port is portable across framework defaults, with an explicit operator-verification warning. |
+
+Rejected new candidates include automatic CPU sizing, fixed GC pause targets, large pages, NUMA settings, Shenandoah or
+ZGC recommendations, automatic NMT enablement, and a universal native-overhead multiplier. They are unavailable on part
+of the supported range, depend on workload/host/cluster policy, or cannot be derived reliably from current local
+observations.
+
+## Platform behavior and limitations
+
+- **Spring MVC and WebFlux:** both use the same engine and DTOs. Spring's virtual-thread property is explanatory only.
+  Spring Actuator probe groups are included only when the adapter reports them enabled. WebFlux/Netty can use native
+  allocations that the standard direct-buffer MXBean does not fully describe, so direct memory must be load-tested.
+- **Quarkus 3.33 LTS:** the same calculation is used. Quarkus does not expose a single application-wide virtual-thread
+  switch equivalent to Spring's property, so that bubble is absent. SmallRye Health contributes `/q/health/started`,
+  `/q/health/ready`, and `/q/health/live`; a separate management interface can move them.
+- **HotSpot options:** generated flags are documented HotSpot options. Alternative JVM implementations require manual
+  review.
+- **Snapshots:** current classes, threads, buffers, pools, and cgroup usage can all grow after the panel is opened.
+  Recommendations must be tested after warmup and under representative peak load.
+- **NMT:** BootUI detects the startup option but does not execute or parse `jcmd VM.native_memory`; no confidence claim
+  depends on NMT output.
+- **YAML scope:** the output is a container fragment, not a complete Deployment. It does not invent CPU resources,
+  container names, images, security context, or a `ports` declaration.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -654,24 +654,29 @@ Features:
 - The Live Memory panel shows memory pool usage.
 - The JVM Tuning panel shows JVM input arguments.
 - The JVM Tuning panel explains `spring.threads.virtual.enabled=true`, detects whether Spring virtual threads are
-  enabled in the current application, and shows an information or warning bubble. The detected state feeds the sizing
-  calculations, but generated JVM or Kubernetes snippets do not set the Spring property.
+  enabled in the current application, and shows an information or warning bubble. The detected state is explanatory:
+  generated JVM or Kubernetes snippets do not set the Spring property, and virtual threads do not trigger a speculative
+  native-stack discount.
 - The JVM Tuning panel provides a bare-metal JVM memory calculator that partitions a user-chosen
   target JVM process memory into JVM regions
   (`heap = total − headRoom − directMemory − metaspace − codeCache − stack×threads`),
-  using the live loaded-class count from `ClassLoadingMXBean` (with a 1.25× safety
-  factor) and a live-or-floored platform-thread count. When virtual threads are enabled, the calculator uses a smaller
-  platform-thread floor and stack size because request concurrency no longer reserves one native stack per request.
+  using the live loaded-class count from `ClassLoadingMXBean` (with an explicit 1.25× safety
+  factor), the greater of the 10 MiB direct-memory fallback and observed direct-buffer use, and a platform-thread count
+  floored at 250 by default.
 - The JVM Tuning panel suggests bare-metal JVM options derived from the calculator output, including `-Xms`/`-Xmx`
-  (equal for predictable startup), `-XX:MaxMetaspaceSize`, `-XX:ReservedCodeCacheSize`,
-  `-XX:MaxDirectMemorySize`, `-Xss`, GC selection (G1 below 4 GB, ZGC above), and
-  out-of-memory safeguards.
-- The JVM Tuning panel suggests Kubernetes resources and `JAVA_TOOL_OPTIONS` with `requests.memory == limits.memory`
-  for Guaranteed QoS and percentage-based heap sizing (`-XX:MaxRAMPercentage` / `-XX:InitialRAMPercentage`) instead of
-  fixed `-Xmx` / `-Xms`, while keeping fixed non-heap caps and warnings visible.
-- The JVM Tuning panel lets the user opt into a Burstable Kubernetes request based on the current memory snapshot,
-  and lets the user include or omit Kubernetes startup/readiness/liveness health probes. The toggle
-  initializes from the current application health-probe configuration and is recommended for Kubernetes deployments.
+  (equal for a fixed modeled heap), `-XX:MaxMetaspaceSize`, `-XX:ReservedCodeCacheSize`, and `-Xss`. It deliberately
+  leaves the running JVM's collector unchanged and does not synthesize direct-memory, pre-touch, compact-header,
+  string-deduplication, or out-of-memory policy flags from a memory snapshot.
+- The JVM Tuning panel suggests Kubernetes resources and `JAVA_TOOL_OPTIONS` with percentage-based heap sizing
+  (`-XX:MaxRAMPercentage`, `-XX:MinRAMPercentage`, and `-XX:InitialRAMPercentage`) instead of fixed `-Xmx` / `-Xms`.
+  Equal memory request and limit values are reported as `Depends on CPU`, because Kubernetes Guaranteed QoS also
+  requires equal, non-zero CPU request and limit values for every container.
+- The JVM Tuning panel lets the user attempt a lower, Burstable Kubernetes request based first on the current cgroup
+  memory snapshot, with committed JVM pools plus observed direct buffers as a lower-confidence fallback. It can include
+  startup/readiness/liveness probes using framework-default paths and the named container port `http`; operators must
+  verify both when application, management-server, or container-port configuration differs.
+- The model, generated-option inventory, platform behavior, evidence, and limitations are documented in
+  [JVM-TUNING-CHECKS.md](JVM-TUNING-CHECKS.md).
 
 Acceptance criteria:
 


### PR DESCRIPTION
## Summary

Makes the JVM Tuning advisor conservative, deterministic, and source-backed across the shared engine, Spring MVC, Spring WebFlux, Quarkus, and Vue UI.

- keeps the transparent Paketo-derived memory partition while correcting rounding and live-observation handling
- removes speculative GC, compact-header, string-deduplication, pre-touch, direct-memory-cap, and OOM-policy flags
- corrects Kubernetes heap percentages, cgroup snapshots, QoS labels, confidence, health-probe ports, and Burstable boundaries
- adds focused positive, negative, and boundary coverage plus a maintained evidence/decision document

## Research method

The audit used the frozen `main` snapshot `d98836f0158b8b25d290252500b90a2b73371f9e` (which remains the current PR base). Before implementation, exactly three independent long-context audits researched authoritative current documentation and comparable open-source tooling first, built cited source ledgers, then classified every existing behavior as KEEP, MODIFY, REMOVE, or a new candidate:

- Claude Opus 5, max effort
- GPT-5.6 Terra, max effort
- Gemini 3.1 Pro, high effort

The baseline was Java 17/current JDK behavior, Spring Boot 4.1, and Quarkus 3.33 LTS. Synthesis accepted only source-backed behavior that BootUI can observe reliably and compute deterministically; workload-, host-, or policy-dependent advice was rejected.

The consolidated source ledger and full decision inventory are in [`docs/JVM-TUNING-CHECKS.md`](https://github.com/jdubois/boot-ui/blob/jdubois-jvm-tuning-advisor-audit/docs/JVM-TUNING-CHECKS.md). It cites Oracle JDK 17/26 launcher and NMT documentation, OpenJDK JEPs, Paketo's Java memory calculator and `libjvm` source, Kubernetes resource/QoS/probe documentation, Linux cgroup v2, Spring Boot Actuator, and Quarkus SmallRye Health.

## Before / after inventory

| Area | Before | After |
| --- | --- | --- |
| Core formula | Paketo-style partition | **KEEP**, with explicit observable adaptations |
| Metaspace / heap rendering | MiB truncation could understate caps or exceed the modeled plan | Metaspace/caps round up; rendered heap rounds down |
| Direct memory | Fixed fallback plus generated hard cap | Greater of 10 MiB or observed direct-buffer use; modeled but not hard-capped |
| Virtual threads | Speculative 80-thread / 512 KiB stack discount | Conservative `max(live, 250)` platform-thread reserve and 1 MiB stacks |
| Bare-metal options | Selected GC and emitted workload/policy flags | Only `Xms`, `Xmx`, metaspace, code cache, and stack sizing |
| Kubernetes options | 75% ceiling and extra policy flags | Modeled `MaxRAMPercentage`, `MinRAMPercentage`, `InitialRAMPercentage`, metaspace, code cache, and stack sizing |
| Container support | Forced `UseContainerSupport` | Omitted: Linux-only and already enabled by default where supported |
| Current snapshot | Selected JVM pools plus reserved stacks | cgroup current usage when available; committed JVM pools plus direct buffers otherwise |
| Pod QoS | Memory equality claimed `Guaranteed` | Equal memory reports `Depends on CPU`; reduced request reports `Burstable` |
| Confidence | NMT startup flag could imply high confidence | `Medium` only for matching limit/current cgroup observations; otherwise `Low` |
| Health probes | Hard-coded port 8080 | Framework-default paths on named port `http`, with verification warning |
| Boundary handling | Extreme input/snapshot arithmetic could overflow | Clamp before MiB conversion and saturate snapshot arithmetic |

Rejected candidates include automatic CPU sizing, GC pause targets, collector changes, large pages, NUMA, automatic NMT, and universal native-overhead multipliers.

## Platform behavior

- **Spring MVC / WebFlux:** share the engine and DTO contract. Spring's virtual-thread property is explanatory only; generated options never set it. Netty native demand is called out as potentially exceeding standard direct-buffer MXBean visibility.
- **Quarkus 3.33 LTS:** uses the same calculation. No application-wide virtual-thread switch is inferred; SmallRye Health contributes its framework-default paths.
- **Java 17–26 HotSpot:** generated option families are valid across the supported range. Collector and deployment policy remain unchanged.
- **Kubernetes:** output remains a container fragment, not a complete Deployment; it does not invent CPU settings, ports, images, or security policy.

## Validation

- `./mvnw -T 1C -B -ntp -Dmaven.repo.local=.m2 -Pcoverage clean install` — full 30-module reactor and coverage checks
- focused engine memory suite — 35 tests
- focused Vue JVM/Live Memory suite — 10 tests
- Spring controller JVM Tuning suite — 3 tests
- Quarkus JVM Tuning integration suite — 3 tests
- Spring Boot 4.1 JVM Tuning Playwright suite — 3 tests
- generated bare-metal and Kubernetes options parsed by OpenJDK 26
- Java Spotless and all UI/Spring E2E/Quarkus E2E Prettier checks

## Limitations

Runtime classes, threads, buffers, memory pools, and cgroup usage are snapshots and can grow after the panel is opened. BootUI detects the NMT startup setting but does not consume `jcmd VM.native_memory`. The generated named health-probe port and framework-default paths must be reconciled with the final deployment. Only JDK 26 is installed locally, so Quarkus browser coverage is delegated to the repository's supported-JDK CI job; Quarkus adapter integration coverage passes locally.