### PR TITLE
Polish the BootUI application shell

### DIFF
--- a/bootui-quarkus-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/app-shell.spec.js
@@ -79,7 +79,8 @@ test.describe('BootUI app shell (Quarkus)', () => {
 
   test('footer reflects the Quarkus platform', async ({page}) => {
     await page.goto('/bootui/')
-    await expect(page.locator('.bootui-footer')).toContainText('developer UI for Quarkus')
+    await expect(page.locator('.bootui-footer')).toContainText('Local-only developer console')
+    await expect(page.locator('.bootui-footer')).toContainText('Quarkus')
   })
 
   test('sidebar links to the BootUI GitHub project', async ({page}) => {

--- a/bootui-quarkus-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/app-shell.spec.js
@@ -66,6 +66,14 @@ const PANEL_HEADINGS = {
   'claude-code': /^Claude Code/
 }
 
+async function expandAllSidebarGroups(page) {
+  const toggles = page.locator('aside .bootui-nav-group__toggle')
+  for (let index = 0; index < (await toggles.count()); index += 1) {
+    const toggle = toggles.nth(index)
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click()
+  }
+}
+
 test.describe('BootUI app shell (Quarkus)', () => {
   test('navbar shows the application name and Quarkus / Java versions', async ({page}) => {
     await page.goto('/bootui/')
@@ -89,6 +97,26 @@ test.describe('BootUI app shell (Quarkus)', () => {
     const contributeLink = page.getByRole('link', {name: /Contribute to the project/})
     await expect(contributeLink).toHaveAttribute('href', 'https://github.com/jdubois/boot-ui')
     await expect(contributeLink.locator('.bi-github')).toBeVisible()
+  })
+
+  test('expanded sidebar groups scroll without moving the footer actions', async ({page}) => {
+    await page.setViewportSize({width: 1280, height: 400})
+    await page.goto('/bootui/')
+    await expandAllSidebarGroups(page)
+
+    const layout = await page.locator('aside.bootui-sidebar').evaluate((sidebar) => {
+      const nav = sidebar.querySelector('.sidebar-nav')
+      const bottom = sidebar.querySelector('.sidebar-bottom').getBoundingClientRect()
+      return {
+        navScrollable: nav.scrollHeight > nav.clientHeight,
+        sectionsDoNotShrink: [...nav.querySelectorAll('.bootui-nav-section')].every(
+          (section) => getComputedStyle(section).flexShrink === '0'
+        ),
+        bottomVisible: bottom.top >= 0 && bottom.bottom <= innerHeight
+      }
+    })
+
+    expect(layout).toEqual({navScrollable: true, sectionsDoNotShrink: true, bottomVisible: true})
   })
 
   test('the Advisors sidebar group uses the framework-aware Quarkus label', async ({page}) => {

--- a/bootui-quarkus-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/overview.spec.js
@@ -78,10 +78,10 @@ test.describe('Overview view (Quarkus)', () => {
     await expect(tip).toHaveCount(0)
   })
 
-  test('links to the BootUI GitHub project with the Quarkus-flavored tagline', async ({openView}) => {
+  test('links to the BootUI GitHub project', async ({openView}) => {
     const page = await openView('overview', 'Overview')
 
-    await expect(page.getByRole('link', {name: /The missing developer UI for Quarkus/})).toHaveAttribute(
+    await expect(page.getByRole('link', {name: /View BootUI on GitHub/})).toHaveAttribute(
       'href',
       'https://github.com/jdubois/boot-ui'
     )

--- a/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
@@ -1,6 +1,14 @@
 // @ts-check
 import {expect, test} from '@playwright/test'
 
+async function expandAllSidebarGroups(page) {
+  const toggles = page.locator('aside .bootui-nav-group__toggle')
+  for (let index = 0; index < (await toggles.count()); index += 1) {
+    const toggle = toggles.nth(index)
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') await toggle.click()
+  }
+}
+
 /**
  * Small smoke suite for the WebFlux (reactive) BootUI adapter.
  *
@@ -28,6 +36,26 @@ test.describe('BootUI on Spring WebFlux', () => {
     const subtitle = page.locator('.topbar-subtitle')
     await expect(subtitle).toContainText(/Spring Boot \d+\.\d+/)
     await expect(subtitle).toContainText(/Java /)
+  })
+
+  test('expanded sidebar groups scroll without moving the footer actions', async ({page}) => {
+    await page.setViewportSize({width: 1280, height: 400})
+    await page.goto('/bootui/')
+    await expandAllSidebarGroups(page)
+
+    const layout = await page.locator('aside.bootui-sidebar').evaluate((sidebar) => {
+      const nav = sidebar.querySelector('.sidebar-nav')
+      const bottom = sidebar.querySelector('.sidebar-bottom').getBoundingClientRect()
+      return {
+        navScrollable: nav.scrollHeight > nav.clientHeight,
+        sectionsDoNotShrink: [...nav.querySelectorAll('.bootui-nav-section')].every(
+          (section) => getComputedStyle(section).flexShrink === '0'
+        ),
+        bottomVisible: bottom.top >= 0 && bottom.bottom <= innerHeight
+      }
+    })
+
+    expect(layout).toEqual({navScrollable: true, sectionsDoNotShrink: true, bottomVisible: true})
   })
 
   test('redirects the root path to /overview', async ({page}) => {

--- a/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
@@ -271,11 +271,14 @@ test.describe('BootUI app shell', () => {
     await page.setViewportSize({width: 1280, height: 400})
     await page.goto('/bootui/')
     await page.locator('main .page-panel h2').first().waitFor()
+    await expandAllSidebarGroups(page)
 
     const layout = await page.evaluate(() => {
       const shell = document.querySelector('.bootui-shell')
       const workspace = document.querySelector('.bootui-workspace')
       const sidebar = document.querySelector('aside.bootui-sidebar')
+      const sidebarNav = sidebar.querySelector('.sidebar-nav')
+      const sidebarBottom = sidebar.querySelector('.sidebar-bottom').getBoundingClientRect()
       const doc = document.scrollingElement
       return {
         // The page itself must not scroll: scrolling lives inside the app, not the document.
@@ -284,8 +287,13 @@ test.describe('BootUI app shell', () => {
         workspaceOverflowY: getComputedStyle(workspace).overflowY,
         workspaceScrollable: workspace.scrollHeight > workspace.clientHeight,
         sidebarOverflowY: getComputedStyle(sidebar).overflowY,
-        sidebarNavOverflowY: getComputedStyle(sidebar.querySelector('.sidebar-nav')).overflowY,
-        sidebarNavOverscroll: getComputedStyle(sidebar.querySelector('.sidebar-nav')).overscrollBehaviorY
+        sidebarNavOverflowY: getComputedStyle(sidebarNav).overflowY,
+        sidebarNavOverscroll: getComputedStyle(sidebarNav).overscrollBehaviorY,
+        sidebarNavScrollable: sidebarNav.scrollHeight > sidebarNav.clientHeight,
+        sidebarSectionsDoNotShrink: [...sidebarNav.querySelectorAll('.bootui-nav-section')].every(
+          (section) => getComputedStyle(section).flexShrink === '0'
+        ),
+        sidebarBottomVisible: sidebarBottom.top >= 0 && sidebarBottom.bottom <= innerHeight
       }
     })
 
@@ -297,6 +305,9 @@ test.describe('BootUI app shell', () => {
     expect(layout.sidebarOverflowY).toBe('hidden')
     expect(layout.sidebarNavOverflowY).toBe('auto')
     expect(layout.sidebarNavOverscroll).toBe('contain')
+    expect(layout.sidebarNavScrollable).toBe(true)
+    expect(layout.sidebarSectionsDoNotShrink).toBe(true)
+    expect(layout.sidebarBottomVisible).toBe(true)
 
     // Scrolling the main content moves only the content, not the sidebar or the document.
     const sidebar = page.locator('aside.bootui-sidebar')
@@ -308,6 +319,12 @@ test.describe('BootUI app shell', () => {
     expect(contentScrollTop).toBeGreaterThan(0)
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
     expect(await sidebar.evaluate((el) => el.getBoundingClientRect().top)).toBe(sidebarTopBefore)
+
+    const navScrollTop = await sidebar.locator('.sidebar-nav').evaluate((nav) => {
+      nav.scrollTop = nav.scrollHeight
+      return nav.scrollTop
+    })
+    expect(navScrollTop).toBeGreaterThan(0)
   })
 
   test('sidebar groups panels into collapsible sections', async ({page}) => {

--- a/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
@@ -284,7 +284,8 @@ test.describe('BootUI app shell', () => {
         workspaceOverflowY: getComputedStyle(workspace).overflowY,
         workspaceScrollable: workspace.scrollHeight > workspace.clientHeight,
         sidebarOverflowY: getComputedStyle(sidebar).overflowY,
-        sidebarOverscroll: getComputedStyle(sidebar).overscrollBehaviorY
+        sidebarNavOverflowY: getComputedStyle(sidebar.querySelector('.sidebar-nav')).overflowY,
+        sidebarNavOverscroll: getComputedStyle(sidebar.querySelector('.sidebar-nav')).overscrollBehaviorY
       }
     })
 
@@ -292,9 +293,10 @@ test.describe('BootUI app shell', () => {
     expect(layout.shellOverflowY).toBe('hidden')
     expect(layout.workspaceOverflowY).toBe('auto')
     expect(layout.workspaceScrollable).toBe(true)
-    // The sidebar is its own scroll region and never chains into the rest of the page.
-    expect(layout.sidebarOverflowY).toBe('auto')
-    expect(layout.sidebarOverscroll).toBe('contain')
+    // Only the navigation list scrolls, keeping the brand and bottom actions fixed.
+    expect(layout.sidebarOverflowY).toBe('hidden')
+    expect(layout.sidebarNavOverflowY).toBe('auto')
+    expect(layout.sidebarNavOverscroll).toBe('contain')
 
     // Scrolling the main content moves only the content, not the sidebar or the document.
     const sidebar = page.locator('aside.bootui-sidebar')

--- a/bootui-spring-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/overview.spec.js
@@ -69,7 +69,7 @@ test.describe('Overview view', () => {
   test('links to the BootUI GitHub project', async ({openView}) => {
     const page = await openView('overview', 'Overview')
 
-    await expect(page.getByRole('link', {name: /The missing developer UI for Spring Boot/})).toHaveAttribute(
+    await expect(page.getByRole('link', {name: /View BootUI on GitHub/})).toHaveAttribute(
       'href',
       'https://github.com/jdubois/boot-ui'
     )

--- a/bootui-ui/src/main/frontend/src/App.test.js
+++ b/bootui-ui/src/main/frontend/src/App.test.js
@@ -300,6 +300,29 @@ describe('App sidebar navigation', () => {
   })
 })
 
+describe('App shell chrome', () => {
+  beforeEach(() => {
+    stubLocalStorage()
+    mockShellFetch()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    restoreLocalStorage()
+    document.body.innerHTML = ''
+  })
+
+  it('keeps the header concise and identifies the local runtime in the footer', async () => {
+    const {wrapper} = await mountApp()
+
+    expect(wrapper.find('.topbar-heading .eyebrow').exists()).toBe(false)
+    expect(wrapper.find('.topbar-title').text()).toBe('bootui-sample')
+    expect(wrapper.find('.bootui-footer__context').text()).toContain('Local-only developer console')
+    expect(wrapper.find('.bootui-footer__context').text()).toContain('Spring Boot')
+    expect(wrapper.find('.bootui-footer a').text()).toContain('View BootUI on GitHub')
+  })
+})
+
 describe('App command palette', () => {
   beforeEach(() => {
     stubLocalStorage()
@@ -597,13 +620,15 @@ describe('App shell footer', () => {
     mockShellFetch('spring-boot')
     const {wrapper} = await mountApp()
 
-    expect(wrapper.find('.bootui-footer a').text()).toBe('BootUI - The missing developer UI for Spring Boot!')
+    expect(wrapper.find('.bootui-footer__context').text()).toContain('Spring Boot')
+    expect(wrapper.find('.bootui-footer a').text()).toContain('View BootUI on GitHub')
   })
 
   it('labels the footer for Quarkus when the manifest platform is quarkus', async () => {
     mockShellFetch('quarkus')
     const {wrapper} = await mountApp()
 
-    expect(wrapper.find('.bootui-footer a').text()).toBe('BootUI - The missing developer UI for Quarkus!')
+    expect(wrapper.find('.bootui-footer__context').text()).toContain('Quarkus')
+    expect(wrapper.find('.bootui-footer a').text()).toContain('View BootUI on GitHub')
   })
 })

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -338,11 +338,6 @@ const frameworkLabel = computed(() => {
   if (platform === 'spring-boot') return 'Spring Boot'
   return null
 })
-const footerText = computed(() =>
-  frameworkLabel.value
-    ? `BootUI - The missing developer UI for ${frameworkLabel.value}!`
-    : 'BootUI - The missing developer UI!'
-)
 const githubProjectUrl = 'https://github.com/jdubois/boot-ui'
 function navTitle(r) {
   return resolveRouteTitle(r, panels.value?.platform)
@@ -604,7 +599,6 @@ function onGlobalKeydown(e) {
       <div class="authentication-card">
         <span class="authentication-icon"><i class="bi bi-shield-lock"></i></span>
         <div>
-          <div class="eyebrow">Remote access</div>
           <h1 id="authentication-title">Unlock BootUI</h1>
           <p>
             This API requires authentication outside localhost. Copy the bearer token from the application startup log.
@@ -827,7 +821,6 @@ function onGlobalKeydown(e) {
               <i aria-hidden="true" class="bi bi-list"></i>
             </button>
             <div class="topbar-heading">
-              <div class="eyebrow">Inspecting</div>
               <h1 class="topbar-title">{{ applicationTitle }}</h1>
               <p class="topbar-subtitle mb-0">{{ runtimeSummary }}</p>
             </div>
@@ -907,8 +900,16 @@ function onGlobalKeydown(e) {
         </main>
 
         <footer class="bootui-footer">
+          <span class="bootui-footer__context">
+            <i aria-hidden="true" class="bi bi-shield-check"></i>
+            Local-only developer console
+            <span v-if="frameworkLabel" aria-hidden="true" class="bootui-footer__separator">·</span>
+            <span v-if="frameworkLabel">{{ frameworkLabel }}</span>
+          </span>
           <a :href="githubProjectUrl" rel="noopener noreferrer" target="_blank">
-            {{ footerText }}
+            <i aria-hidden="true" class="bi bi-github"></i>
+            View BootUI on GitHub
+            <i aria-hidden="true" class="bi bi-box-arrow-up-right bootui-footer__external"></i>
           </a>
         </footer>
       </div>
@@ -1386,8 +1387,7 @@ function onGlobalKeydown(e) {
   flex-shrink: 0;
   gap: 1.4rem;
   height: 100vh;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
   overscroll-behavior: contain;
   padding: 1.25rem;
   /* impeccable-disable-next-line layout-transition -- collapsible sidebar/drawer animates width by design */
@@ -1567,8 +1567,8 @@ function onGlobalKeydown(e) {
 
 .brand-card {
   align-items: center;
-  background: linear-gradient(135deg, rgba(25, 135, 84, 0.12), rgba(13, 110, 253, 0.1));
-  border: 1px solid rgba(25, 135, 84, 0.14);
+  background: var(--bootui-surface);
+  border: 1px solid var(--bootui-border);
   border-radius: 1.25rem;
   color: inherit;
   display: flex;
@@ -1618,20 +1618,19 @@ function onGlobalKeydown(e) {
 }
 
 .sidebar-nav {
+  flex: 1;
   gap: 0.45rem;
-}
-
-.eyebrow {
-  color: var(--bootui-text-muted);
-  font-size: 0.7rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  margin-bottom: 0.55rem;
-  text-transform: uppercase;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0.15rem 0.25rem 0.75rem 0;
+  scrollbar-color: var(--bootui-border-alt) transparent;
+  scrollbar-width: thin;
 }
 
 .bootui-nav-link {
   align-items: center;
+  border-radius: var(--bootui-radius-md);
   color: var(--bootui-nav-link-color);
   display: flex;
   gap: 0.75rem;
@@ -1766,6 +1765,7 @@ function onGlobalKeydown(e) {
 .sidebar-bottom {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
 }
 
 .contribute-card {
@@ -1812,10 +1812,16 @@ function onGlobalKeydown(e) {
 
 .topbar {
   align-items: center;
+  backdrop-filter: blur(18px);
+  background: var(--bootui-sidebar-bg);
+  border-bottom: 1px solid var(--bootui-border-subtle);
   display: flex;
   gap: 1rem;
   justify-content: space-between;
-  padding: 1.5rem 2rem 1rem;
+  padding: 1.25rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .topbar-lead {
@@ -1949,18 +1955,46 @@ function onGlobalKeydown(e) {
 }
 
 .bootui-footer {
+  align-items: center;
+  border-top: 1px solid var(--bootui-border-subtle);
   color: var(--bootui-text-muted);
+  display: flex;
   font-size: 0.82rem;
-  padding: 0 2rem 1.25rem;
-  text-align: center;
+  gap: 1rem;
+  justify-content: space-between;
+  margin: 0 2rem;
+  padding: 1rem 0 1.25rem;
 }
 
 .bootui-footer a {
+  align-items: center;
   color: inherit;
+  display: inline-flex;
+  gap: 0.4rem;
+  text-decoration: none;
 }
 
 .bootui-footer a:hover {
   color: var(--bootui-green-dark);
+}
+
+.bootui-footer__context {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.bootui-footer__context > .bi {
+  color: var(--bootui-green-dark);
+}
+
+.bootui-footer__separator {
+  color: var(--bootui-text-subtle);
+  margin-inline: 0.1rem;
+}
+
+.bootui-footer__external {
+  font-size: 0.7rem;
 }
 
 .page-slide-enter-active,
@@ -2000,6 +2034,11 @@ function onGlobalKeydown(e) {
     padding-left: 1.25rem;
     padding-right: 1.25rem;
   }
+
+  .bootui-footer {
+    margin-left: 0;
+    margin-right: 0;
+  }
 }
 
 @media (max-width: 575.98px) {
@@ -2023,6 +2062,12 @@ function onGlobalKeydown(e) {
   .bootui-footer {
     padding-left: 1rem;
     padding-right: 1rem;
+  }
+
+  .bootui-footer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.65rem;
   }
 
   :global(button),

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1648,6 +1648,7 @@ function onGlobalKeydown(e) {
 .bootui-nav-section {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   gap: 0.25rem;
 }
 

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -902,9 +902,11 @@ function onGlobalKeydown(e) {
         <footer class="bootui-footer">
           <span class="bootui-footer__context">
             <i aria-hidden="true" class="bi bi-shield-check"></i>
-            Local-only developer console
-            <span v-if="frameworkLabel" aria-hidden="true" class="bootui-footer__separator">·</span>
-            <span v-if="frameworkLabel">{{ frameworkLabel }}</span>
+            <span class="bootui-footer__context-copy">
+              Local-only developer console
+              <span v-if="frameworkLabel" aria-hidden="true" class="bootui-footer__separator">·</span>
+              <span v-if="frameworkLabel">{{ frameworkLabel }}</span>
+            </span>
           </span>
           <a :href="githubProjectUrl" rel="noopener noreferrer" target="_blank">
             <i aria-hidden="true" class="bi bi-github"></i>
@@ -1623,6 +1625,7 @@ function onGlobalKeydown(e) {
   min-height: 0;
   overflow-x: hidden;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 0.15rem 0.25rem 0.75rem 0;
   scrollbar-color: var(--bootui-border-alt) transparent;
   scrollbar-width: thin;
@@ -1988,6 +1991,10 @@ function onGlobalKeydown(e) {
   color: var(--bootui-green-dark);
 }
 
+.bootui-footer__context-copy {
+  min-width: 0;
+}
+
 .bootui-footer__separator {
   color: var(--bootui-text-subtle);
   margin-inline: 0.1rem;
@@ -2047,6 +2054,7 @@ function onGlobalKeydown(e) {
     flex-direction: column;
     padding-left: 1rem;
     padding-right: 1rem;
+    position: static;
   }
 
   .topbar-actions {


### PR DESCRIPTION
## What does this PR do?

Polishes the shared BootUI application shell with a cleaner sticky header, independently scrolling navigation, and a more informative responsive footer.

## Why is this change needed?

The shell had a few visual-system drifts: decorative gradients appeared outside selected states, header eyebrows added unnecessary hierarchy, and the footer read as a slogan instead of dependable console chrome. This refinement brings the menu, header, and footer back in line with the Calm Control Room design system without changing routes or runtime behavior.

Closes # N/A (no linked issue)

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Focused validation:
- `npm test -- --run src/App.test.js src/accessibility.test.js src/responsiveMotion.test.js`
- `npm run build`
- `npm run format:check`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (no behavior change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed