### PR TITLE
docs: complete panel access matrix

### DIFF
--- a/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
+++ b/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
@@ -12,14 +12,19 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 class BackendPanelCatalogConsistencyTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Pattern PANEL_ACCESS_ROW = Pattern.compile(
+            "^\\|\\s*[^|]+\\|\\s*([^|]+?)\\s*\\|\\s*`([^`]+)`\\s*\\|\\s*`([^`]+)`\\s*\\|\\s*(.*?)\\s*\\|$",
+            Pattern.MULTILINE);
 
     private static final List<ManifestResource> MANIFEST_RESOURCES = List.of(
             new ManifestResource("/io/github/jdubois/bootui/conformance/expected-panels-spring.json", "spring-boot"),
@@ -76,6 +81,31 @@ class BackendPanelCatalogConsistencyTest {
                     .containsPattern(Pattern.compile(
                             "^" + Pattern.quote(headingPrefix + panel.title()) + "$", Pattern.MULTILINE));
         }
+    }
+
+    @Test
+    void backendCatalogMatchesPropertiesPanelAccessMatrix() {
+        String properties = readPropertiesMarkdown();
+        String accessMatrix = properties.substring(
+                properties.indexOf("## Panel access settings"), properties.indexOf("## Per-panel action details"));
+        Matcher rows = PANEL_ACCESS_ROW.matcher(accessMatrix);
+        List<PanelAccessMetadata> documented = new ArrayList<>();
+        while (rows.find()) {
+            documented.add(new PanelAccessMetadata(
+                    rows.group(1).trim(), rows.group(2), rows.group(3), markdownCodeValue(rows.group(4))));
+        }
+
+        List<PanelAccessMetadata> expected = BootUiPanels.all().stream()
+                .map(panel -> new PanelAccessMetadata(
+                        panel.title(),
+                        panel.id(),
+                        "bootui.panels." + panel.id() + ".enabled",
+                        panel.actionCapable()
+                                ? "bootui.panels." + panel.id() + ".read-only"
+                                : "Not applicable; view-only."))
+                .toList();
+
+        assertThat(documented).containsExactlyInAnyOrderElementsOf(expected);
     }
 
     @Test
@@ -140,13 +170,29 @@ class BackendPanelCatalogConsistencyTest {
     }
 
     private static String readFeaturesMarkdown() {
+        return readDocumentation("FEATURES.md");
+    }
+
+    private static String readPropertiesMarkdown() {
+        return readDocumentation("PROPERTIES.md");
+    }
+
+    private static String readDocumentation(String filename) {
         Path root = findRepositoryRoot(Path.of(".").toAbsolutePath());
-        Path features = root.resolve("docs").resolve("FEATURES.md");
+        Path documentation = root.resolve("docs").resolve(filename);
         try {
-            return Files.readString(features);
+            return Files.readString(documentation);
         } catch (IOException ex) {
-            throw new UncheckedIOException("Failed to read " + features, ex);
+            throw new UncheckedIOException("Failed to read " + documentation, ex);
         }
+    }
+
+    private static String markdownCodeValue(String value) {
+        String trimmed = value.trim();
+        if (trimmed.startsWith("`") && trimmed.endsWith("`")) {
+            return trimmed.substring(1, trimmed.length() - 1);
+        }
+        return trimmed;
     }
 
     private static Path findRepositoryRoot(Path start) {
@@ -165,4 +211,6 @@ class BackendPanelCatalogConsistencyTest {
     private record ManifestResource(String path, String platform) {}
 
     private record PanelMetadata(String id, String title, boolean actionCapable) {}
+
+    private record PanelAccessMetadata(String title, String id, String enabledProperty, String readOnlyProperty) {}
 }

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -155,11 +155,12 @@ Enforced identically on Spring and Quarkus (`PanelAccessFilter` / `QuarkusPanelA
 | Group           | Panel                     | Panel id                    | Enable property                                   | Read-only property                        |
 | --------------- | ------------------------- | --------------------------- | ------------------------------------------------- | ----------------------------------------- |
 | Overview        | Overview                  | `overview`                  | `bootui.panels.overview.enabled`                  | Not applicable; view-only.                |
-| Overview        | Live Activity             | `activity`                  | `bootui.panels.activity.enabled`                  | Not applicable; view-only.                |
+| Overview        | Live Activity             | `activity`                  | `bootui.panels.activity.enabled`                  | `bootui.panels.activity.read-only`         |
 | Overview        | GitHub                    | `github`                    | `bootui.panels.github.enabled`                    | `bootui.panels.github.read-only`          |
 | Advisors        | Architecture              | `architecture`              | `bootui.panels.architecture.enabled`              | `bootui.panels.architecture.read-only`    |
 | Advisors        | REST API                  | `rest-api`                  | `bootui.panels.rest-api.enabled`                  | `bootui.panels.rest-api.read-only`        |
 | Advisors        | Spring                    | `spring`                    | `bootui.panels.spring.enabled`                    | `bootui.panels.spring.read-only`          |
+| Advisors        | Database                  | `database-advisor`          | `bootui.panels.database-advisor.enabled`          | `bootui.panels.database-advisor.read-only` |
 | Advisors        | Hibernate                 | `hibernate`                 | `bootui.panels.hibernate.enabled`                 | `bootui.panels.hibernate.read-only`       |
 | Advisors        | Memory                    | `memory`                    | `bootui.panels.memory.enabled`                    | `bootui.panels.memory.read-only`          |
 | Advisors        | Security                  | `security`                  | `bootui.panels.security.enabled`                  | `bootui.panels.security.read-only`        |
@@ -182,7 +183,9 @@ Enforced identically on Spring and Quarkus (`PanelAccessFilter` / `QuarkusPanelA
 | Configuration   | Conditions                | `conditions`                | `bootui.panels.conditions.enabled`                | Not applicable; view-only.                |
 | Configuration   | Mappings                  | `mappings`                  | `bootui.panels.mappings.enabled`                  | Not applicable; view-only.                |
 | Database        | Database Connection Pools | `database-connection-pools` | `bootui.panels.database-connection-pools.enabled` | Not applicable; view-only.                |
+| Database        | Transactions              | `transactions`              | `bootui.panels.transactions.enabled`              | `bootui.panels.transactions.read-only`    |
 | Database        | SQL Trace                 | `sql-trace`                 | `bootui.panels.sql-trace.enabled`                 | `bootui.panels.sql-trace.read-only`       |
+| Database        | Hibernate Statistics      | `hibernate-statistics`      | `bootui.panels.hibernate-statistics.enabled`      | `bootui.panels.hibernate-statistics.read-only` |
 | Database        | Spring Data               | `data`                      | `bootui.panels.data.enabled`                      | Not applicable; view-only.                |
 | Database        | Flyway                    | `flyway`                    | `bootui.panels.flyway.enabled`                    | `bootui.panels.flyway.read-only`          |
 | Database        | Liquibase                 | `liquibase`                 | `bootui.panels.liquibase.enabled`                 | `bootui.panels.liquibase.read-only`       |


### PR DESCRIPTION
## What does this PR do?

Documents the missing Database Advisor, Transactions, and Hibernate Statistics panel access properties, corrects Live Activity's read-only entry, and adds a catalog consistency test that prevents future drift.

## Why is this change needed?

The property reference omitted three runtime-supported panels from its access matrix, making their enable and read-only keys difficult to discover. The new conformance assertion keeps every documented panel id, title, enable key, and read-only capability aligned with `BootUiPanels`.

Fixes: #788

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A - documentation and conformance-test changes only.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed