### PR TITLE
Fix Docker publish workflow failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,14 +56,15 @@ FROM eclipse-temurin:25-jdk-noble AS build
 
 WORKDIR /app
 
-# Install curl so the Maven wrapper can download maven-wrapper.jar (this base image
-# ships without curl/wget, and the wrapper jar is not committed to the repository).
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
 # Copy the whole multi-module project (see .dockerignore for exclusions).
 COPY . .
+
+# The wrapper jar is intentionally not committed. Fetch and verify it through BuildKit
+# before Maven starts instead of relying on the wrapper's unchecked runtime download.
+ADD --checksum=sha256:4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1 \
+    https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar \
+    .mvn/wrapper/maven-wrapper.jar
+
 RUN chmod +x mvnw
 
 # Build the sample app and its reactor dependencies. The Maven local repository

--- a/Dockerfile-aot
+++ b/Dockerfile-aot
@@ -63,14 +63,15 @@ FROM eclipse-temurin:25-jdk-noble AS build
 
 WORKDIR /app
 
-# Install curl as a fallback the Maven wrapper can use to bootstrap
-# maven-wrapper.jar if the committed wrapper jar is ever unavailable.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
 # Copy the whole multi-module project (see .dockerignore for exclusions).
 COPY . .
+
+# The wrapper jar is intentionally not committed. Fetch and verify it through BuildKit
+# before Maven starts instead of relying on the wrapper's unchecked runtime download.
+ADD --checksum=sha256:4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1 \
+    https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar \
+    .mvn/wrapper/maven-wrapper.jar
+
 RUN chmod +x mvnw
 
 # Build the sample app with the `aot` Maven profile, which runs

--- a/Dockerfile-crac
+++ b/Dockerfile-crac
@@ -50,6 +50,13 @@ WORKDIR /app
 
 # Copy the whole multi-module project (see .dockerignore for exclusions).
 COPY . .
+
+# The wrapper jar is intentionally not committed. Fetch and verify it through BuildKit
+# before Maven starts instead of relying on the wrapper's unchecked runtime download.
+ADD --checksum=sha256:4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1 \
+    https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar \
+    .mvn/wrapper/maven-wrapper.jar
+
 RUN chmod +x mvnw
 
 # Build the sample app and its reactor dependencies. The sample app binds the

--- a/Dockerfile-quarkus
+++ b/Dockerfile-quarkus
@@ -67,12 +67,6 @@ FROM eclipse-temurin:21-jdk-noble
 
 WORKDIR /app
 
-# Install curl so the Maven wrapper can download maven-wrapper.jar (this base image ships without
-# curl/wget, and the wrapper jar is not committed to the repository).
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
 # Run as a non-root user. Quarkus dev mode writes under target/, and BootUI writes its runtime state
 # under the working directory, so /app and everything under it is owned by this user.
 RUN useradd --uid 1001 --create-home --home-dir /home/bootui --shell /usr/sbin/nologin bootui \
@@ -80,6 +74,14 @@ RUN useradd --uid 1001 --create-home --home-dir /home/bootui --shell /usr/sbin/n
 
 # Copy the whole multi-module project (see .dockerignore for exclusions).
 COPY --chown=1001:1001 . .
+
+# The wrapper jar is intentionally not committed. Fetch and verify it through BuildKit
+# before Maven starts instead of relying on the wrapper's unchecked runtime download.
+ADD --chown=1001:1001 \
+    --checksum=sha256:4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1 \
+    https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar \
+    .mvn/wrapper/maven-wrapper.jar
+
 RUN chmod +x mvnw
 
 USER 1001

--- a/Dockerfile-webflux
+++ b/Dockerfile-webflux
@@ -67,14 +67,15 @@ FROM eclipse-temurin:25-jdk-noble AS build
 
 WORKDIR /app
 
-# Install curl so the Maven wrapper can download maven-wrapper.jar (this base image
-# ships without curl/wget, and the wrapper jar is not committed to the repository).
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
 # Copy the whole multi-module project (see .dockerignore for exclusions).
 COPY . .
+
+# The wrapper jar is intentionally not committed. Fetch and verify it through BuildKit
+# before Maven starts instead of relying on the wrapper's unchecked runtime download.
+ADD --checksum=sha256:4e2fbf6554bc8a4702cdfdd3bef464f423393d784ddbb037216320ce55d5e4e1 \
+    https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar \
+    .mvn/wrapper/maven-wrapper.jar
+
 RUN chmod +x mvnw
 
 # Build the sample app and its reactor dependencies. The Maven local repository

--- a/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/NativeHintsConfiguration.java
+++ b/bootui-spring-sample-app/src/main/java/io/github/jdubois/bootui/sample/config/NativeHintsConfiguration.java
@@ -38,9 +38,10 @@ import org.springframework.context.annotation.ImportRuntimeHints;
  *   <li><b>Hibernate JCache region factory reflection</b> — Hibernate resolves the configured {@code
  *       jcache} region factory and instantiates {@code JCacheRegionFactory} reflectively through its
  *       public no-arg constructor, which is registered here.
- *   <li><b>Caffeine JCache configuration resources</b> — Typesafe Config loads the sample's {@code
- *       application.conf} and Caffeine's default {@code reference.conf} at runtime, so both resources
- *       are included in the native image.
+ *   <li><b>Caffeine JCache native support</b> — Typesafe Config loads the sample's {@code
+ *       application.conf} and Caffeine's default {@code reference.conf} at runtime. Caffeine then
+ *       loads the generated {@code PSMS} node implementation by name. The resources and the node's
+ *       constructors are included in the native image.
  *   <li><b>Hibernate identifier-array reflection</b> — Hibernate's multi-id entity loader
  *       reflectively instantiates a {@code UUID[]} array for the {@code SampleAuditEntry} {@code
  *       UUID} identifier. GraalVM requires the array type to be registered for reflective
@@ -114,6 +115,15 @@ class NativeHintsConfiguration {
             // not infer that lookup, so the native image otherwise starts without the "caffeine"
             // configuration root and fails while Hibernate creates its JCache regions.
             hints.resources().registerPattern("application.conf").registerPattern("reference.conf");
+
+            // The sample's maximum-size JCache configuration selects Caffeine's generated PSMS
+            // node implementation. NodeFactory loads it by name and invokes its package-private
+            // constructor, which native-image cannot infer from the application configuration.
+            hints.reflection()
+                    .registerTypeIfPresent(
+                            classLoader,
+                            "com.github.benmanes.caffeine.cache.PSMS",
+                            MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
 
             // Hibernate builds a multi-id entity loader for every entity and, for the
             // SampleAuditEntry UUID identifier, reflectively instantiates a UUID[] array through

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/config/NativeHintsConfigurationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/config/NativeHintsConfigurationTests.java
@@ -32,4 +32,12 @@ class NativeHintsConfigurationTests {
         assertThat(RuntimeHintsPredicates.resource().forResource("reference.conf"))
                 .accepts(hints);
     }
+
+    @Test
+    void registersCaffeineGeneratedNodeConstructors() {
+        assertThat(RuntimeHintsPredicates.reflection()
+                        .onType(TypeReference.of("com.github.benmanes.caffeine.cache.PSMS"))
+                        .withMemberCategory(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS))
+                .accepts(hints);
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Retains the generated Caffeine cache node required by the Spring native sample and makes Maven Wrapper bootstrap deterministic across all Docker image builds.

## Why is this change needed?

The Docker publish workflow failed in three matrix jobs. Both native images started without `com.github.benmanes.caffeine.cache.PSMS`, while the ARM64 JVM image could not load `org.apache.maven.wrapper.MavenWrapperMain` after runtime wrapper download failure.

Failed run: https://github.com/jdubois/boot-ui/actions/runs/32371839809

Closes # N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Focused native-hint tests and `spotless:check` pass. All six Dockerfiles pass BuildKit validation. A full local native container build was blocked before native compilation by npm registry TLS resets in the Docker builder.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: no user-facing behavior change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed