### PR TITLE
Add isolated Spring sample runner

### DIFF
--- a/bootui-spring-sample-app/run-local.sh
+++ b/bootui-spring-sample-app/run-local.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPOSITORY_ROOT=$(dirname "$SCRIPT_DIR")
+
+export MAVEN_OPTS="${MAVEN_OPTS:+$MAVEN_OPTS }-Dmaven.repo.local=$REPOSITORY_ROOT/.m2"
+
+cd "$REPOSITORY_ROOT"
+
+./mvnw -B -ntp -DskipTests -pl bootui-spring-sample-app -am install
+exec ./mvnw -B -ntp -Dmaven.test.skip=true -pl bootui-spring-sample-app \
+    spring-boot:run -Dspring-boot.run.profiles=dev "$@"


### PR DESCRIPTION
## What does this PR do?

Adds an executable `bootui-spring-sample-app/run-local.sh` helper that builds the Spring sample's reactor dependency closure without running tests, installs artifacts into the current worktree's `.m2`, and starts the sample with the `dev` profile.

## Why is this change needed?

Testing local module changes through the Spring Boot sample currently requires manually installing several modules. The helper makes that workflow one step while preventing concurrent worktrees from writing BootUI artifacts to the shared Maven repository.

Closes # N/A

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [ ] Added or updated tests where applicable

Validated the script with `sh -n` and confirmed `-pl bootui-spring-sample-app -am` selects only the parent, core, engine, conformance, Spring autoconfiguration, UI, MVC starter, and sample app modules.

## Screenshots (UI changes)

N/A

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed