### PR TITLE
Add Hibernate second-level cache sample action

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/sample-api.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/sample-api.spec.js
@@ -17,6 +17,7 @@ test.describe('Sample application REST API', () => {
     expect(body).not.toContain('BootUI console')
     expect(body).toContain('Sample action lab')
     expect(body).toContain('GET /api/sample/products')
+    expect(body).toContain('Test Hibernate second-level cache')
     expect(body).toContain('Create session data')
     expect(body).toContain('Secure API as admin')
     expect(body).toContain('Secure SQL request as admin')
@@ -33,6 +34,10 @@ test.describe('Sample application REST API', () => {
     await page.getByRole('button', {name: 'Run an SQL query'}).click()
     await expect(page.locator('#sample-action-status')).toContainText(/Ran a live SQL SELECT and matched \d+ product/)
     await expect(page.locator('#sample-action-result')).toContainText('Sample Console')
+
+    await page.getByRole('button', {name: 'Test Hibernate second-level cache'}).click()
+    await expect(page.locator('#sample-action-status')).toContainText(/Observed \d+ second-level cache hit/)
+    await expect(page.locator('#sample-action-result')).toContainText('Hits: +1')
 
     await page.getByRole('button', {name: 'Create session data'}).click()
     await expect(page.locator('#session-data-status')).toContainText('Added 5 attributes')
@@ -96,6 +101,17 @@ test.describe('Sample application REST API', () => {
     const names = products.map((p) => p.name)
     expect(names).toContain('Sample Console')
     expect(names).not.toContain('BootUI Starter')
+  })
+
+  test('GET /api/sample/hibernate-second-level-cache produces a cache hit', async ({request}) => {
+    const response = await request.get('/api/sample/hibernate-second-level-cache')
+    expect(response.status()).toBe(200)
+    const body = await response.json()
+    expect(body.loads).toBe(2)
+    expect(body.missCountDelta).toBeGreaterThanOrEqual(1)
+    expect(body.putCountDelta).toBeGreaterThanOrEqual(1)
+    expect(body.hitCountDelta).toBeGreaterThanOrEqual(1)
+    expect(body.regionName).toBe('io.github.jdubois.bootui.sample.catalog.Product')
   })
 
   test('GET /api/sample/metrics-burst records custom meters', async ({request}) => {

--- a/bootui-spring-sample-app/pom.xml
+++ b/bootui-spring-sample-app/pom.xml
@@ -46,6 +46,16 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-jcache</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>jcache</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-flyway</artifactId>
         </dependency>

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/Product.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/Product.java
@@ -1,9 +1,13 @@
 package io.github.jdubois.bootui.sample.catalog;
 
 import jakarta.persistence.*;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
 
 @Entity
 @Table(name = "sample_products")
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 // Hibernate Advisor demo: the IDENTITY id below intentionally triggers HIB-ID-001.
 public class Product {
 

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleController.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleController.java
@@ -32,6 +32,7 @@ public class SampleController {
 
     private final SampleSettings settings;
     private final SampleCatalog catalog;
+    private final SampleHibernateCacheScenarios hibernateCacheScenarios;
     private final SampleTransactionScenarios transactionScenarios;
     private final ObservationRegistry observationRegistry;
     private final Counter ordersProcessedCounter;
@@ -41,12 +42,14 @@ public class SampleController {
     public SampleController(
             SampleSettings settings,
             SampleCatalog catalog,
+            SampleHibernateCacheScenarios hibernateCacheScenarios,
             SampleTransactionScenarios transactionScenarios,
             MeterRegistry meterRegistry,
             ObservationRegistry observationRegistry,
             RestClient quarkusRestClient) {
         this.settings = settings;
         this.catalog = catalog;
+        this.hibernateCacheScenarios = hibernateCacheScenarios;
         this.transactionScenarios = transactionScenarios;
         this.observationRegistry = observationRegistry;
         this.quarkusRestClient = quarkusRestClient;
@@ -71,6 +74,11 @@ public class SampleController {
     @GetMapping("/product-search")
     public List<ProductSummary> productSearch(@RequestParam(name = "term", defaultValue = "console") String term) {
         return catalog.searchProducts(term);
+    }
+
+    @GetMapping("/hibernate-second-level-cache")
+    public Map<String, Object> hibernateSecondLevelCache() {
+        return hibernateCacheScenarios.run();
     }
 
     @GetMapping("/transaction-samples")

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleHibernateCacheScenarios.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/catalog/SampleHibernateCacheScenarios.java
@@ -1,0 +1,76 @@
+package io.github.jdubois.bootui.sample.catalog;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import java.util.Map;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SampleHibernateCacheScenarios {
+
+    private final ProductRepository products;
+    private final EntityManagerFactory entityManagerFactory;
+
+    public SampleHibernateCacheScenarios(ProductRepository products, EntityManagerFactory entityManagerFactory) {
+        this.products = products;
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    public synchronized Map<String, Object> run() {
+        Long productId = products.findAll().stream()
+                .findFirst()
+                .map(Product::getId)
+                .orElseThrow(() -> new IllegalStateException("No sample product is available"));
+
+        entityManagerFactory.getCache().evict(Product.class);
+        Statistics statistics =
+                entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        long hitsBefore = statistics.getSecondLevelCacheHitCount();
+        long missesBefore = statistics.getSecondLevelCacheMissCount();
+        long putsBefore = statistics.getSecondLevelCachePutCount();
+
+        ProductSummary firstLoad = loadInNewPersistenceContext(productId);
+        ProductSummary secondLoad = loadInNewPersistenceContext(productId);
+
+        return Map.of(
+                "product",
+                secondLoad,
+                "loads",
+                2,
+                "firstLoadProduct",
+                firstLoad.name(),
+                "hitCountDelta",
+                statistics.getSecondLevelCacheHitCount() - hitsBefore,
+                "missCountDelta",
+                statistics.getSecondLevelCacheMissCount() - missesBefore,
+                "putCountDelta",
+                statistics.getSecondLevelCachePutCount() - putsBefore,
+                "regionName",
+                Product.class.getName());
+    }
+
+    private ProductSummary loadInNewPersistenceContext(Long productId) {
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        try {
+            transaction.begin();
+            Product product = entityManager.find(Product.class, productId);
+            if (product == null) {
+                throw new IllegalStateException("Sample product " + productId + " was not found");
+            }
+            ProductSummary summary = ProductSummary.from(product);
+            transaction.commit();
+            return summary;
+        } catch (RuntimeException failure) {
+            if (transaction.isActive()) {
+                transaction.rollback();
+            }
+            throw failure;
+        } finally {
+            entityManager.close();
+        }
+    }
+}

--- a/bootui-spring-sample-app/src/main/resources/application.conf
+++ b/bootui-spring-sample-app/src/main/resources/application.conf
@@ -1,0 +1,7 @@
+caffeine.jcache {
+  default {
+    policy.maximum.size = 100
+  }
+
+  io.github.jdubois.bootui.sample.catalog.Product {}
+}

--- a/bootui-spring-sample-app/src/main/resources/application.properties
+++ b/bootui-spring-sample-app/src/main/resources/application.properties
@@ -27,6 +27,11 @@ spring.sql.init.mode=always
 # counters to demonstrate in the sample app (mirrors HIB-CONFIG-007's own tuning recommendation).
 spring.jpa.properties.hibernate.generate_statistics=true
 
+# Back the Product entity's Hibernate second-level cache with a small, local Caffeine JCache region.
+spring.jpa.properties.hibernate.cache.use_second_level_cache=true
+spring.jpa.properties.hibernate.cache.region.factory_class=jcache
+spring.jpa.properties.hibernate.javax.cache.provider=com.github.benmanes.caffeine.jcache.spi.CaffeineCachingProvider
+
 # Flyway manages the "catalog" tables (db/migration); Liquibase manages the separate "inventory" tables.
 # The sample app applies only the base migration state on startup, leaving two Flyway migrations and two Liquibase
 # change sets pending so the BootUI actions can be exercised manually.

--- a/bootui-spring-sample-app/src/main/resources/static/index.html
+++ b/bootui-spring-sample-app/src/main/resources/static/index.html
@@ -265,6 +265,11 @@
           <small>Inspect: SQL Trace, Spring Data</small>
         </article>
         <article class="test-action">
+          <button class="button" id="hibernate-cache-button" type="button">Test Hibernate second-level cache</button>
+          <p>Loads one entity twice in separate persistence contexts to produce a cache miss, put, and hit.</p>
+          <small>Inspect: Hibernate Statistics</small>
+        </article>
+        <article class="test-action">
           <button class="button" id="transaction-samples-button" type="button">Generate transaction samples</button>
           <p>Creates committed, slow, rolled-back, and nested transaction boundaries in one safe request.</p>
           <small>Inspect: Transactions</small>
@@ -390,6 +395,7 @@
   const chatResult = document.getElementById('ai-chat-result')
   const productsButton = document.getElementById('products-button')
   const sqlQueryButton = document.getElementById('sql-query-button')
+  const hibernateCacheButton = document.getElementById('hibernate-cache-button')
   const transactionSamplesButton = document.getElementById('transaction-samples-button')
   const greetingButton = document.getElementById('greeting-button')
   const publicApiButton = document.getElementById('public-api-button')
@@ -515,6 +521,24 @@
       showSampleResult(
         `Ran a live SQL SELECT and matched ${products.length} product(s) for "${term}"`,
         `${names}\n\nOpen BootUI SQL Trace to inspect the captured statement.`
+      )
+    })
+  )
+
+  hibernateCacheButton.addEventListener('click', () =>
+    runSampleAction(hibernateCacheButton, 'Testing Hibernate second-level cache...', async () => {
+      const response = await fetch('/api/sample/hibernate-second-level-cache', {
+        headers: {Accept: 'application/json'}
+      })
+      const body = await response.json()
+      if (!response.ok) {
+        throw new Error(body.error || `Hibernate cache request failed with HTTP ${response.status}`)
+      }
+      showSampleResult(
+        `Observed ${body.hitCountDelta} second-level cache hit(s) across ${body.loads} entity loads`,
+        `Product: ${body.product.name}\nRegion: ${body.regionName}\n` +
+          `Misses: +${body.missCountDelta}\nPuts: +${body.putCountDelta}\nHits: +${body.hitCountDelta}\n\n` +
+          'Open BootUI Hibernate Statistics to inspect the region and cumulative counters.'
       )
     })
   )

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -452,6 +452,21 @@ class BootUiSampleApplicationIntegrationTests {
     }
 
     @Test
+    void hibernateSecondLevelCacheSampleProducesMissPutAndHit() {
+        ResponseEntity<Map> response = getMap("/api/sample/hibernate-second-level-cache");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body.get("loads")).isEqualTo(2);
+        assertThat(((Number) body.get("missCountDelta")).longValue()).isGreaterThanOrEqualTo(1);
+        assertThat(((Number) body.get("putCountDelta")).longValue()).isGreaterThanOrEqualTo(1);
+        assertThat(((Number) body.get("hitCountDelta")).longValue()).isGreaterThanOrEqualTo(1);
+        assertThat(body.get("regionName")).isEqualTo(Product.class.getName());
+        assertThat(((Map<?, ?>) body.get("product")).get("name")).isNotNull();
+    }
+
+    @Test
     void rootIndexPageIntroducesTheSampleApp() {
         ResponseEntity<String> response = getString("/");
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1301,7 +1301,9 @@ listener hook exists solely on the blocking `PlatformTransactionManager` SPI. Ca
 size, and the slow-transaction and connection-hold thresholds are all configurable under `bootui.transactions.*`.
 The Spring sample's product list and uncached product-search operations use explicit read-only service transactions, so
 loading or checking products produces representative entries in this panel as well as SQL Trace. Its sample action lab
-also has a one-click transaction scenario set that generates committed, slow, rolled-back, and nested boundaries.
+also has a one-click transaction scenario set that generates committed, slow, rolled-back, and nested boundaries, plus a
+Hibernate second-level cache action that loads one entity through two persistence contexts to produce visible miss, put,
+and hit counters in Hibernate Statistics.
 
 Like SQL Trace, the panel refreshes over **Server-Sent Events**: the browser subscribes to
 `/bootui/api/transactions/stream` and the server pushes a small coalesced notification whenever a transaction completes,


### PR DESCRIPTION
## What does this PR do?

Adds a sample-app action that exercises Hibernate's second-level cache and reports the observed miss, put, and hit deltas.

## Why is this change needed?

The Hibernate Statistics panel exposes second-level cache metrics, but the sample app had no direct way to generate representative cache activity. The new action uses a bounded Caffeine JCache region and loads the same `Product` through two separate persistence contexts so reviewers can observe a real cache hit.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Focused validation included `BootUiSampleApplicationIntegrationTests`, the Spring sample `sample-api.spec.js` Playwright suite, Maven Spotless, and Prettier checks.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed