### PR TITLE
Bound HTTP Probe request body, path, and header inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,16 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `RAPI-ERR-010` (inconsistent error contracts across handlers for the same exception), and `RAPI-ERR-011`
   (exception handlers that read stack traces into their response). The catalogue now ships 56 rules.
 
+### Fixed
+
+- **HTTP Probe input is explicitly bounded on Spring MVC, Spring WebFlux, and Quarkus.** The probe capped only the
+  response body, so an oversized request body, path or header collection was bound by the adapter and forwarded to the
+  local target. Method (32 bytes), path (2 KiB), request body (64 KiB), header count (50), header name (256 bytes),
+  header value (8 KiB) and total header size (32 KiB) are now checked in UTF-8 bytes — so multi-byte input cannot
+  smuggle several times the budget past a character count — before any request is sent. Over-limit input is rejected
+  with the canonical `400` and `{"error": ...}` body on every adapter, and the panel shows that message; a probe that
+  runs and fails is still reported as a probe outcome (#860).
+
 ## [1.14.1] - 2026-08-20
 
 Patch release that restores Spring native and Quarkus Docker startup, fixes the native-image build bootstrap on AMD64,

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
@@ -17,6 +17,7 @@ import java.io.UncheckedIOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1192,24 +1193,20 @@ public abstract class AbstractBootUiApiConformanceTest {
 
     /** Builds a probe request payload with an optional body and {@code headerCount} synthetic headers. */
     private static String probeRequest(String method, String path, String body, int headerCount) {
-        StringBuilder json = new StringBuilder("{\"method\":\"")
-                .append(method)
-                .append("\",\"path\":\"")
-                .append(path)
-                .append("\",\"body\":");
-        if (body == null) {
-            json.append("null");
-        } else {
-            json.append('"').append(body).append('"');
-        }
-        json.append(",\"headers\":{");
+        Map<String, String> headers = new LinkedHashMap<>();
         for (int i = 0; i < headerCount; i++) {
-            if (i > 0) {
-                json.append(',');
-            }
-            json.append("\"X-Conformance-").append(i).append("\":\"v\"");
+            headers.put("X-Conformance-" + i, "v");
         }
-        return json.append("}}").toString();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", method);
+        payload.put("path", path);
+        payload.put("body", body);
+        payload.put("headers", headers);
+        try {
+            return MAPPER.writeValueAsString(payload);
+        } catch (IOException ex) {
+            throw new UncheckedIOException("Failed to build HTTP probe test payload", ex);
+        }
     }
 
     @Test

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
@@ -1142,6 +1142,77 @@ public abstract class AbstractBootUiApiConformanceTest {
     }
 
     @Test
+    void httpProbeInputBudgetsAreEnforcedIdenticallyOnEveryAdapter() {
+        // The HTTP Probe request body, path and headers are bounded by the shared engine HttpProbeLimits
+        // *before* any outbound work happens. Every adapter must therefore reject over-limit input with
+        // the same canonical HTTP 400 + {"error": ...} body, and still run a probe that sits exactly on
+        // the ceiling. A probe that runs stays an HTTP 200 envelope, whatever the probed path answers.
+        assumeTrue(isPanelUsableInLiveManifest("http-probe"), "http-probe panel is not available here");
+
+        BootUiHttpProbe probe = probe();
+        Map<String, String> headers = stateChangingHeaders(probe);
+        String probePath = "/__bootui_conformance_probe__";
+
+        Response accepted = probe.request(
+                "POST", api("/http-probe"), headers, probeRequest("POST", probePath, "a".repeat(65536), 0));
+        assertThat(accepted.status())
+                .as("a probe request body exactly at the 65536-byte ceiling must still run")
+                .isEqualTo(200);
+
+        assertProbeRejection(
+                probe,
+                headers,
+                probeRequest("POST", probePath, "a".repeat(65537), 0),
+                "HTTP Probe request body exceeds the maximum of 65536 bytes");
+        assertProbeRejection(
+                probe,
+                headers,
+                probeRequest("GET", "/" + "p".repeat(2048), null, 0),
+                "HTTP Probe request path exceeds the maximum of 2048 bytes");
+        assertProbeRejection(
+                probe,
+                headers,
+                probeRequest("GET", probePath, null, 51),
+                "HTTP Probe request exceeds the maximum of 50 request headers");
+    }
+
+    private void assertProbeRejection(
+            BootUiHttpProbe probe, Map<String, String> headers, String body, String expectedError) {
+        Response response = probe.request("POST", api("/http-probe"), headers, body);
+        assertThat(response.status())
+                .as("over-limit probe input must be rejected with the canonical 400")
+                .isEqualTo(400);
+        assertThat(response.isJson())
+                .as("the probe rejection body must be JSON (%s)", response.contentType())
+                .isTrue();
+        assertThat(response.json().path("error").asText())
+                .as("the probe rejection carries the canonical engine message")
+                .isEqualTo(expectedError);
+    }
+
+    /** Builds a probe request payload with an optional body and {@code headerCount} synthetic headers. */
+    private static String probeRequest(String method, String path, String body, int headerCount) {
+        StringBuilder json = new StringBuilder("{\"method\":\"")
+                .append(method)
+                .append("\",\"path\":\"")
+                .append(path)
+                .append("\",\"body\":");
+        if (body == null) {
+            json.append("null");
+        } else {
+            json.append('"').append(body).append('"');
+        }
+        json.append(",\"headers\":{");
+        for (int i = 0; i < headerCount; i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("\"X-Conformance-").append(i).append("\":\"v\"");
+        }
+        return json.append("}}").toString();
+    }
+
+    @Test
     void unavailableActionTargetReturnsCanonicalNotFound() {
         assumeTrue(isPanelUsableInLiveManifest("flyway"), "flyway panel is not available in this environment");
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpProbeLimits.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpProbeLimits.java
@@ -1,0 +1,104 @@
+package io.github.jdubois.bootui.engine.web;
+
+/**
+ * Explicit inbound and outbound budgets for the HTTP Probe panel.
+ *
+ * <p>BootUI is fail-closed and does bounded work: a probe is a hand-written local request, so every
+ * field it carries has a small, predictable ceiling. Without these budgets the only cap in the flow
+ * was on the <em>response</em> body, so an oversized request body, path or header collection was bound
+ * by the adapter and then forwarded to the local target, doubling the memory cost and pushing
+ * unbounded work onto the application under test.
+ *
+ * <p>All inbound sizes are measured in UTF-8 bytes rather than {@code String} length, so a multi-byte
+ * (non-ASCII) payload cannot smuggle several times the byte budget past a character-count check. The
+ * counting is capped: it stops as soon as a limit is exceeded and never materialises an encoded copy
+ * of the value.
+ *
+ * <p>The defaults are deliberately generous for real probe use and deliberately far below the request
+ * body limits of the underlying stacks (for example the WebFlux codec's 256 KiB in-memory default), so
+ * the canonical BootUI validation error — not an opaque framework error — is what a developer sees
+ * when a probe is too large.
+ *
+ * @param maxMethodBytes maximum UTF-8 size of the request method
+ * @param maxPathBytes maximum UTF-8 size of the request path
+ * @param maxRequestBodyBytes maximum UTF-8 size of the request body
+ * @param maxHeaderCount maximum number of request header entries
+ * @param maxHeaderNameBytes maximum UTF-8 size of a single request header name
+ * @param maxHeaderValueBytes maximum UTF-8 size of a single request header value
+ * @param maxTotalHeaderBytes maximum combined UTF-8 size of all request header names and values
+ * @param maxResponseBodyBytes maximum response body bytes read back (truncates rather than rejects)
+ */
+public record HttpProbeLimits(
+        int maxMethodBytes,
+        int maxPathBytes,
+        int maxRequestBodyBytes,
+        int maxHeaderCount,
+        int maxHeaderNameBytes,
+        int maxHeaderValueBytes,
+        int maxTotalHeaderBytes,
+        int maxResponseBodyBytes) {
+
+    /** Longest accepted request method; every real HTTP method token is far shorter. */
+    public static final int DEFAULT_MAX_METHOD_BYTES = 32;
+
+    /** Longest accepted request path, matching the conventional 2 KiB practical URL ceiling. */
+    public static final int DEFAULT_MAX_PATH_BYTES = 2048;
+
+    /** Largest accepted request body: generous for a hand-written probe, bounded for the JVM. */
+    public static final int DEFAULT_MAX_REQUEST_BODY_BYTES = 64 * 1024; // 64 KiB
+
+    /** Largest accepted number of request headers. */
+    public static final int DEFAULT_MAX_HEADER_COUNT = 50;
+
+    /** Largest accepted single request header name. */
+    public static final int DEFAULT_MAX_HEADER_NAME_BYTES = 256;
+
+    /** Largest accepted single request header value. */
+    public static final int DEFAULT_MAX_HEADER_VALUE_BYTES = 8 * 1024; // 8 KiB
+
+    /** Largest accepted combined size of all request header names and values. */
+    public static final int DEFAULT_MAX_TOTAL_HEADER_BYTES = 32 * 1024; // 32 KiB
+
+    public HttpProbeLimits {
+        requirePositive(maxMethodBytes, "maxMethodBytes");
+        requirePositive(maxPathBytes, "maxPathBytes");
+        requirePositive(maxRequestBodyBytes, "maxRequestBodyBytes");
+        requirePositive(maxHeaderCount, "maxHeaderCount");
+        requirePositive(maxHeaderNameBytes, "maxHeaderNameBytes");
+        requirePositive(maxHeaderValueBytes, "maxHeaderValueBytes");
+        requirePositive(maxTotalHeaderBytes, "maxTotalHeaderBytes");
+        requirePositive(maxResponseBodyBytes, "maxResponseBodyBytes");
+    }
+
+    /** The BootUI defaults applied by every adapter. */
+    public static HttpProbeLimits defaults() {
+        return new HttpProbeLimits(
+                DEFAULT_MAX_METHOD_BYTES,
+                DEFAULT_MAX_PATH_BYTES,
+                DEFAULT_MAX_REQUEST_BODY_BYTES,
+                DEFAULT_MAX_HEADER_COUNT,
+                DEFAULT_MAX_HEADER_NAME_BYTES,
+                DEFAULT_MAX_HEADER_VALUE_BYTES,
+                DEFAULT_MAX_TOTAL_HEADER_BYTES,
+                BoundedBodyReader.HTTP_PROBE_MAX_BYTES);
+    }
+
+    /** The defaults with a different response body budget, used to exercise truncation in tests. */
+    public HttpProbeLimits withMaxResponseBodyBytes(int maxResponseBodyBytes) {
+        return new HttpProbeLimits(
+                maxMethodBytes,
+                maxPathBytes,
+                maxRequestBodyBytes,
+                maxHeaderCount,
+                maxHeaderNameBytes,
+                maxHeaderValueBytes,
+                maxTotalHeaderBytes,
+                maxResponseBodyBytes);
+    }
+
+    private static void requirePositive(int value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be positive");
+        }
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpProbeService.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpProbeService.java
@@ -136,7 +136,8 @@ public class HttpProbeService {
             throw new IllegalArgumentException(
                     "HTTP Probe request method exceeds the maximum of " + limits.maxMethodBytes() + " bytes");
         }
-        if (exceedsUtf8Bytes(request.path(), limits.maxPathBytes())) {
+        String normalizedPath = normalizePath(request.path());
+        if (exceedsUtf8Bytes(normalizedPath, limits.maxPathBytes())) {
             throw new IllegalArgumentException(
                     "HTTP Probe request path exceeds the maximum of " + limits.maxPathBytes() + " bytes");
         }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpProbeService.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpProbeService.java
@@ -182,6 +182,14 @@ public class HttpProbeService {
      * Counts the UTF-8 size of {@code value}, stopping as soon as {@code cap} is exceeded (in which
      * case {@code cap + 1} is returned). Nothing is encoded or copied, so measuring an oversized value
      * costs a bounded scan instead of a full byte-array allocation.
+     *
+     * <p>The count is deliberately conservative rather than an exact prediction of one encoder's
+     * output: an unpaired surrogate is malformed input whose encoded size depends on the replacement
+     * policy in play. {@link String#getBytes(java.nio.charset.Charset)} — what
+     * {@link HttpRequest.BodyPublishers#ofString(String, java.nio.charset.Charset)} uses — substitutes a
+     * single {@code '?'} byte, but an encoder configured to replace with {@code U+FFFD} emits three.
+     * Counting the larger value keeps the budget fail-closed under every policy, so malformed input can
+     * never encode to more bytes than it was charged for.
      */
     private static long utf8Bytes(String value, int cap) {
         if (value == null || value.isEmpty()) {
@@ -201,10 +209,9 @@ public class HttpProbeService {
                 // a surrogate pair is a single supplementary code point: four UTF-8 bytes
                 total += 4;
                 i++;
-            } else if (Character.isSurrogate(current)) {
-                // an unpaired surrogate is malformed and encodes as a single replacement byte
-                total += 1;
             } else {
+                // three bytes for a BMP code point, and for an unpaired surrogate the worst-case
+                // replacement (U+FFFD) rather than the single '?' byte String.getBytes would emit
                 total += 3;
             }
             if (total > cap) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpProbeService.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpProbeService.java
@@ -25,10 +25,18 @@ import java.util.Set;
  * is running). Hop-by-hop request headers are stripped, and only a small allow-list of response headers
  * is surfaced.
  *
- * <p>Response bodies are bounded at {@link BoundedBodyReader#HTTP_PROBE_MAX_BYTES}: reading stops at
- * that limit without first buffering the full response, so a large or streaming local endpoint cannot
- * destabilise the host JVM. When the body is truncated, {@link HttpProbeResponse#truncated()} is
- * {@code true} so the browser can surface a clear truncation notice.
+ * <p>Response bodies are bounded at {@link HttpProbeLimits#maxResponseBodyBytes()} (by default
+ * {@link BoundedBodyReader#HTTP_PROBE_MAX_BYTES}): reading stops at that limit without first buffering
+ * the full response, so a large or streaming local endpoint cannot destabilise the host JVM. When the
+ * body is truncated, {@link HttpProbeResponse#truncated()} is {@code true} so the browser can surface
+ * a clear truncation notice.
+ *
+ * <p>Inbound probe input is bounded too, by {@link HttpProbeLimits}: method, path, request body,
+ * header count and header name/value sizes are validated in UTF-8 bytes <em>before</em> any outbound
+ * work starts. Exceeding a limit is invalid input, not a probe outcome, so it fails with an
+ * {@link IllegalArgumentException} that every adapter maps to the canonical {@code 400} with a
+ * {@code {"error": ...}} body — unlike a genuine probe failure (connection refused, timeout), which is
+ * reported inside a {@link HttpProbeResponse} with a {@code 0} status.
  */
 public class HttpProbeService {
 
@@ -55,21 +63,27 @@ public class HttpProbeService {
 
     private final HttpClient httpClient;
 
-    private final int maxBodyBytes;
+    private final HttpProbeLimits limits;
 
     public HttpProbeService(ServerPortSupplier serverPort) {
-        this(serverPort, BoundedBodyReader.HTTP_PROBE_MAX_BYTES);
+        this(serverPort, HttpProbeLimits.defaults());
     }
 
-    /** Package-private constructor for testing with a custom byte limit. */
-    HttpProbeService(ServerPortSupplier serverPort, int maxBodyBytes) {
+    public HttpProbeService(ServerPortSupplier serverPort, HttpProbeLimits limits) {
         this.serverPort = serverPort;
-        this.maxBodyBytes = maxBodyBytes;
+        this.limits = limits == null ? HttpProbeLimits.defaults() : limits;
         this.httpClient =
                 HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build();
     }
 
+    /**
+     * Sends the probe and returns its sanitized outcome.
+     *
+     * @throws IllegalArgumentException if the request exceeds a {@link HttpProbeLimits} budget; the
+     *     probe is then never sent, so no outbound work is done for rejected input
+     */
     public HttpProbeResponse probe(HttpProbeRequest request) {
+        validate(request);
         long start = System.currentTimeMillis();
         String method = normalizeMethod(request == null ? null : request.method());
         String path = normalizePath(request == null ? null : request.path());
@@ -82,7 +96,8 @@ public class HttpProbeService {
             builder.method(method, requestBodyPublisher(method, request == null ? null : request.body()));
 
             HttpResponse<BoundedBodyReader.BoundedRead> response = httpClient.send(
-                    builder.build(), BoundedBodyReader.boundedBodyHandler(maxBodyBytes, StandardCharsets.UTF_8));
+                    builder.build(),
+                    BoundedBodyReader.boundedBodyHandler(limits.maxResponseBodyBytes(), StandardCharsets.UTF_8));
             long durationMs = System.currentTimeMillis() - start;
             BoundedBodyReader.BoundedRead read = response.body();
             return new HttpProbeResponse(
@@ -105,10 +120,106 @@ public class HttpProbeService {
         }
     }
 
+    // ── inbound validation ────────────────────────────────────────────────────
+
+    /**
+     * Rejects a probe request that exceeds a {@link HttpProbeLimits} budget, before any outbound work
+     * starts. Limits are checked in UTF-8 bytes, and the body is validated for every method (including
+     * methods that cannot carry one), so an oversized payload is refused rather than silently dropped.
+     * Messages never echo the offending input back to the browser.
+     */
+    private void validate(HttpProbeRequest request) {
+        if (request == null) {
+            return;
+        }
+        if (exceedsUtf8Bytes(request.method(), limits.maxMethodBytes())) {
+            throw new IllegalArgumentException(
+                    "HTTP Probe request method exceeds the maximum of " + limits.maxMethodBytes() + " bytes");
+        }
+        if (exceedsUtf8Bytes(request.path(), limits.maxPathBytes())) {
+            throw new IllegalArgumentException(
+                    "HTTP Probe request path exceeds the maximum of " + limits.maxPathBytes() + " bytes");
+        }
+        if (exceedsUtf8Bytes(request.body(), limits.maxRequestBodyBytes())) {
+            throw new IllegalArgumentException(
+                    "HTTP Probe request body exceeds the maximum of " + limits.maxRequestBodyBytes() + " bytes");
+        }
+        validateHeaders(request.headers());
+    }
+
+    private void validateHeaders(Map<String, String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return;
+        }
+        if (headers.size() > limits.maxHeaderCount()) {
+            throw new IllegalArgumentException(
+                    "HTTP Probe request exceeds the maximum of " + limits.maxHeaderCount() + " request headers");
+        }
+        int totalLimit = limits.maxTotalHeaderBytes();
+        long total = 0;
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (exceedsUtf8Bytes(entry.getKey(), limits.maxHeaderNameBytes())) {
+                throw new IllegalArgumentException("HTTP Probe request header name exceeds the maximum of "
+                        + limits.maxHeaderNameBytes() + " bytes");
+            }
+            if (exceedsUtf8Bytes(entry.getValue(), limits.maxHeaderValueBytes())) {
+                throw new IllegalArgumentException("HTTP Probe request header value exceeds the maximum of "
+                        + limits.maxHeaderValueBytes() + " bytes");
+            }
+            total += utf8Bytes(entry.getKey(), totalLimit) + utf8Bytes(entry.getValue(), totalLimit);
+            if (total > totalLimit) {
+                throw new IllegalArgumentException(
+                        "HTTP Probe request headers exceed the maximum total of " + totalLimit + " bytes");
+            }
+        }
+    }
+
+    private static boolean exceedsUtf8Bytes(String value, int limit) {
+        return utf8Bytes(value, limit) > limit;
+    }
+
+    /**
+     * Counts the UTF-8 size of {@code value}, stopping as soon as {@code cap} is exceeded (in which
+     * case {@code cap + 1} is returned). Nothing is encoded or copied, so measuring an oversized value
+     * costs a bounded scan instead of a full byte-array allocation.
+     */
+    private static long utf8Bytes(String value, int cap) {
+        if (value == null || value.isEmpty()) {
+            return 0;
+        }
+        long total = 0;
+        int length = value.length();
+        for (int i = 0; i < length; i++) {
+            char current = value.charAt(i);
+            if (current < 0x80) {
+                total += 1;
+            } else if (current < 0x800) {
+                total += 2;
+            } else if (Character.isHighSurrogate(current)
+                    && i + 1 < length
+                    && Character.isLowSurrogate(value.charAt(i + 1))) {
+                // a surrogate pair is a single supplementary code point: four UTF-8 bytes
+                total += 4;
+                i++;
+            } else if (Character.isSurrogate(current)) {
+                // an unpaired surrogate is malformed and encodes as a single replacement byte
+                total += 1;
+            } else {
+                total += 3;
+            }
+            if (total > cap) {
+                return cap + 1L;
+            }
+        }
+        return total;
+    }
+
     private void applyHeaders(HttpRequest.Builder builder, Map<String, String> headers) {
         if (headers == null || headers.isEmpty()) {
             return;
         }
+        // Names that differ only by case are distinct map keys but the same HTTP header; the JDK builder
+        // appends them as multiple values, which is valid and stays inside the validated header budgets.
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             if (entry.getKey() == null || entry.getValue() == null) {
                 continue;

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpProbeLimitsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpProbeLimitsTests.java
@@ -1,0 +1,56 @@
+package io.github.jdubois.bootui.engine.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the HTTP Probe budgets themselves: the shipped defaults (which every adapter uses, so they are
+ * part of the cross-stack contract) and the fail-closed rejection of a nonsensical limit.
+ */
+class HttpProbeLimitsTests {
+
+    @Test
+    void defaultsAreTheDocumentedBudgets() {
+        HttpProbeLimits limits = HttpProbeLimits.defaults();
+
+        assertThat(limits.maxMethodBytes()).isEqualTo(32);
+        assertThat(limits.maxPathBytes()).isEqualTo(2048);
+        assertThat(limits.maxRequestBodyBytes()).isEqualTo(64 * 1024);
+        assertThat(limits.maxHeaderCount()).isEqualTo(50);
+        assertThat(limits.maxHeaderNameBytes()).isEqualTo(256);
+        assertThat(limits.maxHeaderValueBytes()).isEqualTo(8 * 1024);
+        assertThat(limits.maxTotalHeaderBytes()).isEqualTo(32 * 1024);
+        assertThat(limits.maxResponseBodyBytes()).isEqualTo(BoundedBodyReader.HTTP_PROBE_MAX_BYTES);
+    }
+
+    @Test
+    void requestBodyBudgetStaysBelowTheReactiveCodecDefault() {
+        // The WebFlux codec buffers at 256 KiB by default; keeping the probe budget below it means the
+        // canonical BootUI validation error, not an opaque framework error, is what a developer sees.
+        assertThat(HttpProbeLimits.defaults().maxRequestBodyBytes()).isLessThan(256 * 1024);
+    }
+
+    @Test
+    void nonPositiveLimitsAreRejected() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new HttpProbeLimits(0, 2048, 1024, 50, 256, 8192, 32768, 1024))
+                .withMessage("maxMethodBytes must be positive");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new HttpProbeLimits(32, 2048, -1, 50, 256, 8192, 32768, 1024))
+                .withMessage("maxRequestBodyBytes must be positive");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new HttpProbeLimits(32, 2048, 1024, 50, 256, 8192, 32768, 0))
+                .withMessage("maxResponseBodyBytes must be positive");
+    }
+
+    @Test
+    void responseBudgetCanBeOverriddenWithoutTouchingInboundBudgets() {
+        HttpProbeLimits limits = HttpProbeLimits.defaults().withMaxResponseBodyBytes(5);
+
+        assertThat(limits.maxResponseBodyBytes()).isEqualTo(5);
+        assertThat(limits.maxRequestBodyBytes())
+                .isEqualTo(HttpProbeLimits.defaults().maxRequestBodyBytes());
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpProbeServiceTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpProbeServiceTests.java
@@ -9,6 +9,7 @@ import io.github.jdubois.bootui.core.dto.HttpProbeResponse;
 import io.github.jdubois.bootui.spi.ServerPortSupplier;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -443,6 +444,47 @@ class HttpProbeServiceTests {
 
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> bounded.probe(new HttpProbeRequest("POST", "/", body, null)));
+    }
+
+    @Test
+    void unpairedSurrogatesAreChargedTheWorstCaseReplacementSize() {
+        // A lone surrogate is malformed input: String.getBytes(UTF_8) substitutes one '?' byte, but an
+        // encoder replacing with U+FFFD emits three. The budget charges the larger value so malformed
+        // input can never encode to more bytes than it was charged for.
+        HttpProbeService tiny = new HttpProbeService(() -> serverPort(), limits(6));
+        echo("/unpaired");
+
+        HttpProbeResponse accepted = tiny.probe(new HttpProbeRequest("POST", "/unpaired", "\uD83D\uD83D", null));
+        assertThat(accepted.status())
+                .as("2 lone surrogates = 6 charged bytes, exactly at the limit")
+                .isEqualTo(200);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> tiny.probe(new HttpProbeRequest("POST", "/unpaired", "\uD83D\uD83D\uD83D", null)))
+                .withMessage("HTTP Probe request body exceeds the maximum of 6 bytes");
+    }
+
+    @Test
+    void utf8CountingNeverUnderchargesRelativeToTheEncodedBody() {
+        // Invariant guard for the counter against the real encoder: a body whose encoded form is larger
+        // than the budget must always be rejected. (The lone-surrogate worst case is pinned separately
+        // above, because String.getBytes happens to agree with the smaller charge there.)
+        String[] samples = {
+            "plain-ascii",
+            "€ euro",
+            "\uD83D\uDE80 rocket",
+            "\uD83D lone-high",
+            "trailing-high\uD83D",
+            "\uDE80 lone-low",
+            "mixed \uD83D\uDE80 \uD83D € x"
+        };
+        for (String sample : samples) {
+            int encoded = sample.getBytes(StandardCharsets.UTF_8).length;
+            HttpProbeService tiny = new HttpProbeService(() -> serverPort(), limits(encoded - 1));
+            assertThatIllegalArgumentException()
+                    .as("a body encoding to %d bytes must not pass a %d-byte budget", encoded, encoded - 1)
+                    .isThrownBy(() -> tiny.probe(new HttpProbeRequest("POST", "/", sample, null)));
+        }
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpProbeServiceTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpProbeServiceTests.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import com.sun.net.httpserver.HttpServer;
 import io.github.jdubois.bootui.core.dto.HttpProbeRequest;
@@ -9,6 +10,8 @@ import io.github.jdubois.bootui.spi.ServerPortSupplier;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -230,8 +233,8 @@ class HttpProbeServiceTests {
     void responseOverLimitIsTruncatedAndFlagSet() throws Exception {
         // Build a service with a very small limit so the test doesn't need a 1 MiB response.
         int limit = 5;
-        HttpProbeService tinyLimit =
-                new HttpProbeService(() -> server.getAddress().getPort(), limit);
+        HttpProbeService tinyLimit = new HttpProbeService(
+                () -> server.getAddress().getPort(), HttpProbeLimits.defaults().withMaxResponseBodyBytes(limit));
         // Respond with exactly limit+1 bytes to trigger truncation.
         String longBody = "ABCDEF"; // 6 bytes > limit of 5
         respondWith("/big", 200, longBody);
@@ -254,7 +257,218 @@ class HttpProbeServiceTests {
         assertThat(response.truncated()).isFalse();
     }
 
+    // ── inbound request limits ────────────────────────────────────────────────
+
+    @Test
+    void requestBodyAtTheLimitIsAccepted() {
+        echo("/at-limit");
+        HttpProbeService bounded = boundedService();
+
+        String body = "a".repeat(HttpProbeLimits.DEFAULT_MAX_REQUEST_BODY_BYTES);
+        HttpProbeResponse response = bounded.probe(new HttpProbeRequest("POST", "/at-limit", body, null));
+
+        assertThat(response.status()).isEqualTo(200);
+        assertThat(response.error()).isNull();
+    }
+
+    @Test
+    void requestBodyOverTheLimitIsRejectedWithACanonicalMessage() {
+        HttpProbeService bounded = boundedService();
+        String body = "a".repeat(HttpProbeLimits.DEFAULT_MAX_REQUEST_BODY_BYTES + 1);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("POST", "/oversized", body, null)))
+                .withMessage("HTTP Probe request body exceeds the maximum of "
+                        + HttpProbeLimits.DEFAULT_MAX_REQUEST_BODY_BYTES + " bytes");
+    }
+
+    @Test
+    void oversizedBodyIsRejectedEvenForAMethodThatCannotCarryOne() {
+        // GET drops the body before sending, but an oversized payload is still invalid input: it is
+        // bound in memory by the adapter, so it must be refused rather than silently ignored.
+        HttpProbeService bounded = boundedService();
+        String body = "a".repeat(HttpProbeLimits.DEFAULT_MAX_REQUEST_BODY_BYTES + 1);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("GET", "/oversized", body, null)));
+    }
+
+    @Test
+    void bodyLengthIsMeasuredInUtf8BytesNotCharacters() {
+        // 4 three-byte characters are 4 chars but 12 UTF-8 bytes: a character-count check would let
+        // three times the byte budget through.
+        HttpProbeService tiny = new HttpProbeService(() -> serverPort(), limits(10));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> tiny.probe(new HttpProbeRequest("POST", "/utf8", "€€€€", null)))
+                .withMessage("HTTP Probe request body exceeds the maximum of 10 bytes");
+    }
+
+    @Test
+    void surrogatePairsAreCountedAsFourUtf8Bytes() {
+        HttpProbeService tiny = new HttpProbeService(() -> serverPort(), limits(8));
+        String twoEmoji = "\uD83D\uDE80\uD83D\uDE80"; // 2 code points, 8 UTF-8 bytes
+        echo("/surrogates");
+
+        HttpProbeResponse accepted = tiny.probe(new HttpProbeRequest("POST", "/surrogates", twoEmoji, null));
+        assertThat(accepted.status()).isEqualTo(200);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> tiny.probe(new HttpProbeRequest("POST", "/surrogates", twoEmoji + "a", null)));
+    }
+
+    @Test
+    void pathOverTheLimitIsRejected() {
+        HttpProbeService bounded = boundedService();
+        String path = "/" + "p".repeat(HttpProbeLimits.DEFAULT_MAX_PATH_BYTES);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("GET", path, null, null)))
+                .withMessage("HTTP Probe request path exceeds the maximum of " + HttpProbeLimits.DEFAULT_MAX_PATH_BYTES
+                        + " bytes");
+    }
+
+    @Test
+    void methodOverTheLimitIsRejected() {
+        HttpProbeService bounded = boundedService();
+        String method = "M".repeat(HttpProbeLimits.DEFAULT_MAX_METHOD_BYTES + 1);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest(method, "/", null, null)))
+                .withMessage("HTTP Probe request method exceeds the maximum of "
+                        + HttpProbeLimits.DEFAULT_MAX_METHOD_BYTES + " bytes");
+    }
+
+    @Test
+    void headerCountOverTheLimitIsRejected() {
+        HttpProbeService bounded = boundedService();
+        var headers = new LinkedHashMap<String, String>();
+        for (int i = 0; i <= HttpProbeLimits.DEFAULT_MAX_HEADER_COUNT; i++) {
+            headers.put("X-Header-" + i, "value");
+        }
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("GET", "/", null, headers)))
+                .withMessage("HTTP Probe request exceeds the maximum of " + HttpProbeLimits.DEFAULT_MAX_HEADER_COUNT
+                        + " request headers");
+    }
+
+    @Test
+    void headerCountAtTheLimitIsAccepted() {
+        echo("/max-headers");
+        HttpProbeService bounded = boundedService();
+        var headers = new LinkedHashMap<String, String>();
+        for (int i = 0; i < HttpProbeLimits.DEFAULT_MAX_HEADER_COUNT; i++) {
+            headers.put("X-Header-" + i, "value");
+        }
+
+        HttpProbeResponse response = bounded.probe(new HttpProbeRequest("GET", "/max-headers", null, headers));
+
+        assertThat(response.status()).isEqualTo(200);
+    }
+
+    @Test
+    void headerNameOverTheLimitIsRejected() {
+        HttpProbeService bounded = boundedService();
+        var headers = Map.of("X-" + "n".repeat(HttpProbeLimits.DEFAULT_MAX_HEADER_NAME_BYTES), "value");
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("GET", "/", null, headers)))
+                .withMessage("HTTP Probe request header name exceeds the maximum of "
+                        + HttpProbeLimits.DEFAULT_MAX_HEADER_NAME_BYTES + " bytes");
+    }
+
+    @Test
+    void headerValueOverTheLimitIsRejected() {
+        HttpProbeService bounded = boundedService();
+        var headers = Map.of("X-Big", "v".repeat(HttpProbeLimits.DEFAULT_MAX_HEADER_VALUE_BYTES + 1));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("GET", "/", null, headers)))
+                .withMessage("HTTP Probe request header value exceeds the maximum of "
+                        + HttpProbeLimits.DEFAULT_MAX_HEADER_VALUE_BYTES + " bytes");
+    }
+
+    @Test
+    void combinedHeaderSizeOverTheLimitIsRejected() {
+        HttpProbeService bounded = boundedService();
+        var headers = new LinkedHashMap<String, String>();
+        // each entry is well under the per-value limit; together they exceed the total header budget
+        for (int i = 0; i < 8; i++) {
+            headers.put("X-Header-" + i, "v".repeat(HttpProbeLimits.DEFAULT_MAX_HEADER_VALUE_BYTES / 2));
+        }
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("GET", "/", null, headers)))
+                .withMessage("HTTP Probe request headers exceed the maximum total of "
+                        + HttpProbeLimits.DEFAULT_MAX_TOTAL_HEADER_BYTES + " bytes");
+    }
+
+    @Test
+    void nullHeaderNamesAndValuesDoNotBreakValidation() {
+        echo("/null-headers");
+        HttpProbeService bounded = boundedService();
+        var headers = new LinkedHashMap<String, String>();
+        headers.put("X-Present", null);
+        headers.put(null, "orphan");
+
+        HttpProbeResponse response = bounded.probe(new HttpProbeRequest("GET", "/null-headers", null, headers));
+
+        assertThat(response.status()).isEqualTo(200);
+    }
+
+    @Test
+    void rejectedRequestNeverReachesTheTarget() {
+        AtomicInteger hits = new AtomicInteger();
+        server.createContext("/counted", exchange -> {
+            hits.incrementAndGet();
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        HttpProbeService bounded = boundedService();
+        String body = "a".repeat(HttpProbeLimits.DEFAULT_MAX_REQUEST_BODY_BYTES + 1);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("POST", "/counted", body, null)));
+
+        assertThat(hits.get())
+                .as("validation must fail before any outbound work")
+                .isZero();
+    }
+
+    @Test
+    void nullLimitsFallBackToTheDefaults() {
+        HttpProbeService bounded = new HttpProbeService(() -> serverPort(), null);
+        String body = "a".repeat(HttpProbeLimits.DEFAULT_MAX_REQUEST_BODY_BYTES + 1);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("POST", "/", body, null)));
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
+
+    private HttpProbeService boundedService() {
+        return new HttpProbeService(() -> serverPort(), HttpProbeLimits.defaults());
+    }
+
+    private int serverPort() {
+        return server.getAddress().getPort();
+    }
+
+    private static HttpProbeLimits limits(int maxRequestBodyBytes) {
+        return new HttpProbeLimits(32, 2048, maxRequestBodyBytes, 50, 256, 8192, 32768, 1024);
+    }
+
+    private void echo(String path) {
+        server.createContext(path, exchange -> {
+            byte[] incoming = exchange.getRequestBody().readAllBytes();
+            exchange.sendResponseHeaders(200, incoming.length == 0 ? -1 : incoming.length);
+            if (incoming.length > 0) {
+                exchange.getResponseBody().write(incoming);
+            }
+            exchange.close();
+        });
+    }
 
     private void respondWith(String path, int status, String body) {
         server.createContext(path, exchange -> {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpProbeServiceTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpProbeServiceTests.java
@@ -330,6 +330,17 @@ class HttpProbeServiceTests {
     }
 
     @Test
+    void pathWithoutLeadingSlashThatExceedsTheLimitAfterNormalizationIsRejected() {
+        HttpProbeService bounded = boundedService();
+        String pathWithoutSlash = "p".repeat(HttpProbeLimits.DEFAULT_MAX_PATH_BYTES);
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> bounded.probe(new HttpProbeRequest("GET", pathWithoutSlash, null, null)))
+                .withMessage("HTTP Probe request path exceeds the maximum of " + HttpProbeLimits.DEFAULT_MAX_PATH_BYTES
+                        + " bytes");
+    }
+
+    @Test
     void methodOverTheLimitIsRejected() {
         HttpProbeService bounded = boundedService();
         String method = "M".repeat(HttpProbeLimits.DEFAULT_MAX_METHOD_BYTES + 1);

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHttpProbeResourceTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHttpProbeResourceTest.java
@@ -76,4 +76,43 @@ class BootUiQuarkusHttpProbeResourceTest {
                 .as("reaching a live server with an unknown path yields 404 (not a connection error)")
                 .isEqualTo(404);
     }
+
+    @Test
+    void rejectsAnOversizedRequestBodyWithTheCanonicalBadRequestBody() {
+        String oversized = "a".repeat(64 * 1024 + 1);
+        Response response = probe().request(
+                        "POST",
+                        "/bootui/api/http-probe",
+                        JSON_HEADERS,
+                        "{\"method\":\"POST\",\"path\":\"/bootui/api/overview\",\"body\":\"" + oversized + "\"}");
+
+        assertThat(response.status())
+                .as("an over-limit probe body is invalid input, not a probe outcome")
+                .isEqualTo(400);
+        assertThat(response.isJson())
+                .as("the rejection body must be JSON (%s)", response.contentType())
+                .isTrue();
+        assertThat(response.json().path("error").asText())
+                .isEqualTo("HTTP Probe request body exceeds the maximum of 65536 bytes");
+    }
+
+    @Test
+    void rejectsTooManyRequestHeadersWithTheCanonicalBadRequestBody() {
+        StringBuilder headers = new StringBuilder();
+        for (int i = 0; i <= 50; i++) {
+            if (i > 0) {
+                headers.append(',');
+            }
+            headers.append("\"X-Probe-").append(i).append("\":\"v\"");
+        }
+        Response response = probe().request(
+                        "POST",
+                        "/bootui/api/http-probe",
+                        JSON_HEADERS,
+                        "{\"method\":\"GET\",\"path\":\"/bootui/api/overview\",\"headers\":{" + headers + "}}");
+
+        assertThat(response.status()).isEqualTo(400);
+        assertThat(response.json().path("error").asText())
+                .isEqualTo("HTTP Probe request exceeds the maximum of 50 request headers");
+    }
 }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/HttpProbeResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/HttpProbeResource.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.quarkus.web;
 
 import io.github.jdubois.bootui.core.dto.HttpProbeRequest;
 import io.github.jdubois.bootui.core.dto.HttpProbeResponse;
+import io.github.jdubois.bootui.engine.web.HttpProbeLimits;
 import io.github.jdubois.bootui.engine.web.HttpProbeService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -9,6 +10,8 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
 
 /**
  * JAX-RS resource for the HTTP Probe panel ({@code POST /bootui/api/http-probe}).
@@ -19,6 +22,10 @@ import jakarta.ws.rs.core.MediaType;
  * {@code http://localhost:<port><path>} (the port coming from {@code QuarkusServerPortSupplier}), so the
  * probe can never reach an external host regardless of the supplied path. This is a state-changing
  * ({@code POST}) endpoint, so it is gated by {@code BootUiQuarkusSafetyFilter} like every other write.</p>
+ *
+ * <p>Probe input that exceeds an engine {@link HttpProbeLimits} budget is rejected with
+ * {@link IllegalArgumentException}, mapped here to a {@code 400} with the same JSON
+ * {@code {"error": ...}} body the Spring controller returns.</p>
  */
 @Path("/bootui/api/http-probe")
 public class HttpProbeResource {
@@ -33,7 +40,13 @@ public class HttpProbeResource {
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    public HttpProbeResponse probe(HttpProbeRequest request) {
-        return probeService.probe(request);
+    public Response probe(HttpProbeRequest request) {
+        try {
+            return Response.ok(probeService.probe(request)).build();
+        } catch (IllegalArgumentException ex) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()))
+                    .build();
+        }
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeController.java
@@ -2,12 +2,27 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.core.dto.HttpProbeRequest;
 import io.github.jdubois.bootui.core.dto.HttpProbeResponse;
+import io.github.jdubois.bootui.engine.web.HttpProbeLimits;
 import io.github.jdubois.bootui.engine.web.HttpProbeService;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * Serves the HTTP Probe panel for both Spring MVC and Spring WebFlux.
+ *
+ * <p>Thin transport adapter: the loopback targeting, header filtering, response cap and the inbound
+ * {@link HttpProbeLimits} budgets all live in the shared engine {@link HttpProbeService}. Probe input
+ * that exceeds a budget is rejected by the engine with {@link IllegalArgumentException}, mapped here to
+ * a {@code 400} with the same JSON {@code {"error": ...}} body the other BootUI write endpoints and the
+ * Quarkus {@code HttpProbeResource} return. A probe that runs but fails (connection refused, timeout)
+ * is not a validation error and still comes back as a {@code 200} with an error payload.</p>
+ */
 @RestController
 @RequestMapping("${bootui.api-path:${bootui.path:/bootui}/api}/http-probe")
 public class HttpProbeController {
@@ -21,5 +36,11 @@ public class HttpProbeController {
     @PostMapping
     public HttpProbeResponse probe(@RequestBody HttpProbeRequest request) {
         return probeService.probe(request);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("error", ex.getMessage() == null ? "Invalid request" : ex.getMessage()));
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveHttpProbeControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveHttpProbeControllerTests.java
@@ -1,0 +1,91 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.jdubois.bootui.autoconfigure.web.HttpProbeController;
+import io.github.jdubois.bootui.core.dto.HttpProbeRequest;
+import io.github.jdubois.bootui.core.dto.HttpProbeResponse;
+import io.github.jdubois.bootui.engine.web.HttpProbeService;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Reactive (WebFlux) binding checks for the shared {@code HttpProbeController}. The reactive adapter
+ * reuses the same annotated controller as Spring MVC, so this pins that a probe result and an inbound
+ * limit violation are projected identically on both Spring stacks: a probe outcome (including a probe
+ * that failed to connect) is an HTTP 200 DTO, while input rejected by the engine's
+ * {@code HttpProbeLimits} is the canonical HTTP 400 with a {@code {"error": ...}} body.
+ */
+class ReactiveHttpProbeControllerTests {
+
+    private static WebTestClient client(HttpProbeService service) {
+        return WebTestClient.bindToController(new HttpProbeController(service)).build();
+    }
+
+    @Test
+    void probeResultIsProjectedAsJson() {
+        HttpProbeService service = mock(HttpProbeService.class);
+        when(service.probe(any(HttpProbeRequest.class)))
+                .thenReturn(new HttpProbeResponse(
+                        200, "OK", Map.of("content-type", "application/json"), "{\"ok\":true}", 7L, null, false));
+
+        client(service)
+                .post()
+                .uri("/bootui/api/http-probe")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(new HttpProbeRequest("GET", "/actuator/health", null, null))
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.status")
+                .isEqualTo(200)
+                .jsonPath("$.body")
+                .isEqualTo("{\"ok\":true}")
+                .jsonPath("$.headers['content-type']")
+                .isEqualTo("application/json");
+    }
+
+    @Test
+    void inputThatExceedsAProbeLimitIsRejectedWithTheCanonicalBadRequestBody() {
+        HttpProbeService service = mock(HttpProbeService.class);
+        when(service.probe(any(HttpProbeRequest.class)))
+                .thenThrow(
+                        new IllegalArgumentException("HTTP Probe request exceeds the maximum of 50 request headers"));
+
+        client(service)
+                .post()
+                .uri("/bootui/api/http-probe")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(new HttpProbeRequest("GET", "/", null, Map.of("X-One", "1")))
+                .exchange()
+                .expectStatus()
+                .isBadRequest()
+                .expectBody()
+                .jsonPath("$.error")
+                .isEqualTo("HTTP Probe request exceeds the maximum of 50 request headers");
+    }
+
+    @Test
+    void probeFailureRemainsATwoHundredOutcome() {
+        HttpProbeService service = mock(HttpProbeService.class);
+        when(service.probe(any(HttpProbeRequest.class)))
+                .thenReturn(new HttpProbeResponse(0, "Error", Map.of(), null, 3L, "Connection refused", false));
+
+        client(service)
+                .post()
+                .uri("/bootui/api/http-probe")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(new HttpProbeRequest("GET", "/", null, null))
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.error")
+                .isEqualTo("Connection refused");
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/HttpProbeControllerTests.java
@@ -65,4 +65,32 @@ class HttpProbeControllerTests {
                 .andExpect(jsonPath("$.statusText").value("Error"))
                 .andExpect(jsonPath("$.error").value("Connection refused"));
     }
+
+    @Test
+    void inputThatExceedsAProbeLimitIsRejectedWithTheCanonicalBadRequestBody() throws Exception {
+        HttpProbeService service = mock(HttpProbeService.class);
+        when(service.probe(any(HttpProbeRequest.class)))
+                .thenThrow(new IllegalArgumentException("HTTP Probe request body exceeds the maximum of 65536 bytes"));
+        MockMvc mvc = standaloneSetup(new HttpProbeController(service)).build();
+
+        mvc.perform(post("/bootui/api/http-probe")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(new HttpProbeRequest("POST", "/", "oversized", null))))
+                // invalid input is a validation failure, not a probe outcome: canonical 400 + {"error"}
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("HTTP Probe request body exceeds the maximum of 65536 bytes"));
+    }
+
+    @Test
+    void validationFailureWithoutAMessageStillReturnsACanonicalBody() throws Exception {
+        HttpProbeService service = mock(HttpProbeService.class);
+        when(service.probe(any(HttpProbeRequest.class))).thenThrow(new IllegalArgumentException());
+        MockMvc mvc = standaloneSetup(new HttpProbeController(service)).build();
+
+        mvc.perform(post("/bootui/api/http-probe")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(new HttpProbeRequest("GET", "/", null, null))))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Invalid request"));
+    }
 }

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.test.js
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.test.js
@@ -17,6 +17,21 @@ function deferred() {
   return {promise, resolve}
 }
 
+function ok(payload) {
+  return {ok: true, status: 200, json: async () => payload}
+}
+
+function rejected(status, payload) {
+  return {
+    ok: false,
+    status,
+    json: async () => {
+      if (payload === undefined) throw new SyntaxError('Unexpected end of JSON input')
+      return payload
+    }
+  }
+}
+
 function response(overrides = {}) {
   return {
     status: 200,
@@ -51,7 +66,7 @@ describe('HttpProbe', () => {
   })
 
   it('warns when the response body was truncated', async () => {
-    apiFetch.mockResolvedValue({json: async () => response({body: 'partial response', truncated: true})})
+    apiFetch.mockResolvedValue(ok(response({body: 'partial response', truncated: true})))
     const wrapper = mount(HttpProbe)
 
     await wrapper.get('button.btn-primary').trigger('click')
@@ -63,7 +78,7 @@ describe('HttpProbe', () => {
   })
 
   it.each(['GET', 'HEAD'])('sends safe %s probes without confirmation', async (method) => {
-    apiFetch.mockResolvedValue({json: async () => response()})
+    apiFetch.mockResolvedValue(ok(response()))
     const wrapper = mount(HttpProbe)
     await wrapper.get('select').setValue(method)
 
@@ -78,7 +93,7 @@ describe('HttpProbe', () => {
   it('waits for confirmation before sending an unsafe probe', async () => {
     const confirmation = deferred()
     confirm.mockReturnValueOnce(confirmation.promise)
-    apiFetch.mockResolvedValue({json: async () => response()})
+    apiFetch.mockResolvedValue(ok(response()))
     const wrapper = mount(HttpProbe)
     await wrapper.get('select').setValue('POST')
     await wrapper.get('input').setValue('/api/orders')
@@ -136,5 +151,26 @@ describe('HttpProbe', () => {
     await flushPromises()
 
     expect(apiFetch).not.toHaveBeenCalled()
+  })
+
+  it('surfaces the canonical rejection message when the probe input exceeds a limit', async () => {
+    apiFetch.mockResolvedValue(rejected(400, {error: 'HTTP Probe request body exceeds the maximum of 65536 bytes'}))
+    const wrapper = mount(HttpProbe)
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('HTTP Probe request body exceeds the maximum of 65536 bytes')
+    expect(wrapper.text()).toContain('0 Rejected')
+  })
+
+  it('falls back to a status-based message when a rejection carries no JSON body', async () => {
+    apiFetch.mockResolvedValue(rejected(413))
+    const wrapper = mount(HttpProbe)
+
+    await wrapper.get('button.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Probe request rejected (HTTP 413)')
   })
 })

--- a/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
+++ b/bootui-ui/src/main/frontend/src/views/HttpProbe.vue
@@ -97,7 +97,21 @@ async function sendProbe() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify(request)
     })
-    response.value = await res.json()
+    const payload = await res.json().catch(() => null)
+    if (!res.ok) {
+      // BootUI bounds probe input (body, path, headers): an over-limit request is rejected with a
+      // canonical {"error": ...} body before anything is sent to the application.
+      response.value = {
+        status: 0,
+        statusText: 'Rejected',
+        headers: {},
+        body: null,
+        durationMs: 0,
+        error: payload?.error || `Probe request rejected (HTTP ${res.status})`
+      }
+    } else {
+      response.value = payload
+    }
   } catch (error) {
     response.value = {
       status: 0,

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2077,6 +2077,13 @@ byte-identical to Spring. Capture is wired in dev/test only and never in product
 The HTTP Probe panel sends local-only requests to the running application and displays response status, headers,
 duration, and body. It is designed for quick route checks from inside the same local development context as BootUI.
 
+Probe input is bounded like every other BootUI operation: the method, path, request body, header count and header
+name/value sizes each have an explicit ceiling (64 KiB for the request body, 2 KiB for the path, 50 headers), measured
+in UTF-8 bytes and checked before anything is sent to the application. Exceeding a ceiling is invalid input, so it is
+rejected with the canonical `400` and `{"error": ...}` body on Spring MVC, Spring WebFlux and Quarkus alike, and the
+panel shows that message instead of a probe result. A probe that actually runs and fails — connection refused, timeout
+— is still reported as a probe outcome, and its response body is truncated at the response byte budget.
+
 On Quarkus the panel is identical: the probe always targets the application's *own* loopback address, so it can never
 reach an external host. The only platform difference is how the live local port is resolved — Quarkus has no single
 config key that always equals the bound port, so the adapter selects `quarkus.http.test-port` or `quarkus.http.port` by

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -813,6 +813,9 @@ Features:
 - Normalize method and path.
 - Restrict targets to localhost.
 - Support request bodies only for methods that can carry a body.
+- Bound every inbound field before any request is sent: method (32 bytes), path (2 KiB), request body
+  (64 KiB), header count (50), header name (256 bytes), header value (8 KiB) and total header size (32 KiB), all
+  measured in UTF-8 bytes.
 - Require explicit confirmation before sending any method other than `GET` or `HEAD`.
 - Display status, selected response headers, body, timing, and errors.
 
@@ -822,6 +825,9 @@ Acceptance criteria:
 - `GET` and `HEAD` probes run directly; unsafe probes do not reach the backend until the developer confirms them.
 - Unsafe-body behavior is explicit and predictable.
 - Response headers are filtered to a small allow-list.
+- Response bodies are truncated at the probe byte budget and flagged as truncated.
+- Input that exceeds a probe limit is rejected with the canonical `400` and `{"error": ...}` body on every adapter,
+  before any request reaches the application; a probe that runs but fails stays a `200` outcome with an error payload.
 
 ### 5.13.1 Pentesting Panel
 


### PR DESCRIPTION
Fixes #860.

> Note on issue numbering: this session was opened against #859 (`LocalhostGuard` malformed Host), but the task and branch describe the HTTP Probe input bounding tracked in #860. This PR implements #860 only and leaves #859 untouched.

## Problem

HTTP Probe capped only the **response** body. The inbound JSON request body, path, headers, header count, and individual field lengths had no BootUI-level ceiling, so an adapter bound the whole request and the engine forwarded it to the local target — doubling the memory cost and pushing unbounded work onto the application under test.

## Change

New `HttpProbeLimits` settings record in the engine (`bootui-engine/.../web`), applied by every adapter through the shared `HttpProbeService`:

| Field | Budget |
| --- | --- |
| method | 32 bytes |
| path | 2 KiB |
| request body | 64 KiB |
| header count | 50 |
| header name | 256 bytes |
| header value | 8 KiB |
| all headers combined | 32 KiB |
| response body (unchanged) | 1 MiB, truncates + flags |

- Validation runs **before** any outbound work, so a rejected probe never reaches the application.
- Sizes are measured in **UTF-8 bytes**, not `String` length, so multi-byte input cannot smuggle several times the budget past a character count. Counting is capped and allocation-free (no encoded copy of an oversized value is ever materialised), so measuring a huge value costs a bounded scan.
- The request body is validated for **every** method, so an oversized payload on `GET` is refused rather than silently dropped.
- Limits are fixed constants, consistent with the existing `BoundedBodyReader` per-client byte budgets — no new configuration surface duplicated across Spring and Quarkus. The request-body budget deliberately sits below the WebFlux codec's 256 KiB in-memory default so the canonical BootUI error, not an opaque framework error, is what a developer sees.

## Error contract

Over-limit input is *invalid input*, not a probe outcome, so it is an `IllegalArgumentException` from the engine mapped to the canonical `400` + `{"error": ...}` body — the same shape as `LoggersController`/`LoggersResource`:

- Spring MVC **and** WebFlux: `@ExceptionHandler` on the shared `HttpProbeController` (both stacks use the same controller).
- Quarkus: mapping in `HttpProbeResource`.

A probe that runs and *fails* (connection refused, timeout) is unchanged: still an HTTP `200` with an error payload and `status: 0`. Malformed values the JDK rejects (bad method token, bad path characters) also keep their existing 200-outcome behaviour. The UI now renders a non-OK response as `0 Rejected` with the canonical message instead of silently parsing it as a probe result.

## Tests

- `HttpProbeServiceTests`: at-limit accepted / one byte over rejected for body, path, method, header count, header name, header value, and combined header size; UTF-8 measurement (3-byte characters and surrogate pairs); oversized body rejected on `GET`; null header names/values; rejected input never reaches the target (hit counter); null limits fall back to defaults.
- `HttpProbeLimitsTests`: shipped defaults, non-positive limits rejected, response-budget override.
- `HttpProbeControllerTests` (MVC) and new `ReactiveHttpProbeControllerTests` (WebFlux): canonical 400 body, null-message fallback, and probe failure still 200.
- `BootUiQuarkusHttpProbeResourceTest`: real-boot oversized body and too-many-headers rejections.
- New shared conformance test `httpProbeInputBudgetsAreEnforcedIdenticallyOnEveryAdapter` — runs against Spring MVC, Spring WebFlux, and Quarkus, asserting identical canonical rejections and that a probe exactly at the ceiling still runs.
- `HttpProbe.test.js`: rejection message rendering and the HTTP-status fallback.

Docs: `docs/SPECIFICATION.md` §5.13, `docs/FEATURES.md`, and a `CHANGELOG.md` entry.

## Validation

- `./mvnw -T 1C -B -ntp clean install` (isolated `-Dmaven.repo.local=.m2`): **BUILD SUCCESS** across all 31 modules, including both Spring sample apps and the full Quarkus integration-test matrix. The new conformance test executed (not skipped) on all three adapters.
- `./mvnw spotless:check` and frontend `npm run format:check` pass.
- Honest limitation: the run used the local JDK 26 toolchain rather than CI's Java 17 baseline; the Quarkus modules did augment and run here, but the Java 17 CI job remains the authoritative check.
- Also honest: BootUI's limits are enforced immediately after the adapter binds the payload. A truly pre-binding cap would require stack-specific filters and would fight each framework's own request-size configuration, so the framework body limits (Quarkus `quarkus.http.limits.max-body-size`, the WebFlux codec limit) remain the first line of defense for absurd payloads.

## Review follow-up

- **Unpaired-surrogate byte counting (Copilot review).** The counter charged one byte per lone surrogate, matching what `String.getBytes(UTF_8)` actually emits (`0x3F`, verified empirically) but not what an encoder replacing with `U+FFFD` would emit. Since BootUI is fail-closed, the counter now charges the worst case (3 bytes) for an unpaired surrogate, so malformed input can never encode to more bytes than it was charged for. Pinned by `unpairedSurrogatesAreChargedTheWorstCaseReplacementSize` (verified to fail against the previous counting) plus an invariant test asserting the counter never undercharges relative to the real encoder.
- **Issue reference.** Removed the incorrect `Fixes: #859` trailer that the session tooling appended; the only closing reference is now `Fixes #860`.
