### PR TITLE
Fix Spring native JCache startup

### DIFF
--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/NativeHintsConfiguration.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/NativeHintsConfiguration.java
@@ -35,6 +35,9 @@ import org.springframework.context.annotation.ImportRuntimeHints;
  *       {@code UnionSubclassEntityPersister}, which Hibernate instantiates reflectively via its
  *       public 4-arg constructor. Neither Hibernate 7.2 nor Spring Boot's AOT hints register that
  *       constructor, so its public constructors are registered here.
+ *   <li><b>Hibernate JCache region factory reflection</b> — Hibernate resolves the configured {@code
+ *       jcache} region factory and instantiates {@code JCacheRegionFactory} reflectively through its
+ *       public no-arg constructor, which is registered here.
  *   <li><b>Hibernate identifier-array reflection</b> — Hibernate's multi-id entity loader
  *       reflectively instantiates a {@code UUID[]} array for the {@code SampleAuditEntry} {@code
  *       UUID} identifier. GraalVM requires the array type to be registered for reflective
@@ -92,6 +95,16 @@ class NativeHintsConfiguration {
                     .registerTypeIfPresent(
                             classLoader,
                             "org.hibernate.persister.entity.UnionSubclassEntityPersister",
+                            MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
+
+            // Hibernate resolves the configured "jcache" region factory by name and reflectively
+            // invokes its no-arg constructor. Spring Boot's AOT processing does not infer this
+            // constructor, so the native executable otherwise fails while building the
+            // SessionFactory.
+            hints.reflection()
+                    .registerTypeIfPresent(
+                            classLoader,
+                            "org.hibernate.cache.jcache.internal.JCacheRegionFactory",
                             MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
 
             // Hibernate builds a multi-id entity loader for every entity and, for the

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/config/NativeHintsConfigurationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/config/NativeHintsConfigurationTests.java
@@ -1,0 +1,24 @@
+package io.github.jdubois.bootui.sample.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+class NativeHintsConfigurationTests {
+
+    @Test
+    void registersJCacheRegionFactoryPublicConstructor() {
+        RuntimeHints hints = new RuntimeHints();
+        new NativeHintsConfiguration.SampleRuntimeHints()
+                .registerHints(hints, getClass().getClassLoader());
+
+        assertThat(RuntimeHintsPredicates.reflection()
+                        .onType(TypeReference.of("org.hibernate.cache.jcache.internal.JCacheRegionFactory"))
+                        .withMemberCategory(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS))
+                .accepts(hints);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Registers Hibernate's `JCacheRegionFactory` public constructor in the Spring sample application's runtime hints and adds a focused hint-registration test.

## Why is this change needed?

GitHub Actions run 32344348527 built the native image successfully, but its smoke test failed while Hibernate initialized the second-level cache. Hibernate resolves the configured `jcache` region factory by name and reflectively invokes its no-arg constructor; GraalVM omitted that constructor without explicit reflection metadata, causing `NoSuchMethodException: JCacheRegionFactory.<init>()`.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Targeted validation:

- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-spring-sample-app -am -Dtest=NativeHintsConfigurationTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-spring-sample-app spotless:check`

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: sample-only native metadata fix)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed