### PR TITLE
fix(memory): harden advisor JVM diagnostics

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/ContainerMemoryLimitDetector.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/ContainerMemoryLimitDetector.java
@@ -5,6 +5,7 @@ import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalLong;
 
@@ -12,50 +13,79 @@ final class ContainerMemoryLimitDetector {
 
     private static final Logger log = System.getLogger(ContainerMemoryLimitDetector.class.getName());
     private static final long CGROUP_V1_UNLIMITED_SENTINEL_FLOOR = Long.MAX_VALUE / 2;
+    private static final Path SELF_CGROUP_FILE = Path.of("/proc/self/cgroup");
+    private static final Path SELF_MOUNTINFO_FILE = Path.of("/proc/self/mountinfo");
 
-    private static final List<Path> STANDARD_CGROUP_LIMIT_FILES =
-            List.of(Path.of("/sys/fs/cgroup/memory.max"), Path.of("/sys/fs/cgroup/memory/memory.limit_in_bytes"));
+    private static final List<CgroupMemoryFiles> ROOT_CGROUP_FILES = List.of(
+            new CgroupMemoryFiles(
+                    List.of(Path.of("/sys/fs/cgroup/memory.max")),
+                    Path.of("/sys/fs/cgroup/memory.current"),
+                    Path.of("/sys/fs/cgroup/memory.stat"),
+                    "inactive_file"),
+            new CgroupMemoryFiles(
+                    List.of(Path.of("/sys/fs/cgroup/memory/memory.limit_in_bytes")),
+                    Path.of("/sys/fs/cgroup/memory/memory.usage_in_bytes"),
+                    Path.of("/sys/fs/cgroup/memory/memory.stat"),
+                    "total_inactive_file"));
 
-    private static final List<Path> STANDARD_CGROUP_CURRENT_FILES =
-            List.of(Path.of("/sys/fs/cgroup/memory.current"), Path.of("/sys/fs/cgroup/memory/memory.usage_in_bytes"));
-
-    private final List<Path> limitFiles;
-    private final List<Path> currentFiles;
+    private final List<CgroupMemoryFiles> files;
 
     ContainerMemoryLimitDetector(List<Path> limitFiles, List<Path> currentFiles) {
-        this.limitFiles = List.copyOf(limitFiles);
-        this.currentFiles = List.copyOf(currentFiles);
+        this(pairFiles(limitFiles, currentFiles));
+    }
+
+    private ContainerMemoryLimitDetector(List<CgroupMemoryFiles> files) {
+        this.files = List.copyOf(files);
     }
 
     static ContainerMemoryLimitDetector standard() {
-        return new ContainerMemoryLimitDetector(STANDARD_CGROUP_LIMIT_FILES, STANDARD_CGROUP_CURRENT_FILES);
+        List<CgroupMemoryFiles> files =
+                new ArrayList<>(resolveProcessCgroupFiles(SELF_CGROUP_FILE, SELF_MOUNTINFO_FILE));
+        files.addAll(ROOT_CGROUP_FILES);
+        return new ContainerMemoryLimitDetector(files);
+    }
+
+    static ContainerMemoryLimitDetector fromProcFiles(Path selfCgroupFile, Path selfMountinfoFile) {
+        return new ContainerMemoryLimitDetector(resolveProcessCgroupFiles(selfCgroupFile, selfMountinfoFile));
     }
 
     static ContainerMemoryLimitDetector disabled() {
-        return new ContainerMemoryLimitDetector(List.of(), List.of());
+        return new ContainerMemoryLimitDetector(List.<CgroupMemoryFiles>of());
     }
 
     OptionalLong detectLimit() {
-        for (Path limitFile : limitFiles) {
-            OptionalLong limit = readValue(limitFile);
-            if (limit.isPresent()) {
-                return limit;
-            }
-        }
-        return OptionalLong.empty();
+        return detect().limit();
     }
 
     OptionalLong detectCurrentUsage() {
-        for (Path currentFile : currentFiles) {
-            OptionalLong current = readValue(currentFile);
-            if (current.isPresent()) {
-                return current;
-            }
-        }
-        return OptionalLong.empty();
+        return detect().current();
     }
 
-    private OptionalLong readValue(Path file) {
+    CgroupMemorySample detect() {
+        for (CgroupMemoryFiles candidate : files) {
+            OptionalLong limit = readEffectiveLimit(candidate.limitFiles());
+            if (limit.isPresent()) {
+                return new CgroupMemorySample(
+                        limit,
+                        readUsage(candidate.currentFile()),
+                        readInactiveFile(candidate.statFile(), candidate.inactiveFileKey()));
+            }
+        }
+        return CgroupMemorySample.unavailable();
+    }
+
+    private OptionalLong readEffectiveLimit(List<Path> limitFiles) {
+        OptionalLong effectiveLimit = OptionalLong.empty();
+        for (Path limitFile : limitFiles) {
+            OptionalLong limit = readLimit(limitFile);
+            if (limit.isPresent() && (effectiveLimit.isEmpty() || limit.getAsLong() < effectiveLimit.getAsLong())) {
+                effectiveLimit = limit;
+            }
+        }
+        return effectiveLimit;
+    }
+
+    private OptionalLong readLimit(Path file) {
         if (!Files.isRegularFile(file)) {
             return OptionalLong.empty();
         }
@@ -65,6 +95,35 @@ final class ContainerMemoryLimitDetector {
             log.log(Level.DEBUG, "Could not read cgroup memory value from " + file, ex);
             return OptionalLong.empty();
         }
+    }
+
+    private OptionalLong readUsage(Path file) {
+        if (!Files.isRegularFile(file)) {
+            return OptionalLong.empty();
+        }
+        try {
+            return parseNonNegative(Files.readString(file));
+        } catch (IOException ex) {
+            log.log(Level.DEBUG, "Could not read cgroup memory value from " + file, ex);
+            return OptionalLong.empty();
+        }
+    }
+
+    private OptionalLong readInactiveFile(Path file, String key) {
+        if (file == null || key == null || !Files.isRegularFile(file)) {
+            return OptionalLong.empty();
+        }
+        try {
+            for (String line : Files.readAllLines(file)) {
+                String[] parts = line.trim().split("\\s+", 2);
+                if (parts.length == 2 && key.equals(parts[0])) {
+                    return parseNonNegative(parts[1]);
+                }
+            }
+        } catch (IOException ex) {
+            log.log(Level.DEBUG, "Could not read cgroup memory statistics from " + file, ex);
+        }
+        return OptionalLong.empty();
     }
 
     static OptionalLong parseLimit(String rawLimit) {
@@ -83,4 +142,190 @@ final class ContainerMemoryLimitDetector {
             return OptionalLong.empty();
         }
     }
+
+    private static OptionalLong parseNonNegative(String rawValue) {
+        String value = rawValue == null ? "" : rawValue.trim();
+        if (value.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        try {
+            long parsed = Long.parseLong(value);
+            return parsed >= 0 ? OptionalLong.of(parsed) : OptionalLong.empty();
+        } catch (NumberFormatException ex) {
+            log.log(Level.DEBUG, "Could not parse cgroup memory value '" + value + "'", ex);
+            return OptionalLong.empty();
+        }
+    }
+
+    private static List<CgroupMemoryFiles> pairFiles(List<Path> limitFiles, List<Path> currentFiles) {
+        List<CgroupMemoryFiles> pairs = new ArrayList<>();
+        int size = Math.min(limitFiles.size(), currentFiles.size());
+        for (int index = 0; index < size; index++) {
+            pairs.add(new CgroupMemoryFiles(List.of(limitFiles.get(index)), currentFiles.get(index), null, null));
+        }
+        return pairs;
+    }
+
+    private static List<CgroupMemoryFiles> resolveProcessCgroupFiles(Path selfCgroupFile, Path selfMountinfoFile) {
+        List<CgroupMemoryFiles> files = new ArrayList<>();
+        try {
+            List<String> cgroupLines = Files.readAllLines(selfCgroupFile);
+            List<CgroupMount> mounts = parseMounts(Files.readAllLines(selfMountinfoFile));
+            CgroupPath v2 = findCgroupPath(cgroupLines, true);
+            if (v2 != null) {
+                for (CgroupMount mount : mounts) {
+                    if ("cgroup2".equals(mount.fileSystemType())) {
+                        files.addAll(filesFor(v2, mount, "memory.max", "memory.current", "inactive_file"));
+                    }
+                }
+            }
+            CgroupPath v1Memory = findCgroupPath(cgroupLines, false);
+            if (v1Memory != null) {
+                for (CgroupMount mount : mounts) {
+                    if ("cgroup".equals(mount.fileSystemType()) && mount.hasMemoryController()) {
+                        files.addAll(filesFor(
+                                v1Memory,
+                                mount,
+                                "memory.limit_in_bytes",
+                                "memory.usage_in_bytes",
+                                "total_inactive_file"));
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            log.log(Level.DEBUG, "Could not resolve the process cgroup memory paths", ex);
+        }
+        return List.copyOf(files);
+    }
+
+    private static List<CgroupMemoryFiles> filesFor(
+            CgroupPath cgroup,
+            CgroupMount mount,
+            String limitFileName,
+            String currentFileName,
+            String inactiveFileKey) {
+        Path directory = resolveCgroupDirectory(cgroup.path(), mount);
+        if (directory == null) {
+            return List.of();
+        }
+        return List.of(new CgroupMemoryFiles(
+                ancestorLimitFiles(directory, Path.of(mount.mountPoint()).normalize(), limitFileName),
+                directory.resolve(currentFileName),
+                directory.resolve("memory.stat"),
+                inactiveFileKey));
+    }
+
+    private static List<Path> ancestorLimitFiles(Path directory, Path mountPoint, String limitFileName) {
+        List<Path> limitFiles = new ArrayList<>();
+        Path current = directory;
+        while (current != null && current.startsWith(mountPoint)) {
+            limitFiles.add(current.resolve(limitFileName));
+            if (current.equals(mountPoint)) {
+                break;
+            }
+            current = current.getParent();
+        }
+        return List.copyOf(limitFiles);
+    }
+
+    private static Path resolveCgroupDirectory(String cgroupPath, CgroupMount mount) {
+        Path root = Path.of(mount.root()).normalize();
+        Path processPath = Path.of(cgroupPath).normalize();
+        Path mountPoint = Path.of(mount.mountPoint()).normalize();
+        if (!processPath.startsWith(root)) {
+            // A cgroup namespace can expose the process as "/" while mountinfo retains the host
+            // hierarchy root. In that view the mount point is already the process cgroup.
+            return mountPoint;
+        }
+        Path directory = mountPoint.resolve(root.relativize(processPath)).normalize();
+        return directory.startsWith(mountPoint) ? directory : null;
+    }
+
+    private static CgroupPath findCgroupPath(List<String> lines, boolean unified) {
+        for (String line : lines) {
+            String[] fields = line.split(":", 3);
+            if (fields.length != 3) {
+                continue;
+            }
+            if (unified && fields[1].isEmpty()) {
+                return new CgroupPath(unescapeProcPath(fields[2]));
+            }
+            if (!unified) {
+                for (String controller : fields[1].split(",")) {
+                    if ("memory".equals(controller)) {
+                        return new CgroupPath(unescapeProcPath(fields[2]));
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static List<CgroupMount> parseMounts(List<String> lines) {
+        List<CgroupMount> mounts = new ArrayList<>();
+        for (String line : lines) {
+            int separator = line.indexOf(" - ");
+            if (separator < 0) {
+                continue;
+            }
+            String[] beforeSeparator = line.substring(0, separator).split("\\s+");
+            String[] afterSeparator = line.substring(separator + 3).split("\\s+");
+            if (beforeSeparator.length < 5 || afterSeparator.length < 3) {
+                continue;
+            }
+            String fileSystemType = afterSeparator[0];
+            String mountRoot = unescapeProcPath(beforeSeparator[3]);
+            String mountPoint = unescapeProcPath(beforeSeparator[4]);
+            boolean hasMemoryController = hasMemoryController(afterSeparator[2])
+                    || hasMemoryController(
+                            Path.of(mountPoint).getFileName() == null
+                                    ? ""
+                                    : Path.of(mountPoint).getFileName().toString());
+            mounts.add(new CgroupMount(mountRoot, mountPoint, fileSystemType, hasMemoryController));
+        }
+        return mounts;
+    }
+
+    private static boolean hasMemoryController(String value) {
+        for (String token : value.split(",")) {
+            if ("memory".equals(token)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String unescapeProcPath(String path) {
+        return path.replace("\\040", " ")
+                .replace("\\011", "\t")
+                .replace("\\012", "\n")
+                .replace("\\134", "\\");
+    }
+
+    record CgroupMemorySample(OptionalLong limit, OptionalLong current, OptionalLong inactiveFile) {
+
+        CgroupMemorySample {
+            limit = limit == null ? OptionalLong.empty() : limit;
+            current = current == null ? OptionalLong.empty() : current;
+            inactiveFile = inactiveFile == null ? OptionalLong.empty() : inactiveFile;
+        }
+
+        static CgroupMemorySample unavailable() {
+            return new CgroupMemorySample(OptionalLong.empty(), OptionalLong.empty(), OptionalLong.empty());
+        }
+
+        OptionalLong workingSet() {
+            if (current.isEmpty() || inactiveFile.isEmpty()) {
+                return OptionalLong.empty();
+            }
+            long used = current.getAsLong();
+            return OptionalLong.of(Math.max(0, used - inactiveFile.getAsLong()));
+        }
+    }
+
+    private record CgroupMemoryFiles(List<Path> limitFiles, Path currentFile, Path statFile, String inactiveFileKey) {}
+
+    private record CgroupPath(String path) {}
+
+    private record CgroupMount(String root, String mountPoint, String fileSystemType, boolean hasMemoryController) {}
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCollector.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCollector.java
@@ -4,6 +4,7 @@ import io.github.jdubois.bootui.core.dto.HeapClassHistogramEntryDto;
 import io.github.jdubois.bootui.core.dto.ThreadDumpReport;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.BufferPoolSnapshot;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.ClassLoadingData;
+import io.github.jdubois.bootui.engine.memory.MemoryContext.GcEvent;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.GcSample;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.GcTrend;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.HeapContentData;
@@ -80,12 +81,27 @@ final class MemoryCollector {
         // from the recent-overhead window; the post-histogram runtime reading becomes the baseline
         // for the next scan.
         GcSample preHistogramGc = currentGcSample();
+        GcEvent preHistogramGcEvent = readLastGcEvent().asGcEvent();
         HeapContentData heapContent = collectHeapContent();
+        GcSample postHistogramGc = currentGcSample();
+        GcEvent postHistogramGcEvent = readLastGcEvent().asGcEvent();
         PostGcHeapData postGcHeap = collectPostGcHeap(heapContent.available());
         ClassLoadingData classLoading = collectClassLoading();
-        RuntimeData runtime = collectRuntime();
+        RuntimeData runtime = collectRuntime(preHistogramGcEvent);
         return new MemoryContext(
-                memory, threads, heapContent, postGcHeap, classLoading, runtime, preHistogramGc, GcTrend.unavailable());
+                memory,
+                threads,
+                heapContent,
+                postGcHeap,
+                classLoading,
+                runtime,
+                preHistogramGc,
+                postHistogramGc,
+                preHistogramGcEvent,
+                postHistogramGcEvent,
+                GcTrend.unavailable(),
+                null,
+                null);
     }
 
     /**
@@ -124,9 +140,9 @@ final class MemoryCollector {
             if (count > 0) {
                 perCollectorCounts.put(gc.getName(), count);
             }
-            // Exclude concurrent-cycle beans (ZGC Cycles, Shenandoah Cycles, G1 Concurrent GC,
-            // ConcurrentMarkSweep) from the STW-only time/count totals. Including their concurrent
-            // phase time would inflate overhead for apps that deliberately chose a concurrent collector.
+            // Exclude concurrent-cycle beans (ZGC/Shenandoah Cycles and legacy ConcurrentMarkSweep)
+            // from the STW-only time/count totals. G1 Concurrent GC is retained because it records
+            // remark/cleanup VM operations rather than concurrent phase elapsed time.
             if (!isConcurrentCycleBean(gc.getName())) {
                 long time = gc.getCollectionTime();
                 if (time >= 0) {
@@ -152,9 +168,10 @@ final class MemoryCollector {
             return false;
         }
         String lower = name.toLowerCase(java.util.Locale.ROOT);
-        // "cycles" covers: ZGC Cycles, ZGC Major Cycles, ZGC Minor Cycles, Shenandoah Cycles
-        // "concurrent" covers: G1 Concurrent GC, ConcurrentMarkSweep (legacy CMS)
-        return lower.contains("cycles") || lower.contains("concurrent");
+        // "cycles" covers: ZGC Cycles, ZGC Major Cycles, ZGC Minor Cycles, Shenandoah Cycles.
+        // G1 Concurrent GC records its remark/cleanup VM operations, so its elapsed time remains
+        // relevant to a stop-the-world overhead metric.
+        return lower.contains("cycles") || "concurrentmarksweep".equals(lower);
     }
 
     private MemoryData collectMemory() {
@@ -194,10 +211,13 @@ final class MemoryCollector {
             gcNames.add(gc.getName());
         }
 
-        OptionalLong containerLimitValue = containerMemoryDetector.detectLimit();
+        ContainerMemoryLimitDetector.CgroupMemorySample containerMemory = containerMemoryDetector.detect();
+        OptionalLong containerLimitValue = containerMemory.limit();
         Long containerLimit = containerLimitValue.isPresent() ? containerLimitValue.getAsLong() : null;
-        OptionalLong containerCurrentValue = containerMemoryDetector.detectCurrentUsage();
+        OptionalLong containerCurrentValue = containerMemory.current();
         Long containerCurrent = containerCurrentValue.isPresent() ? containerCurrentValue.getAsLong() : null;
+        OptionalLong containerWorkingSetValue = containerMemory.workingSet();
+        Long containerWorkingSet = containerWorkingSetValue.isPresent() ? containerWorkingSetValue.getAsLong() : null;
 
         return new MemoryData(
                 heap.getUsed(),
@@ -215,6 +235,7 @@ final class MemoryCollector {
                 gcNames,
                 containerLimit,
                 containerCurrent,
+                containerWorkingSet,
                 bufferPools);
     }
 
@@ -236,7 +257,8 @@ final class MemoryCollector {
                 report.deadlockDetected(),
                 report.deadlockedThreadIds(),
                 report.stateCounts(),
-                report.threads());
+                report.threads(),
+                report.page() != null && report.page().hasMore());
     }
 
     private HeapContentData collectHeapContent() {
@@ -270,7 +292,7 @@ final class MemoryCollector {
                 bean.getLoadedClassCount(), bean.getTotalLoadedClassCount(), bean.getUnloadedClassCount());
     }
 
-    private RuntimeData collectRuntime() {
+    private RuntimeData collectRuntime(GcEvent latestGcEvent) {
         GcSample gc = currentGcSample();
         int pendingFinalization = ManagementFactory.getMemoryMXBean().getObjectPendingFinalizationCount();
         List<String> inputArgs = ManagementFactory.getRuntimeMXBean().getInputArguments();
@@ -281,7 +303,6 @@ final class MemoryCollector {
         long freePhysicalMemory = readOsBeanLong("FreePhysicalMemorySize");
         long totalPhysicalMemory = readOsBeanLong("TotalPhysicalMemorySize");
         Boolean useCompressedOops = readVmOptionBoolean("UseCompressedOops");
-        LastGcEvent lastGcEvent = readLastGcEvent();
 
         return new RuntimeData(
                 gc.uptimeMillis(),
@@ -295,22 +316,33 @@ final class MemoryCollector {
                 totalSwap,
                 useCompressedOops,
                 totalPhysicalMemory,
-                lastGcEvent.durationMillis(),
-                lastGcEvent.collectorName(),
+                latestGcEvent.durationMillis(),
+                latestGcEvent.collectorName(),
                 freePhysicalMemory);
     }
 
     /**
      * A collector's latest event on the shared JVM-uptime time base exposed by {@code GcInfo}.
      */
-    record LastGcEventCandidate(long endTimeMillis, long durationMillis, String collectorName) {}
+    record LastGcEventCandidate(long id, long endTimeMillis, long durationMillis, String collectorName) {
+
+        LastGcEventCandidate(long endTimeMillis, long durationMillis, String collectorName) {
+            this(-1, endTimeMillis, durationMillis, collectorName);
+        }
+    }
 
     /**
      * The duration and originating collector of the single most recently completed garbage collection.
      */
-    record LastGcEvent(long durationMillis, String collectorName) {
+    record LastGcEvent(long id, long endTimeMillis, long durationMillis, String collectorName) {
         static LastGcEvent unavailable() {
-            return new LastGcEvent(-1, null);
+            return new LastGcEvent(-1, -1, -1, null);
+        }
+
+        GcEvent asGcEvent() {
+            return durationMillis < 0
+                    ? GcEvent.unavailable()
+                    : new GcEvent(id, endTimeMillis, durationMillis, collectorName);
         }
     }
 
@@ -326,7 +358,8 @@ final class MemoryCollector {
                 if (bean instanceof com.sun.management.GarbageCollectorMXBean sunBean) {
                     com.sun.management.GcInfo info = sunBean.getLastGcInfo();
                     if (info != null) {
-                        candidates.add(new LastGcEventCandidate(info.getEndTime(), info.getDuration(), bean.getName()));
+                        candidates.add(new LastGcEventCandidate(
+                                info.getId(), info.getEndTime(), info.getDuration(), bean.getName()));
                     }
                 }
             }
@@ -340,7 +373,11 @@ final class MemoryCollector {
     static LastGcEvent latestGcEvent(List<LastGcEventCandidate> candidates) {
         return candidates.stream()
                 .max(Comparator.comparingLong(LastGcEventCandidate::endTimeMillis))
-                .map(candidate -> new LastGcEvent(candidate.durationMillis(), candidate.collectorName()))
+                .map(candidate -> new LastGcEvent(
+                        candidate.id(),
+                        candidate.endTimeMillis(),
+                        candidate.durationMillis(),
+                        candidate.collectorName()))
                 .orElseGet(LastGcEvent::unavailable);
     }
 
@@ -476,7 +513,7 @@ final class MemoryCollector {
         return RuntimeData.DEFAULT_THREAD_STACK_BYTES;
     }
 
-    private static long parseMemorySize(String value) {
+    static long parseMemorySize(String value) {
         if (value == null || value.isBlank()) {
             return -1;
         }
@@ -488,14 +525,15 @@ final class MemoryCollector {
             case 'k' -> multiplier = 1024L;
             case 'm' -> multiplier = 1024L * 1024;
             case 'g' -> multiplier = 1024L * 1024 * 1024;
+            case 't' -> multiplier = 1024L * 1024 * 1024 * 1024;
             default -> multiplier = 1;
         }
         if (multiplier != 1) {
             number = trimmed.substring(0, trimmed.length() - 1);
         }
         try {
-            return Long.parseLong(number.trim()) * multiplier;
-        } catch (NumberFormatException ex) {
+            return Math.multiplyExact(Long.parseLong(number.trim()), multiplier);
+        } catch (ArithmeticException | NumberFormatException ex) {
             return -1;
         }
     }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryContext.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryContext.java
@@ -22,6 +22,9 @@ record MemoryContext(
         ClassLoadingData classLoading,
         RuntimeData runtime,
         GcSample preHistogramGc,
+        GcSample postHistogramGc,
+        GcEvent latestGcEvent,
+        GcEvent postHistogramGcEvent,
         GcTrend gcTrend,
         BufferPoolTrend bufferPoolTrend,
         OldGenTrend oldGenTrend) {
@@ -34,9 +37,43 @@ record MemoryContext(
         classLoading = classLoading == null ? ClassLoadingData.empty() : classLoading;
         runtime = runtime == null ? RuntimeData.empty() : runtime;
         preHistogramGc = preHistogramGc == null ? GcSample.from(runtime) : preHistogramGc;
+        postHistogramGc = postHistogramGc == null ? GcSample.from(runtime) : postHistogramGc;
+        latestGcEvent = latestGcEvent == null ? GcEvent.from(runtime) : latestGcEvent;
+        postHistogramGcEvent = postHistogramGcEvent == null ? GcEvent.unavailable() : postHistogramGcEvent;
         gcTrend = gcTrend == null ? GcTrend.unavailable() : gcTrend;
         bufferPoolTrend = bufferPoolTrend == null ? BufferPoolTrend.unavailable() : bufferPoolTrend;
         oldGenTrend = oldGenTrend == null ? OldGenTrend.unavailable() : oldGenTrend;
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the post-histogram GC baseline. The
+     * fallback retains aggregate GC counters but cannot preserve a per-collector breakdown.
+     */
+    MemoryContext(
+            MemoryData memory,
+            ThreadData threads,
+            HeapContentData heapContent,
+            PostGcHeapData postGcHeap,
+            ClassLoadingData classLoading,
+            RuntimeData runtime,
+            GcSample preHistogramGc,
+            GcTrend gcTrend,
+            BufferPoolTrend bufferPoolTrend,
+            OldGenTrend oldGenTrend) {
+        this(
+                memory,
+                threads,
+                heapContent,
+                postGcHeap,
+                classLoading,
+                runtime,
+                preHistogramGc,
+                null,
+                null,
+                null,
+                gcTrend,
+                bufferPoolTrend,
+                oldGenTrend);
     }
 
     /**
@@ -53,7 +90,20 @@ record MemoryContext(
             RuntimeData runtime,
             GcSample preHistogramGc,
             GcTrend gcTrend) {
-        this(memory, threads, heapContent, postGcHeap, classLoading, runtime, preHistogramGc, gcTrend, null, null);
+        this(
+                memory,
+                threads,
+                heapContent,
+                postGcHeap,
+                classLoading,
+                runtime,
+                preHistogramGc,
+                null,
+                null,
+                null,
+                gcTrend,
+                null,
+                null);
     }
 
     /**
@@ -80,6 +130,9 @@ record MemoryContext(
                 classLoading,
                 runtime,
                 preHistogramGc,
+                postHistogramGc,
+                latestGcEvent,
+                postHistogramGcEvent,
                 trend,
                 bufferPoolTrend,
                 oldGenTrend);
@@ -95,6 +148,9 @@ record MemoryContext(
                 classLoading,
                 runtime,
                 preHistogramGc,
+                postHistogramGc,
+                latestGcEvent,
+                postHistogramGcEvent,
                 gcTrend,
                 trend,
                 oldGenTrend);
@@ -110,9 +166,30 @@ record MemoryContext(
                 classLoading,
                 runtime,
                 preHistogramGc,
+                postHistogramGc,
+                latestGcEvent,
+                postHistogramGcEvent,
                 gcTrend,
                 bufferPoolTrend,
                 trend);
+    }
+
+    /** Returns a copy with the scanner-filtered latest GC event attached. */
+    MemoryContext withLatestGcEvent(GcEvent event) {
+        return new MemoryContext(
+                memory,
+                threads,
+                heapContent,
+                postGcHeap,
+                classLoading,
+                runtime,
+                preHistogramGc,
+                postHistogramGc,
+                event,
+                postHistogramGcEvent,
+                gcTrend,
+                bufferPoolTrend,
+                oldGenTrend);
     }
 
     int heapUsedPercent() {
@@ -147,7 +224,7 @@ record MemoryContext(
     /**
      * A single {@code java.nio} buffer pool reading ({@code BufferPoolMXBean}), typically "direct"
      * or "mapped". Captured per-pool (unlike the aggregated direct-buffer totals below) so
-     * MEM-POOL-007 can track each pool's usage across scans independently.
+     * MEM-POOL-007 can track the direct pool across scans.
      */
     record BufferPoolSnapshot(String name, long used, long capacity, long count) {}
 
@@ -167,6 +244,7 @@ record MemoryContext(
             List<String> gcCollectorNames,
             Long containerMemoryLimitBytes,
             Long containerMemoryCurrentBytes,
+            Long containerMemoryWorkingSetBytes,
             List<BufferPoolSnapshot> bufferPools) {
 
         MemoryData {
@@ -180,6 +258,43 @@ record MemoryContext(
          * Backward-compatible constructor for callers that predate per-pool buffer-pool tracking
          * (MEM-POOL-007's cross-scan growth-without-release rule); defaults to no per-pool readings.
          */
+        MemoryData(
+                long heapUsed,
+                long heapCommitted,
+                long heapMax,
+                long nonHeapUsed,
+                long nonHeapCommitted,
+                long nonHeapMax,
+                List<MemoryPoolSnapshot> pools,
+                long directBufferUsed,
+                long directBufferCapacity,
+                long directBufferCount,
+                long maxDirectMemoryBytes,
+                List<String> inputArguments,
+                List<String> gcCollectorNames,
+                Long containerMemoryLimitBytes,
+                Long containerMemoryCurrentBytes,
+                List<BufferPoolSnapshot> bufferPools) {
+            this(
+                    heapUsed,
+                    heapCommitted,
+                    heapMax,
+                    nonHeapUsed,
+                    nonHeapCommitted,
+                    nonHeapMax,
+                    pools,
+                    directBufferUsed,
+                    directBufferCapacity,
+                    directBufferCount,
+                    maxDirectMemoryBytes,
+                    inputArguments,
+                    gcCollectorNames,
+                    containerMemoryLimitBytes,
+                    containerMemoryCurrentBytes,
+                    null,
+                    bufferPools);
+        }
+
         MemoryData(
                 long heapUsed,
                 long heapCommitted,
@@ -212,6 +327,7 @@ record MemoryContext(
                     gcCollectorNames,
                     containerMemoryLimitBytes,
                     containerMemoryCurrentBytes,
+                    null,
                     List.of());
         }
 
@@ -296,12 +412,34 @@ record MemoryContext(
             boolean deadlockDetected,
             List<Long> deadlockedThreadIds,
             List<ThreadStateCountDto> stateCounts,
-            List<ThreadInfoDto> threads) {
+            List<ThreadInfoDto> threads,
+            boolean detailsTruncated) {
 
         ThreadData {
             deadlockedThreadIds = deadlockedThreadIds == null ? List.of() : List.copyOf(deadlockedThreadIds);
             stateCounts = stateCounts == null ? List.of() : List.copyOf(stateCounts);
             threads = threads == null ? List.of() : List.copyOf(threads);
+        }
+
+        ThreadData(
+                int total,
+                int peak,
+                int daemon,
+                boolean cpuTimeSupported,
+                boolean deadlockDetected,
+                List<Long> deadlockedThreadIds,
+                List<ThreadStateCountDto> stateCounts,
+                List<ThreadInfoDto> threads) {
+            this(
+                    total,
+                    peak,
+                    daemon,
+                    cpuTimeSupported,
+                    deadlockDetected,
+                    deadlockedThreadIds,
+                    stateCounts,
+                    threads,
+                    false);
         }
 
         static ThreadData empty() {
@@ -461,6 +599,37 @@ record MemoryContext(
     }
 
     /**
+     * Identity and duration of the latest completed collector event. GcInfo event ids and end times
+     * share the JVM uptime time base, allowing the scanner to suppress a prior scan's histogram GC.
+     */
+    record GcEvent(long id, long endTimeMillis, long durationMillis, String collectorName) {
+
+        static GcEvent unavailable() {
+            return new GcEvent(-1, -1, -1, null);
+        }
+
+        static GcEvent from(RuntimeData runtime) {
+            return runtime.lastGcDurationMillis() < 0
+                    ? unavailable()
+                    : new GcEvent(-1, -1, runtime.lastGcDurationMillis(), runtime.lastGcCollectorName());
+        }
+
+        boolean available() {
+            return durationMillis >= 0;
+        }
+
+        boolean sameEvent(GcEvent other) {
+            return other != null
+                    && available()
+                    && other.available()
+                    && id >= 0
+                    && id == other.id
+                    && endTimeMillis == other.endTimeMillis
+                    && java.util.Objects.equals(collectorName, other.collectorName);
+        }
+    }
+
+    /**
      * GC activity between the previous scan and this one. The window deliberately spans the previous
      * scan's post-histogram sample to this scan's pre-histogram sample so that neither scan's own
      * forced full GC is counted as application GC overhead. Per-collector deltas allow rules to
@@ -501,8 +670,8 @@ record MemoryContext(
     }
 
     /**
-     * Consecutive-scan growth tracking for {@code java.nio} buffer pools (direct/mapped), used by
-     * MEM-POOL-007 to catch a native-memory leak before a pool's absolute usage crosses
+     * Consecutive-scan growth tracking for {@code java.nio} buffer pools, used by MEM-POOL-007 to
+     * catch a direct-memory leak before the pool's absolute usage crosses
      * MEM-POOL-003's static high-water threshold. A pool's streak counts how many scans in a row
      * (including this one) its used-byte reading has strictly increased over the previous scan with
      * no decrease in between; any decrease, a plateau, or a pool not seen in the previous scan resets

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRules.java
@@ -263,7 +263,10 @@ final class MetaspaceSaturationRule extends AbstractMemoryRule {
     @Override
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         Optional<MemoryPoolSnapshot> metaspace = context.memory().metaspacePool();
-        if (metaspace.isEmpty() || metaspace.get().max() <= 0) {
+        if (metaspace.isEmpty()) {
+            return skipped("No Metaspace pool is exposed by this JVM.");
+        }
+        if (metaspace.get().max() <= 0) {
             return skipped("Metaspace has no configured maximum (effectively unbounded).");
         }
         MemoryPoolSnapshot pool = metaspace.get();
@@ -378,8 +381,8 @@ final class MissingHeapSizingInContainerRule extends AbstractMemoryRule {
                 "Heap sizing is left to default container ergonomics",
                 MemoryCategory.GC_CONFIGURATION,
                 "INFO",
-                "Notes a detected container memory limit with neither -Xmx nor -XX:MaxRAMPercentage set. The JVM is container-aware and defaults the max heap to about 25% of the limit, which is safe but conservative and easy to overlook.",
-                "Set -XX:MaxRAMPercentage (or an explicit -Xmx) if you want the heap sized deliberately rather than at the ~25% default.",
+                "Notes a detected container memory limit with neither -Xmx/-XX:MaxHeapSize nor an explicit RAM-sizing option set. The JVM is container-aware and normally defaults the max heap to about 25% of the limit, while small-heap ergonomics can use 50%.",
+                "Set -XX:MaxRAMPercentage (or an explicit -Xmx/-XX:MaxHeapSize) if you want the heap sized deliberately rather than by default ergonomics.",
                 "https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html"));
     }
 
@@ -389,12 +392,15 @@ final class MissingHeapSizingInContainerRule extends AbstractMemoryRule {
         if (memory.containerMemoryLimitBytes() == null) {
             return skipped("No container memory limit was detected.");
         }
-        boolean explicitMaxHeap = memory.hasJvmArgumentPrefix("-Xmx");
-        boolean ramPercentage = memory.hasJvmArgumentPrefix("-XX:MaxRAMPercentage");
-        if (!explicitMaxHeap && !ramPercentage) {
-            return violation(
-                    "Container memory limit " + MemoryFormat.bytes(memory.containerMemoryLimitBytes())
-                            + " detected but neither -Xmx nor -XX:MaxRAMPercentage is set; the heap defaults to ~25% of the limit.");
+        boolean explicitMaxHeap =
+                memory.hasJvmArgumentPrefix("-Xmx") || memory.hasJvmArgumentPrefix("-XX:MaxHeapSize=");
+        boolean ramSizing = memory.hasJvmArgumentPrefix("-XX:MaxRAMPercentage")
+                || memory.hasJvmArgumentPrefix("-XX:MaxRAMFraction")
+                || memory.hasJvmArgumentPrefix("-XX:MaxRAM=");
+        if (!explicitMaxHeap && !ramSizing) {
+            return violation("Container memory limit " + MemoryFormat.bytes(memory.containerMemoryLimitBytes())
+                    + " detected but neither -Xmx/-XX:MaxHeapSize nor an explicit RAM-sizing option is set; the"
+                    + " heap defaults to about 25% of the limit (50% for small limits).");
         }
         return pass();
     }
@@ -543,7 +549,7 @@ final class RunawayCpuThreadRule extends AbstractMemoryRule {
                         "Runnable threads with very high lifetime CPU usage",
                         MemoryCategory.THREADS,
                         "INFO",
-                        "Highlights RUNNABLE threads whose accumulated CPU time is a large fraction of the JVM's uptime, i.e. they have kept a core busy for much of the process's life. CPU time is cumulative since the thread started, so this is a hot-loop candidate to investigate, not a confirmed problem.",
+                        "Highlights RUNNABLE platform threads whose accumulated CPU time is a large fraction of the JVM's uptime, i.e. they have kept a core busy for much of the process's life. CPU time is cumulative since the thread started, so this is a hot-loop candidate to investigate, not a confirmed problem. The rule skips when its bounded platform-thread detail page is incomplete.",
                         "Correlate with two consecutive thread snapshots; if CPU keeps climbing for the same thread, profile its stack for a hot or spinning loop.",
                         "https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/ThreadMXBean.html"));
     }
@@ -553,6 +559,10 @@ final class RunawayCpuThreadRule extends AbstractMemoryRule {
         ThreadData threads = context.threads();
         if (!threads.cpuTimeSupported()) {
             return skipped("Per-thread CPU timing is not supported or not enabled on this JVM.");
+        }
+        if (threads.detailsTruncated()) {
+            return skipped(
+                    "Per-thread details are capped at 1,000 platform threads; CPU-hot-thread analysis is incomplete.");
         }
         long uptimeMillis = context.runtime().uptimeMillis();
         if (uptimeMillis <= 0) {
@@ -911,7 +921,8 @@ final class UnequalInitialAndMaxHeapRule extends AbstractMemoryRule {
             return skipped("Initial or maximum heap size is not available.");
         }
         if (initial < memory.heapMax()) {
-            return violation("-Xms " + MemoryFormat.bytes(initial) + " is smaller than -Xmx "
+            String initialLabel = memory.hasJvmArgumentPrefix("-Xms") ? "-Xms" : "Initial heap";
+            return violation(initialLabel + " " + MemoryFormat.bytes(initial) + " is smaller than -Xmx "
                     + MemoryFormat.bytes(memory.heapMax())
                     + "; for a low-latency collector, setting them equal avoids heap-resize latency.");
         }
@@ -934,7 +945,7 @@ final class CompressedOopsCliffRule extends AbstractMemoryRule {
                 "Max heap is just above the compressed-oops threshold",
                 MemoryCategory.HEAP_PRESSURE,
                 "INFO",
-                "Notes a max heap just above the boundary where the JVM disables compressed ordinary object pointers, after which 64-bit references take more space and a heap just over the boundary can hold fewer live objects than one capped just below it. The boundary defaults to ~32 GiB but scales with -XX:ObjectAlignmentInBytes. The note is skipped for ZGC (which does not use compressed oops) and when compressed oops are explicitly disabled.",
+                "Notes a max heap just above the boundary where HotSpot ergonomically disables compressed ordinary object pointers, after which 64-bit references take more space and a heap just over the boundary can hold fewer live objects than one capped just below it. The boundary defaults to ~32 GiB but scales with -XX:ObjectAlignmentInBytes. A false live UseCompressedOops value above that boundary is the expected ergonomic symptom, not a reason to skip; the note is skipped for ZGC and an explicit -XX:-UseCompressedOops.",
                 "Either cap the heap just below the compressed-oops boundary, or grow it well past this range (and scale out) when a larger heap is genuinely required.",
                 "https://wiki.openjdk.org/display/HotSpot/CompressedOops"));
     }
@@ -949,17 +960,17 @@ final class CompressedOopsCliffRule extends AbstractMemoryRule {
         if (memory.usesGarbageCollector("zgc") || memory.usesGarbageCollector("z generational")) {
             return skipped("ZGC does not use compressed object pointers, so the heap-size cliff does not apply.");
         }
-        // Ground-truth check: try the live VM option before falling back to the arg heuristic.
+        // The live option is false ergonomically once an oversized heap has already crossed the
+        // boundary, so only an explicit disable suppresses this advisory.
         Boolean useCompressedOops = context.runtime().useCompressedOops();
-        if (useCompressedOops != null) {
-            if (!useCompressedOops) {
-                return skipped("Compressed object pointers are disabled (UseCompressedOops=false).");
-            }
-        } else if (memory.hasJvmArgument("-XX:-UseCompressedOops")) {
+        if (memory.hasJvmArgument("-XX:-UseCompressedOops")) {
             return skipped("Compressed object pointers are explicitly disabled (-XX:-UseCompressedOops).");
         }
         long alignment = parseObjectAlignmentBytes(memory.inputArguments());
         long boundary = alignment * COMPRESSED_OOPS_HEAP_PER_ALIGNMENT_BYTE;
+        if (useCompressedOops != null && !useCompressedOops && heapMax <= boundary) {
+            return skipped("Compressed object pointers are disabled (UseCompressedOops=false).");
+        }
         long upperBound = boundary + boundary / 4;
         if (heapMax > boundary && heapMax <= upperBound) {
             return violation("Max heap " + MemoryFormat.bytes(heapMax) + " is just above the ~"
@@ -1108,7 +1119,7 @@ final class PlatformThreadStackReservationRule extends AbstractMemoryRule {
                 "Platform thread stacks reserve a large amount of native memory",
                 MemoryCategory.NATIVE_MEMORY,
                 "HIGH",
-                "Estimates the native memory reserved for platform thread stacks (live platform threads times the -Xss/-XX:ThreadStackSize reservation) and flags when stacks alone are a large contributor to the off-heap footprint. Thread stacks are demand-paged virtual address-space reservations, not committed/resident memory: a JVM with many idle or shallow-call-depth threads can reserve a large amount while only a small fraction of it is ever touched (becomes resident), so a large reservation alone does not prove memory pressure. Virtual threads are excluded because their stacks live on the heap. Severity is HIGH only when the reservation is both a large share (>=20%) of a detected container memory limit AND, combined with memory already resident in the container, fully realizing the reservation would breach that limit (current + reserved >= limit) -- i.e. there is confirmed resident risk, not just a large reservation. Otherwise this is reported at MEDIUM: still worth reviewing, but without confirmed resident risk it may never materialize as actual memory pressure.",
+                "Estimates the native memory reserved for platform thread stacks (live platform threads times the -Xss/-XX:ThreadStackSize reservation) and flags when stacks alone are a large contributor to the off-heap footprint. Thread stacks are demand-paged virtual address-space reservations, not committed/resident memory: a JVM with many idle or shallow-call-depth threads can reserve a large amount while only a small fraction of it is ever touched (becomes resident), so a large reservation alone does not prove memory pressure. Virtual threads are excluded because their stacks live on the heap. Severity is HIGH only when the reservation is both a large share (>=20%) of a detected container memory limit and a worst-case bound would exceed that limit. Cgroup usage already includes touched stack pages, so this bound can double-count them; it is an escalation signal, not proof that the reservation will become resident.",
                 "Reduce the platform thread count (bound pools, prefer virtual threads or async I/O) or lower an oversized -Xss so thread stacks do not dominate native memory.",
                 "https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html"));
     }
@@ -1122,24 +1133,24 @@ final class PlatformThreadStackReservationRule extends AbstractMemoryRule {
         long stackBytes = context.runtime().threadStackBytes();
         long reserved = (long) platformThreads * stackBytes;
         Long limit = context.memory().containerMemoryLimitBytes();
-        Long current = context.memory().containerMemoryCurrentBytes();
+        Long current = context.memory().containerMemoryWorkingSetBytes() != null
+                ? context.memory().containerMemoryWorkingSetBytes()
+                : context.memory().containerMemoryCurrentBytes();
         boolean relativeBreach = limit != null && limit > 0 && reserved >= limit * CONTAINER_PERCENT_THRESHOLD / 100;
         boolean absoluteBreach = reserved >= ABSOLUTE_THRESHOLD;
         if (relativeBreach || absoluteBreach) {
-            // Confirmed resident risk: fully realizing the reservation, on top of memory already
-            // resident in the container, would breach the container limit. This distinguishes a
-            // genuine near-OOM risk from a large-but-mostly-untouched virtual-memory reservation --
-            // thread stacks are demand-paged, while cgroup accounting tracks resident usage, not
-            // reservations (kernel.org: memory.current is charged/resident memory, not a reservation).
-            boolean confirmedResidentRisk = relativeBreach && current != null && current + reserved >= limit;
-            String severity = confirmedResidentRisk ? MemoryRuleSupport.HIGH : MemoryRuleSupport.MEDIUM;
+            // This is a worst-case bound: cgroup usage already includes touched stack pages, but
+            // the JVM does not expose how much of each stack reservation is resident.
+            boolean worstCaseBreach = relativeBreach && current != null && current + reserved >= limit;
+            String severity = worstCaseBreach ? MemoryRuleSupport.HIGH : MemoryRuleSupport.MEDIUM;
             String relativeNote = limit != null && limit > 0
                     ? " (" + MemoryFormat.percentOf(reserved, limit) + "% of the container memory limit "
                             + MemoryFormat.bytes(limit) + ")"
                     : "";
-            String residencyNote = confirmedResidentRisk
-                    ? " Combined with the " + MemoryFormat.bytes(current) + " already resident in the container,"
-                            + " fully realizing this reservation would breach the container limit."
+            String residencyNote = worstCaseBreach
+                    ? " This worst-case bound double-counts touched stack pages already included in the "
+                            + MemoryFormat.bytes(current) + " charged to the container; fully realizing the"
+                            + " reservation would breach the limit."
                     : " This is a virtual-memory reservation, not confirmed resident usage; only a fraction of it"
                             + " may ever become resident.";
             return violation(
@@ -1301,7 +1312,7 @@ final class ContainerMemoryPressureRule extends AbstractMemoryRule {
                 "Container memory usage is near the cgroup limit",
                 MemoryCategory.NATIVE_MEMORY,
                 "HIGH",
-                "Reads the current cgroup memory usage (memory.current for cgroup v2, memory.usage_in_bytes for v1) and compares it against the detected container memory limit. When usage approaches the limit the container is at risk of an immediate OOM kill by the kernel, which is abrupt and does not trigger JVM OutOfMemoryError handling. Caveat: raw cgroup current-usage numbers can overstate real memory pressure. cgroup v2's memory.current includes reclaimable page cache, not only the process's own footprint, and cgroup v1's memory.usage_in_bytes is documented by the kernel itself as an approximate 'fuzz value' (the kernel's own guidance for an exact figure is memory.stat's RSS+CACHE breakdown). Treat a reading near the limit as a strong signal to investigate, not an exact resident-set measurement.",
+                "Reads the current cgroup memory usage (memory.current for cgroup v2, memory.usage_in_bytes for v1) and compares its working set against the detected container memory limit. When memory.stat exposes inactive file cache, the rule subtracts that reclaimable portion before evaluating pressure. A working set near the limit leaves little room for the next allocation; if the kernel cannot reclaim enough charged memory, it may OOM-kill a process without invoking JVM OutOfMemoryError handling.",
                 "Lower -Xmx/-XX:MaxRAMPercentage, reduce non-heap memory (thread stacks, Metaspace, direct buffers), or raise the container memory limit to restore headroom.",
                 "https://docs.oracle.com/en/java/javase/21/troubleshoot/diagnostic-tools.html"));
     }
@@ -1317,11 +1328,15 @@ final class ContainerMemoryPressureRule extends AbstractMemoryRule {
         if (current == null || current <= 0) {
             return skipped("Current container memory usage is not available (no cgroup files readable).");
         }
-        int percent = MemoryFormat.percentOf(current, limit);
+        Long workingSet = memory.containerMemoryWorkingSetBytes();
+        long measuredUsage = workingSet != null ? workingSet : current;
+        int percent = MemoryFormat.percentOf(measuredUsage, limit);
         if (percent >= THRESHOLD_PERCENT) {
-            return violation("Container memory usage is " + percent + "% of the cgroup limit ("
-                    + MemoryFormat.bytes(current) + " of " + MemoryFormat.bytes(limit)
-                    + "); the process is at immediate risk of an OOM kill.");
+            String usageLabel = workingSet != null ? "Container working set" : "Container memory usage";
+            return violation(
+                    usageLabel + " is " + percent + "% of the cgroup limit ("
+                            + MemoryFormat.bytes(measuredUsage) + " of " + MemoryFormat.bytes(limit)
+                            + "); if the kernel cannot reclaim enough charged memory for the next allocation, it may OOM-kill a process.");
         }
         return pass();
     }
@@ -1584,12 +1599,12 @@ final class GcEventDurationOutlierRule extends AbstractMemoryRule {
                 MemoryCategory.GC_CONFIGURATION,
                 "MEDIUM",
                 "Compares GcInfo.endTime across collector beans to identify the garbage-collection event that"
-                        + " actually completed most recently, then flags when its duration exceeds "
+                        + " actually completed most recently before this scan's histogram, then flags when its duration exceeds "
                         + PAUSE_THRESHOLD_MILLIS + " ms. GcInfo duration is elapsed collection time and is not"
                         + " necessarily a stop-the-world pause for concurrent collectors. This complements the"
                         + " lifetime and recent GC-overhead-ratio checks (MEM-GC-002/MEM-GC-003): a JVM can stay"
                         + " under those ratio thresholds while still reporting a long collection event. This is"
-                        + " a single-sample reading taken fresh on every scan, not a cross-scan trend.",
+                        + " a single-event reading; an unchanged event from the prior scan's histogram is skipped.",
                 "Capture unified GC logs (-Xlog:gc*:file=gc.log:time,level,tags) and inspect the event's phases"
                         + " and cause before tuning heap size, allocation rate, or collector pause goals.",
                 "https://docs.oracle.com/en/java/javase/21/docs/api/jdk.management/com/sun/management/GcInfo.html"));
@@ -1597,15 +1612,16 @@ final class GcEventDurationOutlierRule extends AbstractMemoryRule {
 
     @Override
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
-        long durationMillis = context.runtime().lastGcDurationMillis();
+        MemoryContext.GcEvent latestGcEvent = context.latestGcEvent();
+        long durationMillis = latestGcEvent.durationMillis();
         if (durationMillis < 0) {
-            return skipped("The most recent GC event duration is not available (requires a HotSpot JVM and at"
-                    + " least one collection since JVM start).");
+            return skipped("No new application GC event is available (requires a HotSpot JVM and a collection since"
+                    + " the previous scan).");
         }
         if (durationMillis < PAUSE_THRESHOLD_MILLIS) {
             return pass();
         }
-        String collectorName = context.runtime().lastGcCollectorName();
+        String collectorName = latestGcEvent.collectorName();
         String collectorNote = collectorName != null && !collectorName.isBlank() ? " (" + collectorName + ")" : "";
         return violation("The most recently completed GC event took " + durationMillis + " ms" + collectorNote
                 + ", at or above the " + PAUSE_THRESHOLD_MILLIS + " ms threshold.");
@@ -1624,21 +1640,22 @@ final class BufferPoolGrowthWithoutReleaseRule extends AbstractMemoryRule {
         super(
                 new MemoryRuleDefinition(
                         "MEM-POOL-007",
-                        "Buffer pool usage has grown on every recent scan without release",
+                        "Direct buffer usage has grown on every recent scan without release",
                         MemoryCategory.MEMORY_POOLS,
                         "MEDIUM",
-                        "Tracks each java.nio buffer pool's (BufferPoolMXBean, typically 'direct' and 'mapped') used-byte"
-                                + " reading across scans and flags a pool whose usage has strictly increased on every one of"
+                        "Tracks the java.nio 'direct' BufferPoolMXBean used-byte reading across scans and flags usage"
+                                + " that has strictly increased on every one of"
                                 + " the last " + GROWTH_STREAK_THRESHOLD + " consecutive scans with no decrease in"
-                                + " between -- the classic native-memory-leak signature of leaked direct/mapped ByteBuffers"
-                                + " (common with NIO channel or Netty-style misuse where buffers are allocated but never"
-                                + " released). This can catch a leak while the pool is still well under MEM-POOL-003's"
+                                + " between -- a native-memory-leak signal for leaked direct ByteBuffers (common with NIO"
+                                + " channel or Netty-style misuse where buffers are allocated but never released). Mapped"
+                                + " buffers are excluded because their usage follows file mappings rather than the direct"
+                                + " memory cap. This can catch a leak while direct memory is still well under MEM-POOL-003's"
                                 + " static high-water threshold, since a monotonic trend is a stronger signal than any"
                                 + " single absolute reading. Escalates to HIGH when the growing pool is the 'direct' pool"
                                 + " and MEM-POOL-003's static threshold has also been crossed. Requires several consecutive"
                                 + " user-triggered scans to build a trend; the first scans only establish the baseline.",
-                        "Audit code paths that allocate direct or mapped ByteBuffers (including NIO channels and libraries"
-                                + " like Netty) for missing release/cleaner calls, and confirm the pool eventually plateaus"
+                        "Audit code paths that allocate direct ByteBuffers (including NIO channels and libraries like"
+                                + " Netty) for missing release/cleaner calls, and confirm the pool eventually plateaus"
                                 + " or shrinks under normal load instead of only ever growing.",
                         "https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/BufferPoolMXBean.html"));
     }
@@ -1655,17 +1672,19 @@ final class BufferPoolGrowthWithoutReleaseRule extends AbstractMemoryRule {
         boolean directPoolAtStaticThreshold = MemoryRuleSupport.VIOLATION.equals(
                 new DirectBufferGrowthRule().evaluate(context).status());
         for (MemoryContext.BufferPoolSnapshot pool : pools) {
+            if (!"direct".equalsIgnoreCase(pool.name())) {
+                continue;
+            }
             int streak = trend.streakFor(pool.name());
             if (streak < GROWTH_STREAK_THRESHOLD) {
                 continue;
             }
-            boolean isDirectPool = "direct".equalsIgnoreCase(pool.name());
-            if (isDirectPool && directPoolAtStaticThreshold) {
+            if (directPoolAtStaticThreshold) {
                 escalateToHigh = true;
             }
             details.add("'" + pool.name() + "' buffer pool usage grew on " + streak
                     + " consecutive scans without a decrease (now " + MemoryFormat.bytes(pool.used())
-                    + "); this is the classic native-memory-leak signature for leaked direct/mapped buffers.");
+                    + "); review direct-buffer allocation and release paths for a native-memory leak.");
         }
         if (details.isEmpty()) {
             return pass();

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryScanner.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 
 /**
- * Bounded, on-demand Memory Advisor.
+ * On-demand Memory Advisor.
  *
  * <p>The scanner aggregates the JVM data already produced by the Memory, Threads, and Heap Dump
  * panels into a {@link MemoryContext} and runs a curated registry of static health rules.
@@ -55,6 +55,9 @@ public final class MemoryScanner {
      */
     private MemoryContext.GcSample previousGcSample;
 
+    /** Post-histogram latest GC event from the previous scan, guarded by single-flight admission. */
+    private MemoryContext.GcEvent previousPostHistogramGcEvent = MemoryContext.GcEvent.unavailable();
+
     /**
      * Cross-scan state for MEM-POOL-007's buffer-pool growth-without-release trend: each pool's used
      * bytes and consecutive-increase streak as of the previous scan. Guarded by single-flight admission.
@@ -85,8 +88,9 @@ public final class MemoryScanner {
     /**
      * Builds the production scanner over the shared {@link ThreadDumpService} and the
      * {@code GC.class_histogram} diagnostic command, exactly as both adapters did inline before the
-     * extraction. The thread snapshot is read unbounded ({@code limit 1000}) so the thread rules see
-     * the full picture; the histogram forces a full GC, so callers gate the scan accordingly.
+     * extraction. The thread snapshot retains complete summary counts but bounds per-thread detail to
+     * 1,000 rows; the CPU-hot-thread rule skips when that detail is truncated. The histogram forces a
+     * full GC, so callers gate the scan accordingly.
      */
     public static MemoryScanner create(ThreadDumpService threadDumpService, Clock clock) {
         return new MemoryScanner(
@@ -124,16 +128,22 @@ public final class MemoryScanner {
                     List.of());
         }
 
-        MemoryContext.GcSample currentSample = MemoryContext.GcSample.from(context.runtime());
+        MemoryContext.GcSample currentSample = context.postHistogramGc();
         MemoryContext.GcTrend trend = previousGcSample == null
                 ? MemoryContext.GcTrend.unavailable()
                 : MemoryContext.GcTrend.between(previousGcSample, context.preHistogramGc());
         previousGcSample = currentSample;
+        MemoryContext.GcEvent latestGcEvent = context.latestGcEvent().sameEvent(previousPostHistogramGcEvent)
+                ? MemoryContext.GcEvent.unavailable()
+                : context.latestGcEvent();
+        previousPostHistogramGcEvent = context.postHistogramGcEvent();
         MemoryContext.BufferPoolTrend bufferPoolTrend =
                 computeBufferPoolTrend(context.memory().bufferPools());
         MemoryContext.OldGenTrend oldGenTrend = computeOldGenTrend(context.postGcHeap());
-        MemoryContext evaluated =
-                context.withGcTrend(trend).withBufferPoolTrend(bufferPoolTrend).withOldGenTrend(oldGenTrend);
+        MemoryContext evaluated = context.withGcTrend(trend)
+                .withLatestGcEvent(latestGcEvent)
+                .withBufferPoolTrend(bufferPoolTrend)
+                .withOldGenTrend(oldGenTrend);
 
         List<MemoryRuleResultDto> results = MemoryRuleRegistry.activeRules().stream()
                 .map(rule -> rule.evaluate(evaluated))

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCollectorTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCollectorTests.java
@@ -35,4 +35,112 @@ class MemoryCollectorTests {
         assertThat(detector.detectLimit()).isEqualTo(OptionalLong.of(1_073_741_824L));
         assertThat(detector.detectCurrentUsage()).isEqualTo(OptionalLong.of(536_870_912L));
     }
+
+    @Test
+    void resolvesNestedCgroupV2PathsAndComputesWorkingSet() throws Exception {
+        Path mountPoint = tempDir.resolve("cgroup2");
+        Path processCgroup = mountPoint.resolve("kubepods/pod-a");
+        Files.createDirectories(processCgroup);
+        Files.writeString(processCgroup.resolve("memory.max"), "1073741824\n");
+        Files.writeString(processCgroup.resolve("memory.current"), "805306368\n");
+        Files.writeString(processCgroup.resolve("memory.stat"), "inactive_file 268435456\n");
+        Path selfCgroup = tempDir.resolve("self.cgroup");
+        Path mountInfo = tempDir.resolve("mountinfo");
+        Files.writeString(selfCgroup, "0::/kubepods/pod-a\n");
+        Files.writeString(mountInfo, "29 23 0:26 / " + mountPoint + " rw - cgroup2 cgroup rw\n");
+
+        ContainerMemoryLimitDetector detector = ContainerMemoryLimitDetector.fromProcFiles(selfCgroup, mountInfo);
+        ContainerMemoryLimitDetector.CgroupMemorySample sample = detector.detect();
+
+        assertThat(sample.limit()).isEqualTo(OptionalLong.of(1_073_741_824L));
+        assertThat(sample.current()).isEqualTo(OptionalLong.of(805_306_368L));
+        assertThat(sample.workingSet()).isEqualTo(OptionalLong.of(536_870_912L));
+    }
+
+    @Test
+    void usesTheMostRestrictiveFiniteParentCgroupLimit() throws Exception {
+        Path mountPoint = tempDir.resolve("cgroup2");
+        Path parentCgroup = mountPoint.resolve("kubepods");
+        Path processCgroup = parentCgroup.resolve("pod-a");
+        Files.createDirectories(processCgroup);
+        Files.writeString(processCgroup.resolve("memory.max"), "2147483648\n");
+        Files.writeString(processCgroup.resolve("memory.current"), "536870912\n");
+        Files.writeString(parentCgroup.resolve("memory.max"), "1073741824\n");
+        Path selfCgroup = tempDir.resolve("self.cgroup");
+        Path mountInfo = tempDir.resolve("mountinfo");
+        Files.writeString(selfCgroup, "0::/kubepods/pod-a\n");
+        Files.writeString(mountInfo, "29 23 0:26 / " + mountPoint + " rw - cgroup2 cgroup rw\n");
+
+        ContainerMemoryLimitDetector detector = ContainerMemoryLimitDetector.fromProcFiles(selfCgroup, mountInfo);
+
+        assertThat(detector.detectLimit()).isEqualTo(OptionalLong.of(1_073_741_824L));
+        assertThat(detector.detectCurrentUsage()).isEqualTo(OptionalLong.of(536_870_912L));
+    }
+
+    @Test
+    void resolvesNestedCgroupV1MemoryControllerPaths() throws Exception {
+        Path mountPoint = tempDir.resolve("memory");
+        Path processCgroup = mountPoint.resolve("docker/example");
+        Files.createDirectories(processCgroup);
+        Files.writeString(processCgroup.resolve("memory.limit_in_bytes"), "1073741824\n");
+        Files.writeString(processCgroup.resolve("memory.usage_in_bytes"), "805306368\n");
+        Files.writeString(processCgroup.resolve("memory.stat"), "total_inactive_file 268435456\n");
+        Path selfCgroup = tempDir.resolve("self.cgroup");
+        Path mountInfo = tempDir.resolve("mountinfo");
+        Files.writeString(selfCgroup, "7:memory:/docker/example\n");
+        Files.writeString(mountInfo, "30 23 0:27 / " + mountPoint + " rw - cgroup cgroup rw,memory\n");
+
+        ContainerMemoryLimitDetector detector = ContainerMemoryLimitDetector.fromProcFiles(selfCgroup, mountInfo);
+        ContainerMemoryLimitDetector.CgroupMemorySample sample = detector.detect();
+
+        assertThat(sample.limit()).isEqualTo(OptionalLong.of(1_073_741_824L));
+        assertThat(sample.current()).isEqualTo(OptionalLong.of(805_306_368L));
+        assertThat(sample.workingSet()).isEqualTo(OptionalLong.of(536_870_912L));
+    }
+
+    @Test
+    void fallsBackToV1MemoryControllerWhenUnifiedMountHasNoMemoryLimit() throws Exception {
+        Path unifiedMount = tempDir.resolve("unified");
+        Path memoryMount = tempDir.resolve("memory");
+        Path processCgroup = memoryMount.resolve("docker/example");
+        Files.createDirectories(unifiedMount);
+        Files.createDirectories(processCgroup);
+        Files.writeString(processCgroup.resolve("memory.limit_in_bytes"), "1073741824\n");
+        Files.writeString(processCgroup.resolve("memory.usage_in_bytes"), "536870912\n");
+        Path selfCgroup = tempDir.resolve("self.cgroup");
+        Path mountInfo = tempDir.resolve("mountinfo");
+        Files.writeString(selfCgroup, "0::/\n7:memory:/docker/example\n");
+        Files.writeString(
+                mountInfo,
+                "29 23 0:26 / " + unifiedMount + " rw - cgroup2 cgroup rw\n" + "30 23 0:27 / " + memoryMount
+                        + " rw - cgroup cgroup rw,memory\n");
+
+        ContainerMemoryLimitDetector detector = ContainerMemoryLimitDetector.fromProcFiles(selfCgroup, mountInfo);
+
+        assertThat(detector.detectLimit()).isEqualTo(OptionalLong.of(1_073_741_824L));
+        assertThat(detector.detectCurrentUsage()).isEqualTo(OptionalLong.of(536_870_912L));
+    }
+
+    @Test
+    void resolvesNamespaceRootWhenMountInfoUsesTheHostCgroupRoot() throws Exception {
+        Path mountPoint = tempDir.resolve("memory");
+        Files.createDirectories(mountPoint);
+        Files.writeString(mountPoint.resolve("memory.limit_in_bytes"), "1073741824\n");
+        Files.writeString(mountPoint.resolve("memory.usage_in_bytes"), "536870912\n");
+        Path selfCgroup = tempDir.resolve("self.cgroup");
+        Path mountInfo = tempDir.resolve("mountinfo");
+        Files.writeString(selfCgroup, "7:memory:/\n");
+        Files.writeString(mountInfo, "30 23 0:27 /docker/example " + mountPoint + " rw - cgroup cgroup rw,memory\n");
+
+        ContainerMemoryLimitDetector detector = ContainerMemoryLimitDetector.fromProcFiles(selfCgroup, mountInfo);
+
+        assertThat(detector.detectLimit()).isEqualTo(OptionalLong.of(1_073_741_824L));
+        assertThat(detector.detectCurrentUsage()).isEqualTo(OptionalLong.of(536_870_912L));
+    }
+
+    @Test
+    void parsesTerabyteMemorySizesAcceptedByHotSpot() {
+        assertThat(MemoryCollector.parseMemorySize("1t")).isEqualTo(1024L * 1024 * 1024 * 1024);
+        assertThat(MemoryCollector.parseMemorySize("1T")).isEqualTo(1024L * 1024 * 1024 * 1024);
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryRulesTests.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.github.jdubois.bootui.core.dto.HeapClassHistogramEntryDto;
 import io.github.jdubois.bootui.core.dto.MemoryReport;
 import io.github.jdubois.bootui.core.dto.MemoryRuleResultDto;
+import io.github.jdubois.bootui.core.dto.ThreadInfoDto;
 import io.github.jdubois.bootui.core.dto.ThreadStateCountDto;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.ClassLoadingData;
+import io.github.jdubois.bootui.engine.memory.MemoryContext.GcEvent;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.GcSample;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.GcTrend;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.HeapContentData;
@@ -112,11 +114,26 @@ class MemoryRulesTests {
     }
 
     @Test
-    void compressedOopsCliffSkippedWhenVmOptionReturnsFalse() {
+    void compressedOopsCliffReportsHotSpotErgonomicDisableAboveBoundary() {
         MemoryData memory =
                 memory(10 * GB, 40 * GB, List.of(), null, List.of("-Xmx40g"), List.of("G1 Young Generation"));
         RuntimeData runtime = runtimeWithCompressedOops(Boolean.FALSE);
         MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), runtime);
+
+        assertThat(find(scan(context), "MEM-HEAP-004")).isNotNull();
+    }
+
+    @Test
+    void compressedOopsCliffIsSkippedWhenExplicitlyDisabled() {
+        MemoryData memory = memory(
+                10 * GB,
+                40 * GB,
+                List.of(),
+                null,
+                List.of("-Xmx40g", "-XX:-UseCompressedOops"),
+                List.of("G1 Young Generation"));
+        MemoryContext context = context(
+                memory, ThreadData.empty(), PostGcHeapData.unavailable(), runtimeWithCompressedOops(Boolean.FALSE));
 
         assertThat(find(scan(context), "MEM-HEAP-004")).isNull();
     }
@@ -177,10 +194,10 @@ class MemoryRulesTests {
     }
 
     @Test
-    void stackReservationWithConfirmedResidentRiskIsHigh() {
+    void stackReservationWithWorstCaseContainerBoundIsHigh() {
         // 300 threads * 1 MiB stack = 300 MiB reservation, >=20% of the 1 GiB limit (ratio breach).
         // 800 MiB already resident + 300 MiB reservation = 1100 MiB >= the 1 GiB limit, so fully
-        // realizing the reservation would breach the container limit: confirmed resident risk.
+        // realizing the reservation would breach the container limit as a worst-case bound.
         ThreadData threads = threads(300);
         MemoryData memory = memoryWithCurrent(256 * MB, 2 * GB, 1 * GB, 800 * MB);
         MemoryContext context = context(memory, threads, PostGcHeapData.unavailable(), healthyRuntime());
@@ -189,7 +206,7 @@ class MemoryRulesTests {
 
         assertThat(result).isNotNull();
         assertThat(result.severity()).isEqualTo("HIGH");
-        assertThat(result.sampleViolations().get(0)).contains("already resident");
+        assertThat(result.sampleViolations().get(0)).contains("worst-case").contains("double-counts");
     }
 
     @Test
@@ -364,6 +381,45 @@ class MemoryRulesTests {
         assertThat(result.severity()).isEqualTo("INFO");
     }
 
+    @Test
+    void cpuHotThreadRuleSkipsWhenThreadDetailsAreTruncated() {
+        ThreadInfoDto hot = new ThreadInfoDto(
+                1001,
+                "worker-1001",
+                "RUNNABLE",
+                5,
+                false,
+                false,
+                290_000L,
+                100_000L,
+                0,
+                0,
+                false,
+                false,
+                false,
+                null,
+                null,
+                null,
+                List.of());
+        ThreadData threads = new ThreadData(
+                1001,
+                1001,
+                0,
+                true,
+                false,
+                List.of(),
+                List.of(new ThreadStateCountDto("RUNNABLE", 1001)),
+                List.of(hot),
+                true);
+        MemoryContext context = context(
+                memory(256 * MB, 2 * GB, List.of(), null, List.of()),
+                threads,
+                PostGcHeapData.unavailable(),
+                healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-THREAD-004")).isNull();
+    }
+
     // --- MEM-GC-003: recent GC overhead (cross-scan trend) -----------------------------------
 
     @Test
@@ -430,7 +486,7 @@ class MemoryRulesTests {
         assertThat(MemoryCollector.isConcurrentCycleBean("ZGC Cycles")).isTrue();
         assertThat(MemoryCollector.isConcurrentCycleBean("ZGC Major Cycles")).isTrue();
         assertThat(MemoryCollector.isConcurrentCycleBean("Shenandoah Cycles")).isTrue();
-        assertThat(MemoryCollector.isConcurrentCycleBean("G1 Concurrent GC")).isTrue();
+        assertThat(MemoryCollector.isConcurrentCycleBean("G1 Concurrent GC")).isFalse();
         assertThat(MemoryCollector.isConcurrentCycleBean("ConcurrentMarkSweep")).isTrue();
         assertThat(MemoryCollector.isConcurrentCycleBean("G1 Young Generation")).isFalse();
         assertThat(MemoryCollector.isConcurrentCycleBean("G1 Old Generation")).isFalse();
@@ -488,6 +544,14 @@ class MemoryRulesTests {
     @Test
     void containerCurrentWellBelowLimitIsNotFlagged() {
         MemoryData memory = memoryWithCurrent(256 * MB, 2 * GB, 4 * GB, GB);
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-FOOTPRINT-003")).isNull();
+    }
+
+    @Test
+    void reclaimableInactiveFileCacheDoesNotTriggerContainerPressure() {
+        MemoryData memory = memoryWithWorkingSet(256 * MB, 2 * GB, 4 * GB, 3700L * MB, 2 * GB);
         MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
 
         assertThat(find(scan(context), "MEM-FOOTPRINT-003")).isNull();
@@ -581,6 +645,19 @@ class MemoryRulesTests {
                 gcContextWithCollectors(600_000, 10_000, Map.of("G1 Young Generation", 100L, "G1 Old Generation", 0L));
         MemoryContext second =
                 gcContextWithCollectors(620_000, 11_000, Map.of("G1 Young Generation", 110L, "G1 Old Generation", 0L));
+        MemoryScanner scanner = new MemoryScanner(sequence(first, second), CLOCK);
+
+        scanner.scan();
+
+        assertThat(find(scanner.scan(), "MEM-GC-005")).isNull();
+    }
+
+    @Test
+    void g1FullGcLifetimeCountIsNotReportedAsAScanDelta() {
+        MemoryContext first =
+                gcContextWithCollectors(600_000, 10_000, Map.of("G1 Young Generation", 100L, "G1 Old Generation", 3L));
+        MemoryContext second =
+                gcContextWithCollectors(620_000, 11_000, Map.of("G1 Young Generation", 110L, "G1 Old Generation", 3L));
         MemoryScanner scanner = new MemoryScanner(sequence(first, second), CLOCK);
 
         scanner.scan();
@@ -840,11 +917,35 @@ class MemoryRulesTests {
     }
 
     @Test
+    void containerLimitWithHotSpotMaxHeapAliasIsNotFlagged() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of("-XX:MaxHeapSize=2g"));
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-GC-001")).isNull();
+    }
+
+    @Test
     void containerLimitWithRamPercentageIsNotFlagged() {
         MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of("-XX:MaxRAMPercentage=75.0"));
         MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
 
         assertThat(find(scan(context), "MEM-GC-001")).isNull();
+    }
+
+    @Test
+    void containerLimitWithMaxRamFractionIsNotFlagged() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of("-XX:MaxRAMFraction=2"));
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-GC-001")).isNull();
+    }
+
+    @Test
+    void containerLimitWithOnlyMinRamPercentageIsStillFlagged() {
+        MemoryData memory = memory(256 * MB, 2 * GB, List.of(), 4 * GB, List.of("-XX:MinRAMPercentage=50.0"));
+        MemoryContext context = context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
+
+        assertThat(find(scan(context), "MEM-GC-001")).isNotNull();
     }
 
     @Test
@@ -1048,6 +1149,20 @@ class MemoryRulesTests {
         assertThat(find(scan(context), "MEM-GC-006")).isNull();
     }
 
+    @Test
+    void priorScansHistogramGcEventIsNotReportedAsANewOutlier() {
+        GcEvent applicationEvent = new GcEvent(5, 500, 200, "G1 Young Generation");
+        GcEvent histogramEvent = new GcEvent(6, 1_000, 1_500, "G1 Old Generation");
+        MemoryScanner scanner = new MemoryScanner(
+                sequence(
+                        gcEventContext(applicationEvent, histogramEvent),
+                        gcEventContext(histogramEvent, new GcEvent(7, 2_000, 1_500, "G1 Old Generation"))),
+                CLOCK);
+
+        assertThat(find(scanner.scan(), "MEM-GC-006")).isNull();
+        assertThat(find(scanner.scan(), "MEM-GC-006")).isNull();
+    }
+
     // --- MEM-POOL-007: buffer pool growth without release (new rule) -------------------------
 
     @Test
@@ -1099,6 +1214,23 @@ class MemoryRulesTests {
                         bufferPoolContext(150 * MB, 10 * MB, 1 * GB),
                         bufferPoolContext(120 * MB, 10 * MB, 1 * GB),
                         bufferPoolContext(180 * MB, 10 * MB, 1 * GB)),
+                CLOCK);
+
+        scanner.scan();
+        scanner.scan();
+        scanner.scan();
+
+        assertThat(find(scanner.scan(), "MEM-POOL-007")).isNull();
+    }
+
+    @Test
+    void mappedBufferGrowthIsNotReportedAsADirectMemoryLeak() {
+        MemoryScanner scanner = new MemoryScanner(
+                sequence(
+                        bufferPoolContext("mapped", 100 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext("mapped", 150 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext("mapped", 200 * MB, 10 * MB, 1 * GB),
+                        bufferPoolContext("mapped", 250 * MB, 10 * MB, 1 * GB)),
                 CLOCK);
 
         scanner.scan();
@@ -1200,6 +1332,7 @@ class MemoryRulesTests {
             long uptimeMillis, long gcTimeMillis, Map<String, Long> collectorCounts) {
         long gcCount =
                 collectorCounts.values().stream().mapToLong(Long::longValue).sum();
+        GcSample sample = new GcSample(uptimeMillis, gcTimeMillis, gcCount, collectorCounts);
         return new MemoryContext(
                 memory(256 * MB, 2 * GB, List.of(), null, List.of()),
                 ThreadData.empty(),
@@ -1207,8 +1340,31 @@ class MemoryRulesTests {
                 PostGcHeapData.unavailable(),
                 ClassLoadingData.empty(),
                 new RuntimeData(uptimeMillis, gcTimeMillis, gcCount, 0, -1, MB, 4, -1, -1, null),
-                new GcSample(uptimeMillis, gcTimeMillis, gcCount, collectorCounts),
-                GcTrend.unavailable());
+                sample,
+                sample,
+                null,
+                null,
+                GcTrend.unavailable(),
+                null,
+                null);
+    }
+
+    private static MemoryContext gcEventContext(GcEvent latestGcEvent, GcEvent postHistogramGcEvent) {
+        GcSample sample = new GcSample(300_000, 1_500, 50);
+        return new MemoryContext(
+                memory(256 * MB, 2 * GB, List.of(), null, List.of()),
+                ThreadData.empty(),
+                HeapContentData.unavailable(),
+                PostGcHeapData.unavailable(),
+                ClassLoadingData.empty(),
+                healthyRuntime(),
+                sample,
+                sample,
+                latestGcEvent,
+                postHistogramGcEvent,
+                GcTrend.unavailable(),
+                null,
+                null);
     }
 
     private static RuntimeData healthyRuntime() {
@@ -1250,6 +1406,11 @@ class MemoryRulesTests {
      */
     private static MemoryContext bufferPoolContext(
             long directPoolUsed, long directBufferCapacity, long maxDirectMemoryBytes) {
+        return bufferPoolContext("direct", directPoolUsed, directBufferCapacity, maxDirectMemoryBytes);
+    }
+
+    private static MemoryContext bufferPoolContext(
+            String poolName, long poolUsed, long directBufferCapacity, long maxDirectMemoryBytes) {
         MemoryData memory = new MemoryData(
                 256 * MB,
                 256 * MB,
@@ -1266,7 +1427,7 @@ class MemoryRulesTests {
                 List.of("G1 Young Generation"),
                 null,
                 null,
-                List.of(new MemoryContext.BufferPoolSnapshot("direct", directPoolUsed, directPoolUsed, 10)));
+                List.of(new MemoryContext.BufferPoolSnapshot(poolName, poolUsed, poolUsed, 10)));
         return context(memory, ThreadData.empty(), PostGcHeapData.unavailable(), healthyRuntime());
     }
 
@@ -1322,6 +1483,11 @@ class MemoryRulesTests {
 
     private static MemoryData memoryWithCurrent(
             long heapUsed, long heapMax, Long containerLimit, Long containerCurrent) {
+        return memoryWithWorkingSet(heapUsed, heapMax, containerLimit, containerCurrent, null);
+    }
+
+    private static MemoryData memoryWithWorkingSet(
+            long heapUsed, long heapMax, Long containerLimit, Long containerCurrent, Long containerWorkingSet) {
         return new MemoryData(
                 heapUsed,
                 heapUsed,
@@ -1337,6 +1503,8 @@ class MemoryRulesTests {
                 List.of(),
                 List.of("G1 Young Generation"),
                 containerLimit,
-                containerCurrent);
+                containerCurrent,
+                containerWorkingSet,
+                List.of());
     }
 }

--- a/docs/MEMORY-CHECKS.md
+++ b/docs/MEMORY-CHECKS.md
@@ -8,11 +8,12 @@ This advisor is complementary to the **Live Memory** and **Threads** panels: tho
 
 ## Availability and bounds
 
-The panel is always available (the JVM always exposes memory and thread beans). Readings that a particular JVM does not expose — a class histogram, per-thread CPU time, cumulative GC time, a previous-GC baseline, a container memory limit — are skipped gracefully and reported rather than failing the panel. The class histogram is only collected on an explicit scan. The Rule results panel lists only checks that found findings, ordered by severity, finding count, and rule id.
+The panel is always available (the JVM always exposes memory and thread beans). Readings that a particular JVM does not expose — a class histogram, per-thread CPU time, cumulative GC time, a previous-GC baseline, a container memory limit — are skipped gracefully and reported rather than failing the panel. The class histogram is only collected on an explicit scan. `ThreadMXBean` observations cover platform threads, not virtual threads; the CPU-hot-thread rule also skips when its bounded 1,000-row thread-detail page is incomplete. The Rule results panel lists only checks that found findings, ordered by severity, finding count, and rule id.
 
 ## Known limitations
 
-- **Container-limit detection assumes the process's cgroup is the container root.** Every container-aware check (MEM-FOOTPRINT-001/002/003/004, MEM-GC-001/004/007, MEM-POOL-004) uses one shared detector for the fixed root-level cgroup limit/current paths (for example `/sys/fs/cgroup/memory.max`). This is correct under the default modern Docker/Kubernetes setup where the process's own cgroup **is** the container root. It is not correct under `--cgroupns=host` or some older/nested container runtimes, where the process's actual cgroup lives elsewhere in the hierarchy; in that situation these paths read as "no container memory limit detected." A full fix would resolve the process's cgroup path via `/proc/self/cgroup` and `/proc/self/mountinfo`; no supported public JVM API exposes HotSpot's internal cgroup metrics.
+- **Container data is Linux cgroup data, not a process RSS measurement.** The shared detector resolves the process's cgroup through `/proc/self/cgroup` and `/proc/self/mountinfo`, then uses the most restrictive finite limit on its path to the cgroup mount root. When `memory.stat` supplies inactive file cache, container-pressure checks use `current - inactive_file` as a working-set estimate. The estimate remains cgroup-scoped, includes descendants, and can differ from process RSS; unavailable or unsupported cgroup mounts are skipped.
+- **The explicit histogram can influence cumulative GC counters.** `GC.class_histogram` requests a full GC unless the JVM cannot run one at that instant. Recent-GC and G1 Full-GC interval rules use a post-histogram baseline to exclude the scans' own collections, and the latest-event rule ignores an unchanged event from the prior histogram. Lifetime findings remain review prompts that should be correlated with GC logs.
 
 ## Severity scale
 
@@ -50,7 +51,7 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-HEAP-004 - Max heap is just above the compressed-oops threshold
 
 - **Severity**: INFO
-- **Detects**: A max heap in the narrow 25% window just above the boundary where the JVM disables compressed ordinary object pointers, after which 64-bit references take more space and a heap just over the boundary can hold fewer live objects than one capped just below it. The documented boundary is `4 GiB * ObjectAlignmentInBytes` (32 GiB at the default 8-byte alignment), so the default warning window is above 32 GiB through 40 GiB; deliberately larger heaps such as 47 GiB are not described as "just above." The rule reads the live `UseCompressedOops` VM option via HotSpot JMX when available, falling back to the input-arguments heuristic on non-HotSpot JVMs; it is skipped for ZGC and when compressed oops are disabled.
+- **Detects**: A max heap in the narrow 25% window just above the boundary where HotSpot ergonomically disables compressed ordinary object pointers, after which 64-bit references take more space and a heap just over the boundary can hold fewer live objects than one capped just below it. The documented boundary is `4 GiB * ObjectAlignmentInBytes` (32 GiB at the default 8-byte alignment), so the default warning window is above 32 GiB through 40 GiB; deliberately larger heaps such as 47 GiB are not described as "just above." A live `UseCompressedOops=false` result above that boundary is the expected HotSpot symptom and does not suppress the finding. The rule is skipped for ZGC and when compressed oops are explicitly disabled with `-XX:-UseCompressedOops`.
 - **Recommendation**: Either cap the heap just below the compressed-oops boundary, or grow it well past this range (and scale out) when a larger heap is genuinely required.
 - **Learn more**: <https://wiki.openjdk.org/display/HotSpot/CompressedOops>
 
@@ -86,15 +87,15 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 
 ### MEM-FOOTPRINT-002 - Platform thread stacks reserve a large amount of native memory
 
-- **Severity**: MEDIUM; HIGH only when the reservation is also a confirmed resident risk (see below)
-- **Detects**: Estimates native memory reserved for platform thread stacks (live platform threads times the -Xss/-XX:ThreadStackSize reservation) and flags when stacks alone reserve at least 1 GiB or at least 20% of the detected container memory limit. The actual stack size is read from the live `ThreadStackSize` JVM option via HotSpot JMX when available, falling back to any -Xss/-XX:ThreadStackSize command-line flag, and finally to a 1 MiB compile-time default. Thread stacks are demand-paged virtual-memory reservations, not committed/resident memory (kernel.org: cgroup `memory.current` tracks charged/resident memory, not reservations; the `/proc` docs' own VmSize-vs-VmRSS example shows a roughly 10x virtual-vs-resident gap) — a JVM with many idle or shallow-call-depth threads can reserve a large amount of stack memory while only a small fraction of it is ever touched (becomes resident), so a large reservation alone does not prove memory pressure. Severity is HIGH only when the reservation is both a large share (>=20%) of a detected container memory limit **and**, combined with memory already resident in the container, fully realizing the reservation would breach that limit (`current + reserved >= limit`) — i.e. there is confirmed resident risk, not just a large reservation. Otherwise the finding is reported at MEDIUM: still worth reviewing, but without confirmed resident risk it may never materialize as actual memory pressure. Virtual threads are excluded because their stacks live on the heap.
+- **Severity**: MEDIUM; HIGH only when a worst-case container bound would be breached
+- **Detects**: Estimates native memory reserved for platform thread stacks (live platform threads times the -Xss/-XX:ThreadStackSize reservation) and flags when stacks alone reserve at least 1 GiB or at least 20% of the detected container memory limit. The actual stack size is read from the live `ThreadStackSize` JVM option via HotSpot JMX when available, falling back to any -Xss/-XX:ThreadStackSize command-line flag, and finally to a 1 MiB compile-time default. Thread stacks are demand-paged virtual-memory reservations, not committed/resident memory, so a large reservation alone does not prove memory pressure. HIGH means the working set plus the full reservation would exceed the cgroup limit; it is a worst-case bound, not confirmed residency, because touched stack pages are already included in cgroup usage and therefore counted twice. Virtual threads are excluded because their stacks live on the heap.
 - **Recommendation**: Reduce the platform thread count (bound pools, prefer virtual threads or async I/O) or lower an oversized -Xss so thread stacks do not dominate native memory.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html>
 
 ### MEM-FOOTPRINT-003 - Container memory usage is near the cgroup limit
 
 - **Severity**: HIGH
-- **Detects**: Reads current container memory usage from cgroup files (cgroup v2: `memory.current`; cgroup v1: `memory.usage_in_bytes`) and compares it against the detected container memory limit. When usage reaches 90% of the limit the container is at immediate risk of an OOM kill by the kernel, which is abrupt and does not invoke JVM OutOfMemoryError handling or heap-dump logic. Caveat: raw cgroup current-usage numbers can overstate real memory pressure — cgroup v2's `memory.current` includes reclaimable page cache, not only the process's own footprint, and cgroup v1's `memory.usage_in_bytes` is documented by the kernel itself as an approximate "fuzz value" (the kernel's own guidance for an exact figure is `memory.stat`'s RSS+CACHE breakdown). Treat a reading near the limit as a strong signal to investigate, not an exact resident-set measurement.
+- **Detects**: Resolves the process's cgroup and reads its limit/current values (cgroup v2: `memory.max`/`memory.current`; cgroup v1: `memory.limit_in_bytes`/`memory.usage_in_bytes`). When `memory.stat` exposes inactive file cache, the rule subtracts it before comparing the working set to the limit. A working set at 90% or more leaves little headroom; if the kernel cannot reclaim enough charged memory for the next allocation, it may OOM-kill a process without invoking JVM OutOfMemoryError handling or heap-dump logic.
 - **Recommendation**: Lower -Xmx/-XX:MaxRAMPercentage, reduce non-heap footprint (thread stacks, Metaspace, direct buffers), or raise the container memory limit to restore headroom.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/troubleshoot/diagnostic-tools.html>
 
@@ -149,11 +150,11 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 - **Recommendation**: Remove -Xint, -XX:-UseCompiler, or -XX:TieredStopAtLevel<4 from production JVM arguments unless specifically required for a diagnostic session.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/vm/java-virtual-machine-technology-overview.html>
 
-### MEM-POOL-007 - Buffer pool usage has grown on every recent scan without release
+### MEM-POOL-007 - Direct buffer usage has grown on every recent scan without release
 
-- **Severity**: MEDIUM (HIGH when the growing pool is the "direct" pool and MEM-POOL-003's static threshold has also been crossed)
-- **Detects**: Tracks each java.nio buffer pool's (`BufferPoolMXBean`, typically "direct" and "mapped") used-byte reading across scans and flags a pool whose usage has strictly increased on every one of the last 3 consecutive scans with no decrease in between — the classic native-memory-leak signature of leaked direct/mapped `ByteBuffer`s (common with NIO channel or Netty-style misuse where buffers are allocated but never released). This can catch a leak while the pool is still well under MEM-POOL-003's static high-water threshold, since a monotonic trend is a stronger signal than any single absolute reading. Requires several consecutive user-triggered scans to build a trend; the first scans only establish the baseline.
-- **Recommendation**: Audit code paths that allocate direct or mapped ByteBuffers (including NIO channels and libraries like Netty) for missing release/cleaner calls, and confirm the pool eventually plateaus or shrinks under normal load instead of only ever growing.
+- **Severity**: MEDIUM (HIGH when MEM-POOL-003's static threshold has also been crossed)
+- **Detects**: Tracks the `direct` `BufferPoolMXBean` used-byte reading across scans and flags usage that has strictly increased on every one of the last 3 consecutive scans with no decrease in between. This is a native-memory-leak signal for leaked direct `ByteBuffer`s, such as NIO-channel or Netty-style misuse where buffers are allocated but never released. Mapped buffers are excluded: their usage follows file mappings rather than the direct-memory cap. Requires several consecutive user-triggered scans to build a trend; confirm it persists under representative load because a warming cache can also grow monotonically.
+- **Recommendation**: Audit code paths that allocate direct ByteBuffers (including NIO channels and libraries like Netty) for missing release/cleaner calls, and confirm the pool eventually plateaus or shrinks under normal load instead of only ever growing.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/BufferPoolMXBean.html>
 
 ## GC configuration
@@ -161,21 +162,21 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-GC-001 - Heap sizing is left to default container ergonomics
 
 - **Severity**: INFO
-- **Detects**: A detected container memory limit with neither -Xmx nor -XX:MaxRAMPercentage set. The JVM is container-aware and defaults the max heap to about 25% of the limit, which is safe but conservative and easy to overlook.
-- **Recommendation**: Set -XX:MaxRAMPercentage (or an explicit -Xmx) if you want the heap sized deliberately rather than at the ~25% default.
+- **Detects**: A detected container memory limit with neither `-Xmx`/`-XX:MaxHeapSize` nor an explicit maximum-RAM sizing option (`-XX:MaxRAMPercentage`, `-XX:MaxRAMFraction`, or `-XX:MaxRAM`) set. The JVM is container-aware and normally defaults the max heap to about 25% of the limit; the small-heap ergonomics can instead use 50%.
+- **Recommendation**: Set `-XX:MaxRAMPercentage` (or an explicit `-Xmx`/`-XX:MaxHeapSize`) if you want the heap sized deliberately rather than by default ergonomics.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/specs/man/java.html>
 
 ### MEM-GC-002 - Cumulative GC time is a large share of uptime
 
 - **Severity**: MEDIUM
-- **Detects**: After at least 10 minutes of uptime, flags when total **stop-the-world** collection time is at least 10% of JVM uptime. Concurrent-cycle beans (ZGC Cycles, Shenandoah Cycles, G1 Concurrent GC) are excluded because their concurrent phases run while the application executes. No collector-independent universal threshold exists, so the rule retains this conservative review threshold rather than tuning it from anecdotal application sizes. The cumulative average can be skewed by startup, so corroborate it with recent GC metrics.
+- **Detects**: After at least 10 minutes of uptime, flags when total **stop-the-world** collection time is at least 10% of JVM uptime. ZGC/Shenandoah cycle beans and the legacy CMS concurrent collector are excluded because they report concurrent work; G1's `G1 Concurrent GC` manager remains included because it measures its remark/cleanup VM operations. No collector-independent universal threshold exists, so the rule retains this conservative review threshold rather than tuning it from anecdotal application sizes. The cumulative average can be skewed by startup, so corroborate it with recent GC metrics.
 - **Recommendation**: Increase the heap (-Xmx/-XX:MaxRAMPercentage), reduce the allocation rate, or review the collector choice if GC consistently consumes this much time.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/gctuning/factors-affecting-garbage-collection-performance.html>
 
 ### MEM-GC-003 - Recent GC overhead is high
 
 - **Severity**: MEDIUM (HIGH when recent GC overhead is at least 25%)
-- **Detects**: Compares **stop-the-world** GC time against wall-clock time over the interval between the last two scans, excluding the scan's own forced histogram GC. Concurrent-cycle beans (ZGC Cycles, Shenandoah Cycles, G1 Concurrent GC) are excluded from the time delta to avoid false positives with concurrent collectors. The first scan only establishes a baseline; later scans fire when GC used at least 10% of the interval, and escalate to HIGH at 25%.
+- **Detects**: Compares **stop-the-world** GC time against wall-clock time over the interval from the previous scan's post-histogram sample to the current scan's pre-histogram sample, excluding both scans' own forced histogram GC. ZGC/Shenandoah cycle beans and the legacy CMS concurrent collector are excluded; G1's `G1 Concurrent GC` manager remains included because it measures remark/cleanup VM operations. The first scan only establishes a baseline; later scans fire when GC used at least 10% of the interval, and escalate to HIGH at 25%.
 - **Recommendation**: Re-run the scan after a representative workload; if recent GC overhead stays high, increase the heap (-Xmx/-XX:MaxRAMPercentage), reduce the allocation rate, or review the collector choice.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/GarbageCollectorMXBean.html>
 
@@ -189,14 +190,14 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-GC-005 - G1 Full GC occurred between scans
 
 - **Severity**: MEDIUM
-- **Detects**: An increase in the "G1 Old Generation" GarbageCollectorMXBean collection count between two consecutive scans. A G1 Full GC is G1's fallback path, triggered when its normal concurrent-marking/mixed-collection cycle could not keep up with the allocation rate (to-space exhaustion, humongous-allocation failure, or concurrent mark failure). Since JDK 10 (JEP 307, "Parallel Full GC for G1") this fallback runs on multiple threads, so it is not single-threaded — but it is still a fully stop-the-world pause across the entire heap; even one Full GC per scan window is a sign that G1 failed to reclaim memory through its normal cycle and indicates heap or tuning pressure. The first scan only establishes a baseline.
+- **Detects**: An increase in the "G1 Old Generation" GarbageCollectorMXBean collection count from the previous scan's post-histogram sample to the current scan's pre-histogram sample. A G1 Full GC is G1's fallback path, triggered when its normal concurrent-marking/mixed-collection cycle could not keep up with the allocation rate (to-space exhaustion, humongous-allocation failure, or concurrent mark failure). Since JDK 10 (JEP 307, "Parallel Full GC for G1") this fallback runs on multiple threads, so it is not single-threaded — but it is still a fully stop-the-world pause across the entire heap; even one Full GC per scan window is a sign that G1 failed to reclaim memory through its normal cycle and indicates heap or tuning pressure. The first scan only establishes a baseline.
 - **Recommendation**: Increase -Xmx or tune -XX:G1HeapRegionSize to reduce humongous allocations; consider -XX:G1ReservePercent and -XX:InitiatingHeapOccupancyPercent to give G1 more headroom for concurrent marking.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/gctuning/garbage-first-g1-garbage-collector1.html>
 
 ### MEM-GC-006 - Most recently completed GC event was long
 
 - **Severity**: MEDIUM
-- **Detects**: Reads each HotSpot collector bean's `getLastGcInfo()`, compares `GcInfo.endTime` values on their shared JVM-uptime time base, and evaluates the event that actually completed most recently. It flags when that event's duration is at least 1000 ms. Duration is elapsed collection time and is not necessarily a stop-the-world pause for a concurrent collector, so the finding deliberately says "GC event" rather than "pause." This is a fresh single-sample reading, not a cross-scan trend.
+- **Detects**: Reads each HotSpot collector bean's `getLastGcInfo()` before the scan's histogram, compares `GcInfo.endTime` values on their shared JVM-uptime time base, and evaluates the event that actually completed most recently. An unchanged event from the prior scan's histogram is skipped, so the advisor does not report its own forced collection as a new outlier. It flags a new event when its duration is at least 1000 ms. Duration is elapsed collection time and is not necessarily a stop-the-world pause for a concurrent collector, so the finding deliberately says "GC event" rather than "pause."
 - **Recommendation**: Capture unified GC logs (`-Xlog:gc*:file=gc.log:time,level,tags`) and inspect the event's phases and cause before tuning heap size, allocation rate, or collector pause goals.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/api/jdk.management/com/sun/management/GcInfo.html>
 
@@ -240,7 +241,7 @@ The panel is always available (the JVM always exposes memory and thread beans). 
 ### MEM-THREAD-004 - Runnable threads with very high lifetime CPU usage
 
 - **Severity**: INFO
-- **Detects**: RUNNABLE threads whose accumulated CPU time is a large fraction of the JVM's uptime, i.e. they have kept a core busy for much of the process's life. CPU time is cumulative since the thread started, so this is a hot-loop candidate to investigate, not a confirmed problem.
+- **Detects**: RUNNABLE platform threads whose accumulated CPU time is a large fraction of the JVM's uptime, i.e. they have kept a core busy for much of the process's life. CPU time is cumulative since the thread started, so this is a hot-loop candidate to investigate, not a confirmed problem. The rule skips when more than 1,000 platform-thread detail rows exist because it cannot make a complete CPU assessment from a bounded page.
 - **Recommendation**: Correlate with two consecutive thread snapshots; if CPU keeps climbing for the same thread, profile its stack for a hot or spinning loop.
 - **Learn more**: <https://docs.oracle.com/en/java/javase/21/docs/api/java.management/java/lang/management/ThreadMXBean.html>
 


### PR DESCRIPTION
## Summary
- preserve post-histogram per-collector GC baselines so G1 Full GC findings report true scan-window deltas, and suppress a prior scan's histogram GC from the latest-event outlier rule
- include G1 remark/cleanup time in stop-the-world overhead, restore the HotSpot compressed-oops threshold advisory, and recognize equivalent heap/RAM sizing flags and terabyte memory suffixes
- resolve cgroup v1/v2 process paths and hierarchical limits, derive a working-set estimate from inactive file cache, and make container findings reflect that evidence
- bound CPU-hot-thread analysis when the 1,000-row detail page is incomplete, restrict direct-buffer leak trending to direct buffers, and align the full 36-rule contract documentation

## Validation
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:apply`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:check`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-engine -am -Dtest=MemoryRulesTests,MemoryCollectorTests,MemoryScannerTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 test`

## Advisor audit protocol

- Independent reviewers: Claude Opus 5 (max, long context), GPT-5.6 Terra (max, long context), and Gemini 3.1 Pro (high, long context), all against the same frozen `main` snapshot.
- Evidence sources: official HotSpot/JDK, Linux cgroup/container, GC, and comparable diagnostic-tool guidance were researched before evaluating all memory rules.
- Decision process: rules were classified as KEEP, MODIFY, REMOVE, or SPLIT; accepted changes were limited to deterministic scan-window deltas, bounded observations, exact collector/container semantics, and documented thresholds. Speculative workload tuning remained deferred.
- Delivery policy: focused and full validation plus hosted CI are required; the final 36-rule contract and limitations are documented, and auto-merge is disabled.