### PR TITLE
Polish all BootUI panels

### DIFF
--- a/bootui-quarkus-sample-app/e2e/tests/health.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/health.spec.js
@@ -27,7 +27,9 @@ test.describe('Health view (Quarkus)', () => {
   test('renders nested component details in a readable table', async ({openView, page}) => {
     await openView('health', 'Health')
 
-    const dbSummary = page.locator('details.card > summary', {hasText: /Database connections health check/}).first()
+    const dbSummary = page
+      .locator('details.health-node > summary', {hasText: /Database connections health check/})
+      .first()
     const dbNode = dbSummary.locator('xpath=..')
     await expect(dbNode).toBeVisible()
     await expect(dbNode).toContainText('Details')

--- a/bootui-spring-sample-app/e2e/tests/health.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/health.spec.js
@@ -16,7 +16,7 @@ test.describe('Health view', () => {
   test('renders nested component details in a readable table', async ({openView, page}) => {
     await openView('health', 'Health')
 
-    const diskSpaceSummary = page.locator('details.card > summary', {hasText: /^diskSpace/}).first()
+    const diskSpaceSummary = page.locator('details.health-node > summary', {hasText: /^diskSpace/}).first()
     const diskSpaceNode = diskSpaceSummary.locator('xpath=..')
     await expect(diskSpaceNode).toBeVisible()
     await expect(diskSpaceNode).toContainText('Details')

--- a/bootui-spring-sample-app/e2e/tests/live-memory.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/live-memory.spec.js
@@ -5,7 +5,7 @@ test.describe('Live Memory view', () => {
   test('renders heap and non-heap live memory cards without tuning panels', async ({openView, page}) => {
     await openView('live-memory', 'Live Memory')
 
-    await expect(page.locator('.card', {hasText: 'Heap Memory'}).first()).toBeVisible()
+    await expect(page.locator('.card', {hasText: 'Heap memory'}).first()).toBeVisible()
     await expect(page.locator('.card', {hasText: /Non[- ]?Heap/i}).first()).toBeVisible()
     await expect(page.locator('.card', {hasText: 'Recommended JVM Options'})).toHaveCount(0)
     await expect(page.locator('.card', {hasText: 'Kubernetes calculator'})).toHaveCount(0)

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -995,6 +995,16 @@ function onGlobalKeydown(e) {
   /* Skeleton loaders */
   --bootui-skeleton-base: #e2e8f0;
   --bootui-skeleton-shine: #f1f5f9;
+
+  /* Machine-output panes (log tails, stack traces, container logs). These stay
+     dark in both themes because they render terminal output, so they carry their
+     own foreground token rather than inheriting the surface text color. */
+  --bootui-code-pane-bg: #111827;
+  --bootui-code-pane-text: #f1f5f9;
+  --bootui-code-pane-border: rgba(15, 23, 42, 0.35);
+
+  /* Subtle highlight for a changed/overridden row (never a warm cream). */
+  --bootui-highlight-bg: rgba(255, 193, 7, 0.14);
 }
 
 .authentication-gate {
@@ -1117,6 +1127,11 @@ function onGlobalKeydown(e) {
   /* Skeleton loaders */
   --bootui-skeleton-base: #334155;
   --bootui-skeleton-shine: #475569;
+
+  /* Machine-output panes keep their terminal identity; only the hairline adapts. */
+  --bootui-code-pane-border: rgba(226, 232, 240, 0.14);
+
+  --bootui-highlight-bg: rgba(255, 193, 7, 0.16);
 }
 
 :global(body) {
@@ -1319,6 +1334,42 @@ function onGlobalKeydown(e) {
   border-radius: var(--bootui-radius-md);
 }
 
+/* DESIGN.md "Buttons": the primary action is solid Spring green, not Bootstrap's
+   default blue. Bootstrap 5.3 drives every `.btn` variant from local custom
+   properties, so re-pointing them here brands every primary action in the console
+   without each panel restating the palette. Signal blue keeps its own meaning on
+   `.text-primary`, `.bg-primary`, and chart series. */
+:global(.btn-primary) {
+  --bs-btn-bg: #198754;
+  --bs-btn-border-color: #198754;
+  --bs-btn-hover-bg: #146c43;
+  --bs-btn-hover-border-color: #146c43;
+  --bs-btn-active-bg: #146c43;
+  --bs-btn-active-border-color: #146c43;
+  --bs-btn-disabled-bg: #198754;
+  --bs-btn-disabled-border-color: #198754;
+  --bs-btn-focus-shadow-rgb: 25, 135, 84;
+}
+
+:global(.btn-outline-primary) {
+  --bs-btn-color: #146c43;
+  --bs-btn-border-color: #198754;
+  --bs-btn-hover-bg: #198754;
+  --bs-btn-hover-border-color: #198754;
+  --bs-btn-active-bg: #146c43;
+  --bs-btn-active-border-color: #146c43;
+  --bs-btn-disabled-color: #146c43;
+  --bs-btn-disabled-border-color: #198754;
+  --bs-btn-focus-shadow-rgb: 25, 135, 84;
+}
+
+/* Dark theme lifts only the outline text; the solid fill keeps #198754 so white
+   label text stays above 4.5:1 on both shells. */
+:global(:root[data-bootui-theme='dark'] .btn-outline-primary) {
+  --bs-btn-color: #34d068;
+  --bs-btn-disabled-color: #34d068;
+}
+
 :global(.progress) {
   border-radius: var(--bootui-radius-pill);
   overflow: hidden;
@@ -1329,6 +1380,12 @@ function onGlobalKeydown(e) {
   transition: width 500ms ease;
 }
 
+/* Every dense table lives in a scroll region. Bootstrap's `.table-responsive`
+   only sets `overflow-x: auto`, which lets an inner table widen its flex/grid
+   parent and chains the scroll to the workspace on touch. Owning those two
+   behaviours here keeps the containment identical on every panel instead of
+   depending on each one remembering the companion class. */
+:global(.table-responsive),
 :global(.bootui-table-scroll) {
   max-width: 100%;
   overscroll-behavior-inline: contain;
@@ -1339,10 +1396,43 @@ function onGlobalKeydown(e) {
   min-width: var(--bootui-table-min-width, 42rem);
 }
 
+/* A card header that carries a section title should be a real heading. Normalise
+   the heading metrics here so using `<h3>` instead of a styled `<div>` costs
+   nothing visually. */
+:global(.card-header > h2),
+:global(.card-header > h3),
+:global(.card-header > h4),
+:global(.card-header > h5),
+:global(.card-header > h6) {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0;
+}
+
+/* Bootstrap ships `code` in its own pink (#d63384), a hue that appears nowhere in
+   the BootUI palette — and `code` is the console's most common element (every bean
+   name, property key, class, and SQL fragment). Inheriting the surrounding colour
+   keeps the mono/sans split doing the work DESIGN.md assigns it, and makes code
+   inside a selected or tinted row adopt that row's foreground instead of staying
+   pink at unreadable contrast. */
+:global(code) {
+  color: inherit;
+}
+
 :global(.bootui-break-anywhere) {
   overflow-wrap: anywhere;
   white-space: normal;
   word-break: break-word;
+}
+
+/* Terminal-style output (log tails, stack traces, container logs). */
+:global(.bootui-code-pane) {
+  background: var(--bootui-code-pane-bg);
+  border: 1px solid var(--bootui-code-pane-border);
+  border-radius: var(--bootui-radius-md);
+  color: var(--bootui-code-pane-text);
+  font-family: var(--bs-font-monospace);
+  overflow: auto;
 }
 
 .bootui-shell {

--- a/bootui-ui/src/main/frontend/src/designSystem.test.js
+++ b/bootui-ui/src/main/frontend/src/designSystem.test.js
@@ -1,0 +1,167 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+import {parse as parseTemplate} from '@vue/compiler-dom'
+import {parse as parseSfc} from '@vue/compiler-sfc'
+import {describe, expect, it} from 'vitest'
+
+const sourceRoot = path.dirname(fileURLToPath(import.meta.url))
+const viewsRoot = path.join(sourceRoot, 'views')
+const appSource = fs.readFileSync(path.join(sourceRoot, 'App.vue'), 'utf8')
+
+function vueFiles(directory) {
+  return fs.readdirSync(directory, {withFileTypes: true}).flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) return vueFiles(entryPath)
+    return entry.name.endsWith('.vue') ? [entryPath] : []
+  })
+}
+
+function descriptorFor(file) {
+  return parseSfc(fs.readFileSync(file, 'utf8'), {filename: file}).descriptor
+}
+
+function relative(file) {
+  return path.relative(sourceRoot, file)
+}
+
+function staticClasses(node) {
+  const classAttribute = node.props?.find((property) => property.type === 6 && property.name === 'class')
+  return new Set(classAttribute?.value?.content.split(/\s+/).filter(Boolean) ?? [])
+}
+
+function walk(template, visit, lineOffset = 0) {
+  const ast = parseTemplate(template)
+
+  function descend(node, ancestors) {
+    if (node.type === 1) {
+      visit(node, ancestors, lineOffset + node.loc.start.line)
+      node.children.forEach((child) => descend(child, [...ancestors, node]))
+      return
+    }
+    node.children?.forEach((child) => descend(child, ancestors))
+  }
+
+  descend(ast, [])
+}
+
+describe('BootUI design system contracts', () => {
+  // DESIGN.md "The Eyebrow-Containment Rule": the uppercase tracked label is a
+  // sidebar nav-group affordance. Anywhere else it is the AI-SaaS-slop tell the
+  // system explicitly rejects. Status badges may still normalise a machine-supplied
+  // severity token such as "critical" to "CRITICAL".
+  it('keeps uppercase tracked labels out of panel content', () => {
+    const issues = []
+
+    for (const file of vueFiles(viewsRoot)) {
+      const {descriptor} = {descriptor: descriptorFor(file)}
+
+      if (descriptor.template) {
+        walk(
+          descriptor.template.content,
+          (node, _ancestors, line) => {
+            const classes = staticClasses(node)
+            if (classes.has('text-uppercase') && !classes.has('badge')) {
+              issues.push(`${relative(file)}:${line}: content eyebrow via .text-uppercase`)
+            }
+          },
+          descriptor.template.loc.start.line - 1
+        )
+      }
+
+      const styles = descriptor.styles.map((style) => style.content).join('\n')
+      for (const [, selector] of styles.matchAll(/([^{}]+)\{[^{}]*text-transform:\s*uppercase[^{}]*\}/g)) {
+        const name = selector.trim().split('\n').pop().trim()
+        // The command palette is the keyboard twin of the sidebar rail, so its
+        // nav-group headers carry the same documented label treatment.
+        if (name === '.cp-section-label') continue
+        issues.push(`${relative(file)}: content eyebrow via text-transform: uppercase on ${name}`)
+      }
+    }
+
+    expect(issues).toEqual([])
+  })
+
+  // DESIGN.md "Cards / Containers": cards never nest. The health tree is recursive,
+  // so this also guards against a component re-entering itself as a card.
+  it('never nests a card inside another card', () => {
+    const issues = []
+
+    for (const file of vueFiles(viewsRoot)) {
+      const descriptor = descriptorFor(file)
+      if (!descriptor.template) continue
+
+      walk(
+        descriptor.template.content,
+        (node, ancestors, line) => {
+          if (!staticClasses(node).has('card')) return
+          if (ancestors.some((ancestor) => staticClasses(ancestor).has('card'))) {
+            issues.push(`${relative(file)}:${line}: card nested inside another card`)
+          }
+        },
+        descriptor.template.loc.start.line - 1
+      )
+    }
+
+    expect(issues).toEqual([])
+  })
+
+  // DESIGN.md "Buttons": the primary action is solid Spring green. Bootstrap's own
+  // blue is the default-admin-template failure state the system rejects.
+  it('brands the primary button with Spring green in both themes', () => {
+    const primary = appSource.slice(appSource.indexOf(':global(.btn-primary)'))
+    const primaryBlock = primary.slice(0, primary.indexOf('}'))
+
+    expect(primaryBlock).toContain('--bs-btn-bg: #198754')
+    expect(primaryBlock).toContain('--bs-btn-hover-bg: #146c43')
+    expect(appSource).toContain(":global(:root[data-bootui-theme='dark'] .btn-outline-primary)")
+  })
+
+  // Bootstrap's `.table-responsive` only sets `overflow-x`. Owning the containment
+  // globally keeps a wide table from widening its flex parent or chaining its
+  // scroll to the workspace on touch, on every panel rather than the ones that
+  // remembered the companion class.
+  it('contains table scrolling globally rather than per panel', () => {
+    const rule = appSource.slice(appSource.indexOf(':global(.table-responsive)'))
+    const block = rule.slice(0, rule.indexOf('}'))
+
+    expect(block).toContain('overscroll-behavior-inline: contain')
+    expect(block).toContain('max-width: 100%')
+  })
+
+  // Every route-level panel must say something on first paint. Panels that own no
+  // fetch of their own (static, streaming, or embedded sub-modes) are exempt.
+  it('gives every data panel a first-paint loading affordance', () => {
+    const exempt = new Set([
+      'BeanGraph.vue', // canvas rendered by BeansGraphMode, which owns the state
+      'BeansGraphMode.vue', // sub-mode of Beans.vue, which owns the PanelHeader
+      'HttpProbe.vue', // request builder: nothing loads until the user probes
+      'LiveFlowMode.vue', // sub-mode of Live Activity
+      'LogTail.vue', // streams over EventSource and reports its connection state
+      'NotFound.vue', // static route
+      'Overview.vue' // scanner tiles carry their own idle/scanned state
+    ])
+
+    const missing = fs
+      .readdirSync(viewsRoot)
+      .filter((name) => name.endsWith('.vue') && !exempt.has(name))
+      .filter((name) => !fs.readFileSync(path.join(viewsRoot, name), 'utf8').includes('PanelSkeleton'))
+
+    expect(missing).toEqual([])
+  })
+
+  // Terminal output stays dark in both themes, but it must do so through the shared
+  // token rather than a hard-coded hex repeated in each panel.
+  it('routes machine-output panes through the shared code-pane tokens', () => {
+    expect(appSource).toContain('--bootui-code-pane-bg: #111827')
+
+    const offenders = vueFiles(viewsRoot).filter((file) =>
+      descriptorFor(file)
+        .styles.map((style) => style.content)
+        .join('\n')
+        .includes('#111827')
+    )
+
+    expect(offenders.map(relative)).toEqual([])
+  })
+})

--- a/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.js
+++ b/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.js
@@ -45,6 +45,9 @@ export function useAdvisorPanel(props, options) {
   const error = ref(null)
   const actionMessage = ref(null)
   const loading = ref(false)
+  // True only until the mount-time report GET settles, so a panel can show its
+  // skeleton on first paint without flashing it on every later refresh or scan.
+  const initialLoading = ref(true)
 
   const {dismissLoading, dismiss, restore} = useDismissedRules(loadReport)
 
@@ -167,9 +170,15 @@ export function useAdvisorPanel(props, options) {
     }, 6000)
   }
 
-  onMounted(() => {
-    if (manifestAvailable.value) {
-      loadReport()
+  onMounted(async () => {
+    if (!manifestAvailable.value) {
+      initialLoading.value = false
+      return
+    }
+    try {
+      await loadReport()
+    } finally {
+      initialLoading.value = false
     }
   })
 
@@ -182,6 +191,7 @@ export function useAdvisorPanel(props, options) {
     error,
     actionMessage,
     loading,
+    initialLoading,
     dismissLoading,
     dismiss,
     restore,

--- a/bootui-ui/src/main/frontend/src/views/Ai.vue
+++ b/bootui-ui/src/main/frontend/src/views/Ai.vue
@@ -528,7 +528,7 @@ const detectedFrameworkLabel = computed(() => {
           <span class="text-info fs-3"><i class="bi bi-broadcast-pin"></i></span>
           <div>
             <div class="d-flex align-items-center gap-2 flex-wrap mb-1">
-              <h5 class="mb-0">No AI chat completions recorded yet</h5>
+              <h3 class="h5 mb-0">No AI chat completions recorded yet</h3>
               <span class="badge text-bg-info">Telemetry ready</span>
             </div>
             <p class="text-muted mb-0">
@@ -601,7 +601,7 @@ const detectedFrameworkLabel = computed(() => {
         <div v-if="chart" class="card mb-3">
           <div class="card-body">
             <div class="d-flex justify-content-between align-items-center mb-2">
-              <h6 class="mb-0">Token usage (last {{ series.minutes }} min)</h6>
+              <h3 class="fs-6 mb-0">Token usage (last {{ series.minutes }} min)</h3>
               <select
                 v-model="windowMinutes"
                 aria-label="Token usage time window"
@@ -721,7 +721,7 @@ const detectedFrameworkLabel = computed(() => {
 
         <div class="card mb-3">
           <div class="card-body">
-            <h6>Usage by model</h6>
+            <h3 class="fs-6">Usage by model</h3>
             <div class="table-responsive">
               <table class="table table-sm mb-0">
                 <caption class="visually-hidden">
@@ -816,7 +816,7 @@ const detectedFrameworkLabel = computed(() => {
           </div>
         </div>
 
-        <h5>Recent chats</h5>
+        <h3 class="h5">Recent chats</h3>
 
         <div class="row g-2 mb-2">
           <div class="col-md-4">
@@ -1027,7 +1027,7 @@ const detectedFrameworkLabel = computed(() => {
                           </dl>
 
                           <div v-if="miniTimeline" class="mb-3">
-                            <h6>Span timeline</h6>
+                            <h4 class="fs-6">Span timeline</h4>
                             <svg
                               :viewBox="'0 0 ' + miniTimeline.width + ' ' + miniTimeline.height"
                               class="w-100"
@@ -1048,7 +1048,7 @@ const detectedFrameworkLabel = computed(() => {
                           </div>
 
                           <div v-if="detail.toolCalls && detail.toolCalls.length" class="mb-3">
-                            <h6>Tool calls</h6>
+                            <h4 class="fs-6">Tool calls</h4>
                             <ul class="list-group">
                               <li
                                 v-for="tc in detail.toolCalls"
@@ -1064,7 +1064,7 @@ const detectedFrameworkLabel = computed(() => {
                           </div>
 
                           <div v-if="detail.vectorOperations && detail.vectorOperations.length" class="mb-3">
-                            <h6>Vector operations</h6>
+                            <h4 class="fs-6">Vector operations</h4>
                             <ul class="list-group">
                               <li
                                 v-for="vo in detail.vectorOperations"
@@ -1081,7 +1081,7 @@ const detectedFrameworkLabel = computed(() => {
                           </div>
 
                           <div v-if="detail.events && detail.events.length" class="mb-3">
-                            <h6>Events</h6>
+                            <h4 class="fs-6">Events</h4>
                             <ul class="list-group">
                               <li
                                 v-for="(ev, ei) in detail.events"
@@ -1095,7 +1095,7 @@ const detectedFrameworkLabel = computed(() => {
                           </div>
 
                           <div v-if="groupedAttributes.length">
-                            <h6>Span attributes ({{ detail.attributes.length }})</h6>
+                            <h4 class="fs-6">Span attributes ({{ detail.attributes.length }})</h4>
                             <details v-for="[ns, attrs] in groupedAttributes" :key="ns" class="mb-1">
                               <summary class="text-muted small">{{ ns }} ({{ attrs.length }})</summary>
                               <table class="table table-sm mt-1">

--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -3,6 +3,7 @@ import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -41,6 +42,8 @@ const panel = useAdvisorPanel(props, {
       {{ panel.actionMessage }}
     </div>
 
+    <PanelSkeleton v-if="panel.initialLoading" />
+
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
@@ -63,7 +66,7 @@ const panel = useAdvisorPanel(props, {
       <div class="row g-3 mb-3">
         <div class="col-lg-5">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Violations by severity</div>
+            <div class="card-header"><h3>Violations by severity</h3></div>
             <div class="card-body">
               <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -96,7 +99,7 @@ const panel = useAdvisorPanel(props, {
 
         <div class="col-lg-7">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Base packages</div>
+            <div class="card-header"><h3>Base packages</h3></div>
             <div class="card-body">
               <div v-if="!panel.report.basePackages || panel.report.basePackages.length === 0" class="text-muted">
                 No application base package was detected.
@@ -114,7 +117,7 @@ const panel = useAdvisorPanel(props, {
       <div class="card">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
-            <div class="fw-semibold">Rule results</div>
+            <h3 class="fs-6 fw-semibold mb-0">Rule results</h3>
             <div class="text-muted small">
               <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
                 {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'violating rule') }},
@@ -139,8 +142,8 @@ const panel = useAdvisorPanel(props, {
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
               <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-              <span class="badge text-bg-light border">{{ result.category }}</span>
-              <span class="text-muted small">{{ result.id }}</span>
+              <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+              <span class="text-muted small font-monospace">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
@@ -191,8 +194,8 @@ const panel = useAdvisorPanel(props, {
             <div v-for="result in panel.report.analysisErrors" :key="result.id" class="list-group-item">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span class="badge text-bg-secondary">{{ result.status }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
               </div>
               <div class="small fw-semibold">{{ result.name }}</div>
               <ul v-if="result.sampleViolations && result.sampleViolations.length" class="small mb-0 mt-1">
@@ -211,8 +214,8 @@ const panel = useAdvisorPanel(props, {
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
                 <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"

--- a/bootui-ui/src/main/frontend/src/views/BeanGraph.vue
+++ b/bootui-ui/src/main/frontend/src/views/BeanGraph.vue
@@ -471,9 +471,19 @@ function centerFocusedNode() {
 }
 
 /* ── Nodes shared ───────────────────────────────────────────────────────────── */
+/* The SVG focus ring below replaces the UA outline, but only for
+   :focus-visible. Keep the native outline anywhere that selector does not
+   apply so keyboard focus is never silently removed. */
+.bg-node:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.bg-node:focus-visible {
+  outline: none;
+}
+
 .bg-node {
   cursor: pointer;
-  outline: none;
 }
 
 .bg-focus-ring {
@@ -484,12 +494,12 @@ function centerFocusedNode() {
 }
 
 .bg-focus-ring--outer {
-  stroke: #fff;
+  stroke: var(--bootui-surface-solid);
   stroke-width: 6;
 }
 
 .bg-focus-ring--inner {
-  stroke: #000;
+  stroke: var(--bootui-blue);
   stroke-width: 3;
 }
 

--- a/bootui-ui/src/main/frontend/src/views/Beans.vue
+++ b/bootui-ui/src/main/frontend/src/views/Beans.vue
@@ -3,6 +3,7 @@ import {defineAsyncComponent, onBeforeUnmount, onMounted, ref, watch} from 'vue'
 import {apiFetch} from '../api.js'
 import {isAbortError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
 import ServerListFooter from './components/ServerListFooter.vue'
 
@@ -15,6 +16,7 @@ const classification = ref('')
 
 const {
   error,
+  hasLoaded,
   items: visibleBeans,
   load,
   loadMore,
@@ -150,7 +152,9 @@ function showBeanGraph(bean) {
         </div>
       </div>
 
-      <div class="table-responsive">
+      <PanelSkeleton v-if="loading && !hasLoaded" :rows="8" />
+
+      <div v-else class="table-responsive">
         <table class="table table-sm table-hover beans-table">
           <colgroup>
             <col class="beans-table-name" />
@@ -182,16 +186,16 @@ function showBeanGraph(bean) {
                 </button>
               </td>
               <td>
-                <small :title="b.type" class="text-truncate d-block">{{ b.type }}</small>
+                <code :title="b.type" class="small text-truncate d-block">{{ b.type }}</code>
               </td>
               <td>{{ b.scope }}</td>
               <td>
                 <span class="badge bg-light text-dark">{{ b.classification }}</span>
               </td>
               <td>
-                <small :title="b.dependencies.join(', ')" class="text-muted text-truncate d-block">{{
+                <code :title="b.dependencies.join(', ')" class="small text-muted text-truncate d-block">{{
                   b.dependencies.join(', ')
-                }}</small>
+                }}</code>
               </td>
             </tr>
             <tr v-if="!loading && matchedCount === 0">
@@ -312,5 +316,10 @@ function showBeanGraph(bean) {
 
 .beans-table-dependencies {
   width: 20%;
+}
+@media (prefers-reduced-motion: reduce) {
+  .beans-view-switcher__option {
+    transition: none;
+  }
 }
 </style>

--- a/bootui-ui/src/main/frontend/src/views/BeansGraphMode.vue
+++ b/bootui-ui/src/main/frontend/src/views/BeansGraphMode.vue
@@ -381,11 +381,11 @@ async function loadConditionEvidence() {
           </dl>
 
           <div v-if="focusedBean?.resource" class="bean-details__section">
-            <h4>Recorded resource</h4>
+            <h4 class="fs-6">Recorded resource</h4>
             <code>{{ focusedBean.resource }}</code>
           </div>
           <div v-if="focusedBean?.aliases?.length" class="bean-details__section">
-            <h4>Aliases</h4>
+            <h4 class="fs-6">Aliases</h4>
             <ul class="bean-details__compact-list">
               <li v-for="alias in focusedBean.aliases" :key="alias">
                 <code>{{ alias }}</code>
@@ -395,7 +395,7 @@ async function loadConditionEvidence() {
 
           <div class="bean-details__section">
             <div class="bean-details__section-heading">
-              <h4>Why this bean exists</h4>
+              <h4 class="fs-6">Why this bean exists</h4>
               <span v-if="conditionLoading" class="text-muted small" role="status">Loading…</span>
             </div>
             <div v-if="conditionError" class="alert alert-warning py-2 small mb-2" role="alert">

--- a/bootui-ui/src/main/frontend/src/views/Conditions.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.test.js
@@ -79,7 +79,7 @@ describe('Conditions', () => {
     const wrapper = mount(Conditions)
     await flushPromises()
 
-    await wrapper.findAll('a.nav-link')[1].trigger('click')
+    await wrapper.findAll('button.nav-link')[1].trigger('click')
     await flushPromises() // flush Vue watcher so the debounce timer is set
     await vi.advanceTimersByTimeAsync(250)
     await flushPromises()
@@ -109,7 +109,7 @@ describe('Conditions', () => {
     expect(capturedSignal?.aborted).toBe(false)
 
     // Changing the tab calls scheduleReload via a Vue watcher.
-    await wrapper.findAll('a.nav-link')[1].trigger('click')
+    await wrapper.findAll('button.nav-link')[1].trigger('click')
     await flushPromises() // flush Vue watcher so scheduleReload() runs
     expect(capturedSignal?.aborted).toBe(true)
 
@@ -132,7 +132,7 @@ describe('Conditions', () => {
     await flushPromises()
     expect(wrapper.findComponent({name: 'ServerListFooter'}).exists()).toBe(true)
 
-    await wrapper.findAll('a.nav-link')[1].trigger('click')
+    await wrapper.findAll('button.nav-link')[1].trigger('click')
     await flushPromises()
 
     expect(wrapper.findComponent({name: 'ServerListFooter'}).exists()).toBe(false)
@@ -155,7 +155,7 @@ describe('Conditions', () => {
     vi.stubGlobal('fetch', staleFetch)
     const wrapper = mount(Conditions)
 
-    await wrapper.findAll('a.nav-link')[1].trigger('click')
+    await wrapper.findAll('button.nav-link')[1].trigger('click')
     await flushPromises()
     vi.stubGlobal(
       'fetch',
@@ -229,7 +229,7 @@ describe('Conditions', () => {
     vi.stubGlobal('fetch', fetchMock)
     const wrapper = mount(Conditions)
 
-    await wrapper.findAll('a.nav-link')[1].trigger('click')
+    await wrapper.findAll('button.nav-link')[1].trigger('click')
     await flushPromises()
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(null, false, 500)))
     await vi.advanceTimersByTimeAsync(250)
@@ -264,7 +264,7 @@ describe('Conditions', () => {
     expect(appendSignal?.aborted).toBe(false)
 
     // A tab change causes scheduleReload which aborts the append.
-    await wrapper.findAll('a.nav-link')[1].trigger('click')
+    await wrapper.findAll('button.nav-link')[1].trigger('click')
     await flushPromises() // flush Vue watcher so scheduleReload() runs
     expect(appendSignal?.aborted).toBe(true)
 
@@ -294,5 +294,89 @@ describe('Conditions', () => {
     wrapper.unmount()
 
     expect(appendSignal?.aborted).toBe(true)
+  })
+
+  it('shows a skeleton on first paint instead of an empty list', async () => {
+    let resolveFetch
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise((resolve) => (resolveFetch = resolve)))
+    )
+
+    const wrapper = mount(Conditions)
+    await flushPromises()
+
+    expect(wrapper.find('.skeleton-wrapper').exists()).toBe(true)
+    expect(wrapper.text()).not.toContain('entries matched')
+
+    resolveFetch(jsonResponse(conditionsResponse()))
+    await flushPromises()
+
+    expect(wrapper.find('.skeleton-wrapper').exists()).toBe(false)
+    expect(wrapper.text()).toContain('1 of 1 positive entries matched')
+  })
+
+  it('separates "nothing was reported" from "nothing matched the filter"', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse(
+          conditionsResponse({
+            positiveMatches: [],
+            counts: {positiveMatched: 0, positiveTotal: 0, negativeMatched: 1, negativeTotal: 1}
+          })
+        )
+      )
+    )
+
+    const wrapper = mount(Conditions)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No positive condition entries were reported.')
+    expect(wrapper.text()).not.toContain('match your filter')
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        jsonResponse(
+          conditionsResponse({
+            positiveMatches: [],
+            counts: {positiveMatched: 0, positiveTotal: 12, negativeMatched: 1, negativeTotal: 1}
+          })
+        )
+      )
+    )
+    await wrapper.find('input').setValue('nothing-matches-this')
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No positive entries match your filter.')
+    expect(wrapper.text()).not.toContain('were reported')
+  })
+
+  it('exposes the outcome tabs as buttons so Space activates them', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(conditionsResponse())))
+
+    const wrapper = mount(Conditions)
+    await flushPromises()
+
+    const tabs = wrapper.findAll('button.nav-link')
+
+    expect(tabs).toHaveLength(2)
+    expect(wrapper.findAll('a.nav-link')).toHaveLength(0)
+    expect(tabs[0].attributes('role')).toBe('tab')
+    expect(tabs[0].attributes('aria-selected')).toBe('true')
+    expect(tabs[1].attributes('aria-selected')).toBe('false')
+  })
+
+  it('renders auto-configuration classes and conditions in the monospace stack', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(conditionsResponse())))
+
+    const wrapper = mount(Conditions)
+    await flushPromises()
+
+    expect(wrapper.find('code').text()).toContain('WebMvcAutoConfiguration')
+    expect(wrapper.find('.font-monospace').text()).toBe('OnClassCondition')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/Conditions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Conditions.vue
@@ -3,6 +3,7 @@ import {getJson} from '../api.js'
 import {computed, onBeforeUnmount, onMounted, ref, watch} from 'vue'
 import {describeLoadError, isAbortError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import {SERVER_PAGE_SIZE} from '../utils/useServerPagedList.js'
 import ServerListFooter from './components/ServerListFooter.vue'
 
@@ -11,6 +12,7 @@ const tab = ref('positive')
 const filter = ref('')
 const loading = ref(false)
 const loadingMore = ref(false)
+const hasLoaded = ref(false)
 const error = ref(null)
 
 let baseAc = null
@@ -107,6 +109,7 @@ async function load(loadOpts = {}) {
       if (baseAc === ac) {
         baseAc = null
         loading.value = false
+        hasLoaded.value = true
       }
     }
   }
@@ -157,32 +160,64 @@ onBeforeUnmount(() => {
 
 <template>
   <div>
-    <PanelHeader icon="bi-check2-circle" title="Auto-configuration conditions" :error="error" />
-    <ul class="nav nav-tabs mb-3">
-      <li class="nav-item">
-        <a :class="{active: tab === 'positive'}" class="nav-link" href="#" @click.prevent="tab = 'positive'">
+    <PanelHeader
+      icon="bi-check2-circle"
+      title="Auto-configuration conditions"
+      :error="error"
+      :loading="loading"
+      @refresh="load"
+    />
+    <ul class="nav nav-tabs mb-3" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button
+          :aria-selected="tab === 'positive'"
+          :class="{active: tab === 'positive'}"
+          class="nav-link"
+          role="tab"
+          type="button"
+          @click="tab = 'positive'"
+        >
           Positive ({{ counts.positiveMatched || 0 }})
-        </a>
+        </button>
       </li>
-      <li class="nav-item">
-        <a :class="{active: tab === 'negative'}" class="nav-link" href="#" @click.prevent="tab = 'negative'">
+      <li class="nav-item" role="presentation">
+        <button
+          :aria-selected="tab === 'negative'"
+          :class="{active: tab === 'negative'}"
+          class="nav-link"
+          role="tab"
+          type="button"
+          @click="tab = 'negative'"
+        >
           Negative ({{ counts.negativeMatched || 0 }})
-        </a>
+        </button>
       </li>
     </ul>
     <input v-model="filter" aria-label="Filter conditions" class="form-control mb-3" placeholder="Filter…" />
-    <p class="small text-muted">{{ matchedCount }} of {{ totalCount }} {{ tab }} entries matched</p>
-    <div v-for="e in entries" :key="e.autoConfigurationClass + e.condition + e.message" class="mb-2">
-      <div class="d-flex">
-        <span :class="tab === 'positive' ? 'bg-success' : 'bg-secondary'" class="badge me-2">{{ e.outcome }}</span>
-        <div>
-          <strong>{{ e.autoConfigurationClass }}</strong>
-          <div class="small text-muted">{{ e.condition }}</div>
-          <div class="small">{{ e.message }}</div>
+    <PanelSkeleton v-if="loading && !hasLoaded" :rows="6" />
+    <template v-else>
+      <p class="small text-muted">{{ matchedCount }} of {{ totalCount }} {{ tab }} entries matched</p>
+      <div v-for="e in entries" :key="e.autoConfigurationClass + e.condition + e.message" class="mb-2">
+        <div class="d-flex gap-2">
+          <span
+            :class="tab === 'positive' ? 'bg-success' : 'bg-secondary'"
+            class="badge align-self-start flex-shrink-0"
+            >{{ e.outcome }}</span
+          >
+          <div class="min-w-0">
+            <code class="fw-semibold bootui-break-anywhere">{{ e.autoConfigurationClass }}</code>
+            <div class="small text-muted font-monospace bootui-break-anywhere">{{ e.condition }}</div>
+            <div class="small bootui-break-anywhere">{{ e.message }}</div>
+          </div>
         </div>
       </div>
-    </div>
-    <div v-if="!loading && matchedCount === 0" class="text-muted py-3">No {{ tab }} entries match your filter.</div>
+      <div v-if="matchedCount === 0 && totalCount === 0" class="text-muted py-3">
+        No {{ tab }} condition entries were reported.
+      </div>
+      <div v-else-if="!loading && matchedCount === 0" class="text-muted py-3">
+        No {{ tab }} entries match your filter.
+      </div>
+    </template>
     <ServerListFooter
       v-if="!loading"
       :loading="loadingMore"
@@ -195,3 +230,9 @@ onBeforeUnmount(() => {
     />
   </div>
 </template>
+
+<style scoped>
+.min-w-0 {
+  min-width: 0;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -9,6 +9,7 @@ import {useFlashMessage} from '../utils/useFlashMessage.js'
 import FlashBanner from './components/FlashBanner.vue'
 import ServerListFooter from './components/ServerListFooter.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 
 const MAX_PROPERTY_SUGGESTIONS = 200
 const props = defineProps(panelProps)
@@ -41,6 +42,7 @@ const {message: banner, flash, clear} = useFlashMessage(8000)
 const {
   data,
   error,
+  hasLoaded,
   items: visibleProperties,
   load,
   loadMore,
@@ -375,7 +377,9 @@ watch([filter, sourceFilter, showOnlyOverrides], scheduleReload)
       <span v-if="!data?.activeProfiles?.length">(none)</span>
     </p>
 
-    <div class="table-responsive">
+    <PanelSkeleton v-if="loading && !hasLoaded" :rows="8" />
+
+    <div v-else class="table-responsive">
       <table class="table table-sm align-middle">
         <thead class="table-light">
           <tr>
@@ -576,7 +580,9 @@ code.text-body {
   word-break: break-all;
 }
 
+/* The edited row keeps a cool amber tint from the shared token: a warm cream
+   surface is forbidden and would not survive the dark theme. */
 .table-active input {
-  background: #fffbe6;
+  background: var(--bootui-highlight-bg);
 }
 </style>

--- a/bootui-ui/src/main/frontend/src/views/Copilot.vue
+++ b/bootui-ui/src/main/frontend/src/views/Copilot.vue
@@ -562,7 +562,7 @@ watch(
     <PanelSkeleton v-if="initialLoading" />
     <div v-else-if="!available" class="card border-info">
       <div class="card-body">
-        <h5 class="card-title"><i class="bi bi-info-circle me-2"></i>{{ panelConfig.emptyTitle }}</h5>
+        <h3 class="h5 card-title"><i class="bi bi-info-circle me-2"></i>{{ panelConfig.emptyTitle }}</h3>
         <p class="card-text mb-1">
           BootUI looked for sessions under <code>{{ sessionStateDir }}</code
           >.
@@ -579,11 +579,10 @@ watch(
         Use <em>Reveal raw</em> on an event to inspect the source JSON locally.
       </div>
 
-      <section class="card border-0 shadow-sm mb-3">
-        <div class="card-body">
+      <section class="mb-3">
+        <div class="dashboard-band">
           <div class="d-flex flex-wrap justify-content-between gap-3 mb-3">
             <div>
-              <div class="text-uppercase small text-muted fw-semibold">Dashboard</div>
               <h3 class="mb-1">{{ panelConfig.title }} activity overview</h3>
               <div v-if="panelConfig.inspiration" class="small text-muted mt-1">
                 Inspired by
@@ -631,7 +630,7 @@ watch(
               <div class="card h-100">
                 <div class="card-body">
                   <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
-                    <h5 class="card-title mb-0">Activity, last 24 hours</h5>
+                    <h3 class="h5 card-title mb-0">Activity, last 24 hours</h3>
                     <div class="d-flex align-items-center gap-3">
                       <div class="btn-group btn-group-sm" role="group" aria-label="Activity chart mode">
                         <input
@@ -705,7 +704,7 @@ watch(
 
                   <div class="border-top mt-4 pt-3">
                     <div class="d-flex justify-content-between align-items-center mb-3">
-                      <h5 class="card-title mb-0">Activity, last 7 days</h5>
+                      <h3 class="h5 card-title mb-0">Activity, last 7 days</h3>
                       <span class="small text-muted"
                         >{{ formatNumber(dashboard?.activeLast7Days ?? 0) }} active sessions</span
                       >
@@ -768,7 +767,7 @@ watch(
             <div class="col-xl-4">
               <div class="card h-100">
                 <div class="card-body">
-                  <h5 class="card-title">Event mix</h5>
+                  <h3 class="h5 card-title">Event mix</h3>
                   <div v-if="categoryRows.length === 0" class="text-muted small">No categories recorded yet.</div>
                   <div v-for="row in categoryRows" v-else :key="row.label" class="mb-3">
                     <div class="d-flex justify-content-between small mb-1">
@@ -791,7 +790,7 @@ watch(
             <div class="col-lg-5">
               <div class="card h-100">
                 <div class="card-body">
-                  <h5 class="card-title">Top tools</h5>
+                  <h3 class="h5 card-title">Top tools</h3>
                   <div v-if="topToolRows.length === 0" class="text-muted small">No tool calls recorded yet.</div>
                   <div
                     v-for="tool in topToolRows"
@@ -820,7 +819,7 @@ watch(
             <div class="col-lg-3">
               <div class="card h-100">
                 <div class="card-body">
-                  <h5 class="card-title">Models</h5>
+                  <h3 class="h5 card-title">Models</h3>
                   <div v-if="modelRows.length === 0" class="text-muted small">No model metadata recorded.</div>
                   <div v-for="model in modelRows" v-else :key="model.label" class="mb-2">
                     <div class="d-flex justify-content-between small mb-1">
@@ -843,7 +842,7 @@ watch(
             <div class="col-lg-4">
               <div class="card h-100">
                 <div class="card-body">
-                  <h5 class="card-title">Recent sessions</h5>
+                  <h3 class="h5 card-title">Recent sessions</h3>
                   <div v-if="(dashboard?.recentSessions ?? []).length === 0" class="text-muted small">
                     No recent sessions.
                   </div>
@@ -878,7 +877,7 @@ watch(
       <section class="card shadow-sm">
         <div class="card-header bg-body d-flex flex-wrap align-items-center justify-content-between gap-2">
           <div>
-            <h4 class="mb-0">Session explorer</h4>
+            <h3 class="h4 mb-0">Session explorer</h3>
             <div class="small text-muted d-flex flex-wrap gap-2">
               <span>Drill into sanitized events and reveal one raw event at a time when needed.</span>
               <span v-if="explorerMaxSessions">Limit: {{ formatNumber(explorerMaxSessions) }} sessions</span>
@@ -977,9 +976,9 @@ watch(
               <div v-else-if="detailLoading" class="text-muted">Loading session…</div>
               <div v-else-if="!detail" class="alert alert-warning">Session not found.</div>
               <template v-else>
-                <div class="card mb-3">
-                  <div class="card-body">
-                    <h5 class="card-title mb-2">
+                <div class="session-summary mb-3">
+                  <div class="session-summary__body">
+                    <h4 class="h5 mb-2">
                       <code>{{ detail.summary.id }}</code>
                       <span v-if="detail.summary.model" class="badge text-bg-primary ms-2">{{
                         detail.summary.model
@@ -987,7 +986,7 @@ watch(
                       <span v-if="detail.summary.status" class="badge text-bg-info ms-2">{{
                         detail.summary.status
                       }}</span>
-                    </h5>
+                    </h4>
                     <div class="small text-muted mb-2">
                       <span v-if="detail.summary.workingDirectory"
                         ><i class="bi bi-folder me-1"></i>{{ detail.summary.workingDirectory }}</span
@@ -1232,6 +1231,22 @@ watch(
 </template>
 
 <style scoped>
+/* Dashboard band and session summary group content without stacking a second
+   card inside a card. */
+.dashboard-band {
+  padding: 0 0 0.25rem;
+}
+
+.session-summary {
+  background: var(--bootui-surface);
+  border: 1px solid var(--bootui-border);
+  border-radius: var(--bootui-radius-lg);
+}
+
+.session-summary__body {
+  padding: 1.25rem;
+}
+
 .metric-card {
   border-color: var(--bs-border-color-translucent);
 }

--- a/bootui-ui/src/main/frontend/src/views/Crac.vue
+++ b/bootui-ui/src/main/frontend/src/views/Crac.vue
@@ -8,6 +8,7 @@ import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/sca
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useConfirm} from '../utils/useConfirm.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -17,6 +18,7 @@ const report = ref(null)
 const error = ref(null)
 const actionMessage = ref(null)
 const loading = ref(false)
+const initialLoading = ref(true)
 const installingDockerfile = ref(false)
 const dockerInstallResult = ref(null)
 const installingEntrypoint = ref(false)
@@ -173,6 +175,8 @@ async function loadReport() {
     error.value = null
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load CRaC readiness report')
+  } finally {
+    initialLoading.value = false
   }
 }
 
@@ -327,6 +331,8 @@ onMounted(loadReport)
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning" role="status" aria-live="polite">{{ actionMessage }}</div>
 
+    <PanelSkeleton v-if="initialLoading" />
+
     <template v-if="report">
       <div v-if="runtime" class="card mb-3">
         <div class="card-header d-flex justify-content-between align-items-center">
@@ -391,7 +397,9 @@ onMounted(loadReport)
       </div>
 
       <div v-if="hasGeneratedFiles" class="card mb-3">
-        <div class="card-header fw-semibold"><i class="bi bi-box-seam me-1"></i>Container assets</div>
+        <div class="card-header">
+          <h3><i class="bi bi-box-seam me-1"></i>Container assets</h3>
+        </div>
         <div class="card-body">
           <p class="small text-muted mb-3">
             Generate a CRaC-enabled container for this application: a multi-stage
@@ -625,7 +633,7 @@ onMounted(loadReport)
       </div>
 
       <div class="card mb-3">
-        <div class="card-header fw-semibold">Concerns by severity</div>
+        <div class="card-header"><h3>Concerns by severity</h3></div>
         <div class="card-body">
           <div v-if="!hasScanData" class="text-center text-muted py-4">
             <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -733,7 +741,7 @@ onMounted(loadReport)
               <span class="badge text-bg-warning">{{ finding.status }}</span>
               <span :class="severityClass(finding.severity)" class="badge">{{ finding.severity }}</span>
               <span class="badge text-bg-light border">{{ finding.category }}</span>
-              <span class="text-muted small">{{ finding.id }}</span>
+              <span class="text-muted small font-monospace">{{ finding.id }}</span>
             </div>
             <h3 class="h6 mb-1">{{ finding.name }}</h3>
             <div class="small text-muted mb-2">{{ finding.description }}</div>

--- a/bootui-ui/src/main/frontend/src/views/Data.vue
+++ b/bootui-ui/src/main/frontend/src/views/Data.vue
@@ -3,6 +3,7 @@ import {apiFetch} from '../api.js'
 import {computed, onMounted, ref} from 'vue'
 import {describeLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import UnavailableState from './components/UnavailableState.vue'
 
 const report = ref(null)
@@ -12,6 +13,7 @@ const filter = ref('')
 const storeFilter = ref('')
 const error = ref(null)
 const springDataPresent = ref(true)
+const initialLoading = ref(true)
 
 async function load() {
   try {
@@ -24,6 +26,8 @@ async function load() {
     report.value = await res.json()
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load Spring Data repositories')
+  } finally {
+    initialLoading.value = false
   }
 }
 
@@ -95,7 +99,9 @@ onMounted(load)
   <div>
     <PanelHeader icon="bi-database" title="Spring Data repositories" :error="error" />
 
-    <UnavailableState v-if="!springDataPresent" variant="info">
+    <PanelSkeleton v-if="initialLoading" />
+
+    <UnavailableState v-else-if="!springDataPresent" variant="info">
       Spring Data is not on the classpath of this application. Add a Spring Data starter (e.g.
       <code>spring-boot-starter-data-jpa</code>) to see repositories here.
     </UnavailableState>
@@ -162,7 +168,7 @@ onMounted(load)
           <div v-if="!detail" class="text-muted small">Select a repository to see its methods.</div>
           <div v-else class="card">
             <div class="card-body">
-              <h5 class="card-title mb-1">{{ shortName(detail.repositoryInterface) }}</h5>
+              <h3 class="h5 card-title mb-1">{{ shortName(detail.repositoryInterface) }}</h3>
               <div class="text-muted small mb-3">
                 <code class="bootui-break-anywhere">{{ detail.repositoryInterface }}</code>
               </div>
@@ -191,9 +197,9 @@ onMounted(load)
                 </template>
               </dl>
 
-              <h6 class="mb-2">
+              <h4 class="fs-6 mb-2">
                 Methods <span class="badge bg-secondary">{{ detail.methods.length }}</span>
-              </h6>
+              </h4>
               <div class="table-responsive bootui-table-scroll">
                 <table class="table table-sm table-hover bootui-data-table data-methods-table">
                   <thead>

--- a/bootui-ui/src/main/frontend/src/views/DatabaseAdvisor.vue
+++ b/bootui-ui/src/main/frontend/src/views/DatabaseAdvisor.vue
@@ -4,6 +4,7 @@ import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -101,6 +102,8 @@ function diagnosticClass(level) {
       {{ panel.actionMessage }}
     </div>
 
+    <PanelSkeleton v-if="panel.initialLoading" />
+
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
@@ -134,7 +137,7 @@ function diagnosticClass(level) {
       <div class="row g-3 mb-3">
         <div class="col-lg-5">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Findings by severity</div>
+            <div class="card-header"><h3>Findings by severity</h3></div>
             <div class="card-body">
               <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -167,7 +170,7 @@ function diagnosticClass(level) {
 
         <div class="col-lg-7">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Datasources</div>
+            <div class="card-header"><h3>Datasources</h3></div>
             <div class="card-body">
               <div v-if="dataSources.length === 0" class="text-muted">No DataSource bean was detected.</div>
               <ul v-else class="list-unstyled mb-0">
@@ -220,7 +223,7 @@ function diagnosticClass(level) {
       <div class="card">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
-            <div class="fw-semibold">Rule results</div>
+            <h3 class="fs-6 fw-semibold mb-0">Rule results</h3>
             <div class="text-muted small">
               <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
                 {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'violating rule') }},
@@ -245,8 +248,8 @@ function diagnosticClass(level) {
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
               <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-              <span class="badge text-bg-light border">{{ result.category }}</span>
-              <span class="text-muted small">{{ result.id }}</span>
+              <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+              <span class="text-muted small font-monospace">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
@@ -298,8 +301,8 @@ function diagnosticClass(level) {
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
                 <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"

--- a/bootui-ui/src/main/frontend/src/views/DatabaseConnectionPools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DatabaseConnectionPools.vue
@@ -18,10 +18,11 @@ const history = ref([])
 const lastUpdated = ref(null)
 
 const SERIES = [
-  {key: 'active', label: 'Active', color: '#dc3545'},
-  {key: 'idle', label: 'Idle', color: '#198754'},
-  {key: 'total', label: 'Total', color: '#0d6efd'},
-  {key: 'pending', label: 'Pending', color: '#fd7e14'}
+  // Categorical chart series read from the theme tokens so both shells stay legible.
+  {key: 'active', label: 'Active', color: 'var(--bootui-danger)'},
+  {key: 'idle', label: 'Idle', color: 'var(--bootui-chart-calls)'},
+  {key: 'total', label: 'Total', color: 'var(--bootui-chart-input)'},
+  {key: 'pending', label: 'Pending', color: 'var(--bootui-chart-vector)'}
 ]
 
 const pools = computed(() => report.value?.pools ?? [])
@@ -179,7 +180,7 @@ watch(
       <div class="card-body d-flex align-items-start gap-3">
         <span class="text-warning fs-3"><i class="bi bi-info-circle"></i></span>
         <div>
-          <h5 class="mb-1">Database connection pool metrics are unavailable</h5>
+          <h3 class="h5 mb-1">Database connection pool metrics are unavailable</h3>
           <p class="text-muted mb-2">
             BootUI can inspect active, idle, total, and pending connection counts when the application exposes a
             supported JDBC connection pool bean. This application does not currently provide one.
@@ -201,7 +202,7 @@ watch(
       <div v-else class="row g-3">
         <div class="col-lg-4">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Pools</div>
+            <div class="card-header"><h3>Pools</h3></div>
             <div class="list-group list-group-flush pool-list">
               <button
                 v-for="pool in pools"
@@ -345,8 +346,8 @@ watch(
 }
 
 .chart-box {
-  background: linear-gradient(180deg, rgba(13, 110, 253, 0.08), rgba(25, 135, 84, 0.06));
-  border: 1px solid rgba(13, 110, 253, 0.12);
+  background: var(--bootui-surface-alt);
+  border: 1px solid var(--bootui-border);
   border-radius: var(--bootui-radius-lg);
   min-height: 12rem;
   padding: 1rem;

--- a/bootui-ui/src/main/frontend/src/views/DevServices.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevServices.vue
@@ -360,7 +360,7 @@ async function responseMessage(res) {
                 </dd>
               </dl>
 
-              <h6>Connection details</h6>
+              <h4 class="fs-6">Connection details</h4>
               <div v-if="detailEntries(selected).length === 0" class="text-muted small">
                 No connection detail values exposed.
               </div>
@@ -379,7 +379,7 @@ async function responseMessage(res) {
 
               <template v-if="logs">
                 <div class="d-flex justify-content-between align-items-center mt-3">
-                  <h6 class="mb-0">Logs</h6>
+                  <h4 class="fs-6 mb-0">Logs</h4>
                   <span v-if="logs.truncated" class="badge text-bg-warning">Tail {{ logs.maxBytes }} bytes</span>
                 </div>
                 <pre class="logs rounded border p-2 mt-2 mb-0"><code>{{
@@ -400,9 +400,10 @@ async function responseMessage(res) {
 </template>
 
 <style scoped>
+/* Container logs are terminal output and keep their own dark identity. */
 .logs {
-  background: #111827;
-  color: #f8f9fa;
+  background: var(--bootui-code-pane-bg);
+  color: var(--bootui-code-pane-text);
   max-height: 360px;
   overflow: auto;
   white-space: pre-wrap;
@@ -415,7 +416,7 @@ td code {
 }
 
 .selected-row > td {
-  --bs-table-bg: rgba(13, 110, 253, 0.08);
+  --bs-table-bg: var(--bootui-nav-hover-bg);
 }
 
 @media (max-width: 991.98px) {
@@ -441,10 +442,10 @@ td code {
   }
 
   tr {
-    background: #fff;
-    border: 1px solid rgba(15, 23, 42, 0.08);
+    background: var(--bootui-surface);
+    border: 1px solid var(--bootui-border);
     border-radius: var(--bootui-radius-lg);
-    box-shadow: 0 0.75rem 1.75rem rgba(15, 23, 42, 0.06);
+    box-shadow: var(--bootui-shadow-sm);
     padding: 0.75rem;
   }
 
@@ -453,14 +454,15 @@ td code {
     padding: 0.35rem 0;
   }
 
+  /* Stacked-card column label. Sentence case: the uppercase tracked treatment is
+     reserved for sidebar nav groups. */
   td::before {
-    color: var(--bootui-secondary);
+    color: var(--bootui-text-muted);
     content: attr(data-label);
     display: block;
-    font-size: 0.75rem;
-    font-weight: 600;
+    font-size: 0.85rem;
+    font-weight: 500;
     margin-bottom: 0.15rem;
-    text-transform: uppercase;
   }
 
   td.text-end {

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -8,6 +8,7 @@ import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import {useFlashMessage} from '../utils/useFlashMessage.js'
 import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 import UnavailableState from './components/UnavailableState.vue'
@@ -163,9 +164,7 @@ onUnmounted(clearReconnectTimer)
       </div>
     </div>
 
-    <div v-if="loading && !status" class="card">
-      <div class="card-body text-muted">Loading DevTools status…</div>
-    </div>
+    <PanelSkeleton v-if="loading && !status" />
 
     <div v-else-if="status" class="row g-4">
       <div class="col-lg-6">

--- a/bootui-ui/src/main/frontend/src/views/Email.vue
+++ b/bootui-ui/src/main/frontend/src/views/Email.vue
@@ -322,7 +322,7 @@ function downloadUrl(id) {
 }
 
 .email-drawer {
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--bootui-border);
 }
 
 .email-html-frame {

--- a/bootui-ui/src/main/frontend/src/views/Exceptions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Exceptions.vue
@@ -378,12 +378,12 @@ onMounted(() => {
                           <div v-if="detailLoading" class="text-muted small">Loading detail…</div>
                           <template v-else-if="detail">
                             <div v-if="detail.group && detail.group.message" class="mb-3">
-                              <div class="text-muted small text-uppercase">Message</div>
+                              <h4 class="fs-6 text-muted fw-semibold mb-0">Message</h4>
                               <div class="exception-message-full">{{ detail.group.message }}</div>
                             </div>
 
                             <div class="mb-3">
-                              <div class="text-muted small text-uppercase mb-1">Stack trace</div>
+                              <h4 class="fs-6 text-muted fw-semibold mb-1">Stack trace</h4>
                               <pre class="stack-pane rounded border p-2 mb-0"><code><span
                                 v-for="(f, i) in detail.frames"
                                 :key="i"
@@ -405,9 +405,9 @@ onMounted(() => {
                             </div>
 
                             <div v-if="detail.occurrences && detail.occurrences.length">
-                              <div class="text-muted small text-uppercase mb-1">
+                              <h4 class="fs-6 text-muted fw-semibold mb-1">
                                 Recent occurrences ({{ detail.occurrences.length }})
-                              </div>
+                              </h4>
                               <div class="table-responsive">
                                 <table class="table table-sm align-middle mb-0">
                                   <thead>
@@ -453,7 +453,7 @@ onMounted(() => {
 
 <style scoped>
 .exception-drawer {
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--bootui-border);
 }
 
 .exception-message {
@@ -465,9 +465,11 @@ onMounted(() => {
   word-break: break-word;
 }
 
+/* Terminal output keeps its own dark identity in both themes; the shared tokens
+   let the surrounding chrome stay theme-aware without re-declaring the palette. */
 .stack-pane {
-  background: #111827;
-  color: #e2e8f0;
+  background: var(--bootui-code-pane-bg);
+  color: var(--bootui-code-pane-text);
   font-family: var(--bs-font-monospace);
   font-size: 0.8rem;
   max-height: 22rem;

--- a/bootui-ui/src/main/frontend/src/views/Flyway.vue
+++ b/bootui-ui/src/main/frontend/src/views/Flyway.vue
@@ -9,6 +9,7 @@ import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import UnavailableState from './components/UnavailableState.vue'
 
 const props = defineProps(panelProps)
@@ -17,6 +18,7 @@ const {confirm} = useConfirm()
 const report = ref(null)
 const error = ref(null)
 const flywayPresent = ref(true)
+const initialLoading = ref(true)
 const filter = ref('')
 const {message: banner, flash, clear} = useFlashMessage()
 const busy = ref(null)
@@ -32,6 +34,8 @@ async function load() {
     report.value = await res.json()
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load Flyway migrations')
+  } finally {
+    initialLoading.value = false
   }
 }
 
@@ -121,7 +125,9 @@ onMounted(load)
 
     <FlashBanner :message="banner" @dismiss="clear" />
 
-    <UnavailableState v-if="!flywayPresent" variant="info">
+    <PanelSkeleton v-if="initialLoading" />
+
+    <UnavailableState v-else-if="!flywayPresent" variant="info">
       Flyway is not on the classpath of this application. Add the <code>flyway-core</code> dependency to see schema
       migrations here.
     </UnavailableState>
@@ -149,9 +155,9 @@ onMounted(load)
 
       <div v-for="db in databases" :key="db.name" class="card mb-3">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
-          <span>
+          <h3 class="fs-6 fw-semibold mb-0">
             <i class="bi bi-database me-1"></i><code class="bootui-break-anywhere">{{ db.name }}</code>
-          </span>
+          </h3>
           <span class="small d-flex flex-wrap align-items-center gap-1">
             <span class="me-2"
               >Current: <strong>{{ db.currentVersion || '—' }}</strong></span

--- a/bootui-ui/src/main/frontend/src/views/GitHub.vue
+++ b/bootui-ui/src/main/frontend/src/views/GitHub.vue
@@ -467,7 +467,7 @@ function securitySignalUrl(signal) {
             <div class="card-body">
               <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
                 <div>
-                  <div class="text-muted small text-uppercase fw-semibold">Repository</div>
+                  <h3 class="fs-6 text-muted fw-semibold mb-0">Repository</h3>
                   <h3 class="h4 mb-1">
                     <a
                       v-if="repository?.htmlUrl"
@@ -512,7 +512,7 @@ function securitySignalUrl(signal) {
         <div class="col-lg-4">
           <div class="card h-100">
             <div class="card-body">
-              <div class="text-muted small text-uppercase fw-semibold">Credential</div>
+              <h3 class="fs-6 text-muted fw-semibold mb-0">Credential</h3>
               <div class="fw-semibold mt-1">
                 {{ credential?.authenticated ? 'Authenticated' : 'Unauthenticated' }}
               </div>
@@ -997,5 +997,15 @@ function securitySignalUrl(signal) {
 .workflow-event-badge--default {
   background: var(--bs-tertiary-bg);
   color: var(--bs-secondary-color);
+}
+@media (prefers-reduced-motion: reduce) {
+  .metric-card {
+    transition: none;
+  }
+
+  .metric-card:hover,
+  .metric-card:focus-visible {
+    transform: none;
+  }
 }
 </style>

--- a/bootui-ui/src/main/frontend/src/views/GraalVm.vue
+++ b/bootui-ui/src/main/frontend/src/views/GraalVm.vue
@@ -8,6 +8,7 @@ import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/sca
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useConfirm} from '../utils/useConfirm.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 
@@ -18,6 +19,7 @@ const report = ref(null)
 const error = ref(null)
 const actionMessage = ref(null)
 const loading = ref(false)
+const initialLoading = ref(true)
 const installing = ref(false)
 const installResult = ref(null)
 const installingDockerfile = ref(false)
@@ -194,6 +196,8 @@ async function loadReport() {
     error.value = null
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load GraalVM readiness report')
+  } finally {
+    initialLoading.value = false
   }
 }
 
@@ -433,6 +437,8 @@ onBeforeUnmount(stopProgressPolling)
       </div>
     </div>
 
+    <PanelSkeleton v-if="initialLoading" />
+
     <template v-if="report">
       <div class="alert alert-info">
         <strong>Heuristic readiness checks.</strong>
@@ -461,7 +467,7 @@ onBeforeUnmount(stopProgressPolling)
       <div class="row g-3 mb-3">
         <div class="col-lg-5">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Concerns by severity</div>
+            <div class="card-header"><h3>Concerns by severity</h3></div>
             <div class="card-body">
               <div v-if="!hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -814,7 +820,7 @@ onBeforeUnmount(stopProgressPolling)
               <span class="badge text-bg-warning">{{ finding.status }}</span>
               <span :class="severityClass(finding.severity)" class="badge">{{ finding.severity }}</span>
               <span class="badge text-bg-light border">{{ finding.category }}</span>
-              <span class="text-muted small">{{ finding.id }}</span>
+              <span class="text-muted small font-monospace">{{ finding.id }}</span>
             </div>
             <h3 class="h6 mb-1">{{ finding.name }}</h3>
             <div class="small text-muted mb-2">{{ finding.description }}</div>

--- a/bootui-ui/src/main/frontend/src/views/Health.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Health.test.js
@@ -207,7 +207,7 @@ describe('Health', () => {
     expect(wrapper.text()).toContain('livenessState')
     expect(wrapper.text()).toContain('ping')
     expect(wrapper.text()).toContain('readinessState')
-    expect(wrapper.findAll('h6').filter((heading) => heading.text() === 'Details')).toHaveLength(0)
+    expect(wrapper.findAll('.health-node__section-label').filter((label) => label.text() === 'Details')).toHaveLength(0)
     expect(wrapper.text()).not.toContain('0 details')
   })
 

--- a/bootui-ui/src/main/frontend/src/views/Health.vue
+++ b/bootui-ui/src/main/frontend/src/views/Health.vue
@@ -97,7 +97,7 @@ const statusMessage = computed(() => {
         <div class="card-body">
           <div class="health-summary__row">
             <div class="health-summary__status">
-              <div class="health-summary__eyebrow">Overall status</div>
+              <div class="health-summary__status-label">Overall status</div>
               <span
                 :class="{
                   'bg-success': root.status === 'UP',
@@ -137,10 +137,10 @@ const statusMessage = computed(() => {
 
       <div v-if="healthGuidance" class="card border-info mb-3">
         <div class="card-body">
-          <h5 class="card-title d-flex align-items-center gap-2">
+          <h3 class="h5 card-title d-flex align-items-center gap-2">
             <i class="bi bi-info-circle text-info"></i>
             {{ setupTitle }}
-          </h5>
+          </h3>
           <p class="text-muted mb-3">
             {{ setupIntro }}
           </p>
@@ -157,7 +157,7 @@ const statusMessage = computed(() => {
       </div>
 
       <template v-if="!healthUnavailable || hasHealthComponents">
-        <h5 class="mb-2">Component tree</h5>
+        <h3 class="h5 mb-2">Component tree</h3>
         <HealthNode :node="root" />
       </template>
     </template>
@@ -176,12 +176,14 @@ const statusMessage = computed(() => {
   flex-shrink: 0;
 }
 
-.health-summary__eyebrow {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+/* Sentence-case metric labels, not uppercase tracked eyebrows: the
+   Eyebrow-Containment Rule reserves that treatment for sidebar nav groups.
+   Metric values are machine counters, so they render in the mono stack — the
+   same pairing the Hibernate Statistics runtime overview uses. */
+.health-summary__status-label {
   color: var(--bootui-text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
   margin-bottom: 0.4rem;
 }
 
@@ -217,17 +219,17 @@ const statusMessage = computed(() => {
 }
 
 .health-summary__metric dt {
-  font-size: 0.72rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
   color: var(--bootui-text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
   margin-bottom: 0.3rem;
 }
 
 .health-summary__metric dd {
-  font-size: 1.6rem;
+  font-family: var(--bs-font-monospace);
+  font-size: clamp(1.15rem, 2vw, 2.1rem);
   font-weight: 700;
+  letter-spacing: -0.03em;
   line-height: 1.1;
   color: var(--bootui-text);
   margin: 0 0 0.2rem;

--- a/bootui-ui/src/main/frontend/src/views/HeapDump.vue
+++ b/bootui-ui/src/main/frontend/src/views/HeapDump.vue
@@ -7,6 +7,7 @@ import {describeLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
 import {useConfirm} from '../utils/useConfirm.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -17,6 +18,7 @@ const report = ref(null)
 const error = ref(null)
 const actionMessage = ref(null)
 const loading = ref(false)
+const initialLoading = ref(true)
 const live = ref(true)
 const filter = ref('')
 const smartFilter = ref('')
@@ -105,6 +107,8 @@ async function loadReport(options = {}) {
     error.value = null
   } catch (e) {
     if (requestId === reportRequestId) error.value = describeLoadError(e, 'Unable to load heap dump report')
+  } finally {
+    initialLoading.value = false
   }
 }
 
@@ -246,6 +250,8 @@ onBeforeUnmount(() => {
       <span v-if="readOnly">Capture and delete are read-only. {{ readOnlyReason }}</span>
     </div>
 
+    <PanelSkeleton v-if="initialLoading" />
+
     <template v-if="report">
       <div v-if="!report.hotspotAvailable" class="alert alert-secondary">
         Heap dumps are not supported on this JVM (the HotSpot diagnostic MXBean is unavailable).
@@ -385,7 +391,7 @@ onBeforeUnmount(() => {
 
         <div class="col-lg-4">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Capture options</div>
+            <div class="card-header"><h3>Capture options</h3></div>
             <div class="card-body">
               <div class="form-check form-switch mb-3">
                 <input id="heapDumpLive" v-model="live" :disabled="readOnly" class="form-check-input" type="checkbox" />
@@ -409,7 +415,7 @@ onBeforeUnmount(() => {
       </div>
 
       <div class="card">
-        <div class="card-header fw-semibold">Captured dumps</div>
+        <div class="card-header"><h3>Captured dumps</h3></div>
         <div v-if="report.dumps.length === 0" class="card-body text-center text-muted py-5">
           <i class="bi bi-folder2-open fs-2 d-block mb-2"></i>
           <div class="fw-semibold text-body">No heap dumps on disk</div>

--- a/bootui-ui/src/main/frontend/src/views/Hibernate.vue
+++ b/bootui-ui/src/main/frontend/src/views/Hibernate.vue
@@ -3,6 +3,7 @@ import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -37,16 +38,11 @@ const panel = useAdvisorPanel(props, {
         />
       </template>
     </PanelHeader>
-    <div class="alert alert-info d-flex align-items-start gap-2">
-      <i class="bi bi-info-circle flex-shrink-0" aria-hidden="true"></i>
-      <div>
-        Many of those rules are best practices from Vlad Mihalcea, who reviewed the code himself - join him at
-        <a href="https://vladmihalcea.com" rel="noopener noreferrer" target="_blank">https://vladmihalcea.com</a>
-      </div>
-    </div>
     <div v-if="panel.actionMessage" class="alert alert-warning" role="status" aria-live="polite">
       {{ panel.actionMessage }}
     </div>
+
+    <PanelSkeleton v-if="panel.initialLoading" />
 
     <template v-if="panel.report">
       <AdvisorSummary
@@ -65,12 +61,16 @@ const panel = useAdvisorPanel(props, {
         <strong>Heuristic Hibernate rules.</strong>
         {{ panel.report.disclaimer }}
         <span v-if="panel.readOnly">Scanning is read-only. {{ panel.readOnlyReason }}</span>
+        <span class="d-block mt-2">
+          Many of those rules are best practices from Vlad Mihalcea, who reviewed the code himself - join him at
+          <a href="https://vladmihalcea.com" rel="noopener noreferrer" target="_blank">https://vladmihalcea.com</a>
+        </span>
       </div>
 
       <div class="row g-3 mb-3">
         <div class="col-lg-5">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Findings by severity</div>
+            <div class="card-header"><h3>Findings by severity</h3></div>
             <div class="card-body">
               <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -103,7 +103,7 @@ const panel = useAdvisorPanel(props, {
 
         <div class="col-lg-7">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Entity packages</div>
+            <div class="card-header"><h3>Entity packages</h3></div>
             <div class="card-body">
               <div v-if="!panel.report.entityPackages || panel.report.entityPackages.length === 0" class="text-muted">
                 No mapped entity package was detected.
@@ -121,7 +121,7 @@ const panel = useAdvisorPanel(props, {
       <div class="card">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
-            <div class="fw-semibold">Rule results</div>
+            <h3 class="fs-6 fw-semibold mb-0">Rule results</h3>
             <div class="text-muted small">
               <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
                 {{ panel.visibleResults.length }}
@@ -146,8 +146,8 @@ const panel = useAdvisorPanel(props, {
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
               <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-              <span class="badge text-bg-light border">{{ result.category }}</span>
-              <span class="text-muted small">{{ result.id }}</span>
+              <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+              <span class="text-muted small font-monospace">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
@@ -199,8 +199,8 @@ const panel = useAdvisorPanel(props, {
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
                 <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"

--- a/bootui-ui/src/main/frontend/src/views/HttpExchanges.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpExchanges.vue
@@ -2,6 +2,7 @@
 import {computed, onMounted, ref, watch} from 'vue'
 import {useRoute} from 'vue-router'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import ServerListFooter from './components/ServerListFooter.vue'
 import {formatNumber} from '../utils/format.js'
 import {useAutoRefresh} from '../utils/useAutoRefresh.js'
@@ -15,6 +16,7 @@ const expanded = ref(new Set())
 const {
   data,
   error,
+  hasLoaded,
   items: exchanges,
   load,
   loadMore,
@@ -192,7 +194,9 @@ onMounted(() => {
       </div>
     </div>
 
-    <div class="table-responsive">
+    <PanelSkeleton v-if="loading && !hasLoaded" :rows="8" />
+
+    <div v-else class="table-responsive">
       <table class="table table-sm align-middle http-exchanges-table">
         <thead>
           <tr>
@@ -345,7 +349,7 @@ onMounted(() => {
   border: 1px solid var(--bs-border-color);
   border-radius: 0.5rem;
   padding: 1rem;
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.04);
+  box-shadow: var(--bootui-shadow-sm);
 }
 
 .headers-list {

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -211,7 +211,7 @@ function clearForm() {
         </div>
 
         <div v-if="response.headers && Object.keys(response.headers).length" class="mb-3">
-          <h6>Headers</h6>
+          <h4 class="fs-6">Headers</h4>
           <ul class="list-unstyled small mb-0">
             <li v-for="(value, name) in response.headers" :key="name">
               <code>{{ name }}</code
@@ -221,7 +221,7 @@ function clearForm() {
         </div>
 
         <div>
-          <h6>Body</h6>
+          <h4 class="fs-6">Body</h4>
           <div v-if="response.truncated" class="alert alert-warning mb-2 py-1 small">
             <i class="bi bi-scissors me-1"></i>Response body was truncated at the configured byte limit.
           </div>

--- a/bootui-ui/src/main/frontend/src/views/Jms.vue
+++ b/bootui-ui/src/main/frontend/src/views/Jms.vue
@@ -92,9 +92,13 @@ function directionLabel(direction) {
   return direction === 'PRODUCE' ? 'Produced' : 'Consumed'
 }
 
+function showReadOnlyMessage() {
+  flash(readOnlyReason.value, 'warning')
+}
+
 async function clearAll() {
   if (readOnly.value) {
-    flash(readOnlyReason.value, 'warning')
+    showReadOnlyMessage()
     return
   }
   if (

--- a/bootui-ui/src/main/frontend/src/views/Kafka.vue
+++ b/bootui-ui/src/main/frontend/src/views/Kafka.vue
@@ -239,9 +239,9 @@ async function clearAll() {
                   </td>
                   <td class="text-truncate small">
                     <template v-if="m.groupId || m.listenerId">
-                      <span v-if="m.groupId">{{ m.groupId }}</span>
+                      <span v-if="m.groupId" class="font-monospace">{{ m.groupId }}</span>
                       <span v-if="m.groupId && m.listenerId"> / </span>
-                      <span v-if="m.listenerId">{{ m.listenerId }}</span>
+                      <span v-if="m.listenerId" class="font-monospace">{{ m.listenerId }}</span>
                     </template>
                     <span v-else class="text-muted">—</span>
                   </td>

--- a/bootui-ui/src/main/frontend/src/views/Liquibase.vue
+++ b/bootui-ui/src/main/frontend/src/views/Liquibase.vue
@@ -9,6 +9,7 @@ import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
 import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import UnavailableState from './components/UnavailableState.vue'
 
 const props = defineProps(panelProps)
@@ -19,6 +20,7 @@ const platform = computed(() => panels.value?.platform ?? 'spring-boot')
 const report = ref(null)
 const error = ref(null)
 const liquibasePresent = ref(true)
+const initialLoading = ref(true)
 const filter = ref('')
 const {message: banner, flash, clear} = useFlashMessage()
 const busy = ref(null)
@@ -34,6 +36,8 @@ async function load() {
     report.value = await res.json()
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load Liquibase change sets')
+  } finally {
+    initialLoading.value = false
   }
 }
 
@@ -117,7 +121,9 @@ onMounted(load)
 
     <FlashBanner :message="banner" @dismiss="clear" />
 
-    <UnavailableState v-if="!liquibasePresent" variant="info">
+    <PanelSkeleton v-if="initialLoading" />
+
+    <UnavailableState v-else-if="!liquibasePresent" variant="info">
       <template v-if="platform === 'quarkus'">
         Liquibase is not configured on this application. Add the <code>quarkus-liquibase</code> extension and a change
         log to see change sets here.
@@ -156,9 +162,9 @@ onMounted(load)
 
       <div v-for="db in databases" :key="db.name" class="card mb-3">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
-          <span>
+          <h3 class="fs-6 fw-semibold mb-0">
             <i class="bi bi-database me-1"></i><code class="bootui-break-anywhere">{{ db.name }}</code>
-          </span>
+          </h3>
           <span class="d-flex flex-wrap align-items-center gap-1">
             <span class="badge bg-success me-1">{{ db.applied }} applied</span>
             <span v-if="db.pending > 0" class="badge bg-warning text-dark">{{ db.pending }} pending</span>

--- a/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveActivity.vue
@@ -2,6 +2,7 @@
 import {computed, defineAsyncComponent, onBeforeUnmount, onMounted, ref, watch} from 'vue'
 import {apiFetch} from '../api.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import UnavailableState from './components/UnavailableState.vue'
 import FlashBanner from './components/FlashBanner.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
@@ -129,6 +130,7 @@ async function loadActivity() {
 
 const {
   autoRefresh,
+  initialLoading,
   loading,
   load: refreshNow,
   retryConnection,
@@ -657,6 +659,8 @@ function toggleFlow() {
     </div>
 
     <UnavailableState v-if="!manifestAvailable" icon="bi-broadcast" :message="manifestUnavailableReason" />
+
+    <PanelSkeleton v-else-if="initialLoading && !report" :rows="8" />
 
     <template v-else-if="report">
       <UnavailableState
@@ -1375,5 +1379,10 @@ function toggleFlow() {
 
 .activity-spark-error {
   fill: var(--bs-danger, #dc3545);
+}
+@media (prefers-reduced-motion: reduce) {
+  .activity-kpi-link {
+    transition: none;
+  }
 }
 </style>

--- a/bootui-ui/src/main/frontend/src/views/LiveFlowMode.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveFlowMode.vue
@@ -810,7 +810,7 @@ watch(selectedId, async (id) => {
 }
 
 .flow-note {
-  border-left: 3px solid var(--bootui-border-alt);
+  border-left: 1px solid var(--bootui-border-alt);
   padding: 0.15rem 0 0.15rem 0.6rem;
 }
 
@@ -938,9 +938,19 @@ watch(selectedId, async (id) => {
 }
 
 /* ── Nodes ─────────────────────────────────────────────────────────────────── */
+/* The SVG focus ring below replaces the UA outline, but only for
+   :focus-visible. Keep the native outline anywhere that selector does not
+   apply so keyboard focus is never silently removed. */
+.flow-node:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.flow-node:focus-visible {
+  outline: none;
+}
+
 .flow-node {
   cursor: pointer;
-  outline: none;
 }
 
 .flow-node--app {

--- a/bootui-ui/src/main/frontend/src/views/LiveMemory.test.js
+++ b/bootui-ui/src/main/frontend/src/views/LiveMemory.test.js
@@ -89,7 +89,7 @@ describe('LiveMemory', () => {
 
     expect(fetch).toHaveBeenCalledWith('api/live-memory')
     const renderedText = wrapper.text()
-    const panelOrder = ['Heap Memory', 'Non-Heap Memory', 'Memory Pools']
+    const panelOrder = ['Heap memory', 'Non-heap memory', 'Memory pools']
     const panelPositions = panelOrder.map((label) => {
       const position = renderedText.indexOf(label)
       expect(position).toBeGreaterThanOrEqual(0)
@@ -134,7 +134,7 @@ describe('LiveMemory', () => {
     wrapper.getComponent(PanelHeader).vm.$emit('refresh')
     await flushPromises()
 
-    expect(wrapper.text()).toContain('Heap Memory')
+    expect(wrapper.text()).toContain('Heap memory')
     expect(wrapper.getComponent(FlashBanner).text()).toContain('Showing the last successful snapshot')
     expect(wrapper.getComponent(FlashBanner).find('button.btn-close').exists()).toBe(false)
   })

--- a/bootui-ui/src/main/frontend/src/views/LiveMemory.vue
+++ b/bootui-ui/src/main/frontend/src/views/LiveMemory.vue
@@ -43,33 +43,32 @@ const staleMessage = {
           <div class="card h-100">
             <div class="card-header d-flex align-items-center gap-2">
               <i class="bi bi-stack text-success"></i>
-              <strong>Heap Memory</strong>
+              <h3>Heap memory</h3>
             </div>
             <div class="card-body">
               <div class="d-flex justify-content-between mb-1">
                 <span class="text-muted small">Used</span>
-                <span class="fw-semibold">{{ formatBytes(data.heap.usedBytes) }}</span>
+                <span class="fw-semibold font-monospace">{{ formatBytes(data.heap.usedBytes) }}</span>
               </div>
               <ProgressBar
                 :bar-class="memoryProgressClass(data.heap.usedPercent)"
-                class="mb-3"
                 label="Heap memory used"
                 :value="data.heap.usedPercent"
                 :value-text="`${data.heap.usedPercent}% of maximum used`"
-                style="height: 10px"
+                class="live-memory-bar mb-3"
               />
               <div class="row text-center g-2">
                 <div class="col-4">
                   <div class="text-muted small">Used</div>
-                  <div class="fw-semibold">{{ formatBytes(data.heap.usedBytes) }}</div>
+                  <div class="fw-semibold font-monospace">{{ formatBytes(data.heap.usedBytes) }}</div>
                 </div>
                 <div class="col-4">
                   <div class="text-muted small">Committed</div>
-                  <div class="fw-semibold">{{ formatBytes(data.heap.committedBytes) }}</div>
+                  <div class="fw-semibold font-monospace">{{ formatBytes(data.heap.committedBytes) }}</div>
                 </div>
                 <div class="col-4">
                   <div class="text-muted small">Max</div>
-                  <div class="fw-semibold">{{ formatBytes(data.heap.maxBytes) }}</div>
+                  <div class="fw-semibold font-monospace">{{ formatBytes(data.heap.maxBytes) }}</div>
                 </div>
               </div>
             </div>
@@ -81,33 +80,32 @@ const staleMessage = {
           <div class="card h-100">
             <div class="card-header d-flex align-items-center gap-2">
               <i class="bi bi-cpu text-info"></i>
-              <strong>Non-Heap Memory</strong>
+              <h3>Non-heap memory</h3>
             </div>
             <div class="card-body">
               <div class="d-flex justify-content-between mb-1">
                 <span class="text-muted small">Used</span>
-                <span class="fw-semibold">{{ formatBytes(data.nonHeap.usedBytes) }}</span>
+                <span class="fw-semibold font-monospace">{{ formatBytes(data.nonHeap.usedBytes) }}</span>
               </div>
               <ProgressBar
                 bar-class="bg-info"
-                class="mb-3"
                 label="Non-heap memory used"
                 :value="data.nonHeap.usedPercent"
                 :value-text="`${data.nonHeap.usedPercent}% used`"
-                style="height: 10px"
+                class="live-memory-bar mb-3"
               />
               <div class="row text-center g-2">
                 <div class="col-4">
                   <div class="text-muted small">Used</div>
-                  <div class="fw-semibold">{{ formatBytes(data.nonHeap.usedBytes) }}</div>
+                  <div class="fw-semibold font-monospace">{{ formatBytes(data.nonHeap.usedBytes) }}</div>
                 </div>
                 <div class="col-4">
                   <div class="text-muted small">Committed</div>
-                  <div class="fw-semibold">{{ formatBytes(data.nonHeap.committedBytes) }}</div>
+                  <div class="fw-semibold font-monospace">{{ formatBytes(data.nonHeap.committedBytes) }}</div>
                 </div>
                 <div class="col-4">
                   <div class="text-muted small">Max</div>
-                  <div class="fw-semibold">
+                  <div class="fw-semibold font-monospace">
                     {{ data.nonHeap.maxBytes < 0 ? 'Unlimited' : formatBytes(data.nonHeap.maxBytes) }}
                   </div>
                 </div>
@@ -119,7 +117,9 @@ const staleMessage = {
       </div>
 
       <div class="card mb-4">
-        <div class="card-header"><i class="bi bi-table me-2"></i>Memory Pools</div>
+        <div class="card-header">
+          <h3><i class="bi bi-table me-2"></i>Memory pools</h3>
+        </div>
         <div class="table-responsive">
           <table class="table table-sm table-hover mb-0">
             <thead class="table-light">
@@ -128,28 +128,30 @@ const staleMessage = {
                 <th class="text-end">Used</th>
                 <th class="text-end">Committed</th>
                 <th class="text-end">Max</th>
-                <th style="width: 140px">Usage</th>
+                <th class="live-memory-usage-column">Usage</th>
               </tr>
             </thead>
             <tbody>
+              <tr v-if="!data.pools || data.pools.length === 0">
+                <td class="text-muted py-3" colspan="5">The JVM did not report any memory pools for this runtime.</td>
+              </tr>
               <tr v-for="pool in data.pools" :key="pool.name">
                 <td>
                   <code>{{ pool.name }}</code>
                 </td>
-                <td class="text-end">{{ formatBytes(pool.usedBytes) }}</td>
-                <td class="text-end">{{ formatBytes(pool.committedBytes) }}</td>
-                <td class="text-end">{{ pool.maxBytes < 0 ? '∞' : formatBytes(pool.maxBytes) }}</td>
+                <td class="text-end font-monospace">{{ formatBytes(pool.usedBytes) }}</td>
+                <td class="text-end font-monospace">{{ formatBytes(pool.committedBytes) }}</td>
+                <td class="text-end font-monospace">{{ pool.maxBytes < 0 ? '∞' : formatBytes(pool.maxBytes) }}</td>
                 <td>
                   <div class="d-flex align-items-center gap-2">
                     <ProgressBar
                       :bar-class="memoryProgressClass(pool.usedPercent)"
-                      class="flex-grow-1"
+                      class="flex-grow-1 live-memory-bar live-memory-bar--row"
                       :label="`${pool.name} memory pool used`"
                       :value="pool.usedPercent"
                       :value-text="`${pool.usedPercent}% used`"
-                      style="height: 6px"
                     />
-                    <span class="text-muted small" style="width: 32px; text-align: right">{{ pool.usedPercent }}%</span>
+                    <span class="text-muted small live-memory-percent">{{ pool.usedPercent }}%</span>
                   </div>
                 </td>
               </tr>
@@ -165,3 +167,23 @@ const staleMessage = {
     />
   </div>
 </template>
+
+<style scoped>
+.live-memory-usage-column {
+  min-width: 8.75rem;
+}
+
+.live-memory-percent {
+  font-family: var(--bs-font-monospace);
+  min-width: 2.75rem;
+  text-align: right;
+}
+
+.live-memory-bar {
+  height: 0.625rem;
+}
+
+.live-memory-bar--row {
+  height: 0.375rem;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/LogTail.vue
+++ b/bootui-ui/src/main/frontend/src/views/LogTail.vue
@@ -177,9 +177,10 @@ onBeforeUnmount(() => disconnect(false))
 </template>
 
 <style scoped>
+/* Terminal output keeps its own dark identity in both themes. */
 .log-pane {
-  background: #111827;
-  color: #f8f9fa;
+  background: var(--bootui-code-pane-bg);
+  color: var(--bootui-code-pane-text);
   font-family: var(--bs-font-monospace);
   font-size: 0.875rem;
   height: 70vh;

--- a/bootui-ui/src/main/frontend/src/views/Loggers.vue
+++ b/bootui-ui/src/main/frontend/src/views/Loggers.vue
@@ -7,6 +7,7 @@ import {useServerPagedList} from '../utils/useServerPagedList.js'
 import FlashBanner from './components/FlashBanner.vue'
 import ServerListFooter from './components/ServerListFooter.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 
 const props = defineProps(panelProps)
@@ -17,6 +18,7 @@ const {message, flash, clear} = useFlashMessage(3000)
 const {
   data,
   error,
+  hasLoaded,
   items: visibleLoggers,
   load,
   loadMore,
@@ -72,7 +74,7 @@ watch(filter, scheduleReload)
 
 <template>
   <div>
-    <PanelHeader icon="bi-journal-text" title="Loggers" :error="error" />
+    <PanelHeader icon="bi-journal-text" title="Loggers" :error="error" :loading="loading" @refresh="load" />
     <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Logger levels are read-only.</ReadOnlyNotice>
     <FlashBanner :message="message" @dismiss="clear" />
     <input
@@ -82,7 +84,9 @@ watch(filter, scheduleReload)
       placeholder="Filter loggers by name…"
     />
     <p v-if="data" class="small text-muted">{{ matchedCount }} of {{ totalCount }} loggers matched</p>
-    <div class="table-responsive">
+    <PanelSkeleton v-if="loading && !hasLoaded" :rows="6" />
+
+    <div v-else class="table-responsive">
       <table class="table table-sm table-hover loggers-table">
         <colgroup>
           <col class="loggers-table-name" />

--- a/bootui-ui/src/main/frontend/src/views/Mappings.vue
+++ b/bootui-ui/src/main/frontend/src/views/Mappings.vue
@@ -136,7 +136,7 @@ watch(filter, scheduleMappingsReload)
                   <code>{{ r.pattern }}</code>
                 </td>
                 <td>
-                  <small>{{ r.handler }}</small>
+                  <code class="small">{{ r.handler }}</code>
                 </td>
               </tr>
             </tbody>

--- a/bootui-ui/src/main/frontend/src/views/McpServer.vue
+++ b/bootui-ui/src/main/frontend/src/views/McpServer.vue
@@ -9,6 +9,7 @@ import {useFlashMessage} from '../utils/useFlashMessage.js'
 import {getBootUiApiPath} from '../utils/bootUiPath.js'
 import FlashBanner from './components/FlashBanner.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
 import UnavailableState from './components/UnavailableState.vue'
 
@@ -110,9 +111,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: manif
 
     <UnavailableState v-if="!manifestAvailable" icon="bi-plug" :message="manifestUnavailableReason" />
 
-    <div v-else-if="loading && !status" class="card">
-      <div class="card-body text-muted">Loading MCP server status…</div>
-    </div>
+    <PanelSkeleton v-else-if="loading && !status" />
 
     <template v-else-if="status">
       <!-- Toggle card -->
@@ -126,10 +125,10 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: manif
               <i class="bi" :class="enabled ? 'bi-plug-fill' : 'bi-plug'"></i>
             </div>
             <div>
-              <h2 class="h5 fw-bold mb-1">
+              <h3 class="h5 fw-bold mb-1">
                 MCP server is
                 <span :class="enabled ? 'text-success' : 'text-secondary'">{{ enabled ? 'enabled' : 'disabled' }}</span>
-              </h2>
+              </h3>
               <p class="text-muted small mb-0">
                 Toggling here overrides the
                 <code>bootui.mcp.enabled</code> property at runtime (configured: <code>{{ status.configuredMode }}</code
@@ -251,7 +250,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: manif
           </p>
 
           <div v-if="actionTools.length" class="mb-3">
-            <div class="text-uppercase text-muted small fw-semibold mb-2">Action tools</div>
+            <h4 class="fs-6 text-muted fw-semibold mb-2">Action tools</h4>
             <ul class="list-group list-group-flush">
               <li v-for="tool in actionTools" :key="tool.name" class="list-group-item px-0">
                 <div class="d-flex align-items-center justify-content-between gap-2">
@@ -268,7 +267,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: manif
           </div>
 
           <div v-if="readTools.length">
-            <div class="text-uppercase text-muted small fw-semibold mb-2">Read tools</div>
+            <h4 class="fs-6 text-muted fw-semibold mb-2">Read tools</h4>
             <ul class="list-group list-group-flush">
               <li v-for="tool in readTools" :key="tool.name" class="list-group-item px-0">
                 <div class="d-flex align-items-center justify-content-between gap-2">

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -4,6 +4,7 @@ import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -56,6 +57,8 @@ function formatBytes(value) {
       {{ panel.actionMessage }}
     </div>
 
+    <PanelSkeleton v-if="panel.initialLoading" />
+
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
@@ -78,7 +81,7 @@ function formatBytes(value) {
       <div class="row g-3 mb-3">
         <div class="col-lg-5">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Findings by severity</div>
+            <div class="card-header"><h3>Findings by severity</h3></div>
             <div class="card-body">
               <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -111,7 +114,7 @@ function formatBytes(value) {
 
         <div class="col-lg-7">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Runtime snapshot</div>
+            <div class="card-header"><h3>Runtime snapshot</h3></div>
             <div class="card-body">
               <div v-if="!summary" class="text-muted">Run memory checks to capture a runtime snapshot.</div>
               <dl v-else class="row mb-0 small">
@@ -148,7 +151,7 @@ function formatBytes(value) {
       <div class="card">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
-            <div class="fw-semibold">Rule results</div>
+            <h3 class="fs-6 fw-semibold mb-0">Rule results</h3>
             <div class="text-muted small">
               <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
                 {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'finding') }}, sorted
@@ -173,8 +176,8 @@ function formatBytes(value) {
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
               <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-              <span class="badge text-bg-light border">{{ result.category }}</span>
-              <span class="text-muted small">{{ result.id }}</span>
+              <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+              <span class="text-muted small font-monospace">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
@@ -225,8 +228,8 @@ function formatBytes(value) {
             <div v-for="result in panel.report.analysisErrors" :key="result.id" class="list-group-item">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span class="badge text-bg-secondary">{{ result.status }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
               </div>
               <div class="small fw-semibold">{{ result.name }}</div>
               <ul v-if="result.sampleViolations && result.sampleViolations.length" class="small mb-0 mt-1">
@@ -245,8 +248,8 @@ function formatBytes(value) {
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
                 <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"

--- a/bootui-ui/src/main/frontend/src/views/Metrics.vue
+++ b/bootui-ui/src/main/frontend/src/views/Metrics.vue
@@ -537,7 +537,7 @@ const panelLoading = computed(() => loading.value || meterLoading.value || loadi
       </div>
     </template>
 
-    <div v-else class="text-muted">Loading metrics…</div>
+    <PanelSkeleton v-else :rows="8" />
   </div>
 </template>
 

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -390,7 +390,7 @@ onActivated(refreshScores)
         <div class="card overall-card">
           <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center gap-4">
             <div v-if="scoredCount > 0" class="flex-shrink-0 min-w-0">
-              <div class="text-uppercase text-muted fw-bold small">Overall score</div>
+              <h3 class="fs-6 text-muted fw-semibold mb-0">Overall score</h3>
               <div class="d-flex align-items-center gap-3 mt-2">
                 <div :class="['overall-gauge', `overall-gauge--${overallBandTone}`]">
                   <span class="overall-gauge__value">{{ Number.isFinite(overall) ? overall : '—' }}</span>
@@ -439,7 +439,7 @@ onActivated(refreshScores)
                 </p>
               </template>
               <div v-else>
-                <div class="text-uppercase text-muted fw-bold small">Overall score</div>
+                <h3 class="fs-6 text-muted fw-semibold mb-0">Overall score</h3>
                 <p class="text-muted small mb-0 mt-1">
                   {{ scoredCount }} of {{ totalCount }} scanners scored — run the advisors to compute a combined
                   security &amp; health score.

--- a/bootui-ui/src/main/frontend/src/views/Pentesting.vue
+++ b/bootui-ui/src/main/frontend/src/views/Pentesting.vue
@@ -4,6 +4,7 @@ import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -63,6 +64,8 @@ function coverageStatusLabel(status) {
       {{ panel.actionMessage }}
     </div>
 
+    <PanelSkeleton v-if="panel.initialLoading" />
+
     <template v-if="panel.report">
       <AdvisorSummary
         :score="completeScan ? panel.score : null"
@@ -112,7 +115,7 @@ function coverageStatusLabel(status) {
       <div class="row g-3 mb-3">
         <div class="col-12">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Severity breakdown</div>
+            <div class="card-header"><h3>Severity breakdown</h3></div>
             <div class="card-body">
               <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -147,7 +150,7 @@ function coverageStatusLabel(status) {
       <div class="card">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
-            <div class="fw-semibold">Findings</div>
+            <h3 class="fs-6 fw-semibold mb-0">Findings</h3>
             <div class="text-muted small">{{ panel.report.findingsFound }} heuristic finding(s)</div>
           </div>
           <span v-if="completeScan && panel.report.findingsFound === 0" class="badge text-bg-info">
@@ -178,7 +181,7 @@ function coverageStatusLabel(status) {
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="panel.severityClass(finding.severity)" class="badge">{{ finding.severity }}</span>
               <span class="badge text-bg-light border">{{ finding.confidence }} confidence</span>
-              <span class="text-muted small">{{ finding.id }}</span>
+              <span class="text-muted small font-monospace">{{ finding.id }}</span>
             </div>
             <h3 class="h6 mb-1">{{ finding.title }}</h3>
             <div class="small text-muted mb-2">{{ finding.owaspCategory }} on {{ finding.target }}</div>

--- a/bootui-ui/src/main/frontend/src/views/RestApi.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestApi.vue
@@ -3,6 +3,7 @@ import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -41,6 +42,8 @@ const panel = useAdvisorPanel(props, {
       {{ panel.actionMessage }}
     </div>
 
+    <PanelSkeleton v-if="panel.initialLoading" />
+
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
@@ -67,7 +70,7 @@ const panel = useAdvisorPanel(props, {
       <div class="row g-3 mb-3">
         <div class="col-lg-5">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Findings by severity</div>
+            <div class="card-header"><h3>Findings by severity</h3></div>
             <div class="card-body">
               <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -100,7 +103,7 @@ const panel = useAdvisorPanel(props, {
 
         <div class="col-lg-7">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Base packages</div>
+            <div class="card-header"><h3>Base packages</h3></div>
             <div class="card-body">
               <div v-if="!panel.report.basePackages || panel.report.basePackages.length === 0" class="text-muted">
                 No application base package was detected.
@@ -118,7 +121,7 @@ const panel = useAdvisorPanel(props, {
       <div class="card">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
-            <div class="fw-semibold">Rule findings</div>
+            <h3 class="fs-6 fw-semibold mb-0">Rule findings</h3>
             <div class="text-muted small">
               <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
                 {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'flagged rule') }},
@@ -143,8 +146,8 @@ const panel = useAdvisorPanel(props, {
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
               <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-              <span class="badge text-bg-light border">{{ result.category }}</span>
-              <span class="text-muted small">{{ result.id }}</span>
+              <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+              <span class="text-muted small font-monospace">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
@@ -196,8 +199,8 @@ const panel = useAdvisorPanel(props, {
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
                 <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"

--- a/bootui-ui/src/main/frontend/src/views/RestClientTrace.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestClientTrace.vue
@@ -325,9 +325,9 @@ function clearTrace() {
         </section>
 
         <section v-if="report.topCalls.length" class="mb-4">
-          <h5 class="mb-2">
+          <h3 class="h5 mb-2">
             Most frequent calls <span class="badge bg-secondary">{{ report.topCalls.length }}</span>
-          </h5>
+          </h3>
           <div class="table-responsive">
             <table class="table table-sm table-hover align-middle">
               <thead>
@@ -368,9 +368,9 @@ function clearTrace() {
 
         <section>
           <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
-            <h5 class="mb-0">
+            <h3 class="h5 mb-0">
               Recent calls <span class="badge bg-secondary">{{ filteredEntries.length }}</span>
-            </h5>
+            </h3>
             <div class="d-flex flex-wrap gap-2">
               <select
                 v-model="methodFilter"

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -4,6 +4,7 @@ import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 import UnavailableState from './components/UnavailableState.vue'
 
@@ -12,6 +13,7 @@ const panels = inject('panels', ref(null))
 const isQuarkus = computed(() => panels.value?.platform === 'quarkus')
 const fwName = computed(() => (isQuarkus.value ? 'Quarkus' : 'Spring Security'))
 const policyNoun = computed(() => (isQuarkus.value ? 'Permission policies' : 'Filter chains'))
+const policyMetricLabel = computed(() => (isQuarkus.value ? 'Permission policies' : 'Filter chains analysed'))
 const panel = useAdvisorPanel(props, {
   apiPath: 'api/security',
   loadErrorMessage: 'Unable to load Security Advisor report',
@@ -53,6 +55,8 @@ const panel = useAdvisorPanel(props, {
       :message="panel.manifestUnavailableReason"
     />
 
+    <PanelSkeleton v-else-if="panel.initialLoading" />
+
     <template v-else-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
@@ -63,22 +67,8 @@ const panel = useAdvisorPanel(props, {
         :metrics="[
           {label: 'Rules evaluated', value: panel.report.rulesEvaluated},
           {label: 'Advisor findings', value: panel.report.violationsFound},
-          {label: 'Filter chains analysed', value: panel.report.filterChainsAnalyzed}
+          {label: policyMetricLabel, value: panel.report.filterChainsAnalyzed}
         ]"
-        v-if="!isQuarkus"
-      />
-      <AdvisorSummary
-        :score="panel.score"
-        :dismissed-count="panel.dismissedResults.length"
-        :scan-status-label="panel.scanStatusLabel(panel.report.scan.status)"
-        :scan-status-class="panel.scanStatusBadgeClass(panel.report.scan.status)"
-        :scan-time="panel.scanTime()"
-        :metrics="[
-          {label: 'Rules evaluated', value: panel.report.rulesEvaluated},
-          {label: 'Advisor findings', value: panel.report.violationsFound},
-          {label: 'Permission policies', value: panel.report.filterChainsAnalyzed}
-        ]"
-        v-else
       />
       <div class="alert alert-info">
         <strong>Heuristic {{ fwName }} rules.</strong>
@@ -89,7 +79,7 @@ const panel = useAdvisorPanel(props, {
       <div class="row g-3 mb-3">
         <div class="col-lg-5">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Findings by severity</div>
+            <div class="card-header"><h3>Findings by severity</h3></div>
             <div class="card-body">
               <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -122,7 +112,9 @@ const panel = useAdvisorPanel(props, {
 
         <div class="col-lg-7">
           <div class="card h-100">
-            <div class="card-header fw-semibold">{{ policyNoun }}</div>
+            <div class="card-header">
+              <h3>{{ policyNoun }}</h3>
+            </div>
             <div class="card-body">
               <div v-if="!panel.report.filterChains || panel.report.filterChains.length === 0" class="text-muted">
                 No {{ isQuarkus ? 'HTTP permission policy was' : 'Spring Security filter chain was' }} detected.
@@ -140,7 +132,7 @@ const panel = useAdvisorPanel(props, {
       <div class="card">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
-            <div class="fw-semibold">Rule results</div>
+            <h3 class="fs-6 fw-semibold mb-0">Rule results</h3>
             <div class="text-muted small">
               <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
                 {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'violating rule') }},
@@ -165,8 +157,8 @@ const panel = useAdvisorPanel(props, {
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
               <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-              <span class="badge text-bg-light border">{{ result.category }}</span>
-              <span class="text-muted small">{{ result.id }}</span>
+              <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+              <span class="text-muted small font-monospace">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
@@ -217,8 +209,8 @@ const panel = useAdvisorPanel(props, {
             <div v-for="result in panel.report.analysisErrors" :key="result.id" class="list-group-item">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span class="badge text-bg-secondary">{{ result.status }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
               </div>
               <div class="small fw-semibold">{{ result.name }}</div>
               <ul v-if="result.sampleViolations && result.sampleViolations.length" class="small mb-0 mt-1">
@@ -237,8 +229,8 @@ const panel = useAdvisorPanel(props, {
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
                 <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"

--- a/bootui-ui/src/main/frontend/src/views/Spring.vue
+++ b/bootui-ui/src/main/frontend/src/views/Spring.vue
@@ -4,6 +4,7 @@ import {useAdvisorPanel} from '../utils/useAdvisorPanel.js'
 import {panelProps} from '../utils/panelState.js'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const props = defineProps(panelProps)
@@ -58,6 +59,8 @@ const panel = useAdvisorPanel(props, {
       {{ panel.actionMessage }}
     </div>
 
+    <PanelSkeleton v-if="panel.initialLoading" />
+
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
@@ -80,7 +83,7 @@ const panel = useAdvisorPanel(props, {
       <div class="row g-3 mb-3">
         <div class="col-lg-5">
           <div class="card h-100">
-            <div class="card-header fw-semibold">Findings by severity</div>
+            <div class="card-header"><h3>Findings by severity</h3></div>
             <div class="card-body">
               <div v-if="!panel.hasScanData" class="text-center text-muted py-4">
                 <i class="bi bi-search fs-2 d-block mb-2"></i>
@@ -113,7 +116,9 @@ const panel = useAdvisorPanel(props, {
 
         <div class="col-lg-7">
           <div class="card h-100">
-            <div class="card-header fw-semibold">{{ isQuarkus ? 'Idioms inspected' : 'Context inspected' }}</div>
+            <div class="card-header">
+              <h3>{{ isQuarkus ? 'Idioms inspected' : 'Context inspected' }}</h3>
+            </div>
             <div class="card-body">
               <div v-if="!panel.report.inspected || panel.report.inspected.length === 0" class="text-muted">
                 No {{ isQuarkus ? 'application idiom' : 'application context' }} details were collected.
@@ -131,7 +136,7 @@ const panel = useAdvisorPanel(props, {
       <div class="card">
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
-            <div class="fw-semibold">Rule results</div>
+            <h3 class="fs-6 fw-semibold mb-0">Rule results</h3>
             <div class="text-muted small">
               <template v-if="panel.hasScanData && panel.visibleResults.length > 0">
                 {{ panel.visibleResults.length }} {{ panel.pluralize(panel.visibleResults.length, 'violating rule') }},
@@ -156,8 +161,8 @@ const panel = useAdvisorPanel(props, {
             <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
               <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
               <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-              <span class="badge text-bg-light border">{{ result.category }}</span>
-              <span class="text-muted small">{{ result.id }}</span>
+              <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+              <span class="text-muted small font-monospace">{{ result.id }}</span>
               <button
                 class="btn btn-sm btn-outline-secondary ms-auto"
                 type="button"
@@ -208,8 +213,8 @@ const panel = useAdvisorPanel(props, {
             <div v-for="result in panel.report.analysisErrors" :key="result.id" class="list-group-item">
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span class="badge text-bg-secondary">{{ result.status }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
               </div>
               <div class="small fw-semibold">{{ result.name }}</div>
               <ul v-if="result.sampleViolations && result.sampleViolations.length" class="small mb-0 mt-1">
@@ -228,8 +233,8 @@ const panel = useAdvisorPanel(props, {
               <div class="d-flex flex-wrap align-items-center gap-2 mb-1">
                 <span :class="panel.statusClass(result.status)" class="badge">{{ result.status }}</span>
                 <span :class="panel.severityClass(result.severity)" class="badge">{{ result.severity }}</span>
-                <span class="badge text-bg-light border">{{ result.category }}</span>
-                <span class="text-muted small">{{ result.id }}</span>
+                <span class="badge text-bg-light border font-monospace">{{ result.category }}</span>
+                <span class="text-muted small font-monospace">{{ result.id }}</span>
                 <button
                   class="btn btn-sm btn-outline-secondary ms-auto"
                   type="button"

--- a/bootui-ui/src/main/frontend/src/views/SpringCache.vue
+++ b/bootui-ui/src/main/frontend/src/views/SpringCache.vue
@@ -222,9 +222,9 @@ function showReadOnlyMessage() {
 
       <section class="mb-4">
         <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
-          <h5 class="mb-0">
+          <h3 class="h5 mb-0">
             Caches <span class="badge bg-secondary">{{ report.cacheCount }}</span>
-          </h5>
+          </h3>
           <input
             v-model="cacheFilter"
             aria-label="Filter caches"
@@ -256,7 +256,9 @@ function showReadOnlyMessage() {
                   <code>{{ cache.managerName }}</code>
                   <span v-if="cache.managerNoOp" class="badge text-bg-secondary ms-1">No-op</span>
                 </td>
-                <td class="fw-semibold">{{ cache.name }}</td>
+                <td>
+                  <code class="fw-semibold">{{ cache.name }}</code>
+                </td>
                 <td>
                   <code>{{ shortName(cache.nativeType) }}</code>
                   <div class="small text-muted">{{ cache.nativeType || 'No native cache reported' }}</div>
@@ -292,9 +294,9 @@ function showReadOnlyMessage() {
 
       <section v-if="platform !== 'quarkus'">
         <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
-          <h5 class="mb-0">
+          <h3 class="h5 mb-0">
             Annotation operations <span class="badge bg-secondary">{{ report.operationCount }}</span>
-          </h5>
+          </h3>
           <input
             v-model="operationFilter"
             aria-label="Filter cache operations"
@@ -376,7 +378,7 @@ function showReadOnlyMessage() {
       </section>
 
       <section v-else>
-        <h5 class="mb-2">Cached operations</h5>
+        <h3 class="h5 mb-2">Cached operations</h3>
         <div class="alert alert-secondary small mb-0">
           Quarkus binds caching with build-time annotations (<code>@CacheResult</code>,
           <code>@CacheInvalidate</code>, <code>@CacheInvalidateAll</code>) woven into your methods at compile time, so

--- a/bootui-ui/src/main/frontend/src/views/SpringSecurity.vue
+++ b/bootui-ui/src/main/frontend/src/views/SpringSecurity.vue
@@ -3,11 +3,13 @@ import {apiFetch, getJson} from '../api.js'
 import {computed, inject, onMounted, ref} from 'vue'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 
 const report = ref(null)
 const error = ref(null)
 const springSecurityPresent = ref(true)
+const initialLoading = ref(true)
 const panels = inject('panels', ref(null))
 const isReactive = computed(() => (panels.value?.platform ?? 'spring-boot') === 'spring-boot-reactive')
 
@@ -35,6 +37,8 @@ async function load() {
     }
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load Spring Security')
+  } finally {
+    initialLoading.value = false
   }
 }
 
@@ -155,7 +159,9 @@ onMounted(() => {
   <div>
     <PanelHeader icon="bi-person-lock" title="Spring Security" :error="error" />
 
-    <div v-if="!springSecurityPresent" class="alert alert-info">
+    <PanelSkeleton v-if="initialLoading" />
+
+    <div v-else-if="!springSecurityPresent" class="alert alert-info">
       <template v-if="isReactive">
         No application <code>SecurityWebFilterChain</code> was detected. Add
         <code>spring-boot-starter-security</code> and configure a reactive security chain to inspect it here.
@@ -174,10 +180,10 @@ onMounted(() => {
       </div>
 
       <!-- Filter chains -->
-      <h5 class="mt-3 mb-2">
+      <h3 class="h5 mt-3 mb-2">
         {{ isReactive ? 'WebFilter chains' : 'Filter chains' }}
         <span class="badge bg-secondary">{{ report.chains.length }}</span>
-      </h5>
+      </h3>
 
       <div v-if="report.chains.length === 0" class="alert alert-secondary">
         No {{ isReactive ? 'WebFilter' : 'filter' }} chains detected. Spring Security may be present but not configured.
@@ -235,7 +241,7 @@ onMounted(() => {
       </div>
 
       <!-- Authentication -->
-      <h5 class="mt-4 mb-2">Authentication</h5>
+      <h3 class="h5 mt-4 mb-2">Authentication</h3>
       <div v-if="report.auth">
         <dl class="row small">
           <template v-if="report.auth.authenticationProviderTypes.length">
@@ -281,7 +287,7 @@ onMounted(() => {
       </div>
 
       <!-- Endpoints -->
-      <h5 class="mt-4 mb-2">
+      <h3 class="h5 mt-4 mb-2">
         Endpoints
         <span v-if="endpoints" class="badge bg-secondary">{{ endpoints.total }}</span>
         <SpinnerButton
@@ -291,7 +297,7 @@ onMounted(() => {
           label="Reload"
           @click="loadEndpoints"
         />
-      </h5>
+      </h3>
       <p class="text-muted small">
         <template v-if="isReactive">
           Annotation-based Spring WebFlux mappings are evaluated against each reactive chain with a sanitized
@@ -370,7 +376,7 @@ onMounted(() => {
       <div v-else class="text-muted small">Loading endpoints…</div>
 
       <!-- Explain tool -->
-      <h5 class="mt-4 mb-2">Explain a request</h5>
+      <h3 class="h5 mt-4 mb-2">Explain a request</h3>
       <p class="text-muted small">
         <template v-if="isReactive">
           Enter a method and path to run each reactive chain's public matcher without reusing data from your current

--- a/bootui-ui/src/main/frontend/src/views/SqlTrace.vue
+++ b/bootui-ui/src/main/frontend/src/views/SqlTrace.vue
@@ -293,9 +293,9 @@ function clearTrace() {
         </section>
 
         <section v-if="report.topStatements.length" class="mb-4">
-          <h5 class="mb-2">
+          <h3 class="h5 mb-2">
             Most frequent statements <span class="badge bg-secondary">{{ report.topStatements.length }}</span>
-          </h5>
+          </h3>
           <div class="table-responsive">
             <table class="table table-sm table-hover align-middle">
               <thead>
@@ -336,9 +336,9 @@ function clearTrace() {
 
         <section>
           <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
-            <h5 class="mb-0">
+            <h3 class="h5 mb-0">
               Recent executions <span class="badge bg-secondary">{{ filteredEntries.length }}</span>
-            </h5>
+            </h3>
             <div class="d-flex flex-wrap gap-2">
               <select
                 v-model="categoryFilter"

--- a/bootui-ui/src/main/frontend/src/views/Threads.vue
+++ b/bootui-ui/src/main/frontend/src/views/Threads.vue
@@ -7,6 +7,8 @@ import {useAutoRefresh} from '../utils/useAutoRefresh.js'
 import {useConfirm} from '../utils/useConfirm.js'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
 import PanelHeader from './components/PanelHeader.vue'
+import ReadOnlyNotice from './components/ReadOnlyNotice.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import ServerListFooter from './components/ServerListFooter.vue'
 
 const props = defineProps(panelProps)
@@ -23,6 +25,7 @@ const downloadError = ref(null)
 const {
   data,
   error,
+  hasLoaded,
   items: threads,
   load: loadThreads,
   loadMore,
@@ -162,9 +165,7 @@ watch([filter, state], scheduleReload)
     </div>
 
     <template v-else>
-      <div v-if="readOnly" class="text-muted small mb-2">
-        <i class="bi bi-lock me-1"></i>Thread-dump download is read-only. {{ readOnlyReason }}
-      </div>
+      <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Thread-dump download is read-only.</ReadOnlyNotice>
       <div v-if="downloadError" class="alert alert-danger py-2" role="alert">{{ downloadError }}</div>
 
       <div v-if="deadlockDetected" class="alert alert-danger" role="alert">
@@ -200,7 +201,9 @@ watch([filter, state], scheduleReload)
         </div>
       </div>
 
-      <div class="table-responsive">
+      <PanelSkeleton v-if="listLoading && !hasLoaded" :rows="8" />
+
+      <div v-else class="table-responsive">
         <table class="table table-sm table-hover threads-table">
           <thead>
             <tr>

--- a/bootui-ui/src/main/frontend/src/views/Traces.vue
+++ b/bootui-ui/src/main/frontend/src/views/Traces.vue
@@ -397,7 +397,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
 .waterfall-track {
   position: relative;
   height: 16px;
-  background: rgba(0, 0, 0, 0.05);
+  background: var(--bootui-border);
   border-radius: var(--bootui-radius-xs);
 }
 
@@ -411,7 +411,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchTraces)
 }
 
 .trace-drawer {
-  border: 1px solid rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--bootui-border);
 }
 
 code {

--- a/bootui-ui/src/main/frontend/src/views/Transactions.vue
+++ b/bootui-ui/src/main/frontend/src/views/Transactions.vue
@@ -313,9 +313,9 @@ function clearTransactions() {
 
         <section>
           <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
-            <h5 class="mb-0">
+            <h3 class="h5 mb-0">
               Recent transactions <span class="badge bg-secondary">{{ filteredEntries.length }}</span>
-            </h5>
+            </h3>
             <div class="d-flex flex-wrap gap-2">
               <select
                 v-model="statusFilter"

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -7,6 +7,7 @@ import {panelProps, usePanelState} from '../utils/panelState.js'
 import {hasScanResult, scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {useDismissedRules} from '../utils/useDismissedRules.js'
 import PanelHeader from './components/PanelHeader.vue'
+import PanelSkeleton from './components/PanelSkeleton.vue'
 import SpinnerButton from './components/SpinnerButton.vue'
 import AdvisorSummary from './components/AdvisorSummary.vue'
 
@@ -16,6 +17,7 @@ const data = ref(null)
 const error = ref(null)
 const actionMessage = ref(null)
 const loading = ref(false)
+const initialLoading = ref(true)
 const search = ref('')
 const vulnerableOnly = ref(false)
 
@@ -202,6 +204,8 @@ async function loadDependencies() {
     error.value = null
   } catch (e) {
     error.value = describeLoadError(e, 'Unable to load dependencies')
+  } finally {
+    initialLoading.value = false
   }
 }
 
@@ -266,6 +270,8 @@ onMounted(loadDependencies)
     </PanelHeader>
     <div v-if="actionMessage" class="alert alert-warning" role="status" aria-live="polite">{{ actionMessage }}</div>
 
+    <PanelSkeleton v-if="initialLoading" />
+
     <template v-if="data">
       <div class="alert alert-info">
         <strong>On-demand external scan.</strong>
@@ -287,7 +293,7 @@ onMounted(loadDependencies)
       />
 
       <div class="card mb-3">
-        <div class="card-header fw-semibold">Severity breakdown</div>
+        <div class="card-header"><h3>Severity breakdown</h3></div>
         <div class="card-body">
           <div v-if="!hasScanData" class="text-center text-muted py-4">
             <i class="bi bi-search fs-2 d-block mb-2"></i>

--- a/bootui-ui/src/main/frontend/src/views/advisorPanelStates.test.js
+++ b/bootui-ui/src/main/frontend/src/views/advisorPanelStates.test.js
@@ -1,0 +1,112 @@
+import {flushPromises, mount} from '@vue/test-utils'
+import {afterEach, describe, expect, it, vi} from 'vitest'
+
+import Spring from './Spring.vue'
+
+const report = {
+  scan: {status: 'COMPLETED', scannedAt: '2024-05-01T10:15:00Z'},
+  rulesEvaluated: 12,
+  violationsFound: 2,
+  componentsAnalyzed: 87,
+  disclaimer: 'Heuristic checks only.',
+  severityCounts: [{severity: 'HIGH', count: 2}],
+  inspected: ['org.example.App'],
+  results: [],
+  analysisErrors: []
+}
+
+function mountSpring() {
+  return mount(Spring, {
+    global: {
+      stubs: {AutoRefreshToggle: true},
+      provide: {panels: {value: {platform: 'spring-boot'}}}
+    }
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('advisor panel first paint', () => {
+  it('shows the shared skeleton until the mount-time report settles', async () => {
+    let resolveReport
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise((resolve) => (resolveReport = resolve)))
+    )
+
+    const wrapper = mountSpring()
+    await flushPromises()
+
+    expect(wrapper.find('.skeleton-wrapper').exists()).toBe(true)
+    expect(wrapper.find('.advisor-score-card').exists()).toBe(false)
+
+    resolveReport({ok: true, status: 200, headers: new Headers(), json: () => Promise.resolve(report)})
+    await flushPromises()
+
+    expect(wrapper.find('.skeleton-wrapper').exists()).toBe(false)
+    expect(wrapper.find('.advisor-score-card').exists()).toBe(true)
+  })
+
+  it('clears the first-paint state even when the report request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+
+    const wrapper = mountSpring()
+    await flushPromises()
+
+    expect(wrapper.find('.skeleton-wrapper').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Unable to load Spring Advisor report')
+  })
+
+  it('renders rule identifiers and categories in the monospace stack', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers(),
+        json: () =>
+          Promise.resolve({
+            ...report,
+            results: [
+              {
+                id: 'SPRING-001',
+                name: 'Field injection',
+                category: 'BEANS',
+                severity: 'HIGH',
+                status: 'VIOLATION',
+                violationCount: 3,
+                description: 'Field injection hides dependencies.',
+                recommendation: 'Use constructor injection.',
+                sampleViolations: ['org.example.OrderService'],
+                dismissed: false
+              }
+            ]
+          })
+      })
+    )
+
+    const wrapper = mountSpring()
+    await flushPromises()
+
+    const ruleId = wrapper.findAll('.font-monospace').filter((node) => node.text() === 'SPRING-001')
+    const category = wrapper.findAll('.badge.font-monospace').filter((node) => node.text() === 'BEANS')
+
+    expect(ruleId).toHaveLength(1)
+    expect(category).toHaveLength(1)
+  })
+
+  it('titles the rule results section with a heading below the panel h2', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ok: true, status: 200, headers: new Headers(), json: () => Promise.resolve(report)})
+    )
+
+    const wrapper = mountSpring()
+    await flushPromises()
+
+    expect(wrapper.findAll('h2')).toHaveLength(1)
+    expect(wrapper.findAll('h3').map((heading) => heading.text())).toContain('Rule results')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/AdvisorSummary.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/AdvisorSummary.test.js
@@ -1,3 +1,6 @@
+import {readFileSync} from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
 import {mount} from '@vue/test-utils'
 import {describe, expect, it} from 'vitest'
 
@@ -64,5 +67,36 @@ describe('AdvisorSummary', () => {
   it('omits the dismissed note when nothing is dismissed', () => {
     const wrapper = mount(AdvisorSummary, {props: {...baseProps, score: 100, dismissedCount: 0}})
     expect(wrapper.text()).not.toContain('excluded from this score')
+  })
+
+  it('labels the score in sentence case rather than an uppercase tracked eyebrow', () => {
+    const wrapper = mount(AdvisorSummary, {props: {...baseProps, score: 90}})
+    const label = wrapper.find('.advisor-summary__band-label')
+
+    expect(label.exists()).toBe(true)
+    expect(label.text()).toBe('Advisor score')
+    expect(wrapper.find('.advisor-summary__eyebrow').exists()).toBe(false)
+    expect(wrapper.html()).not.toContain('text-uppercase')
+  })
+
+  it('keeps every metric label sentence case in the order the panel supplied', () => {
+    const wrapper = mount(AdvisorSummary, {props: {...baseProps, score: 90}})
+
+    expect(wrapper.findAll('.advisor-summary__metric dt').map((dt) => dt.text())).toEqual([
+      'Scan status',
+      'Rules evaluated',
+      'Advisor findings',
+      'Beans analysed'
+    ])
+  })
+
+  it('renders machine counters in the monospace stack and keeps labels sans', () => {
+    const source = readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), 'AdvisorSummary.vue'), 'utf8')
+    const metricValue = source.slice(source.indexOf('.advisor-summary__metric dd {'))
+    const metricLabel = source.slice(source.indexOf('.advisor-summary__metric dt {'))
+
+    expect(metricValue.slice(0, metricValue.indexOf('}'))).toContain('font-family: var(--bs-font-monospace)')
+    expect(metricLabel.slice(0, metricLabel.indexOf('}'))).not.toContain('text-transform')
+    expect(source).not.toContain('text-transform: uppercase')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/components/AdvisorSummary.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/AdvisorSummary.vue
@@ -32,7 +32,7 @@ const gaugeLabel = computed(() =>
             <span class="advisor-summary__max">/ 100</span>
           </div>
           <div class="advisor-summary__band">
-            <div class="advisor-summary__eyebrow">Advisor score</div>
+            <div class="advisor-summary__band-label">Advisor score</div>
             <span :class="['badge', `text-bg-${bandTone}`, 'fs-6']">{{ bandLabel }}</span>
           </div>
         </div>
@@ -92,23 +92,26 @@ const gaugeLabel = computed(() =>
 }
 
 .advisor-summary__value {
-  font-size: 1.9rem;
+  font-family: var(--bs-font-monospace);
+  font-size: clamp(1.45rem, 2vw, 2.1rem);
   font-weight: 800;
+  letter-spacing: -0.03em;
   line-height: 1;
 }
 
 .advisor-summary__max {
-  font-size: 0.65rem;
+  font-size: 0.72rem;
   font-weight: 600;
-  opacity: 0.7;
+  /* Weight and size carry the demotion; opacity would drop the pair below AA. */
+  color: var(--bootui-text-muted);
 }
 
-.advisor-summary__eyebrow {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+/* Sentence-case metric label, not an uppercase tracked eyebrow: the
+   Eyebrow-Containment Rule reserves that treatment for sidebar nav groups. */
+.advisor-summary__band-label {
   color: var(--bootui-text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
   margin-bottom: 0.35rem;
 }
 
@@ -132,24 +135,26 @@ const gaugeLabel = computed(() =>
 }
 
 .advisor-summary__metric dt {
-  font-size: 0.72rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
   color: var(--bootui-text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
   margin-bottom: 0.3rem;
 }
 
 .advisor-summary__metric dd {
-  font-size: 1.4rem;
+  font-family: var(--bs-font-monospace);
+  font-size: clamp(1.15rem, 2vw, 2.1rem);
   font-weight: 700;
+  letter-spacing: -0.03em;
   line-height: 1.1;
   color: var(--bootui-text);
   margin: 0;
 }
 
 .advisor-summary__metric--status dd {
+  font-family: inherit;
   font-size: 1rem;
+  letter-spacing: normal;
 }
 
 .advisor-summary__hint {

--- a/bootui-ui/src/main/frontend/src/views/components/AiSetupChecklist.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/AiSetupChecklist.vue
@@ -121,7 +121,7 @@ const otlpEndpoint = computed(() => getBootUiApiPath() + '/otlp/v1/traces')
   <div v-if="!frameworkDetected">
     <div class="d-flex align-items-center gap-2 mb-2">
       <i class="bi bi-stars text-warning"></i>
-      <h6 class="mb-0">{{ isQuarkus ? 'Set up AI instrumentation' : 'Choose a framework to instrument' }}</h6>
+      <h3 class="fs-6 mb-0">{{ isQuarkus ? 'Set up AI instrumentation' : 'Choose a framework to instrument' }}</h3>
     </div>
     <template v-if="isQuarkus">
       <p class="text-muted small">

--- a/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/CommandPalette.vue
@@ -376,11 +376,11 @@ defineExpose({focusInput})
   font-weight: 600;
 }
 
+/* Per-result metadata, not a group header: the uppercase tracked treatment is
+   reserved for the nav-group headers themselves (.cp-section-label below). */
 .cp-item-group {
   color: var(--bootui-text-muted, #56667b);
   font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
 }
 
 .cp-item-num {

--- a/bootui-ui/src/main/frontend/src/views/components/HealthNode.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/HealthNode.test.js
@@ -1,0 +1,52 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it} from 'vitest'
+
+import HealthNode from './HealthNode.vue'
+
+const nestedTree = {
+  name: 'application',
+  status: 'UP',
+  details: {},
+  components: [
+    {
+      name: 'db',
+      status: 'UP',
+      details: {database: 'PostgreSQL'},
+      components: [{name: 'primary', status: 'UP', details: {validationQuery: 'isValid()'}, components: []}]
+    }
+  ]
+}
+
+describe('HealthNode', () => {
+  // The component renders itself for every child, so using `.card` as its root
+  // would nest a card inside a card at every depth of the health tree.
+  it('never renders a card, so recursion cannot nest cards', () => {
+    const wrapper = mount(HealthNode, {props: {node: nestedTree}})
+
+    expect(wrapper.findAll('.card')).toHaveLength(0)
+    expect(wrapper.findAll('.health-node').length).toBeGreaterThan(2)
+  })
+
+  it('labels the detail and component groups in sentence case', () => {
+    const wrapper = mount(HealthNode, {props: {node: nestedTree}})
+    const labels = wrapper.findAll('.health-node__section-label').map((label) => label.text())
+
+    expect(labels).toContain('Details')
+    expect(labels).toContain('Components')
+    expect(wrapper.html()).not.toContain('text-uppercase')
+  })
+
+  it('renders contributor names in the monospace stack', () => {
+    const wrapper = mount(HealthNode, {props: {node: nestedTree}})
+    const names = wrapper.findAll('.health-node__name').map((name) => name.text())
+
+    expect(names).toEqual(['application', 'db', 'primary'])
+  })
+
+  it('tints nested contributors so depth stays readable', () => {
+    const wrapper = mount(HealthNode, {props: {node: nestedTree}})
+
+    expect(wrapper.find('.health-node').classes()).not.toContain('health-node--nested')
+    expect(wrapper.findAll('.health-node--nested').length).toBe(2)
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/components/HealthNode.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/HealthNode.vue
@@ -45,11 +45,11 @@ const hasDetails = (node) => detailCount(node) > 0
 </script>
 
 <template>
-  <details :open="depth < 2 || node.status !== 'UP'" class="card mb-2">
-    <summary class="card-header d-flex justify-content-between align-items-center gap-2">
-      <span class="d-flex align-items-center gap-2">
+  <details :open="depth < 2 || node.status !== 'UP'" :class="['health-node', {'health-node--nested': depth > 0}]">
+    <summary class="health-node__summary">
+      <span class="d-flex align-items-center gap-2 flex-wrap">
         <i :class="statusIcon(node.status)" class="bi"></i>
-        <strong>{{ node.name }}</strong>
+        <strong class="health-node__name">{{ node.name }}</strong>
         <span v-if="childCount(node)" class="text-muted small">
           {{ childCount(node) }} {{ childCount(node) === 1 ? 'component' : 'components' }}
         </span>
@@ -60,16 +60,67 @@ const hasDetails = (node) => detailCount(node) > 0
       <span :class="statusClass(node.status)" class="badge">{{ node.status }}</span>
     </summary>
 
-    <div v-if="childCount(node) || hasDetails(node)" class="card-body">
+    <div v-if="childCount(node) || hasDetails(node)" class="health-node__body">
       <section v-if="hasDetails(node)" class="mb-3">
-        <h6 class="text-muted text-uppercase small mb-2">Details</h6>
+        <p class="health-node__section-label">Details</p>
         <HealthDetails :value="node.details" />
       </section>
 
       <section v-if="childCount(node)">
-        <h6 v-if="hasDetails(node)" class="text-muted text-uppercase small mb-2">Components</h6>
+        <p v-if="hasDetails(node)" class="health-node__section-label">Components</p>
         <HealthNode v-for="c in node.components" :key="c.name" :depth="depth + 1" :node="c" />
       </section>
     </div>
   </details>
 </template>
+
+<style scoped>
+/* The tree is recursive, so this disclosure must never be a `.card` — that would
+   nest a card inside a card at every depth. A hairline-bordered disclosure row
+   carries the same separation without the stacked chrome. */
+.health-node {
+  background: var(--bootui-surface);
+  border: 1px solid var(--bootui-border);
+  border-radius: var(--bootui-radius-md);
+  margin-bottom: 0.5rem;
+}
+
+.health-node--nested {
+  background: var(--bootui-surface-alt);
+}
+
+.health-node:last-child {
+  margin-bottom: 0;
+}
+
+.health-node__summary {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0.6rem 0.85rem;
+}
+
+.health-node__summary:focus-visible {
+  outline: 2px solid var(--bootui-blue);
+  outline-offset: -2px;
+}
+
+/* Contributor names come from the health backend, so they read as machine data. */
+.health-node__name {
+  font-family: var(--bs-font-monospace);
+}
+
+.health-node__body {
+  border-top: 1px solid var(--bootui-border);
+  padding: 0.85rem;
+}
+
+.health-node__section-label {
+  color: var(--bootui-text-muted);
+  font-size: 0.85rem;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+</style>

--- a/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/PanelHeader.vue
@@ -140,7 +140,19 @@ onBeforeUnmount(stopRelativeTimer)
   align-items: center;
   display: flex;
   flex-shrink: 0;
+  flex-wrap: wrap;
   gap: 0.5rem;
+}
+
+/* Below the drawer breakpoint the action cluster can exceed the viewport, so it
+   stops being an unshrinkable row and wraps under the title instead of pushing a
+   horizontal scrollbar onto the workspace. */
+@media (max-width: 575.98px) {
+  .panel-header__actions {
+    flex-shrink: 1;
+    min-width: 0;
+    width: 100%;
+  }
 }
 
 .last-fetched-text {

--- a/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
@@ -125,16 +125,16 @@ function onRun() {
 
 <style scoped>
 .scanner-card {
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 1.1rem;
-  box-shadow: 0 0.75rem 2rem rgba(15, 23, 42, 0.06);
+  border: 1px solid var(--bootui-border);
+  border-radius: var(--bootui-radius-lg);
+  box-shadow: var(--bootui-shadow-sm);
   transition:
     transform 160ms ease,
     box-shadow 160ms ease;
 }
 
 .scanner-card:hover {
-  box-shadow: 0 1rem 2.4rem rgba(15, 23, 42, 0.12);
+  box-shadow: var(--bootui-shadow-md);
   transform: translateY(-2px);
 }
 
@@ -151,7 +151,7 @@ function onRun() {
 
 .scanner-icon--primary {
   background: rgba(13, 110, 253, 0.12);
-  color: #0d6efd;
+  color: var(--bootui-blue);
 }
 
 .scanner-icon--danger {
@@ -171,11 +171,11 @@ function onRun() {
 
 .scanner-icon--success {
   background: rgba(25, 135, 84, 0.12);
-  color: #198754;
+  color: var(--bootui-green);
 }
 
 .scanner-status {
-  font-size: 0.66rem;
+  font-size: 0.72rem;
   font-weight: 700;
 }
 
@@ -186,7 +186,7 @@ function onRun() {
 }
 
 .scanner-score--success {
-  color: #198754;
+  color: var(--bootui-green);
 }
 
 .scanner-score--warning {
@@ -203,5 +203,17 @@ function onRun() {
 
 .min-w-0 {
   min-width: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scanner-card {
+    transition: none;
+  }
+
+  .scanner-card:hover,
+  .scanner-card:focus-visible,
+  .scanner-card:focus-within {
+    transform: none;
+  }
 }
 </style>


### PR DESCRIPTION
## What does this PR do?

Polishes all 54 BootUI panel routes against the existing "Calm Control Room" design system without changing API behavior, panel availability, or safety boundaries.

The pass fixes shared causes first, including Spring-green primary actions, responsive panel headers and tables, consistent machine-output styling, first-load advisor skeletons, semantic heading structure, and a non-nested health tree. It then removes panel-specific visual drift such as content eyebrows, stock Bootstrap styling, inconsistent empty states, missing reduced-motion handling, weak focus treatment, and mobile overflow.

## Why is this change needed?

BootUI's panels had evolved unevenly: mature surfaces followed the documented visual system, while others retained stock Bootstrap colors, inconsistent loading and empty states, inaccessible hierarchy, or responsive defects. A systematic pass makes the console feel coherent and trustworthy across every panel while preserving the existing product behavior.

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Additional validation: 849 Vitest tests passed, the frontend production build succeeded, formatting checks passed for the frontend and both E2E projects, the Spring MVC Playwright suite passed with 157 tests and 6 skips, and the Impeccable detector reported no findings.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed