### PR TITLE
Fix Oracle Database Advisor disclaimer

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/databaseadvisor/DatabaseAdvisorScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/databaseadvisor/DatabaseAdvisorScanner.java
@@ -38,7 +38,7 @@ public final class DatabaseAdvisorScanner {
     private static final String ANALYZER = "BootUI Database Advisor";
     private static final String DISCLAIMER =
             "Read-only JDBC schema introspection (tables, columns, primary/foreign keys, indexes) via "
-                    + "DatabaseMetaData, with PostgreSQL and MySQL/MariaDB catalog augmentation, plus "
+                    + "DatabaseMetaData, with PostgreSQL, MySQL/MariaDB, and Oracle catalog augmentation, plus "
                     + "cross-reference checks against the Hibernate metamodel when both are available. These checks "
                     + "are review prompts, not verdicts.";
     private static final Comparator<DatabaseAdvisorRuleResultDto> IMPORTANCE_ORDER = Comparator.comparingInt(

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/databaseadvisor/DatabaseAdvisorScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/databaseadvisor/DatabaseAdvisorScannerTests.java
@@ -66,6 +66,7 @@ class DatabaseAdvisorScannerTests {
         assertThat(report.diagnostics()).isEmpty();
         assertThat(report.dataSources()).isEmpty();
         assertThat(report.truncated()).isFalse();
+        assertThat(report.disclaimer()).contains("PostgreSQL, MySQL/MariaDB, and Oracle catalog augmentation");
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Updates the Database Advisor disclaimer to list Oracle catalog augmentation alongside PostgreSQL and MySQL/MariaDB, with regression coverage for the wording.

## Why is this change needed?

Oracle 19c+ advisor rules are implemented, but the UI's engine-generated disclaimer omitted Oracle and understated the panel's supported vendor-specific checks.

N/A - no linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Targeted validation: `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-engine -Dtest=DatabaseAdvisorScannerTests test`; repository formatting passed with `spotless:check`.

## Screenshots (UI changes)

N/A - the UI renders the corrected shared report disclaimer; no Vue layout or styling changed.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

Documentation already described Oracle support accurately, so no documentation change was required.