### PR TITLE
Fix cross-platform release readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.14.0] - 2026-08-16
+## [1.14.0] - 2026-08-18
 
 Feature release headlined by three new database diagnostics — the **Database advisor**, **Transactions**, and
 **Hibernate Statistics** panels — plus Live Activity's animated **Live flow** service map and complete MCP access to
@@ -57,9 +57,14 @@ BootUI's safely exposable features.
 - **Panel documentation is now contract-checked.** Conformance tests keep backend manifests, feature headings, access
   properties, read endpoints, MCP tool lists, screenshot files, and screenshot embeds aligned with authoritative code
   catalogs (#797–#804).
-- **Build and release integrity is stricter.** CI adds focused coverage gates and deterministic OSV checks, while the
-  release workflow validates version transitions and immutable release commits/tags, publishes only the intended Maven
-  Central modules, and preserves resumable post-publication verification (#723, #731, #739, #741, #778).
+- **The complete console now follows one Calm Control Room visual system.** All 54 panel routes, the application shell,
+  and the new Hibernate Statistics surface have clearer hierarchy, responsive headers and tables, consistent loading and
+  empty states, accessible focus and heading treatment, reduced-motion support, and deliberate machine-output styling
+  without changing routes, APIs, availability, or safety boundaries (#812, #813, #816).
+- **Build and release integrity is stricter.** CI adds focused coverage gates and deterministic OSV checks, runs Spring
+  browser suites in parallel with the Java reactor, and removes warning-shaped build noise, while the release workflow
+  validates version transitions and immutable release commits/tags, publishes only the intended Maven Central modules,
+  and preserves resumable post-publication verification (#723, #731, #739, #741, #778, #811, #814).
 
 ### Fixed
 
@@ -84,6 +89,10 @@ BootUI's safely exposable features.
 - **Shared UI state is more resilient.** Data panels avoid stale-request races, platform-aware navigation recovers after
   manifest changes, keyboard behavior and chart contrast are improved, and responsive/reduced-motion layouts no longer
   hide or over-animate controls (#721, #722, #730, #735, #737).
+- **Expanded navigation stays inside the sidebar.** Sections remain in one vertically scrollable column instead of
+  wrapping into off-screen columns when the available height is exhausted (#815).
+- **Non-Linux hosts no longer log an expected cgroup discovery stack trace.** Missing procfs cgroup files are treated as
+  unavailable optional container-memory data (#817).
 - **Dev Services classification is consistent across Spring and Quarkus**, including datasource and messaging service
   type inference (#772).
 

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -789,6 +789,7 @@ class OsvVulnerabilityScannerTests {
             resultsArray.append("]");
             byte[] body = ("{\"results\":" + resultsArray + "}").getBytes(StandardCharsets.UTF_8);
             exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.getResponseHeaders().add("Connection", "close");
             exchange.sendResponseHeaders(200, body.length);
             exchange.getResponseBody().write(body);
             exchange.close();
@@ -825,6 +826,8 @@ class OsvVulnerabilityScannerTests {
         String firstResults = "{\"results\":[" + "{},".repeat(999) + "{}]}";
         server.createContext("/v1/querybatch", exchange -> {
             int call = calls.incrementAndGet();
+            // Avoid the JDK test server intermittently corrupting a reused connection between chunks.
+            exchange.getResponseHeaders().add("Connection", "close");
             if (call == 1) {
                 byte[] body = firstResults.getBytes(StandardCharsets.UTF_8);
                 exchange.sendResponseHeaders(200, body.length);


### PR DESCRIPTION
## What does this PR do?

Makes the Spring OSV chunking fixture deterministic across operating systems and completes the 1.14.0 changelog for changes merged after the initial release-note preparation.

## Why is this change needed?

The Windows cross-platform build intermittently failed because the JDK test HTTP server reused a keep-alive connection between back-to-back OSV chunk requests and could abort the second exchange. The fixture now requests a fresh connection for each chunk, matching the existing Quarkus test workaround. The changelog date and entries now cover merged work through #817.

Closes #

N/A

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

The two OSV chunking tests passed in 10 consecutive runs. Spotless checks and the release-profile reactor also pass.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed