### PR TITLE
Restructure implementation roadmap

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -5,11 +5,8 @@
 BootUI adds a safe, local-only developer console to a running application, shipping on **Spring Boot 4 (servlet and
 WebFlux starters) and Quarkus (an extension)** from one shared, framework-neutral engine that serves the same Vue UI and
 the same `/bootui/api/**` contract on every runtime. The released surface covers 54 panels across runtime introspection,
-configuration, database migrations, services, diagnostics, project health, and developer tooling. The previous merged
-workstream — Live Activity correlation and event capture, the Beans dependency graph, the Email panel, the
-**Transactions** panel, and the **Database** panel — is complete. The next planned panel is a read-only
-**MongoDB** operational view, scoped in §3.5. The **Local Service Map** (§3.6) has shipped — not as a panel of its own,
-but as the **Live flow** mode of the existing Live Activity panel, on all three runtimes.
+configuration, database migrations, services, diagnostics, project health, and developer tooling. The next planned panel
+is a read-only **MongoDB** operational view, scoped in §3.5.
 
 The priorities for every item below remain unchanged:
 
@@ -18,57 +15,6 @@ The priorities for every item below remain unchanged:
 3. Useful runtime explanations.
 4. A polished but simple UI.
 5. Testable architecture.
-
-### Completed for 1.0.0
-
-- Promoted the current grouped sidebar surface to the stable `1.0.0` release line.
-- Added the Security Advisor panel, `/bootui/api/security` API, panel availability/read-only wiring, tests, feature
-  documentation, rule catalogue, and screenshot.
-- Redesigned Overview into an on-demand security & health scoring dashboard that aggregates the available scanner panels.
-- Added token-first activity charts to the Copilot and Claude Code dashboards and refreshed their screenshots.
-- Published the VuePress documentation site with GitHub Pages deployment, setup/sample-app pages, and fixed markdown links.
-- Fixed Spring Modulith Flyway reporting and proxied Hikari datasource discovery so the existing Database panels better
-  match real applications.
-
-### Completed in this workstream
-
-- Shipped §3.1 (Trace ↔ Log ↔ Request correlation) as the **Live Activity** panel: a single reverse-chronological stream
-  that merges requests, SQL, exceptions, and security events from BootUI's existing in-memory buffers, nests correlated
-  signals under the request that produced them, and adds a per-request profiler that joins each request's signals by
-  trace id, serving thread, and time window. It refreshes over a `/bootui/api/activity/stream` Server-Sent Events feed,
-  carries a KPI strip, and deep-links into the HTTP Exchanges, SQL Trace, Exceptions, Health, and Heap Dump panels. The
-  panel is read-only and reuses the existing masking, value-exposure, and panel-toggle model.
-- Shipped §3.3 (E-mail Viewer) as the **Email** panel: a `JavaMailSender` `BeanPostProcessor` captures every outgoing
-  message pass-through by default (with an explicitly opt-in `bootui.email.dev-trap` mode), reveals recipients/subject/body
-  by default — decoupled from the global value-exposure model, with an explicitly opt-in `bootui.email.mask-content`
-  flag for teams that want the old masked-by-default behavior — renders HTML previews sandboxed, and offers a
-  per-message `.eml` download. Captured mail also feeds the Live Activity stream as a `MAIL` entry type.
-- Shipped all five §3.4 Live Activity event-type extensions, bringing the stream to nine merged entry types —
-  `REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `CACHE`, `SCHEDULED`, `MESSAGING`, `MAIL`, and `REST_CLIENT`: Cache
-  operations, Scheduled Task runs, messaging (Kafka and RabbitMQ on both adapters; JMS on Spring), Mail (backed by the
-  Email panel above), and outbound REST client capture on Spring servlet, Spring WebFlux, and Quarkus. Each keeps
-  pass-through-by-default capture, nests under
-  the originating request as a child event when a shared trace id/serving thread/time window is available, and reuses
-  the same masking, bounded-buffer, and panel-toggle model as the original four entry types.
-- Shipped a new **Transactions** panel (Database group): a bounded in-memory `TransactionRecorder` engine service
-  captures every `@Transactional` boundary's method, propagation, isolation, status, duration, and parent/child
-  nesting, following the same ring-buffer/aggregate-stats/pause/clear conventions as SQL Trace. Capture is wired via
-  Spring Framework's `TransactionExecutionListener` SPI against every `ConfigurableTransactionManager` bean (Spring
-  servlet and WebFlux), and correlates each transaction to its SQL statement/connection counts by reusing SQL Trace's
-  existing thread/time-window correlation rather than duplicating it. Quarkus reports the panel honestly unavailable —
-  see `docs/QUARKUS-SUPPORT.md` §5.5.
-
-- Shipped §3.6 (Local Service Map) as Live Activity's **Live flow** mode rather than a separate panel: a
-  `GET /bootui/api/activity/service-map` contract on Spring MVC, Spring WebFlux, and Quarkus that assembles a read-only
-  topology from evidence BootUI already retains — inbound HTTP exchanges folded into one generic local-client lane, and
-  outbound dependencies grouped by safe identity (HTTP origin, configured JDBC pool, produced Kafka topic, published
-  RabbitMQ destination). Assembly, identity normalization, configured-versus-observed state, conservative SQL
-  attribution, and hard cardinality bounds live in a framework-neutral `ServiceMapAssembler`; the adapters only gather
-  beans they already own. The native SVG/Vue map reuses the Beans graph's layout, keyboard, zoom, and hidden-textual-list
-  patterns, and animates a short particle only when a stable edge gains a newly completed interaction after an SSE
-  refresh — never on first load, never for a new dependency, never perpetually — with reduced motion replaced by a brief
-  static edge highlight plus a polite live-region update. Two long-standing Quarkus SSE source-subscription gaps (SQL
-  trace and the exception store) were closed in the same change, since the map refreshes off that same tick.
 
 Each new panel must:
 
@@ -82,324 +28,27 @@ Each new panel must:
 
 ## 2. Roadmap status and next workstream
 
-The previous workstream is complete. The §3.1 correlation item has shipped as the **Live Activity** panel; the §3.3 e-mail
-viewer has shipped too, both as a standalone panel and as a `MAIL` entry type feeding the Live Activity stream; and all
-five §3.4 event-type extensions (Scheduled Task runs, Cache operations, messaging, Mail, and REST call capture) have
-shipped. The bean/dependency graph visualization (§3.2) has now also shipped as the **graph mode** of the existing Beans
-panel.
-
-The current cross-platform baseline is 53 shared routes. Spring Boot serves the full applicable surface. Quarkus serves
-43 panels; nine Spring-specific panels (including Transactions, see below) are intentionally not applicable there, and
-JMS is the only panel still awaiting a Quarkus-native implementation. `docs/QUARKUS-SUPPORT.md` remains authoritative
-for per-panel Quarkus fidelity and availability.
-
-The Local Service Map (§3.6) has since shipped as Live Activity's **Live flow** mode on all three runtimes, reusing the
-Live Activity panel id, route, and availability rather than adding a route, so the cross-platform baseline stays at 52
-shared routes.
-
 MongoDB is the next bounded feature workstream. BootUI already recognizes Spring Data MongoDB repositories in the
 Spring Data panel, but it has no framework-neutral operational view of MongoDB clients, topology, databases,
 collections, or indexes, and the existing JDBC/Flyway/Liquibase panels cannot represent those concepts. The new panel
 will therefore be additive rather than an extension of the SQL-specific panels.
 
-| Priority | Feature                               | Group         | Primary data source                                      | Mutation?         | Status  |
-| -------- | ------------------------------------- | ------------- | -------------------------------------------------------- | ----------------- | ------- |
-| Next     | MongoDB operational view              | Database      | Spring/Quarkus MongoDB client adapters                   | No                | Planned |
-| Done     | Local Service Map (Live flow mode)    | Diagnostics   | Existing HTTP, JDBC, Kafka, and RabbitMQ evidence        | No                | Shipped |
-| Done     | Trace ↔ Log ↔ Request correlation     | Diagnostics   | Existing Traces, Log Tail, and HTTP Exchanges data       | No                | Shipped |
-| Done     | Bean / dependency graph visualization | Configuration | Existing Beans and Conditions data                       | No                | Shipped |
-| Done     | E-mail Viewer                         | Services      | Spring Mail / Quarkus Mailer capture adapters            | No (capture only) | Shipped |
-| Done     | Live Activity — REST call capture     | Diagnostics   | Spring HTTP clients / Quarkus MicroProfile REST clients  | No (capture only) | Shipped |
-| Done     | Live Activity — new event types       | Diagnostics   | Cache, scheduled-task, messaging, mail, and REST capture | No (capture only) | Shipped |
-| Done     | Transactions                          | Database      | Spring `TransactionExecutionListener` capture (Spring-only) | Yes (clear/pause) | Shipped |
-
-Beyond the MongoDB workstream, §3.7 records an unscheduled backlog of candidate panels and panel improvements drawn from
-a survey of the most popular Spring Boot starters. Those candidates are ideas, not commitments: each needs its own scoped
-specification before it enters this table.
-
-The Trace ↔ Log ↔ Request correlation work in §3.1 has shipped as the **Live Activity** panel, building on the
-already-shipped HTTP Exchanges panel and the existing Traces and Log Tail panels. The E-mail Viewer (§3.3) has shipped as
-the **Email** panel (Services group): a `JavaMailSender` `BeanPostProcessor` captures every outgoing message
-pass-through by default, with an explicitly opt-in `bootui.email.dev-trap` mode, recipients/subject/body revealed by
-default (opt-in `bootui.email.mask-content`), a sandboxed HTML preview, and a per-message `.eml` download. All five of
-the §3.4 Live Activity event-type extensions have
-now shipped — Scheduled Task runs, Cache operations, messaging (Kafka and RabbitMQ on both adapters; JMS on Spring), an E-mail Viewer-backed `MAIL` event type, and
-outbound `RestClient`/`RestTemplate`/`WebClient` capture. The bean/dependency graph visualization (§3.2) has shipped as a
-graph mode in the existing Beans panel, completing this workstream. Each capture-oriented feature keeps pass-through
-application behaviour by default
-and makes any dev-trap mode explicitly opt-in.
-
-The **Transactions** panel (Database group) has also shipped: a bounded in-memory `TransactionRecorder`, following the
-same ring-buffer/aggregate-stats/pause/clear conventions as SQL Trace, captures every `@Transactional` boundary's
-method, propagation, isolation, status, duration, and parent/child nesting via Spring Framework's
-`TransactionExecutionListener` SPI, contributed through Spring Boot's standard transaction-manager customization and
-completed for user-defined configurable managers after singleton initialization, without replacing or wrapping the
-application's own transaction management. Completed transactions are correlated to their SQL statement and
-connection counts by reusing SQL Trace's existing thread/time-window correlation logic rather than duplicating it. The
-panel is Spring-only (both servlet and WebFlux, the latter observing any blocking `PlatformTransactionManager` a
-reactive application still uses); Quarkus has no comparable per-boundary listener hook on Narayana JTA or the CDI
-`@Transactional` interceptor without much more invasive instrumentation, so it honestly reports unavailable there
-rather than forcing false parity (see `docs/QUARKUS-SUPPORT.md` §5.5).
+| Priority | Feature                  | Group    | Primary data source                    | Mutation? | Status  |
+| -------- | ------------------------ | -------- | -------------------------------------- | --------- | ------- |
+| Next     | MongoDB operational view | Database | Spring/Quarkus MongoDB client adapters | No        | Planned |
+| Planned  | Declarative HTTP client registry | Services | Spring HTTP clients / Quarkus REST Client metadata | No | Planned |
+| Planned  | Resilience | Services | Resilience4j, Spring Retry, and SmallRye Fault Tolerance | No (capture only) | Planned |
+| Planned  | gRPC | Services | Spring gRPC / Quarkus gRPC registries and metrics | No | Planned |
+| Planned  | Spring Batch | Services | Spring Batch `JobExplorer` / `JobRepository` | No | Planned |
+| Planned  | WebSocket endpoints | Services | Spring WebSocket/STOMP / Quarkus WebSockets Next | No (capture only) | Planned |
+| Planned  | Error-contract catalogue | Services | Spring exception handlers / Quarkus exception mappers | No | Planned |
+| Planned  | Slow-SQL ranking and URI attribution | Database | Existing SQL Trace and HTTP exchange evidence | No | Planned |
+| Planned  | Copy as cURL | Diagnostics | Existing HTTP Exchanges metadata | No | Planned |
+| Planned  | Correlation-ID filtering | Diagnostics | Existing request and Live Activity capture | No (capture only) | Planned |
+| Planned  | Meter provenance and explanation | Diagnostics | Existing meter registry and curated catalogue | No | Planned |
+| Planned  | Cache tiering and hit ratios | Services | Existing cache managers and native statistics | No | Planned |
 
 ## 3. Feature specifications
-
-### 3.1 Trace ↔ Log ↔ Request correlation — Diagnostics ✅ Completed
-
-**Status: completed.** Shipped as the **Live Activity** panel (see `docs/FEATURES.md` → *Live Activity*), which merges
-requests, SQL, exceptions, and security events into one reverse-chronological stream with request-scoped nesting, a
-per-request profiler that correlates each request's signals by trace id / serving thread / time window, an SSE feed at
-`/bootui/api/activity/stream`, and deep links back into the HTTP Exchanges, SQL Trace, and Exceptions panels. The original
-scope and design constraints below are retained for reference.
-
-This is where Aspire and Symfony differentiate. BootUI already owns a trace pipeline (the in-app OTLP sink and Traces
-panel) plus Log Tail, and the HTTP Exchanges panel; the three can be cross-linked by trace and span id.
-
-Scope:
-
-- Where a trace/span id is present, cross-link related items between the Traces, Log Tail, and HTTP Exchanges panels so a
-  user can pivot from a span to its log lines and originating request, and back.
-- Add a "view related" affordance on each side that filters the other panels to the shared trace id.
-- Degrade gracefully: when no trace context is present on a log line, exchange, or span, simply omit the correlation
-  affordance rather than guessing.
-
-Design constraints:
-
-- Read-only and purely client-side/data-join: this feature adds correlation over data the panels already expose; it does
-  not introduce a new capture source.
-- Correlation must not weaken masking; linked views reuse each panel's existing value-exposure rules.
-- Trace propagation is best-effort. Correlation is presented as a convenience, not a guarantee, and must work for the
-  common case where Micrometer Tracing/OTLP is active without breaking when it is not.
-
-### 3.2 Bean / dependency graph visualization — Configuration ✅ Completed
-
-**Status: completed.** Shipped as the **graph mode** of the existing Beans panel (see `docs/FEATURES.md` → *Beans*). The
-original scope and design constraints below are retained for reference.
-
-Layers an Aspire-style relationship view on top of data BootUI already has from the Beans and Conditions panels, without a
-new data source.
-
-Scope:
-
-- Visualize beans and their dependencies as a navigable graph, with the ability to focus on a selected bean and see its
-  direct dependencies and dependents.
-- Reuse the existing BootUI bean classification and Conditions data so users can see why a bean exists and how it is
-  wired.
-- Provide search/focus and bounded rendering so large application contexts stay responsive, consistent with the existing
-  large-app rendering hardening.
-
-Design constraints:
-
-- Read-only.
-- Built entirely from existing Beans/Conditions DTOs; no new endpoint capture beyond what those panels already provide.
-- Bound the rendered graph (focus + neighborhood, not the full context at once) to keep the frontend bundle and runtime
-  performance within the project's large-app budget.
-- Avoid heavy graph libraries where a lightweight approach is sufficient, in line with the bundle-size risk in §5.
-
-### 3.3 E-mail Viewer — Services ✅ Completed
-
-**Status: completed.** Shipped as the **Email** panel (see `docs/FEATURES.md` → *Email*). The original scope and
-design constraints below are retained for reference.
-
-Captured outgoing mail (HTML preview plus raw source) is a high-value dev-loop aid with no built-in Spring equivalent.
-
-Scope:
-
-- Intercept the application's `JavaMailSender` so every `send(...)` is recorded into a bounded ring buffer **before
-  delegating to the real sender** — pass-through by default, so application behaviour is unchanged.
-- Capture parsed `from`/`to`/`cc`/`subject`, HTML and text parts, and attachment metadata (name/size/type, not contents).
-- List captured messages newest-first (bounded), with a detail view rendering the HTML part in a sandboxed frame, the
-  text alternative, headers, and attachment metadata; plus per-message `.eml` download.
-- An optional, explicitly opt-in **"dev trap" mode** records without actually sending (like MailDev/GreenMail), off by
-  default so BootUI never silently swallows mail.
-
-Design constraints:
-
-- Available only when a `JavaMailSender` bean is present (e.g. `spring-boot-starter-mail`); otherwise fail closed.
-- Recipients, subjects, and bodies are revealed by default, like BootUI's other
-  data-capture panels (HTTP Exchanges, SQL Trace) — email content is not a config secret, so masking is decoupled from
-  the global value-exposure model. An opt-in `bootui.email.mask-content` flag applies the same name-based
-  `SecretMasker` heuristic for teams routing real customer PII through a shared dev environment. HTML is rendered
-  sandboxed to prevent script execution.
-- Fixed-size buffer; no persistence to disk beyond on-demand `.eml` download.
-
-### 3.4 Live Activity — event types and correlation — Diagnostics ✅ Completed
-
-**Status: completed.** All five event-type extensions below have shipped. Live Activity now merges nine entry types —
-`REQUEST`, `SQL`, `EXCEPTION`, `SECURITY`, `CACHE`, `SCHEDULED`, `MESSAGING`, `MAIL`, and `REST_CLIENT` — from
-BootUI's existing in-memory buffers (see `docs/SPECIFICATION.md` §5.14.2). The original scope, prioritized by value
-versus new-instrumentation cost and drawn from the same comparable-dashboard benchmarks (Laravel Telescope, Symfony Web
-Profiler, .NET Aspire) already guiding this workstream, is retained below for reference.
-
-Scope — new event types, roughly in priority order:
-
-- **Scheduled Task runs — implemented on both adapters.** Each `@Scheduled` method *execution* (start/success/failure,
-  duration, exception if any) is captured as a `SCHEDULED` entry, reusing the existing Scheduled Tasks panel's
-  discovery/naming so a captured run and its static definition share the same identifier. On Spring, the framework's own
-  Micrometer instrumentation (`ScheduledTaskObservationContext`, present since Spring Framework 6.1) is tapped via a
-  `SchedulingConfigurer` bean that installs an `ObservationHandler` — no AOP proxying or bean wrapping needed — feeding a
-  bounded, framework-neutral `ScheduledTaskRunStore` in `bootui-engine`. **On Quarkus**, the scheduler
-  (`io.quarkus.scheduler.Scheduler`) exposes only one CDI-bean-limited `JobInstrumenter` SPI, already claimed by
-  `quarkus-opentelemetry` when scheduler tracing is enabled, so registering a second one would create ambiguous CDI
-  resolution and break the app's own tracing. Instead, `QuarkusScheduledTaskRunRecorder` observes the ordinary CDI
-  `io.quarkus.scheduler.SuccessfulExecution`/`FailedExecution` events that `BaseScheduler` always fires after every
-  execution regardless of how many other observers exist — the same, documented mechanism Quarkus's own Dev UI scheduler
-  page uses — and feeds the same `ScheduledTaskRunStore`. Since these events fire only on completion, the trigger's
-  `getFireTime()` is used as a proxy for the run's start timestamp (a small margin of error from invoker-chain overhead,
-  acceptable for a duration display, not precise profiling); the method identifier comes from
-  `Trigger.getMethodDescription()` (`declaringClassName#methodName`, matching the static panel's own identifier), so a
-  programmatically registered job (no method description) is not captured, matching the Spring adapter's method-only
-  scope. The observer is gated on the `SCHEDULER` capability (R2: `quarkus-scheduler` is `provided`-scope, excluded from
-  bean discovery when the capability or a non-production launch mode is absent), matching the existing
-  `QuarkusSecurityEventCapture` pattern. No request parent (background thread); a correlated exception is both
-  summarized inline via `detail` (the run recorder observes the failure directly) and — when that same failure is
-  independently captured into the shared exception log buffer — nested as a full `EXCEPTION` child entry the same way
-  `REQUEST` does today, via a serving-thread + time-window join against the run's execution window (the same tiered
-  strategy the SQL/exception profiler already uses, minus the trace-id tier: a background job is not a distributed-trace
-  participant). The KPI strip's "Scheduled failures" tile and the
-  `REQUEST`/`SQL`/`EXCEPTION` deep-link pattern (into `/scheduled`, prefilling its filter with the runnable name) both
-  ship on both adapters.
-- **Cache operations. ✅ Shipped (Spring servlet and WebFlux adapters).** The Cache panel showed topology and aggregate
-  hit/miss counters only; a lightweight, bounded `CACHE` event (hit/miss/put/evict/clear, cache name, key hash — never
-  the raw key/value) now explains *why* those counters moved and nests as a `REQUEST` child, mirroring how `SQL` nests
-  today. Captured by decorating `CacheManager`/`Cache` beans (`CacheActivityCacheManagerBeanPostProcessor`), so both
-  annotation-driven (`@Cacheable`/`@CachePut`/`@CacheEvict`) and programmatic `CacheManager` access are covered; the
-  capture beans now live in the shared `BootUiEngineConfiguration` so both the servlet and WebFlux adapters wire them
-  identically. Correlation is trace-id-based: the servlet adapter also falls back to serving-thread tiering like `SQL`,
-  while WebFlux (which has no thread-per-request invariant) correlates purely via the OpenTelemetry-backed trace id
-  provider already used for its SQL/exception/security capture. Feeds a new `cacheHitRatioPercent` KPI tile deep-linked
-  to `/cache` on both adapters. Quarkus is out of scope for now — `quarkus-cache`'s built-in interceptors cast the
-  resolved cache to an internal, non-public `AbstractCache` type, so a Spring-style decorator implementing only the
-  public `Cache` interface would fail with a `ClassCastException`; there is no comparable runtime interception seam, so
-  the Quarkus adapter continues to report `cacheHitRatioPercent: null` (see `docs/QUARKUS-SUPPORT.md`).
-- **Messaging (Kafka/RabbitMQ/JMS) publish and consume — shipped.** The highest-value new-instrumentation
-  candidate after mail and
-  REST calls: async messaging is exactly where a Telescope/Aspire-style console helps most, since message flow is
-  otherwise invisible outside the debugger. As scoped below, this landed **Kafka-first**: a `KafkaActivityRecorder`
-  (framework-neutral, `bootui-engine`) is fed by `KafkaProducerCaptureBeanPostProcessor` /
-  `KafkaConsumerCaptureBeanPostProcessor` (`bootui-spring-autoconfigure`, `@ConditionalOnClass(KafkaTemplate)`), which
-  wrap application-owned `KafkaTemplate`/`@KafkaListener` container factory beans — composing with, not replacing, any
-  existing `ProducerListener`/`RecordInterceptor` — feeding both the standalone **Kafka** panel (Services group) and,
-  like Cache/Mail/REST Client, a `MESSAGING` entry into the merged Live Activity feed (topic, partition, offset, a hash
-  of the key, direction, success/failure, consumer group id, listener id, duration).
-  Message values/payloads are never captured (out of scope by design, sidestepping the payload-masking problem
-  entirely). Controlled by `bootui.kafka.*` (see `docs/PROPERTIES.md`). **Spring JMS has now shipped**:
-  `JmsProducerCaptureBeanPostProcessor` wraps every `JmsTemplate` bean via a
-  CGLIB proxy to intercept `send`/`convertAndSend` calls, and `JmsListenerCaptureBeanPostProcessor` wraps every
-  `AbstractJmsListenerContainerFactory` to intercept `createListenerContainer()` and wrap the returned container's
-  listener with a matching plain or session-aware capture adapter, preserving its original dispatch path. Both feed a
-  dedicated framework-neutral `JmsActivityRecorder` shared by Live Activity and a standalone **JMS** panel with
-  destination/message-ID/subscription/listener filters and a confirmation-gated clear action. Its independent bounded
-  buffer means JMS traffic cannot evict Kafka or RabbitMQ panel history; `bootui.jms.*` controls JMS without coupling any
-  transport's enablement, retention, hashing, counters, or clear behavior. Gated on both `JmsTemplate` and the Jakarta JMS
-  API, pass-through/fail-open, and not yet ported to Quarkus. The **Quarkus Kafka port (SmallRye Reactive Messaging) has
-  now shipped**, reusing the same
-  `KafkaActivityRecorder` and the same `bootui.kafka.*` keys/defaults: because Quarkus applications use SmallRye's
-  `@Incoming`/`@Outgoing` channel model rather than `spring-kafka`'s imperative templates, the capture point is
-  SmallRye's `OutgoingInterceptor`/`IncomingInterceptor` SPI, implemented by two `@ApplicationScoped` interceptors
-  (`QuarkusKafkaProducerCapture`/`QuarkusKafkaConsumerCapture`, `bootui-quarkus`) that read Kafka record metadata into
-  the shared recorder. They are the sole importers of the SmallRye messaging types, capability-gated on `Capability.KAFKA`
-  via an `ExcludedTypeBuildItem` exactly like Hibernate/Cache/Flyway/Liquibase (production-dark), a no-op for non-Kafka
-  (in-memory/RabbitMQ/JMS) channels, pass-through/fail-open, and set the lowest interceptor precedence so an
-  application's own channel interceptor always wins. `LiveActivityResource` merges the captured `MESSAGING` entries into
-  the feed adapter-side (top-level, no request correlation) via the shared `KafkaActivityEntries` mapping, so both
-  adapters render byte-identical entries. **RabbitMQ has also shipped on both
-  adapters** via a parallel `RabbitActivityRecorder` (`bootui-engine`) fed on Spring by
-  `RabbitProducerCaptureBeanPostProcessor` (`addBeforePublishPostProcessors` on every `RabbitTemplate` bean,
-  composing with any existing post-processors) and `RabbitConsumerCaptureBeanPostProcessor` (prepends a
-  `MethodInterceptor` to every `AbstractRabbitListenerContainerFactory`'s advice chain, composing with existing
-  advice, timing the `onMessage(Message)` invocation); on Quarkus it uses the same SmallRye
-  `OutgoingInterceptor`/`IncomingInterceptor` SPI as the Kafka capture
-  (`QuarkusRabbitProducerCapture`/`QuarkusRabbitConsumerCapture`), capability-gated on `IncomingRabbitMQMetadata`
-  class presence via a `registerRabbitCapture` deployment build-step (production-dark, R2), exactly like
-  Hibernate/Cache/Flyway. Both adapters use the same DTO for direction, routing metadata, success/failure, timing, and
-  (opt-in via `bootui.rabbitmq.capture-correlation-id=true`, default `false`) a hashed correlation ID; Quarkus leaves
-  producer exchange, consumer queue, and producer duration unavailable because SmallRye's callbacks do not expose them.
-  Neither adapter captures the message body, arbitrary headers, or raw exception messages. Both SmallRye capture pairs
-  are the sole importers of their connector-specific metadata types, are excluded from bean discovery when their
-  extension is absent, are pass-through/fail-open, and use the lowest interceptor precedence so an application's own
-  channel interceptor wins.
-  `LiveActivityResource` merges both recorders' `MESSAGING` entries into the feed adapter-side (top-level, no request
-  correlation), preserving the same wire shape across adapters. Kafka, RabbitMQ, and JMS are three unrelated client APIs,
-  so each keeps an adapter-specific interception seam, a framework-neutral recorder, and an independent bounded buffer.
-  Interception itself is more invasive than any existing capture source: it means wrapping the app's own messaging beans
-  (a `BeanPostProcessor`, mirroring the existing HTTP Exchanges repository wrapper) or registering interceptor/advice
-  hooks, so pass-through-by-default and fail-open wrapping are non-negotiable design constraints; message bodies are
-  never captured rather than entrusted to a generic masker (they are arbitrary, potentially large application payloads,
-  unlike a SQL statement or HTTP header). On Quarkus, the interception point was different in kind, not just in wiring:
-  Quarkus applications typically use SmallRye Reactive Messaging (`@Incoming`/`@Outgoing` channels) rather than Spring's imperative
-  `spring-kafka`/`spring-rabbit` templates, so the Quarkus capture is a per-adapter interceptor pair rather than the
-  thinner Cache/Flyway provider seams — closer to the Beans panel's `BeanProvider` split (CDI vs. Spring bean
-  introspection) in spirit, though the shared, framework-neutral recorders and entry mappings keep the engine seam intact.
-  The panel-registration plumbing itself (an unconditional recorder `@Produces` bean
-  plus the capability-gated interceptor beans) follows the existing optional-dependency template with a single
-  build step per optional connector, which also lights up the standalone Kafka and RabbitMQ panels on both adapters.
-- **Captured email — ✅ Shipped (both adapters).** The standalone Email panel (§3.3) already captured every outgoing
-  message via the shared, framework-neutral `EmailCaptureService`; this item only adds a `MAIL` entry to the merged Live
-  Activity feed, so — like Cache and Scheduled Task runs — it needed no new capture instrumentation, just a read of an
-  existing buffer. Unlike `MESSAGING` entries (always top-level, no correlation attempted, since a message has no
-  single owning request), `MAIL` nests as a `REQUEST` child whenever the captured message's trace id matches an
-  in-flight request — the same trace-id-then-thread `parentRequestId` join `SQL`/`CACHE` already use (`EXCEPTION`/
-  `SECURITY` predate this join and are correlated differently depending on adapter: on Spring **servlet** (MVC),
-  neither carries a trace id — the exception-resolver context has none, nor does Spring Boot's audit repository — so
-  they correlate by method/path + serving thread and by a thread-classifier registry respectively; on Spring
-  **WebFlux** and Quarkus, both *do* join by trace id like `SQL`/`CACHE`/`MAIL`, since each has its own
-  `TraceIdProvider`-backed capture point — see `ActivityEntryDto.parentId`) — so an email sent from inside a request
-  handler shows up in that request's profiler drawer. `EmailCaptureService.subscribe(...)`
-  feeds the same `BootUiChangeStream`/`ReactiveBootUiChangeStream` coalesced SSE tick the other five in-process sources
-  already use, so a newly captured message refreshes the live feed the same way a new cache access or scheduled-task
-  run does, on both the servlet and WebFlux adapters. On Quarkus, `LiveActivityResource` reads the same
-  `EmailCaptureService` directly (not through the Email panel's own resource) and feeds its merged SSE stream
-  identically, mirroring the Spring wiring exactly.
-- **Outbound REST call capture — ✅ Shipped (Spring servlet, Spring WebFlux, and Quarkus adapters).** Every `RestClient`/`RestTemplate`/
-  `WebClient` built through Spring Boot's auto-configured builders is instrumented via Spring Boot's own
-  `RestClientCustomizer`/`RestTemplateCustomizer`/`WebClientCustomizer` hooks, attaching a `RestClientTraceInterceptor`
-  (`RestClient`/`RestTemplate`) or `RestClientTraceExchangeFilter` (`WebClient`) from inside the `customize(...)`
-  callback — so a disabled panel or `bootui.rest-client-trace.enabled=false` adds no interceptor at all, and
-  pass-through application behaviour is unaffected either way. Both customizer configurations live in the shared
-  `BootUiEngineConfiguration`, gated by `@ConditionalOnClass` on the optional `spring-boot-restclient`/
-  `spring-boot-webclient` modules, so servlet and WebFlux wire identically and the configuration is skipped entirely
-  when a module is absent. The framework-neutral `RestClientTraceRecorder` (`bootui-engine`) captures each call (client
-  type, URI, method, status, duration, headers/call-site when enabled) into a bounded buffer, feeding both the
-  standalone REST Client panel and, like Cache/Mail, a `REST_CLIENT` entry into the merged Live Activity feed —
-  nesting as a `REQUEST` child via the same trace-id-then-thread join `SQL`/`CACHE`/`MAIL` use (see the `MAIL` bullet
-  above for why `EXCEPTION`/`SECURITY` are not part of that list), and adding
-  `restCallErrorRatePercent`/`restCallP95LatencyMs` KPI tiles deep-linked to `/rest-client-trace`. Quarkus uses the
-  supported MicroProfile `RestClientListener` SPI (`QuarkusRestClientTraceListener`, registered through a generated
-  service-provider entry only when `Capability.REST_CLIENT_REACTIVE` is present) to attach a
-  `QuarkusRestClientTraceFilter` at transport-bracketing priority on every client proxy. Capture is metadata-only on
-  Quarkus: no headers or bodies are read, and URI credentials/sensitive query values are sanitized before storage.
-  Quarkus reports pre-response transport failures with status `0`; the filter maps those to failed calls with no HTTP
-  status, while real `4xx`/`5xx` responses remain transport-successful error responses. A capability-absent exclusion
-  keeps the optional listener type unlinked, and the recorder's Quarkus OTel `TraceIdProvider` feeds trace-only Live
-  Activity correlation.
-
-**Done** — Quarkus REST Client capture shipped (issue #653).
-
-Scope — enhancements on top of the shipped event types, generally cheaper than a new source and some of higher value:
-
-- **Extend the KPI strip** with metrics for each new source as it lands — this has now shipped for every source that
-  has one: outbound-call error rate/p95 (REST call capture), cache hit ratio (Cache), and scheduled-task failure count
-  (Scheduled Task runs).
-- **Verify persistence and filtering stay generic over `type`** as new event types are added — `JdbcActivityStore`,
-  `BufferedActivityStore`, and the client-side type filter chips pick up new types automatically; keep confirming this
-  with tests if any further event type lands.
-- **Add deep links** for each entry type into its own source panel — Cache, Scheduled Tasks, Kafka, RabbitMQ, JMS, and
-  REST Client entries now link to `/cache`, `/scheduled`, `/kafka`, `/rabbitmq`, `/jms`, and `/rest-client-trace`,
-  respectively, joining the existing
-  per-entry deep links into HTTP Exchanges (REQUEST), SQL Trace (SQL), and Exceptions (EXCEPTION); the KPI strip's own
-  launchpad cards additionally deep-link Health and Heap usage.
-
-Design constraints:
-
-- Every new source stays **read-only** and **fails closed** when its backing bean/class is absent, consistent with
-  §3.1/§3.3 and the cross-cutting rules in §4.
-- Messaging payloads are never captured; cache values are omitted and cache keys are hashed rather than shown raw even
-  under full exposure.
-- New capture buffers are bounded and self-filtering (BootUI's own traffic must not appear in its own feed), consistent
-  with the existing `bootui.monitoring.exclude-self` behaviour.
-- Actual shipped sequencing: Scheduled Task runs and Cache operations landed first, then `MESSAGING` (initially Kafka,
-  later RabbitMQ and Spring JMS), then Mail, and finally REST call capture — all five event types now ship, each with
-  `REQUEST`-nesting where a nesting relationship applies (`MESSAGING` is deliberately always top-level).
 
 ### 3.5 MongoDB operational view — Database 📋 Planned
 
@@ -456,209 +105,667 @@ Acceptance criteria:
 - The sample applications cover absent-client, unreachable-server, insufficient-permission, empty-database, and
   multi-client states without requiring MongoDB for the default Docker-free test path.
 
-### 3.6 Local Service Map — Live Activity ✅ Completed
+### 3.6 Declarative HTTP client registry — Services 📋 Planned
 
-**Status: completed.** Shipped as the **Live flow** mode of the Live Activity panel (see `docs/FEATURES.md` →
-*Live Activity → Live flow*, and `docs/SPECIFICATION.md` §5.14.2.1), on Spring MVC, Spring WebFlux, and Quarkus in one
-step rather than the MVC-only MVP originally sketched below — the framework-neutral `ServiceMapAssembler` made the two
-extra adapters thin enough that a stack-specific phase would have cost more than it saved. It is a **mode**, not a new
-panel: the map is a second reading of evidence Live Activity already merges, so it reuses that panel's id, route,
-availability, read-only policy, and SSE tick instead of adding a 53rd route. The original scope is retained below, with
-two deliberate deviations recorded inline: the surface is a Live Activity mode rather than an Overview panel, and one
-generic inbound local-HTTP-client lane was added so the map shows what reaches the application as well as what it
-reaches out to.
+BootUI's REST Client panel shows calls that have already happened, but it does not show which HTTP clients the application
+declares, how each client resolves its target, or which effective transport policies apply before the first request. This
+new panel provides that static and runtime configuration view without making network calls or replacing REST Client trace.
 
-The Local Service Map answers: "What external systems does this running application depend on, and what evidence
-has BootUI recently observed for each relationship?" It assembles a single, read-only topology from data BootUI
-already owns rather than introducing distributed tracing infrastructure, network discovery, or active health probes.
+Scope:
 
-User value:
+- Add one shared HTTP client registry panel and stable `/bootui/api/http-clients/**` contract for Spring servlet, Spring
+  WebFlux, and Quarkus.
+- Discover Spring `@HttpExchange` interfaces, OpenFeign clients, `RestClient.Builder` beans, and `WebClient.Builder` beans,
+  plus Quarkus/MicroProfile `@RegisterRestClient` interfaces and framework-managed client builders.
+- Report each client's framework/type, bean or registration name, declared interface where applicable, configured base
+  URL, safely resolved base URL after property interpolation, and effective timeout, connection-pool, retry, redirect,
+  proxy, and TLS settings when the framework exposes them.
+- Show provenance for every effective value so users can distinguish a client-specific override from builder, framework,
+  or application defaults. Unknown or inaccessible values must remain explicitly unavailable rather than inferred.
+- Cross-link a client to matching retained calls in REST Client trace only when BootUI can attribute them safely. Ambiguous
+  builder-derived clients remain unlinked rather than being matched by a guessed host or bean name.
+- Support multiple named clients and multiple builders while returning the same stable DTOs and UI on every adapter.
 
-- Give developers an immediate mental model of the application's local integration surface without searching across
-  Connection Pools, REST Client, Kafka, RabbitMQ, traces, and configuration panels.
-- Distinguish **configured** dependencies from **observed** runtime relationships so absence of traffic is not mistaken
-  for absence of a dependency.
-- Highlight retained failures and last-seen activity as debugging evidence, while explicitly avoiding claims about the
-  current health of a remote system.
-- Provide an evidence trail and deep link from every node to its source panel, turning the map into a navigation surface
-  rather than a decorative diagram.
+Architecture:
 
-Initial scope:
+- Put normalization, ordering, provenance, safe URL handling, and report assembly in a JSON-free, framework-neutral engine
+  service behind a neutral HTTP client metadata provider SPI.
+- Keep Spring HTTP Interface, OpenFeign, MicroProfile REST Client, and Quarkus types in optional, adapter-specific
+  providers. Gate each provider on its dependency and native framework capability so applications without that client
+  technology do not load its classes.
+- Inspect existing registrations, bean definitions, customizers, and framework metadata without instantiating lazy clients,
+  replacing application-owned builders, or adding interceptors. Reuse REST Client trace's existing capture path for
+  observed-call links.
+- Treat client configuration as live policy input where supported. Route displayable URLs and settings through the
+  exposure policy, always remove user-info and secret query values, and never serialize credentials, private keys, trust
+  material, proxy passwords, or arbitrary customizer state.
 
-- Center the running application and group outbound dependencies by safe identity: HTTP origin
-  (`scheme://host:port`), JDBC pool/target, Kafka topic, and RabbitMQ exchange/routing destination.
-- **Added during implementation:** fold completed *incoming* requests into a single generic local HTTP client lane
-  feeding the application. Per-caller nodes are deliberately not derived — a remote address is neither a stable identity
-  nor safe to display here — so the lane stays one honest node rather than a guessed caller inventory.
-- Show protocol, configured/observed state, retained interaction and failure counts, distinct operation count, and
-  last-seen time where the source supports them.
-- Reuse only existing bounded sources: REST-client trace capture, masked connection-pool reports, Kafka activity, and
-  RabbitMQ activity. Include producer/publisher evidence only; incoming consumer traffic is not an outbound edge.
-- Offer protocol and text filters, keyboard-selectable nodes, an accessible textual detail view, responsive layouts, and
-  links to the source evidence panels.
-- Respect every source panel's enablement setting. If a source panel is disabled or unavailable, its evidence must not be
-  included in the map.
+Out of scope for the first release:
 
-Safety and interpretation:
+- Sending test requests, probing target availability, resolving DNS, or validating credentials.
+- Capturing request or response bodies, adding a new HTTP interception path, or changing REST Client trace retention.
+- Editing client configuration, retry policies, TLS settings, or proxy settings.
+- Reconstructing clients created manually outside framework-managed interfaces and builders.
+- Guessing effective settings that the framework or underlying client library does not expose safely.
 
-- Opening the panel performs no network call, probe, DNS lookup, connection attempt, scan, or new interception.
-- JDBC labels and details must use the existing exposure/masking policy. HTTP identities must omit user-info, paths,
-  query values, and fragments. Messaging payloads remain completely out of scope.
-- A retained failure means only that an interaction in the bounded buffer failed; it must not be presented as live
-  dependency health. Unknown and stale evidence must remain visually distinct from healthy or failing states.
-- Cardinality must be bounded before rendering. High-cardinality destinations should be summarized or truncated with a
-  visible explanation rather than silently overwhelming the graph.
+Acceptance criteria:
 
-Architecture and sequencing:
+- Opening the panel performs no network call and does not instantiate a lazy client or mutate an application-owned builder.
+- Equivalent Spring servlet, Spring WebFlux, and Quarkus clients produce the same core response shape, with
+  adapter-specific unavailable fields represented explicitly.
+- Applications without a supported HTTP client technology load normally and show a framework-correct unavailable or empty
+  state without optional classloading failures.
+- Named clients and builder beans retain distinct identities, and value provenance correctly distinguishes defaults from
+  client-specific overrides.
+- Base URLs never expose user-info, credentials, secret query values, or TLS/proxy secrets under any exposure mode.
+- REST Client trace links appear only for safely attributable calls; ambiguous and unmatched calls do not create false
+  relationships.
+- Sample applications and fixtures cover absent clients, multiple named clients, unresolved placeholders, masked URLs,
+  inherited defaults, client-specific overrides, and ambiguous builder-derived clients without requiring external
+  services.
 
-- **Shipped as delivered:** a framework-neutral, JSON-free `ServiceMapAssembler` (`bootui-engine`) over existing core
-  DTOs and recorders, plus a stable core DTO contract (`ServiceMapReport`/`ServiceMapNodeDto`/`ServiceMapEdgeDto`/
-  `ServiceMapInteractionDto`/`ServiceMapTruncationDto`) and three thin bindings: one shared `LiveServiceMapController`
-  registered in both Spring autoconfigurations, and a `LiveServiceMapResource` on Quarkus.
-- No instrumentation was added. A relationship that cannot be derived safely from existing evidence is absent rather
-  than guessed.
-- The shared availability-driven conformance suite asserts the contract, bounds, and identity safety on all three
-  runtimes.
-- Keep graph layout in the Vue client and report assembly, grouping, sorting, bounds, and interpretation in the engine.
-  Do not introduce a graph database or a new visualization dependency unless native SVG proves insufficient.
+### 3.7 Resilience — Services 📋 Planned
 
-**Later increment — opaque flow correlation, Cache as a first-class dependency, and causal motion sequencing.** The
-map's animation originally treated every stable edge's new evidence as an independent blip; it had no notion that an
-inbound request, a cache access, a SQL statement, and an outbound call could be evidence of the very same request's
-path through the application. This increment closes that gap without adding any new capture:
+BootUI exposes raw metrics that resilience libraries may publish, but it does not explain which protections apply to each
+operation, their current runtime state, or why a call was retried, rejected, or short-circuited. This panel provides one
+cross-platform view over Resilience4j and Spring Retry on Spring, and SmallRye Fault Tolerance on Quarkus.
 
-- `ServiceMapAssembler` now derives an opaque `ServiceMapInteractionDto.flowId` from whatever distributed-trace id
-  (already captured by the HTTP Exchanges, SQL Trace, REST Client, and Cache recorders) was active when each
-  interaction completed — one-way SHA-256 (`ServiceMapIdentities.flowId`), never the raw trace id, and `null` for a
-  blank/absent trace or for Kafka/RabbitMQ (which never carry a trace id at capture time and stay uncorrelated).
-  Interactions sharing a trace share a `flowId`, letting the client recognize one causal flow across edges instead of
-  treating every edge as unrelated.
-- **Cache joins the map as a first-class dependency (Spring MVC and Spring WebFlux only).** The same
-  `CacheActivityRecorder` behind the Cache panel and Live Activity's `CACHE` entries now also feeds
-  `ServiceMapSources.cacheEvents`, gated identically (Cache panel enabled *and* the recorder itself capturing).
-  Accesses group by the safe cache-manager/cache-name identity — never the accessed key or value — and surface the
-  same `HIT`/`MISS`/`PUT`/`EVICT`/`CLEAR` operations Live Activity already shows. Cache dependencies are
-  observed-only (`configured: false`), the same honesty rule Kafka/RabbitMQ dependencies use, since no independent
-  cache-configuration evidence is wired in yet. A `MISS` is never a retained failure, since it is a normal outcome.
-  Quarkus continues to honestly report `cacheAvailable: false` — it has no comparable interception seam for
-  `quarkus-cache` (see `docs/QUARKUS-SUPPORT.md`) — with no invented capture path. One notable side effect: because
-  `ServiceMapAssembler` is fully shared, Quarkus's and Spring WebFlux's existing OpenTelemetry-backed trace id
-  stamping on HTTP/SQL/REST capture already gives both adapters the same `flowId` correlation for those three
-  sources at no extra cost; only cache participates on Spring MVC/WebFlux alone.
-- **A new pure `sequenceFlowPulses` helper (`bootui-ui`)** paces a batch of freshly diffed pulses: within a shared,
-  non-null `flowId`, the inbound leg always starts immediately and downstream pulses start only once that inbound pulse
-  would have finished arriving at the application. Downstream completions replay in ascending retained timestamp order
-  (cache precedes JDBC/outbound HTTP only as an equal-millisecond tie-break), so the UI never invents an execution order,
-  and further downstream pulses in the same flow are staggered by a small, bounded step. Pulses with no `flowId`, and any
-  flow whose current batch carries no retained inbound pulse, are left untouched — they animate immediately exactly
-  as before, so an orphaned downstream pulse never waits for an inbound arrival that batch will never carry. The
-  animation queue's existing concurrency and per-edge caps apply unchanged regardless of sequencing, so a
-  causally-sequenced burst can never exceed the same bounds an unrelated one would.
-- **Slow interactions are now unmistakable by timing, not color alone:** duration itself now differs by tone — a calm
-  amber pulse (with a restrained trailing halo) for a slow completion runs 1200–1500ms, a normal completion
-  650–850ms, and a failure 900–1100ms — and a non-color "slow" text label appears in the node detail view and in
-  live-region announcements alongside the existing amber/red styling. A sequenced pulse's CSS Motion Path animation
-  stays fully transparent for its entire mount-relative delay, so it never flashes into view before its causal
-  predecessor has arrived; every pulse still plays exactly once, linearly, with no bounce, loop, or drift.
-- Reduced motion is deliberately unchanged in timing: it never sequences or delays anything (there is no travel to
-  pace), so every changed edge is still emphasized immediately. Its live-region announcement was extended with a
-  `describeFlowSequence` narration so a screen-reader user gets the same causal story — "Flow: &lt;inbound&gt; →
-  &lt;cache&gt; → &lt;outbound&gt;" — that sighted users read from the sequenced motion.
+Scope:
 
-**Later refinement — bounded hybrid layout and transient target evidence.** Typical maps now use a fixed-radius
-right-facing fan through six dependencies, while denser maps switch to a spacious two-column rack bounded at 1,040
-logical pixels wide. A 72-pixel row pitch reserves the SLOW/ERROR chip and ring envelope; the 28-node rack is 1,046
-pixels tall inside the existing scrollable stage. Smooth fan paths and deterministic dense routes keep every connector
-clear of unrelated nodes, and CSS Motion Path consumes each connector's exact path with mount-relative timing. Retained
-failures no longer permanently color topology nodes or edges. Accepted slow/failure pulses instead schedule
-reference-counted target rings and explicit `SLOW · <duration>` / `ERROR` chips for exactly their own delay and duration;
-inbound targets the application, outbound targets the dependency, and failure wins only while overlapping slow.
-Reduced-motion users receive the same target semantics as a brief static emphasis plus explicit live narration.
+- Add one shared `resilience` panel and stable `/bootui/api/resilience/**` contract for Spring servlet, Spring WebFlux, and
+  Quarkus.
+- Discover configured circuit breakers, retries, rate limiters, bulkheads, and time limiters, including annotation-driven
+  and registry-backed definitions where the library exposes them safely.
+- Report the protected bean/class and method, policy type, effective configuration, configuration provenance, and current
+  runtime state. Include bounded success, failure, retry, rejection, timeout, and short-circuit counts where native
+  registries or metrics expose them.
+- Show circuit-breaker state (`CLOSED`, `OPEN`, `HALF_OPEN`, or an explicit adapter-specific/unknown state), retry limits
+  and delay policy, rate-limit capacity and refresh policy, bulkhead concurrency/queue limits, and timeout thresholds.
+- Capture bounded, metadata-only resilience events and feed them into Live Activity as a `RESILIENCE` entry type. Include
+  policy name/type, protected operation, outcome, attempt number where applicable, duration, and safe failure category;
+  never capture method arguments, return values, payloads, or raw exception messages.
+- Correlate events to an originating request through the existing trace-id or safe adapter-specific correlation path when
+  available. Background and asynchronously detached events remain top-level rather than being matched heuristically.
+- Support multiple named registries and policies while returning the same stable DTOs and UI on every adapter.
 
-Complexity and risks:
+Architecture:
 
-- **Estimated complexity: medium for the MVC MVP; medium-high for a shared production feature.** Aggregation is
-  straightforward, but identity normalization, partial evidence, dense graph UX, optional source wiring, and equivalent
-  adapter semantics require careful contracts.
-- The largest product risk is false confidence: incomplete observation can look authoritative. Copy and visual states
-  must continuously communicate configured vs. observed vs. unknown.
-- The largest technical risks are leaking endpoint/configuration details, creating unbounded/high-cardinality graphs,
-  misclassifying incoming messaging as outbound, and coupling the engine to framework-specific recorder types.
+- Put DTO assembly, normalization, ordering, bounds, state mapping, and event-to-Live-Activity mapping in JSON-free,
+  framework-neutral engine services behind neutral resilience metadata and event provider SPIs.
+- Keep Resilience4j, Spring Retry, and SmallRye Fault Tolerance types in optional adapter providers. Gate each provider on
+  its dependency, registry/bean presence, and native framework capability so absent libraries cannot cause classloading
+  failures.
+- Prefer native registries, event publishers, retry listeners, and metrics over wrapping application beans or replacing
+  interceptors. Any listener registration must compose with application listeners, remain pass-through/fail-open, and be
+  removed or disabled when capture is disabled.
+- Treat policy configuration and panel enablement as live inputs where supported. Hash or omit high-cardinality operation
+  identifiers when necessary, route displayable values through the exposure policy, and keep event buffers independently
+  bounded so resilience traffic cannot evict unrelated Live Activity sources.
 
-Acceptance criteria (met):
+Out of scope for the first release:
 
-- A Spring MVC sample with JDBC configuration and a retained outbound HTTP failure renders both relationships without
-  making any request from the map itself.
-- Empty, source-disabled, unavailable, malformed-identity, and high-cardinality inputs render safely and clearly.
-- No secret, HTTP path/query value, message payload, or unmasked JDBC credential reaches the response.
-- The panel remains usable by keyboard and screen reader and at desktop and mobile widths.
-- The feature ships inside Live Activity rather than as its own sidebar entry, so the cross-panel synthesis has to earn
-  attention next to the feed it complements before it would ever justify a route of its own.
+- Opening, closing, or resetting circuit breakers; changing retry, rate-limit, bulkhead, or timeout configuration.
+- Invoking protected operations, generating synthetic failures, or probing downstream services.
+- Capturing method arguments, return values, request/response bodies, message payloads, or raw exception messages.
+- Reimplementing resilience behavior or creating a BootUI abstraction that application code depends on.
+- Inferring a policy or runtime state when a framework does not expose sufficient metadata.
 
-### 3.7 Ecosystem survey backlog — candidates 📋 Not scheduled
+Acceptance criteria:
 
-These candidates come from a survey of the 50 most-starred Spring Boot starter projects on GitHub. Almost all of them
-are pure integration libraries with no introspection of their own: they wire up rich runtime state that nobody can see.
-The items below are **not scheduled** and rank behind the MongoDB workstream in §3.5; each still needs its own scoped
-specification before it can be picked up. Every one of them must respect the panel rules in §1 and §4 — read-only or
-confirmation-gated, fail-closed when the dependency is absent, masked through the existing exposure policy, and honestly
-reported as unavailable on a stack that cannot support it rather than forked into a stack-specific UI contract.
+- Opening the panel performs no protected call, network request, state transition, or policy mutation.
+- Equivalent Resilience4j, Spring Retry, and SmallRye policies produce the same core response shape, with unsupported
+  policy types or fields represented explicitly rather than guessed.
+- Applications without a supported resilience library load normally and show a framework-correct unavailable or empty
+  state without optional classloading failures.
+- Listener and event capture composes with application-owned listeners/interceptors, remains pass-through on BootUI
+  failures, and stops cleanly when the panel or capture is disabled.
+- Live Activity shows bounded metadata-only retry, rejection, timeout, short-circuit, and breaker-transition events, with
+  request correlation only when supported by retained evidence.
+- No method argument, return value, payload, credential, raw exception message, or unbounded operation identifier reaches
+  the response or event buffer.
+- Sample applications and fixtures cover absent libraries, multiple named policies, inherited and overridden
+  configuration, every supported policy type, state transitions, exhausted retries, rate-limit rejection, bulkhead
+  rejection, timeout, disabled capture, and unavailable adapter capabilities without external services.
 
-#### 3.7.1 Candidate new panels
+### 3.8 gRPC — Services 📋 Planned
 
-- **A1. Declarative HTTP client registry — Services.** The REST Client panel shows calls that happened; nothing shows
-  which clients are _declared_ and how they resolve. Enumerate `@HttpExchange` interfaces, Feign clients, and
-  `RestClient`/`WebClient` builder beans on Spring plus `@RegisterRestClient` interfaces on Quarkus, with base URL,
-  resolved URL after property interpolation, effective timeout/pool/retry configuration, and inherited-versus-overridden
-  provenance for each value. Cross-link each client to its recent calls in REST Client trace. Read-only, no network on
-  render, available on all three stacks. Highest value-to-effort item in this list.
-- **A2. Resilience — Services.** Rate limiting, retry, and circuit breaking are invisible at runtime except as raw
-  meters. Show live circuit-breaker state (closed/open/half-open), per-method retry and bulkhead configuration, and
-  rate-limit rules with consumed/rejected counts, over Resilience4j on Spring and SmallRye Fault Tolerance on Quarkus.
-  Breaker state transitions are a natural additional Live Activity event type.
-- **A3. GraphQL — Services.** The Mappings panel is HTTP-route-only, so a GraphQL application is near-invisible today.
-  Show the introspected schema, registered queries/mutations/subscriptions, the resolver bean and method behind each
-  field, registered `DataLoader`s, and batch-loading gaps, backed by Spring for GraphQL and Quarkus SmallRye GraphQL.
-  Pair it with an N+1 heuristic sourced from existing SQL Trace evidence rather than a new capture path.
-- **A4. gRPC — Services.** Mirror for gRPC what Mappings does for HTTP: registered services and methods, method types
-  (unary/streaming), listening port, TLS state, interceptors, and per-method call/duration/status-code counts. Most of
-  the data is already published by the common Spring gRPC starters and by Quarkus gRPC.
-- **A5. Spring Batch — Services.** `JobExplorer`/`JobRepository` expose deployed jobs, executions with parameters,
-  per-step read/write/skip/commit counts, exit status, and failure exceptions entirely read-only. BootUI has Scheduled
-  Tasks but nothing for batch. Spring-only; Quarkus reports it honestly unavailable, like Transactions.
-- **A6. WebSocket / messaging endpoints — Services.** Declared endpoints and paths, active session count,
-  subscriptions, and metadata-only recent frame activity (matching the Kafka panel's payload rule), over Spring
-  `@MessageMapping`/STOMP and Quarkus WebSockets Next registries.
-- **Lower priority.** A Pulsar panel as a fourth Messaging panel beside Kafka/RabbitMQ/JMS, reusing the existing
-  `MESSAGING` recorder. An object-storage panel is tempting but would have to stay configuration-only, since listing
-  buckets on render would violate the no-network-on-page-load rule.
+BootUI's Mappings and REST Client panels explain HTTP endpoints and calls, but gRPC services, methods, client channels,
+transport security, and call outcomes remain invisible. This panel provides a read-only local registry and aggregate
+runtime view for Spring gRPC and Quarkus gRPC without enabling reflection or recording individual calls.
 
-#### 3.7.2 Candidate improvements to existing panels
+Scope:
 
-The identifiers below are the survey's own labels; the gaps in the sequence are deliberate, since a few surveyed ideas
-were reviewed and not carried into this backlog.
+- Add one shared `grpc` panel and stable `/bootui/api/grpc/**` contract for Spring servlet, Spring WebFlux, and Quarkus
+  when their supported gRPC integration is present.
+- Discover registered server services and methods, including full service/method names, method type
+  (`UNARY`, `CLIENT_STREAMING`, `SERVER_STREAMING`, or `BIDI_STREAMING`), implementation class, and interceptor chain
+  where exposed safely.
+- Report server transport configuration including listening address/port, plaintext or TLS state, reflection enablement,
+  maximum message limits, keepalive settings, and other bounded framework-exposed values.
+- Discover framework-managed outbound client channels and stubs, including registration name, target authority after safe
+  normalization, load-balancing policy, plaintext or TLS state, retry enablement, message limits, and interceptors where
+  the framework exposes them.
+- Show aggregate per-service and per-method call counts, in-progress calls, latency, and gRPC status-code counts from
+  existing native observations or metrics. Missing metric families remain explicitly unavailable rather than triggering a
+  second instrumentation path.
+- Support multiple servers and named client channels while returning the same stable DTOs and UI on every adapter.
 
-- **B1. Error-contract catalogue — REST API and Exceptions.** The Exceptions panel shows what was thrown; nothing shows
-  the _declared_ mapping. Catalogue every `@ControllerAdvice`/`@ExceptionHandler` and `@Provider ExceptionMapper` with
-  its resolved status and body shape, plus RFC 9457 `ProblemDetail` usage, and add REST API advisor rules for endpoints
-  with no mapped handler, inconsistent error bodies across controllers, and stack traces leaking into responses.
-- **B2. Slow-SQL ranking and URI attribution — SQL Trace.** Reuse the thread/time-window correlation already built for
-  Transactions to attribute statements to the inbound request path, and add a top-N-by-total-time ranking of normalized
-  statements beside the existing N+1 detection. A Database advisor rule for string-concatenated SQL fits the same work.
-- **B3. Copy-as-cURL and bounded body capture — HTTP Exchanges.** A copy-as-cURL action closes the loop with the HTTP
-  Probe panel: capture a request, replay it with a tweak. Opt-in, size-bounded, masked body capture would follow the
-  Email panel's existing dev-trap precedent.
-- **B4. Correlation-id filtering — Live Activity.** Recognize the common correlation headers (`X-Correlation-ID`,
-  `X-Request-ID`, `X-Flow-ID`) explicitly, and add filter-by-id and copy-id actions on top of the existing trace ↔ log ↔
-  request correlation.
-- **B5. Meter provenance and explanation — Metrics.** Group meters by the integration that contributes them, with a
-  short explanation of what each family means. This applies the "explain before you dump" principle to the panel that is
-  still closest to a raw dump.
-- **B7. Cache tiering and hit ratios — Cache.** A multi-level cache looks like a single `CacheManager` from outside.
-  Surface the manager implementation type, tier structure, per-cache hit/miss/eviction statistics where the provider
-  exposes them, and distributed invalidation events as a Live Activity entry.
-- **B9. Session actions — HTTP Sessions.** Add invalidate-session as an explicit, write-policy-gated, clearly labelled
-  action, with the same treatment as the existing Flyway clean and Transactions clear actions.
+Architecture:
+
+- Put DTO assembly, method-type and status normalization, ordering, bounds, identity handling, and aggregate metric joins
+  in a JSON-free, framework-neutral engine service behind neutral gRPC metadata and metrics provider SPIs.
+- Keep Spring gRPC, `io.grpc`, Micrometer, Quarkus gRPC, and adapter metric types in optional providers. Gate providers on
+  their dependencies, beans, and Quarkus capabilities so applications without gRPC cannot load optional classes.
+- Read existing local registries, server definitions, managed-channel configuration, observations, and metrics. Do not
+  enable server reflection, create channels or stubs, resolve DNS, register a second tracing interceptor, or record
+  individual calls.
+- Route targets, authorities, interceptor names, and transport settings through the exposure policy. Remove user-info and
+  secret parameters, never serialize credentials or TLS key/trust material, and bound method, channel, interceptor, and
+  metric cardinality before assembly.
+
+Out of scope for the first release:
+
+- Invoking RPCs, browsing remote reflection data, health-checking services, or testing client connectivity.
+- Capturing request/response messages, protobuf payloads, metadata values, individual call histories, or Live Activity
+  events.
+- Editing channel, server, retry, load-balancing, keepalive, TLS, or reflection configuration.
+- Generating clients, rendering arbitrary protobuf message editors, or acting as a gRPC debugging proxy.
+- Adding custom call interception solely to synthesize metrics absent from the application's native instrumentation.
+
+Acceptance criteria:
+
+- Opening the panel creates no channel or stub, performs no DNS lookup or RPC, and does not enable reflection or add an
+  interceptor.
+- Equivalent Spring and Quarkus services, methods, and channels produce the same core response shape, with
+  framework-specific unavailable fields represented explicitly.
+- Applications without supported gRPC integration load normally and show a framework-correct unavailable state without
+  optional classloading failures.
+- Unary and all streaming method types are classified correctly, and multiple servers/channels retain distinct stable
+  identities.
+- Aggregate calls, latency, in-progress work, and status-code counts are joined only from existing native metrics; absent
+  or ambiguous series do not create invented values.
+- No protobuf payload, metadata value, credential, raw target secret, or TLS key/trust material reaches the response.
+- Sample applications and fixtures cover absent gRPC support, unary and streaming services, multiple named channels,
+  plaintext and TLS metadata, reflection on/off, metric presence/absence, status-code aggregates, malformed targets, and
+  high-cardinality bounds without external services.
+
+### 3.9 Spring Batch — Services 📋 Planned
+
+BootUI shows scheduled task definitions and runs, but it does not expose Spring Batch jobs, executions, step progress, or
+failure outcomes. Spring Batch already retains this operational history through `JobExplorer` and `JobRepository`, making
+it available for a strictly read-only Spring panel without adding capture or controlling jobs.
+
+Scope:
+
+- Add one shared `batch` panel and stable `/bootui/api/batch/**` contract for Spring servlet and Spring WebFlux. Quarkus
+  reports the panel honestly unavailable because it has no equivalent Spring Batch runtime.
+- Discover registered job names and available job metadata, then list bounded, pageable job instances and executions
+  newest-first.
+- Report each execution's job name, instance and execution identifiers, start/create/end/update times, batch status, exit
+  code, safely rendered exit description, and identifying/non-identifying job parameters with type and provenance.
+- Show step executions with status, timing, read/write/filter/skip/commit/rollback counts, termination state, and bounded,
+  safely rendered failure summaries.
+- Provide server-side filtering by job name, status, execution identifier, and time range, plus drill-down from a job to
+  its instances, executions, and steps.
+- Treat running executions as live data and refresh their progress without creating a separate recorder or Live Activity
+  event source.
+
+Architecture:
+
+- Put DTO assembly, paging, filtering, ordering, status normalization, bounds, and safe failure rendering in a JSON-free,
+  framework-neutral engine service behind a neutral batch metadata provider SPI.
+- Keep Spring Batch types in a classpath- and bean-gated Spring provider. Both servlet and WebFlux adapters use the same
+  provider and controller contract; Quarkus wires only explicit unavailability metadata.
+- Query `JobExplorer` for read-only history and use repository metadata only where necessary to explain configuration.
+  Never call `JobLauncher`, `JobOperator`, `JobRepository` mutation methods, or application job beans.
+- Route parameter names/values, exit descriptions, and failure details through the exposure and masking policy. Bound
+  queries and response cardinality before loading step details so a large batch repository cannot exhaust the application.
+
+Out of scope for the first release:
+
+- Launching, restarting, stopping, abandoning, or deleting jobs or executions.
+- Editing job parameters, repository state, execution context, or Spring Batch configuration.
+- Capturing item payloads, execution-context values, reader/writer contents, or full exception stack traces.
+- Adding a Batch event type to Live Activity or installing listeners around application jobs and steps.
+- Providing a Quarkus-specific batch implementation without a comparable native runtime contract.
+
+Acceptance criteria:
+
+- Opening or refreshing the panel never launches, stops, restarts, abandons, or otherwise mutates a job execution.
+- Spring servlet and Spring WebFlux return the same stable DTOs and paging behavior for equivalent Spring Batch metadata;
+  Quarkus reports a clear not-applicable reason.
+- Applications without Spring Batch or without a `JobExplorer` load normally and show a framework-correct unavailable
+  state without optional classloading failures.
+- Large job repositories remain bounded through server-side paging and filtering, and running execution progress refreshes
+  without loading unrelated history.
+- Job parameters, exit descriptions, and failure summaries respect masking and exposure policy; execution-context values,
+  item payloads, and full stack traces never reach the response.
+- Sample applications and fixtures cover absent Batch support, empty repositories, multiple jobs and instances, running,
+  completed, stopped, and failed executions, step skip/rollback counts, masked parameters, long failure descriptions, and
+  high-cardinality paging without external services.
+
+### 3.10 WebSocket endpoints — Services 📋 Planned
+
+BootUI's Mappings panel explains request/response HTTP routes, but long-lived WebSocket endpoints, STOMP message mappings,
+active sessions, subscriptions, and frame activity remain invisible. This panel provides a bounded, metadata-only view
+over Spring WebSocket/STOMP and Quarkus WebSockets Next without capturing message payloads or feeding the general Live
+Activity stream.
+
+Scope:
+
+- Add one shared `websockets` panel and stable `/bootui/api/websockets/**` contract for Spring servlet, Spring WebFlux,
+  and Quarkus when their supported WebSocket integration is present.
+- Discover Spring WebSocket handlers, STOMP endpoints, `@MessageMapping` destinations, broker prefixes, and application
+  destination prefixes, plus Quarkus WebSockets Next endpoints, paths, callback methods, and supported message types.
+- Report each endpoint's normalized path/destination, implementation class and method, direction/callback type, declared
+  subprotocols, handshake policy metadata, and interceptor/filter names where exposed safely.
+- Show active session counts by endpoint and bounded session metadata using opaque stable session identifiers, connection
+  time, last-activity time, negotiated subprotocol, and safe local/remote transport metadata.
+- Show bounded subscriptions for STOMP and equivalent framework-exposed channel/topic registrations, grouped by endpoint
+  and destination without exposing user/session principals or arbitrary subscription headers.
+- Capture recent metadata-only inbound and outbound frame activity: endpoint, opaque session id, direction, frame/message
+  type, destination where applicable, payload size, timestamp, duration, and success/failure category. Never capture
+  payload bytes/text or arbitrary headers.
+- Keep recent frame activity in the WebSocket panel's independent bounded buffer; do not add a WebSocket event type to
+  Live Activity in the first release.
+
+Architecture:
+
+- Put DTO assembly, endpoint normalization, ordering, bounds, session identity hashing, and activity aggregation in
+  JSON-free, framework-neutral engine services behind neutral WebSocket metadata, session, and activity provider SPIs.
+- Keep Spring WebSocket/STOMP and Quarkus WebSockets Next types in optional adapter providers. Gate each provider on its
+  dependency, beans, and Quarkus capability so absent integrations cannot cause classloading failures.
+- Prefer native endpoint registries, lifecycle hooks, channel interceptors, and connection callbacks. Capture must compose
+  with application interceptors, preserve dispatch order and backpressure, remain pass-through/fail-open, and add no
+  payload decoding or copying.
+- Route endpoint paths, destinations, transport metadata, and failure categories through the exposure policy. Hash session
+  identifiers, omit principals and arbitrary headers, and enforce independent limits for endpoints, sessions,
+  subscriptions, and activity before serialization.
+
+Out of scope for the first release:
+
+- Sending frames, opening or closing sessions, subscribing/unsubscribing clients, or disconnecting users.
+- Capturing payload text/bytes, application objects, arbitrary headers, authentication tokens, principals, cookies, or
+  query-string values.
+- Acting as a WebSocket client, broker, proxy, replay tool, or protocol debugger.
+- Adding WebSocket activity to Live Activity or correlating individual frames to HTTP requests heuristically.
+- Supporting third-party WebSocket stacks that bypass the framework-managed Spring or Quarkus integration.
+
+Acceptance criteria:
+
+- Opening the panel establishes no connection, sends no frame, changes no subscription, and does not close an application
+  session.
+- Equivalent Spring and Quarkus endpoints, sessions, and activity produce the same core response shape, with
+  framework-specific unavailable fields represented explicitly.
+- Applications without supported WebSocket integration load normally and show a framework-correct unavailable state
+  without optional classloading failures.
+- Capture composes with application interceptors/callbacks, preserves dispatch and backpressure behavior, remains
+  pass-through on BootUI failures, and stops cleanly when disabled.
+- Payloads, arbitrary headers, principals, credentials, cookies, raw session identifiers, and secret query values never
+  enter the buffer or response.
+- Endpoint, session, subscription, and activity cardinality is independently bounded with visible truncation, and WebSocket
+  traffic cannot evict another panel's retained data.
+- Sample applications and fixtures cover absent support, Spring STOMP, Spring native handlers, Quarkus WebSockets Next,
+  multiple endpoints, active/closed sessions, subscriptions, inbound/outbound text and binary metadata, failures,
+  disabled capture, and high-cardinality truncation without external services.
+
+### 3.11 Error-contract catalogue — REST API and Exceptions 📋 Planned
+
+BootUI's Exceptions panel shows failures that have occurred, while the REST API panel explains declared endpoints. Neither
+shows which exception handlers define the application's error contract, which status and body shape each handler returns,
+or whether endpoints have consistent and safe failure responses. This enhancement adds the catalogue to REST API and
+cross-links retained failures from Exceptions rather than creating another panel.
+
+Scope:
+
+- Extend the existing REST API contract and UI with a stable, pageable error-contract catalogue for Spring servlet,
+  Spring WebFlux, and Quarkus; keep the existing panel id, route, enablement, and read-only policy.
+- Discover Spring `@ControllerAdvice`, `@RestControllerAdvice`, and `@ExceptionHandler` methods, plus Jakarta REST
+  `@Provider` `ExceptionMapper` implementations on Quarkus.
+- Report each handled exception type, declaring component and method, precedence/scope, resolved or declared HTTP status,
+  produced media types, and safely inferred response-body category.
+- Identify RFC 9457 `ProblemDetail`/problem-details usage and framework-native equivalents without instantiating handlers
+  or executing application code.
+- Resolve handler precedence and applicability where the framework exposes enough metadata. Ambiguous or dynamic mappings
+  remain explicitly unresolved rather than being assigned a guessed handler.
+- Cross-link an Exceptions entry to its declared handler and REST API error contract when exception type and retained
+  request evidence allow safe attribution; unmatched and ambiguous failures remain unlinked.
+- Add evidence-based REST API advisor findings for endpoint exception types with no declared mapping, inconsistent error
+  body categories or media types across related controllers, and configurations that may expose stack traces or raw
+  exception details.
+
+Architecture:
+
+- Put normalized DTO assembly, ordering, paging, handler precedence, body-category classification, cross-linking, and
+  advisory policy in JSON-free, framework-neutral engine services behind a neutral error-contract provider SPI.
+- Keep Spring MVC/WebFlux resolver types and Quarkus/Jakarta REST mapper types in thin adapter providers. Use native
+  handler registries and metadata where available, with classpath and capability gates for optional integrations.
+- Reuse the REST API panel and Exceptions data already retained by BootUI. Do not invoke handlers, synthesize requests,
+  throw exceptions, or add another exception-capture path.
+- Route component names, exception types, media types, inferred schemas, and retained failure details through the existing
+  masking and exposure policy. Advisor findings must cite concrete configuration or declaration evidence and avoid claims
+  based solely on the absence of observed failures.
+
+Out of scope for the first release:
+
+- Invoking exception handlers, generating failures, replaying requests, or validating response bodies over the network.
+- Capturing additional exception payloads, response bodies, stack traces, or method arguments.
+- Editing handler precedence, status mappings, serialization, stack-trace settings, or application error configuration.
+- Full static control-flow analysis to prove every exception an endpoint may throw.
+- Inferring dynamic handler behavior or arbitrary response schemas by executing application code.
+
+Acceptance criteria:
+
+- Opening the REST API error-contract view invokes no handler, sends no request, and does not alter exception resolution.
+- Equivalent Spring servlet, Spring WebFlux, and Quarkus mappings produce the same core response shape, with dynamic or
+  unsupported fields explicitly unresolved.
+- Applications without advice or exception mappers show a clear empty state without optional classloading failures.
+- Handler precedence and scope distinguish global and controller-specific mappings, including ambiguous mappings, without
+  inventing certainty.
+- Exceptions cross-links appear only when retained evidence safely identifies a declared handler; ambiguous and unmatched
+  failures do not create false relationships.
+- Advisor findings identify only evidence-backed unmapped exceptions, inconsistent contracts, or unsafe detail exposure,
+  with clear remediation and no raw stack trace or sensitive response content in the report.
+- Sample applications and fixtures cover global/local handlers, inheritance, precedence, multiple exception types,
+  `ProblemDetail`, custom response bodies, Quarkus exception mappers, ambiguous/dynamic status, unmapped retained
+  exceptions, inconsistent contracts, safe/unsafe stack-trace settings, and high-cardinality paging.
+
+### 3.12 Slow-SQL ranking and URI attribution — SQL Trace 📋 Planned
+
+SQL Trace shows retained statements chronologically and already detects N+1 patterns, but it does not rank normalized
+statements by cumulative cost or explain which inbound request routes are responsible for that database work. This
+enhancement derives both views from BootUI's existing bounded SQL and HTTP evidence and adds a conservative Database
+advisor rule for likely string-concatenated SQL.
+
+Scope:
+
+- Extend the existing SQL Trace contract and UI with top-N rankings by cumulative duration, maximum duration, execution
+  count, average duration, error count, and available percentile estimates; keep the existing panel id, route,
+  enablement, capture controls, and retention settings.
+- Normalize statements using the existing SQL normalization and masking rules so equivalent parameterized executions
+  aggregate without exposing bound values.
+- Attribute a statement execution to an inbound request using the existing trace-id-first, then safe serving-thread and
+  time-window correlation used by Transactions. WebFlux and Quarkus must use trace context where thread affinity is not
+  reliable.
+- Group attributed work by normalized route template when available, falling back to a masked method/path only when it is
+  safe and unambiguous. Never group by raw query string or path parameter value.
+- Show per-route database totals, top normalized statements, statement count, error count, and share of retained database
+  time, with deep links between the route ranking and filtered SQL Trace entries.
+- Keep unattributed and ambiguously attributed executions visible in explicit buckets rather than forcing a request
+  relationship.
+- Add an evidence-based Database advisor rule for statements that appear to embed dynamic literal values instead of bind
+  parameters, with clear confidence and limitations so generated SQL and legitimate constants do not become categorical
+  findings.
+
+Architecture:
+
+- Put ranking, aggregation, normalization, bounds, route attribution, and advisory policy in JSON-free,
+  framework-neutral engine services over the existing SQL Trace and HTTP exchange DTOs/recorders.
+- Reuse existing adapter trace-id providers and request-correlation evidence. Do not add JDBC wrappers, request
+  interceptors, SQL parsing dependencies, or a second statement recorder.
+- Compute rankings over the bounded retained window and state that window explicitly; results are diagnostic evidence, not
+  lifetime database metrics.
+- Route SQL, route templates, paths, and error metadata through the existing masking and exposure policy. Bound ranked
+  groups and route/statement cross-products before serialization to prevent high-cardinality workloads from expanding the
+  response.
+
+Out of scope for the first release:
+
+- Database-side execution plans, table statistics, index recommendations, or active query profiling.
+- Capturing bind values, request query strings, path parameters, request/response bodies, or additional SQL text.
+- Persisting rankings beyond the existing SQL Trace retention window.
+- Claiming causal request attribution when trace/thread/time evidence is absent or ambiguous.
+- Automatically rewriting SQL or treating the concatenated-SQL heuristic as proof of a vulnerability.
+
+Acceptance criteria:
+
+- The ranking uses only retained SQL Trace evidence and adds no database call, JDBC interception, or request capture.
+- Equivalent Spring servlet, Spring WebFlux, and Quarkus evidence produces the same ranking and attribution DTOs, with
+  adapter-specific unavailable correlation represented explicitly.
+- Aggregate counts and durations reconcile with the retained statements in the selected window, including truncation and
+  clear handling of ties.
+- Route attribution uses trace context where available, refuses ambiguous thread/time matches, and never exposes query
+  strings or path-parameter values.
+- Normalization aggregates equivalent parameterized statements without merging materially different statements or
+  exposing literals removed by masking policy.
+- The concatenated-SQL advisor reports only evidence-backed candidates with confidence and limitations, and never exposes
+  captured literal values in its evidence.
+- Sample applications and fixtures cover repeated and one-off statements, ties, errors, N+1 overlap, trace-correlated and
+  thread-correlated requests, WebFlux context shifts, ambiguous/unattributed work, route templates, masked paths,
+  high-cardinality truncation, and likely/false-positive concatenated SQL patterns.
+
+### 3.13 Copy as cURL — HTTP Exchanges 📋 Planned
+
+HTTP Exchanges captures enough request metadata to help reproduce an observed call, but developers must currently rebuild
+the command by hand. This enhancement adds a safe, client-side copy-as-cURL action using only retained metadata BootUI
+already exposes, without capturing bodies or replaying the request.
+
+Scope:
+
+- Add a **Copy as cURL** action to each eligible HTTP Exchanges request detail on Spring servlet, Spring WebFlux, and
+  Quarkus; keep the existing panel id, route, enablement, read-only policy, and backend contract.
+- Generate a deterministic command from the request method, normalized scheme/host/port/path, query-parameter names, and a
+  small explicit allowlist of safe headers.
+- Preserve query-parameter names and replace every value with a quoted placeholder so the command is useful as a template
+  without copying retained values into the clipboard.
+- Include only allowlisted, currently exposed request headers whose values are not masked. Omit authorization, cookies,
+  proxy authorization, forwarding headers, API keys, tracing headers, and unknown/custom headers regardless of exposure
+  mode.
+- Use robust shell quoting for URLs, header names/values, and methods so captured metacharacters cannot turn the copied
+  text into additional shell commands.
+- Explain omitted bodies, headers, and query values in the action feedback so users understand that the generated command
+  is a safe template rather than a byte-for-byte replay.
+
+Architecture:
+
+- Implement cURL command assembly as a pure, shared frontend helper over the existing HTTP Exchange DTO; no endpoint,
+  recorder, buffer, or adapter changes are required.
+- Centralize the safe-header allowlist, URL sanitization, placeholder generation, and POSIX shell quoting in testable
+  helpers rather than assembling command fragments in the component.
+- Reuse the existing masking/exposure state as an additional restriction, never as permission to include a header or query
+  value outside this feature's stricter policy.
+- Use the browser clipboard API through the existing UI action/notification pattern and surface permission or clipboard
+  failures clearly.
+
+Out of scope for the first release:
+
+- Capturing or including request/response bodies, multipart data, files, form values, or binary content.
+- Including original query-parameter values, sensitive headers, cookies, credentials, tracing identifiers, or arbitrary
+  custom headers.
+- Replaying the request, invoking cURL, opening a network connection, or automatically sending the command to HTTP Probe.
+- Generating platform-specific PowerShell or Windows Command Prompt syntax.
+- Claiming the generated command exactly reproduces transport behavior, redirects, TLS state, or client middleware.
+
+Acceptance criteria:
+
+- Copying a command performs no network request and changes no backend or capture state.
+- The same HTTP Exchange DTO produces byte-identical cURL text on every adapter.
+- Every query parameter retains its name but uses a placeholder value, including repeated, empty, encoded, and malformed
+  parameters.
+- Only explicitly allowlisted, unmasked headers appear; sensitive and unknown headers are omitted under every exposure
+  mode.
+- Shell metacharacters, quotes, newlines, and option-like values in retained metadata cannot escape their argument or add
+  another command.
+- Requests with unavailable authority/path metadata show a clear disabled reason rather than producing an invalid or
+  misleading command.
+- Frontend tests cover common methods, ports, encoded paths, repeated query parameters, safe and sensitive headers,
+  masked values, CR/LF input, shell metacharacters, missing metadata, clipboard denial, and body-present exchanges.
+
+### 3.14 Correlation-ID filtering — Live Activity 📋 Planned
+
+Live Activity correlates retained evidence through trace ids, serving threads, and time windows, but many applications also
+use business or gateway correlation headers that developers recognize directly. This enhancement captures a bounded,
+explicit set of correlation identifiers, makes them filterable across related activity, and permits copying only when
+BootUI's value-exposure policy allows it.
+
+Scope:
+
+- Recognize `X-Correlation-ID`, `X-Request-ID`, and `X-Flow-ID` case-insensitively on inbound requests across Spring
+  servlet, Spring WebFlux, and Quarkus.
+- Allow additional header names through a bounded configuration property. Reject reserved sensitive names such as
+  authorization, cookies, proxy credentials, and API-key headers even when configured.
+- Capture at most a small fixed number of normalized, length-bounded identifiers per request and propagate their opaque
+  lookup identities to child Live Activity entries already correlated with that request.
+- Show identifier names and masked values in request details by default. Reveal and enable copy actions only when the live
+  value-exposure policy permits the specific value.
+- Add exact filter-by-ID input and per-identifier filter actions. Matching must work while values remain masked in the
+  response, and must include the owning request plus its correlated child events without broad substring matching.
+- Cross-link matching retained entries in Live Activity, HTTP Exchanges, and other panels that already preserve the same
+  request/trace relationship; do not add new correlation guesses for unrelated events.
+
+Architecture:
+
+- Put header-name validation, normalization, bounds, opaque lookup identity generation, filtering, and child propagation
+  in JSON-free, framework-neutral engine helpers shared by all adapters.
+- Extract configured correlation headers at the existing inbound request capture points. Do not add another servlet
+  filter, WebFlux filter, Quarkus route filter, or request-body read.
+- Keep the bounded raw identifier only where required for exposure-controlled rendering and clipboard use; use a
+  one-way-derived lookup identity for matching and child propagation so filtering does not require broadcasting raw values
+  in every activity DTO.
+- Apply the live exposure and masking policy at response assembly time. Never log identifiers, include them in error
+  messages, use them as metric labels, or place them in URLs/query strings generated by BootUI.
+
+Out of scope for the first release:
+
+- Generating, replacing, or propagating correlation headers on behalf of the application.
+- Reading identifiers from request/response bodies, cookies, authentication tokens, messaging payloads, or arbitrary
+  unconfigured headers.
+- Fuzzy, prefix, regular-expression, or case-insensitive value matching.
+- Correlating background or messaging activity that does not already share retained request/trace evidence.
+- Persisting identifiers beyond existing in-memory retention or exporting them to telemetry systems.
+
+Acceptance criteria:
+
+- The three built-in header names and valid configured names behave identically across Spring servlet, Spring WebFlux, and
+  Quarkus, including case-insensitive header-name matching.
+- Reserved sensitive header names, invalid names, overlong names/values, and values beyond the per-request cap are rejected
+  or visibly truncated according to one canonical policy.
+- Values are masked by default; reveal and copy remain unavailable until value exposure permits them, and policy changes
+  take effect without restarting capture.
+- Exact filtering works from a user-supplied raw value without exposing that value in unrelated response entries, logs,
+  metric labels, or BootUI-generated URLs.
+- A match returns the owning request and existing correlated children, while unrelated entries with similar or partial
+  values remain excluded.
+- Capture adds no request-body access, duplicate request filter, propagation behavior, or unbounded identifier
+  cardinality.
+- Tests cover built-in/custom names, mixed casing, multiple IDs, duplicate headers, reserved/invalid names, empty and
+  overlong values, masking and live exposure changes, copy denial/success, exact/non-match filtering, child propagation,
+  eviction, and equivalent behavior on all three adapters.
+
+### 3.15 Meter provenance and explanation — Metrics 📋 Planned
+
+The Metrics panel is close to a raw registry dump: it shows meter names, tags, and values without explaining which
+integration contributed a family, what the measurements mean, or how related meters should be read together. This
+enhancement groups meters by evidence-backed provenance and combines native descriptions with a curated BootUI catalogue
+for common integrations.
+
+Scope:
+
+- Extend the existing Metrics contract and UI with provenance groups and concise meter-family explanations on Spring
+  servlet, Spring WebFlux, and Quarkus; keep the existing panel id, route, enablement, and read-only policy.
+- Group related meters into integration families such as JVM, process, system, HTTP server/client, datasource pools,
+  caches, messaging, resilience, gRPC, and framework/runtime metrics when names and native metadata provide sufficient
+  evidence.
+- Show each group's contributor/integration, meter count, available description coverage, common tag keys, base units,
+  and a short explanation of what the family measures and how to interpret its principal counters, gauges, timers, and
+  distributions.
+- Prefer the registry's native meter description and base unit for an individual meter. Use a curated, versioned BootUI
+  catalogue to explain well-known meter families when native descriptions are absent or too narrow.
+- Mark explanation source and confidence (`NATIVE`, `CURATED`, or `UNKNOWN`) and preserve unmatched/custom meters in an
+  explicit **Application / unclassified** group rather than assigning guessed provenance.
+- Add group, provenance, and explanation-availability filters while preserving existing meter-name and tag filtering.
+
+Architecture:
+
+- Put family matching, provenance classification, explanation lookup, ordering, and bounds in JSON-free,
+  framework-neutral engine services over existing neutral meter metadata.
+- Keep the curated catalogue as versioned project data keyed by stable meter-family patterns, with tests against supported
+  Spring Boot, Micrometer, Quarkus, and common integration naming conventions.
+- Use native descriptions and base units from existing registries; do not instantiate binders, register meters, scrape
+  external endpoints, or infer contributors from current numeric values.
+- Bound family-pattern evaluation and group cardinality, and route meter/tag names and descriptions through the existing
+  exposure policy. Never include tag values in catalogue matching or explanations.
+
+Out of scope for the first release:
+
+- Changing meter registration, tags, histograms, percentiles, exporters, or observation configuration.
+- Querying Prometheus, OTLP backends, or any external monitoring system.
+- Generating alerts, health claims, SLOs, or recommendations from current metric values.
+- Exhaustively documenting arbitrary application-defined meters or third-party naming conventions without stable evidence.
+- Assigning provenance from tag values, stack traces, classpath presence alone, or speculative name similarity.
+
+Acceptance criteria:
+
+- Opening the enhanced Metrics view registers no meter or binder and performs no external scrape or network request.
+- Equivalent meter metadata produces the same provenance and explanation DTOs across Spring servlet, Spring WebFlux, and
+  Quarkus.
+- Native descriptions take precedence and are visibly distinguished from curated explanations; unknown meters remain
+  unclassified without invented documentation.
+- Curated family matching is deterministic, versioned, and tested against naming collisions so application meters with
+  similar prefixes are not silently misclassified.
+- Group counts reconcile with the filtered meter set, every meter belongs to exactly one group, and high-cardinality
+  registries remain bounded and pageable.
+- Tag values do not influence provenance and no sensitive tag value is copied into an explanation.
+- Fixtures cover native/curated/unknown descriptions, common integration families, naming collisions, custom meters,
+  missing units, renamed/versioned families, filters, high cardinality, and equivalent adapter output.
+
+### 3.16 Cache tiering and hit ratios — Cache 📋 Planned
+
+The Cache panel shows cache managers and aggregate topology, but a multi-level or composed cache can still appear as one
+opaque manager and provider statistics are not explained consistently. This provider-agnostic enhancement exposes
+framework-available tier structure and native per-cache effectiveness metrics without adding invalidation capture or
+provider-specific promises.
+
+Scope:
+
+- Extend the existing Cache contract and UI with hierarchical manager/cache/tier metadata and native statistics on Spring
+  servlet, Spring WebFlux, and any Quarkus cache integration that exposes equivalent metadata; keep the existing panel id,
+  route, enablement, read-only policy, and existing clear-action policy.
+- Report each cache manager's implementation type, wrapping/composition structure, declared caches, dynamic-cache state,
+  and safely discoverable backing tiers.
+- Represent each tier with a stable identity, implementation category, local/distributed classification when explicitly
+  exposed, configured maximum size/expiry policy where available, and parent/child order.
+- Show per-cache and per-tier native request, hit, miss, put, eviction, removal, load-success/failure, and size statistics
+  where exposed, plus derived hit/miss ratios only when their source counters share compatible semantics and windows.
+- Label every statistic with source, scope, and availability so application-lifetime provider counters are not confused
+  with BootUI's bounded Cache activity recorder.
+- Preserve opaque managers and caches in the report when their implementation does not expose tiers or statistics rather
+  than using reflection heuristics to invent structure.
+
+Architecture:
+
+- Extend the framework-neutral Cache DTOs and engine assembly with bounded hierarchical tier and statistic records,
+  deterministic ordering, safe ratio derivation, and explicit provenance.
+- Extend existing cache adapter/provider SPIs to return only metadata and native statistics they can access through public,
+  supported APIs. Do not import provider libraries into core/engine or hard-code first-release support for named vendors.
+- Keep optional provider/framework types in gated adapter implementations and report unsupported capabilities honestly.
+  Do not use deep reflection into internal cache implementations or trigger cache creation while discovering topology.
+- Reuse existing masking, manager/cache enablement, and clear-action policy. Bound managers, caches, tiers, and statistic
+  series before serialization and refresh live native counters without resetting them.
+
+Out of scope for the first release:
+
+- Capturing distributed invalidation events or adding another Cache/Live Activity event type.
+- Reading, browsing, searching, exporting, warming, or mutating cache entries beyond the panel's existing clear action.
+- Enabling provider statistics, resetting counters, changing expiry/size/tiering configuration, or forcing cache creation.
+- Promising tier discovery or hit ratios for providers that do not expose compatible public metadata.
+- Inferring local/distributed state, tier order, or counter semantics from implementation names alone.
+
+Acceptance criteria:
+
+- Opening or refreshing the panel creates no cache, loads no entry, enables/resets no statistic, and performs no network
+  request.
+- Equivalent exposed tier and statistic metadata produces the same core DTOs across adapters; unsupported providers or
+  fields remain explicitly unavailable.
+- Opaque and dynamically created cache managers render safely without deep reflection, classloading failures, or invented
+  tier structure.
+- Derived ratios are shown only for compatible counters with a known denominator and scope, including correct handling of
+  zero requests, unavailable counters, and counter resets.
+- Existing clear actions retain their current confirmation, enablement, and read-only behavior; this enhancement adds no
+  new mutation.
+- High-cardinality managers/caches/tiers/statistics are bounded with visible truncation and deterministic ordering.
+- Fixtures cover single-tier, composed, opaque, dynamic, local/distributed-declared, statistics-present/absent, zero/reset
+  counters, incompatible scopes, adapter unavailability, existing clear policy, and high-cardinality truncation.
 
 ## 4. Cross-cutting work for every new panel
 
@@ -680,21 +787,13 @@ For each feature above, the following must move together, consistent with the ex
 
 ## 5. Risks
 
-| Risk                                                              | Feature(s) | Impact | Mitigation                                                                                                |
-| ----------------------------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------------------------------------- |
-| Exposing sensitive headers, trace context, or mail body           | 3.1, 3.3   | High   | Loopback-only activation, masking/value-exposure on every new surface, sandboxed HTML, and focused tests. |
-| Unbounded capture buffers or large rendered graphs/lists          | 3.2, 3.3   | Medium | Fixed-size buffers, server-side paging, bounded snapshots, and focus-and-neighborhood graph rendering.    |
-| Optional Actuator endpoints, libraries, beans, or servers missing | all        | Medium | Internal bridges, classpath/bean gating, stable empty DTOs, and clear unavailable reasons per panel.      |
-| Bean/dependency graph or correlation bloating the bundle          | 3.1, 3.2   | Medium | Bounded rendering, lightweight visualization, and lazy-loaded panels.                                     |
-| Silently swallowing application mail                              | 3.3        | Medium | Pass-through by default; "dev trap" mode strictly opt-in.                                                 |
-| Over-broad or noisy new Live Activity event types (e.g. cache operations) | 3.4 | Medium | Explicit opt-in wiring by bean/class presence, bounded buffers, masked payloads/hashed cache keys. |
-| Messaging capture's added optional-dependency surface (Kafka/RabbitMQ/JMS clients), invasive interception of app-owned messaging beans, and a per-adapter capture design (SmallRye Reactive Messaging on Quarkus vs. imperative templates on Spring) | 3.4 | High | Kafka and RabbitMQ shipped on **both adapters**, and JMS on Spring, with classpath/capability gating identical to Hibernate/Cache/Flyway/Liquibase, pass-through/fail-open wrapping, bounded metadata-only buffers, and no message-value/payload capture. |
+| Risk                                                              | Feature(s) | Impact | Mitigation                                                                                                    |
+| ----------------------------------------------------------------- | ---------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| Optional Actuator endpoints, libraries, beans, or servers missing | all        | Medium | Internal bridges, classpath/bean gating, stable empty DTOs, and clear unavailable reasons per panel.          |
 | MongoDB inspection leaks credentials/documents or performs surprising network work | 3.5 | High | Never expose documents or raw connection strings; initial render is network-free; inspection is explicit, bounded, timed out, masked, and read-only. |
 | MongoDB optional drivers break applications without the extension | 3.5 | High | Keep driver types in adapter-only providers and use Spring classpath gates plus Quarkus capability/exclusion build steps. |
 | Large MongoDB catalog or partial permissions make inspection slow or misleading | 3.5 | Medium | Hard caps, paging, configurable timeouts, partial-result DTOs, and per-target permission errors. |
 | Scope creep beyond the planned MongoDB inventory/advisor surface | 3.5 | High | Keep document browsing, arbitrary commands, writes, tracing, and migrations out of the first release. |
-| Incomplete service-map evidence creates false confidence or false health claims | 3.6 | High | **Shipped:** `configured` and `observed` are separate fields that are never collapsed, `outcome` is `NO_EVIDENCE`/`OBSERVED_OK`/`RETAINED_FAILURES`, statement-to-pool attribution is refused when ambiguous, and the copy states plainly that a retained failure is evidence, not a health check. |
-| Service-map identities expose secrets or create an unbounded topology | 3.6 | High | **Shipped:** HTTP identities are reduced to `scheme://host[:port]` (user-info, path, query, and fragment dropped); JDBC targets independently strip authority/Oracle credentials and parameter tails regardless of exposure mode; complete sanitized identities drive grouping and SHA-256-derived stable ids while only labels are truncated; payloads/keys/SQL text never enter the contract; and 28 dependencies / 6 interactions per edge are enforced before serialization with visible truncation. |
 
 ## 6. Validation checklist
 


### PR DESCRIPTION
## What does this PR do?

Cleans up `docs/PLAN.md` by removing delivered work and replacing the loose candidate backlog with scoped planned specifications for the selected roadmap items.

The roadmap now keeps MongoDB as the next workstream, records the remaining approved items as planned without fixed ordering, and gives each item explicit scope, architecture, exclusions, and acceptance criteria. GraphQL, Pulsar, object storage, and HTTP session invalidation were removed.

## Why is this change needed?

Completed work and partially developed candidate notes made the implementation plan difficult to scan and left future items at inconsistent levels of detail. This gives reviewers and contributors a roadmap focused only on active work, with enough constraints to evaluate and implement each item safely across supported adapters.

N/A - no source issue.

## How was it tested?

Documentation-only change; runtime tests are not applicable.

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [ ] Added or updated tests where applicable

## Screenshots (UI changes)

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed