### PR TITLE
Reduce Maven output in container workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
             exit 1
           fi
 
-          CURRENT_VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
+          CURRENT_VERSION="$(./mvnw -B -ntp -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
           echo "Preparing release $TAG from $CURRENT_VERSION"
 
           ./mvnw -B -ntp versions:set \
@@ -263,7 +263,7 @@ jobs:
         run: |
          set -euo pipefail
 
-         VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
+         VERSION="$(./mvnw -B -ntp -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
          EXPECTED_TAG="v$VERSION"
 
          if [[ "$VERSION" == *-SNAPSHOT ]]; then
@@ -334,7 +334,7 @@ jobs:
         run: |
          set -euo pipefail
 
-         VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
+         VERSION="$(./mvnw -B -ntp -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
          EXPECTED_TAG="v$VERSION"
 
          if [[ "$(git rev-parse HEAD)" != "$RELEASE_SHA" ]]; then
@@ -393,7 +393,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
+          VERSION="$(./mvnw -B -ntp -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
           BASE="https://repo1.maven.org/maven2/com/julien-dubois/bootui"
 
           # Every published artifact: the parent POM and one JAR per published module.
@@ -435,9 +435,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
-          SPRING_BOOT_VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=spring-boot.version | tail -n 1)"
-          QUARKUS_VERSION="$(./mvnw -q -N -DforceStdout help:evaluate -Dexpression=quarkus.platform.version | tail -n 1)"
+          VERSION="$(./mvnw -B -ntp -q -N -DforceStdout help:evaluate -Dexpression=project.version | tail -n 1)"
+          SPRING_BOOT_VERSION="$(./mvnw -B -ntp -q -N -DforceStdout help:evaluate -Dexpression=spring-boot.version | tail -n 1)"
+          QUARKUS_VERSION="$(./mvnw -B -ntp -q -N -DforceStdout help:evaluate -Dexpression=quarkus.platform.version | tail -n 1)"
           echo "Smoke-testing BootUI ${VERSION} against the published Maven Central artifacts."
           echo "Distributions: Spring MVC (servlet starter), Spring WebFlux (reactive starter), Quarkus extension."
 
@@ -543,7 +543,7 @@ jobs:
           LOG_MVC="$(mktemp)"
           # Standalone project outside the reactor; no -o (must resolve from Central).
           # fork=false keeps the app in the Maven JVM so killing this PID stops it cleanly.
-          ./mvnw -ntp -f "$MVC_SMOKE_DIR/pom.xml" -Dmaven.test.skip=true \
+          ./mvnw -B -ntp -f "$MVC_SMOKE_DIR/pom.xml" -Dmaven.test.skip=true \
             -Dspring-boot.run.fork=false \
             spring-boot:run > "$LOG_MVC" 2>&1 &
           MVC_PID=$!
@@ -559,7 +559,7 @@ jobs:
           WEBFLUX_SMOKE_DIR="$(mktemp -d)"
           create_spring_smoke_project "$WEBFLUX_SMOKE_DIR" "bootui-spring-boot-starter-reactive" "8081"
           LOG_WEBFLUX="$(mktemp)"
-          ./mvnw -ntp -f "$WEBFLUX_SMOKE_DIR/pom.xml" -Dmaven.test.skip=true \
+          ./mvnw -B -ntp -f "$WEBFLUX_SMOKE_DIR/pom.xml" -Dmaven.test.skip=true \
             -Dspring-boot.run.fork=false \
             spring-boot:run > "$LOG_WEBFLUX" 2>&1 &
           WEBFLUX_PID=$!

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN chmod +x mvnw
 # image size. (Requires BuildKit, the default in modern Docker.)
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
-    ./mvnw -DskipTests -pl bootui-spring-sample-app -am clean package
+    ./mvnw -B -ntp -DskipTests -pl bootui-spring-sample-app -am clean package
 
 # Explode the repackaged Spring Boot jar into its layers (dependencies,
 # spring-boot-loader, snapshot-dependencies, application). These are copied

--- a/Dockerfile-aot
+++ b/Dockerfile-aot
@@ -87,7 +87,7 @@ RUN chmod +x mvnw
 # not in the image. (Requires BuildKit, the default in modern Docker.)
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
-    ./mvnw -Paot -DskipTests -pl bootui-spring-sample-app -am clean package
+    ./mvnw -B -ntp -Paot -DskipTests -pl bootui-spring-sample-app -am clean package
 
 # Explode the repackaged Spring Boot jar into its layers (dependencies,
 # spring-boot-loader, snapshot-dependencies, application). These are copied

--- a/Dockerfile-crac
+++ b/Dockerfile-crac
@@ -70,7 +70,7 @@ RUN chmod +x mvnw
 # not in the image. (Requires BuildKit, the default in modern Docker.)
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
-    ./mvnw -Pcrac -DskipTests -pl bootui-spring-sample-app -am clean package
+    ./mvnw -B -ntp -Pcrac -DskipTests -pl bootui-spring-sample-app -am clean package
 
 # Runtime stage with a CRaC-enabled JDK (BellSoft Liberica with CRaC support).
 FROM bellsoft/liberica-runtime-container:jdk-21-crac-slim-glibc

--- a/Dockerfile-native
+++ b/Dockerfile-native
@@ -63,7 +63,7 @@ ENV NATIVE_IMAGE_OPTIONS="-H:+StaticExecutableWithDynamicLibC"
 # root, so the Maven/npm home is /root.
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
-    ./mvnw -Pnative -DskipTests -pl bootui-spring-sample-app -am clean package
+    ./mvnw -B -ntp -Pnative -DskipTests -pl bootui-spring-sample-app -am clean package
 
 # Move the native executable to a known path (the native-maven-plugin names it
 # after the module artifactId, i.e. bootui-spring-sample-app).

--- a/Dockerfile-webflux
+++ b/Dockerfile-webflux
@@ -87,7 +87,7 @@ RUN chmod +x mvnw
 # image size. (Requires BuildKit, the default in modern Docker.)
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
-    ./mvnw -DskipTests -pl bootui-spring-webflux-sample-app -am clean package
+    ./mvnw -B -ntp -DskipTests -pl bootui-spring-webflux-sample-app -am clean package
 
 # Explode the repackaged Spring Boot jar into its layers (dependencies,
 # spring-boot-loader, snapshot-dependencies, application). These are copied


### PR DESCRIPTION
## What does this PR do?

Adds Maven batch mode (`-B`) and disables transfer progress (`-ntp`) consistently across Docker image builds and the remaining release workflow Maven invocations.

## Why is this change needed?

Dependency-transfer progress makes GitHub Actions logs unnecessarily large, especially for GraalVM native image builds. This keeps useful lifecycle, warning, and error output while removing repetitive transfer progress.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [ ] Added or updated tests where applicable

The release integrity policy check passes, and the workflow/Dockerfile diff passes Git whitespace validation. Application tests are not applicable because this only changes Maven CLI logging flags.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes (N/A: no product behavior change)
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed