### PR TITLE
Fix flaky OSV chunk failure test

### DIFF
--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -825,8 +825,11 @@ class OsvVulnerabilityScannerTests {
         AtomicInteger calls = new AtomicInteger();
         String firstResults = "{\"results\":[" + "{},".repeat(999) + "{}]}";
         server.createContext("/v1/querybatch", exchange -> {
+            try (var requestBody = exchange.getRequestBody()) {
+                requestBody.readAllBytes();
+            }
             int call = calls.incrementAndGet();
-            // Avoid the JDK test server intermittently corrupting a reused connection between chunks.
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
             exchange.getResponseHeaders().add("Connection", "close");
             if (call == 1) {
                 byte[] body = firstResults.getBytes(StandardCharsets.UTF_8);


### PR DESCRIPTION
## What does this PR do?

Makes the Spring OSV partial-chunk failure fixture consume each request body completely before sending its response, matching the reliable Quarkus fixture behavior.

## Why is this change needed?

The Java 17 baseline intermittently failed because the JDK test HTTP server responded to a large query batch without draining its request body. That could abort or corrupt the exchange before the scanner sent the second chunk, and the existing `Connection: close` mitigation did not eliminate the failure.

Closes #

N/A

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

The affected test passed 20 consecutive runs, and the exact parallel coverage build from the failed workflow completed successfully.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed