### PR TITLE
Fix native Caffeine configuration resources

### DIFF
--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/NativeHintsConfiguration.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/NativeHintsConfiguration.java
@@ -38,6 +38,9 @@ import org.springframework.context.annotation.ImportRuntimeHints;
  *   <li><b>Hibernate JCache region factory reflection</b> — Hibernate resolves the configured {@code
  *       jcache} region factory and instantiates {@code JCacheRegionFactory} reflectively through its
  *       public no-arg constructor, which is registered here.
+ *   <li><b>Caffeine JCache configuration resources</b> — Typesafe Config loads the sample's {@code
+ *       application.conf} and Caffeine's default {@code reference.conf} at runtime, so both resources
+ *       are included in the native image.
  *   <li><b>Hibernate identifier-array reflection</b> — Hibernate's multi-id entity loader
  *       reflectively instantiates a {@code UUID[]} array for the {@code SampleAuditEntry} {@code
  *       UUID} identifier. GraalVM requires the array type to be registered for reflective
@@ -106,6 +109,11 @@ class NativeHintsConfiguration {
                             classLoader,
                             "org.hibernate.cache.jcache.internal.JCacheRegionFactory",
                             MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
+
+            // Typesafe Config discovers these HOCON resources by name at runtime. Spring AOT does
+            // not infer that lookup, so the native image otherwise starts without the "caffeine"
+            // configuration root and fails while Hibernate creates its JCache regions.
+            hints.resources().registerPattern("application.conf").registerPattern("reference.conf");
 
             // Hibernate builds a multi-id entity loader for every entity and, for the
             // SampleAuditEntry UUID identifier, reflectively instantiates a UUID[] array through

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/config/NativeHintsConfigurationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/config/NativeHintsConfigurationTests.java
@@ -10,15 +10,26 @@ import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 
 class NativeHintsConfigurationTests {
 
-    @Test
-    void registersJCacheRegionFactoryPublicConstructor() {
-        RuntimeHints hints = new RuntimeHints();
+    private final RuntimeHints hints = new RuntimeHints();
+
+    NativeHintsConfigurationTests() {
         new NativeHintsConfiguration.SampleRuntimeHints()
                 .registerHints(hints, getClass().getClassLoader());
+    }
 
+    @Test
+    void registersJCacheRegionFactoryPublicConstructor() {
         assertThat(RuntimeHintsPredicates.reflection()
                         .onType(TypeReference.of("org.hibernate.cache.jcache.internal.JCacheRegionFactory"))
                         .withMemberCategory(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS))
+                .accepts(hints);
+    }
+
+    @Test
+    void registersCaffeineJCacheConfigurationResources() {
+        assertThat(RuntimeHintsPredicates.resource().forResource("application.conf"))
+                .accepts(hints);
+        assertThat(RuntimeHintsPredicates.resource().forResource("reference.conf"))
                 .accepts(hints);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Registers the sample app's `application.conf` and Caffeine's `reference.conf` as Spring AOT resources so they are included in the GraalVM native image. It also adds regression coverage for both resource hints.

## Why is this change needed?

The native Docker images for both `linux/amd64` and `linux/arm64` exited during startup because Typesafe Config could not find the `caffeine` configuration root while Hibernate initialized JCache. Spring AOT includes `application.properties` automatically, but it does not infer the runtime HOCON lookups.

Closes #

N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Ran `NativeHintsConfigurationTests` and generated the Spring AOT reachability metadata, confirming that both `application.conf` and `reference.conf` are included.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed