### PR TITLE
Fix Quarkus Docker startup with pinned H2

### DIFF
--- a/Dockerfile-quarkus
+++ b/Dockerfile-quarkus
@@ -101,10 +101,13 @@ RUN ./mvnw -B -ntp -DskipTests -pl bootui-quarkus-deployment,bootui-quarkus-samp
 ENV QUARKUS_HTTP_HOST=0.0.0.0
 ENV QUARKUS_HTTP_PORT=8082
 
-# Run Docker-free on in-memory H2 instead of the PostgreSQL Dev Service. db-kind is a build-time
-# setting, but dev mode re-augments at startup and reads these environment variables; the explicit URL
-# also disables datasource Dev Services so no container is required. Hibernate ORM builds the schema.
+# Run Docker-free on in-memory H2 instead of the PostgreSQL Dev Service. db-kind and db-version are
+# build-time settings, but dev mode re-augments at startup and reads these environment variables; the
+# explicit URL also disables datasource Dev Services so no container is required. Hibernate ORM builds
+# the schema. Keep the expected version aligned with the Flyway-compatible flyway-verified-h2.version
+# pin in the root POM so Hibernate accepts the deliberately older H2 driver at container startup.
 ENV QUARKUS_DATASOURCE_DB_KIND=h2
+ENV QUARKUS_DATASOURCE_DB_VERSION=2.3.232
 ENV QUARKUS_DATASOURCE_USERNAME=sa
 ENV QUARKUS_DATASOURCE_JDBC_URL="jdbc:h2:mem:bootui;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=false"
 


### PR DESCRIPTION
## What does this PR do?

Configures the Quarkus Docker sample to expect H2 2.3.232 during dev-mode augmentation while preserving the Flyway-compatible dependency pin.

## Why is this change needed?

GitHub Actions run 32344348527 failed both Quarkus Docker smoke-test jobs because current Quarkus/Hibernate ORM expects H2 2.4.240 or newer, but the sample deliberately resolves H2 2.3.232. Hibernate rejected the actual driver version at container startup before `/bootui/api/panels` became ready.

## How was it tested?

- [x] Built `bootui-quarkus-sample-app` and dependencies on JDK 21 with an isolated `.m2` repository
- [x] Started the sample under Docker/Linux with the Dockerfile's H2 environment and workflow-equivalent gateway trust; `/bootui/api/panels` and `/bootui/` both returned HTTP 200
- [x] Ran `./mvnw -B -ntp -Dmaven.repo.local="$PWD/.m2" spotless:check`
- [x] Updated the directly coupled Docker configuration comment

## Screenshots (UI changes)

Not applicable.

## Checklist

- [x] Documentation/comments updated where applicable
- [x] Public API remains backward compatible
- [x] No secrets, tokens, or local paths committed