### PR TITLE
Fix native Maven wrapper bootstrap on amd64

### DIFF
--- a/Dockerfile-native
+++ b/Dockerfile-native
@@ -33,6 +33,13 @@ WORKDIR /app
 
 # Copy the whole multi-module project (see .dockerignore for exclusions).
 COPY . .
+
+# The wrapper jar is intentionally not committed. Fetch the pinned artifact through BuildKit
+# instead of relying on architecture-specific downloader availability in the GraalVM image.
+ADD --checksum=sha256:4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1 \
+    https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar \
+    .mvn/wrapper/maven-wrapper.jar
+
 RUN chmod +x mvnw
 
 # Build a "mostly static" native image: statically link everything (including zlib) except glibc,


### PR DESCRIPTION
## What does this PR do?

Fetches the pinned Maven Wrapper JAR through BuildKit before the Spring native-image build invokes `./mvnw`.

## Why is this change needed?

The `ghcr.io/graalvm/graalvm-community:25` amd64 image used by `Dockerfile-native` has no usable wrapper downloader. Because `maven-wrapper.jar` is intentionally ignored, [Actions run 32344348527](https://github.com/jdubois/boot-ui/actions/runs/32344348527) failed with `MavenWrapperMain` `ClassNotFoundException`; the arm64 build only proceeded because its base happened to bootstrap differently. Remote `ADD` with the Maven Central SHA-256 makes both architectures use the same verified wrapper artifact without committing the binary or changing the build command.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable — verified the pinned remote JAR SHA-256 matches the repository's wrapper artifact and `git diff --check` passes; local Docker validation was unavailable because the daemon was not running

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes — N/A; build bootstrap only
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed