### PR TITLE
Expand Hibernate advisor with targeted performance checks

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
@@ -13,6 +13,7 @@ final class HibernateRuleRegistry {
             new LobLazyFetchRule(),
             new LazyBasicWithoutEnhancementRule(),
             new CollectionFetchJoinAnnotationRule(),
+            new SubselectCollectionFetchRule(),
             // Identifiers
             new IdentityIdentifierRule(),
             new TableIdentifierRule(),
@@ -82,6 +83,8 @@ final class HibernateRuleRegistry {
             new FailOnPaginationOverCollectionFetchRule(),
             new FormatSqlInProductionRule(),
             new BindParameterLoggingInProductionRule(),
+            new SqlCommentsRule(),
+            new OracleJdbcFetchSizeRule(),
 
             // Caching
             new CacheAssociationCoverageRule(),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
@@ -935,8 +935,8 @@ final class JdbcBatchSizeRule extends AbstractHibernateRule {
                         "JDBC batching should be configured for writes",
                         HibernateCategory.CONFIGURATION,
                         "INFO",
-                        "Detects missing or non-positive hibernate.jdbc.batch_size.",
-                        "Set a bounded JDBC batch size such as 25 for write-capable applications, then tune it with representative workloads.",
+                        "Detects hibernate.jdbc.batch_size values below 2, which cannot combine multiple statements into one JDBC batch.",
+                        "Set a bounded JDBC batch size between 5 and 30 for write-capable applications, then tune it with representative workloads.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#batch-session-batch"));
     }
 
@@ -944,10 +944,10 @@ final class JdbcBatchSizeRule extends AbstractHibernateRule {
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
         Integer batchSize = context.firstIntegerProperty(
                 "spring.jpa.properties.hibernate.jdbc.batch_size", "hibernate.jdbc.batch_size");
-        if (batchSize != null && batchSize > 0) {
+        if (batchSize != null && batchSize > 1) {
             return pass();
         }
-        return violation(List.of("hibernate.jdbc.batch_size is not configured with a positive value."));
+        return violation(List.of("hibernate.jdbc.batch_size is not configured with a value greater than 1."));
     }
 }
 
@@ -969,7 +969,7 @@ final class OrderedBatchingRule extends AbstractHibernateRule {
     HibernateRuleResultDto evaluateRule(HibernateContext context) {
         Integer batchSize = context.firstIntegerProperty(
                 "spring.jpa.properties.hibernate.jdbc.batch_size", "hibernate.jdbc.batch_size");
-        if (batchSize == null || batchSize <= 0) {
+        if (batchSize == null || batchSize <= 1) {
             return skipped("JDBC batching is not configured.");
         }
         List<String> details = new ArrayList<>();
@@ -1408,7 +1408,7 @@ final class CollectionFetchJoinAnnotationRule extends AbstractHibernateRule {
                         HibernateCategory.FETCHING,
                         "MEDIUM",
                         "Detects collection-valued associations annotated with @Fetch(FetchMode.JOIN), which forces every fetch path through a SQL JOIN and undermines pagination.",
-                        "Prefer @Fetch(FetchMode.SELECT) or SUBSELECT for collections and request JOIN FETCH only on the specific query that needs the graph.",
+                        "Prefer @Fetch(FetchMode.SELECT), explicit entity queries, or DTO projections, and request JOIN FETCH only on the specific query that needs the graph.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#fetching-strategies"));
     }
 
@@ -1423,6 +1423,40 @@ final class CollectionFetchJoinAnnotationRule extends AbstractHibernateRule {
                 Annotation fetch = attribute.fetchAnnotation();
                 if (fetch != null && "JOIN".equals(attribute.annotationValueName(fetch, "value"))) {
                     details.add(attribute.description() + " is a collection mapped with @Fetch(FetchMode.JOIN).");
+                }
+            }
+        }
+        return violation(details);
+    }
+}
+
+final class SubselectCollectionFetchRule extends AbstractHibernateRule {
+
+    SubselectCollectionFetchRule() {
+        super(
+                new HibernateRuleDefinition(
+                        "HIB-FETCH-008",
+                        "Subselect collection fetching should be reviewed",
+                        HibernateCategory.FETCHING,
+                        "INFO",
+                        "Detects collection associations annotated with @Fetch(FetchMode.SUBSELECT), which initializes the same collection role for every owner loaded in the persistence context.",
+                        "Use SUBSELECT only for bounded owner sets. Prefer an explicit entity query or DTO projection when the collection can be large or when only a subset is needed.",
+                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#fetching-fetchmode-subselect"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        List<String> details = new ArrayList<>();
+        for (HibernateEntityModel entity : context.entities()) {
+            for (HibernateAttributeModel attribute : entity.attributes()) {
+                if (!attribute.isCollectionAssociation()) {
+                    continue;
+                }
+                Annotation fetch = attribute.fetchAnnotation();
+                if (fetch != null && "SUBSELECT".equals(attribute.annotationValueName(fetch, "value"))) {
+                    details.add(
+                            attribute.description()
+                                    + " uses @Fetch(FetchMode.SUBSELECT); verify that owner and collection cardinalities stay bounded.");
                 }
             }
         }
@@ -2267,6 +2301,81 @@ final class BindParameterLoggingInProductionRule extends AbstractHibernateRule {
                     List.of("Bind-parameter logging is enabled at TRACE while a production profile is active."));
         }
         return pass();
+    }
+}
+
+final class SqlCommentsRule extends AbstractHibernateRule {
+
+    SqlCommentsRule() {
+        super(
+                new HibernateRuleDefinition(
+                        "HIB-CONFIG-019",
+                        "SQL comments should be enabled intentionally",
+                        HibernateCategory.CONFIGURATION,
+                        "INFO",
+                        "Detects hibernate.use_sql_comments=true, which adds text to every generated SQL statement and can fragment database or JDBC statement caches.",
+                        "Disable SQL comments unless a measured observability benefit outweighs the extra statement text and cache cardinality.",
+                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#configurations-logging"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        if (context.isPropertyTrue("spring.jpa.properties.hibernate.use_sql_comments", "hibernate.use_sql_comments")) {
+            return violation(
+                    List.of(
+                            "hibernate.use_sql_comments is enabled; confirm that statement-cache efficiency and network overhead are acceptable."));
+        }
+        return pass();
+    }
+}
+
+final class OracleJdbcFetchSizeRule extends AbstractHibernateRule {
+
+    OracleJdbcFetchSizeRule() {
+        super(new HibernateRuleDefinition(
+                "HIB-CONFIG-020",
+                "Oracle JDBC fetch size should exceed the driver default",
+                HibernateCategory.CONFIGURATION,
+                "INFO",
+                "Detects Oracle-backed persistence units that leave hibernate.jdbc.fetch_size unset or at 10 or less.",
+                "For result sets that commonly exceed ten rows, set and measure a bounded hibernate.jdbc.fetch_size above Oracle's default of 10; keep the driver default when queries are consistently small.",
+                "https://vladmihalcea.com/resultset-statement-fetching-with-jdbc-and-hibernate/"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        if (!isOracle(context)) {
+            return skipped("The persistence unit is not known to use Oracle.");
+        }
+        Integer fetchSize = context.firstIntegerProperty(
+                "spring.jpa.properties.hibernate.jdbc.fetch_size", "hibernate.jdbc.fetch_size");
+        if (fetchSize != null && fetchSize > 10) {
+            return pass();
+        }
+        String configured = fetchSize == null ? "not configured" : "set to " + fetchSize;
+        return violation(List.of("Oracle was detected and hibernate.jdbc.fetch_size is " + configured
+                + "; the Oracle JDBC driver defaults to fetching 10 rows per roundtrip."));
+    }
+
+    private boolean isOracle(HibernateContext context) {
+        String databaseKind = context.firstProperty("quarkus.datasource.db-kind", "spring.jpa.database");
+        if ("oracle".equalsIgnoreCase(databaseKind)) {
+            return true;
+        }
+        String url = context.firstProperty(
+                "spring.datasource.url", "jakarta.persistence.jdbc.url", "hibernate.connection.url");
+        if (url != null && url.toLowerCase(Locale.ROOT).startsWith("jdbc:oracle:")) {
+            return true;
+        }
+        String driver = context.firstProperty(
+                "spring.datasource.driver-class-name",
+                "jakarta.persistence.jdbc.driver",
+                "hibernate.connection.driver_class");
+        if (driver != null && driver.toLowerCase(Locale.ROOT).startsWith("oracle.jdbc.")) {
+            return true;
+        }
+        String dialect = context.firstProperty("spring.jpa.database-platform", "hibernate.dialect");
+        return dialect != null && dialect.toLowerCase(Locale.ROOT).startsWith("org.hibernate.dialect.oracle");
     }
 }
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
@@ -38,6 +38,8 @@ import java.util.Set;
 import java.util.UUID;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.NaturalId;
 import org.hibernate.annotations.Where;
@@ -1235,6 +1237,95 @@ class HibernateRulesTests {
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
+    // --- Hypersistence-inspired configuration and fetching checks ----------------
+
+    @Test
+    void jdbcBatchSizeRuleFlagsBatchSizeOne() {
+        TestEnvironment environment = new TestEnvironment().withProperty("hibernate.jdbc.batch_size", "1");
+
+        HibernateRuleResultDto result = new JdbcBatchSizeRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .containsExactly("hibernate.jdbc.batch_size is not configured with a value greater than 1.");
+    }
+
+    @Test
+    void orderedBatchingRuleSkipsBatchSizeOne() {
+        TestEnvironment environment = new TestEnvironment().withProperty("hibernate.jdbc.batch_size", "1");
+
+        HibernateRuleResultDto result = new OrderedBatchingRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.SKIPPED);
+    }
+
+    @Test
+    void subselectCollectionFetchRuleFlagsSubselectMapping() {
+        HibernateRuleResultDto result = new SubselectCollectionFetchRule()
+                .evaluate(context(new TestEnvironment(), SubselectCollectionEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("children", "cardinalities stay bounded"));
+    }
+
+    @Test
+    void sqlCommentsRuleFlagsEnabledComments() {
+        TestEnvironment environment = new TestEnvironment().withProperty("hibernate.use_sql_comments", "true");
+
+        HibernateRuleResultDto result = new SqlCommentsRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.INFO);
+    }
+
+    @Test
+    void oracleJdbcFetchSizeRuleFlagsMissingAndSmallValues() {
+        for (String fetchSize : List.of("", "10")) {
+            TestEnvironment environment = new TestEnvironment()
+                    .withProperty("spring.datasource.url", "jdbc:oracle:thin:@localhost:1521/FREEPDB1");
+            if (!fetchSize.isEmpty()) {
+                environment.withProperty("hibernate.jdbc.fetch_size", fetchSize);
+            }
+
+            HibernateRuleResultDto result = new OracleJdbcFetchSizeRule().evaluate(context(environment));
+
+            assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        }
+    }
+
+    @Test
+    void oracleJdbcFetchSizeRulePassesForMeasuredLargerValue() {
+        TestEnvironment environment = new TestEnvironment()
+                .withProperty("quarkus.datasource.db-kind", "oracle")
+                .withProperty("hibernate.jdbc.fetch_size", "50");
+
+        HibernateRuleResultDto result = new OracleJdbcFetchSizeRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void oracleJdbcFetchSizeRuleSkipsOtherDatabases() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty("spring.datasource.url", "jdbc:postgresql://localhost/app");
+
+        HibernateRuleResultDto result = new OracleJdbcFetchSizeRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.SKIPPED);
+    }
+
+    @Test
+    void oracleJdbcFetchSizeRuleDoesNotMatchOracleInAnUnrelatedJdbcUrlSegment() {
+        TestEnvironment environment =
+                new TestEnvironment().withProperty("spring.datasource.url", "jdbc:postgresql://oracle-migration/app");
+
+        HibernateRuleResultDto result = new OracleJdbcFetchSizeRule().evaluate(context(environment));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.SKIPPED);
+    }
+
     // --- HIB-ENTITY-009 ----------------------------------------------------------
 
     @Test
@@ -1782,5 +1873,15 @@ class HibernateRulesTests {
         Long id;
 
         String isbn;
+    }
+
+    @Entity
+    static class SubselectCollectionEntity {
+        @Id
+        Long id;
+
+        @OneToMany
+        @Fetch(FetchMode.SUBSELECT)
+        List<SequenceEntity> children;
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
@@ -57,7 +57,7 @@ import org.springframework.data.domain.Page;
 
 class HibernateScannerTests {
 
-    private static final int RULE_COUNT = 72;
+    private static final int RULE_COUNT = 75;
     private static final String AFFECTED_HIBERNATE_VERSION = "7.3.9.Final";
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookup.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookup.java
@@ -30,12 +30,13 @@ import org.eclipse.microprofile.config.Config;
  *       build step) — there is no {@code quarkus.hibernate-orm.enhancement.*} switch to turn it off. The engine
  *       consumes this internal adapter fact separately from ordinary Hibernate enhancement settings, which request
  *       enhancement features but do not prove that application classes were transformed.</li>
- *   <li><strong>Maps batch fetching, slow-query logging, JDBC time zone, statistics, IN-clause padding,
- *       pagination-over-collection and second-level/query caching</strong> to their real
+ *   <li><strong>Maps batch fetching, JDBC statement fetch size, slow-query logging, JDBC time zone, statistics,
+ *       IN-clause padding, pagination-over-collection and second-level/query caching</strong> to their real
  *       {@code quarkus.hibernate-orm.*} equivalents (all confirmed by decompiling the
  *       {@code quarkus-hibernate-orm}/{@code -deployment} 3.33.2.1 jars — see the per-alias notes on
  *       {@link #KEY_ALIASES}). Before this mapping existed, {@code HIB-FETCH-002} and
- *       {@code HIB-CONFIG-006}/{@code -007}/{@code -009}/{@code -010}/{@code -011}/{@code -013}/{@code -016}
+ *       {@code HIB-CONFIG-006}/{@code -007}/{@code -009}/{@code -010}/{@code -011}/{@code -013}/{@code -016}/
+ *       {@code -020}
  *       could never observe an operator's setting on Quarkus, no matter which native property name they used.</li>
  *   <li><strong>Reads the Quarkus-native {@code quarkus.hibernate-orm.log.bind-parameters} convenience
  *       flag</strong> (and its deprecated {@code .bind-param} alias) as the synthetic {@code "trace"} value of
@@ -127,6 +128,10 @@ public final class QuarkusHibernatePropertyLookup implements Function<String, St
             Map.entry(
                     "spring.jpa.properties.hibernate.jdbc.batch_size",
                     "quarkus.hibernate-orm.jdbc.statement-batch-size"),
+            Map.entry("hibernate.jdbc.fetch_size", "quarkus.hibernate-orm.jdbc.statement-fetch-size"),
+            Map.entry(
+                    "spring.jpa.properties.hibernate.jdbc.fetch_size",
+                    "quarkus.hibernate-orm.jdbc.statement-fetch-size"),
             Map.entry("hibernate.default_batch_fetch_size", "quarkus.hibernate-orm.fetch.batch-size"),
             Map.entry(
                     "spring.jpa.properties.hibernate.default_batch_fetch_size",

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookupTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/hibernate/QuarkusHibernatePropertyLookupTest.java
@@ -143,6 +143,15 @@ class QuarkusHibernatePropertyLookupTest {
     }
 
     @Test
+    void mapsJdbcFetchSizeToQuarkusStatementFetchSize() {
+        QuarkusHibernatePropertyLookup lookup = lookup(Map.of("quarkus.hibernate-orm.jdbc.statement-fetch-size", "50"));
+
+        assertThat(lookup.apply("hibernate.jdbc.fetch_size")).isEqualTo("50");
+        assertThat(lookup.apply("spring.jpa.properties.hibernate.jdbc.fetch_size"))
+                .isEqualTo("50");
+    }
+
+    @Test
     void mapsGenerateStatisticsToQuarkusStatistics() {
         // HIB-CONFIG-007.
         QuarkusHibernatePropertyLookup lookup = lookup(Map.of("quarkus.hibernate-orm.statistics", "true"));

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -114,8 +114,8 @@ Dismissed rules remove all of their findings from the score.
 - **Fires when**: a `@OneToMany` or `@ManyToMany` declares `@Fetch(FetchMode.JOIN)`.
 - **Why it matters**: this forces every fetch path through a SQL JOIN, undermines pagination, and risks cartesian
   products.
-- **Recommendation**: prefer `@Fetch(FetchMode.SELECT)` or `SUBSELECT` for collections, and request `JOIN FETCH` only in
-  the specific queries that need the graph.
+- **Recommendation**: prefer `@Fetch(FetchMode.SELECT)`, an explicit entity query, or a DTO projection, and request
+  `JOIN FETCH` only in the specific queries that need the graph.
 
 ### HIB-FETCH-007 - Lazy basic attributes require bytecode enhancement
 
@@ -125,6 +125,17 @@ Dismissed rules remove all of their findings from the score.
 - **Why it matters**: without enhancement, Hibernate cannot intercept access to a basic field and the requested lazy
   column loading is ineffective.
 - **Recommendation**: enable Hibernate bytecode enhancement, or remove the misleading `LAZY` declaration.
+
+### HIB-FETCH-008 - Subselect collection fetching should be reviewed
+
+- **Severity**: INFO
+- **Inspects**: collection associations declaring `@Fetch(FetchMode.SUBSELECT)`.
+- **Fires when**: a mapped `@OneToMany` or `@ManyToMany` uses subselect fetching.
+- **Why it matters**: accessing one collection initializes the same collection role for every matching owner currently
+  loaded in the persistence context. This avoids classic N+1 selects, but an unexpectedly large owner set can fetch much
+  more data than the caller needs.
+- **Recommendation**: keep `SUBSELECT` only for bounded owner sets. Prefer an explicit entity query or DTO projection when
+  owner or collection cardinality can be large.
 
 ## Identifiers
 
@@ -684,9 +695,9 @@ subqueries, or multiple roots may be skipped rather than inferred incorrectly.
 
 - **Severity**: INFO
 - **Inspects**: `hibernate.jdbc.batch_size` and Spring's `spring.jpa.properties.*` variant.
-- **Fires when**: the property is absent or non-positive.
+- **Fires when**: the property is absent or less than 2. A batch size of 1 cannot combine multiple statements.
 - **Why it matters**: write-heavy code otherwise sends insert/update/delete statements one at a time.
-- **Recommendation**: set a bounded batch size, such as 25, and tune it with representative workloads.
+- **Recommendation**: start with a bounded batch size between 5 and 30, then tune it with representative workloads.
 - **Quarkus**: `quarkus.hibernate-orm.jdbc.statement-batch-size` has no native default, so an unset value leaves
   Hibernate batching disabled and this INFO prompt remains applicable.
 
@@ -694,7 +705,7 @@ subqueries, or multiple roots may be skipped rather than inferred incorrectly.
 
 - **Severity**: INFO
 - **Inspects**: `hibernate.order_inserts` and `hibernate.order_updates` when JDBC batching is enabled.
-- **Fires when**: a positive batch size is configured but either ordering property is not `true`.
+- **Fires when**: a batch size greater than 1 is configured but either ordering property is not `true`.
 - **Why it matters**: batches are grouped by SQL/table shape; interleaved entity types reduce batch efficiency.
 - **Recommendation**: enable both ordering properties when batching writes across multiple entity types.
 - **Quarkus**: `hibernate.order_inserts`/`hibernate.order_updates` have no first-class `quarkus.hibernate-orm.*`
@@ -882,6 +893,26 @@ subqueries, or multiple roots may be skipped rather than inferred incorrectly.
 - **Quarkus**: also detects the Quarkus-native `quarkus.hibernate-orm.log.bind-parameters` convenience flag (and its
   deprecated `.bind-param` alias), which `QuarkusHibernatePropertyLookup` reports as the neutral TRACE logger state -
   Quarkus's own guide explicitly warns against enabling this in production.
+
+### HIB-CONFIG-019 - SQL comments should be enabled intentionally
+
+- **Severity**: INFO
+- **Inspects**: `hibernate.use_sql_comments`.
+- **Fires when**: generated SQL comments are enabled.
+- **Why it matters**: comments add text to every generated statement and can increase network traffic or fragment
+  database/JDBC statement caches when comment text varies.
+- **Recommendation**: keep comments only when their measured observability benefit outweighs the statement-cache cost.
+
+### HIB-CONFIG-020 - Oracle JDBC fetch size should exceed the driver default
+
+- **Severity**: INFO
+- **Inspects**: configured database kind, dialect, JDBC URL/driver, and `hibernate.jdbc.fetch_size`.
+- **Fires when**: Oracle is identifiable and the fetch size is absent or no greater than Oracle JDBC's default of 10.
+- **Why it matters**: iterating result sets larger than ten rows can require avoidable database roundtrips. PostgreSQL and
+  MySQL have different driver behavior, so this check deliberately does not prescribe a global fetch size.
+- **Recommendation**: for Oracle queries that commonly return more than ten rows, benchmark a bounded fetch size above 10;
+  retain the default when result sets are consistently small.
+- **Quarkus**: reads `quarkus.hibernate-orm.jdbc.statement-fetch-size` through the native property lookup.
 
 ## Caching
 


### PR DESCRIPTION
## What does this PR do?

Expands the Hibernate Advisor from 72 to 75 rules with targeted checks for `@Fetch(SUBSELECT)`, generated SQL comments, and Oracle JDBC fetch sizing. It also treats a JDBC batch size of `1` as ineffective and maps Quarkus's native statement fetch-size property into the shared advisor.

## Why is this change needed?

The existing advisor covered eager fetching, identifier strategies, batching, OSIV, and pagination, but missed several high-confidence configuration and fetch-plan risks highlighted by Hibernate performance guidance. The new rules remain bounded and static: runtime-only concerns such as observed N+1 queries and statement-cache hit rates are not inferred without telemetry.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Focused engine and Quarkus property-lookup tests pass, along with the repository Spotless check.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed