### PR TITLE
Show Live Flow inline in Live Activity

### DIFF
--- a/bootui-quarkus-sample-app/e2e/tests/activity.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/activity.spec.js
@@ -274,11 +274,10 @@ test.describe('Live Activity view (Quarkus)', () => {
     await page.request.get('/api/sample/product-search')
 
     await openView('activity', 'Live Activity')
-    await page.getByRole('button', {name: 'Live flow view'}).click()
 
     const map = page.locator('.flow-map')
     await expect(map).toBeVisible({timeout: 15_000})
-    await expect(page.locator('.activity-table')).toHaveCount(0)
+    await expect(page.locator('.activity-table')).toBeVisible()
     await expect(map.locator('.flow-node--app')).toBeVisible()
     await expect(map).toContainText('contacts nothing and probes nothing')
 

--- a/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
@@ -80,12 +80,11 @@ test.describe('BootUI on Spring WebFlux', () => {
         .filter({hasText: /Live Activity/})
         .first()
     ).toBeVisible({timeout: 15_000})
-    await page.getByRole('button', {name: 'Live flow view'}).click()
 
     const flow = page.locator('.flow-map')
     await expect(flow).toBeVisible({timeout: 15_000})
     await expect(flow).toContainText('contacts nothing and probes nothing')
-    await expect(page.locator('.activity-table')).toHaveCount(0)
+    await expect(page.locator('.activity-table')).toBeVisible()
   })
 
   test('raw Spring Security panel exposes reactive chains and mappings without blocking', async ({

--- a/bootui-spring-sample-app/e2e/tests/activity.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/activity.spec.js
@@ -208,12 +208,11 @@ test.describe('Live Activity view', () => {
     await page.request.get('/api/sample/product-search')
 
     await openView('activity', 'Live Activity')
-    await page.getByRole('button', {name: 'Live flow view'}).click()
 
     const map = page.locator('.flow-map')
     await expect(map).toBeVisible({timeout: 15_000})
-    // The feed is replaced, not stacked beside the map.
-    await expect(page.locator('.activity-table')).toHaveCount(0)
+    // The map is shown inline without replacing the event feed.
+    await expect(page.locator('.activity-table')).toBeVisible()
     // The running application is the centre of the map, and the map states plainly that it contacts nothing.
     await expect(map.locator('.flow-node--app')).toBeVisible()
     await expect(map).toContainText('contacts nothing and probes nothing')
@@ -236,7 +235,6 @@ test.describe('Live Activity view', () => {
     await page.request.get('/api/sample/product-search')
 
     await openView('activity', 'Live Activity')
-    await page.getByRole('button', {name: 'Live flow view'}).click()
 
     const map = page.locator('.flow-map')
     await expect(map.locator('.flow-node[role="button"]').first()).toBeVisible({timeout: 15_000})

--- a/bootui-ui/src/main/frontend/src/utils/serviceMap.js
+++ b/bootui-ui/src/main/frontend/src/utils/serviceMap.js
@@ -170,12 +170,10 @@ const MARGIN = 32
 const LANE_GAP = 112
 const FAN_RADIUS = 288
 const FAN_ROW_PITCH = 72
-const FAN_MIN_HEIGHT = 320
 const FAN_MIN_WIDTH = 800
 const RACK_GAP = 72
 const RACK_COLUMN_GAP = 32
 const RACK_ROW_GAP = 26
-const RACK_MIN_HEIGHT = 320
 export const FAN_DEPENDENCY_THRESHOLD = 6
 const EDGE_SOURCE_GAP = 4
 const EDGE_TARGET_GAP = 8
@@ -183,7 +181,7 @@ const TARGET_RING_PADDING = 5
 const TARGET_CHIP_WIDTH = 96
 const TARGET_CHIP_HEIGHT = 20
 const TARGET_CHIP_Y = -13
-export const MAX_SERVICE_MAP_WIDTH = 1040
+export const MAX_SERVICE_MAP_WIDTH = 1228
 
 function boxRect(box) {
   return {
@@ -426,10 +424,15 @@ export function layoutServiceMap(map, {nodeWidth = NODE_W, nodeHeight = NODE_H} 
     : count
       ? (count - 1) * FAN_ROW_PITCH + nodeHeight
       : APP_H
-  const height = Math.max(dense ? RACK_MIN_HEIGHT : FAN_MIN_HEIGHT, contentHeight + MARGIN * 2)
+  const height = Math.max(contentHeight, APP_H, inbound ? nodeHeight : 0) + MARGIN * 2
   const cy = height / 2
-  // Keep the application visually central even when filtering hides the inbound lane.
-  const cx = MARGIN + nodeWidth + LANE_GAP + APP_W / 2
+  const leftExtent = inbound ? APP_W / 2 + LANE_GAP + nodeWidth + MARGIN : APP_W / 2 + MARGIN
+  const rightExtent = dense
+    ? APP_W / 2 + RACK_GAP + nodeWidth * 2 + RACK_COLUMN_GAP + MARGIN
+    : FAN_RADIUS + nodeWidth / 2 + MARGIN
+  const halfWidth = Math.ceil(Math.max(FAN_MIN_WIDTH / 2, leftExtent, rightExtent))
+  const width = halfWidth * 2
+  const cx = halfWidth
   const firstRackX = cx + APP_W / 2 + RACK_GAP + nodeWidth / 2
 
   const positions = new Map()
@@ -448,9 +451,6 @@ export function layoutServiceMap(map, {nodeWidth = NODE_W, nodeHeight = NODE_H} 
   for (const box of dependencyBoxes) {
     positions.set(box.node.id, box)
   }
-
-  const furthestRight = Math.max(cx + APP_W / 2, ...dependencyBoxes.map((box) => box.x + box.w / 2))
-  const width = dense ? MAX_SERVICE_MAP_WIDTH : Math.max(FAN_MIN_WIDTH, Math.ceil(furthestRight + MARGIN))
 
   const edges = map.edges
     .map((edge) => {

--- a/bootui-ui/src/main/frontend/src/utils/serviceMap.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/serviceMap.test.js
@@ -258,7 +258,9 @@ describe('layoutServiceMap', () => {
 
     expect(first).toEqual(second)
     expect(first.width).toBeLessThanOrEqual(MAX_SERVICE_MAP_WIDTH)
-    expect(first.height).toBeGreaterThanOrEqual(320)
+    expect(first.application.x).toBe(first.width / 2)
+    expect(first.height).toBeGreaterThanOrEqual(124)
+    if (count <= 1) expect(first.height).toBe(124)
     if (count === 28) expect(first.height).toBe(1046)
     expect(first.height).toBeLessThanOrEqual(1046)
     for (let left = 0; left < boxes.length; left += 1) {
@@ -342,7 +344,7 @@ describe('layoutServiceMap', () => {
     const result = layoutServiceMap(mapWith(28))
 
     expect(result.mode).toBe('rack')
-    expect(result.width).toBe(1040)
+    expect(result.width).toBe(1228)
     expect(result.height).toBe(1046)
     expect(Math.max(...result.edges.map(routeLength))).toBeLessThanOrEqual(665)
   })

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.test.js
@@ -121,6 +121,7 @@ describe('LiveActivity', () => {
   afterEach(() => {
     wrapper?.unmount()
     wrapper = null
+    safeLocalStorage.removeItem('bootui.activity.flowCollapsed')
     vi.unstubAllGlobals()
   })
 
@@ -574,36 +575,51 @@ describe('LiveActivity', () => {
     expect(switchButton.attributes('disabled')).toBeDefined()
   })
 
-  it('opens on the feed and offers Live flow as a second reading of the same evidence', async () => {
-    vi.stubGlobal('fetch', stubFetch(activityReport(), requestProfile()))
-
-    wrapper = mountLiveActivity()
-    await flushPromises()
-
-    const options = wrapper.findAll('.activity-view-switcher__option')
-    expect(options.map((option) => option.text())).toEqual(['Feed', 'Live flow'])
-    expect(options[0].attributes('aria-pressed')).toBe('true')
-    expect(options[1].attributes('aria-pressed')).toBe('false')
-    expect(wrapper.find('.activity-table').exists()).toBe(true)
-  })
-
-  it('swaps the feed for the Live flow map without fetching the map until that mode is opened', async () => {
+  it('shows Live flow between the KPI summary and activity feed controls by default', async () => {
     const fetchMock = stubFetch(activityReport(), requestProfile())
     vi.stubGlobal('fetch', fetchMock)
 
     wrapper = mountLiveActivity()
     await flushPromises()
-    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('service-map'))).toBe(false)
 
-    await wrapper.findAll('.activity-view-switcher__option')[1].trigger('click')
-    await flushPromises()
+    const toggle = wrapper.get('[aria-controls="activity-live-flow"]')
+    expect(toggle.text()).toContain('Minimize map')
+    expect(toggle.attributes('aria-expanded')).toBe('true')
+    expect(wrapper.find('.flow-map').isVisible()).toBe(true)
+    expect(wrapper.find('.activity-table').exists()).toBe(true)
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('service-map'))).toBe(true)
 
-    expect(wrapper.find('.activity-table').exists()).toBe(false)
-    expect(wrapper.findAll('.activity-view-switcher__option')[1].attributes('aria-pressed')).toBe('true')
+    const kpis = wrapper.get('.activity-kpis').element
+    const flow = wrapper.get('.activity-flow').element
+    const controls = wrapper.get('.activity-feed-controls').element
+    expect(kpis.compareDocumentPosition(flow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(flow.compareDocumentPosition(controls) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
-  it('keeps feed unavailability scoped to Feed while Live flow renders configured JDBC evidence', async () => {
-    safeLocalStorage.removeItem('bootui.activity.mode')
+  it('remembers when Live flow is minimized without hiding the activity feed', async () => {
+    vi.stubGlobal('fetch', stubFetch(activityReport(), requestProfile()))
+
+    wrapper = mountLiveActivity()
+    await flushPromises()
+
+    await wrapper.get('[aria-controls="activity-live-flow"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[aria-controls="activity-live-flow"]').text()).toContain('Show map')
+    expect(wrapper.get('[aria-controls="activity-live-flow"]').attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find('.flow-map').isVisible()).toBe(false)
+    expect(wrapper.find('.activity-table').exists()).toBe(true)
+    expect(safeLocalStorage.getItem('bootui.activity.flowCollapsed')).toBe('true')
+
+    wrapper.unmount()
+    wrapper = mountLiveActivity()
+    await flushPromises()
+
+    expect(wrapper.get('[aria-controls="activity-live-flow"]').attributes('aria-expanded')).toBe('false')
+    expect(wrapper.find('.flow-map').isVisible()).toBe(false)
+  })
+
+  it('shows configured Live flow evidence alongside the unavailable feed state', async () => {
     const configuredJdbcMap = {
       available: true,
       unavailableReason: null,
@@ -676,15 +692,11 @@ describe('LiveActivity', () => {
     const feedUnavailable =
       'No live activity sources are available yet. Enable HTTP exchange recording, SQL tracing, REST client tracing, exception capture, or security logs to populate this stream.'
     expect(wrapper.text()).toContain(feedUnavailable)
-    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('service-map'))).toBe(false)
-
-    await wrapper.findAll('.activity-view-switcher__option')[1].trigger('click')
     await vi.waitFor(() => {
       expect(fetchMock.mock.calls.some(([url]) => String(url).includes('service-map'))).toBe(true)
     })
     await flushPromises()
 
-    expect(wrapper.text()).not.toContain(feedUnavailable)
     const jdbcNode = wrapper.get('.flow-node--jdbc')
     expect(jdbcNode.attributes('aria-label')).toContain('jdbc:postgresql://localhost:5432/shop')
     expect(jdbcNode.attributes('aria-label')).toContain('configured, no recent evidence')

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
@@ -24,15 +24,14 @@ import {
   nestEntries
 } from '../utils/activityStream.js'
 
-// Live Flow is a second reading of the same evidence, so it ships as a mode of this panel rather than a
-// panel of its own. Keeping it in a route-level async chunk means the feed — the default view — never
-// pays for the map's layout and motion code.
+// Live Flow is a second reading of the same evidence, so it ships inside this panel rather than as a
+// panel of its own. Keep its layout and motion code in a route-level async chunk.
 const LiveFlowMode = defineAsyncComponent(() => import('./LiveFlowMode.vue'))
 
 const TYPES = ['REQUEST', 'SQL', 'EXCEPTION', 'SECURITY', 'CACHE', 'SCHEDULED', 'MESSAGING', 'MAIL', 'REST_CLIENT']
 const SEVERITIES = ['OK', 'SLOW', 'WARN', 'ERROR']
 const FILTERS_STORAGE_KEY = 'bootui.activity.filters'
-const MODE_STORAGE_KEY = 'bootui.activity.mode'
+const FLOW_COLLAPSED_STORAGE_KEY = 'bootui.activity.flowCollapsed'
 const PERSISTENCE_DOCS_URL = 'https://www.julien-dubois.com/boot-ui/properties#live-activity-durable-persistence'
 
 const props = defineProps(panelProps)
@@ -43,9 +42,7 @@ const {message: banner, flash, clear: clearBanner} = useFlashMessage()
 const report = ref(null)
 const error = ref(null)
 const lastFetched = ref(null)
-// 'feed' (default) or 'flow'. Remembered per browser so a developer who works in the map does not have
-// to reselect it on every visit.
-const mode = ref(safeLocalStorage.getItem(MODE_STORAGE_KEY) === 'flow' ? 'flow' : 'feed')
+const flowCollapsed = ref(safeLocalStorage.getItem(FLOW_COLLAPSED_STORAGE_KEY) === 'true')
 // Incremented after every successful feed refresh so the map re-reads the same evidence off the same
 // SSE tick instead of running a second poll of its own.
 const flowRefreshTick = ref(0)
@@ -572,11 +569,9 @@ function clearFilters() {
   errorsOnly.value = false
 }
 
-const flowMode = computed(() => mode.value === 'flow')
-
-function setMode(next) {
-  mode.value = next
-  safeLocalStorage.setItem(MODE_STORAGE_KEY, next)
+function toggleFlow() {
+  flowCollapsed.value = !flowCollapsed.value
+  safeLocalStorage.setItem(FLOW_COLLAPSED_STORAGE_KEY, String(flowCollapsed.value))
 }
 </script>
 
@@ -595,32 +590,6 @@ function setMode(next) {
       @refresh="refreshNow"
       @retry-auto-refresh="retryConnection"
     >
-      <template #actions>
-        <div class="activity-view-switcher" role="group" aria-label="Live Activity view">
-          <button
-            type="button"
-            class="activity-view-switcher__option"
-            title="Reverse-chronological event feed"
-            aria-label="Feed view"
-            :aria-pressed="!flowMode"
-            @click="setMode('feed')"
-          >
-            <i class="bi bi-list-ul" aria-hidden="true"></i>
-            <span>Feed</span>
-          </button>
-          <button
-            type="button"
-            class="activity-view-switcher__option"
-            title="Service map of recently observed dependencies"
-            aria-label="Live flow view"
-            :aria-pressed="flowMode"
-            @click="setMode('flow')"
-          >
-            <i class="bi bi-diagram-2" aria-hidden="true"></i>
-            <span>Live flow</span>
-          </button>
-        </div>
-      </template>
       <template #subtitle-actions>
         <span v-if="report && !persistent">
           Currently saving {{ formatNumber(memoryEventCount) }} event{{ memoryEventCount === 1 ? '' : 's' }} in memory
@@ -689,14 +658,14 @@ function setMode(next) {
 
     <UnavailableState v-if="!manifestAvailable" icon="bi-broadcast" :message="manifestUnavailableReason" />
 
-    <UnavailableState
-      v-else-if="report && !available && !flowMode"
-      icon="bi-broadcast"
-      message="No live activity sources are available yet. Enable HTTP exchange recording, SQL tracing, REST client tracing, exception capture, or security logs to populate this stream."
-    />
-
     <template v-else-if="report">
-      <div v-if="kpis" class="row g-2 mb-3 activity-kpis">
+      <UnavailableState
+        v-if="!available"
+        icon="bi-broadcast"
+        message="No live activity sources are available yet. Enable HTTP exchange recording, SQL tracing, REST client tracing, exception capture, or security logs to populate this stream."
+      />
+
+      <div v-if="available && kpis" class="row g-2 mb-3 activity-kpis">
         <div class="col-6 col-lg-3">
           <div class="card h-100">
             <div class="card-body py-2">
@@ -848,10 +817,34 @@ function setMode(next) {
         </div>
       </div>
 
-      <LiveFlowMode v-if="flowMode" :refresh-tick="flowRefreshTick" :paused="paused" />
+      <section class="activity-flow mb-3" aria-labelledby="activity-flow-title">
+        <div class="activity-flow__header">
+          <div>
+            <h3 id="activity-flow-title" class="h5 mb-1">
+              <i class="bi bi-diagram-2 me-2" aria-hidden="true"></i>Live flow
+            </h3>
+            <p class="text-muted small mb-0">
+              A live service map assembled from the same retained activity as the feed.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-sm btn-outline-secondary"
+            :aria-expanded="!flowCollapsed"
+            aria-controls="activity-live-flow"
+            @click="toggleFlow"
+          >
+            <i :class="['bi', flowCollapsed ? 'bi-chevron-down' : 'bi-chevron-up', 'me-1']" aria-hidden="true"></i>
+            {{ flowCollapsed ? 'Show map' : 'Minimize map' }}
+          </button>
+        </div>
+        <div id="activity-live-flow" v-show="!flowCollapsed" class="activity-flow__body">
+          <LiveFlowMode :refresh-tick="flowRefreshTick" :paused="paused" :visible="!flowCollapsed" />
+        </div>
+      </section>
 
-      <template v-else>
-        <div class="d-flex flex-wrap align-items-end gap-2 mb-3">
+      <template v-if="available">
+        <div class="activity-feed-controls d-flex flex-wrap align-items-end gap-2 mb-3">
           <div class="activity-text-filter">
             <label class="form-label small mb-1" for="activity-text-filter">Filter</label>
             <input
@@ -1213,34 +1206,18 @@ function setMode(next) {
 </template>
 
 <style scoped>
-/* View switcher — same shape as the Beans panel's list/graph switcher so the two graph surfaces read
-   as one system. The gradient marks the selected option and nothing else. */
-.activity-view-switcher {
-  border: 1px solid var(--bootui-border-alt);
-  border-radius: var(--bootui-radius-pill);
-  display: inline-flex;
-  overflow: hidden;
+.activity-flow {
+  border-top: 1px solid var(--bootui-border);
+  padding-top: 1rem;
 }
 
-.activity-view-switcher__option {
+.activity-flow__header {
   align-items: center;
-  background: transparent;
-  border: 0;
-  color: var(--bootui-text-muted);
-  display: inline-flex;
-  font-size: 0.85rem;
-  gap: 0.35rem;
-  padding: 0.25rem 0.75rem;
-}
-
-.activity-view-switcher__option[aria-pressed='true'] {
-  background: var(--bootui-nav-active-bg);
-  color: #fff;
-}
-
-.activity-view-switcher__option:focus-visible {
-  outline: 2px solid var(--bootui-green-dark);
-  outline-offset: -2px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 0.85rem;
 }
 
 .activity-drawer-backdrop {

--- a/bootui-ui/src/main/frontend/src/views/LiveFlowMode.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveFlowMode.test.js
@@ -184,6 +184,35 @@ describe('LiveFlowMode', () => {
     expect(wrapper.findAll('.flow-edge')).toHaveLength(1)
   })
 
+  it('centres the compact viewport from the application hub rendered bounds', async () => {
+    vi.stubGlobal('fetch', stubFetch(serviceMap()))
+    stubMatchMedia(false)
+
+    wrapper = mountFlow()
+    await flushPromises()
+
+    const stage = wrapper.get('.flow-stage')
+    const application = wrapper.get('.flow-node--app')
+    stage.element.getBoundingClientRect = () => ({left: 0, top: 0, width: 600, height: 200})
+    application.element.getBoundingClientRect = () => ({left: 420, top: 80, width: 172, height: 60})
+
+    await wrapper.get('[aria-label="Zoom in"]').trigger('click')
+    await flushPromises()
+
+    expect(stage.element.scrollLeft).toBe(206)
+    expect(stage.element.scrollTop).toBe(10)
+  })
+
+  it('adapts the viewport height to small maps and caps dense maps', async () => {
+    vi.stubGlobal('fetch', stubFetch(serviceMap()))
+    stubMatchMedia(false)
+
+    wrapper = mountFlow()
+    await flushPromises()
+
+    expect(wrapper.get('.flow-stage').attributes('style')).toContain('height: 126px')
+  })
+
   it('distinguishes a configured dependency with no evidence from an observed one', async () => {
     vi.stubGlobal(
       'fetch',

--- a/bootui-ui/src/main/frontend/src/views/LiveFlowMode.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveFlowMode.vue
@@ -31,13 +31,17 @@ const props = defineProps({
    */
   refreshTick: {type: Number, default: 0},
   /** Whether the parent panel's live stream is currently paused. */
-  paused: {type: Boolean, default: false}
+  paused: {type: Boolean, default: false},
+  /** Whether the map viewport is currently visible and can be centered. */
+  visible: {type: Boolean, default: true}
 })
 
 const PROTOCOL_OPTIONS = ['HTTP_INBOUND', 'CACHE', 'HTTP', 'JDBC', 'KAFKA', 'RABBITMQ']
 const MIN_ZOOM = 0.6
 const MAX_ZOOM = 1.6
 const ZOOM_STEP = 0.2
+const MIN_STAGE_HEIGHT = 120
+const MAX_STAGE_HEIGHT = 384
 
 const report = ref(null)
 const error = ref(null)
@@ -102,6 +106,9 @@ const rovingId = computed(() => {
 const hasFilters = computed(() => Boolean(protocolFilter.value || textFilter.value.trim()))
 const dependencyCount = computed(() => filtered.value.nodes.filter((node) => node.kind === 'DEPENDENCY').length)
 const failingCount = computed(() => filtered.value.nodes.filter((node) => node.outcome === 'RETAINED_FAILURES').length)
+const stageHeight = computed(() =>
+  Math.min(MAX_STAGE_HEIGHT, Math.max(MIN_STAGE_HEIGHT, Math.round(layout.value.height * zoom.value + 2)))
+)
 
 async function loadServiceMap() {
   if (requestInFlight) {
@@ -119,10 +126,12 @@ async function loadServiceMap() {
     }
     const next = normalizeServiceMap(await response.json())
     if (unmounted) return
+    const firstLoad = report.value === null
     applyNewEvidence(next, animationEligibleAtStart && !props.paused && requestPauseGeneration === pauseGeneration)
     report.value = next
     error.value = null
     lastFetched.value = Date.now()
+    if (firstLoad) void centerApplication()
   } catch (err) {
     if (unmounted) return
     error.value = formatLoadError(err, 'Could not load the service map')
@@ -264,6 +273,17 @@ function resetZoom() {
   zoom.value = 1
 }
 
+async function centerApplication() {
+  await nextTick()
+  const stage = scrollElement.value
+  const application = svgElement.value?.querySelector('.flow-node--app')
+  if (!props.visible || !stage || !application) return
+  const stageBounds = stage.getBoundingClientRect()
+  const applicationBounds = application.getBoundingClientRect()
+  stage.scrollLeft += applicationBounds.left + applicationBounds.width / 2 - (stageBounds.left + stageBounds.width / 2)
+  stage.scrollTop += applicationBounds.top + applicationBounds.height / 2 - (stageBounds.top + stageBounds.height / 2)
+}
+
 function clearFilters() {
   protocolFilter.value = ''
   textFilter.value = ''
@@ -335,6 +355,15 @@ watch(
     if (!paused) return
     pauseGeneration += 1
     clearTransientEvidence()
+  }
+)
+
+watch(zoom, centerApplication)
+
+watch(
+  () => props.visible,
+  (visible) => {
+    if (visible) void centerApplication()
   }
 )
 
@@ -442,6 +471,7 @@ watch(selectedId, async (id) => {
         v-if="filtered.nodes.length"
         ref="scrollElement"
         class="flow-stage"
+        :style="{height: `${stageHeight}px`}"
         role="region"
         aria-label="Service map of this application's local integration surface"
       >
@@ -804,11 +834,11 @@ watch(selectedId, async (id) => {
   background: var(--bootui-surface-alt);
   border: 1px solid var(--bootui-border);
   border-radius: var(--bootui-radius-md);
-  height: clamp(22rem, 58vh, 38rem);
 }
 
 .flow-svg {
   display: block;
+  margin-inline: auto;
 }
 
 /* ── Edges ─────────────────────────────────────────────────────────────────── */

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -284,10 +284,12 @@ the reactive adapter.
 
 #### Live flow (service map)
 
-Live Activity has a second reading of the same evidence: a **Live flow** mode, reached from the Feed / Live flow switch
-next to the panel title. Where the feed answers "what just happened, in order?", the map answers "what does this
-application actually talk to?" — the running application at the centre, a single generic **Local HTTP clients** lane
-feeding into it, and one node per outbound dependency, grouped by safe identity. It is served by
+Live Activity opens with a compact **Live flow** service map between the KPI summary and the feed controls. Its viewport
+adapts to the graph's content (up to a bounded scrolling height for dense maps) and centres on **This application**.
+Developers who want a denser event-first view can minimize the map; that preference is remembered in the browser, while
+the feed remains visible and usable underneath. Where the feed answers "what just happened, in order?", the map answers
+"what does this application actually talk to?" — the running application at the centre, a single generic **Local HTTP
+clients** lane feeding into it, and one node per outbound dependency, grouped by safe identity. It is served by
 `GET /bootui/api/activity/service-map` on Spring MVC, Spring WebFlux, and Quarkus.
 
 Nothing new is instrumented and nothing is contacted. The map is assembled entirely from bounded buffers other panels


### PR DESCRIPTION
## What does this PR do?

Shows the Live Flow service map inline in the Live Activity panel by default, between the KPI summary and feed controls, with a remembered minimize preference. The map viewport adapts to its content and keeps the `This application` node at the exact center of the graph.

## Why is this change needed?

The graphical view should be immediately visible without replacing the event feed or requiring a separate tab. Keeping it compact, centered, and collapsible preserves the feed-first workflow for users who prefer a denser panel.

Closes: N/A (no linked issue)

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Additional validation:

- `npm test -- serviceMap.test.js LiveFlowMode.test.js LiveActivity.test.js`
- `npm run build`
- Verified the current frontend against the Spring MVC sample backend and measured a 0px offset between the application node and map viewport center.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed