### PR TITLE
Fix cgroup detection on non-Linux hosts

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/ContainerMemoryLimitDetector.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/ContainerMemoryLimitDetector.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -168,6 +169,9 @@ final class ContainerMemoryLimitDetector {
 
     private static List<CgroupMemoryFiles> resolveProcessCgroupFiles(Path selfCgroupFile, Path selfMountinfoFile) {
         List<CgroupMemoryFiles> files = new ArrayList<>();
+        if (!Files.isRegularFile(selfCgroupFile) || !Files.isRegularFile(selfMountinfoFile)) {
+            return List.of();
+        }
         try {
             List<String> cgroupLines = Files.readAllLines(selfCgroupFile);
             List<CgroupMount> mounts = parseMounts(Files.readAllLines(selfMountinfoFile));
@@ -192,6 +196,8 @@ final class ContainerMemoryLimitDetector {
                     }
                 }
             }
+        } catch (NoSuchFileException ex) {
+            return List.of();
         } catch (IOException ex) {
             log.log(Level.DEBUG, "Could not resolve the process cgroup memory paths", ex);
         }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCollectorTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCollectorTests.java
@@ -139,6 +139,14 @@ class MemoryCollectorTests {
     }
 
     @Test
+    void skipsCgroupDiscoveryWhenProcFilesAreUnavailable() {
+        ContainerMemoryLimitDetector detector = ContainerMemoryLimitDetector.fromProcFiles(
+                tempDir.resolve("missing-cgroup"), tempDir.resolve("missing-mountinfo"));
+
+        assertThat(detector.detect()).isEqualTo(ContainerMemoryLimitDetector.CgroupMemorySample.unavailable());
+    }
+
+    @Test
     void parsesTerabyteMemorySizesAcceptedByHotSpot() {
         assertThat(MemoryCollector.parseMemorySize("1t")).isEqualTo(1024L * 1024 * 1024 * 1024);
         assertThat(MemoryCollector.parseMemorySize("1T")).isEqualTo(1024L * 1024 * 1024 * 1024);


### PR DESCRIPTION
## What does this PR do?

Treats missing procfs cgroup files as an unsupported platform instead of logging an expected `NoSuchFileException` stack trace.

## Why is this change needed?

BootUI attempts Linux cgroup discovery when the memory advisor is initialized. On hosts such as macOS, `/proc/self/cgroup` and `/proc/self/mountinfo` do not exist, and the WebFlux sample's DEBUG logging exposes a noisy stack trace even though container memory data is optional and the exception is caught.

Closes #N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Focused `MemoryCollectorTests` pass, including a regression test for unavailable procfs files. Spotless formatting checks pass for the affected reactor.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

No documentation update is required because this restores the documented graceful handling of unavailable cgroup data.