### PR TITLE
Fix Docker profile activity test

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/activity.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/activity.spec.js
@@ -217,10 +217,13 @@ test.describe('Live Activity view', () => {
     await expect(map.locator('.flow-node--app')).toBeVisible()
     await expect(map).toContainText('contacts nothing and probes nothing')
 
-    // The configured H2 datasource is drawn as a dependency of this application.
+    // The configured datasource is drawn as a dependency in both the dev (H2) and Docker (PostgreSQL) profiles.
     const database = map.locator('.flow-node--jdbc').first()
     await expect(database).toBeVisible()
-    await expect(database).toHaveAttribute('aria-label', /jdbc:h2:mem:bootui_sample/)
+    await expect(database).toHaveAttribute(
+      'aria-label',
+      /jdbc:(?:h2:mem:bootui_sample|postgresql:\/\/[^/]+\/bootui_sample)/
+    )
 
     // Selecting it opens the evidence detail with a deep link back to the source panel.
     await database.click()


### PR DESCRIPTION
## What does this PR do?

Allows the Live Activity datasource assertion to match the sample application's H2 development datasource or PostgreSQL Docker-profile datasource.

## Why is this change needed?

The Docker image publishing workflow runs the shared Spring MVC Playwright suite with the `docker` profile. The service map correctly reports PostgreSQL in that profile, but the test hard-coded the development-only H2 URL, blocking all image build and publish jobs.

Failed run: https://github.com/jdubois/boot-ui/actions/runs/32143967105

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected Spring MVC sample app with the Docker profile
- [x] Ran the focused Playwright test against the Docker profile
- [x] Updated the existing test expectation

## Screenshots (UI changes)

N/A — test-only change.

## Checklist

- [x] Documentation update not required because behavior is unchanged
- [x] Public API remains backward compatible
- [x] No secrets, tokens, or local paths committed
