### PR TITLE
Fix sidebar horizontal overflow

### DIFF
--- a/bootui-quarkus-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/app-shell.spec.js
@@ -106,9 +106,16 @@ test.describe('BootUI app shell (Quarkus)', () => {
 
     const layout = await page.locator('aside.bootui-sidebar').evaluate((sidebar) => {
       const nav = sidebar.querySelector('.sidebar-nav')
+      const navRect = nav.getBoundingClientRect()
       const bottom = sidebar.querySelector('.sidebar-bottom').getBoundingClientRect()
       return {
         navScrollable: nav.scrollHeight > nav.clientHeight,
+        navDoesNotWrap: getComputedStyle(nav).flexWrap === 'nowrap',
+        noHorizontalOverflow: nav.scrollWidth <= nav.clientWidth + 1,
+        itemsStayInsideNav: [...nav.querySelectorAll('.bootui-nav-section, .bootui-nav-link')].every((item) => {
+          const itemRect = item.getBoundingClientRect()
+          return itemRect.left >= navRect.left - 1 && itemRect.right <= navRect.right + 1
+        }),
         sectionsDoNotShrink: [...nav.querySelectorAll('.bootui-nav-section')].every(
           (section) => getComputedStyle(section).flexShrink === '0'
         ),
@@ -116,7 +123,14 @@ test.describe('BootUI app shell (Quarkus)', () => {
       }
     })
 
-    expect(layout).toEqual({navScrollable: true, sectionsDoNotShrink: true, bottomVisible: true})
+    expect(layout).toEqual({
+      navScrollable: true,
+      navDoesNotWrap: true,
+      noHorizontalOverflow: true,
+      itemsStayInsideNav: true,
+      sectionsDoNotShrink: true,
+      bottomVisible: true
+    })
   })
 
   test('the Advisors sidebar group uses the framework-aware Quarkus label', async ({page}) => {

--- a/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
@@ -45,9 +45,16 @@ test.describe('BootUI on Spring WebFlux', () => {
 
     const layout = await page.locator('aside.bootui-sidebar').evaluate((sidebar) => {
       const nav = sidebar.querySelector('.sidebar-nav')
+      const navRect = nav.getBoundingClientRect()
       const bottom = sidebar.querySelector('.sidebar-bottom').getBoundingClientRect()
       return {
         navScrollable: nav.scrollHeight > nav.clientHeight,
+        navDoesNotWrap: getComputedStyle(nav).flexWrap === 'nowrap',
+        noHorizontalOverflow: nav.scrollWidth <= nav.clientWidth + 1,
+        itemsStayInsideNav: [...nav.querySelectorAll('.bootui-nav-section, .bootui-nav-link')].every((item) => {
+          const itemRect = item.getBoundingClientRect()
+          return itemRect.left >= navRect.left - 1 && itemRect.right <= navRect.right + 1
+        }),
         sectionsDoNotShrink: [...nav.querySelectorAll('.bootui-nav-section')].every(
           (section) => getComputedStyle(section).flexShrink === '0'
         ),
@@ -55,7 +62,14 @@ test.describe('BootUI on Spring WebFlux', () => {
       }
     })
 
-    expect(layout).toEqual({navScrollable: true, sectionsDoNotShrink: true, bottomVisible: true})
+    expect(layout).toEqual({
+      navScrollable: true,
+      navDoesNotWrap: true,
+      noHorizontalOverflow: true,
+      itemsStayInsideNav: true,
+      sectionsDoNotShrink: true,
+      bottomVisible: true
+    })
   })
 
   test('redirects the root path to /overview', async ({page}) => {

--- a/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
@@ -278,6 +278,7 @@ test.describe('BootUI app shell', () => {
       const workspace = document.querySelector('.bootui-workspace')
       const sidebar = document.querySelector('aside.bootui-sidebar')
       const sidebarNav = sidebar.querySelector('.sidebar-nav')
+      const sidebarNavRect = sidebarNav.getBoundingClientRect()
       const sidebarBottom = sidebar.querySelector('.sidebar-bottom').getBoundingClientRect()
       const doc = document.scrollingElement
       return {
@@ -290,6 +291,14 @@ test.describe('BootUI app shell', () => {
         sidebarNavOverflowY: getComputedStyle(sidebarNav).overflowY,
         sidebarNavOverscroll: getComputedStyle(sidebarNav).overscrollBehaviorY,
         sidebarNavScrollable: sidebarNav.scrollHeight > sidebarNav.clientHeight,
+        sidebarNavDoesNotWrap: getComputedStyle(sidebarNav).flexWrap === 'nowrap',
+        sidebarNavHasNoHorizontalOverflow: sidebarNav.scrollWidth <= sidebarNav.clientWidth + 1,
+        sidebarItemsStayInsideNav: [
+          ...sidebarNav.querySelectorAll('.bootui-nav-section, .bootui-nav-group__items, .bootui-nav-link')
+        ].every((item) => {
+          const itemRect = item.getBoundingClientRect()
+          return itemRect.left >= sidebarNavRect.left - 1 && itemRect.right <= sidebarNavRect.right + 1
+        }),
         sidebarSectionsDoNotShrink: [...sidebarNav.querySelectorAll('.bootui-nav-section')].every(
           (section) => getComputedStyle(section).flexShrink === '0'
         ),
@@ -306,6 +315,9 @@ test.describe('BootUI app shell', () => {
     expect(layout.sidebarNavOverflowY).toBe('auto')
     expect(layout.sidebarNavOverscroll).toBe('contain')
     expect(layout.sidebarNavScrollable).toBe(true)
+    expect(layout.sidebarNavDoesNotWrap).toBe(true)
+    expect(layout.sidebarNavHasNoHorizontalOverflow).toBe(true)
+    expect(layout.sidebarItemsStayInsideNav).toBe(true)
     expect(layout.sidebarSectionsDoNotShrink).toBe(true)
     expect(layout.sidebarBottomVisible).toBe(true)
 

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1621,6 +1621,7 @@ function onGlobalKeydown(e) {
 
 .sidebar-nav {
   flex: 1;
+  flex-wrap: nowrap;
   gap: 0.45rem;
   min-height: 0;
   overflow-x: hidden;


### PR DESCRIPTION
## What does this PR do?

Prevents expanded sidebar sections from wrapping into columns and adds cross-runtime regression coverage for sidebar overflow.

## Why is this change needed?

Bootstrap's `.nav` retained `flex-wrap: wrap`, so the non-shrinking sections in the expanded vertical sidebar wrapped into additional columns to the right when vertical space ran out. This caused horizontal overflow and moved navigation items outside the sidebar bounds.

The fix sets `.sidebar-nav { flex-wrap: nowrap; }`, preserving a single vertical column and allowing the existing vertical scrolling behavior to contain all expanded items.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Validation completed successfully with the focused frontend tests and build, plus the real Spring Playwright test `main content scrolls while the sidebar stays fixed`. The Spring MVC, WebFlux, and Quarkus browser specs now assert vertical scrolling, no horizontal overflow, and that all expanded navigation items remain within sidebar bounds.

## Screenshots (UI changes)

Not applicable; this fixes overflow without changing the intended sidebar design.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

No documentation update is needed for this layout bug fix, and the public API is unchanged.