### PR TITLE
Optimize BootUI frontend loading

### DIFF
--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import {apiFetch} from './api.js'
-import {computed, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, watch} from 'vue'
+import {computed, defineAsyncComponent, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, watch} from 'vue'
 import {useRoute, useRouter} from 'vue-router'
 import {
   applyTheme,
@@ -24,7 +24,7 @@ import {
 import {recordRecentPanel} from './utils/recentPanels.js'
 import {safeLocalStorage} from './utils/safeStorage.js'
 import CommandPalette from './views/components/CommandPalette.vue'
-import ConfirmDialog from './views/components/ConfirmDialog.vue'
+const ConfirmDialog = defineAsyncComponent(() => import('./views/components/ConfirmDialog.vue'))
 
 const router = useRouter()
 const route = useRoute()

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -1,7 +1,6 @@
 import {createApp} from 'vue'
 import {createRouter, createWebHashHistory} from 'vue-router'
 import 'bootstrap/dist/css/bootstrap.min.css'
-import 'bootstrap/js/dist/collapse'
 import './generated/bootstrap-icons.css'
 import App from './App.vue'
 import {routes} from './routes.js'

--- a/bootui-ui/src/main/frontend/src/views/Crac.vue
+++ b/bootui-ui/src/main/frontend/src/views/Crac.vue
@@ -1,4 +1,5 @@
 <script setup>
+import 'bootstrap/js/dist/collapse'
 import {computed, onMounted, ref} from 'vue'
 import {actionBusyMessage, apiFetch, getJson, isActionBusyError} from '../api.js'
 import {formatClockTime} from '../utils/format.js'

--- a/bootui-ui/src/main/frontend/src/views/GraalVm.vue
+++ b/bootui-ui/src/main/frontend/src/views/GraalVm.vue
@@ -1,4 +1,5 @@
 <script setup>
+import 'bootstrap/js/dist/collapse'
 import {computed, onBeforeUnmount, onMounted, ref} from 'vue'
 import {actionBusyMessage, apiFetch, getJson, isActionBusyError} from '../api.js'
 import {formatClockTime} from '../utils/format.js'

--- a/bootui-ui/src/main/frontend/src/views/SpringSecurity.vue
+++ b/bootui-ui/src/main/frontend/src/views/SpringSecurity.vue
@@ -1,4 +1,5 @@
 <script setup>
+import 'bootstrap/js/dist/collapse'
 import {apiFetch, getJson} from '../api.js'
 import {computed, inject, onMounted, ref} from 'vue'
 import {describeLoadError, formatLoadError} from '../utils/loadError.js'

--- a/bootui-ui/src/main/frontend/src/views/components/ConfirmDialog.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {nextTick, ref, watch} from 'vue'
+import {nextTick, onMounted, ref, watch} from 'vue'
 import {confirmState, settleConfirm} from '../../utils/useConfirm.js'
 
 const dialogEl = ref(null)
@@ -11,30 +11,30 @@ function supportsModal() {
   return dialogEl.value && typeof dialogEl.value.showModal === 'function'
 }
 
-watch(
-  () => confirmState.open,
-  async (open) => {
-    const el = dialogEl.value
-    if (!el) return
-    if (open) {
-      // Remember the control that launched the prompt so focus can return to it.
-      trigger = document.activeElement
-      if (!el.open) {
-        if (supportsModal()) el.showModal()
-        else el.setAttribute('open', '')
-      }
-      await nextTick()
-      // Default focus to the safe choice: Cancel for destructive prompts.
-      const target = confirmState.options.danger ? cancelBtn.value : confirmBtn.value
-      target?.focus()
-    } else if (el.open) {
-      if (typeof el.close === 'function') el.close()
-      else el.removeAttribute('open')
-      if (trigger && typeof trigger.focus === 'function') trigger.focus()
-      trigger = null
+async function syncDialog(open) {
+  const el = dialogEl.value
+  if (!el) return
+  if (open) {
+    // Remember the control that launched the prompt so focus can return to it.
+    trigger = document.activeElement
+    if (!el.open) {
+      if (supportsModal()) el.showModal()
+      else el.setAttribute('open', '')
     }
+    await nextTick()
+    // Default focus to the safe choice: Cancel for destructive prompts.
+    const target = confirmState.options.danger ? cancelBtn.value : confirmBtn.value
+    target?.focus()
+  } else if (el.open) {
+    if (typeof el.close === 'function') el.close()
+    else el.removeAttribute('open')
+    if (trigger && typeof trigger.focus === 'function') trigger.focus()
+    trigger = null
   }
-)
+}
+
+watch(() => confirmState.open, syncDialog)
+onMounted(() => syncDialog(confirmState.open))
 
 // Escape on a modal <dialog> fires a native `cancel` event; handle it (and the
 // fallback keydown) through the shared settle path so the promise resolves false.


### PR DESCRIPTION
## What does this PR do?

Defers the confirmation dialog and Bootstrap collapse JavaScript until their UI surfaces are needed, reducing the initial JavaScript payload while preserving panel behavior.

## Why is this change needed?

The BootUI shell was loading confirmation and accordion behavior before users opened those interactions. Moving those dependencies behind existing lazy boundaries reduces first-load cost. The deferred confirmation dialog also synchronizes state on mount so an already-open confirmation cannot be missed while its chunk loads.

Closes #

## How was this tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Additional validation: full frontend Vitest suite passed (100 files, 972 tests), production build passed, and frontend formatting checks passed.

## Screenshots (UI changes)

N/A - no visual styling or interaction design changed.

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed