### PR TITLE
Organize database advisor checks by database

### DIFF
--- a/docs/DATABASE-ADVISOR-CHECKS.md
+++ b/docs/DATABASE-ADVISOR-CHECKS.md
@@ -202,7 +202,7 @@ express).
   application logic must tolerate several `NULL`s in that column, document that the constraint only applies when
   every column is present.
 
-## Dialect-specific (PostgreSQL, MySQL, MariaDB and Oracle)
+## Dialect detection and catalog augmentation
 
 Dialect-specific catalog augmentation runs in addition to the generic checks above. The dialect is detected from
 `DatabaseMetaData.getDatabaseProductName()`, the product version string and the JDBC URL — MariaDB is detected as its
@@ -221,6 +221,8 @@ PostgreSQL 11's `INCLUDE` columns, PostgreSQL 12's concurrent-index-build visibi
 `NULLS NOT DISTINCT` are each selected from the reported server version; Oracle's `ALL_*`/`SYS_CONTEXT` augmentation
 requires 19c or later. When a server is too old, or a role cannot read a catalog view, the matching rule reports
 `SKIPPED` with that reason.
+
+## PostgreSQL
 
 ### DB-PG-001 - Invalid PostgreSQL indexes
 
@@ -280,6 +282,11 @@ requires 19c or later. When a server is too old, or a role cannot read a catalog
   identity and publishes updates or deletes`).
 - **Recommendation**: add a primary key (restores the `DEFAULT` replica identity), or set one explicitly with
   `ALTER TABLE ... REPLICA IDENTITY FULL/USING INDEX ...`.
+
+## MySQL and MariaDB
+
+These checks share one section because they apply to both MySQL and MariaDB. Version-aware catalog queries account for
+their differences where necessary.
 
 ### DB-MYSQL-001 - Tables on a non-transactional storage engine
 


### PR DESCRIPTION
## What does this PR do?

Organizes Database Advisor documentation into dedicated PostgreSQL, MySQL and MariaDB, and Oracle sections, with shared dialect detection documented separately.

## Why is this change needed?

The previous hierarchy grouped PostgreSQL and MySQL/MariaDB under a generic dialect-specific heading while Oracle appeared as a peer section, making the documentation inconsistent and harder to scan.

Closes # N/A

## How was it tested?

Documentation-only change; verified the Markdown structure and diff formatting.

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed