### PR TITLE
Stop publishing sample and test modules to Maven Central

### DIFF
--- a/.github/instructions/release.instructions.md
+++ b/.github/instructions/release.instructions.md
@@ -9,7 +9,8 @@ applyTo: ".github/workflows/release.yml,.github/workflows/build.yml,.github/scri
 - Keep `quarkus.platform.version` independent from the BootUI project version.
 - Published artifacts are the parent POM, core, engine, UI, Spring autoconfigure, both Spring starters (MVC and
   reactive), Quarkus parent, Quarkus runtime, and Quarkus deployment. Sample apps, integration tests, and conformance
-  must retain `maven.deploy.skip=true`.
+  must retain `maven.deploy.skip=true`, remain in the Central plugin's `excludeArtifacts` list, and stay outside the
+  publication-only reactor in `release.yml`.
 - The source-less published modules (`bootui-ui`, `bootui-spring-boot-starter`, and
   `bootui-spring-boot-starter-reactive`) must attach their empty `javadoc.jar` during `package`, before release-profile
   signing at `verify`.

--- a/.github/scripts/check-release-integrity.sh
+++ b/.github/scripts/check-release-integrity.sh
@@ -3,9 +3,14 @@
 set -euo pipefail
 
 readonly WORKFLOW="${1:-.github/workflows/release.yml}"
+readonly ROOT_POM="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/pom.xml"
 
 if [[ ! -r "$WORKFLOW" ]]; then
   printf 'Cannot read release workflow: %s\n' "$WORKFLOW" >&2
+  exit 2
+fi
+if [[ ! -r "$ROOT_POM" ]]; then
+  printf 'Cannot read root POM: %s\n' "$ROOT_POM" >&2
   exit 2
 fi
 
@@ -54,6 +59,51 @@ require_literal 'git verify-tag "$EXPECTED_TAG"' 'existing tag signature verific
 require_literal 'ref: ${{ env.RELEASE_SHA }}' 'immutable release checkout'
 require_literal "if: env.RESUME_AFTER_PUBLISH != 'true'" 'deploy skip for publication continuation'
 require_literal 'gh workflow run pages.yml --ref "$RELEASE_TAG"' 'tag-pinned documentation deployment'
+require_literal '-pl .,bootui-core,bootui-engine,bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-boot-starter-reactive,bootui-ui,bootui-quarkus-parent,bootui-quarkus,bootui-quarkus-deployment' \
+  'publication-only Maven reactor'
+
+excluded_artifacts="$(
+  sed -n '/<excludeArtifacts>/,/<\/excludeArtifacts>/p' "$ROOT_POM"
+)"
+readonly excluded_artifacts
+readonly expected_exclusions=(
+  bootui-conformance
+  bootui-coverage
+  bootui-spring-sample-app
+  bootui-spring-webflux-sample-app
+  bootui-quarkus-sample-app
+  bootui-quarkus-integration-tests-aggregator
+  bootui-quarkus-integration-tests
+  bootui-quarkus-cache-integration-tests
+  bootui-quarkus-datasource-integration-tests
+  bootui-quarkus-email-integration-tests
+  bootui-quarkus-flyway-integration-tests
+  bootui-quarkus-health-integration-tests
+  bootui-quarkus-hibernate-integration-tests
+  bootui-quarkus-liquibase-integration-tests
+  bootui-quarkus-micrometer-integration-tests
+  bootui-quarkus-otel-integration-tests
+  bootui-quarkus-prod-shell-guard-integration-tests
+  bootui-quarkus-rabbit-integration-tests
+  bootui-quarkus-rest-client-integration-tests
+  bootui-quarkus-scheduler-integration-tests
+  bootui-quarkus-security-integration-tests
+)
+for artifact in "${expected_exclusions[@]}"; do
+  if ! grep -Fq "<excludeArtifact>${artifact}</excludeArtifact>" <<<"$excluded_artifacts"; then
+    report_error "root POM must exclude non-distribution artifact '$artifact' from Central publishing"
+  fi
+done
+
+actual_exclusion_count="$(grep -c '<excludeArtifact>' <<<"$excluded_artifacts" || true)"
+readonly actual_exclusion_count
+if [[ "$actual_exclusion_count" -ne "${#expected_exclusions[@]}" ]]; then
+  report_error "root POM Central exclusion list contains unexpected artifacts"
+fi
+
+if grep -Fq '<skip>${maven.deploy.skip}</skip>' "$ROOT_POM"; then
+  report_error "Central publishing does not support the legacy per-module <skip> configuration"
+fi
 
 require_order './mvnw -B -ntp -Prelease clean verify' 'git commit -m "Release $TAG"' \
   'release verification must happen before the release commit'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,7 +380,12 @@ jobs:
           # No -Dgpg.passphrase here: that user property is deprecated by maven-gpg-plugin
           # ("may leak sensitive information"). The plugin already reads the passphrase from
           # the MAVEN_GPG_PASSPHRASE env var above (its passphraseEnvName default) instead.
+          # Build only Central distribution modules and their required reactor dependencies during
+          # publication. The complete reactor was already verified before the immutable release
+          # commit and tag were created.
           ./mvnw -B -ntp -Prelease clean deploy \
+            -pl .,bootui-core,bootui-engine,bootui-spring-autoconfigure,bootui-spring-boot-starter,bootui-spring-boot-starter-reactive,bootui-ui,bootui-quarkus-parent,bootui-quarkus,bootui-quarkus-deployment \
+            -am \
             -Dcentral.autoPublish="${CENTRAL_AUTO_PUBLISH}"
 
       - name: Wait for Maven Central availability
@@ -392,7 +397,7 @@ jobs:
           BASE="https://repo1.maven.org/maven2/com/julien-dubois/bootui"
 
           # Every published artifact: the parent POM and one JAR per published module.
-          # This list must stay in sync with the modules that have maven.deploy.skip != true.
+          # This list must stay in sync with the publication reactor and Central exclusions.
           # Missing any one artifact causes the release to fail with the coordinate in the error.
           ARTIFACTS=(
             "bootui-parent/${VERSION}/bootui-parent-${VERSION}.pom"

--- a/pom.xml
+++ b/pom.xml
@@ -79,14 +79,6 @@
         <archunit.version>1.4.2</archunit.version>
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <central.autoPublish>true</central.autoPublish>
-        <!--
-            central-publishing-maven-plugin does NOT honor maven.deploy.skip (it implements its own
-            skip mechanism). Default it here so every module inherits it, then tie the plugin's own
-            <skip> to it below - modules that already set <maven.deploy.skip>true</maven.deploy.skip>
-            (sample apps, integration tests, conformance) now also skip Central publishing instead of
-            silently uploading multi-hundred-MB fat jars on every release.
-        -->
-        <maven.deploy.skip>false</maven.deploy.skip>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
@@ -288,7 +280,35 @@
                     <configuration>
                         <publishingServerId>central</publishingServerId>
                         <autoPublish>${central.autoPublish}</autoPublish>
-                        <skip>${maven.deploy.skip}</skip>
+                        <!--
+                            This extension stages the whole reactor from its root execution. Per-module
+                            maven.deploy.skip values are therefore not sufficient to keep non-distribution
+                            modules out of the Central bundle. Exclude them explicitly with the plugin's
+                            supported reactor-level filter.
+                        -->
+                        <excludeArtifacts>
+                            <excludeArtifact>bootui-conformance</excludeArtifact>
+                            <excludeArtifact>bootui-coverage</excludeArtifact>
+                            <excludeArtifact>bootui-spring-sample-app</excludeArtifact>
+                            <excludeArtifact>bootui-spring-webflux-sample-app</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-sample-app</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-integration-tests-aggregator</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-cache-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-datasource-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-email-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-flyway-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-health-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-hibernate-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-liquibase-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-micrometer-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-otel-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-prod-shell-guard-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-rabbit-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-rest-client-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-scheduler-integration-tests</excludeArtifact>
+                            <excludeArtifact>bootui-quarkus-security-integration-tests</excludeArtifact>
+                        </excludeArtifacts>
                         <!--
                             Sonatype only mandates md5+sha1 checksums (sha256/sha512 are optional, see
                             https://central.sonatype.org/publish/requirements/#provide-file-checksums). The


### PR DESCRIPTION
## What does this PR do?

Restricts Maven Central publication to BootUI's 10 distribution coordinates and adds release-integrity guards for that scope.

## Why is this change needed?

The Central publishing extension ignored the unsupported per-module `<skip>` configuration and staged the entire reactor. Each recent release therefore published 30 coordinates and 404 files, including the 129.7 MiB Spring MVC and 62.6 MiB WebFlux sample application fat JARs.

This change uses the plugin's supported `excludeArtifacts` filter and narrows the publication reactor as defense in depth. A locally generated Central bundle contains only the intended coordinates and drops from about 203 MiB to 10.8 MiB before signatures.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Additional checks:

- `bash .github/scripts/check-release-integrity.sh`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:check`
- Generated a Central bundle against a closed localhost endpoint and confirmed exactly 10 coordinates, 102 unsigned files, and 10.8 MiB uncompressed

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed