### PR TITLE
Refine unavailable auto-refresh status

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/stream-status.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/stream-status.spec.js
@@ -89,7 +89,7 @@ async function latestStreamUrl(page) {
 async function readStatusStyles(page) {
   return page.locator('.auto-refresh-control').evaluate((control) => {
     const retryButton = control.querySelector('.auto-refresh-retry')
-    const label = control.querySelector('.auto-refresh-status--unavailable')
+    const label = control.querySelector('.auto-refresh-paused-label')
     const dot = control.querySelector('.auto-refresh-dot--unavailable')
     if (!(retryButton instanceof HTMLElement) || !(label instanceof HTMLElement) || !(dot instanceof HTMLElement)) {
       throw new Error('Stream status elements are missing')
@@ -191,7 +191,7 @@ test.describe('stream connection status', () => {
     }
 
     await emitLatestStreamEvent(page, 'error')
-    await expect(page.locator('.auto-refresh-control')).toContainText('Stream unavailable')
+    await expect(page.locator('.auto-refresh-control')).toContainText('Updates paused')
 
     const retry = page.getByRole('button', {name: 'Retry auto-refresh stream connection now'})
     await retry.focus()

--- a/bootui-ui/src/main/frontend/src/views/components/AutoRefreshToggle.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/AutoRefreshToggle.test.js
@@ -24,11 +24,13 @@ describe('AutoRefreshToggle', () => {
     expect(wrapper.find('.auto-refresh-dot--reconnecting').exists()).toBe(true)
   })
 
-  it('shows an unavailable stream and emits retry from the same control', async () => {
+  it('shows unavailable updates as a quiet status capsule and emits retry', async () => {
     const wrapper = render('unavailable')
 
-    expect(wrapper.text()).toContain('Auto-refresh')
-    expect(wrapper.text()).toContain('Stream unavailable')
+    expect(wrapper.text()).toContain('Updates paused')
+    expect(wrapper.find('.auto-refresh-paused').exists()).toBe(true)
+    expect(wrapper.find('.auto-refresh-dot--unavailable').exists()).toBe(true)
+    expect(wrapper.find('input[type="checkbox"]').exists()).toBe(false)
 
     await wrapper.get('button[aria-label="Retry auto-refresh stream connection now"]').trigger('click')
 
@@ -48,12 +50,12 @@ describe('AutoRefreshToggle', () => {
     expect(liveRegion.text()).toContain('connected')
   })
 
-  it('still emits switch changes independently of stream status', async () => {
+  it('still emits switch changes independently of reconnecting status', async () => {
     const onUpdateModelValue = vi.fn()
     const wrapper = mount(AutoRefreshToggle, {
       props: {
         modelValue: true,
-        connectionState: 'unavailable',
+        connectionState: 'reconnecting',
         'onUpdate:modelValue': onUpdateModelValue
       }
     })

--- a/bootui-ui/src/main/frontend/src/views/components/AutoRefreshToggle.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/AutoRefreshToggle.vue
@@ -18,7 +18,6 @@ const announcement = ref('')
 
 const statusText = computed(() => {
   if (props.connectionState === 'reconnecting') return 'Reconnecting\u2026'
-  if (props.connectionState === 'unavailable') return 'Stream unavailable'
   return null
 })
 
@@ -44,8 +43,24 @@ function updateValue(event) {
 </script>
 
 <template>
-  <div class="auto-refresh-control" :title="title">
-    <div class="form-check form-switch mb-0 auto-refresh-toggle">
+  <div
+    class="auto-refresh-control"
+    :title="connectionState === 'unavailable' ? 'Auto-refresh is paused while the stream is unavailable' : title"
+  >
+    <div v-if="connectionState === 'unavailable'" class="auto-refresh-paused">
+      <span class="auto-refresh-dot auto-refresh-dot--unavailable" aria-hidden="true"></span>
+      <span class="auto-refresh-paused-label small">Updates paused</span>
+      <button
+        class="auto-refresh-retry"
+        type="button"
+        aria-label="Retry auto-refresh stream connection now"
+        title="Try reconnecting"
+        @click="emit('retry')"
+      >
+        <i class="bi bi-arrow-clockwise" aria-hidden="true"></i>
+      </button>
+    </div>
+    <div v-else class="form-check form-switch mb-0 auto-refresh-toggle">
       <input
         :id="inputId"
         :checked="modelValue"
@@ -59,8 +74,7 @@ function updateValue(event) {
           class="auto-refresh-dot"
           :class="{
             'auto-refresh-dot--live': modelValue && (!connectionState || connectionState === 'connected'),
-            'auto-refresh-dot--reconnecting': modelValue && connectionState === 'reconnecting',
-            'auto-refresh-dot--unavailable': modelValue && connectionState === 'unavailable'
+            'auto-refresh-dot--reconnecting': modelValue && connectionState === 'reconnecting'
           }"
           aria-hidden="true"
         ></span>
@@ -70,15 +84,6 @@ function updateValue(event) {
     <span v-if="statusText" class="auto-refresh-status small" :class="`auto-refresh-status--${connectionState}`">
       {{ statusText }}
     </span>
-    <button
-      v-if="connectionState === 'unavailable'"
-      class="auto-refresh-retry small"
-      type="button"
-      aria-label="Retry auto-refresh stream connection now"
-      @click="emit('retry')"
-    >
-      Retry now
-    </button>
     <span role="status" aria-live="polite" aria-atomic="true" class="visually-hidden">{{ announcement }}</span>
   </div>
 </template>
@@ -95,6 +100,24 @@ function updateValue(event) {
   align-items: center;
   display: inline-flex;
   gap: 0.35rem;
+}
+
+.auto-refresh-paused {
+  align-items: center;
+  background: color-mix(in srgb, var(--bootui-surface, #ffffff) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--bootui-text-subtle, #5b6b80) 25%, transparent);
+  border-radius: var(--bootui-radius-pill, 999px);
+  box-shadow: var(--bootui-shadow-sm, 0 0.25rem 0.75rem rgba(15, 23, 42, 0.05));
+  display: inline-flex;
+  gap: 0.45rem;
+  min-height: 2.125rem;
+  padding: 0.2rem 0.25rem 0.2rem 0.65rem;
+}
+
+.auto-refresh-paused-label {
+  color: var(--bootui-text, #152033);
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .auto-refresh-dot {
@@ -117,7 +140,7 @@ function updateValue(event) {
 }
 
 .auto-refresh-dot--unavailable {
-  background: var(--bootui-danger, #dc3545);
+  background: var(--bootui-warning-text, #997404);
 }
 
 .auto-refresh-status {
@@ -129,25 +152,25 @@ function updateValue(event) {
   color: var(--bootui-warning-text-strong, #6f5300);
 }
 
-.auto-refresh-status--unavailable {
-  color: var(--bootui-text, #152033);
-}
-
 .auto-refresh-retry {
-  background: none;
+  align-items: center;
+  background: color-mix(in srgb, var(--bootui-blue, #0d6efd) 8%, transparent);
   border: none;
-  border-radius: var(--bootui-radius-xs, 0.35rem);
+  border-radius: var(--bootui-radius-pill, 999px);
   color: var(--bootui-blue, #0d6efd);
   cursor: pointer;
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: 1rem;
   font-weight: 600;
-  padding: 0.1rem;
-  text-decoration: underline;
-  text-underline-offset: 0.12em;
-  white-space: nowrap;
+  height: 1.625rem;
+  justify-content: center;
+  padding: 0;
+  width: 1.625rem;
 }
 
 .auto-refresh-retry:hover {
-  text-decoration-thickness: 2px;
+  background: color-mix(in srgb, var(--bootui-blue, #0d6efd) 14%, transparent);
 }
 
 .auto-refresh-retry:focus-visible {

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.test.js
@@ -76,7 +76,8 @@ describe('PanelHeader', () => {
       }
     })
 
-    expect(wrapper.find('.auto-refresh-control').text()).toContain('Stream unavailable')
+    expect(wrapper.find('.auto-refresh-control').text()).toContain('Updates paused')
+    expect(wrapper.find('.auto-refresh-paused').exists()).toBe(true)
     expect(wrapper.find('.stream-status-indicator').exists()).toBe(false)
 
     await wrapper.get('button[aria-label="Retry auto-refresh stream connection now"]').trigger('click')

--- a/bootui-ui/src/main/frontend/src/views/streamWiring.test.js
+++ b/bootui-ui/src/main/frontend/src/views/streamWiring.test.js
@@ -113,7 +113,8 @@ describe('streaming panel SSE wiring', () => {
     await nextTick()
 
     const retry = wrapper.get('.auto-refresh-retry')
-    expect(retry.text()).toBe('Retry now')
+    expect(wrapper.get('.auto-refresh-paused').text()).toContain('Updates paused')
+    expect(retry.attributes('aria-label')).toBe('Retry auto-refresh stream connection now')
     expect(instances).toHaveLength(5)
 
     await retry.trigger('click')


### PR DESCRIPTION
## What does this PR do?

Replaces the disconnected "Stream unavailable" and "Retry now" elements with one compact "Updates paused" status capsule containing an amber state indicator and an icon-only reconnect action.

## Why is this change needed?

The previous unavailable state read like a separate error message and text link rather than part of the auto-refresh control. The capsule keeps recovery visible while fitting BootUI's calm, integrated control-room design.

N/A (no linked issue).

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on an isolated local port
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed