### PR TITLE
Fix flaky MCP capacity release test

### DIFF
--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/mcp/McpDispatcherTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/mcp/McpDispatcherTests.java
@@ -451,7 +451,18 @@ class McpDispatcherTests {
         interruptedCaller.join(5_000);
         assertThat(finished.await(5, TimeUnit.SECONDS)).isTrue();
 
-        assertThat(dispatcher.dispatch(call("slow"))).isInstanceOf(ToolCallResult.class);
+        McpDispatchOutcome capacityError =
+                new ProtocolError(McpProtocol.SERVER_AT_CAPACITY, McpProtocol.RATE_LIMITED_MESSAGE);
+        McpDispatchOutcome retry;
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        do {
+            retry = dispatcher.dispatch(call("slow"));
+            if (retry.equals(capacityError)) {
+                Thread.sleep(1);
+            }
+        } while (retry.equals(capacityError) && System.nanoTime() < deadline);
+
+        assertThat(retry).isInstanceOf(ToolCallResult.class);
         assertThat(dispatcher.runtimeStats().snapshot().callCount()).isEqualTo(2);
     }
 


### PR DESCRIPTION
## Summary

- retry the interrupted MCP dispatch only while the expected capacity response is observable
- preserve the production concurrency limit while waiting for the worker's outer cleanup to release its permit
- remove the timing assumption exposed by JDK 25

## Validation

- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-engine -Dtest=McpDispatcherTests spotless:check test`