### PR TITLE
docs: complete MCP tool lists

### DIFF
--- a/docs/AI-AGENTS.md
+++ b/docs/AI-AGENTS.md
@@ -87,15 +87,16 @@ agent will see before you wire it up.
 Tools whose backing panel/controller is absent (for example Hibernate or Spring Security when those libraries are not on
 the classpath) are simply not advertised.
 
-- **Advisor scans (actions):** `architecture_scan`, `spring_scan`, `hibernate_scan`, `memory_scan`, `security_scan`,
-  `pentest_scan`, `rest_api_scan`, `graalvm_scan`, `crac_scan`, `vulnerabilities_scan`. Each runs the same scan as the
-  panel's action button and returns the report DTO; `vulnerabilities_scan` additionally makes outbound calls to
-  OSV.dev to check dependencies for known vulnerabilities.
+- **Advisor scans (actions):** `architecture_scan`, `spring_scan`, `hibernate_scan`, `database_advisor_scan`,
+  `memory_scan`, `security_scan`, `pentest_scan`, `rest_api_scan`, `graalvm_scan`, `crac_scan`,
+  `vulnerabilities_scan`. Each runs the same scan as the panel's action button and returns the report DTO;
+  `vulnerabilities_scan` additionally makes outbound calls to OSV.dev to check dependencies for known vulnerabilities.
 - **Diagnostics reads:** `get_live_activity`, `get_exceptions`, `get_exception_detail`, `get_security_logs`,
-  `get_sql_traces`, `get_traces`, `get_log_tail`, `get_http_exchanges`. `get_live_activity` returns the correlated feed
-  the [Live Activity panel](FEATURES.md) shows (HTTP requests, SQL statements, exceptions, and security events grouped
-  by request/trace); `get_exception_detail` takes a required `id` (from `get_exceptions` or `get_live_activity`) and
-  returns that exception group's full stack trace, causes, and individual occurrences.
+  `get_sql_traces`, `get_transactions` (Spring MVC/WebFlux only), `get_traces`, `get_log_tail`, `get_http_exchanges`.
+  `get_live_activity` returns the correlated feed the [Live Activity panel](FEATURES.md) shows (HTTP requests, SQL
+  statements, exceptions, and security events grouped by request/trace); `get_exception_detail` takes a required `id`
+  (from `get_exceptions` or `get_live_activity`) and returns that exception group's full stack trace, causes, and
+  individual occurrences.
 - **Core context reads:** `get_overview`, `get_health`, `get_config` (masked), `get_beans`, `get_mappings`,
   `get_loggers`, `get_conditions` (Spring MVC/WebFlux only), `get_scheduled_tasks`, `get_cache_stats`,
   `get_database_connection_pools`.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1830,15 +1830,16 @@ The panel explains what the server does and lists every tool it exposes. Tools r
 rather than reimplementing anything, so every tool returns the same masked, bounded shape as the REST API, in three
 groups:
 
-- **Advisor scans (actions):** `architecture_scan`, `spring_scan`, `hibernate_scan`, `memory_scan`, `security_scan`,
-  `pentest_scan`, `rest_api_scan`, `graalvm_scan`, `crac_scan`, `vulnerabilities_scan`. Each triggers the same scan the
-  panel's action button runs and returns the report DTO; `vulnerabilities_scan` additionally makes outbound calls to
-  OSV.dev.
+- **Advisor scans (actions):** `architecture_scan`, `spring_scan`, `hibernate_scan`, `database_advisor_scan`,
+  `memory_scan`, `security_scan`, `pentest_scan`, `rest_api_scan`, `graalvm_scan`, `crac_scan`,
+  `vulnerabilities_scan`. Each triggers the same scan the panel's action button runs and returns the report DTO;
+  `vulnerabilities_scan` additionally makes outbound calls to OSV.dev.
 - **Diagnostics reads:** `get_live_activity`, `get_exceptions`, `get_exception_detail`, `get_security_logs`,
-  `get_sql_traces`, `get_traces`, `get_log_tail`, `get_http_exchanges`. `get_live_activity` returns the correlated feed
-  the [Live Activity panel](#live-activity) shows (HTTP requests, SQL statements, exceptions, security events,
-  scheduled-task runs, and — Spring only — cache accesses, grouped by request/trace); `get_exception_detail` takes a required `id` (from `get_exceptions` or
-  `get_live_activity`) and returns that exception group's full stack trace, causes, and individual occurrences.
+  `get_sql_traces`, `get_transactions` (Spring MVC/WebFlux only), `get_traces`, `get_log_tail`, `get_http_exchanges`.
+  `get_live_activity` returns the correlated feed the [Live Activity panel](#live-activity) shows (HTTP requests, SQL
+  statements, exceptions, security events, scheduled-task runs, and — Spring only — cache accesses, grouped by
+  request/trace); `get_exception_detail` takes a required `id` (from `get_exceptions` or `get_live_activity`) and returns
+  that exception group's full stack trace, causes, and individual occurrences.
 - **Core context reads:** `get_overview`, `get_health`, `get_config` (masked), `get_beans`, `get_mappings`,
   `get_loggers`, `get_conditions` (Spring MVC/WebFlux only — Quarkus has no runtime condition-match graph),
   `get_scheduled_tasks`, `get_cache_stats`, `get_database_connection_pools`.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -2108,16 +2108,17 @@ Design rules:
   `tools/call` remains an HTTP `200` MCP response but returns an in-band tool error (`isError: true`) with the canonical
   busy message. Panel disabled/read-only policy is checked first, and the aggregate MCP concurrent-call cap remains a
   separate capacity limit.
-- **Tool surface.** Advisor scans as action tools (`architecture_scan`, `spring_scan`, `hibernate_scan`, `memory_scan`,
-  `security_scan`, `pentest_scan`, `rest_api_scan`, `graalvm_scan`, `crac_scan`, `vulnerabilities_scan`); diagnostics
-  reads (`get_live_activity`, `get_exceptions`, `get_exception_detail`, `get_security_logs`, `get_sql_traces`,
-  `get_traces`, `get_log_tail`, `get_http_exchanges`); and core context reads (`get_overview`, `get_health`,
-  `get_config`, `get_beans`, `get_mappings`, `get_loggers`, `get_conditions`, `get_scheduled_tasks`, `get_cache_stats`,
-  `get_database_connection_pools`). `get_live_activity` returns the same correlated feed as the Live Activity panel;
-  `get_exception_detail` takes a required `id` argument and returns one exception group's full stack trace, causes,
-  and occurrences. `vulnerabilities_scan` makes outbound calls to OSV.dev, unlike every other read/scan tool which
-  stays local. Tools whose backing controller is absent (conditional on classpath, e.g. Hibernate or Spring Security)
-  or not applicable to the running stack (e.g. `get_conditions` on Quarkus) are not advertised.
+- **Tool surface.** Advisor scans as action tools (`architecture_scan`, `spring_scan`, `hibernate_scan`,
+  `database_advisor_scan`, `memory_scan`, `security_scan`, `pentest_scan`, `rest_api_scan`, `graalvm_scan`, `crac_scan`,
+  `vulnerabilities_scan`); diagnostics reads (`get_live_activity`, `get_exceptions`, `get_exception_detail`,
+  `get_security_logs`, `get_sql_traces`, `get_transactions` (Spring MVC/WebFlux only), `get_traces`, `get_log_tail`,
+  `get_http_exchanges`); and core context reads (`get_overview`, `get_health`, `get_config`, `get_beans`, `get_mappings`,
+  `get_loggers`, `get_conditions`, `get_scheduled_tasks`, `get_cache_stats`, `get_database_connection_pools`).
+  `get_live_activity` returns the same correlated feed as the Live Activity panel; `get_exception_detail` takes a
+  required `id` argument and returns one exception group's full stack trace, causes, and occurrences.
+  `vulnerabilities_scan` makes outbound calls to OSV.dev, unlike every other read/scan tool which stays local. Tools
+  whose backing controller is absent (conditional on classpath, e.g. Hibernate or Spring Security) or not applicable
+  to the running stack (e.g. `get_conditions` and `get_transactions` on Quarkus) are not advertised.
 - **Agent guidance.** Initialization instructions direct agents to establish overview/health context, prefer the smallest
   relevant read, correlate exception and trace identifiers, verify advisor findings before changing code, and account for
   active scan costs (`memory_scan` may trigger a full GC; `pentest_scan` sends bounded loopback probes). Tool descriptions


### PR DESCRIPTION
## What does this PR do?

Adds `database_advisor_scan` and `get_transactions` to the canonical MCP tool inventories, with transaction diagnostics identified as Spring MVC/WebFlux-only.

## Why is this change needed?

The runtime catalogs already advertise these tools, but the AI agent guide, feature documentation, and specification omitted them, making the documented MCP surface incomplete.

Fixes: #793

## How was it tested?

Documentation-only change; reviewed the final diff and verified all three inventories against the Spring MVC, Spring WebFlux, and Quarkus MCP catalogs.

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed