### PR TITLE
Fix build warnings across Spring, Quarkus, and UI tests

### DIFF
--- a/bootui-engine/pom.xml
+++ b/bootui-engine/pom.xml
@@ -227,4 +227,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/bootui-quarkus-integration-tests/base/pom.xml
+++ b/bootui-quarkus-integration-tests/base/pom.xml
@@ -89,11 +89,9 @@
                 </executions>
             </plugin>
             <!--
-              Install the JBoss LogManager as the JVM's java.util.logging LogManager for the test fork.
-              This is the documented Quarkus test setup: at runtime Quarkus always uses the JBoss
-              LogManager, and QuarkusLoggerProvider only reports itself available when that manager is
-              installed. Setting it here makes the Loggers IT (and the shared write-path conformance test)
-              exercise the real backend deterministically instead of depending on JVM-global init order.
+              The shared Quarkus parent installs JBoss LogManager on every test fork's JVM command line.
+              This makes the Loggers IT (and the shared write-path conformance test) exercise the real
+              backend deterministically instead of depending on JVM-global init order.
 
               forkCount is pinned to 1 here too, overriding the root pom's pluginManagement default (see the
               maven-surefire-plugin comment there for the general port-safety rationale of forked test
@@ -119,9 +117,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-quarkus-integration-tests/flyway/pom.xml
+++ b/bootui-quarkus-integration-tests/flyway/pom.xml
@@ -22,6 +22,16 @@
         flyway-present and flyway-absent paths are each proven in isolation — the same split used for the
         Cache-present/absent and SmallRye-Health-present/absent coverage.</description>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${flyway-verified-h2.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <!--
         Uses an in-memory H2 datasource (quarkus-jdbc-h2), so a @QuarkusTest boots without Docker. Never published.
     -->

--- a/bootui-quarkus-integration-tests/prod-shell-guard/pom.xml
+++ b/bootui-quarkus-integration-tests/prod-shell-guard/pom.xml
@@ -82,10 +82,9 @@
                 </executions>
             </plugin>
             <!--
-              Install the JBoss LogManager as the JVM's java.util.logging LogManager for the test fork.
-              QuarkusProdModeTest's own static initializer requires this (it casts the root
-              java.util.logging.Logger to org.jboss.logmanager.Logger), so this is not optional here the way
-              it might be for a plain @QuarkusTest module.
+              The shared Quarkus parent installs JBoss LogManager on every test fork's JVM command line.
+              QuarkusProdModeTest's own static initializer requires it (it casts the root
+              java.util.logging.Logger to org.jboss.logmanager.Logger).
 
               forkCount=1: same override as every other bootui-quarkus-integration-tests/* submodule (and
               bootui-quarkus itself); see bootui-quarkus-integration-tests/base/pom.xml for the full
@@ -98,9 +97,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-quarkus-integration-tests/rabbit/pom.xml
+++ b/bootui-quarkus-integration-tests/rabbit/pom.xml
@@ -64,6 +64,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
                 <extensions>true</extensions>
@@ -82,6 +86,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
+                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager
+                        -javaagent:${org.mockito:mockito-core:jar}
+                        -javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-quarkus-integration-tests/rabbit/pom.xml
+++ b/bootui-quarkus-integration-tests/rabbit/pom.xml
@@ -86,9 +86,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager
-                        -javaagent:${org.mockito:mockito-core:jar}
-                        -javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
+                    <argLine>${quarkus.test.argLine}
+                        -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-quarkus-parent/pom.xml
+++ b/bootui-quarkus-parent/pom.xml
@@ -46,6 +46,15 @@
                     <artifactId>quarkus-extension-maven-plugin</artifactId>
                     <version>${quarkus.platform.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <configuration>
+                        <!-- JBossLoggerFinder can initialize before Surefire applies systemPropertyVariables,
+                             so install Quarkus' LogManager on the forked JVM command line. -->
+                        <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/bootui-quarkus-parent/pom.xml
+++ b/bootui-quarkus-parent/pom.xml
@@ -16,6 +16,12 @@
     <name>BootUI :: Quarkus Parent</name>
     <description>Shared Quarkus LTS dependency and plugin management for the BootUI Quarkus modules.</description>
 
+    <properties>
+        <quarkus.test.argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager
+            --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+            -javaagent:${net.bytebuddy:byte-buddy-agent:jar}</quarkus.test.argLine>
+    </properties>
+
     <!--
         Keep the Quarkus BOM one inheritance level closer than bootui-parent's Spring Boot BOM. Maven's
         nearest-wins dependency management then gives every Quarkus module the platform-tested versions of
@@ -34,6 +40,12 @@
     </dependencyManagement>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -50,9 +62,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
-                        <!-- JBossLoggerFinder can initialize before Surefire applies systemPropertyVariables,
-                             so install Quarkus' LogManager on the forked JVM command line. -->
-                        <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>
+                        <argLine>${quarkus.test.argLine}</argLine>
                     </configuration>
                 </plugin>
             </plugins>

--- a/bootui-quarkus-sample-app/pom.xml
+++ b/bootui-quarkus-sample-app/pom.xml
@@ -48,6 +48,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${flyway-verified-h2.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/bootui-quarkus/pom.xml
+++ b/bootui-quarkus/pom.xml
@@ -364,9 +364,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-quarkus/pom.xml
+++ b/bootui-quarkus/pom.xml
@@ -368,7 +368,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager
+                    <argLine>${quarkus.test.argLine}
                         -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>

--- a/bootui-quarkus/pom.xml
+++ b/bootui-quarkus/pom.xml
@@ -306,6 +306,10 @@
                  skips compile-bound plugin goals, leaving the template — which lacks `artifact` — in target/classes
                  and breaking the Dev UI's DevUIProcessor under quarkus:dev. -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-extension-maven-plugin</artifactId>
                 <executions>
@@ -364,6 +368,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
+                    <argLine>-Djava.util.logging.manager=org.jboss.logmanager.LogManager
+                        -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-spring-autoconfigure/pom.xml
+++ b/bootui-spring-autoconfigure/pom.xml
@@ -314,7 +314,18 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-spring-autoconfigure/pom.xml
+++ b/bootui-spring-autoconfigure/pom.xml
@@ -318,4 +318,41 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>macos-aarch64-netty-dns-tests</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver-dns-native-macos</artifactId>
+                    <classifier>osx-aarch_64</classifier>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>macos-x86_64-netty-dns-tests</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver-dns-native-macos</artifactId>
+                    <classifier>osx-x86_64</classifier>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/kafka/KafkaConsumerCaptureBeanPostProcessor.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/kafka/KafkaConsumerCaptureBeanPostProcessor.java
@@ -40,6 +40,7 @@ public final class KafkaConsumerCaptureBeanPostProcessor implements BeanPostProc
     }
 
     @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
         if (!(bean instanceof AbstractKafkaListenerContainerFactory<?, ?, ?> factory)) {
             return bean;
@@ -49,10 +50,8 @@ public final class KafkaConsumerCaptureBeanPostProcessor implements BeanPostProc
             return bean;
         }
         try {
-            @SuppressWarnings("unchecked")
             RecordInterceptor<Object, Object> existing = (RecordInterceptor<Object, Object>)
                     new DirectFieldAccessor(factory).getPropertyValue("recordInterceptor");
-            @SuppressWarnings({"unchecked", "rawtypes"})
             AbstractKafkaListenerContainerFactory untyped = (AbstractKafkaListenerContainerFactory) factory;
             untyped.setRecordInterceptor(new CapturingRecordInterceptor(existing, recorder, beanName));
         } catch (RuntimeException ex) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigMetadataCatalog.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/ConfigMetadataCatalog.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.*;
-import tools.jackson.core.TreeNode;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -105,11 +104,7 @@ public final class ConfigMetadataCatalog {
         if (node == null || node.isNull()) {
             return null;
         }
-        // Bind to the stable treeToValue(TreeNode, Class) overload (present in every Jackson 3
-        // release). The treeToValue(JsonNode, Class) overload was only added in jackson-databind
-        // 3.1, so calling it directly throws NoSuchMethodError when a transitive dependency pulls
-        // an older Jackson 3 (e.g. 3.0.x from Spring Boot 4.0) onto the classpath.
-        return objectMapper.treeToValue((TreeNode) node, Object.class);
+        return objectMapper.convertValue(node, Object.class);
     }
 
     ConfigPropertySuggestionDto get(String name) {

--- a/bootui-spring-sample-app/pom.xml
+++ b/bootui-spring-sample-app/pom.xml
@@ -125,6 +125,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <version>${flyway-verified-h2.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/bootui-spring-sample-app/pom.xml
+++ b/bootui-spring-sample-app/pom.xml
@@ -142,6 +142,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <!--
@@ -158,6 +162,13 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationDevProfileTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationDevProfileTests.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -64,8 +65,8 @@ class BootUiSampleApplicationDevProfileTests {
 
     @Test
     void servesSampleProductsFromInMemoryH2() {
-        ResponseEntity<List> response =
-                client().get().uri("/api/sample/products").retrieve().toEntity(List.class);
+        ResponseEntity<List<Map<String, Object>>> response =
+                client().get().uri("/api/sample/products").retrieve().toEntity(new ParameterizedTypeReference<>() {});
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -75,8 +76,8 @@ class BootUiSampleApplicationDevProfileTests {
 
     @Test
     void overviewReportsBootUiActiveWithoutDocker() {
-        ResponseEntity<Map> response =
-                client().get().uri("/bootui/api/overview").retrieve().toEntity(Map.class);
+        ResponseEntity<Map<String, Object>> response =
+                client().get().uri("/bootui/api/overview").retrieve().toEntity(new ParameterizedTypeReference<>() {});
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -84,8 +85,8 @@ class BootUiSampleApplicationDevProfileTests {
 
     @Test
     void healthIsUpWithoutRedisOrDatabaseDocker() {
-        ResponseEntity<Map> response =
-                client().get().uri("/actuator/health").retrieve().toEntity(Map.class);
+        ResponseEntity<Map<String, Object>> response =
+                client().get().uri("/actuator/health").retrieve().toEntity(new ParameterizedTypeReference<>() {});
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -94,11 +95,11 @@ class BootUiSampleApplicationDevProfileTests {
 
     @Test
     void chatReportsAiUnavailableWhenOllamaDisabled() {
-        ResponseEntity<Map> response = client().post()
+        ResponseEntity<Map<String, Object>> response = client().post()
                 .uri("/api/chat")
                 .body(Map.of("message", "Hello"))
                 .retrieve()
-                .toEntity(Map.class);
+                .toEntity(new ParameterizedTypeReference<>() {});
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
         assertThat(response.getBody()).isNotNull();

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiSampleApplicationIntegrationTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -104,21 +105,21 @@ class BootUiSampleApplicationIntegrationTests {
         return client;
     }
 
-    private ResponseEntity<Map> getMap(String path) {
-        return client().get().uri(path).retrieve().toEntity(Map.class);
+    private ResponseEntity<Map<String, Object>> getMap(String path) {
+        return client().get().uri(path).retrieve().toEntity(new ParameterizedTypeReference<>() {});
     }
 
-    private ResponseEntity<Map> postMap(String path, Object body) {
+    private ResponseEntity<Map<String, Object>> postMap(String path, Object body) {
         return client().post()
                 .uri(path)
                 .headers(headers -> applyCsrfToken(path, headers))
                 .body(body)
                 .retrieve()
-                .toEntity(Map.class);
+                .toEntity(new ParameterizedTypeReference<>() {});
     }
 
-    private ResponseEntity<List> getList(String path) {
-        return client().get().uri(path).retrieve().toEntity(List.class);
+    private ResponseEntity<List<Object>> getList(String path) {
+        return client().get().uri(path).retrieve().toEntity(new ParameterizedTypeReference<>() {});
     }
 
     private ResponseEntity<String> getString(String path) {
@@ -150,7 +151,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void overviewEndpointReturnsActivationMetadata() {
-        ResponseEntity<Map> response = getMap("/bootui/api/overview");
+        var response = getMap("/bootui/api/overview");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -178,7 +179,7 @@ class BootUiSampleApplicationIntegrationTests {
     void configEndpointListsPropertiesAndMasksSecrets() {
         postMap("/bootui/api/config/overrides", Map.of("name", "demo.api.token", "value", "topsecret"));
 
-        ResponseEntity<Map> response = getMap("/bootui/api/config");
+        var response = getMap("/bootui/api/config");
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         Map<?, ?> body = response.getBody();
@@ -200,7 +201,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void healthEndpointReturnsStatus() {
-        ResponseEntity<Map> response = getMap("/bootui/api/health");
+        var response = getMap("/bootui/api/health");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -210,19 +211,20 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void loggersEndpointExposesKnownLoggers() {
-        ResponseEntity<Map> response = getMap("/bootui/api/loggers");
+        var response = getMap("/bootui/api/loggers");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
         assertThat(body).isNotNull();
-        assertThat((Iterable<Object>) body.get("availableLevels")).contains("INFO", "DEBUG");
+        assertThat((Iterable<?>) body.get("availableLevels"))
+                .anyMatch("INFO"::equals)
+                .anyMatch("DEBUG"::equals);
         assertThat((Iterable<?>) body.get("loggers")).isNotEmpty();
     }
 
     @Test
     void postLoggerLevelChangesEffectiveLevel() {
-        ResponseEntity<Map> response =
-                postMap("/bootui/api/loggers/io.github.jdubois.bootui.sample", Map.of("level", "WARN"));
+        var response = postMap("/bootui/api/loggers/io.github.jdubois.bootui.sample", Map.of("level", "WARN"));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -233,8 +235,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void invalidLoggerLevelReturnsBadRequest() {
-        ResponseEntity<Map> response =
-                postMap("/bootui/api/loggers/io.github.jdubois.bootui.sample", Map.of("level", "NOT-A-LEVEL"));
+        var response = postMap("/bootui/api/loggers/io.github.jdubois.bootui.sample", Map.of("level", "NOT-A-LEVEL"));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).isNotNull();
@@ -243,8 +244,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void configOverrideRoundtripPersistsAndDeletes() throws Exception {
-        ResponseEntity<Map> put =
-                postMap("/bootui/api/config/overrides", Map.of("name", "sample.greeting", "value", "Hola"));
+        var put = postMap("/bootui/api/config/overrides", Map.of("name", "sample.greeting", "value", "Hola"));
 
         assertThat(put.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> putBody = put.getBody();
@@ -255,11 +255,11 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(Files.exists(OVERRIDES_FILE)).isTrue();
         assertThat(Files.readString(OVERRIDES_FILE)).contains("sample.greeting=Hola");
 
-        ResponseEntity<Map> delete = client().delete()
+        ResponseEntity<Map<String, Object>> delete = client().delete()
                 .uri("/bootui/api/config/overrides/sample.greeting")
                 .headers(headers -> applyCsrfToken("/bootui/api/config/overrides/sample.greeting", headers))
                 .retrieve()
-                .toEntity(Map.class);
+                .toEntity(new ParameterizedTypeReference<>() {});
         assertThat(delete.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> deleteBody = delete.getBody();
         assertThat(deleteBody).isNotNull();
@@ -269,7 +269,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void beansEndpointReturnsBeanList() {
-        ResponseEntity<Map> response = getMap("/bootui/api/beans");
+        var response = getMap("/bootui/api/beans");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -279,7 +279,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void mappingsEndpointReturnsContexts() {
-        ResponseEntity<Map> response = getMap("/bootui/api/mappings");
+        var response = getMap("/bootui/api/mappings");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -290,7 +290,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void conditionsEndpointReturnsStableDto() {
-        ResponseEntity<Map> response = getMap("/bootui/api/conditions");
+        var response = getMap("/bootui/api/conditions");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -303,7 +303,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void startupEndpointReturnsStableDto() {
-        ResponseEntity<Map> response = getMap("/bootui/api/startup");
+        var response = getMap("/bootui/api/startup");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -313,7 +313,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void scheduledEndpointFindsSampleTask() {
-        ResponseEntity<Map> response = getMap("/bootui/api/scheduled");
+        var response = getMap("/bootui/api/scheduled");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -329,7 +329,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void memoryEndpointReturnsJvmMemoryReport() {
-        ResponseEntity<Map> response = getMap("/bootui/api/live-memory");
+        var response = getMap("/bootui/api/live-memory");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -367,7 +367,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void profilesEndpointReturnsActiveProfileReport() {
-        ResponseEntity<Map> response = getMap("/bootui/api/profile-diff");
+        var response = getMap("/bootui/api/profile-diff");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -378,7 +378,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void httpProbeEndpointCallsLoopbackSampleEndpoint() {
-        ResponseEntity<Map> response = postMap(
+        var response = postMap(
                 "/bootui/api/http-probe",
                 Map.of("method", "get", "path", "api/hello", "headers", Map.of("X-Ignored", "ok")));
 
@@ -393,7 +393,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void logTailRecentEndpointReturnsSerializedLogLines() {
-        ResponseEntity<List> response = getList("/bootui/api/log-tail/recent");
+        var response = getList("/bootui/api/log-tail/recent");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
@@ -423,7 +423,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void sampleChatEndpointReportsUnavailableWhenSpringAiClientIsDisabled() {
-        ResponseEntity<Map> response = postMap("/api/chat", Map.of("message", "What can BootUI show me?"));
+        var response = postMap("/api/chat", Map.of("message", "What can BootUI show me?"));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
         assertThat(response.getBody()).isNotNull();
@@ -432,7 +432,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void sampleChatEndpointRejectsBlankMessages() {
-        ResponseEntity<Map> response = postMap("/api/chat", Map.of("message", " "));
+        var response = postMap("/api/chat", Map.of("message", " "));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).isNotNull();
@@ -441,19 +441,19 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void sampleProductsEndpointReturnsSqlInitializedProducts() {
-        ResponseEntity<List> response = getList("/api/sample/products");
+        var response = getList("/api/sample/products");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody())
-                .extracting(product -> ((Map<?, ?>) product).get("name"))
-                .contains("BootUI Starter", "Sample Console")
-                .doesNotContain("Archived Prototype");
+        List<String> names = response.getBody().stream()
+                .map(product -> String.valueOf(((Map<?, ?>) product).get("name")))
+                .toList();
+        assertThat(names).contains("BootUI Starter", "Sample Console").doesNotContain("Archived Prototype");
     }
 
     @Test
     void hibernateSecondLevelCacheSampleProducesMissPutAndHit() {
-        ResponseEntity<Map> response = getMap("/api/sample/hibernate-second-level-cache");
+        var response = getMap("/api/sample/hibernate-second-level-cache");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -510,7 +510,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void dataEndpointFindsSampleJpaRepository() {
-        ResponseEntity<Map> response = getMap("/bootui/api/data/repositories");
+        var response = getMap("/bootui/api/data/repositories");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -528,7 +528,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void dataRepositoryDetailIncludesAnnotatedQueryMethod() {
-        ResponseEntity<Map> response = getMap("/bootui/api/data/repositories/" + ProductRepository.class.getName());
+        var response = getMap("/bootui/api/data/repositories/" + ProductRepository.class.getName());
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -547,10 +547,10 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(before).isNotNull();
         long capturedBefore = ((Number) before.get("totalCaptured")).longValue();
 
-        ResponseEntity<List> search = client().get()
+        ResponseEntity<List<Object>> search = client().get()
                 .uri("/api/sample/product-search?term=console")
                 .retrieve()
-                .toEntity(List.class);
+                .toEntity(new ParameterizedTypeReference<>() {});
         assertThat(search.getStatusCode()).isEqualTo(HttpStatus.OK);
 
         Map<?, ?> after = getMap("/bootui/api/transactions").getBody();
@@ -567,7 +567,7 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat(before).isNotNull();
         long capturedBefore = ((Number) before.get("totalCaptured")).longValue();
 
-        ResponseEntity<Map> sampleResponse = getMap("/api/sample/transaction-samples");
+        var sampleResponse = getMap("/api/sample/transaction-samples");
         assertThat(sampleResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(sampleResponse.getBody()).containsEntry("slowMillis", 650);
 
@@ -604,7 +604,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void flywayEndpointListsAppliedAndPendingCatalogMigrations() {
-        ResponseEntity<Map> response = getMap("/bootui/api/flyway/migrations");
+        var response = getMap("/bootui/api/flyway/migrations");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -628,7 +628,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void liquibaseEndpointListsAppliedAndPendingInventoryChangeSets() {
-        ResponseEntity<Map> response = getMap("/bootui/api/liquibase/changesets");
+        var response = getMap("/bootui/api/liquibase/changesets");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -657,7 +657,7 @@ class BootUiSampleApplicationIntegrationTests {
     void cacheEndpointFindsSampleCachesAndClearsOneCache() {
         getList("/api/sample/products");
 
-        ResponseEntity<Map> response = getMap("/bootui/api/cache");
+        var response = getMap("/bootui/api/cache");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -674,10 +674,10 @@ class BootUiSampleApplicationIntegrationTests {
         assertThat((Iterable<?>) body.get("operations")).anySatisfy(operation -> {
             Map<?, ?> dto = (Map<?, ?>) operation;
             assertThat(dto.get("operation")).isEqualTo("@Cacheable");
-            assertThat((Iterable<Object>) dto.get("caches")).contains("sample-products");
+            assertThat((Iterable<?>) dto.get("caches")).anyMatch("sample-products"::equals);
         });
 
-        ResponseEntity<Map> clear = postMap(
+        var clear = postMap(
                 "/bootui/api/cache/clear",
                 Map.of("managerName", "cacheManager", "cacheName", "sample-products", "confirm", true));
         assertThat(clear.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -687,7 +687,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void springSecurityEndpointFindsSampleFilterChains() {
-        ResponseEntity<Map> response = getMap("/bootui/api/spring-security");
+        var response = getMap("/bootui/api/spring-security");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -708,7 +708,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void springSecurityExplainMatchesSecureApiRequest() {
-        ResponseEntity<Map> response = getMap("/bootui/api/spring-security/explain?method=GET&path=/api/secure");
+        var response = getMap("/bootui/api/spring-security/explain?method=GET&path=/api/secure");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -721,7 +721,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void springSecurityEndpointsListsControllerMappingsWithRules() {
-        ResponseEntity<Map> response = getMap("/bootui/api/spring-security/endpoints");
+        var response = getMap("/bootui/api/spring-security/endpoints");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();
@@ -745,7 +745,7 @@ class BootUiSampleApplicationIntegrationTests {
 
     @Test
     void securityLogsEndpointListsMaskedAuditEvents() {
-        ResponseEntity<Map> response = getMap("/bootui/api/security-logs");
+        var response = getMap("/bootui/api/security-logs");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         Map<?, ?> body = response.getBody();

--- a/bootui-spring-webflux-sample-app/pom.xml
+++ b/bootui-spring-webflux-sample-app/pom.xml
@@ -102,6 +102,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <!--
@@ -117,6 +121,13 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/bootui-spring-webflux-sample-app/pom.xml
+++ b/bootui-spring-webflux-sample-app/pom.xml
@@ -120,4 +120,41 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>macos-aarch64-netty-dns</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>aarch64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver-dns-native-macos</artifactId>
+                    <classifier>osx-aarch_64</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>macos-x86_64-netty-dns</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                    <arch>x86_64</arch>
+                </os>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver-dns-native-macos</artifactId>
+                    <classifier>osx-x86_64</classifier>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/bootui-spring-webflux-sample-app/pom.xml
+++ b/bootui-spring-webflux-sample-app/pom.xml
@@ -75,6 +75,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
+            <version>${flyway-verified-h2.version}</version>
             <scope>runtime</scope>
         </dependency>
         <!-- Fallback BootUI activation trigger for a bare `mvn spring-boot:run` / `java -jar` with no

--- a/bootui-ui/src/main/frontend/src/views/Threads.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Threads.test.js
@@ -181,6 +181,7 @@ describe('Threads', () => {
     vi.stubGlobal('fetch', fetchMock)
     URL.createObjectURL = vi.fn(() => 'blob:dump')
     URL.revokeObjectURL = vi.fn()
+    const anchorClick = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
 
     const wrapper = mount(Threads, {props: {panel: {}}})
     wrappers.push(wrapper)
@@ -205,6 +206,7 @@ describe('Threads', () => {
     expect(
       fetchMock.mock.calls.some(([url, init]) => String(url).includes('threads/download') && init?.method === 'POST')
     ).toBe(true)
+    expect(anchorClick).toHaveBeenCalledOnce()
   })
 
   it('does not post a thread dump when confirmation is cancelled', async () => {

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,8 @@
         <!-- testcontainers version is managed by the Spring Boot BOM (2.0.x) -->
         <!-- opentelemetry-proto remains on -alpha as the upstream project does not publish stable releases yet -->
         <opentelemetry-proto.version>1.10.0-alpha</opentelemetry-proto.version>
+        <!-- Flyway 12.x has only verified H2 through 2.3.232; keep migration-backed samples on that version. -->
+        <flyway-verified-h2.version>2.3.232</flyway-verified-h2.version>
         <frontend-maven-plugin.version>2.0.2</frontend-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>${maven-resources-plugin.version}</version>
+                    <configuration>
+                        <propertiesEncoding>${project.build.sourceEncoding}</propertiesEncoding>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
         <central.autoPublish>true</central.autoPublish>
         <maven-antrun-plugin.version>3.2.0</maven-antrun-plugin.version>
+        <maven-dependency-plugin.version>3.7.0</maven-dependency-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
@@ -171,6 +172,20 @@
                         <release>${java.version}</release>
                         <parameters>true</parameters>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>${maven-dependency-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>mockito-agent-property</id>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>properties</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What does this PR do?

Eliminates actionable warning and error-shaped output from the full build across Spring, Quarkus, Maven resource processing, Java compilation, and Vitest.

## Why is this change needed?

A successful `clean verify` produced enough noise to obscure real failures and included several forward-compatibility risks on modern JDKs. This configures Mockito and Quarkus instrumentation as startup agents, initializes JBoss LogManager early, loads the correct native Netty DNS resolver on macOS, aligns H2 with Flyway's verified range, and removes compiler and jsdom test warnings without changing public behavior.

Closes #

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

`./mvnw -B -ntp -Dmaven.repo.local=<isolated-repository> clean verify` passes on JDK 26 with none of the targeted warnings or error-shaped lines.

## Screenshots (UI changes)

N/A - the Vue change only prevents jsdom from attempting navigation during an existing download test.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed