### PR TITLE
test: prevent panel documentation drift

### DIFF
--- a/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
+++ b/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
@@ -13,6 +13,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -25,6 +26,11 @@ class BackendPanelCatalogConsistencyTest {
     private static final Pattern PANEL_ACCESS_ROW = Pattern.compile(
             "^\\|\\s*[^|]+\\|\\s*([^|]+?)\\s*\\|\\s*`([^`]+)`\\s*\\|\\s*`([^`]+)`\\s*\\|\\s*(.*?)\\s*\\|$",
             Pattern.MULTILINE);
+    private static final Pattern ENDPOINT_ROW =
+            Pattern.compile("^\\|\\s*`/bootui/api([^`]*)`\\s*\\|\\s*([^|]+?)\\s*\\|", Pattern.MULTILINE);
+    private static final Pattern MCP_TOOL_NAME = Pattern.compile("(?:Map\\.entry\\(|case)\\s*\"([a-z0-9_]+)\"");
+    private static final Pattern SCREENSHOT_ENTRY =
+            Pattern.compile("\\[\\s*'[^']+'\\s*,\\s*'[^']+'\\s*,\\s*'(bootui-[^']+\\.webp)'\\s*,", Pattern.DOTALL);
 
     private static final List<ManifestResource> MANIFEST_RESOURCES = List.of(
             new ManifestResource("/io/github/jdubois/bootui/conformance/expected-panels-spring.json", "spring-boot"),
@@ -109,6 +115,74 @@ class BackendPanelCatalogConsistencyTest {
     }
 
     @Test
+    void readContractCatalogIsDocumentedInSpecificationEndpointTable() {
+        String specification = readDocumentation("SPECIFICATION.md");
+        String endpointTable = section(specification, "### 6.4 API design", "### 6.5 Configuration properties");
+        Matcher rows = ENDPOINT_ROW.matcher(endpointTable);
+        Set<String> documentedGetEndpoints = new LinkedHashSet<>();
+        while (rows.find()) {
+            if (rows.group(2).contains("GET")) {
+                documentedGetEndpoints.add(rows.group(1));
+            }
+        }
+
+        for (BootUiApiContractCatalog.ReadContract contract : BootUiApiContractCatalog.reads()) {
+            assertThat(documentedGetEndpoints)
+                    .as("docs/SPECIFICATION.md section 6.4 GET endpoint for panel '%s'", contract.panelId())
+                    .contains(contract.relativePath());
+        }
+    }
+
+    @Test
+    void mcpToolCatalogIsDocumentedInEveryCanonicalToolList() {
+        String descriptions = readRepositoryFile(
+                "bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptions.java");
+        Set<String> toolNames = matches(descriptions, MCP_TOOL_NAME);
+        assertThat(toolNames).as("MCP tools registered in McpToolDescriptions").isNotEmpty();
+
+        List<DocumentationSection> toolLists = List.of(
+                new DocumentationSection(
+                        "docs/AI-AGENTS.md",
+                        section(readDocumentation("AI-AGENTS.md"), "### Tools the agent can call", "### Safety model")),
+                new DocumentationSection(
+                        "docs/FEATURES.md",
+                        section(readDocumentation("FEATURES.md"), "### MCP Server", "### DevTools")),
+                new DocumentationSection(
+                        "docs/SPECIFICATION.md",
+                        section(
+                                readDocumentation("SPECIFICATION.md"),
+                                "### 6.7 MCP server for AI agents",
+                                "## 7. UX specification")));
+
+        for (DocumentationSection toolList : toolLists) {
+            for (String toolName : toolNames) {
+                assertThat(toolList.content())
+                        .as("%s MCP tool '%s'", toolList.filename(), toolName)
+                        .contains("`" + toolName + "`");
+            }
+        }
+    }
+
+    @Test
+    void screenshotCaptureManifestHasFilesAndFeatureEmbeds() {
+        String captureScript = readRepositoryFile("bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs");
+        String screenshotManifest = section(captureScript, "const screenshots = [", "const baseScreenshots =");
+        Set<String> screenshots = matches(screenshotManifest, SCREENSHOT_ENTRY);
+        assertThat(screenshots).as("documentation screenshot capture manifest").isNotEmpty();
+
+        Path images = repositoryRoot().resolve("docs/images");
+        String features = readFeaturesMarkdown();
+        for (String screenshot : screenshots) {
+            assertThat(images.resolve(screenshot))
+                    .as("docs image for screenshot manifest entry '%s'", screenshot)
+                    .isRegularFile();
+            assertThat(features)
+                    .as("docs/FEATURES.md embed for screenshot manifest entry '%s'", screenshot)
+                    .contains("](./images/" + screenshot + ")");
+        }
+    }
+
+    @Test
     void readContractCatalogCoversEveryDataPanelExactlyOnce() {
         Set<String> expected = BootUiPanels.all().stream()
                 .map(Panel::id)
@@ -178,13 +252,34 @@ class BackendPanelCatalogConsistencyTest {
     }
 
     private static String readDocumentation(String filename) {
-        Path root = findRepositoryRoot(Path.of(".").toAbsolutePath());
-        Path documentation = root.resolve("docs").resolve(filename);
+        return readRepositoryFile("docs/" + filename);
+    }
+
+    private static String readRepositoryFile(String relativePath) {
+        Path file = repositoryRoot().resolve(relativePath);
         try {
-            return Files.readString(documentation);
+            return Files.readString(file);
         } catch (IOException ex) {
-            throw new UncheckedIOException("Failed to read " + documentation, ex);
+            throw new UncheckedIOException("Failed to read " + file, ex);
         }
+    }
+
+    private static String section(String content, String startMarker, String endMarker) {
+        int start = content.indexOf(startMarker);
+        int end = content.indexOf(endMarker, start + startMarker.length());
+        if (start < 0 || end < 0) {
+            throw new IllegalStateException("Unable to find section from '" + startMarker + "' to '" + endMarker + "'");
+        }
+        return content.substring(start, end);
+    }
+
+    private static Set<String> matches(String content, Pattern pattern) {
+        Matcher matcher = pattern.matcher(content);
+        Set<String> matches = new LinkedHashSet<>();
+        while (matcher.find()) {
+            matches.add(matcher.group(1));
+        }
+        return matches;
     }
 
     private static String markdownCodeValue(String value) {
@@ -208,9 +303,15 @@ class BackendPanelCatalogConsistencyTest {
         throw new IllegalStateException("Unable to locate repository root from " + start);
     }
 
+    private static Path repositoryRoot() {
+        return findRepositoryRoot(Path.of(".").toAbsolutePath());
+    }
+
     private record ManifestResource(String path, String platform) {}
 
     private record PanelMetadata(String id, String title, boolean actionCapable) {}
 
     private record PanelAccessMetadata(String title, String id, String enabledProperty, String readOnlyProperty) {}
+
+    private record DocumentationSection(String filename, String content) {}
 }

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -2049,6 +2049,8 @@ Initial endpoints:
 | `/bootui/api/http-probe`                          | POST   | Local HTTP probe                                                                       |
 | `/bootui/api/log-tail/recent`                    | GET    | Recent log lines                                                                       |
 | `/bootui/api/log-tail/stream`                    | GET    | Log stream over Server-Sent Events                                                     |
+| `/bootui/api/exceptions`                         | GET    | Bounded exception groups with status and occurrence summaries                         |
+| `/bootui/api/http-exchanges`                     | GET    | Recent application HTTP request/response metadata                                      |
 | `/bootui/api/traces`                         | GET    | Recent local trace summaries                                                           |
 | `/bootui/api/traces/{traceId}`               | GET    | Trace waterfall detail                                                                 |
 | `/bootui/api/traces`                         | DELETE | Clear retained local traces when not read-only                                         |
@@ -2080,6 +2082,7 @@ Initial endpoints:
 | `/bootui/api/graalvm`                        | GET    | Latest GraalVM native-image readiness report                                           |
 | `/bootui/api/graalvm/scan`                   | POST   | Run explicit native-image readiness checks                                             |
 | `/bootui/api/graalvm/metadata`               | GET    | Download generated reachability metadata scaffold                                      |
+| `/bootui/api/crac`                            | GET    | Latest CRaC checkpoint/restore readiness report                                        |
 | `/bootui/api/flyway/migrations`              | GET    | Flyway migration state and action availability per database                            |
 | `/bootui/api/flyway/migrate`                 | POST   | Run pending Flyway migrations only when confirmed, not read-only, and not Modulith-managed |
 | `/bootui/api/flyway/clean`                   | POST   | Clean Flyway-managed schemas only when confirmed, allowed by Flyway, not read-only, and not Modulith-managed |
@@ -2095,7 +2098,9 @@ Initial endpoints:
 | `/bootui/api/security/scan`          | POST   | Run explicit Spring Security hardening checks                                          |
 | `/bootui/api/pentesting`                        | GET    | Latest local OWASP hygiene report                                                      |
 | `/bootui/api/pentesting/scan`                   | POST   | Run explicit bounded loopback OWASP hygiene checks                                    |
+| `/bootui/api/copilot/dashboard`                 | GET    | Sanitized GitHub Copilot CLI activity dashboard                                        |
 | `/bootui/api/copilot/**`                     | GET    | Sanitized GitHub Copilot CLI session dashboard, token usage, explorer, raw reveal, SSE |
+| `/bootui/api/claude-code/dashboard`             | GET    | Sanitized Claude Code activity dashboard                                               |
 | `/bootui/api/claude-code/**`                 | GET    | Sanitized Claude Code project-log dashboard, token usage, explorer, raw reveal, SSE    |
 | `/bootui/api/mcp-server`                     | GET    | MCP Server panel status (enabled state, configured mode, transport, advertised tools)  |
 | `/bootui/api/mcp-server/toggle`              | POST   | Enable/disable the MCP server at runtime, overriding `bootui.mcp.enabled`               |
@@ -2104,10 +2109,16 @@ Initial endpoints:
 | `/bootui/api/rest-client-trace/clear`        | POST   | Clear the retained REST client call buffer                                              |
 | `/bootui/api/rest-client-trace/recording`    | POST   | Pause/resume REST client call capture at runtime                                        |
 | `/bootui/api/rest-client-trace/stream`       | GET    | REST Client change notifications over Server-Sent Events (re-fetch trigger)             |
+| `/bootui/api/sql-trace`                      | GET    | Current bounded SQL trace snapshot and aggregate statistics                             |
+| `/bootui/api/transactions`                   | GET    | Current bounded transaction-boundary snapshot and aggregate statistics                 |
 | `/bootui/api/activity`                       | GET    | Merged Live Activity stream and KPI summary (params: `type`, `severity`, `since`, `limit`, plus `q`, `until`, `cursor`, `pageSize` when persistence is enabled) |
 | `/bootui/api/activity/stream`                | GET    | Live Activity change notifications over Server-Sent Events (re-fetch trigger)           |
 | `/bootui/api/activity/request/{id}`          | GET    | Per-request profile correlating SQL, exceptions, trace, and auth for one HTTP exchange   |
 | `/bootui/api/activity/use-existing-datasource` | POST | Hot-switch Live Activity from in-memory to the existing `DataSource` (confirmation-gated) |
+| `/bootui/api/email`                          | GET    | Captured outgoing email summaries and content-policy status                             |
+| `/bootui/api/kafka`                          | GET    | Bounded Kafka producer and consumer activity                                            |
+| `/bootui/api/rabbitmq`                       | GET    | Bounded RabbitMQ publisher and consumer activity                                        |
+| `/bootui/api/jms`                            | GET    | Bounded JMS producer and consumer activity                                              |
 
 ### 6.5 Configuration properties
 


### PR DESCRIPTION
## What does this PR do?

Adds conformance guardrails that keep panel properties, API endpoint documentation, MCP tool lists, and screenshot assets/embeds synchronized with their source catalogs and manifests. It also documents the 11 read endpoints exposed by the stricter endpoint check.

## Why is this change needed?

Recent panel additions drifted across documentation surfaces that were not tied to authoritative code. These section-scoped assertions make future omissions fail with the missing panel, endpoint, tool, screenshot, and target file named explicitly.

Fixes: #796

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed