### PR TITLE
Audit Spring Security WebFlux advisor rules

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/AbstractReactiveSecurityRule.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/AbstractReactiveSecurityRule.java
@@ -46,4 +46,28 @@ abstract class AbstractReactiveSecurityRule implements ReactiveSecurityRule {
     SecurityRuleResultDto violation(String severityOverride, List<String> details) {
         return details.isEmpty() ? pass() : ReactiveSecuritySupport.violation(definition, severityOverride, details);
     }
+
+    SecurityRuleResultDto filterViolation(ReactiveSecurityContext context, List<String> details) {
+        if (details.isEmpty() && context.chains().stream().anyMatch(chain -> !chain.filtersObserved())) {
+            return skipped("Web filters could not be observed for every reactive security chain.");
+        }
+        return violation(details);
+    }
+
+    SecurityRuleResultDto corsViolation(ReactiveSecurityContext context, List<String> details) {
+        if (details.isEmpty() && !context.corsObservationComplete()) {
+            return skipped("Reactive CORS sources are present but could not all be inspected.");
+        }
+        return violation(details);
+    }
+
+    SecurityRuleResultDto headerViolation(ReactiveSecurityContext context, List<String> details) {
+        if (details.isEmpty()
+                && context.chains().stream()
+                        .anyMatch(chain -> !chain.filtersObserved()
+                                || (chain.hasHeaderWriterWebFilter() && !chain.headerWritersObserved()))) {
+            return skipped("Header-writer details could not be fully observed.");
+        }
+        return violation(details);
+    }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/CorsConfigObservation.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/CorsConfigObservation.java
@@ -26,6 +26,6 @@ public record CorsConfigObservation(
     }
 
     boolean hasWildcardOriginPattern() {
-        return allowedOriginPatterns.stream().anyMatch(p -> p.equals("*") || p.endsWith("**"));
+        return allowedOriginPatterns.stream().anyMatch("*"::equals);
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/CorsConfigObservation.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/CorsConfigObservation.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.reactivesecurity;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Framework-neutral, read-only observation of one reactive CORS configuration entry (from a
@@ -27,5 +28,57 @@ public record CorsConfigObservation(
 
     boolean hasWildcardOriginPattern() {
         return allowedOriginPatterns.stream().anyMatch("*"::equals);
+    }
+
+    /**
+     * The configured {@code allowedOriginPatterns} that are dangerously broad (wildcard scheme,
+     * wildcard host, or a too-permissive suffix such as {@code *.com}), excluding the exact
+     * {@code "*"} pattern already covered by SEC-RXF-CORS-001/002. Scoped subdomain wildcards such
+     * as {@code https://*.example.com} are intentionally not flagged.
+     */
+    List<String> broadOriginPatterns() {
+        return allowedOriginPatterns.stream()
+                .filter(CorsConfigObservation::isBroadOriginPattern)
+                .toList();
+    }
+
+    static boolean isBroadOriginPattern(String pattern) {
+        if (pattern == null) {
+            return false;
+        }
+        String value = pattern.trim().toLowerCase(Locale.ROOT);
+        if (value.isEmpty() || !value.contains("*") || value.equals("*")) {
+            return false; // exact "*" is handled by SEC-RXF-CORS-001/002
+        }
+        if (value.equals("**") || value.contains("*://")) {
+            return true; // wildcard everything or wildcard scheme
+        }
+        String host = value;
+        int scheme = host.indexOf("://");
+        if (scheme >= 0) {
+            host = host.substring(scheme + 3);
+        }
+        int slash = host.indexOf('/');
+        if (slash >= 0) {
+            host = host.substring(0, slash);
+        }
+        int colon = host.indexOf(':');
+        if (colon >= 0) {
+            host = host.substring(0, colon);
+        }
+        if (!host.contains("*")) {
+            return false;
+        }
+        int dot = host.indexOf('.');
+        String firstLabel = dot >= 0 ? host.substring(0, dot) : host;
+        String rest = dot >= 0 ? host.substring(dot + 1) : "";
+        if (rest.contains("*")) {
+            return true; // wildcard beyond the leftmost host label
+        }
+        if (firstLabel.contains("*")) {
+            // A leftmost-label wildcard is only acceptable with a concrete, multi-label suffix.
+            return rest.isEmpty() || !rest.contains(".");
+        }
+        return false;
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityContext.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityContext.java
@@ -7,16 +7,13 @@ import java.util.Set;
 
 /**
  * Read-only inputs handed to every reactive Spring Security advisor rule: the observed
- * {@code SecurityWebFilterChain}s, CORS/OAuth2 facts, and the precomputed environment snapshot. Built
- * by {@link ReactiveSecurityScanner} from a {@link ReactiveSecurityObservation}.
+ * {@code SecurityWebFilterChain}s, CORS facts, and the precomputed environment snapshot. Built by
+ * {@link ReactiveSecurityScanner} from a {@link ReactiveSecurityObservation}.
  */
 record ReactiveSecurityContext(
         List<WebFilterChainObservation> chains,
         List<CorsConfigObservation> corsConfigs,
-        boolean corsSourcePresent,
-        List<String> reactiveJwtDecoderTypes,
-        List<String> oauth2TokenValidatorTypes,
-        List<String> opaqueTokenIntrospectorTypes,
+        boolean corsObservationComplete,
         ReactiveSecurityEnvironmentSnapshot environment) {
 
     private static final List<String> SENSITIVE_ACTUATOR_ENDPOINTS =
@@ -25,9 +22,6 @@ record ReactiveSecurityContext(
     ReactiveSecurityContext {
         chains = List.copyOf(chains);
         corsConfigs = List.copyOf(corsConfigs);
-        reactiveJwtDecoderTypes = List.copyOf(reactiveJwtDecoderTypes);
-        oauth2TokenValidatorTypes = List.copyOf(oauth2TokenValidatorTypes);
-        opaqueTokenIntrospectorTypes = List.copyOf(opaqueTokenIntrospectorTypes);
         environment = environment == null ? ReactiveSecurityEnvironmentSnapshot.empty() : environment;
     }
 
@@ -35,10 +29,7 @@ record ReactiveSecurityContext(
         return new ReactiveSecurityContext(
                 observation.chains(),
                 observation.corsConfigs(),
-                observation.corsSourcePresent(),
-                observation.reactiveJwtDecoderTypes(),
-                observation.oauth2TokenValidatorTypes(),
-                observation.opaqueTokenIntrospectorTypes(),
+                observation.corsObservationComplete(),
                 observation.environment());
     }
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityEnvironmentSnapshot.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityEnvironmentSnapshot.java
@@ -22,7 +22,9 @@ import java.util.Set;
  *     {@code management.endpoints.web.exposure.exclude}, or {@code null} if not configured
  * @param managementServerPortConfigured whether {@code management.server.port} is configured
  * @param activeProfiles the application's active Spring profiles
- * @param securityDebugEnabled whether {@code spring.security.debug=true}
+ * @param securityDebugEnabled legacy compatibility signal for the unsupported
+ *     {@code spring.security.debug} property; the Spring WebFlux collector always supplies
+ *     {@code false}
  * @param oauth2JwtStaticPublicKeyConfigured whether
  *     {@code spring.security.oauth2.resourceserver.jwt.public-key-location} configures a static public
  *     key instead of a remotely rotatable JWKS
@@ -32,6 +34,16 @@ import java.util.Set;
  *     (falling back to {@code logging.level.org.springframework.security.web})
  * @param suspectedHardcodedSecretKeys property keys (never values) whose names suggest a credential
  *     or secret and whose values appear to be literal strings rather than placeholder references
+ * @param oauth2OpaqueTokenIntrospectionUsesPlainHttp whether the configured opaque-token
+ *     introspection URI uses plain HTTP
+ * @param managementEnvShowValuesAlways whether the host explicitly configures
+ *     {@code management.endpoint.env.show-values=always}
+ * @param managementConfigPropsShowValuesAlways whether the host explicitly configures
+ *     {@code management.endpoint.configprops.show-values=always}
+ * @param managementEnvWebExposed whether the effective Actuator include/exclude and access settings
+ *     make the {@code env} endpoint web-accessible
+ * @param managementConfigPropsWebExposed whether the effective Actuator include/exclude and access
+ *     settings make the {@code configprops} endpoint web-accessible
  */
 public record ReactiveSecurityEnvironmentSnapshot(
         boolean globalTlsConfigured,
@@ -44,12 +56,82 @@ public record ReactiveSecurityEnvironmentSnapshot(
         boolean oauth2JwtIssuerUsesPlainHttp,
         boolean oauth2JwtJwkSetUsesPlainHttp,
         String securityLoggingLevel,
-        Set<String> suspectedHardcodedSecretKeys) {
+        Set<String> suspectedHardcodedSecretKeys,
+        boolean oauth2OpaqueTokenIntrospectionUsesPlainHttp,
+        boolean managementEnvShowValuesAlways,
+        boolean managementConfigPropsShowValuesAlways,
+        boolean managementEnvWebExposed,
+        boolean managementConfigPropsWebExposed) {
 
     public ReactiveSecurityEnvironmentSnapshot {
         activeProfiles = activeProfiles == null ? List.of() : List.copyOf(activeProfiles);
         suspectedHardcodedSecretKeys =
                 suspectedHardcodedSecretKeys == null ? Set.of() : Set.copyOf(suspectedHardcodedSecretKeys);
+    }
+
+    /** Compatibility constructor for snapshots created before effective Actuator exposure signals. */
+    public ReactiveSecurityEnvironmentSnapshot(
+            boolean globalTlsConfigured,
+            String managementExposureInclude,
+            String managementExposureExclude,
+            boolean managementServerPortConfigured,
+            List<String> activeProfiles,
+            boolean securityDebugEnabled,
+            boolean oauth2JwtStaticPublicKeyConfigured,
+            boolean oauth2JwtIssuerUsesPlainHttp,
+            boolean oauth2JwtJwkSetUsesPlainHttp,
+            String securityLoggingLevel,
+            Set<String> suspectedHardcodedSecretKeys,
+            boolean oauth2OpaqueTokenIntrospectionUsesPlainHttp,
+            boolean managementEnvShowValuesAlways,
+            boolean managementConfigPropsShowValuesAlways) {
+        this(
+                globalTlsConfigured,
+                managementExposureInclude,
+                managementExposureExclude,
+                managementServerPortConfigured,
+                activeProfiles,
+                securityDebugEnabled,
+                oauth2JwtStaticPublicKeyConfigured,
+                oauth2JwtIssuerUsesPlainHttp,
+                oauth2JwtJwkSetUsesPlainHttp,
+                securityLoggingLevel,
+                suspectedHardcodedSecretKeys,
+                oauth2OpaqueTokenIntrospectionUsesPlainHttp,
+                managementEnvShowValuesAlways,
+                managementConfigPropsShowValuesAlways,
+                false,
+                false);
+    }
+
+    /** Compatibility constructor for observations created before the additional Boot 4 signals. */
+    public ReactiveSecurityEnvironmentSnapshot(
+            boolean globalTlsConfigured,
+            String managementExposureInclude,
+            String managementExposureExclude,
+            boolean managementServerPortConfigured,
+            List<String> activeProfiles,
+            boolean securityDebugEnabled,
+            boolean oauth2JwtStaticPublicKeyConfigured,
+            boolean oauth2JwtIssuerUsesPlainHttp,
+            boolean oauth2JwtJwkSetUsesPlainHttp,
+            String securityLoggingLevel,
+            Set<String> suspectedHardcodedSecretKeys) {
+        this(
+                globalTlsConfigured,
+                managementExposureInclude,
+                managementExposureExclude,
+                managementServerPortConfigured,
+                activeProfiles,
+                securityDebugEnabled,
+                oauth2JwtStaticPublicKeyConfigured,
+                oauth2JwtIssuerUsesPlainHttp,
+                oauth2JwtJwkSetUsesPlainHttp,
+                securityLoggingLevel,
+                suspectedHardcodedSecretKeys,
+                false,
+                false,
+                false);
     }
 
     /** A snapshot with no signals set, for tests and the empty/DISABLED path. */

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityObservation.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityObservation.java
@@ -9,22 +9,21 @@ import java.util.List;
  * <p>The Spring adapter collects this snapshot — the application's registered
  * {@code SecurityWebFilterChain} beans (BootUI's own {@code bootUiReactiveSecurityWebFilterChain} is
  * excluded, mirroring the raw Spring Security panel's availability check), CORS configuration sources,
- * OAuth2/JWT-related bean type names, and a precomputed {@link ReactiveSecurityEnvironmentSnapshot} —
- * and supplies it to {@link ReactiveSecurityScanner} through a {@code Supplier} seam. The engine owns
- * the rule evaluation; it never reflects into a Spring bean or reads an {@code Environment} itself.
+ * and a precomputed {@link ReactiveSecurityEnvironmentSnapshot} — and supplies it to {@link
+ * ReactiveSecurityScanner} through a {@code Supplier} seam. The engine owns the rule evaluation; it
+ * never reflects into a Spring bean or reads an {@code Environment} itself.
  *
  * @param chains observations of the application's own {@code SecurityWebFilterChain} beans
  * @param corsConfigs observed reactive CORS configuration entries
  * @param corsSourcePresent whether a {@code CorsConfigurationSource} bean is present at all (as
  *     opposed to being present but empty)
- * @param reactiveJwtDecoderTypes simple/fully-qualified type names of {@code ReactiveJwtDecoder} beans
- * @param oauth2TokenValidatorTypes simple/fully-qualified type names of {@code OAuth2TokenValidator}
- *     beans
- * @param opaqueTokenIntrospectorTypes simple/fully-qualified type names of
- *     {@code ReactiveOpaqueTokenIntrospector} beans
+ * @param reactiveJwtDecoderTypes legacy bean-type inventory retained for observation compatibility
+ * @param oauth2TokenValidatorTypes legacy bean-type inventory retained for observation compatibility
+ * @param opaqueTokenIntrospectorTypes legacy bean-type inventory retained for observation compatibility
  * @param environment precomputed, framework-neutral {@code Environment} facts
  * @param errors human-readable, non-sensitive messages describing any part of the observation that
  *     could not be collected (partial discovery); an empty list means the collection was clean
+ * @param corsObservationComplete whether every discovered reactive CORS source was inspectable
  */
 public record ReactiveSecurityObservation(
         List<WebFilterChainObservation> chains,
@@ -34,7 +33,8 @@ public record ReactiveSecurityObservation(
         List<String> oauth2TokenValidatorTypes,
         List<String> opaqueTokenIntrospectorTypes,
         ReactiveSecurityEnvironmentSnapshot environment,
-        List<String> errors) {
+        List<String> errors,
+        boolean corsObservationComplete) {
 
     public ReactiveSecurityObservation {
         chains = List.copyOf(chains);
@@ -44,6 +44,28 @@ public record ReactiveSecurityObservation(
         opaqueTokenIntrospectorTypes = List.copyOf(opaqueTokenIntrospectorTypes);
         environment = environment == null ? ReactiveSecurityEnvironmentSnapshot.empty() : environment;
         errors = List.copyOf(errors);
+    }
+
+    /** Compatibility constructor for observations created before CORS extraction became tri-state. */
+    public ReactiveSecurityObservation(
+            List<WebFilterChainObservation> chains,
+            List<CorsConfigObservation> corsConfigs,
+            boolean corsSourcePresent,
+            List<String> reactiveJwtDecoderTypes,
+            List<String> oauth2TokenValidatorTypes,
+            List<String> opaqueTokenIntrospectorTypes,
+            ReactiveSecurityEnvironmentSnapshot environment,
+            List<String> errors) {
+        this(
+                chains,
+                corsConfigs,
+                corsSourcePresent,
+                reactiveJwtDecoderTypes,
+                oauth2TokenValidatorTypes,
+                opaqueTokenIntrospectorTypes,
+                environment,
+                errors,
+                true);
     }
 
     /** An observation with no application chains and no errors (e.g. Spring Security not present). */

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityRuleRegistry.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 final class ReactiveSecurityRuleRegistry {
 
-    static final int RULE_COUNT = 25;
+    static final int RULE_COUNT = 26;
 
     private static final List<ReactiveSecurityRule> ACTIVE_RULES = List.of(
             // Authorization
@@ -17,6 +17,7 @@ final class ReactiveSecurityRuleRegistry {
             // CORS
             new ReactiveCorsWildcardOriginRule(),
             new ReactiveCorsWildcardWithCredentialsRule(),
+            new ReactiveBroadCorsOriginPatternRule(),
             // Transport & security headers
             new ReactiveHstsHeaderRule(),
             new ReactiveFrameOptionsRule(),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityRuleRegistry.java
@@ -9,10 +9,10 @@ final class ReactiveSecurityRuleRegistry {
     private static final List<ReactiveSecurityRule> ACTIVE_RULES = List.of(
             // Authorization
             new ReactiveAuthorizationFilterRule(),
-            new ReactivePermitAllCatchAllRule(),
+            new ReactiveCatchAllWithoutAuthorizationRule(),
             new ReactiveEffectivelyDisabledSecurityRule(),
             // CSRF
-            new ReactiveCsrfDisabledStatefulRule(),
+            new ReactiveCsrfDisabledLoginRule(),
             new ReactiveCsrfGloballyDisabledRule(),
             // CORS
             new ReactiveCorsWildcardOriginRule(),
@@ -27,19 +27,19 @@ final class ReactiveSecurityRuleRegistry {
             // Actuator exposure
             new ReactiveActuatorWildcardExposureRule(),
             new ReactiveActuatorSensitiveExposureRule(),
-            new ReactiveActuatorUnprotectedRule(),
+            new ReactiveActuatorAuthorizationReviewRule(),
             new ReactiveManagementPortIsolationRule(),
+            new ReactiveActuatorShowValuesRule(),
             // OAuth2 / JWT
-            new ReactiveJwtAudienceValidationRule(),
             new ReactiveJwtStaticKeyRule(),
             new ReactiveInsecureJwtMetadataUrlRule(),
+            new ReactiveInsecureOpaqueTokenIntrospectionUrlRule(),
             // Configuration hygiene
-            new ReactiveSecurityDebugRule(),
             new ReactiveHttpsEnforcementRule(),
             new ReactiveHardcodedSecretPropertyRule(),
             new ReactiveSecurityDebugLoggingProductionRule(),
             // Session management
-            new ReactiveBearerTokenStatefulRule());
+            new ReactiveMixedBearerAndLoginRule());
 
     private ReactiveSecurityRuleRegistry() {}
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityRules.java
@@ -18,8 +18,8 @@ final class ReactiveAuthorizationFilterRule extends AbstractReactiveSecurityRule
                         "Every reactive filter chain should enforce authorization",
                         ReactiveSecurityCategory.AUTHORIZATION,
                         "HIGH",
-                        "Detects a SecurityWebFilterChain that installs no AuthorizationWebFilter, so matched requests are unguarded.",
-                        "Add authorizeExchange(...) with at least anyExchange().authenticated() (or an explicit denyAll) to the chain.",
+                        "Detects a SecurityWebFilterChain whose observed Spring Security filters contain no AuthorizationWebFilter. Custom authorization filters remain outside this bounded snapshot.",
+                        "Add authorizeExchange(...) with at least anyExchange().authenticated() (or denyAll), or verify equivalent custom authorization explicitly.",
                         "https://docs.spring.io/spring-security/reference/reactive/authorization/authorize-http-requests.html"));
     }
 
@@ -27,25 +27,25 @@ final class ReactiveAuthorizationFilterRule extends AbstractReactiveSecurityRule
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
-            if (!chain.hasAuthorizationWebFilter()) {
-                details.add(chain.describe() + " installs no authorization web filter.");
+            if (Boolean.FALSE.equals(chain.authorizationFilterPresent())) {
+                details.add(chain.describe() + " installs no observed AuthorizationWebFilter.");
             }
         }
-        return violation(details);
+        return filterViolation(context, details);
     }
 }
 
-final class ReactivePermitAllCatchAllRule extends AbstractReactiveSecurityRule {
+final class ReactiveCatchAllWithoutAuthorizationRule extends AbstractReactiveSecurityRule {
 
-    ReactivePermitAllCatchAllRule() {
+    ReactiveCatchAllWithoutAuthorizationRule() {
         super(
                 new ReactiveSecurityRuleDefinition(
                         "SEC-RXF-AUTHZ-002",
-                        "Avoid blanket permitAll authorization in reactive chains",
+                        "Catch-all reactive chains with authentication should install authorization",
                         ReactiveSecurityCategory.AUTHORIZATION,
                         "HIGH",
-                        "Detects a reactive chain whose authorization grants every request to anonymous callers (permitAll catch-all) while also configuring authentication.",
-                        "Restrict sensitive paths and finish with anyExchange().authenticated(); keep permitAll only for genuinely public endpoints.",
+                        "Detects a catch-all reactive chain that installs authentication filters but no AuthorizationWebFilter. Runtime filter inspection cannot distinguish permitAll from authenticated authorization decisions once an AuthorizationWebFilter is present.",
+                        "Add authorizeExchange(...) and finish with anyExchange().authenticated() or denyAll(); keep explicit permitAll matchers only for public endpoints.",
                         "https://docs.spring.io/spring-security/reference/reactive/authorization/authorize-http-requests.html"));
     }
 
@@ -53,15 +53,15 @@ final class ReactivePermitAllCatchAllRule extends AbstractReactiveSecurityRule {
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
-            if (Boolean.TRUE.equals(chain.permitsAllAnonymous())
+            if (Boolean.FALSE.equals(chain.authorizationFilterPresent())
                     && chain.matchesAnyRequest()
                     && chain.hasAuthenticationFilter()) {
                 details.add(
                         chain.describe()
-                                + " matches every request and permits it anonymously even though it configures authentication.");
+                                + " matches every request and configures authentication but installs no observed AuthorizationWebFilter.");
             }
         }
-        return violation(details);
+        return filterViolation(context, details);
     }
 }
 
@@ -71,11 +71,11 @@ final class ReactiveEffectivelyDisabledSecurityRule extends AbstractReactiveSecu
         super(
                 new ReactiveSecurityRuleDefinition(
                         "SEC-RXF-AUTHZ-003",
-                        "Reactive application security should not be effectively disabled",
+                        "Reactive applications should not omit both authentication and authorization",
                         ReactiveSecurityCategory.AUTHORIZATION,
                         "HIGH",
-                        "Detects when every reactive filter chain permits all requests anonymously with no authentication mechanism.",
-                        "Define authorization rules requiring authentication for non-public endpoints instead of leaving the app fully open.",
+                        "Detects when every observed reactive filter chain omits both AuthorizationWebFilter and authentication filters. Custom filters remain outside this bounded observation.",
+                        "Define authentication and authorizeExchange rules for non-public endpoints, or verify that custom filters provide equivalent protection.",
                         "https://docs.spring.io/spring-security/reference/reactive/authorization/authorize-http-requests.html"));
     }
 
@@ -85,17 +85,18 @@ final class ReactiveEffectivelyDisabledSecurityRule extends AbstractReactiveSecu
         if (chains.isEmpty()) {
             return pass();
         }
-        boolean anyDeterminable = chains.stream().anyMatch(chain -> chain.permitsAllAnonymous() != null);
-        if (!anyDeterminable) {
-            return skipped("Authorization decisions could not be determined for any chain.");
+        boolean anyUnknown = chains.stream().anyMatch(chain -> chain.authorizationFilterPresent() == null);
+        if (anyUnknown) {
+            return skipped("Web filters could not be observed for every reactive security chain.");
         }
-        boolean allOpen = chains.stream().allMatch(chain -> Boolean.TRUE.equals(chain.permitsAllAnonymous()));
+        boolean allMissingAuthorization =
+                chains.stream().allMatch(chain -> Boolean.FALSE.equals(chain.authorizationFilterPresent()));
         boolean anyAuthentication = chains.stream().anyMatch(WebFilterChainObservation::hasAuthenticationFilter);
-        if (allOpen && !anyAuthentication) {
+        if (allMissingAuthorization && !anyAuthentication) {
             return violation(
                     List.of(
                             "All " + chains.size()
-                                    + " reactive security filter chains permit every request anonymously with no authentication mechanism."));
+                                    + " observed reactive security filter chains omit both AuthorizationWebFilter and authentication filters."));
         }
         return pass();
     }
@@ -105,16 +106,16 @@ final class ReactiveEffectivelyDisabledSecurityRule extends AbstractReactiveSecu
 // CSRF
 // ---------------------------------------------------------------------------
 
-final class ReactiveCsrfDisabledStatefulRule extends AbstractReactiveSecurityRule {
+final class ReactiveCsrfDisabledLoginRule extends AbstractReactiveSecurityRule {
 
-    ReactiveCsrfDisabledStatefulRule() {
+    ReactiveCsrfDisabledLoginRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-CSRF-001",
-                "Reactive stateful chains should enable CSRF protection",
+                "Reactive OAuth2/OIDC login chains should enable CSRF protection",
                 ReactiveSecurityCategory.CSRF,
                 "HIGH",
-                "Detects a reactive chain with OAuth2 login or session-based authentication but no CsrfWebFilter. Without CSRF protection, cross-origin state-changing requests can be forged.",
-                "Add .csrf(Customizer.withDefaults()) or configure a CookieServerCsrfTokenRepository for reactive applications using session-based authentication.",
+                "Detects a reactive chain with an observed OAuth2/OIDC login filter but no CsrfWebFilter. Without CSRF protection, cross-origin state-changing requests can be forged.",
+                "Keep CSRF enabled for browser login chains, using .csrf(Customizer.withDefaults()) or a CookieServerCsrfTokenRepository as appropriate.",
                 "https://docs.spring.io/spring-security/reference/reactive/exploits/csrf.html"));
     }
 
@@ -122,11 +123,11 @@ final class ReactiveCsrfDisabledStatefulRule extends AbstractReactiveSecurityRul
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
-            if (chain.isStateful() && !chain.hasCsrfWebFilter()) {
-                details.add(chain.describe() + " uses session-based authentication but no CsrfWebFilter is installed.");
+            if (chain.hasObservedInteractiveLoginFilter() && !chain.hasCsrfWebFilter()) {
+                details.add(chain.describe() + " has an OAuth2/OIDC login filter but no CsrfWebFilter is installed.");
             }
         }
-        return violation(details);
+        return filterViolation(context, details);
     }
 }
 
@@ -149,12 +150,15 @@ final class ReactiveCsrfGloballyDisabledRule extends AbstractReactiveSecurityRul
             return pass();
         }
         boolean anyHasCsrf = context.chains().stream().anyMatch(WebFilterChainObservation::hasCsrfWebFilter);
-        if (!anyHasCsrf) {
-            return violation(List.of("No CsrfWebFilter was found across all "
-                    + context.chains().size()
-                    + " registered reactive security filter chains. Verify all chains are intentionally stateless."));
+        if (anyHasCsrf) {
+            return pass();
         }
-        return pass();
+        if (context.chains().stream().anyMatch(chain -> !chain.filtersObserved())) {
+            return skipped("Web filters could not be observed for every reactive security chain.");
+        }
+        return violation(List.of("No CsrfWebFilter was found across all "
+                + context.chains().size()
+                + " registered reactive security filter chains. Verify all chains are intentionally stateless."));
     }
 }
 
@@ -170,23 +174,20 @@ final class ReactiveCorsWildcardOriginRule extends AbstractReactiveSecurityRule 
                 "CORS should not allow wildcard origins in reactive applications",
                 ReactiveSecurityCategory.CORS,
                 "MEDIUM",
-                "Detects a reactive CorsConfigurationSource that permits requests from any origin (allowedOrigins: \"*\").",
+                "Detects an inspectable reactive CorsConfigurationSource that permits every origin through the exact \"*\" value in allowedOrigins or allowedOriginPatterns.",
                 "Enumerate allowed origins explicitly, e.g. https://app.example.com, instead of using the wildcard.",
                 "https://docs.spring.io/spring-framework/reference/web/webflux-cors.html"));
     }
 
     @Override
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
-        if (!context.corsSourcePresent()) {
-            return pass();
-        }
         List<String> details = new ArrayList<>();
         for (CorsConfigObservation config : context.corsConfigs()) {
             if (config.hasWildcardOrigin() || config.hasWildcardOriginPattern()) {
                 details.add("CORS config for pattern '" + config.pattern() + "' allows all origins (wildcard).");
             }
         }
-        return violation(details);
+        return corsViolation(context, details);
     }
 }
 
@@ -195,29 +196,25 @@ final class ReactiveCorsWildcardWithCredentialsRule extends AbstractReactiveSecu
     ReactiveCorsWildcardWithCredentialsRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-CORS-002",
-                "CORS wildcard origin must not be combined with allow-credentials in reactive apps",
+                "Credentialed reactive CORS must not trust every origin pattern",
                 ReactiveSecurityCategory.CORS,
                 "HIGH",
-                "Detects a reactive CORS configuration that combines a wildcard origin with allowCredentials=true.",
-                "Replace the wildcard with explicit allowed origins before enabling credentials.",
+                "Detects allowedOriginPatterns=\"*\" with allowCredentials=true, a legal Spring configuration that reflects arbitrary origins while allowing credentials. Spring rejects the separate allowedOrigins=\"*\" plus credentials combination.",
+                "Replace the wildcard origin pattern with explicit trusted origins before enabling credentials.",
                 "https://docs.spring.io/spring-framework/reference/web/webflux-cors.html"));
     }
 
     @Override
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
-        if (!context.corsSourcePresent()) {
-            return pass();
-        }
         List<String> details = new ArrayList<>();
         for (CorsConfigObservation config : context.corsConfigs()) {
-            boolean wildcard = config.hasWildcardOrigin() || config.hasWildcardOriginPattern();
-            if (wildcard && Boolean.TRUE.equals(config.allowCredentials())) {
+            if (config.hasWildcardOriginPattern() && Boolean.TRUE.equals(config.allowCredentials())) {
                 details.add("CORS config for pattern '"
                         + config.pattern()
-                        + "' combines a wildcard origin with allowCredentials=true.");
+                        + "' combines allowedOriginPatterns=\"*\" with allowCredentials=true.");
             }
         }
-        return violation(details);
+        return corsViolation(context, details);
     }
 }
 
@@ -235,7 +232,7 @@ final class ReactiveHstsHeaderRule extends AbstractReactiveSecurityRule {
                         ReactiveSecurityCategory.HEADERS,
                         "MEDIUM",
                         "Detects chains that apply security headers (HttpHeaderWriterWebFilter) but do not include an HSTS writer while TLS is configured.",
-                        "Add a HstsServerHttpHeadersWriter via .headers(h -> h.hsts(Customizer.withDefaults())) to chains serving HTTPS traffic.",
+                        "Keep Spring Security's StrictTransportSecurityServerHttpHeadersWriter defaults via .headers(h -> h.hsts(Customizer.withDefaults())).",
                         "https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-hsts"));
     }
 
@@ -246,11 +243,11 @@ final class ReactiveHstsHeaderRule extends AbstractReactiveSecurityRule {
         }
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
-            if (chain.hasHeaderWriterWebFilter() && !chain.hasHstsWriter()) {
+            if (chain.headerWritersObserved() && chain.hasHeaderWriterWebFilter() && !chain.hasHstsWriter()) {
                 details.add(chain.describe() + " applies security headers without HSTS while TLS is configured.");
             }
         }
-        return violation(details);
+        return headerViolation(context, details);
     }
 }
 
@@ -263,8 +260,8 @@ final class ReactiveFrameOptionsRule extends AbstractReactiveSecurityRule {
                         "X-Frame-Options header should be set in reactive chains",
                         ReactiveSecurityCategory.HEADERS,
                         "MEDIUM",
-                        "Detects chains with security header writers but no FrameOptions writer, leaving the application vulnerable to clickjacking.",
-                        "Enable frame-options protection via .headers(h -> h.frameOptions(Customizer.withDefaults())).",
+                        "Detects chains with security header writers but neither a FrameOptions writer nor an enforcing CSP frame-ancestors directive.",
+                        "Keep frame-options protection via .headers(h -> h.frameOptions(Customizer.withDefaults())) or enforce an appropriate CSP frame-ancestors policy.",
                         "https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-frame-options"));
     }
 
@@ -272,12 +269,16 @@ final class ReactiveFrameOptionsRule extends AbstractReactiveSecurityRule {
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
-            if (chain.hasHeaderWriterWebFilter() && !chain.hasFrameOptionsWriter()) {
-                details.add(chain.describe()
-                        + " applies security headers without X-Frame-Options (clickjacking protection).");
+            if (chain.headerWritersObserved()
+                    && chain.hasHeaderWriterWebFilter()
+                    && !chain.hasFrameOptionsWriter()
+                    && !chain.hasEnforcingFrameAncestorsPolicy()) {
+                details.add(
+                        chain.describe()
+                                + " applies security headers without X-Frame-Options or an enforcing CSP frame-ancestors directive.");
             }
         }
-        return violation(details);
+        return headerViolation(context, details);
     }
 }
 
@@ -299,11 +300,13 @@ final class ReactiveContentTypeOptionsRule extends AbstractReactiveSecurityRule 
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
-            if (chain.hasHeaderWriterWebFilter() && !chain.hasContentTypeOptionsWriter()) {
+            if (chain.headerWritersObserved()
+                    && chain.hasHeaderWriterWebFilter()
+                    && !chain.hasContentTypeOptionsWriter()) {
                 details.add(chain.describe() + " applies security headers without X-Content-Type-Options (nosniff).");
             }
         }
-        return violation(details);
+        return headerViolation(context, details);
     }
 }
 
@@ -312,11 +315,11 @@ final class ReactiveContentSecurityPolicyRule extends AbstractReactiveSecurityRu
     ReactiveContentSecurityPolicyRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-HEAD-004",
-                "Content-Security-Policy should be defined in reactive chains",
+                "Review Content-Security-Policy enforcement for reactive browser chains",
                 ReactiveSecurityCategory.HEADERS,
-                "MEDIUM",
-                "Detects chains with security header writers that do not configure a Content-Security-Policy.",
-                "Configure a Content-Security-Policy via .headers(h -> h.contentSecurityPolicy(csp -> csp.policyDirectives(\"...\"))).",
+                "LOW",
+                "Reports chains whose Spring Security header writers omit Content-Security-Policy or configure it as report-only. Spring intentionally provides no default because a safe policy depends on application context.",
+                "For browser-facing responses, configure a tailored enforcing policy via .headers(h -> h.contentSecurityPolicy(...)); use report-only mode only during a bounded rollout.",
                 "https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-csp"));
     }
 
@@ -324,12 +327,20 @@ final class ReactiveContentSecurityPolicyRule extends AbstractReactiveSecurityRu
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
+            if (!chain.headerWritersObserved()) {
+                continue;
+            }
             if (chain.hasHeaderWriterWebFilter() && !chain.hasCspWriter()) {
                 details.add(
-                        chain.describe() + " applies security headers but does not define a Content-Security-Policy.");
+                        chain.describe()
+                                + " applies Spring Security headers without a Content-Security-Policy; review whether this chain serves browser content.");
+            } else if (chain.hasCspWriter() && Boolean.TRUE.equals(chain.cspReportOnly())) {
+                details.add(
+                        chain.describe()
+                                + " configures Content-Security-Policy-Report-Only, which monitors policy violations but does not enforce the policy.");
             }
         }
-        return violation(details);
+        return headerViolation(context, details);
     }
 }
 
@@ -341,7 +352,7 @@ final class ReactiveHeadersDisabledRule extends AbstractReactiveSecurityRule {
                 "Security headers should not be disabled in reactive chains",
                 ReactiveSecurityCategory.HEADERS,
                 "HIGH",
-                "Detects chains with authentication or authorization filters but no HttpHeaderWriterWebFilter, meaning all Spring Security header protections are absent.",
+                "Detects chains with authentication or authorization filters but no HttpHeaderWriterWebFilter, meaning Spring Security's own header protections are absent. A reverse proxy or custom filter may still add equivalent headers.",
                 "Do not call .headers(h -> h.disable()) unless the application sets equivalent headers via another mechanism.",
                 "https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html"));
     }
@@ -357,7 +368,7 @@ final class ReactiveHeadersDisabledRule extends AbstractReactiveSecurityRule {
                                 + " enforces authentication/authorization but installs no security header writer (HttpHeaderWriterWebFilter).");
             }
         }
-        return violation(details);
+        return filterViolation(context, details);
     }
 }
 
@@ -367,11 +378,11 @@ final class ReactiveWeakHstsPolicyRule extends AbstractReactiveSecurityRule {
         super(
                 new ReactiveSecurityRuleDefinition(
                         "SEC-RXF-HEAD-006",
-                        "HSTS max-age should be at least one year in reactive applications",
+                        "Review HSTS max-age values below Spring Security's one-year default",
                         ReactiveSecurityCategory.HEADERS,
                         "LOW",
-                        "Detects an HSTS writer configured with a max-age below the recommended one-year minimum (31,536,000 seconds).",
-                        "Set hsts.maxAge(Duration.ofDays(365)) or higher, and set includeSubDomains when appropriate.",
+                        "Detects an HSTS writer configured below Spring Security's one-year default (31,536,000 seconds). RFC 6797 does not mandate a universal minimum.",
+                        "Use a shorter rollout only intentionally; otherwise keep Spring Security's Duration.ofDays(365) default and evaluate includeSubDomains separately.",
                         "https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-hsts"));
     }
 
@@ -379,14 +390,14 @@ final class ReactiveWeakHstsPolicyRule extends AbstractReactiveSecurityRule {
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
-            if (chain.hasHstsWriter() && chain.hasWeakHsts()) {
+            if (chain.headerWritersObserved() && chain.hasHstsWriter() && chain.hasWeakHsts()) {
                 details.add(chain.describe()
                         + " configures HSTS with a max-age of "
                         + chain.hstsMaxAgeSeconds()
                         + " seconds, below the recommended 31,536,000 (one year).");
             }
         }
-        return violation(details);
+        return headerViolation(context, details);
     }
 }
 
@@ -402,8 +413,8 @@ final class ReactiveActuatorWildcardExposureRule extends AbstractReactiveSecurit
                 "Actuator endpoints should not be exposed with a wildcard",
                 ReactiveSecurityCategory.ACTUATOR,
                 "HIGH",
-                "Detects management.endpoints.web.exposure.include=* without any exclude, which exposes all Actuator endpoints including sensitive ones.",
-                "Explicitly list only the endpoints you need, or add management.endpoints.web.exposure.exclude to exclude sensitive endpoints.",
+                "Detects management.endpoints.web.exposure.include=* without any exclude. Endpoint enablement and Boot 4 access settings still determine which exposed endpoints are callable.",
+                "Explicitly list only the endpoints you need, add excludes, and review management.endpoint.<id>.access for sensitive endpoints.",
                 "https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.exposing"));
     }
 
@@ -444,16 +455,16 @@ final class ReactiveActuatorSensitiveExposureRule extends AbstractReactiveSecuri
     }
 }
 
-final class ReactiveActuatorUnprotectedRule extends AbstractReactiveSecurityRule {
+final class ReactiveActuatorAuthorizationReviewRule extends AbstractReactiveSecurityRule {
 
-    ReactiveActuatorUnprotectedRule() {
+    ReactiveActuatorAuthorizationReviewRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-ACT-003",
-                "Actuator endpoints should be protected when more than health/info are exposed",
+                "Review authorization for broad reactive Actuator exposure",
                 ReactiveSecurityCategory.ACTUATOR,
-                "HIGH",
-                "Detects that Actuator endpoints beyond health/info are exposed AND every reactive security chain is fully open, leaving sensitive management operations unprotected.",
-                "Add authentication requirements for the /actuator/** path, or restrict sensitive endpoints to a separate management port.",
+                "MEDIUM",
+                "Detects broad Actuator web exposure while every observed application chain omits AuthorizationWebFilter. The advisor cannot prove which chain matches a custom management path or separate management context.",
+                "Verify the actual management path/port has explicit authorization or a restricted network path; add an Actuator-specific SecurityWebFilterChain when needed.",
                 "https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.security"));
     }
 
@@ -462,12 +473,16 @@ final class ReactiveActuatorUnprotectedRule extends AbstractReactiveSecurityRule
         if (!context.exposesBeyondHealthAndInfo()) {
             return pass();
         }
-        boolean allChainsOpen = !context.chains().isEmpty()
-                && context.chains().stream().allMatch(chain -> Boolean.TRUE.equals(chain.permitsAllAnonymous()));
-        if (allChainsOpen) {
+        if (context.chains().stream().anyMatch(chain -> !chain.filtersObserved())) {
+            return skipped("Web filters could not be observed for every reactive security chain.");
+        }
+        boolean allChainsObservedWithoutAuthorization = !context.chains().isEmpty()
+                && context.chains().stream()
+                        .allMatch(chain -> Boolean.FALSE.equals(chain.authorizationFilterPresent()));
+        if (allChainsObservedWithoutAuthorization) {
             return violation(
                     List.of(
-                            "Actuator endpoints beyond health/info are exposed and every reactive security chain permits unauthenticated access."));
+                            "Actuator endpoints beyond health/info are configured for web exposure, and no observed application chain installs AuthorizationWebFilter. Verify management-path authorization separately."));
         }
         return pass();
     }
@@ -500,47 +515,49 @@ final class ReactiveManagementPortIsolationRule extends AbstractReactiveSecurity
     }
 }
 
-// ---------------------------------------------------------------------------
-// OAuth2 / JWT
-// ---------------------------------------------------------------------------
+final class ReactiveActuatorShowValuesRule extends AbstractReactiveSecurityRule {
 
-final class ReactiveJwtAudienceValidationRule extends AbstractReactiveSecurityRule {
-
-    ReactiveJwtAudienceValidationRule() {
-        super(new ReactiveSecurityRuleDefinition(
-                "SEC-RXF-OAUTH2-001",
-                "Reactive JWT resource server should validate the audience claim",
-                ReactiveSecurityCategory.OAUTH2,
-                "MEDIUM",
-                "Detects a ReactiveJwtDecoder bean with no configured OAuth2TokenValidator that checks the audience claim. Without audience validation, a JWT issued for a different service can be replayed against this application.",
-                "Configure a DelegatingReactiveJwtDecoder with a JwtClaimValidator<List<String>>(\"aud\", ...) or use spring.security.oauth2.resourceserver.jwt.audiences.",
-                "https://docs.spring.io/spring-security/reference/reactive/oauth2/resource-server/jwt.html"));
+    ReactiveActuatorShowValuesRule() {
+        super(
+                new ReactiveSecurityRuleDefinition(
+                        "SEC-RXF-ACT-005",
+                        "Reactive Actuator env/configprops values must stay sanitized",
+                        ReactiveSecurityCategory.ACTUATOR,
+                        "HIGH",
+                        "Detects a web-exposed env or configprops endpoint whose host configuration sets show-values=always, revealing unsanitized property values to callers.",
+                        "Leave show-values at never or when-authorized so the Actuator sanitizer masks sensitive values; only relax it behind strict authorization.",
+                        "https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.sanitization"));
     }
 
     @Override
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
-        if (context.reactiveJwtDecoderTypes().isEmpty()) {
-            return pass();
+        List<String> details = new ArrayList<>();
+        if (context.environment().managementEnvShowValuesAlways()
+                && context.environment().managementEnvWebExposed()) {
+            details.add("management.endpoint.env.show-values=always exposes unsanitized /env values.");
         }
-        if (context.oauth2TokenValidatorTypes().isEmpty()) {
-            return violation(
-                    List.of(
-                            "A ReactiveJwtDecoder is configured but no OAuth2TokenValidator was found; the JWT audience claim may not be validated."));
+        if (context.environment().managementConfigPropsShowValuesAlways()
+                && context.environment().managementConfigPropsWebExposed()) {
+            details.add("management.endpoint.configprops.show-values=always exposes unsanitized /configprops values.");
         }
-        return pass();
+        return violation(details);
     }
 }
+
+// ---------------------------------------------------------------------------
+// OAuth2 / JWT
+// ---------------------------------------------------------------------------
 
 final class ReactiveJwtStaticKeyRule extends AbstractReactiveSecurityRule {
 
     ReactiveJwtStaticKeyRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-OAUTH2-002",
-                "Reactive JWT resource servers should avoid static public keys",
+                "Review rotation for reactive JWT static public keys",
                 ReactiveSecurityCategory.OAUTH2,
-                "MEDIUM",
-                "Detects spring.security.oauth2.resourceserver.jwt.public-key-location, which pins JWT verification to a static public key and makes signing-key rotation operationally fragile.",
-                "Prefer issuer-uri or jwk-set-uri so signing-key rotation can be handled through the authorization server's JWKS endpoint.",
+                "LOW",
+                "Detects the supported spring.security.oauth2.resourceserver.jwt.public-key-location configuration. Static verification keys are valid but require an explicit rotation process.",
+                "Document manual key rotation or prefer issuer-uri/jwk-set-uri when the authorization server publishes a trusted JWKS endpoint.",
                 "https://docs.spring.io/spring-security/reference/reactive/oauth2/resource-server/jwt.html"));
     }
 
@@ -584,44 +601,45 @@ final class ReactiveInsecureJwtMetadataUrlRule extends AbstractReactiveSecurityR
     }
 }
 
-// ---------------------------------------------------------------------------
-// Configuration hygiene
-// ---------------------------------------------------------------------------
+final class ReactiveInsecureOpaqueTokenIntrospectionUrlRule extends AbstractReactiveSecurityRule {
 
-final class ReactiveSecurityDebugRule extends AbstractReactiveSecurityRule {
-
-    ReactiveSecurityDebugRule() {
+    ReactiveInsecureOpaqueTokenIntrospectionUrlRule() {
         super(new ReactiveSecurityRuleDefinition(
-                "SEC-RXF-CONFIG-001",
-                "Spring Security debug mode should not be active",
-                ReactiveSecurityCategory.CONFIGURATION,
+                "SEC-RXF-OAUTH2-004",
+                "Opaque-token introspection must use HTTPS in reactive production applications",
+                ReactiveSecurityCategory.OAUTH2,
                 "HIGH",
-                "Detects spring.security.debug=true, which logs full request/response details including authentication headers and session tokens.",
-                "Remove spring.security.debug=true before deploying to any shared or production environment.",
-                "https://docs.spring.io/spring-security/reference/reactive/index.html"));
+                "Detects spring.security.oauth2.resourceserver.opaquetoken.introspection-uri configured with plain HTTP in a production profile. RFC 7662 requires TLS for introspection because access tokens and authorization metadata cross this channel.",
+                "Use an https:// introspection URI and validate the authorization server certificate.",
+                "https://www.rfc-editor.org/rfc/rfc7662.html#section-4"));
     }
 
     @Override
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
-        if (context.environment().securityDebugEnabled()) {
-            return violation(
-                    List.of(
-                            "spring.security.debug=true is active; this logs credential and session details to standard output."));
+        if (!context.isProductionProfileActive()
+                || !context.environment().oauth2OpaqueTokenIntrospectionUsesPlainHttp()) {
+            return pass();
         }
-        return pass();
+        return violation(
+                List.of(
+                        "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri uses plain HTTP; RFC 7662 requires TLS."));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Configuration hygiene
+// ---------------------------------------------------------------------------
 
 final class ReactiveHttpsEnforcementRule extends AbstractReactiveSecurityRule {
 
     ReactiveHttpsEnforcementRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-CONFIG-002",
-                "Reactive application should enforce HTTPS in production",
+                "Review HTTPS enforcement for reactive production applications",
                 ReactiveSecurityCategory.CONFIGURATION,
-                "HIGH",
-                "Detects a production profile active without any TLS configuration or HttpsRedirectWebFilter. Running over plain HTTP in production exposes all traffic.",
-                "Configure TLS (server.ssl.*) or terminate it upstream and set server.forward-headers-strategy, or add .redirectToHttps(Customizer.withDefaults()) to production chains.",
+                "MEDIUM",
+                "Detects a production profile where BootUI cannot observe server TLS, trusted forwarded-header handling, or HttpsRedirectWebFilter. External proxy policy remains outside runtime configuration inspection.",
+                "Confirm upstream TLS explicitly, configure server.forward-headers-strategy when trusted, or add .redirectToHttps(Customizer.withDefaults()) to production chains.",
                 "https://docs.spring.io/spring-security/reference/reactive/exploits/https.html"));
     }
 
@@ -635,7 +653,7 @@ final class ReactiveHttpsEnforcementRule extends AbstractReactiveSecurityRule {
         }
         return violation(
                 List.of(
-                        "A production profile is active but no TLS configuration or HttpsRedirectWebFilter was found. All traffic is served over plain HTTP."));
+                        "A production profile is active, but BootUI could not confirm TLS, trusted forwarded-header handling, or HttpsRedirectWebFilter. Verify the deployment boundary."));
     }
 }
 
@@ -671,10 +689,10 @@ final class ReactiveSecurityDebugLoggingProductionRule extends AbstractReactiveS
     ReactiveSecurityDebugLoggingProductionRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-CONFIG-004",
-                "Spring Security DEBUG logging should not run in production",
+                "Spring Security DEBUG or TRACE logging should not run in production",
                 ReactiveSecurityCategory.CONFIGURATION,
                 "MEDIUM",
-                "Detects DEBUG-level logging configured for Spring Security packages while a production profile is active.",
+                "Detects DEBUG- or TRACE-level logging configured for Spring Security packages while a production profile is active.",
                 "Set logging.level.org.springframework.security to INFO or WARN in the production profile.",
                 "https://docs.spring.io/spring-security/reference/reactive/index.html"));
     }
@@ -685,10 +703,10 @@ final class ReactiveSecurityDebugLoggingProductionRule extends AbstractReactiveS
             return pass();
         }
         String level = context.environment().securityLoggingLevel();
-        if (level != null && "DEBUG".equalsIgnoreCase(level.trim())) {
-            return violation(
-                    List.of(
-                            "logging.level.org.springframework.security is set to DEBUG while a production profile is active."));
+        if (level != null && ("DEBUG".equalsIgnoreCase(level.trim()) || "TRACE".equalsIgnoreCase(level.trim()))) {
+            return violation(List.of("Spring Security logging is set to "
+                    + level.trim().toUpperCase(java.util.Locale.ROOT)
+                    + " while a production profile is active."));
         }
         return pass();
     }
@@ -698,29 +716,29 @@ final class ReactiveSecurityDebugLoggingProductionRule extends AbstractReactiveS
 // Session management
 // ---------------------------------------------------------------------------
 
-final class ReactiveBearerTokenStatefulRule extends AbstractReactiveSecurityRule {
+final class ReactiveMixedBearerAndLoginRule extends AbstractReactiveSecurityRule {
 
-    ReactiveBearerTokenStatefulRule() {
+    ReactiveMixedBearerAndLoginRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-SESSION-001",
-                "Bearer-token resource server should use stateless session management",
+                "Review reactive chains that mix bearer-token and browser OAuth2 filters",
                 ReactiveSecurityCategory.SESSION,
                 "LOW",
-                "Detects a reactive chain that handles bearer-token authentication through AuthenticationWebFilter while also configuring session-based authentication mechanisms. JWTs are self-contained credentials; pairing them with session storage is redundant and increases attack surface.",
-                "For pure bearer-token resource servers, configure .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) to disable server-side sessions.",
-                "https://docs.spring.io/spring-security/reference/reactive/oauth2/resource-server/jwt.html"));
+                "Detects a chain with both Spring Security's bearer-token converter and an observed OAuth2/OIDC login or authorization-code client filter. This mixed topology may be intentional; filter presence does not prove SecurityContext persistence.",
+                "Prefer separate ordered SecurityWebFilterChain beans for browser OAuth2 and resource-server paths. For a pure bearer chain, use securityContextRepository(NoOpServerSecurityContextRepository.getInstance()); WebFlux has no SessionCreationPolicy API.",
+                "https://docs.spring.io/spring-security/reference/reactive/authentication/index.html"));
     }
 
     @Override
     SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
-            if (chain.bearerTokenAuthentication() && chain.isStateful()) {
+            if (chain.bearerTokenAuthentication() && chain.hasObservedInteractiveLoginFilter()) {
                 details.add(
                         chain.describe()
-                                + " configures both bearer-token authentication and session-based authentication; consider using stateless sessions for pure resource server chains.");
+                                + " configures both bearer-token authentication and an OAuth2/OIDC browser filter; review whether separate chains would express the two security models more safely.");
             }
         }
-        return violation(details);
+        return filterViolation(context, details);
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityRules.java
@@ -111,10 +111,10 @@ final class ReactiveCsrfDisabledLoginRule extends AbstractReactiveSecurityRule {
     ReactiveCsrfDisabledLoginRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-CSRF-001",
-                "Reactive OAuth2/OIDC login chains should enable CSRF protection",
+                "Reactive OAuth2/OIDC or formLogin() chains should enable CSRF protection",
                 ReactiveSecurityCategory.CSRF,
                 "HIGH",
-                "Detects a reactive chain with an observed OAuth2/OIDC login filter but no CsrfWebFilter. Without CSRF protection, cross-origin state-changing requests can be forged.",
+                "Detects a reactive chain with an observed OAuth2/OIDC login filter or a formLogin() authentication converter but no CsrfWebFilter. Without CSRF protection, cross-origin state-changing requests can be forged.",
                 "Keep CSRF enabled for browser login chains, using .csrf(Customizer.withDefaults()) or a CookieServerCsrfTokenRepository as appropriate.",
                 "https://docs.spring.io/spring-security/reference/reactive/exploits/csrf.html"));
     }
@@ -124,7 +124,8 @@ final class ReactiveCsrfDisabledLoginRule extends AbstractReactiveSecurityRule {
         List<String> details = new ArrayList<>();
         for (WebFilterChainObservation chain : context.chains()) {
             if (chain.hasObservedInteractiveLoginFilter() && !chain.hasCsrfWebFilter()) {
-                details.add(chain.describe() + " has an OAuth2/OIDC login filter but no CsrfWebFilter is installed.");
+                details.add(chain.describe()
+                        + " has an OAuth2/OIDC or formLogin() login filter but no CsrfWebFilter is installed.");
             }
         }
         return filterViolation(context, details);
@@ -215,6 +216,41 @@ final class ReactiveCorsWildcardWithCredentialsRule extends AbstractReactiveSecu
             }
         }
         return corsViolation(context, details);
+    }
+}
+
+final class ReactiveBroadCorsOriginPatternRule extends AbstractReactiveSecurityRule {
+
+    ReactiveBroadCorsOriginPatternRule() {
+        super(new ReactiveSecurityRuleDefinition(
+                "SEC-RXF-CORS-003",
+                "Reactive CORS should not allow broad origin patterns",
+                ReactiveSecurityCategory.CORS,
+                "MEDIUM",
+                "Detects allowedOriginPatterns that match a dangerously broad set of origins (wildcard scheme or host, e.g. https://*, *://*, *.com) beyond the exact \"*\" already covered by SEC-RXF-CORS-001/002.",
+                "Replace broad patterns with the exact origins (or tightly-scoped subdomain wildcards such as https://*.example.com) the application trusts; broad patterns combined with credentials let untrusted sites make authenticated cross-site calls.",
+                "https://docs.spring.io/spring-framework/reference/web/webflux-cors.html"));
+    }
+
+    @Override
+    SecurityRuleResultDto evaluateRule(ReactiveSecurityContext context) {
+        List<String> details = new ArrayList<>();
+        boolean credentialed = false;
+        for (CorsConfigObservation config : context.corsConfigs()) {
+            List<String> broad = config.broadOriginPatterns();
+            if (broad.isEmpty()) {
+                continue;
+            }
+            boolean allowsCredentials = Boolean.TRUE.equals(config.allowCredentials());
+            credentialed = credentialed || allowsCredentials;
+            String suffix = allowsCredentials ? " with allowCredentials=true" : "";
+            details.add("CORS config for pattern '" + config.pattern() + "' uses broad origin patterns " + broad
+                    + suffix + ".");
+        }
+        if (details.isEmpty()) {
+            return corsViolation(context, details);
+        }
+        return violation(credentialed ? "HIGH" : "MEDIUM", details);
     }
 }
 
@@ -721,11 +757,11 @@ final class ReactiveMixedBearerAndLoginRule extends AbstractReactiveSecurityRule
     ReactiveMixedBearerAndLoginRule() {
         super(new ReactiveSecurityRuleDefinition(
                 "SEC-RXF-SESSION-001",
-                "Review reactive chains that mix bearer-token and browser OAuth2 filters",
+                "Review reactive chains that mix bearer-token and browser login filters",
                 ReactiveSecurityCategory.SESSION,
                 "LOW",
-                "Detects a chain with both Spring Security's bearer-token converter and an observed OAuth2/OIDC login or authorization-code client filter. This mixed topology may be intentional; filter presence does not prove SecurityContext persistence.",
-                "Prefer separate ordered SecurityWebFilterChain beans for browser OAuth2 and resource-server paths. For a pure bearer chain, use securityContextRepository(NoOpServerSecurityContextRepository.getInstance()); WebFlux has no SessionCreationPolicy API.",
+                "Detects a chain with both Spring Security's bearer-token converter and an observed OAuth2/OIDC login, authorization-code client, or formLogin() filter. This mixed topology may be intentional; filter presence does not prove SecurityContext persistence.",
+                "Prefer separate ordered SecurityWebFilterChain beans for browser login and resource-server paths. For a pure bearer chain, use securityContextRepository(NoOpServerSecurityContextRepository.getInstance()); WebFlux has no SessionCreationPolicy API.",
                 "https://docs.spring.io/spring-security/reference/reactive/authentication/index.html"));
     }
 
@@ -736,7 +772,7 @@ final class ReactiveMixedBearerAndLoginRule extends AbstractReactiveSecurityRule
             if (chain.bearerTokenAuthentication() && chain.hasObservedInteractiveLoginFilter()) {
                 details.add(
                         chain.describe()
-                                + " configures both bearer-token authentication and an OAuth2/OIDC browser filter; review whether separate chains would express the two security models more safely.");
+                                + " configures both bearer-token authentication and an OAuth2/OIDC or formLogin() browser filter; review whether separate chains would express the two security models more safely.");
             }
         }
         return filterViolation(context, details);

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/WebFilterChainObservation.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/WebFilterChainObservation.java
@@ -13,9 +13,10 @@ import java.util.Locale;
  *     beans (BootUI's own chain already excluded by the adapter)
  * @param matcher a bounded, non-sensitive description of the chain's security matcher
  * @param webFilterNames simple class names of the {@code WebFilter}s installed in the chain
- * @param permitsAllAnonymous best-effort result of whether the chain permits all requests without
- *     authorization ({@code TRUE} when no {@code AuthorizationWebFilter} is found, {@code null} when
- *     it could not be determined)
+ * @param permitsAllAnonymous legacy best-effort inverse of whether an {@code
+ *     AuthorizationWebFilter} was observed ({@code TRUE} when none was found, {@code null} when the
+ *     chain's filters could not be collected); this does not reveal the filter's authorization
+ *     decisions
  * @param bearerTokenAuthentication whether the chain contains an {@code AuthenticationWebFilter}
  *     backed by Spring Security's reactive bearer-token converter
  * @param headerWriterNames simple class names of the {@code ServerHttpHeadersWriter}s installed by the
@@ -25,6 +26,8 @@ import java.util.Locale;
  * @param hstsIncludeSubdomains the HSTS writer's configured {@code includeSubDomains}
  * @param cspPolicyDirectives the CSP writer's configured {@code policyDirectives}
  * @param cspReportOnly whether the CSP writer emits Content-Security-Policy-Report-Only
+ * @param headerWritersObserved whether header-writer extraction completed; {@code false} means
+ *     rules that require writer details must remain inconclusive
  */
 public record WebFilterChainObservation(
         int index,
@@ -36,13 +39,40 @@ public record WebFilterChainObservation(
         Long hstsMaxAgeSeconds,
         Boolean hstsIncludeSubdomains,
         String cspPolicyDirectives,
-        Boolean cspReportOnly) {
+        Boolean cspReportOnly,
+        boolean headerWritersObserved) {
 
     private static final long HSTS_MIN_MAX_AGE_SECONDS = 31536000L;
 
     public WebFilterChainObservation {
         webFilterNames = List.copyOf(webFilterNames);
         headerWriterNames = headerWriterNames == null ? List.of() : List.copyOf(headerWriterNames);
+    }
+
+    /** Compatibility constructor for observations created before header extraction became tri-state. */
+    public WebFilterChainObservation(
+            int index,
+            String matcher,
+            List<String> webFilterNames,
+            Boolean permitsAllAnonymous,
+            boolean bearerTokenAuthentication,
+            List<String> headerWriterNames,
+            Long hstsMaxAgeSeconds,
+            Boolean hstsIncludeSubdomains,
+            String cspPolicyDirectives,
+            Boolean cspReportOnly) {
+        this(
+                index,
+                matcher,
+                webFilterNames,
+                permitsAllAnonymous,
+                bearerTokenAuthentication,
+                headerWriterNames,
+                hstsMaxAgeSeconds,
+                hstsIncludeSubdomains,
+                cspPolicyDirectives,
+                cspReportOnly,
+                true);
     }
 
     public WebFilterChainObservation(
@@ -65,7 +95,8 @@ public record WebFilterChainObservation(
                 hstsMaxAgeSeconds,
                 hstsIncludeSubdomains,
                 cspPolicyDirectives,
-                cspReportOnly);
+                cspReportOnly,
+                true);
     }
 
     boolean hasWebFilter(String simpleName) {
@@ -73,7 +104,32 @@ public record WebFilterChainObservation(
     }
 
     boolean hasAuthorizationWebFilter() {
-        return hasWebFilter("AuthorizationWebFilter");
+        return Boolean.TRUE.equals(authorizationFilterPresent());
+    }
+
+    boolean filtersObserved() {
+        return permitsAllAnonymous != null;
+    }
+
+    /**
+     * Legacy inverse filter-presence signal. It cannot establish an actual {@code permitAll}
+     * authorization decision.
+     *
+     * @deprecated use {@link #authorizationFilterPresent()} for the directly observed fact
+     */
+    @Deprecated
+    public Boolean permitsAllAnonymous() {
+        return permitsAllAnonymous;
+    }
+
+    /**
+     * Returns the directly observed authorization-filter state without inferring its decisions.
+     *
+     * @return {@code TRUE} when an {@code AuthorizationWebFilter} was observed, {@code FALSE} when
+     *     filters were observed without one, or {@code null} when filter collection failed
+     */
+    public Boolean authorizationFilterPresent() {
+        return permitsAllAnonymous == null ? null : !permitsAllAnonymous;
     }
 
     boolean hasCsrfWebFilter() {
@@ -99,6 +155,27 @@ public record WebFilterChainObservation(
 
     boolean hasCspWriter() {
         return cspPolicyDirectives != null && !cspPolicyDirectives.isBlank();
+    }
+
+    boolean hasEnforcingFrameAncestorsPolicy() {
+        if (!hasCspWriter() || Boolean.TRUE.equals(cspReportOnly)) {
+            return false;
+        }
+        for (String directive : cspPolicyDirectives.split(";")) {
+            String[] parts = directive.trim().toLowerCase(Locale.ROOT).split("\\s+", 2);
+            if (parts.length > 0 && "frame-ancestors".equals(parts[0])) {
+                if (parts.length < 2 || parts[1].isBlank()) {
+                    return false;
+                }
+                for (String source : parts[1].split("\\s+")) {
+                    if (source.contains("*") || source.matches("[a-z][a-z0-9+.-]*:")) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
     }
 
     boolean hasContentTypeOptionsWriter() {
@@ -128,10 +205,9 @@ public record WebFilterChainObservation(
         return "Chain " + index + " (" + (matcher != null ? matcher : "unknown matcher") + ")";
     }
 
-    boolean isStateful() {
-        // Reactive chains using OAuth2 login are stateful; pure bearer-token resource servers are
-        // stateless.
+    boolean hasObservedInteractiveLoginFilter() {
         return hasWebFilter("OAuth2LoginAuthenticationWebFilter")
+                || hasWebFilter("OidcSessionRegistryAuthenticationWebFilter")
                 || hasWebFilter("OAuth2AuthorizationCodeGrantWebFilter");
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/WebFilterChainObservation.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/WebFilterChainObservation.java
@@ -28,6 +28,9 @@ import java.util.Locale;
  * @param cspReportOnly whether the CSP writer emits Content-Security-Policy-Report-Only
  * @param headerWritersObserved whether header-writer extraction completed; {@code false} means
  *     rules that require writer details must remain inconclusive
+ * @param formLoginAuthentication whether the chain contains an {@code AuthenticationWebFilter}
+ *     backed by Spring Security's reactive {@code ServerFormLoginAuthenticationConverter}, i.e. a
+ *     {@code formLogin()} chain
  */
 public record WebFilterChainObservation(
         int index,
@@ -40,7 +43,36 @@ public record WebFilterChainObservation(
         Boolean hstsIncludeSubdomains,
         String cspPolicyDirectives,
         Boolean cspReportOnly,
-        boolean headerWritersObserved) {
+        boolean headerWritersObserved,
+        boolean formLoginAuthentication) {
+
+    /** Compatibility constructor for observations created before formLogin() detection was added. */
+    public WebFilterChainObservation(
+            int index,
+            String matcher,
+            List<String> webFilterNames,
+            Boolean permitsAllAnonymous,
+            boolean bearerTokenAuthentication,
+            List<String> headerWriterNames,
+            Long hstsMaxAgeSeconds,
+            Boolean hstsIncludeSubdomains,
+            String cspPolicyDirectives,
+            Boolean cspReportOnly,
+            boolean headerWritersObserved) {
+        this(
+                index,
+                matcher,
+                webFilterNames,
+                permitsAllAnonymous,
+                bearerTokenAuthentication,
+                headerWriterNames,
+                hstsMaxAgeSeconds,
+                hstsIncludeSubdomains,
+                cspPolicyDirectives,
+                cspReportOnly,
+                headerWritersObserved,
+                false);
+    }
 
     private static final long HSTS_MIN_MAX_AGE_SECONDS = 31536000L;
 
@@ -208,6 +240,7 @@ public record WebFilterChainObservation(
     boolean hasObservedInteractiveLoginFilter() {
         return hasWebFilter("OAuth2LoginAuthenticationWebFilter")
                 || hasWebFilter("OidcSessionRegistryAuthenticationWebFilter")
-                || hasWebFilter("OAuth2AuthorizationCodeGrantWebFilter");
+                || hasWebFilter("OAuth2AuthorizationCodeGrantWebFilter")
+                || formLoginAuthentication;
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityScannerTests.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Pure unit tests for the framework-neutral reactive Spring Security advisor: {@link
- * ReactiveSecurityScanner}, {@link ReactiveSecurityRuleRegistry}, and the 25 {@code SEC-RXF-*} rules.
+ * ReactiveSecurityScanner}, {@link ReactiveSecurityRuleRegistry}, and the 26 {@code SEC-RXF-*} rules.
  * Everything here builds a plain {@link ReactiveSecurityObservation} — no Spring, no reflection, no
  * {@code MockEnvironment} — mirroring how {@code SpringReactiveSecurityObservationCollector} feeds the
  * scanner in production.
@@ -307,6 +307,82 @@ class ReactiveSecurityScannerTests {
     }
 
     @Test
+    void scanDetectsCsrfWebFilterAbsenceForFormLoginChain() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of(
+                        "SecurityContextServerWebExchangeWebFilter",
+                        "AuthorizationWebFilter",
+                        "AuthenticationWebFilter"),
+                Boolean.FALSE,
+                false,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null,
+                true,
+                true);
+        SecurityReport report = scan(chain, List.of(), false);
+
+        // Observed formLogin() converter without CsrfWebFilter should trigger SEC-RXF-CSRF-001, same
+        // as an OAuth2/OIDC login filter.
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-RXF-CSRF-001");
+    }
+
+    @Test
+    void formLoginChainWithCsrfWebFilterDoesNotTriggerCsrfRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of(
+                        "SecurityContextServerWebExchangeWebFilter",
+                        "AuthorizationWebFilter",
+                        "AuthenticationWebFilter",
+                        "CsrfWebFilter"),
+                Boolean.FALSE,
+                false,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null,
+                true,
+                true);
+        SecurityReport report = scan(chain, List.of(), false);
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-RXF-CSRF-001");
+    }
+
+    @Test
+    void plainAuthenticationWebFilterWithoutFormLoginConverterDoesNotTriggerLoginRules() {
+        // A generic AuthenticationWebFilter (e.g. HTTP Basic) whose converter is not
+        // ServerFormLoginAuthenticationConverter must not be mistaken for a formLogin() chain.
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of(
+                        "SecurityContextServerWebExchangeWebFilter",
+                        "AuthorizationWebFilter",
+                        "AuthenticationWebFilter"),
+                Boolean.FALSE,
+                false,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null,
+                true,
+                false);
+        SecurityReport report = scan(chain, List.of(), false);
+
+        assertThat(report.results())
+                .extracting(SecurityRuleResultDto::id)
+                .doesNotContain("SEC-RXF-CSRF-001", "SEC-RXF-SESSION-001");
+    }
+
+    @Test
     void scanDetectsWildcardCorsOrigin() {
         WebFilterChainObservation chain = new WebFilterChainObservation(
                 0,
@@ -371,6 +447,145 @@ class ReactiveSecurityScannerTests {
                 .singleElement()
                 .extracting(SecurityRuleResultDto::severity)
                 .isEqualTo("HIGH");
+    }
+
+    @Test
+    void broadWildcardSchemeOriginPatternTriggersMediumSeverityRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "CorsWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null);
+        SecurityReport report = scan(
+                chain,
+                List.of(new CorsConfigObservation(
+                        "/**", List.of(), List.of("https://*"), List.of(), List.of(), Boolean.FALSE)),
+                true);
+
+        assertThat(report.results())
+                .filteredOn(result -> result.id().equals("SEC-RXF-CORS-003"))
+                .singleElement()
+                .extracting(SecurityRuleResultDto::severity)
+                .isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void broadTopLevelDomainSuffixOriginPatternTriggersMediumSeverityRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "CorsWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null);
+        SecurityReport report = scan(
+                chain,
+                List.of(new CorsConfigObservation(
+                        "/**", List.of(), List.of("https://*.com"), List.of(), List.of(), Boolean.FALSE)),
+                true);
+
+        assertThat(report.results())
+                .filteredOn(result -> result.id().equals("SEC-RXF-CORS-003"))
+                .singleElement()
+                .extracting(SecurityRuleResultDto::severity)
+                .isEqualTo("MEDIUM");
+    }
+
+    @Test
+    void credentialedBroadOriginPatternTriggersHighSeverityBroadPatternRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "CorsWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null);
+        SecurityReport report = scan(
+                chain,
+                List.of(new CorsConfigObservation(
+                        "/**", List.of(), List.of("*://*"), List.of(), List.of(), Boolean.TRUE)),
+                true);
+
+        assertThat(report.results())
+                .filteredOn(result -> result.id().equals("SEC-RXF-CORS-003"))
+                .singleElement()
+                .extracting(SecurityRuleResultDto::severity)
+                .isEqualTo("HIGH");
+    }
+
+    @Test
+    void scopedSubdomainWildcardOriginPatternDoesNotTriggerBroadPatternRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "CorsWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null);
+        SecurityReport report = scan(
+                chain,
+                List.of(new CorsConfigObservation(
+                        "/**", List.of(), List.of("https://*.example.com"), List.of(), List.of(), Boolean.TRUE)),
+                true);
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-RXF-CORS-003");
+    }
+
+    @Test
+    void exactWildcardOriginPatternDoesNotDuplicateBroadPatternRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "CorsWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null);
+        SecurityReport report = scan(
+                chain,
+                List.of(new CorsConfigObservation("/**", List.of(), List.of("*"), List.of(), List.of(), Boolean.TRUE)),
+                true);
+
+        // The exact "*" pattern is already covered by SEC-RXF-CORS-001/002; the broad-pattern rule
+        // must not fire a duplicate finding for it.
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-RXF-CORS-003");
+    }
+
+    @Test
+    void safeExplicitOriginDoesNotTriggerBroadPatternRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "CorsWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null);
+        SecurityReport report = scan(
+                chain,
+                List.of(new CorsConfigObservation(
+                        "/**", List.of(), List.of("https://app.example.com"), List.of(), List.of(), Boolean.TRUE)),
+                true);
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-RXF-CORS-003");
     }
 
     @Test
@@ -702,6 +917,50 @@ class ReactiveSecurityScannerTests {
     }
 
     @Test
+    void scanDetectsMixedBearerTokenAndFormLoginFilters() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "AuthenticationWebFilter"),
+                Boolean.FALSE,
+                true,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                true,
+                true);
+
+        SecurityReport report = scan(chain, List.of(), false);
+
+        // A chain that mixes a bearer-token converter with a formLogin() converter should trigger
+        // SEC-RXF-SESSION-001, the same as mixing bearer-token with an OAuth2/OIDC login filter.
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-RXF-SESSION-001");
+    }
+
+    @Test
+    void bearerTokenAloneWithoutFormLoginDoesNotTriggerMixedSessionRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "AuthenticationWebFilter"),
+                Boolean.FALSE,
+                true,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                true,
+                false);
+
+        SecurityReport report = scan(chain, List.of(), false);
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-RXF-SESSION-001");
+    }
+
+    @Test
     void plainHttpOpaqueTokenIntrospectionIsHighSeverityOnlyInProduction() {
         WebFilterChainObservation chain = new WebFilterChainObservation(
                 0, "any request", List.of("AuthorizationWebFilter"), Boolean.FALSE, List.of(), null, null, null, null);
@@ -767,7 +1026,7 @@ class ReactiveSecurityScannerTests {
     @Test
     void ruleCountMatchesRegistry() {
         assertThat(ReactiveSecurityRuleRegistry.activeRules()).hasSize(RULE_COUNT);
-        assertThat(RULE_COUNT).isEqualTo(25);
+        assertThat(RULE_COUNT).isEqualTo(26);
     }
 
     @Test
@@ -783,9 +1042,9 @@ class ReactiveSecurityScannerTests {
                 .map(r -> r.definition().id())
                 .toList();
         assertThat(ids).doesNotHaveDuplicates();
-        assertThat(ids).hasSize(25);
+        assertThat(ids).hasSize(26);
         assertThat(ids)
-                .contains("SEC-RXF-ACT-005", "SEC-RXF-OAUTH2-004")
+                .contains("SEC-RXF-ACT-005", "SEC-RXF-OAUTH2-004", "SEC-RXF-CORS-003")
                 .doesNotContain("SEC-RXF-CONFIG-001", "SEC-RXF-OAUTH2-001");
         List<String> sorted = ids.stream().sorted().toList();
         // Registry order need not be alphabetical, but must be stable/deterministic across calls.

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityScannerTests.java
@@ -83,7 +83,7 @@ class ReactiveSecurityScannerTests {
                         "AuthorizationWebFilter"),
                 Boolean.FALSE,
                 List.of(
-                        "HstsServerHttpHeadersWriter",
+                        "StrictTransportSecurityServerHttpHeadersWriter",
                         "XFrameOptionsServerHttpHeadersWriter",
                         "XXssProtectionServerHttpHeadersWriter",
                         "ContentTypeOptionsServerHttpHeadersWriter"),
@@ -95,7 +95,7 @@ class ReactiveSecurityScannerTests {
                 false, "*", null, false, List.of(), false, false, false, false, null, Set.of());
         ReactiveSecurityObservation observation = new ReactiveSecurityObservation(
                 List.of(chain),
-                List.of(new CorsConfigObservation("/**", List.of("*"), List.of(), List.of(), List.of(), Boolean.TRUE)),
+                List.of(new CorsConfigObservation("/**", List.of(), List.of("*"), List.of(), List.of(), Boolean.TRUE)),
                 true,
                 List.of(),
                 List.of(),
@@ -179,7 +179,7 @@ class ReactiveSecurityScannerTests {
                 List.of("SecurityContextServerWebExchangeWebFilter", "AuthorizationWebFilter"),
                 Boolean.FALSE,
                 List.of(
-                        "HstsServerHttpHeadersWriter",
+                        "StrictTransportSecurityServerHttpHeadersWriter",
                         "XFrameOptionsServerHttpHeadersWriter",
                         "XXssProtectionServerHttpHeadersWriter",
                         "ContentTypeOptionsServerHttpHeadersWriter"),
@@ -194,24 +194,115 @@ class ReactiveSecurityScannerTests {
     }
 
     @Test
-    void scanDetectsCsrfWebFilterAbsence() {
+    void unknownWebFiltersDoNotCreateMissingAuthorizationOrCsrfFindings() {
+        WebFilterChainObservation chain =
+                new WebFilterChainObservation(0, "any request", List.of(), null, List.of(), null, null, null, null);
+
+        SecurityReport report = scan(chain, List.of(), false);
+
+        assertThat(report.results())
+                .extracting(SecurityRuleResultDto::id)
+                .doesNotContain("SEC-RXF-AUTHZ-001", "SEC-RXF-AUTHZ-002", "SEC-RXF-AUTHZ-003", "SEC-RXF-CSRF-002");
+    }
+
+    @Test
+    void unknownWebFiltersProduceExplicitSkippedRuleResults() {
+        WebFilterChainObservation chain =
+                new WebFilterChainObservation(0, "any request", List.of(), null, List.of(), null, null, null, null);
+        ReactiveSecurityObservation observation = new ReactiveSecurityObservation(
+                List.of(chain),
+                List.of(),
+                false,
+                List.of(),
+                List.of(),
+                List.of(),
+                ReactiveSecurityEnvironmentSnapshot.empty(),
+                List.of());
+        ReactiveSecurityContext context = ReactiveSecurityContext.from(observation);
+
+        assertThat(new ReactiveAuthorizationFilterRule().evaluate(context).status())
+                .isEqualTo(ReactiveSecuritySupport.SKIPPED);
+        assertThat(new ReactiveCsrfGloballyDisabledRule().evaluate(context).status())
+                .isEqualTo(ReactiveSecuritySupport.SKIPPED);
+    }
+
+    @Test
+    void unknownHeaderWritersProduceExplicitSkippedRuleResults() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                false,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                false);
+        ReactiveSecurityObservation observation = new ReactiveSecurityObservation(
+                List.of(chain),
+                List.of(),
+                false,
+                List.of(),
+                List.of(),
+                List.of(),
+                ReactiveSecurityEnvironmentSnapshot.empty(),
+                List.of("Chain 0: header writers could not be collected"));
+        ReactiveSecurityContext context = ReactiveSecurityContext.from(observation);
+
+        assertThat(new ReactiveFrameOptionsRule().evaluate(context).status())
+                .isEqualTo(ReactiveSecuritySupport.SKIPPED);
+        assertThat(new ReactiveContentSecurityPolicyRule().evaluate(context).status())
+                .isEqualTo(ReactiveSecuritySupport.SKIPPED);
+    }
+
+    @Test
+    void catchAllAuthenticationWithoutAuthorizationTriggersDedicatedReview() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0, "any request", List.of("AuthenticationWebFilter"), Boolean.TRUE, List.of(), null, null, null, null);
+
+        SecurityReport report = scan(chain, List.of(), false);
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-RXF-AUTHZ-002");
+    }
+
+    @Test
+    void authorizationFilterDoesNotClaimPermitAllEvenWhenAuthenticationIsPresent() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthenticationWebFilter", "AuthorizationWebFilter"),
+                Boolean.FALSE,
+                List.of(),
+                null,
+                null,
+                null,
+                null);
+
+        SecurityReport report = scan(chain, List.of(), false);
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-RXF-AUTHZ-002");
+    }
+
+    @Test
+    void scanDetectsCsrfWebFilterAbsenceForOidcSessionRegistryLogin() {
         WebFilterChainObservation chain = new WebFilterChainObservation(
                 0,
                 "any request",
                 List.of(
                         "SecurityContextServerWebExchangeWebFilter",
                         "AuthorizationWebFilter",
-                        "OAuth2LoginAuthenticationWebFilter",
-                        "OAuth2AuthorizationCodeGrantWebFilter"),
+                        "OidcSessionRegistryAuthenticationWebFilter"),
                 Boolean.FALSE,
-                List.of("HstsServerHttpHeadersWriter"),
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
                 31536000L,
                 Boolean.TRUE,
                 null,
                 null);
         SecurityReport report = scan(chain, List.of(), false);
 
-        // Stateful chain without CsrfWebFilter should trigger SEC-RXF-CSRF-001
+        // Observed OIDC login without CsrfWebFilter should trigger SEC-RXF-CSRF-001.
         assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-RXF-CSRF-001");
     }
 
@@ -222,7 +313,7 @@ class ReactiveSecurityScannerTests {
                 "any request",
                 List.of("AuthorizationWebFilter", "CorsWebFilter"),
                 Boolean.FALSE,
-                List.of("HstsServerHttpHeadersWriter"),
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
                 31536000L,
                 Boolean.TRUE,
                 null,
@@ -236,13 +327,13 @@ class ReactiveSecurityScannerTests {
     }
 
     @Test
-    void scanDetectsWildcardCorsWithCredentials() {
+    void literalWildcardOriginWithCredentialsDoesNotTriggerPatternRule() {
         WebFilterChainObservation chain = new WebFilterChainObservation(
                 0,
                 "any request",
                 List.of("AuthorizationWebFilter", "CorsWebFilter"),
                 Boolean.FALSE,
-                List.of("HstsServerHttpHeadersWriter"),
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
                 31536000L,
                 Boolean.TRUE,
                 null,
@@ -253,10 +344,69 @@ class ReactiveSecurityScannerTests {
                 true);
 
         assertThat(report.results())
+                .extracting(SecurityRuleResultDto::id)
+                .contains("SEC-RXF-CORS-001")
+                .doesNotContain("SEC-RXF-CORS-002");
+    }
+
+    @Test
+    void credentialedWildcardOriginPatternTriggersHighSeverityRule() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "CorsWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null);
+        SecurityReport report = scan(
+                chain,
+                List.of(new CorsConfigObservation("/**", List.of(), List.of("*"), List.of(), List.of(), Boolean.TRUE)),
+                true);
+
+        assertThat(report.results())
                 .filteredOn(result -> result.id().equals("SEC-RXF-CORS-002"))
                 .singleElement()
                 .extracting(SecurityRuleResultDto::severity)
                 .isEqualTo("HIGH");
+    }
+
+    @Test
+    void partialCorsInspectionSkipsSafeKnownEntriesButKeepsKnownViolations() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0, "any request", List.of("AuthorizationWebFilter"), Boolean.FALSE, List.of(), null, null, null, null);
+        ReactiveSecurityObservation incompleteSafeObservation = new ReactiveSecurityObservation(
+                List.of(chain),
+                List.of(new CorsConfigObservation(
+                        "/**", List.of("https://app.example"), List.of(), List.of(), List.of(), Boolean.TRUE)),
+                true,
+                List.of(),
+                List.of(),
+                List.of(),
+                ReactiveSecurityEnvironmentSnapshot.empty(),
+                List.of("CORS source unavailable"),
+                false);
+        ReactiveSecurityObservation incompleteViolationObservation = new ReactiveSecurityObservation(
+                List.of(chain),
+                List.of(new CorsConfigObservation("/**", List.of("*"), List.of(), List.of(), List.of(), null)),
+                true,
+                List.of(),
+                List.of(),
+                List.of(),
+                ReactiveSecurityEnvironmentSnapshot.empty(),
+                List.of("CORS source unavailable"),
+                false);
+
+        assertThat(new ReactiveCorsWildcardOriginRule()
+                        .evaluate(ReactiveSecurityContext.from(incompleteSafeObservation))
+                        .status())
+                .isEqualTo(ReactiveSecuritySupport.SKIPPED);
+        assertThat(new ReactiveCorsWildcardOriginRule()
+                        .evaluate(ReactiveSecurityContext.from(incompleteViolationObservation))
+                        .status())
+                .isEqualTo(ReactiveSecuritySupport.VIOLATION);
     }
 
     @Test
@@ -284,6 +434,94 @@ class ReactiveSecurityScannerTests {
     }
 
     @Test
+    void hstsOneYearBoundaryMatchesSpringSecurityDefault() {
+        WebFilterChainObservation belowDefault = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31535999L,
+                Boolean.TRUE,
+                null,
+                null);
+        WebFilterChainObservation atDefault = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
+                31536000L,
+                Boolean.TRUE,
+                null,
+                null);
+
+        assertThat(scan(belowDefault, List.of(), false).results())
+                .extracting(SecurityRuleResultDto::id)
+                .contains("SEC-RXF-HEAD-006");
+        assertThat(scan(atDefault, List.of(), false).results())
+                .extracting(SecurityRuleResultDto::id)
+                .doesNotContain("SEC-RXF-HEAD-006");
+    }
+
+    @Test
+    void enforcingCspFrameAncestorsReplacesFrameOptionsButReportOnlyDoesNot() {
+        WebFilterChainObservation enforcingPolicy = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                List.of("ContentTypeOptionsServerHttpHeadersWriter"),
+                null,
+                null,
+                "default-src 'self'; frame-ancestors 'none'",
+                Boolean.FALSE);
+        WebFilterChainObservation reportOnlyPolicy = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                List.of("ContentTypeOptionsServerHttpHeadersWriter"),
+                null,
+                null,
+                "default-src 'self'; frame-ancestors 'none'",
+                Boolean.TRUE);
+        WebFilterChainObservation directiveNameOnlyInUrl = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                List.of("ContentTypeOptionsServerHttpHeadersWriter"),
+                null,
+                null,
+                "default-src 'self'; report-uri https://frame-ancestors.example",
+                Boolean.FALSE);
+        WebFilterChainObservation unrestrictedPolicy = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                List.of("ContentTypeOptionsServerHttpHeadersWriter"),
+                null,
+                null,
+                "default-src 'self'; frame-ancestors *",
+                Boolean.FALSE);
+
+        assertThat(scan(enforcingPolicy, List.of(), false).results())
+                .extracting(SecurityRuleResultDto::id)
+                .doesNotContain("SEC-RXF-HEAD-002");
+        assertThat(scan(reportOnlyPolicy, List.of(), false).results())
+                .extracting(SecurityRuleResultDto::id)
+                .contains("SEC-RXF-HEAD-002");
+        assertThat(scan(directiveNameOnlyInUrl, List.of(), false).results())
+                .extracting(SecurityRuleResultDto::id)
+                .contains("SEC-RXF-HEAD-002");
+        assertThat(scan(unrestrictedPolicy, List.of(), false).results())
+                .extracting(SecurityRuleResultDto::id)
+                .contains("SEC-RXF-HEAD-002");
+    }
+
+    @Test
     void scanDetectsUnconfiguredCspWriter() {
         WebFilterChainObservation chain = new WebFilterChainObservation(
                 0,
@@ -298,7 +536,42 @@ class ReactiveSecurityScannerTests {
 
         SecurityReport report = scan(chain, List.of(), false);
 
-        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-RXF-HEAD-004");
+        assertThat(report.results())
+                .filteredOn(result -> result.id().equals("SEC-RXF-HEAD-004"))
+                .singleElement()
+                .extracting(SecurityRuleResultDto::severity)
+                .isEqualTo("LOW");
+    }
+
+    @Test
+    void scanDetectsReportOnlyCspButAcceptsEnforcingCsp() {
+        WebFilterChainObservation reportOnlyChain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                List.of("ContentSecurityPolicyServerHttpHeadersWriter"),
+                null,
+                null,
+                "default-src 'self'",
+                Boolean.TRUE);
+        WebFilterChainObservation enforcingChain = new WebFilterChainObservation(
+                0,
+                "any request",
+                List.of("AuthorizationWebFilter", "HttpHeaderWriterWebFilter"),
+                Boolean.FALSE,
+                List.of("ContentSecurityPolicyServerHttpHeadersWriter"),
+                null,
+                null,
+                "default-src 'self'",
+                Boolean.FALSE);
+
+        assertThat(scan(reportOnlyChain, List.of(), false).results())
+                .extracting(SecurityRuleResultDto::id)
+                .contains("SEC-RXF-HEAD-004");
+        assertThat(scan(enforcingChain, List.of(), false).results())
+                .extracting(SecurityRuleResultDto::id)
+                .doesNotContain("SEC-RXF-HEAD-004");
     }
 
     @Test
@@ -308,7 +581,7 @@ class ReactiveSecurityScannerTests {
                 "any request",
                 List.of("AuthorizationWebFilter"),
                 Boolean.FALSE,
-                List.of("HstsServerHttpHeadersWriter"),
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
                 31536000L,
                 Boolean.TRUE,
                 null,
@@ -322,6 +595,43 @@ class ReactiveSecurityScannerTests {
         SecurityReport report = scanner.scan();
 
         assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-RXF-ACT-001");
+    }
+
+    @Test
+    void actuatorShowValuesAlwaysRequiresObservedWebExposure() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0, "any request", List.of("AuthorizationWebFilter"), Boolean.FALSE, List.of(), null, null, null, null);
+        ReactiveSecurityEnvironmentSnapshot exposed = new ReactiveSecurityEnvironmentSnapshot(
+                false,
+                "configprops",
+                null,
+                false,
+                List.of(),
+                false,
+                false,
+                false,
+                false,
+                null,
+                Set.of(),
+                false,
+                false,
+                true,
+                false,
+                true);
+        ReactiveSecurityEnvironmentSnapshot notExposed = new ReactiveSecurityEnvironmentSnapshot(
+                false, null, null, false, List.of(), false, false, false, false, null, Set.of(), false, false, true);
+
+        SecurityReport report = scan(chain, exposed);
+
+        SecurityRuleResultDto result = report.results().stream()
+                .filter(candidate -> candidate.id().equals("SEC-RXF-ACT-005"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(result.severity()).isEqualTo("HIGH");
+        assertThat(result.sampleViolations()).singleElement().asString().contains("configprops.show-values");
+        assertThat(scan(chain, notExposed).results())
+                .extracting(SecurityRuleResultDto::id)
+                .doesNotContain("SEC-RXF-ACT-005");
     }
 
     @Test
@@ -366,13 +676,14 @@ class ReactiveSecurityScannerTests {
                 .findFirst()
                 .orElseThrow();
         assertThat(result.status()).isEqualTo(ReactiveSecuritySupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo("LOW");
         assertThat(result.sampleViolations())
                 .containsExactly(
                         "spring.security.oauth2.resourceserver.jwt.public-key-location configures a static verification key; prefer issuer-uri or jwk-set-uri for key rotation.");
     }
 
     @Test
-    void scanDetectsStatefulBearerTokenAuthentication() {
+    void scanDetectsMixedBearerTokenAndOauth2LoginFilters() {
         WebFilterChainObservation chain = new WebFilterChainObservation(
                 0,
                 "any request",
@@ -388,6 +699,69 @@ class ReactiveSecurityScannerTests {
         SecurityReport report = scan(chain, List.of(), false);
 
         assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-RXF-SESSION-001");
+    }
+
+    @Test
+    void plainHttpOpaqueTokenIntrospectionIsHighSeverityOnlyInProduction() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0, "any request", List.of("AuthorizationWebFilter"), Boolean.FALSE, List.of(), null, null, null, null);
+        ReactiveSecurityEnvironmentSnapshot production = new ReactiveSecurityEnvironmentSnapshot(
+                false,
+                null,
+                null,
+                false,
+                List.of("prod"),
+                false,
+                false,
+                false,
+                false,
+                null,
+                Set.of(),
+                true,
+                false,
+                false);
+        ReactiveSecurityEnvironmentSnapshot development = new ReactiveSecurityEnvironmentSnapshot(
+                false,
+                null,
+                null,
+                false,
+                List.of("dev"),
+                false,
+                false,
+                false,
+                false,
+                null,
+                Set.of(),
+                true,
+                false,
+                false);
+
+        SecurityReport productionReport = scan(chain, production);
+        SecurityReport developmentReport = scan(chain, development);
+
+        assertThat(productionReport.results())
+                .filteredOn(result -> result.id().equals("SEC-RXF-OAUTH2-004"))
+                .singleElement()
+                .extracting(SecurityRuleResultDto::severity)
+                .isEqualTo("HIGH");
+        assertThat(developmentReport.results())
+                .extracting(SecurityRuleResultDto::id)
+                .doesNotContain("SEC-RXF-OAUTH2-004");
+    }
+
+    @Test
+    void traceSecurityLoggingTriggersProductionRuleAndRemovedRulesStayAbsent() {
+        WebFilterChainObservation chain = new WebFilterChainObservation(
+                0, "any request", List.of("AuthorizationWebFilter"), Boolean.FALSE, List.of(), null, null, null, null);
+        ReactiveSecurityEnvironmentSnapshot environment = new ReactiveSecurityEnvironmentSnapshot(
+                false, null, null, false, List.of("production"), true, false, false, false, "TRACE", Set.of());
+
+        SecurityReport report = scan(chain, environment);
+
+        assertThat(report.results())
+                .extracting(SecurityRuleResultDto::id)
+                .contains("SEC-RXF-CONFIG-004")
+                .doesNotContain("SEC-RXF-CONFIG-001", "SEC-RXF-OAUTH2-001");
     }
 
     @Test
@@ -410,6 +784,9 @@ class ReactiveSecurityScannerTests {
                 .toList();
         assertThat(ids).doesNotHaveDuplicates();
         assertThat(ids).hasSize(25);
+        assertThat(ids)
+                .contains("SEC-RXF-ACT-005", "SEC-RXF-OAUTH2-004")
+                .doesNotContain("SEC-RXF-CONFIG-001", "SEC-RXF-OAUTH2-001");
         List<String> sorted = ids.stream().sorted().toList();
         // Registry order need not be alphabetical, but must be stable/deterministic across calls.
         List<String> idsAgain = ReactiveSecurityRuleRegistry.activeRules().stream()
@@ -441,7 +818,7 @@ class ReactiveSecurityScannerTests {
                 "any request",
                 List.of("AuthorizationWebFilter"),
                 Boolean.FALSE,
-                List.of("HstsServerHttpHeadersWriter"),
+                List.of("StrictTransportSecurityServerHttpHeadersWriter"),
                 31536000L,
                 Boolean.TRUE,
                 null,
@@ -455,5 +832,11 @@ class ReactiveSecurityScannerTests {
                 List.of(),
                 ReactiveSecurityEnvironmentSnapshot.empty(),
                 List.of());
+    }
+
+    private SecurityReport scan(WebFilterChainObservation chain, ReactiveSecurityEnvironmentSnapshot environment) {
+        ReactiveSecurityObservation observation = new ReactiveSecurityObservation(
+                List.of(chain), List.of(), false, List.of(), List.of(), List.of(), environment, List.of());
+        return ReactiveSecurityScanner.using(() -> observation, CLOCK).scan();
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollector.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollector.java
@@ -156,6 +156,8 @@ public final class SpringReactiveSecurityObservationCollector {
         }
         boolean bearerTokenAuthentication = webFilters != null
                 && webFilters.stream().anyMatch(SpringReactiveSecurityObservationCollector::isBearerTokenFilter);
+        boolean formLoginAuthentication = webFilters != null
+                && webFilters.stream().anyMatch(SpringReactiveSecurityObservationCollector::isFormLoginFilter);
         HeaderWriterInfo headerWriters = detectHeaderWriters(webFilters, index, errors);
         return new WebFilterChainObservation(
                 index,
@@ -168,7 +170,8 @@ public final class SpringReactiveSecurityObservationCollector {
                 headerWriters.hstsIncludeSubdomains(),
                 headerWriters.cspPolicyDirectives(),
                 headerWriters.cspReportOnly(),
-                headerWriters.observed());
+                headerWriters.observed(),
+                formLoginAuthentication);
     }
 
     /**
@@ -266,6 +269,14 @@ public final class SpringReactiveSecurityObservationCollector {
         }
         Object converter = readField(filter, "authenticationConverter");
         return converter != null && converter.getClass().getName().endsWith("ServerBearerTokenAuthenticationConverter");
+    }
+
+    private static boolean isFormLoginFilter(WebFilter filter) {
+        if (!"AuthenticationWebFilter".equals(filter.getClass().getSimpleName())) {
+            return false;
+        }
+        Object converter = readField(filter, "authenticationConverter");
+        return converter != null && converter.getClass().getName().endsWith("ServerFormLoginAuthenticationConverter");
     }
 
     private static HeaderWriterInfo detectHeaderWriters(List<WebFilter> filters, int chainIndex, List<String> errors) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollector.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollector.java
@@ -36,8 +36,8 @@ import org.springframework.web.server.WebFilter;
 
 /**
  * Collects a framework-neutral {@link ReactiveSecurityObservation} from the application's registered
- * {@code SecurityWebFilterChain} beans, CORS/OAuth2 beans, and {@code Environment} for the reactive
- * Spring Security advisor engine.
+ * {@code SecurityWebFilterChain} beans, CORS beans, and {@code Environment} for the reactive Spring
+ * Security advisor engine.
  *
  * <p>This class owns every piece of Spring-specific collection the advisor needs: bean lookups,
  * reflection into Spring Security's internal filter/header-writer fields, and {@code Environment} /
@@ -55,6 +55,7 @@ public final class SpringReactiveSecurityObservationCollector {
 
     private static final String BOOT_UI_CHAIN_BEAN_NAME = "bootUiReactiveSecurityWebFilterChain";
     private static final Duration FILTER_COLLECT_TIMEOUT = Duration.ofSeconds(5);
+    private static final int MAX_HEADER_WRITER_DEPTH = 8;
     private static final String SPRING_MATCHER_PACKAGE = "org.springframework.security.web.server.util.matcher.";
 
     private static final Pattern SUSPECTED_SECRET_KEY = Pattern.compile(
@@ -95,26 +96,19 @@ public final class SpringReactiveSecurityObservationCollector {
         }
 
         ListableBeanFactory beanFactory = beanFactories.getIfAvailable();
-        List<String> reactiveJwtDecoderTypes =
-                beanTypeNames(beanFactory, "org.springframework.security.oauth2.jwt.ReactiveJwtDecoder");
-        List<String> oauth2TokenValidatorTypes =
-                beanTypeNames(beanFactory, "org.springframework.security.oauth2.core.OAuth2TokenValidator");
-        List<String> opaqueTokenIntrospectorTypes = beanTypeNames(
-                beanFactory,
-                "org.springframework.security.oauth2.server.resource.introspection.ReactiveOpaqueTokenIntrospector");
-
         List<CorsConfigObservation> corsConfigs = new ArrayList<>();
-        boolean corsSourcePresent = discoverCors(beanFactory, corsConfigs, errors);
+        CorsDiscovery corsDiscovery = discoverCors(beanFactory, corsConfigs, errors);
 
         return new ReactiveSecurityObservation(
                 chains,
                 corsConfigs,
-                corsSourcePresent,
-                reactiveJwtDecoderTypes,
-                oauth2TokenValidatorTypes,
-                opaqueTokenIntrospectorTypes,
+                corsDiscovery.sourcePresent(),
+                List.of(),
+                List.of(),
+                List.of(),
                 environmentSnapshot(),
-                errors);
+                errors,
+                corsDiscovery.complete());
     }
 
     // ── Application chain discovery (bean-name exclusion, not WebFilterChainProxy reflection) ──────
@@ -156,13 +150,13 @@ public final class SpringReactiveSecurityObservationCollector {
                 : webFilters.stream()
                         .map(filter -> filter.getClass().getSimpleName())
                         .toList();
-        Boolean permitsAllAnonymous = webFilters == null ? null : detectPermitsAllAnonymous(webFilterNames);
+        Boolean permitsAllAnonymous = webFilters == null ? null : !webFilterNames.contains("AuthorizationWebFilter");
         if (webFilters == null) {
             errors.add("Chain " + index + ": web filters could not be collected");
         }
         boolean bearerTokenAuthentication = webFilters != null
                 && webFilters.stream().anyMatch(SpringReactiveSecurityObservationCollector::isBearerTokenFilter);
-        HeaderWriterInfo headerWriters = detectHeaderWriters(webFilters);
+        HeaderWriterInfo headerWriters = detectHeaderWriters(webFilters, index, errors);
         return new WebFilterChainObservation(
                 index,
                 matcher,
@@ -173,7 +167,8 @@ public final class SpringReactiveSecurityObservationCollector {
                 headerWriters.hstsMaxAgeSeconds(),
                 headerWriters.hstsIncludeSubdomains(),
                 headerWriters.cspPolicyDirectives(),
-                headerWriters.cspReportOnly());
+                headerWriters.cspReportOnly(),
+                headerWriters.observed());
     }
 
     /**
@@ -253,14 +248,6 @@ public final class SpringReactiveSecurityObservationCollector {
         }
     }
 
-    /**
-     * A reactive chain with no {@code AuthorizationWebFilter} permits all requests without
-     * authorization (analogous to not having {@code authorizeExchange(...)} at all).
-     */
-    private static Boolean detectPermitsAllAnonymous(List<String> filterNames) {
-        return !filterNames.contains("AuthorizationWebFilter");
-    }
-
     // ── Header writer extraction ───────────────────────────────────────────────────
 
     private record HeaderWriterInfo(
@@ -268,7 +255,10 @@ public final class SpringReactiveSecurityObservationCollector {
             Long hstsMaxAgeSeconds,
             Boolean hstsIncludeSubdomains,
             String cspPolicyDirectives,
-            Boolean cspReportOnly) {}
+            Boolean cspReportOnly,
+            boolean observed) {}
+
+    private record FlattenedWriters(List<Object> writers, boolean complete) {}
 
     private static boolean isBearerTokenFilter(WebFilter filter) {
         if (!"AuthenticationWebFilter".equals(filter.getClass().getSimpleName())) {
@@ -278,26 +268,31 @@ public final class SpringReactiveSecurityObservationCollector {
         return converter != null && converter.getClass().getName().endsWith("ServerBearerTokenAuthenticationConverter");
     }
 
-    private static HeaderWriterInfo detectHeaderWriters(List<WebFilter> filters) {
+    private static HeaderWriterInfo detectHeaderWriters(List<WebFilter> filters, int chainIndex, List<String> errors) {
         if (filters == null) {
-            return new HeaderWriterInfo(List.of(), null, null, null, null);
+            return new HeaderWriterInfo(List.of(), null, null, null, null, false);
         }
         for (Object filter : filters) {
             if (filter == null
                     || !"HttpHeaderWriterWebFilter".equals(filter.getClass().getSimpleName())) {
                 continue;
             }
-            return readHeaderWriterFilter(filter);
+            return readHeaderWriterFilter(filter, chainIndex, errors);
         }
-        return new HeaderWriterInfo(List.of(), null, null, null, null);
+        return new HeaderWriterInfo(List.of(), null, null, null, null, true);
     }
 
-    private static HeaderWriterInfo readHeaderWriterFilter(Object headerFilter) {
+    private static HeaderWriterInfo readHeaderWriterFilter(Object headerFilter, int chainIndex, List<String> errors) {
         Object writerField = readField(headerFilter, "writer");
         if (writerField == null) {
-            return new HeaderWriterInfo(List.of(), null, null, null, null);
+            errors.add("Chain " + chainIndex + ": header writers could not be collected");
+            return new HeaderWriterInfo(List.of(), null, null, null, null, false);
         }
-        List<Object> writers = flattenWriters(writerField);
+        FlattenedWriters flattened = flattenWriters(writerField);
+        List<Object> writers = flattened.writers();
+        if (!flattened.complete()) {
+            errors.add("Chain " + chainIndex + ": header writers could not be fully collected");
+        }
         List<String> names =
                 writers.stream().map(w -> w.getClass().getSimpleName()).toList();
         Long hstsMaxAge = null;
@@ -318,22 +313,35 @@ public final class SpringReactiveSecurityObservationCollector {
                 }
             }
         }
-        return new HeaderWriterInfo(names, hstsMaxAge, hstsIncludeSubdomains, cspDirectives, cspReportOnly);
+        return new HeaderWriterInfo(
+                names, hstsMaxAge, hstsIncludeSubdomains, cspDirectives, cspReportOnly, flattened.complete());
     }
 
-    private static List<Object> flattenWriters(Object writerField) {
+    private static FlattenedWriters flattenWriters(Object writerField) {
+        return flattenWriters(writerField, 0);
+    }
+
+    private static FlattenedWriters flattenWriters(Object writerField, int depth) {
+        if (depth >= MAX_HEADER_WRITER_DEPTH) {
+            return new FlattenedWriters(List.of(writerField), false);
+        }
         Object delegateList = readField(writerField, "writers");
         if (delegateList instanceof List<?> list) {
             List<Object> result = new ArrayList<>();
+            boolean complete = true;
             for (Object item : list) {
                 if (item != null) {
-                    result.addAll(flattenWriters(item));
+                    FlattenedWriters nested = flattenWriters(item, depth + 1);
+                    result.addAll(nested.writers());
+                    complete &= nested.complete();
                 }
             }
-            return result;
+            return new FlattenedWriters(result, complete);
         }
-        // Single writer
-        return List.of(writerField);
+        if (writerField.getClass().getSimpleName().contains("Composite")) {
+            return new FlattenedWriters(List.of(), false);
+        }
+        return new FlattenedWriters(List.of(writerField), true);
     }
 
     private static Long parseHstsMaxAge(Object maxAge) {
@@ -364,23 +372,27 @@ public final class SpringReactiveSecurityObservationCollector {
 
     // ── CORS discovery ────────────────────────────────────────────────────────────
 
-    private static boolean discoverCors(
+    private record CorsDiscovery(boolean sourcePresent, boolean complete) {}
+
+    private static CorsDiscovery discoverCors(
             ListableBeanFactory beanFactory, List<CorsConfigObservation> corsConfigs, List<String> errors) {
         if (beanFactory == null) {
-            return false;
+            return new CorsDiscovery(false, true);
         }
         Class<?> sourceType = classForName("org.springframework.web.cors.reactive.CorsConfigurationSource");
         if (sourceType == null) {
-            return false;
+            return new CorsDiscovery(false, true);
         }
         Map<String, ?> beans;
         try {
             beans = beanFactory.getBeansOfType(sourceType);
         } catch (RuntimeException | LinkageError ex) {
             errors.add("CORS: " + safeMessage(ex));
-            return false;
+            return new CorsDiscovery(false, false);
         }
-        for (Object bean : beans.values()) {
+        boolean complete = true;
+        for (Map.Entry<String, ?> beanEntry : beans.entrySet()) {
+            Object bean = beanEntry.getValue();
             if (bean == null) {
                 continue;
             }
@@ -391,11 +403,21 @@ public final class SpringReactiveSecurityObservationCollector {
                             toCorsObservation(String.valueOf(entry.getKey()), entry.getValue());
                     if (observation != null) {
                         corsConfigs.add(observation);
+                    } else {
+                        complete = false;
+                        errors.add("CORS: configuration entry for " + entry.getKey() + " could not be inspected");
                     }
                 }
+            } else {
+                complete = false;
+                errors.add("CORS: configuration source '"
+                        + beanEntry.getKey()
+                        + "' ("
+                        + bean.getClass().getName()
+                        + ") could not be inspected");
             }
         }
-        return !beans.isEmpty();
+        return new CorsDiscovery(!beans.isEmpty(), complete);
     }
 
     private static CorsConfigObservation toCorsObservation(String pattern, Object config) {
@@ -433,31 +455,6 @@ public final class SpringReactiveSecurityObservationCollector {
         return null;
     }
 
-    private static List<String> beanTypeNames(ListableBeanFactory beanFactory, String className) {
-        if (beanFactory == null) {
-            return List.of();
-        }
-        Class<?> type = classForName(className);
-        if (type == null) {
-            return List.of();
-        }
-        try {
-            String[] names = beanFactory.getBeanNamesForType(type);
-            List<String> result = new ArrayList<>();
-            for (String name : names) {
-                try {
-                    Class<?> beanType = beanFactory.getType(name);
-                    result.add(beanType == null ? name : beanType.getName());
-                } catch (RuntimeException | LinkageError ex) {
-                    result.add(name);
-                }
-            }
-            return result;
-        } catch (RuntimeException | LinkageError ex) {
-            return List.of();
-        }
-    }
-
     private static Class<?> classForName(String name) {
         try {
             return Class.forName(name);
@@ -482,6 +479,7 @@ public final class SpringReactiveSecurityObservationCollector {
         String issuerUri = firstProperty("spring.security.oauth2.resourceserver.jwt.issuer-uri");
         String jwkSetUri = firstProperty("spring.security.oauth2.resourceserver.jwt.jwk-set-uri");
         String publicKeyLocation = firstProperty("spring.security.oauth2.resourceserver.jwt.public-key-location");
+        String introspectionUri = firstProperty("spring.security.oauth2.resourceserver.opaquetoken.introspection-uri");
         boolean staticPublicKeyConfigured = hasText(publicKeyLocation) && !hasText(issuerUri) && !hasText(jwkSetUri);
         String loggingLevel = firstProperty(
                 "logging.level.org.springframework.security", "logging.level.org.springframework.security.web");
@@ -491,12 +489,17 @@ public final class SpringReactiveSecurityObservationCollector {
                 firstHostProperty("management.endpoints.web.exposure.exclude"),
                 firstHostProperty("management.server.port") != null,
                 profiles,
-                isPropertyTrue("spring.security.debug"),
+                false,
                 staticPublicKeyConfigured,
                 usesPlainHttp(issuerUri),
                 usesPlainHttp(jwkSetUri),
                 loggingLevel,
-                suspectedHardcodedSecretKeys());
+                suspectedHardcodedSecretKeys(),
+                usesPlainHttp(introspectionUri),
+                "always".equalsIgnoreCase(firstHostProperty("management.endpoint.env.show-values")),
+                "always".equalsIgnoreCase(firstHostProperty("management.endpoint.configprops.show-values")),
+                isActuatorEndpointWebExposed("env"),
+                isActuatorEndpointWebExposed("configprops"));
     }
 
     private static boolean usesPlainHttp(String value) {
@@ -518,6 +521,42 @@ public final class SpringReactiveSecurityObservationCollector {
         return forwarded != null && ("framework".equalsIgnoreCase(forwarded) || "native".equalsIgnoreCase(forwarded));
     }
 
+    private boolean isActuatorEndpointWebExposed(String endpointId) {
+        String include = firstProperty("management.endpoints.web.exposure.include");
+        if (!containsCommaSeparated(include, endpointId) && !containsCommaSeparated(include, "*")) {
+            return false;
+        }
+        String exclude = firstProperty("management.endpoints.web.exposure.exclude");
+        if (containsCommaSeparated(exclude, endpointId) || containsCommaSeparated(exclude, "*")) {
+            return false;
+        }
+        String endpointPrefix = "management.endpoint." + endpointId;
+        String endpointAccess = firstProperty(endpointPrefix + ".access");
+        if (isPropertyFalse(endpointPrefix + ".enabled")
+                || "none".equalsIgnoreCase(endpointAccess)
+                || "none".equalsIgnoreCase(firstProperty("management.endpoints.access.max-permitted"))) {
+            return false;
+        }
+        if (endpointAccess == null && "none".equalsIgnoreCase(firstProperty("management.endpoints.access.default"))) {
+            return false;
+        }
+        return !isPropertyFalse("management.endpoints.enabled-by-default")
+                || firstProperty(endpointPrefix + ".enabled") != null
+                || endpointAccess != null;
+    }
+
+    private static boolean containsCommaSeparated(String value, String candidate) {
+        if (value == null) {
+            return false;
+        }
+        for (String token : value.split(",")) {
+            if (candidate.equalsIgnoreCase(token.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private String firstProperty(String... keys) {
         for (String key : keys) {
             String value = environment.getProperty(key);
@@ -531,6 +570,11 @@ public final class SpringReactiveSecurityObservationCollector {
     private boolean isPropertyTrue(String... keys) {
         String value = firstProperty(keys);
         return value != null && "true".equalsIgnoreCase(value);
+    }
+
+    private boolean isPropertyFalse(String... keys) {
+        String value = firstProperty(keys);
+        return value != null && "false".equalsIgnoreCase(value);
     }
 
     private String firstHostProperty(String... keys) {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveSpringSecurityAutoConfigurationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveSpringSecurityAutoConfigurationTests.java
@@ -171,7 +171,7 @@ class BootUiReactiveSpringSecurityAutoConfigurationTests {
                     .jsonPath("$.filterChainsAnalyzed")
                     .isEqualTo(1)
                     .jsonPath("$.rulesEvaluated")
-                    .isEqualTo(25);
+                    .isEqualTo(26);
         });
     }
 

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveSpringSecurityAutoConfigurationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveSpringSecurityAutoConfigurationTests.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiMcpTools;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveSecurityController;
 import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveSpringSecurityController;
+import io.github.jdubois.bootui.core.dto.SecurityRuleResultDto;
 import io.github.jdubois.bootui.engine.reactivesecurity.ReactiveSecurityAdvisorService;
 import io.github.jdubois.bootui.engine.safety.ApiTokenAuthenticator;
 import org.junit.jupiter.api.Test;
@@ -175,6 +176,30 @@ class BootUiReactiveSpringSecurityAutoConfigurationTests {
     }
 
     @Test
+    void anyExchangePermitAllStillInstallsAuthorizationWebFilter() {
+        new ReactiveWebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        HttpHandlerAutoConfiguration.class,
+                        WebFluxAutoConfiguration.class,
+                        BootUiReactiveAutoConfiguration.class,
+                        BootUiReactiveSpringSecurityAutoConfiguration.class))
+                .withUserConfiguration(PermitAllSecurityConfiguration.class)
+                .withPropertyValues(
+                        "bootui.enabled=ON",
+                        "bootui.allow-non-localhost=true",
+                        "bootui.authentication.token=test-token")
+                .run(context -> {
+                    var report = context.getBean(ReactiveSecurityAdvisorService.class)
+                            .scan();
+
+                    assertThat(report.filterChainsAnalyzed()).isEqualTo(1);
+                    assertThat(report.results())
+                            .extracting(SecurityRuleResultDto::id)
+                            .doesNotContain("SEC-RXF-AUTHZ-001", "SEC-RXF-AUTHZ-002", "SEC-RXF-AUTHZ-003");
+                });
+    }
+
+    @Test
     void issuesAndAcceptsTheSpaCsrfCookieHeaderPair() {
         runner.run(context -> {
             WebTestClient client = client(context.getSourceApplicationContext());
@@ -276,6 +301,30 @@ class BootUiReactiveSpringSecurityAutoConfigurationTests {
     @Configuration(proxyBeanMethods = false)
     @EnableWebFluxSecurity
     static class SecurityInfrastructureOnlyConfiguration {}
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableWebFluxSecurity
+    static class PermitAllSecurityConfiguration {
+
+        @Bean
+        ReactiveAuthenticationManager permitAllAuthenticationManager() {
+            UserDetails user = User.withUsername("developer")
+                    .password("{noop}password")
+                    .roles("USER")
+                    .build();
+            return new UserDetailsRepositoryReactiveAuthenticationManager(new MapReactiveUserDetailsService(user));
+        }
+
+        @Bean
+        @Order(100)
+        SecurityWebFilterChain permitAllSecurityWebFilterChain(
+                ServerHttpSecurity http, ReactiveAuthenticationManager permitAllAuthenticationManager) {
+            return http.authenticationManager(permitAllAuthenticationManager)
+                    .authorizeExchange(exchange -> exchange.anyExchange().permitAll())
+                    .httpBasic(Customizer.withDefaults())
+                    .build();
+        }
+    }
 
     @RestController
     static class TestController {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollectorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollectorTests.java
@@ -57,6 +57,14 @@ class SpringReactiveSecurityObservationCollectorTests {
         }
     }
 
+    private static final class ServerFormLoginAuthenticationConverter implements ServerAuthenticationConverter {
+
+        @Override
+        public Mono<org.springframework.security.core.Authentication> convert(ServerWebExchange exchange) {
+            return Mono.empty();
+        }
+    }
+
     private static final class CyclicServerHttpHeadersWriter implements ServerHttpHeadersWriter {
 
         @SuppressWarnings("FieldCanBeLocal")
@@ -295,6 +303,39 @@ class SpringReactiveSecurityObservationCollectorTests {
 
         assertThat(collector.collect().chains().get(0).bearerTokenAuthentication())
                 .isTrue();
+    }
+
+    @Test
+    void recognizesFormLoginAuthenticationConverterWithoutReadingCredentials() {
+        ReactiveAuthenticationManager authenticationManager = authentication -> Mono.empty();
+        AuthenticationWebFilter formLoginFilter = new AuthenticationWebFilter(authenticationManager);
+        formLoginFilter.setServerAuthenticationConverter(new ServerFormLoginAuthenticationConverter());
+        SecurityWebFilterChain chain =
+                new MatcherSecurityWebFilterChain(ServerWebExchangeMatchers.anyExchange(), List.of(formLoginFilter));
+
+        SpringReactiveSecurityObservationCollector collector = new SpringReactiveSecurityObservationCollector(
+                chainProvider(List.of(chain)), beanFactoryProvider(null), new MockEnvironment());
+
+        WebFilterChainObservation observation = collector.collect().chains().get(0);
+        assertThat(observation.formLoginAuthentication()).isTrue();
+        // A formLogin() converter must not also be mistaken for a bearer-token converter.
+        assertThat(observation.bearerTokenAuthentication()).isFalse();
+    }
+
+    @Test
+    void doesNotRecognizeAnUnrelatedAuthenticationConverterAsBearerOrFormLogin() {
+        ReactiveAuthenticationManager authenticationManager = authentication -> Mono.empty();
+        AuthenticationWebFilter basicFilter = new AuthenticationWebFilter(authenticationManager);
+        basicFilter.setServerAuthenticationConverter(exchange -> Mono.empty());
+        SecurityWebFilterChain chain =
+                new MatcherSecurityWebFilterChain(ServerWebExchangeMatchers.anyExchange(), List.of(basicFilter));
+
+        SpringReactiveSecurityObservationCollector collector = new SpringReactiveSecurityObservationCollector(
+                chainProvider(List.of(chain)), beanFactoryProvider(null), new MockEnvironment());
+
+        WebFilterChainObservation observation = collector.collect().chains().get(0);
+        assertThat(observation.bearerTokenAuthentication()).isFalse();
+        assertThat(observation.formLoginAuthentication()).isFalse();
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollectorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollectorTests.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.github.jdubois.bootui.engine.reactivesecurity.ReactiveSecurityEnvironmentSnapshot;
 import io.github.jdubois.bootui.engine.reactivesecurity.ReactiveSecurityObservation;
 import io.github.jdubois.bootui.engine.reactivesecurity.WebFilterChainObservation;
 import java.time.Duration;
@@ -25,11 +26,13 @@ import org.springframework.security.web.server.csrf.CsrfWebFilter;
 import org.springframework.security.web.server.header.CompositeServerHttpHeadersWriter;
 import org.springframework.security.web.server.header.ContentSecurityPolicyServerHttpHeadersWriter;
 import org.springframework.security.web.server.header.HttpHeaderWriterWebFilter;
+import org.springframework.security.web.server.header.ServerHttpHeadersWriter;
 import org.springframework.security.web.server.header.StrictTransportSecurityServerHttpHeadersWriter;
 import org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
@@ -50,6 +53,17 @@ class SpringReactiveSecurityObservationCollectorTests {
 
         @Override
         public Mono<org.springframework.security.core.Authentication> convert(ServerWebExchange exchange) {
+            return Mono.empty();
+        }
+    }
+
+    private static final class CyclicServerHttpHeadersWriter implements ServerHttpHeadersWriter {
+
+        @SuppressWarnings("FieldCanBeLocal")
+        private final List<ServerHttpHeadersWriter> writers = List.of(this);
+
+        @Override
+        public Mono<Void> writeHttpHeaders(ServerWebExchange exchange) {
             return Mono.empty();
         }
     }
@@ -207,6 +221,22 @@ class SpringReactiveSecurityObservationCollectorTests {
     }
 
     @Test
+    void cyclicHeaderWriterCompositionIsDepthBounded() {
+        HttpHeaderWriterWebFilter headers = new HttpHeaderWriterWebFilter(new CyclicServerHttpHeadersWriter());
+        SecurityWebFilterChain chain =
+                new MatcherSecurityWebFilterChain(ServerWebExchangeMatchers.anyExchange(), List.of(headers));
+        SpringReactiveSecurityObservationCollector collector = new SpringReactiveSecurityObservationCollector(
+                chainProvider(List.of(chain)), beanFactoryProvider(null), new MockEnvironment());
+
+        ReactiveSecurityObservation observation = collector.collect();
+        WebFilterChainObservation observed = observation.chains().get(0);
+
+        assertThat(observed.headerWriterNames()).contains("CyclicServerHttpHeadersWriter");
+        assertThat(observed.headerWritersObserved()).isFalse();
+        assertThat(observation.errors()).containsExactly("Chain 0: header writers could not be fully collected");
+    }
+
+    @Test
     void collectionDoesNotBlockOnAnAsynchronousChain() {
         SecurityWebFilterChain asynchronousChain = new SecurityWebFilterChain() {
             @Override
@@ -248,7 +278,7 @@ class SpringReactiveSecurityObservationCollectorTests {
 
         ReactiveSecurityObservation observation = collector.collect();
 
-        assertThat(observation.chains().get(0).permitsAllAnonymous()).isNull();
+        assertThat(observation.chains().get(0).authorizationFilterPresent()).isNull();
         assertThat(observation.errors()).containsExactly("Chain 0: web filters could not be collected");
     }
 
@@ -286,6 +316,45 @@ class SpringReactiveSecurityObservationCollectorTests {
             assertThat(cors.allowedOriginPatterns()).containsExactly("*");
             assertThat(cors.allowCredentials()).isTrue();
         });
+    }
+
+    @Test
+    void opaqueCorsSourceProducesAnExplicitPartialObservation() {
+        CorsConfigurationSource source = exchange -> null;
+        ListableBeanFactory beanFactory = mock(ListableBeanFactory.class);
+        doReturn(Map.of("customCorsConfigurationSource", source))
+                .when(beanFactory)
+                .getBeansOfType(any());
+        SpringReactiveSecurityObservationCollector collector = new SpringReactiveSecurityObservationCollector(
+                chainProvider(List.of()), beanFactoryProvider(beanFactory), new MockEnvironment());
+
+        ReactiveSecurityObservation observation = collector.collect();
+
+        assertThat(observation.corsSourcePresent()).isTrue();
+        assertThat(observation.corsConfigs()).isEmpty();
+        assertThat(observation.corsObservationComplete()).isFalse();
+        assertThat(observation.errors()).singleElement().asString().contains("could not be inspected");
+    }
+
+    @Test
+    void mixedInspectableAndOpaqueCorsSourcesRemainIncomplete() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("https://app.example"));
+        UrlBasedCorsConfigurationSource inspectable = new UrlBasedCorsConfigurationSource();
+        inspectable.registerCorsConfiguration("/**", configuration);
+        CorsConfigurationSource opaque = exchange -> null;
+        ListableBeanFactory beanFactory = mock(ListableBeanFactory.class);
+        doReturn(Map.of("inspectable", inspectable, "opaque", opaque))
+                .when(beanFactory)
+                .getBeansOfType(any());
+        SpringReactiveSecurityObservationCollector collector = new SpringReactiveSecurityObservationCollector(
+                chainProvider(List.of()), beanFactoryProvider(beanFactory), new MockEnvironment());
+
+        ReactiveSecurityObservation observation = collector.collect();
+
+        assertThat(observation.corsConfigs()).hasSize(1);
+        assertThat(observation.corsObservationComplete()).isFalse();
+        assertThat(observation.errors()).singleElement().asString().contains("opaque");
     }
 
     @Test
@@ -353,5 +422,55 @@ class SpringReactiveSecurityObservationCollectorTests {
                 .isTrue();
         assertThat(issuerObservation.environment().oauth2JwtStaticPublicKeyConfigured())
                 .isFalse();
+    }
+
+    @Test
+    void capturesBootFourReactiveSignalsAndIgnoresUnsupportedSecurityDebugProperty() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.security.debug", "true")
+                .withProperty(
+                        "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri",
+                        "http://authorization.example/introspect")
+                .withProperty("management.endpoints.web.exposure.include", "env,configprops")
+                .withProperty("management.endpoint.env.show-values", "ALWAYS")
+                .withProperty("management.endpoint.configprops.show-values", "when-authorized");
+        SpringReactiveSecurityObservationCollector collector = new SpringReactiveSecurityObservationCollector(
+                chainProvider(List.of()), beanFactoryProvider(null), environment);
+
+        ReactiveSecurityObservation observation = collector.collect();
+
+        assertThat(observation.environment().securityDebugEnabled()).isFalse();
+        assertThat(observation.environment().oauth2OpaqueTokenIntrospectionUsesPlainHttp())
+                .isTrue();
+        assertThat(observation.environment().managementEnvShowValuesAlways()).isTrue();
+        assertThat(observation.environment().managementConfigPropsShowValuesAlways())
+                .isFalse();
+        assertThat(observation.environment().managementEnvWebExposed()).isTrue();
+        assertThat(observation.environment().managementConfigPropsWebExposed()).isTrue();
+    }
+
+    @Test
+    void actuatorExposureHonorsWildcardExcludesAndAccessCaps() {
+        MockEnvironment excluded = new MockEnvironment()
+                .withProperty("management.endpoints.web.exposure.include", "*")
+                .withProperty("management.endpoints.web.exposure.exclude", "*");
+        MockEnvironment accessDenied = new MockEnvironment()
+                .withProperty("management.endpoints.web.exposure.include", "env,configprops")
+                .withProperty("management.endpoint.env.access", "none")
+                .withProperty("management.endpoints.access.max-permitted", "none");
+
+        ReactiveSecurityEnvironmentSnapshot excludedSnapshot = new SpringReactiveSecurityObservationCollector(
+                        chainProvider(List.of()), beanFactoryProvider(null), excluded)
+                .collect()
+                .environment();
+        ReactiveSecurityEnvironmentSnapshot deniedSnapshot = new SpringReactiveSecurityObservationCollector(
+                        chainProvider(List.of()), beanFactoryProvider(null), accessDenied)
+                .collect()
+                .environment();
+
+        assertThat(excludedSnapshot.managementEnvWebExposed()).isFalse();
+        assertThat(excludedSnapshot.managementConfigPropsWebExposed()).isFalse();
+        assertThat(deniedSnapshot.managementEnvWebExposed()).isFalse();
+        assertThat(deniedSnapshot.managementConfigPropsWebExposed()).isFalse();
     }
 }

--- a/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
@@ -119,12 +119,12 @@ test.describe('BootUI on Spring WebFlux', () => {
     await expect(page.getByText(/Spring MVC mapping/)).toHaveCount(0)
   })
 
-  test('Security advisor runs the 25-rule reactive catalogue', async ({page}) => {
+  test('Security advisor runs the 26-rule reactive catalogue', async ({page}) => {
     await page.goto('/bootui/#/security')
     await expect(page.locator('.panel-availability-alert')).toHaveCount(0)
     await page.getByRole('button', {name: 'Run security checks'}).click()
     await expect(page.getByText('Scan complete', {exact: true})).toBeVisible({timeout: 15_000})
-    await expect(page.getByText('Rules evaluated').locator('..')).toContainText('25')
+    await expect(page.getByText('Rules evaluated').locator('..')).toContainText('26')
   })
 
   test('REST Client records WebClient calls, streams updates, and protects actions with CSRF', async ({

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -539,7 +539,7 @@ relabels the metrics ("Permission policies" in place of "Filter chains") — the
 
 ![BootUI Security panel — Quarkus Security](./images/bootui-quarkus-security.webp)
 
-On **Spring Boot WebFlux** it evaluates a dedicated 25-rule `SEC-RXF-*` catalogue over a framework-neutral observation
+On **Spring Boot WebFlux** it evaluates a dedicated 26-rule `SEC-RXF-*` catalogue over a framework-neutral observation
 of the application's `SecurityWebFilterChain` beans, reactive CORS/OAuth2 beans, and security-relevant configuration.
 The Spring adapter owns collection and excludes BootUI's own permit-all chain; the shared engine owns deterministic
 rule evaluation and never receives Spring types or secret values. See [WEBFLUX-SUPPORT.md](WEBFLUX-SUPPORT.md).

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -508,7 +508,10 @@ as absence.
 This catalogue was audited against Spring Boot 4.1.0 / Spring Security 7.1.0. The audit removed two unsupported
 conclusions while keeping the total at 25: `SEC-RXF-OAUTH2-001` could not establish decoder-local audience validation
 from unrelated validator beans, and `SEC-RXF-CONFIG-001` targeted an unsupported `spring.security.debug` property.
-Their replacements are the directly observable `SEC-RXF-ACT-005` and the RFC-backed `SEC-RXF-OAUTH2-004`.
+Their replacements are the directly observable `SEC-RXF-ACT-005` and the RFC-backed `SEC-RXF-OAUTH2-004`. A follow-up
+review closed two MVC/WebFlux parity gaps, bringing the total to 26: `SEC-RXF-CSRF-001` and `SEC-RXF-SESSION-001` now
+also recognize `formLogin()` chains (previously only OAuth2/OIDC login filters were detected), and the new
+`SEC-RXF-CORS-003` flags broad `allowedOriginPatterns` (e.g. `https://*`) to match the servlet stack's `SEC-CORS-006`.
 
 ### SEC-RXF-AUTHZ-001 - Reactive chain has no AuthorizationWebFilter
 
@@ -534,10 +537,10 @@ claim to distinguish `permitAll`, `authenticated`, role-based, or custom authori
 - **Recommendation**: Define authentication and authorization rules for non-public endpoints, or verify equivalent custom filters.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/authorization/authorize-http-requests.html>
 
-### SEC-RXF-CSRF-001 - Observed OAuth2/OIDC login chain missing CsrfWebFilter
+### SEC-RXF-CSRF-001 - Observed OAuth2/OIDC or formLogin() chain missing CsrfWebFilter
 
 - **Severity**: HIGH
-- **Detects**: A chain with an observed OAuth2/OIDC login filter has no `CsrfWebFilter`.
+- **Detects**: A chain with an observed OAuth2/OIDC login filter or a `formLogin()` authentication converter has no `CsrfWebFilter`.
 - **Recommendation**: Keep CSRF enabled for browser login chains; configure the appropriate reactive token repository.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/csrf.html>
 
@@ -564,6 +567,13 @@ claim to distinguish `permitAll`, `authenticated`, role-based, or custom authori
 
 Spring separately rejects `allowedOrigins="*"` with credentials; that invalid combination remains covered by
 `SEC-RXF-CORS-001`, not misreported as a live credentialed wildcard policy.
+
+### SEC-RXF-CORS-003 - Reactive CORS should not allow broad origin patterns
+
+- **Severity**: MEDIUM (HIGH when any broad pattern has allowCredentials=true)
+- **Detects**: `allowedOriginPatterns` that match a dangerously broad set of origins (wildcard scheme or host, e.g. `https://*`, `*://*`, `*.com`) beyond the exact `"*"` already covered by `SEC-RXF-CORS-001`/`SEC-RXF-CORS-002`.
+- **Recommendation**: Replace broad patterns with the exact origins (or tightly-scoped subdomain wildcards such as `https://*.example.com`) the application trusts; broad patterns combined with credentials let untrusted sites make authenticated cross-site calls.
+- **Learn more**: <https://docs.spring.io/spring-framework/reference/web/webflux-cors.html>
 
 ### SEC-RXF-HEAD-001 - Reactive chain missing HSTS header writer
 
@@ -691,10 +701,10 @@ authorization is not exposed as stable runtime metadata.
 - **Recommendation**: Keep `org.springframework.security` logging at INFO or WARN in production.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/index.html>
 
-### SEC-RXF-SESSION-001 - Reactive chain mixes bearer-token and browser OAuth2 filters
+### SEC-RXF-SESSION-001 - Reactive chain mixes bearer-token and browser login filters
 
 - **Severity**: LOW
-- **Detects**: One chain combines Spring Security's bearer-token converter with an observed OAuth2/OIDC login or authorization-code client filter.
+- **Detects**: One chain combines Spring Security's bearer-token converter with an observed OAuth2/OIDC login, authorization-code client, or `formLogin()` filter.
 - **Recommendation**: Prefer separate ordered chains. For a pure bearer chain, use
   `securityContextRepository(NoOpServerSecurityContextRepository.getInstance())`; WebFlux has no
   `SessionCreationPolicy` API.

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -493,40 +493,52 @@ custom source is never misreported as verified-safe.
 
 The Security advisor also supports Spring WebFlux (reactive) applications. On the reactive stack the Spring adapter
 reads the application's `SecurityWebFilterChain` beans directly, excluding BootUI's own permit-all chain, and inspects
-security-relevant
-reactive beans (`ReactiveJwtDecoder`, `ReactiveOpaqueTokenIntrospector`, `CorsConfigurationSource`)
-and `Environment` properties. It maps those observations into framework-neutral records before the shared engine
-evaluates the rules. Availability is gated on at least one application `SecurityWebFilterChain` bean.
+security-relevant reactive beans (`ReactiveJwtDecoder`, `ReactiveOpaqueTokenIntrospector`,
+`CorsConfigurationSource`) and `Environment` properties. It maps those observations into framework-neutral records
+before the shared engine evaluates the rules. Availability is gated on at least one application
+`SecurityWebFilterChain` bean.
 
 The reactive checks share the same severity scale as the servlet checks. Rule IDs start with
-`SEC-RXF-` to distinguish them from the servlet rules.
+`SEC-RXF-` to distinguish them from the servlet rules. They are passive review prompts, not authorization verdicts:
+Spring Security exposes installed `WebFilter`s but not the decisions inside an `AuthorizationWebFilter`, decoder-local
+JWT validators, custom management-path policy, reverse-proxy TLS policy, handler-level CORS, or custom filter behavior.
+When filter, header-writer, or CORS extraction is unavailable, dependent rules skip instead of treating unknown evidence
+as absence.
+
+This catalogue was audited against Spring Boot 4.1.0 / Spring Security 7.1.0. The audit removed two unsupported
+conclusions while keeping the total at 25: `SEC-RXF-OAUTH2-001` could not establish decoder-local audience validation
+from unrelated validator beans, and `SEC-RXF-CONFIG-001` targeted an unsupported `spring.security.debug` property.
+Their replacements are the directly observable `SEC-RXF-ACT-005` and the RFC-backed `SEC-RXF-OAUTH2-004`.
 
 ### SEC-RXF-AUTHZ-001 - Reactive chain has no AuthorizationWebFilter
 
 - **Severity**: HIGH
-- **Detects**: A `SecurityWebFilterChain` installs no `AuthorizationWebFilter`, meaning all requests pass through without authorization.
-- **Recommendation**: Configure `authorizeExchange(...)` on every chain that handles application traffic.
+- **Detects**: A chain whose filters were successfully observed installs no `AuthorizationWebFilter`.
+- **Recommendation**: Configure `authorizeExchange(...)` on every chain that handles application traffic; verify custom filters separately.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/authorization/authorize-http-requests.html>
 
-### SEC-RXF-AUTHZ-002 - Reactive permitAll catch-all while authentication is active
+### SEC-RXF-AUTHZ-002 - Catch-all authentication chain has no AuthorizationWebFilter
 
 - **Severity**: HIGH
-- **Detects**: A reactive chain grants all requests to anonymous callers (permitAll catch-all) while also configuring authentication filters.
-- **Recommendation**: Restrict sensitive paths and finish with `anyExchange().authenticated()`.
+- **Detects**: A catch-all chain installs authentication filters but no `AuthorizationWebFilter`.
+- **Recommendation**: Add `authorizeExchange(...)` and finish with `anyExchange().authenticated()` or `denyAll()`.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/authorization/authorize-http-requests.html>
 
-### SEC-RXF-AUTHZ-003 - Reactive security chain effectively disables authorization
+`anyExchange().permitAll()` still installs an `AuthorizationWebFilter`; runtime filter inspection therefore does not
+claim to distinguish `permitAll`, `authenticated`, role-based, or custom authorization decisions.
+
+### SEC-RXF-AUTHZ-003 - All observed chains omit authentication and authorization filters
 
 - **Severity**: HIGH
-- **Detects**: The chain appears to offer no effective authorization (no `AuthorizationWebFilter` and no matcher-scoped protection).
-- **Recommendation**: Define authorization rules requiring authentication for non-public endpoints.
+- **Detects**: Every fully observed application chain omits both `AuthorizationWebFilter` and authentication filters.
+- **Recommendation**: Define authentication and authorization rules for non-public endpoints, or verify equivalent custom filters.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/authorization/authorize-http-requests.html>
 
-### SEC-RXF-CSRF-001 - Stateful reactive chain missing CsrfWebFilter
+### SEC-RXF-CSRF-001 - Observed OAuth2/OIDC login chain missing CsrfWebFilter
 
 - **Severity**: HIGH
-- **Detects**: A chain with OAuth2 login or session-based authentication has no `CsrfWebFilter`.
-- **Recommendation**: Add `.csrf(Customizer.withDefaults())` or a `CookieServerCsrfTokenRepository`.
+- **Detects**: A chain with an observed OAuth2/OIDC login filter has no `CsrfWebFilter`.
+- **Recommendation**: Keep CSRF enabled for browser login chains; configure the appropriate reactive token repository.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/csrf.html>
 
 ### SEC-RXF-CSRF-002 - No reactive chain installs CsrfWebFilter
@@ -539,30 +551,33 @@ The reactive checks share the same severity scale as the servlet checks. Rule ID
 ### SEC-RXF-CORS-001 - Reactive CORS allows wildcard origin
 
 - **Severity**: MEDIUM
-- **Detects**: A reactive `CorsConfigurationSource` allows `*` as an origin.
+- **Detects**: An inspectable reactive `CorsConfigurationSource` uses the exact `*` value in `allowedOrigins` or `allowedOriginPatterns`.
 - **Recommendation**: Restrict `allowedOrigins` to explicit, trusted domains.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/integrations/cors.html>
+- **Learn more**: <https://docs.spring.io/spring-framework/reference/web/webflux-cors.html>
 
-### SEC-RXF-CORS-002 - Reactive CORS allows wildcard origin with credentials
+### SEC-RXF-CORS-002 - Reactive CORS allows every origin pattern with credentials
 
 - **Severity**: HIGH
-- **Detects**: `allowedOrigins=*` combined with `allowCredentials=true` — browsers refuse this combination, and allowing credentials with a broad origin is a CORS misconfiguration.
-- **Recommendation**: Specify explicit origins when using `allowCredentials(true)`.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/integrations/cors.html>
+- **Detects**: The legal `allowedOriginPatterns="*"` plus `allowCredentials=true` combination, which reflects arbitrary origins while allowing credentials.
+- **Recommendation**: Specify explicit trusted origins when using `allowCredentials(true)`.
+- **Learn more**: <https://docs.spring.io/spring-framework/docs/7.0.8/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#validateAllowCredentials()>
+
+Spring separately rejects `allowedOrigins="*"` with credentials; that invalid combination remains covered by
+`SEC-RXF-CORS-001`, not misreported as a live credentialed wildcard policy.
 
 ### SEC-RXF-HEAD-001 - Reactive chain missing HSTS header writer
 
 - **Severity**: MEDIUM
-- **Detects**: A chain has an `HttpHeaderWriterWebFilter` but no HSTS writer.
-- **Recommendation**: Add `HstsServerHttpHeadersWriter` via `.headers(h -> h.hsts(Customizer.withDefaults()))`.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html>
+- **Detects**: TLS is observable and a chain has `HttpHeaderWriterWebFilter` but no HSTS writer.
+- **Recommendation**: Keep Spring Security's `StrictTransportSecurityServerHttpHeadersWriter` defaults.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-hsts>
 
 ### SEC-RXF-HEAD-002 - Reactive chain missing X-Frame-Options header writer
 
 - **Severity**: MEDIUM
-- **Detects**: No frame-options writer is installed, leaving clickjacking protection absent.
-- **Recommendation**: Add a `XFrameOptionsServerHttpHeadersWriter`.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html>
+- **Detects**: A chain has Spring Security header writers but neither a frame-options writer nor an enforcing CSP `frame-ancestors` directive.
+- **Recommendation**: Keep `XFrameOptionsServerHttpHeadersWriter` or enforce an appropriate CSP `frame-ancestors` policy.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-frame-options>
 
 ### SEC-RXF-HEAD-003 - Reactive chain missing X-Content-Type-Options header writer
 
@@ -571,88 +586,95 @@ The reactive checks share the same severity scale as the servlet checks. Rule ID
 - **Recommendation**: Add a `ContentTypeOptionsServerHttpHeadersWriter`.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-content-type-options>
 
-### SEC-RXF-HEAD-004 - Reactive chain has no Content-Security-Policy header writer
+### SEC-RXF-HEAD-004 - Reactive Content-Security-Policy needs review
 
-- **Severity**: MEDIUM
-- **Detects**: No CSP writer is installed on any chain.
-- **Recommendation**: Add a `ContentSecurityPolicyServerHttpHeadersWriter` appropriate to your app.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html>
+- **Severity**: LOW
+- **Detects**: A chain with Spring Security header writers has no CSP or configures only `Content-Security-Policy-Report-Only`.
+- **Recommendation**: For browser-facing responses, define a tailored enforcing CSP; keep report-only mode bounded to rollout/monitoring.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-csp>
+
+Spring Security intentionally supplies no CSP default because a reasonable policy depends on application context, so
+this is low-severity browser hardening advice rather than a framework-misconfiguration verdict.
 
 ### SEC-RXF-HEAD-005 - Reactive security headers entirely disabled
 
 - **Severity**: HIGH
-- **Detects**: Authentication/authorization filters are active but no `HttpHeaderWriterWebFilter` is present.
+- **Detects**: Authentication/authorization filters are active but Spring Security installs no `HttpHeaderWriterWebFilter`.
 - **Recommendation**: Enable default headers via `.headers(Customizer.withDefaults())`.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html>
 
-### SEC-RXF-HEAD-006 - Reactive HSTS max-age is too short
+### SEC-RXF-HEAD-006 - Reactive HSTS max-age is below Spring Security's default
 
 - **Severity**: LOW
-- **Detects**: The HSTS `maxAgeInSeconds` is configured but below the recommended one-year minimum.
-- **Recommendation**: Use at least 31536000 seconds (one year).
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html>
+- **Detects**: HSTS max-age is below Spring Security's one-year default (31,536,000 seconds).
+- **Recommendation**: Use shorter rollout values only intentionally; RFC 6797 does not define a universal one-year minimum.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html#webflux-headers-hsts>
 
 ### SEC-RXF-ACT-001 - Actuator exposes all endpoints with wildcard include
 
 - **Severity**: HIGH
-- **Detects**: `management.endpoints.web.exposure.include=*` without any exclude, exposing all Actuator endpoints.
-- **Recommendation**: List only needed endpoints or add excludes.
-- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html>
+- **Detects**: `management.endpoints.web.exposure.include=*` without any exclude.
+- **Recommendation**: List only needed endpoints, add excludes, and review Boot 4 `management.endpoint.<id>.access`.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.exposing>
 
 ### SEC-RXF-ACT-002 - Actuator exposes sensitive endpoints
 
 - **Severity**: MEDIUM
-- **Detects**: One or more sensitive endpoints (`env`, `beans`, `heapdump`, etc.) are explicitly included in `management.endpoints.web.exposure.include`.
-- **Recommendation**: Restrict sensitive endpoints to a separate management port.
-- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html>
+- **Detects**: Exposure configuration includes one or more sensitive endpoint IDs after exclusions.
+- **Recommendation**: Review endpoint enablement/access and protect the management path or isolate its port.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.security>
 
-### SEC-RXF-ACT-003 - Actuator endpoints exposed without protection
+### SEC-RXF-ACT-003 - Broad Actuator exposure has no observed authorization filter
 
-- **Severity**: HIGH
-- **Detects**: Actuator exposes more than health/info AND every reactive chain is fully open.
-- **Recommendation**: Protect Actuator endpoints with authentication or network policies.
-- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html>
+- **Severity**: MEDIUM
+- **Detects**: Actuator web exposure goes beyond health/info while every observed application chain omits `AuthorizationWebFilter`.
+- **Recommendation**: Verify the actual management path/port has explicit authorization or a restricted network path.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.security>
+
+This rule does not claim a custom management path or separate management context is unprotected; chain-to-path
+authorization is not exposed as stable runtime metadata.
 
 ### SEC-RXF-ACT-004 - Sensitive Actuator endpoints on main server port
 
 - **Severity**: INFO
-- **Detects**: Sensitive Actuator endpoints are on the application's main port without a separate management port.
+- **Detects**: Exposure goes beyond health/info and `management.server.port` is unset.
 - **Recommendation**: Set `management.server.port` to isolate management traffic.
-- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/monitoring.html>
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/monitoring.html#actuator.monitoring.customizing-management-server-port>
 
-### SEC-RXF-OAUTH2-001 - Reactive JWT decoder missing audience validation
+### SEC-RXF-ACT-005 - Reactive Actuator values are always unsanitized
 
-- **Severity**: MEDIUM
-- **Detects**: A `ReactiveJwtDecoder` bean exists but no `OAuth2TokenValidator` for the audience claim is registered.
-- **Recommendation**: Configure a `JwtClaimValidator<List<String>>("aud", ...)` or `spring.security.oauth2.resourceserver.jwt.audiences`.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/oauth2/resource-server/jwt.html>
+- **Severity**: HIGH
+- **Detects**: A web-exposed `env` or `configprops` endpoint whose host configuration sets the corresponding
+  `management.endpoint.<id>.show-values=always`.
+- **Recommendation**: Keep values at `never` or `when-authorized` so Actuator sanitization remains active.
+- **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.sanitization>
 
 ### SEC-RXF-OAUTH2-002 - Reactive JWT decoder uses a static public key
 
-- **Severity**: MEDIUM
-- **Detects**: `spring.security.oauth2.resourceserver.jwt.public-key-location` pins JWT verification to a static public key, making signing-key rotation operationally fragile.
-- **Recommendation**: Prefer `issuer-uri` or `jwk-set-uri` so signing-key rotation is handled through the authorization server's JWKS endpoint.
+- **Severity**: LOW
+- **Detects**: The supported `spring.security.oauth2.resourceserver.jwt.public-key-location` configuration is active.
+- **Recommendation**: Document manual key rotation, or use a trusted issuer/JWKS endpoint for automatic rotation.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/oauth2/resource-server/jwt.html>
 
 ### SEC-RXF-OAUTH2-003 - Reactive JWT metadata URL is plain HTTP
 
 - **Severity**: HIGH
-- **Detects**: The `spring.security.oauth2.resourceserver.jwt.issuer-uri` or JWK-set URI is `http://` rather than `https://`.
+- **Detects**: In a production profile, the `spring.security.oauth2.resourceserver.jwt.issuer-uri` or JWK-set URI is `http://` rather than `https://`.
 - **Recommendation**: Use HTTPS to prevent token metadata from being intercepted or tampered.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/oauth2/resource-server/jwt.html>
 
-### SEC-RXF-CONFIG-001 - spring.security.debug is enabled
+### SEC-RXF-OAUTH2-004 - Reactive opaque-token introspection URL is plain HTTP
 
 - **Severity**: HIGH
-- **Detects**: `spring.security.debug=true` is set, printing Spring Security decisions to stdout.
-- **Recommendation**: Disable `spring.security.debug` in production.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/index.html>
+- **Detects**: A production profile configures `spring.security.oauth2.resourceserver.opaquetoken.introspection-uri` with `http://`.
+- **Recommendation**: Use HTTPS and validate the authorization server certificate.
+- **Learn more**: <https://www.rfc-editor.org/rfc/rfc7662.html#section-4>
 
-### SEC-RXF-CONFIG-002 - HTTPS not enforced in production
+### SEC-RXF-CONFIG-002 - Reactive production HTTPS cannot be confirmed
 
-- **Severity**: HIGH
-- **Detects**: A production profile is active but no TLS configuration or `HttpsRedirectWebFilter` was found.
-- **Recommendation**: Configure TLS (`server.ssl.*`) or `HttpsRedirectWebFilter` for production traffic.
+- **Severity**: MEDIUM
+- **Detects**: A production profile where BootUI cannot observe server TLS, trusted forwarded headers, or `HttpsRedirectWebFilter`.
+- **Recommendation**: Confirm upstream TLS, configure trusted forwarded-header handling, or add reactive HTTPS redirect policy.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/exploits/https.html>
 
 ### SEC-RXF-CONFIG-003 - Hardcoded credentials in application properties
@@ -662,16 +684,18 @@ The reactive checks share the same severity scale as the servlet checks. Rule ID
 - **Recommendation**: Move secrets to environment variables, a secrets manager, Spring Cloud Vault, or another externalization mechanism.
 - **Learn more**: <https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html>
 
-### SEC-RXF-CONFIG-004 - Spring Security DEBUG logging in production
+### SEC-RXF-CONFIG-004 - Spring Security DEBUG/TRACE logging in production
 
 - **Severity**: MEDIUM
-- **Detects**: `logging.level.org.springframework.security=DEBUG` while a production profile is active.
+- **Detects**: `logging.level.org.springframework.security` (or the `.web` fallback) is `DEBUG` or `TRACE` while a production profile is active.
 - **Recommendation**: Keep `org.springframework.security` logging at INFO or WARN in production.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/index.html>
 
-### SEC-RXF-SESSION-001 - Bearer-token resource server using stateful sessions
+### SEC-RXF-SESSION-001 - Reactive chain mixes bearer-token and browser OAuth2 filters
 
 - **Severity**: LOW
-- **Detects**: A chain whose `AuthenticationWebFilter` uses Spring Security's reactive bearer-token converter also configures OAuth2 login or session-based authentication (stateful), which is redundant for pure resource servers.
-- **Recommendation**: Configure `.sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))` for pure bearer-token resource server chains.
-- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/oauth2/resource-server/jwt.html>
+- **Detects**: One chain combines Spring Security's bearer-token converter with an observed OAuth2/OIDC login or authorization-code client filter.
+- **Recommendation**: Prefer separate ordered chains. For a pure bearer chain, use
+  `securityContextRepository(NoOpServerSecurityContextRepository.getInstance())`; WebFlux has no
+  `SessionCreationPolicy` API.
+- **Learn more**: <https://docs.spring.io/spring-security/reference/reactive/authentication/index.html>

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -315,7 +315,7 @@ threads. This applies automatically at custom `bootui.api-path` mounts and does 
 
 The large majority of BootUI's panels are live on the reactive adapter, including every advisor scan,
 plus Flyway/Liquibase, Database Connection Pools, Cache, SQL Trace, Log Tail, Security Logs, Exceptions, and Live
-Activity (over a rebuilt reactive streaming/capture layer). The raw **Spring Security** panel and the 25-rule
+Activity (over a rebuilt reactive streaming/capture layer). The raw **Spring Security** panel and the 26-rule
 **Security advisor** are live whenever the application contributes a `SecurityWebFilterChain`; the raw panel's
 path/method-only explanations are clearly marked as best effort. The **REST Client** panel is live after the application
 builds a `WebClient` from Spring Boot's auto-configured `WebClient.Builder`; it provides the same report and actions as the

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -27,8 +27,8 @@ BootUI currently targets:
 Maturity is stated honestly: the **Spring Boot servlet adapter is complete** (all panels). The **Spring Boot WebFlux
 adapter** reuses the same engine and serves the large majority of panels unmodified or over a rebuilt reactive capture
 layer, including **Live Activity** (all nine signal types merge identically to the servlet adapter — see
-`docs/WEBFLUX-SUPPORT.md` §6.4), plus the raw Spring Security panel and the WebFlux-native 25-rule Security advisor; the
-raw Spring Security panel, the WebFlux-native 25-rule Security advisor, and REST Client capture over instrumented
+`docs/WEBFLUX-SUPPORT.md` §6.4), plus the raw Spring Security panel and the WebFlux-native 26-rule Security advisor; the
+raw Spring Security panel, the WebFlux-native 26-rule Security advisor, and REST Client capture over instrumented
 `WebClient` instances; HTTP Sessions is not applicable to a reactive,
 container-session-free stack — see `docs/WEBFLUX-SUPPORT.md` for the current per-panel status. The **Quarkus adapter
 is being built out**, with panels lighting up as the shared engine grows; see `docs/QUARKUS-SUPPORT.md` for the

--- a/docs/TRY-SAMPLE-APP.md
+++ b/docs/TRY-SAMPLE-APP.md
@@ -116,7 +116,7 @@ docker run --rm -p 8081:8081 \
 
 The large majority of panels work identically to the servlet image. The raw **Spring Security** panel shows the
 sample's reactive `SecurityWebFilterChain` and `WebFilter` pipeline with clearly marked best-effort explanations, and
-the **Security advisor** runs its WebFlux-native 25-rule catalogue. The **REST Client** panel captures calls from Spring
+the **Security advisor** runs its WebFlux-native 26-rule catalogue. The **REST Client** panel captures calls from Spring
 Boot's auto-configured `WebClient.Builder`, including live SSE updates and pause/resume/clear actions. **HTTP Sessions**
 stays not applicable (WebFlux has no `HttpSession`). See
 [WEBFLUX-SUPPORT.md](WEBFLUX-SUPPORT.md) for the full current status.

--- a/docs/WEBFLUX-SUPPORT.md
+++ b/docs/WEBFLUX-SUPPORT.md
@@ -283,6 +283,25 @@ deterministic findings across authorization, CSRF, CORS, headers, Actuator expos
 reactive session policy. BootUI's own permit-all chain is excluded from availability and analysis. See
 `docs/SECURITY-CHECKS.md` for the complete reactive catalogue.
 
+The catalogue is aligned with the Java 17 / Spring Boot 4.1.0 / Spring Security 7.1.0 baseline and deliberately
+describes only evidence the adapter can observe: installed filter/header-writer types, inspectable CORS maps, and host
+`Environment` properties. In particular, an installed `AuthorizationWebFilter` does not reveal whether
+its manager chose `permitAll`,
+`authenticated`, a role check, or custom logic; a decoder-local JWT validator is not inferred from unrelated validator
+beans; and management-path authorization, reverse-proxy TLS policy, handler-level CORS, and custom filters remain
+outside the snapshot. Unknown filter, header-writer, or CORS extraction skips dependent conclusions and produces a
+partial observation rather than being treated as an absent protection. Recursive composite header traversal is
+depth-bounded and reports incomplete evidence explicitly.
+
+Two unsupported checks were replaced without changing the 25-rule count: the non-existent reactive
+`spring.security.debug` switch and the unprovable global-bean audience-validator check gave way to host-configured
+Actuator `show-values=always` detection for web-exposed `env`/`configprops` endpoints and RFC 7662 plain-HTTP
+opaque-token introspection detection. Existing findings were narrowed where needed: credentialed CORS now targets the
+legal `allowedOriginPatterns="*"` case, CSP absence is a LOW contextual review (and report-only policies are called out
+as non-enforcing), static JWT keys are LOW rotation advice, HTTPS/Actuator findings avoid claiming knowledge of external
+deployment policy, and the mixed bearer/login rule uses WebFlux's real `NoOpServerSecurityContextRepository`
+remediation rather than servlet-only `SessionCreationPolicy`.
+
 ### 6.7 Not applicable (1 panel)
 
 | Panel        | Reason                                                                                                                                                                                                     |

--- a/docs/WEBFLUX-SUPPORT.md
+++ b/docs/WEBFLUX-SUPPORT.md
@@ -276,7 +276,7 @@ collection, chain match, and authorization simulation remains a Reactor `Mono`/`
 
 ### 6.6 Security advisor (`security`) — live on WebFlux
 
-The advisor uses a dedicated 25-rule reactive catalogue (`SEC-RXF-*`) over a neutral observation model collected from
+The advisor uses a dedicated 26-rule reactive catalogue (`SEC-RXF-*`) over a neutral observation model collected from
 the application's `SecurityWebFilterChain` configuration. It stays distinct from the raw `spring-security` panel:
 the raw panel explains the configured chains and mappings, while the advisor turns the observed posture into bounded,
 deterministic findings across authorization, CSRF, CORS, headers, Actuator exposure, OAuth2/JWT, configuration, and
@@ -301,6 +301,10 @@ legal `allowedOriginPatterns="*"` case, CSP absence is a LOW contextual review (
 as non-enforcing), static JWT keys are LOW rotation advice, HTTPS/Actuator findings avoid claiming knowledge of external
 deployment policy, and the mixed bearer/login rule uses WebFlux's real `NoOpServerSecurityContextRepository`
 remediation rather than servlet-only `SessionCreationPolicy`.
+
+A follow-up parity review brought the catalogue to 26 rules: `SEC-RXF-CSRF-001` and `SEC-RXF-SESSION-001` now also
+recognize `formLogin()` chains, not just OAuth2/OIDC login filters, and the new `SEC-RXF-CORS-003` flags broad
+`allowedOriginPatterns` (e.g. `https://*`) to match the servlet stack's `SEC-CORS-006`.
 
 ### 6.7 Not applicable (1 panel)
 


### PR DESCRIPTION
## Summary

Audits the complete Spring Security WebFlux advisor against the Java 17 / Spring Boot 4.1.0 / Spring Security 7.1.0 baseline, then narrows the implementation to evidence the runtime adapter can actually observe.

- preserves the 25-rule catalogue while replacing two unsupported checks
- stops treating `AuthorizationWebFilter` absence as proof of `permitAll`
- adds tri-state/partial observation behavior instead of success-shaped fallbacks
- corrects CORS, CSP, HSTS, OAuth2, Actuator, logging, and reactive session guidance
- preserves the legacy `WebFilterChainObservation#permitsAllAnonymous()` component/constructor contract while adding an explicit authorization-filter observation

## Research

Three independent read-only audits ran in parallel against the frozen base commit `d98836f0158b8b25d290252500b90a2b73371f9e`:

| Model | Configuration | Scope |
| --- | --- | --- |
| Claude Opus 5 | max, long context | Primary-source rule audit, severity calibration, comparable OSS |
| GPT-5.6 Terra | max, long context | Observability and adapter-boundary audit, primary-source reductions |
| Gemini 3.1 Pro | high, long context | Independent inventory, current API verification, candidate review |

The synthesis favored the least assertive conclusion supported by public behavior. In particular:

- Spring Security 7.1 installs `AuthorizationWebFilter` for `authorizeExchange`, including `permitAll`; filter presence cannot reveal the authorization manager's decision.
- `spring.security.debug` is not a supported WebFlux/Boot 4.1 setting: Boot's `SecurityProperties` has no such property and `@EnableWebFluxSecurity` has no servlet-style `debug` attribute.
- decoder-local JWT validators are the documented reactive customization model, so unrelated `OAuth2TokenValidator` beans cannot prove audience validation.
- Spring Framework rejects `allowedOrigins="*"` with credentials, but explicitly permits `allowedOriginPatterns="*"` with credentials.
- Spring Security intentionally has no universal CSP default; missing CSP is review advice, not a framework-misconfiguration verdict.
- WebFlux has no servlet `SessionCreationPolicy` API; the reactive stateless repository is `NoOpServerSecurityContextRepository`.

Primary references:

- [Spring Boot 4.1 dependency BOM](https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/4.1.0/spring-boot-dependencies-4.1.0.pom)
- [Spring Security 7.1 `ServerHttpSecurity` source](https://raw.githubusercontent.com/spring-projects/spring-security/7.1.0/config/src/main/java/org/springframework/security/config/web/server/ServerHttpSecurity.java)
- [Spring Security reactive configuration](https://docs.spring.io/spring-security/reference/reactive/configuration/webflux.html)
- [Spring Security reactive headers](https://docs.spring.io/spring-security/reference/reactive/exploits/headers.html)
- [Spring Framework 7.0.8 `CorsConfiguration`](https://docs.spring.io/spring-framework/docs/7.0.8/javadoc-api/org/springframework/web/cors/CorsConfiguration.html)
- [Spring Boot 4.1 `SecurityProperties`](https://docs.spring.io/spring-boot/4.1.0/api/java/org/springframework/boot/security/autoconfigure/SecurityProperties.html)
- [Spring Security 7.1 `EnableWebFluxSecurity`](https://raw.githubusercontent.com/spring-projects/spring-security/7.1.0/config/src/main/java/org/springframework/security/config/annotation/web/reactive/EnableWebFluxSecurity.java)
- [Spring Security reactive JWT validation](https://docs.spring.io/spring-security/reference/reactive/oauth2/resource-server/jwt.html#webflux-oauth2resourceserver-jwt-validation-custom)
- [Spring Security reactive authentication context](https://docs.spring.io/spring-security/reference/reactive/authentication/index.html)
- [RFC 7662 token introspection transport security](https://www.rfc-editor.org/rfc/rfc7662.html#section-4)
- [CSP `frame-ancestors` and `X-Frame-Options`](https://www.w3.org/TR/CSP2/#frame-ancestors-and-frame-options)

Comparable-tool review reinforced the runtime boundary: [Semgrep](https://semgrep.dev/docs/writing-rules/overview) and [Find Security Bugs](https://find-sec-bugs.github.io/) can inspect source/bytecode calls such as `csrf().disable()`, while [OWASP ZAP](https://www.zaproxy.org/docs/desktop/start/features/ascan/) performs active DAST. None can turn BootUI's bounded runtime filter-name snapshot into authorization-manager intent; those approaches remain complementary rather than being emulated through fragile reflection.

## Rule-by-rule decisions

| Rule | Decision | Result |
| --- | --- | --- |
| `SEC-RXF-AUTHZ-001` | MODIFY | Reports observed absence of `AuthorizationWebFilter`; unknown filter extraction skips. It no longer claims custom authorization is absent. |
| `SEC-RXF-AUTHZ-002` | MODIFY | Reframed from unobservable catch-all `permitAll` to a catch-all authentication chain missing `AuthorizationWebFilter`. |
| `SEC-RXF-AUTHZ-003` | MODIFY | Uses tri-state structural evidence and skips unknown chains instead of declaring security disabled. |
| `SEC-RXF-CSRF-001` | MODIFY | Targets observed OAuth2/OIDC browser filters, including OIDC session-registry authentication. |
| `SEC-RXF-CSRF-002` | MODIFY | Skips when filter extraction is incomplete; preserves the global review signal otherwise. |
| `SEC-RXF-CORS-001` | MODIFY | Matches only the exact all-origin value and treats opaque custom sources as partial/unknown. |
| `SEC-RXF-CORS-002` | MODIFY | Narrows to the legal credentialed `allowedOriginPatterns="*"` state; the invalid literal-origin combination remains under CORS-001. |
| `SEC-RXF-HEAD-001` | KEEP | Retains TLS-gated HSTS detection and names the current reactive writer/API. |
| `SEC-RXF-HEAD-002` | MODIFY | Accepts a restrictive enforcing CSP `frame-ancestors` policy as clickjacking protection; report-only and unrestricted policies do not count. |
| `SEC-RXF-HEAD-003` | KEEP | Retains observable `nosniff` writer detection. |
| `SEC-RXF-HEAD-004` | MODIFY | Demoted to LOW contextual review and distinguishes report-only from enforcing CSP. |
| `SEC-RXF-HEAD-005` | KEEP | Retains the observable all-header-writers-disabled signal. |
| `SEC-RXF-HEAD-006` | KEEP | Retains the Spring-default one-year boundary while documenting that RFC 6797 has no universal minimum. |
| `SEC-RXF-ACT-001` | KEEP | Retains exact wildcard web exposure detection. |
| `SEC-RXF-ACT-002` | KEEP | Retains explicit sensitive endpoint exposure review. |
| `SEC-RXF-ACT-003` | MODIFY | Demoted to MEDIUM and worded as a topology review because the snapshot cannot map management paths to a chain decision. |
| `SEC-RXF-ACT-004` | KEEP | Retains INFO-level management-port isolation advice. |
| `SEC-RXF-OAUTH2-001` | REMOVE | Global validator-bean inventory cannot establish decoder-local audience validation. |
| `SEC-RXF-OAUTH2-002` | MODIFY | Demoted to LOW rotation advice; Spring Security supports static public-key decoders. |
| `SEC-RXF-OAUTH2-003` | KEEP | Retains production-only plain-HTTP issuer/JWK metadata detection. |
| `SEC-RXF-CONFIG-001` | REMOVE | `spring.security.debug` has no supported reactive effect. |
| `SEC-RXF-CONFIG-002` | MODIFY | Demoted to MEDIUM because an external proxy or load balancer can provide HTTPS beyond process-local evidence. |
| `SEC-RXF-CONFIG-003` | KEEP | Retains key-only suspected-secret reporting; values never enter the snapshot. |
| `SEC-RXF-CONFIG-004` | MODIFY | Covers both DEBUG and TRACE Spring Security logging in production. |
| `SEC-RXF-SESSION-001` | MODIFY | Reviews mixed bearer/browser OAuth2 topology and uses WebFlux-native `NoOpServerSecurityContextRepository` guidance. |

Two bounded replacements keep the catalogue at 25:

- `SEC-RXF-ACT-005` (HIGH): an effectively web-exposed host `env` or `configprops` endpoint with `show-values=always`
- `SEC-RXF-OAUTH2-004` (HIGH): production opaque-token introspection over plain HTTP

Other candidates were deferred where they required authorization-manager inspection, actual management endpoint/path inventory, decoder internals, source analysis, or private reflection. The advisor remains a passive local review tool: it does not send requests, scan endpoints, or mutate the host application.

## Platform and observation behavior

- MVC behavior is unchanged.
- WebFlux uses the shared framework-neutral engine and a thin Spring adapter.
- Filter and header-writer extraction now have known/unknown semantics; failures surface a `PARTIAL` scan.
- Recursive composite header writers are depth-bounded and cycle-safe; incomplete traversal skips dependent rules.
- Opaque or mixed custom CORS sources surface partial evidence instead of silently passing wildcard checks.
- Host-risk findings ignore BootUI's own defaults; ACT-005 separately uses effective endpoint exposure so a host `show-values=always` setting is not missed when BootUI's default exposes `env`/`configprops`.
- The raw filter snapshot still cannot reveal matcher semantics, authorization-manager decisions, external TLS termination, decoder-local validators, or response-specific CSP needs.

## Validation

- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-engine,bootui-spring-autoconfigure -am -Dtest=ReactiveSecurityScannerTests,SpringReactiveSecurityObservationCollectorTests,BootUiReactiveSpringSecurityAutoConfigurationTests -Dsurefire.failIfNoSpecifiedTests=false test`
  - 33 engine advisor tests
  - 20 Spring observation collector tests
  - 6 reactive auto-configuration tests
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -Pcoverage -pl bootui-engine,bootui-spring-autoconfigure,bootui-spring-boot-starter-reactive,bootui-spring-webflux-sample-app -am clean install`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:check`
- frontend, Spring Playwright, and Quarkus Playwright `npm run format:check`
- `BOOTUI_MAVEN_REPO_LOCAL=... npm run test:webflux` — 8 Chromium tests passed

Tests include real `anyExchange().permitAll()` integration behavior, explicit SKIPPED results, mixed partial CORS sources, CORS literal/pattern boundaries, restrictive/report-only/unrestricted CSP behavior, the exact HSTS one-year boundary, OIDC CSRF behavior, cyclic header writers, effective Actuator exposure/access caps, opaque introspection, and production TRACE logging.