### PR TITLE
Exclude Quarkus BootUI traffic from telemetry under any root path or mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `RAPI-ERR-010` (inconsistent error contracts across handlers for the same exception), and `RAPI-ERR-011`
   (exception handlers that read stack traces into their response). The catalogue now ships 56 rules.
 
+### Fixed
+
+- **BootUI's own Quarkus traffic stays out of HTTP Exchanges, Live Activity, and Exceptions under a non-default
+  `quarkus.http.root-path` or a custom `bootui.path` mount.** The HTTP-exchange, exception, pre-mapping exception, and
+  log-based capture points now recognize BootUI's surface through one shared matcher that strips the configured root
+  path and honors the configured UI/API mounts, instead of matching the literal `/bootui` prefix each on its own. A
+  request logged by Quarkus' own error handler while serving the console is excluded too. Application paths that merely
+  resemble the console, such as `/bootui-other`, stay captured (#857).
+
 ## [1.14.1] - 2026-08-20
 
 Patch release that restores Spring native and Quarkus Docker startup, fixes the native-image build bootstrap on AMD64,

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiCustomPathBootTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiCustomPathBootTest.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.quarkus.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.jdubois.bootui.conformance.AbstractBootUiApiConformanceTest;
 import io.github.jdubois.bootui.conformance.BootUiApiContractCatalog.Runtime;
 import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
@@ -119,6 +120,32 @@ class BootUiCustomPathBootTest extends AbstractBootUiApiConformanceTest {
         assertThat(logger.status()).isEqualTo(200);
         assertThat(download.status()).isEqualTo(200);
         assertThat(download.header("content-disposition")).contains("thread-dump.txt");
+    }
+
+    @Test
+    void bootUiTrafficOnTheCustomMountIsExcludedFromHttpExchanges() {
+        BootUiHttpProbe probe = probe();
+        probe.get("/host/api/hello");
+        probe.get("/host/internal/bootui-api/overview");
+
+        Response report = probe.get("/host/internal/bootui-api/http-exchanges");
+        assertThat(report.status()).isEqualTo(200);
+
+        boolean foundHello = false;
+        for (JsonNode exchange : report.json().path("exchanges")) {
+            String path = exchange.path("path").asText("");
+            assertThat(path)
+                    .as("console traffic on the configured mounts must never be retained as host telemetry")
+                    .doesNotContain("/dev-console")
+                    .doesNotContain("bootui-api")
+                    .doesNotContain("/host/bootui");
+            if (path.equals("/host/api/hello")) {
+                foundHello = true;
+            }
+        }
+        assertThat(foundHello)
+                .as("host-application traffic on the same root path must still be captured")
+                .isTrue();
     }
 
     public static final class CustomPathProfile implements QuarkusTestProfile {

--- a/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHttpExchangesRootPathCaptureTest.java
+++ b/bootui-quarkus-integration-tests/base/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHttpExchangesRootPathCaptureTest.java
@@ -1,0 +1,96 @@
+package io.github.jdubois.bootui.quarkus.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe;
+import io.github.jdubois.bootui.conformance.BootUiHttpProbe.Response;
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import java.net.URL;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real-boot regression proof that BootUI's own traffic stays out of the telemetry it reports on when the
+ * host application runs under a non-default {@code quarkus.http.root-path}. The capture filters used to
+ * match the literal {@code /bootui} prefix, so a console request arriving as {@code /app/bootui/**} was
+ * retained as host-application traffic; they now strip the root path through the same shared helper the
+ * safety and panel-access filters use (see {@code BootUiQuarkusSafetyFilterRootPathBootTest} and
+ * {@code QuarkusPanelAccessFilterRootPathBootTest} for their root-path proofs).
+ *
+ * <p>Application traffic under the same root path must keep being captured, so this also pins that the
+ * exclusion did not widen into the host application.</p>
+ */
+@QuarkusTest
+@TestProfile(BootUiQuarkusHttpExchangesRootPathCaptureTest.RootPathProfile.class)
+class BootUiQuarkusHttpExchangesRootPathCaptureTest {
+
+    @TestHTTPResource
+    URL baseUrl;
+
+    /** The HTTP server root (scheme://host:port), independent of how {@code baseUrl} renders the root-path. */
+    private BootUiHttpProbe probe() {
+        String serverRoot = baseUrl.getProtocol() + "://" + baseUrl.getHost() + ":" + baseUrl.getPort();
+        return new BootUiHttpProbe(serverRoot);
+    }
+
+    @Test
+    void consoleTrafficUnderTheRootPathIsExcludedWhileApplicationTrafficIsCaptured() {
+        BootUiHttpProbe probe = probe();
+        probe.get("/app/api/hello");
+        probe.get("/app/bootui/api/overview");
+
+        Response report = probe.get("/app/bootui/api/http-exchanges");
+        assertThat(report.status())
+                .as("GET /app/bootui/api/http-exchanges status")
+                .isEqualTo(200);
+
+        boolean foundHello = false;
+        for (JsonNode exchange : report.json().path("exchanges")) {
+            String path = exchange.path("path").asText("");
+            assertThat(path)
+                    .as("BootUI's own root-path-prefixed traffic must never be retained as host telemetry")
+                    .doesNotContain("/bootui");
+            if (path.equals("/app/api/hello")) {
+                foundHello = true;
+            }
+        }
+        assertThat(foundHello)
+                .as("host-application traffic under the same root path must still be captured")
+                .isTrue();
+    }
+
+    @Test
+    void consoleTrafficUnderTheRootPathIsExcludedFromLiveActivity() {
+        BootUiHttpProbe probe = probe();
+        probe.get("/app/api/hello");
+        probe.get("/app/bootui/api/overview");
+
+        Response activity = probe.get("/app/bootui/api/activity");
+        assertThat(activity.status()).as("GET /app/bootui/api/activity status").isEqualTo(200);
+
+        boolean foundHello = false;
+        for (JsonNode entry : activity.json().path("entries")) {
+            String path = entry.path("path").asText("");
+            assertThat(path)
+                    .as("Live Activity correlates the same capture source, so it must be self-excluded too")
+                    .doesNotContain("/bootui");
+            if (path.equals("/app/api/hello")) {
+                foundHello = true;
+            }
+        }
+        assertThat(foundHello)
+                .as("host-application traffic under the same root path must still reach Live Activity")
+                .isTrue();
+    }
+
+    public static final class RootPathProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.http.root-path", "/app");
+        }
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusBootUiPaths.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusBootUiPaths.java
@@ -11,6 +11,11 @@ public final class QuarkusBootUiPaths {
     public static final String PATH_KEY = "bootui.path";
     public static final String API_PATH_KEY = "bootui.api-path";
 
+    /** Internal, fixed mount serving BootUI's JAX-RS resources and static assets. */
+    private static final String INTERNAL_UI_PATH = BootUiPathNormalizer.DEFAULT_PATH;
+
+    private static final String INTERNAL_API_PATH = INTERNAL_UI_PATH + "/api";
+
     private QuarkusBootUiPaths() {}
 
     public static String uiPath(Config config) {
@@ -38,6 +43,64 @@ public final class QuarkusBootUiPaths {
     public static void validate(Config config) {
         uiPath(config);
         apiPath(config);
+    }
+
+    /**
+     * Whether {@code normalizedPath} — a full Vert.x {@link io.vertx.ext.web.RoutingContext#normalizedPath()},
+     * which still carries the {@code quarkus.http.root-path} prefix — targets BootUI's own console surface.
+     *
+     * <p>This is the single matcher every self-traffic exclusion in the Quarkus adapter uses — HTTP-exchange
+     * capture, request-failure capture, pre-mapping exception capture, and log-based exception capture — so
+     * those capture points can never drift from each other, nor from the access filters that guard the very
+     * same surface. It recognizes a BootUI request in all three mount shapes:</p>
+     * <ul>
+     *   <li>the internal {@code /bootui} and {@code /bootui/api} mounts, which every request ends up on once
+     *       {@link BootUiPathRewriteFilter} has rerouted it;</li>
+     *   <li>the operator-configured {@code bootui.path} / {@code bootui.api-path} mounts, so a request is
+     *       excluded even before that reroute (and regardless of whether the rewrite filter is wired);</li>
+     *   <li>any of the above under a non-default {@code quarkus.http.root-path}, whose prefix is stripped
+     *       first via {@link QuarkusRootPath} exactly as {@link BootUiQuarkusSafetyFilter} and
+     *       {@link QuarkusPanelAccessFilter} strip it.</li>
+     * </ul>
+     *
+     * <p>Matching is a strict {@code /}-delimited prefix match on the request path only, so an unrelated
+     * application path such as {@code /bootui-other} or {@code /api/bootui-proxy} is never mistaken for BootUI
+     * traffic and stays captured. Invalid configuration degrades to the internal mounts rather than throwing:
+     * a capture filter must never disrupt a request, and defaulting narrowly keeps application traffic
+     * captured.</p>
+     *
+     * @param config live MicroProfile configuration, or {@code null} when it cannot be resolved
+     * @param normalizedPath the full normalized request path, or {@code null}
+     */
+    public static boolean isBootUiRequest(Config config, String normalizedPath) {
+        if (normalizedPath == null || normalizedPath.isBlank()) {
+            return false;
+        }
+        String relativePath = normalizedPath;
+        String uiPath = INTERNAL_UI_PATH;
+        String apiPath = INTERNAL_API_PATH;
+        if (config != null) {
+            try {
+                relativePath = QuarkusRootPath.stripPrefix(normalizedPath, rootPrefix(config));
+            } catch (RuntimeException exception) {
+                relativePath = normalizedPath;
+            }
+            try {
+                uiPath = safeUiPath(config);
+                apiPath = safeApiPath(config);
+            } catch (RuntimeException exception) {
+                uiPath = INTERNAL_UI_PATH;
+                apiPath = INTERNAL_API_PATH;
+            }
+        }
+        return isSameOrChild(relativePath, INTERNAL_UI_PATH)
+                || isSameOrChild(relativePath, INTERNAL_API_PATH)
+                || isSameOrChild(relativePath, uiPath)
+                || isSameOrChild(relativePath, apiPath);
+    }
+
+    private static boolean isSameOrChild(String path, String basePath) {
+        return path != null && basePath != null && (path.equals(basePath) || path.startsWith(basePath + "/"));
     }
 
     static String rootPrefix(Config config) {

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/exceptions/QuarkusExceptionCapture.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/exceptions/QuarkusExceptionCapture.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
+import org.eclipse.microprofile.config.Config;
 
 /**
  * Installs and removes the {@link QuarkusExceptionLogHandler} on the root {@code java.util.logging} logger
@@ -29,6 +30,7 @@ public class QuarkusExceptionCapture {
     private final ExceptionStore store;
     private final TraceIdProvider traceIdProvider;
     private final CurrentVertxRequest currentVertxRequest;
+    private final Config config;
     private QuarkusExceptionLogHandler handler;
 
     /**
@@ -40,10 +42,14 @@ public class QuarkusExceptionCapture {
      */
     @Inject
     public QuarkusExceptionCapture(
-            ExceptionStore store, Instance<TraceIdProvider> traceIdProvider, CurrentVertxRequest currentVertxRequest) {
+            ExceptionStore store,
+            Instance<TraceIdProvider> traceIdProvider,
+            CurrentVertxRequest currentVertxRequest,
+            Config config) {
         this.store = store;
         this.traceIdProvider = traceIdProvider.isResolvable() ? traceIdProvider.get() : null;
         this.currentVertxRequest = currentVertxRequest;
+        this.config = config;
     }
 
     void onStart(@Observes StartupEvent event) {
@@ -60,7 +66,8 @@ public class QuarkusExceptionCapture {
                         "io.github.jdubois.bootui.engine",
                         "io.github.jdubois.bootui.core")),
                 traceIdProvider,
-                currentVertxRequest);
+                currentVertxRequest,
+                config);
         root.addHandler(handler);
     }
 

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/exceptions/QuarkusExceptionLogHandler.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/exceptions/QuarkusExceptionLogHandler.java
@@ -2,11 +2,13 @@ package io.github.jdubois.bootui.quarkus.exceptions;
 
 import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
 import io.github.jdubois.bootui.engine.support.InternalPackageMatcher;
+import io.github.jdubois.bootui.quarkus.QuarkusBootUiPaths;
 import io.github.jdubois.bootui.spi.TraceIdProvider;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.vertx.ext.web.RoutingContext;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
+import org.eclipse.microprofile.config.Config;
 
 /**
  * Quarkus log-side capture for the Exceptions panel: a {@code java.util.logging} {@link Handler} attached
@@ -15,7 +17,14 @@ import java.util.logging.LogRecord;
  * the Spring adapter's {@code BootUiExceptionLogAppender}; the store (grouping, cause-chain dedup,
  * capping) is shared, so both platforms serve the identical wire.
  *
- * <p>BootUI's own loggers are dropped so the panel never captures its internals. A {@link ThreadLocal}
+ * <p>BootUI's own loggers are dropped so the panel never captures its internals, and so is any record
+ * emitted while serving a BootUI request — most importantly {@code QuarkusErrorHandler}'s own log of a
+ * failed request, which is emitted under the Quarkus logger and would otherwise slip past the logger-name
+ * check and land BootUI's internals in the panel. That request check goes through
+ * {@link QuarkusBootUiPaths#isBootUiRequest}, the single matcher shared with the HTTP-exchange and
+ * exception capture filters, so it holds under a non-default {@code quarkus.http.root-path} and for a
+ * custom {@code bootui.path} mount alike. A record logged outside any request (a scheduled task, startup)
+ * has no path and stays captured. A {@link ThreadLocal}
  * re-entrancy guard plus the store's own dedup means capture can never recurse into the logging system,
  * and every path is silent so a misbehaving log can never disrupt the application.</p>
  *
@@ -48,17 +57,20 @@ public final class QuarkusExceptionLogHandler extends Handler {
     private final InternalPackageMatcher internalPackages;
     private final TraceIdProvider traceIdProvider;
     private final CurrentVertxRequest currentVertxRequest;
+    private final Config config;
     private final ThreadLocal<Boolean> capturing = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
     public QuarkusExceptionLogHandler(
             ExceptionStore store,
             InternalPackageMatcher internalPackages,
             TraceIdProvider traceIdProvider,
-            CurrentVertxRequest currentVertxRequest) {
+            CurrentVertxRequest currentVertxRequest,
+            Config config) {
         this.store = store;
         this.internalPackages = internalPackages;
         this.traceIdProvider = traceIdProvider;
         this.currentVertxRequest = currentVertxRequest;
+        this.config = config;
     }
 
     @Override
@@ -73,8 +85,11 @@ public final class QuarkusExceptionLogHandler extends Handler {
         capturing.set(Boolean.TRUE);
         try {
             RoutingContext rc = currentRoutingContext();
-            String method = rc == null ? null : rc.request().method().name();
             String path = rc == null ? null : rc.normalizedPath();
+            if (QuarkusBootUiPaths.isBootUiRequest(config, path)) {
+                return; // never capture BootUI's own traffic
+            }
+            String method = rc == null ? null : rc.request().method().name();
             String handler = QuarkusResourceHandlers.currentHandler();
             store.record(thrown, Thread.currentThread().getName(), method, path, handler, "log", currentTraceId());
         } catch (RuntimeException ignored) {

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/exceptions/QuarkusPreMappingExceptionCaptureHandler.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/exceptions/QuarkusPreMappingExceptionCaptureHandler.java
@@ -1,12 +1,15 @@
 package io.github.jdubois.bootui.quarkus.exceptions;
 
 import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
+import io.github.jdubois.bootui.quarkus.QuarkusBootUiPaths;
 import io.github.jdubois.bootui.spi.TraceIdProvider;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.vertx.ext.web.RoutingContext;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.resteasy.reactive.server.core.ResteasyReactiveRequestContext;
 import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
 
@@ -40,12 +43,17 @@ import org.jboss.resteasy.reactive.server.spi.ServerRestHandler;
  * CDI. Its CDI-backed dependencies ({@link ExceptionStore}, the optional {@link TraceIdProvider}, and {@code
  * CurrentVertxRequest}) are therefore resolved lazily, per invocation, via {@link Arc#container()} — cheap for
  * {@code @Singleton}/request-scoped beans and safe even before the container is fully up (guarded to a silent
- * no-op). Every path is wrapped so a diagnostics failure can never disrupt the application's real exception
- * handling or response.
+ * no-op). The live MicroProfile {@code Config} that decides which paths are BootUI's own is read through
+ * {@code ConfigProvider} instead, because the config bean is {@code @Dependent} and this handler has no
+ * lifecycle hook to release a programmatic lookup. Every path is wrapped so a diagnostics failure can never
+ * disrupt the application's real exception handling or response.
+ *
+ * <p>BootUI's own traffic is never captured. The exclusion goes through
+ * {@link QuarkusBootUiPaths#isBootUiRequest}, the single matcher shared with the HTTP-exchange and
+ * exception capture filters, so it holds under a non-default {@code quarkus.http.root-path} and for a custom
+ * {@code bootui.path} mount alike.
  */
 public final class QuarkusPreMappingExceptionCaptureHandler implements ServerRestHandler {
-
-    private static final String BASE_PATH = "/bootui";
 
     @Override
     public void handle(ResteasyReactiveRequestContext requestContext) throws Exception {
@@ -60,7 +68,7 @@ public final class QuarkusPreMappingExceptionCaptureHandler implements ServerRes
             }
             RoutingContext rc = currentRoutingContext(container);
             String path = rc == null ? null : rc.normalizedPath();
-            if (path != null && (path.equals(BASE_PATH) || path.startsWith(BASE_PATH + "/"))) {
+            if (QuarkusBootUiPaths.isBootUiRequest(currentConfig(), path)) {
                 return; // never capture BootUI's own traffic
             }
             InstanceHandle<ExceptionStore> storeHandle = container.instance(ExceptionStore.class);
@@ -92,6 +100,22 @@ public final class QuarkusPreMappingExceptionCaptureHandler implements ServerRes
         try {
             InstanceHandle<CurrentVertxRequest> handle = container.instance(CurrentVertxRequest.class);
             return handle.isAvailable() ? handle.get().getCurrent() : null;
+        } catch (RuntimeException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * The live MicroProfile {@link Config}, or {@code null} when it cannot be resolved. Read through
+     * {@link ConfigProvider} rather than an Arc lookup because the config bean is {@code @Dependent}: a
+     * programmatic lookup would hand back a handle this handler has no lifecycle hook to close, while
+     * {@code ConfigProvider} returns the same running {@code SmallRyeConfig} with no creational context at
+     * all. When it cannot be resolved, BootUI path matching degrades to the internal {@code /bootui} mounts,
+     * which still excludes the default deployment. Fully guarded so capture never disrupts request handling.
+     */
+    private static Config currentConfig() {
+        try {
+            return ConfigProvider.getConfig();
         } catch (RuntimeException ex) {
             return null;
         }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusExceptionCaptureFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusExceptionCaptureFilter.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.quarkus.web;
 
 import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
+import io.github.jdubois.bootui.quarkus.QuarkusBootUiPaths;
 import io.github.jdubois.bootui.quarkus.exceptions.QuarkusResourceHandlers;
 import io.github.jdubois.bootui.spi.TraceIdProvider;
 import io.quarkus.vertx.http.runtime.filters.Filters;
@@ -9,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.Config;
 
 /**
  * Captures unhandled HTTP request failures into the shared {@link ExceptionStore} — the Quarkus analogue
@@ -17,7 +19,9 @@ import jakarta.inject.Inject;
  * modes, so production stays dark. It records in {@link RoutingContext#addBodyEndHandler} so a failure set
  * by a downstream handler is final, and only ever observes — it never short-circuits the response.
  *
- * <p>BootUI's own {@code /bootui} traffic is excluded so the panel never captures its internals, and the
+ * <p>BootUI's own traffic is excluded so the panel never captures its internals — via
+ * {@link QuarkusBootUiPaths#isBootUiRequest}, so the exclusion holds under a non-default
+ * {@code quarkus.http.root-path} and for a custom {@code bootui.path} mount alike — and the
  * request path is taken without its query string to avoid surfacing secrets. The store dedups by
  * cause-chain identity, so a failure also logged by Quarkus (and seen by {@code QuarkusExceptionLogHandler})
  * counts once. In practice {@code QuarkusErrorHandler} logs an unhandled failure synchronously — long before
@@ -46,18 +50,19 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class QuarkusExceptionCaptureFilter {
 
-    private static final String BASE_PATH = "/bootui";
-
     /** After the safety filter (priority 1000); only ever records, never short-circuits. */
     private static final int PRIORITY = 900;
 
     private final ExceptionStore store;
     private final TraceIdProvider traceIdProvider;
+    private final Config config;
 
     @Inject
-    public QuarkusExceptionCaptureFilter(ExceptionStore store, Instance<TraceIdProvider> traceIdProvider) {
+    public QuarkusExceptionCaptureFilter(
+            ExceptionStore store, Instance<TraceIdProvider> traceIdProvider, Config config) {
         this.store = store;
         this.traceIdProvider = traceIdProvider.isResolvable() ? traceIdProvider.get() : null;
+        this.config = config;
     }
 
     public void register(@Observes Filters filters) {
@@ -66,7 +71,7 @@ public class QuarkusExceptionCaptureFilter {
 
     void handle(RoutingContext rc) {
         String path = rc.normalizedPath();
-        if (path != null && (path.equals(BASE_PATH) || path.startsWith(BASE_PATH + "/"))) {
+        if (QuarkusBootUiPaths.isBootUiRequest(config, path)) {
             rc.next();
             return;
         }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusHttpExchangeCaptureFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/QuarkusHttpExchangeCaptureFilter.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.quarkus.web;
 
 import io.github.jdubois.bootui.engine.web.CapturedHttpExchange;
 import io.github.jdubois.bootui.engine.web.HttpExchangeBuffer;
+import io.github.jdubois.bootui.quarkus.QuarkusBootUiPaths;
 import io.github.jdubois.bootui.spi.TraceIdProvider;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.filters.Filters;
@@ -22,6 +23,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.microprofile.config.Config;
 
 /**
  * Captures completed HTTP exchanges into the shared {@link HttpExchangeBuffer} — the Quarkus analogue of
@@ -31,9 +33,10 @@ import java.util.Map;
  *
  * <p>It records in {@link HttpServerResponse#bodyEndHandler} so status, headers, byte count and duration
  * are final (a route filter runs before the response is sent, where those are all defaulted). BootUI's
- * own {@code /bootui} traffic is excluded before recording so the panel never shows its own polling and
- * the self counter mirrors Spring. The buffer caps size and masks downstream, so this filter does
- * minimal, non-blocking work on the event loop.</p>
+ * own traffic is excluded before recording so the panel never shows its own polling and the self counter
+ * mirrors Spring; the exclusion goes through {@link QuarkusBootUiPaths#isBootUiRequest} so it holds under a
+ * non-default {@code quarkus.http.root-path} and for a custom {@code bootui.path} mount alike. The buffer
+ * caps size and masks downstream, so this filter does minimal, non-blocking work on the event loop.</p>
  *
  * <p>When an OpenTelemetry {@link TraceIdProvider} is present (capability-gated), the active server span's
  * trace id is resolved <em>at filter entry</em> — on the event loop, where the span is current — and stamped
@@ -52,18 +55,19 @@ import java.util.Map;
 @ApplicationScoped
 public class QuarkusHttpExchangeCaptureFilter {
 
-    private static final String BASE_PATH = "/bootui";
-
     /** After the safety filter (priority 1000); only ever records, never short-circuits. */
     private static final int PRIORITY = 900;
 
     private final HttpExchangeBuffer buffer;
     private final TraceIdProvider traceIdProvider;
+    private final Config config;
 
     @Inject
-    public QuarkusHttpExchangeCaptureFilter(HttpExchangeBuffer buffer, Instance<TraceIdProvider> traceIdProvider) {
+    public QuarkusHttpExchangeCaptureFilter(
+            HttpExchangeBuffer buffer, Instance<TraceIdProvider> traceIdProvider, Config config) {
         this.buffer = buffer;
         this.traceIdProvider = traceIdProvider.isResolvable() ? traceIdProvider.get() : null;
+        this.config = config;
     }
 
     public void register(@Observes Filters filters) {
@@ -72,7 +76,7 @@ public class QuarkusHttpExchangeCaptureFilter {
 
     void handle(RoutingContext rc) {
         String path = rc.normalizedPath();
-        if (isBootUiRequest(path)) {
+        if (QuarkusBootUiPaths.isBootUiRequest(config, path)) {
             rc.next();
             return;
         }
@@ -137,10 +141,6 @@ public class QuarkusHttpExchangeCaptureFilter {
         } catch (RuntimeException ex) {
             return null;
         }
-    }
-
-    static boolean isBootUiRequest(String path) {
-        return path != null && (path.equals(BASE_PATH) || path.startsWith(BASE_PATH + "/"));
     }
 
     private static URI toUri(HttpServerRequest request) {

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusBootUiPathsTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/QuarkusBootUiPathsTest.java
@@ -45,6 +45,109 @@ class QuarkusBootUiPathsTest {
         assertThat(QuarkusBootUiPaths.safeApiPath(config)).isEqualTo("/bootui/api");
     }
 
+    // --- self-traffic matching ----------------------------------------------------------------------
+
+    @Test
+    void matchesBootUiRequestsUnderTheDefaultRootPath() {
+        Config config = config(Map.of());
+
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/bootui")).isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/bootui/")).isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/bootui/assets/app.js"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/bootui/api/overview"))
+                .isTrue();
+    }
+
+    @Test
+    void matchesBootUiRequestsUnderANonDefaultRootPath() {
+        Config config = config(Map.of("quarkus.http.root-path", "/app"));
+
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/bootui")).isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/bootui/")).isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/bootui/api/exceptions"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/orders")).isFalse();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app")).isFalse();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/")).isFalse();
+    }
+
+    @Test
+    void matchesACustomMountBeforeAndAfterTheInternalReroute() {
+        Config config = config(Map.of(
+                "bootui.path", "/dev-console",
+                "quarkus.http.root-path", "/app"));
+
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/dev-console"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/dev-console/api/overview"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/bootui/api/overview"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/dev-consoles"))
+                .isFalse();
+    }
+
+    @Test
+    void matchesASeparatelyMountedApiPath() {
+        Config config = config(Map.of(
+                "bootui.path", "/console",
+                "bootui.api-path", "/internal/bootui-api"));
+
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/internal/bootui-api"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/internal/bootui-api/mappings"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/internal/bootui-apis"))
+                .isFalse();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/internal")).isFalse();
+    }
+
+    @Test
+    void neverMatchesApplicationPathsThatMerelyLookLikeBootUi() {
+        Config config = config(Map.of("quarkus.http.root-path", "/app"));
+
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/bootui-other"))
+                .isFalse();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/api/bootui-proxy"))
+                .isFalse();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/application/bootui"))
+                .isFalse();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/orders/bootui"))
+                .isFalse();
+        // Vert.x hands filters an already-normalized path: percent-encoded unreserved characters are decoded
+        // and '.'/'..'/'//' segments are collapsed, so those cannot be used to evade the match. An encoded
+        // path separator is deliberately left encoded, and such a path never routes to BootUI either.
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config, "/app/bootui%2Fapi"))
+                .isFalse();
+    }
+
+    @Test
+    void normalizesTheConfiguredRootPathBeforeMatching() {
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(
+                        config(Map.of("quarkus.http.root-path", "/app/")), "/app/bootui/api/overview"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(
+                        config(Map.of("quarkus.http.root-path", "app")), "/app/bootui/api/overview"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config(Map.of("quarkus.http.root-path", "/")), "/bootui"))
+                .isTrue();
+    }
+
+    @Test
+    void degradesToInternalMountsWithoutUsableConfiguration() {
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(null, "/bootui/api/overview"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(null, "/orders")).isFalse();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(null, null)).isFalse();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(config(Map.of()), "  ")).isFalse();
+
+        Config invalid = config(Map.of("bootui.path", "", "bootui.api-path", ""));
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(invalid, "/bootui/api/overview"))
+                .isTrue();
+        assertThat(QuarkusBootUiPaths.isBootUiRequest(invalid, "/orders")).isFalse();
+    }
+
     private static Config config(Map<String, String> properties) {
         return new SmallRyeConfigBuilder()
                 .withSources(new PropertiesConfigSource(properties, "test", 1000))

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/exceptions/QuarkusExceptionLogHandlerTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/exceptions/QuarkusExceptionLogHandlerTest.java
@@ -1,0 +1,130 @@
+package io.github.jdubois.bootui.quarkus.exceptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
+import io.github.jdubois.bootui.engine.support.InternalPackageMatcher;
+import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link QuarkusExceptionLogHandler}'s self-traffic exclusion. Quarkus' own error handler logs an
+ * unhandled request failure under a Quarkus logger name, so the logger-name filter alone does not keep a
+ * failure raised while serving BootUI out of the Exceptions panel; the request path must be checked too,
+ * under any {@code quarkus.http.root-path} or custom {@code bootui.path} mount.
+ */
+class QuarkusExceptionLogHandlerTest {
+
+    @Test
+    void capturesApplicationRequestFailures() {
+        ExceptionStore store = newStore();
+
+        handler(store, routingContext("/orders/42"), Map.of()).publish(failure());
+
+        assertThat(store.totalExceptions()).isEqualTo(1);
+        assertThat(store.groups().get(0).last().requestPath()).isEqualTo("/orders/42");
+    }
+
+    @Test
+    void capturesFailuresLoggedOutsideAnyRequest() {
+        ExceptionStore store = newStore();
+
+        handler(store, null, Map.of()).publish(failure());
+
+        assertThat(store.totalExceptions()).isEqualTo(1);
+        assertThat(store.groups().get(0).last().requestPath()).isNull();
+    }
+
+    @Test
+    void skipsFailuresLoggedWhileServingBootUiUnderTheDefaultRootPath() {
+        ExceptionStore store = newStore();
+
+        handler(store, routingContext("/bootui/api/overview"), Map.of()).publish(failure());
+
+        assertThat(store.totalExceptions()).isZero();
+    }
+
+    @Test
+    void skipsFailuresLoggedWhileServingBootUiUnderANonDefaultRootPath() {
+        ExceptionStore store = newStore();
+
+        handler(store, routingContext("/app/bootui/api/overview"), Map.of("quarkus.http.root-path", "/app"))
+                .publish(failure());
+
+        assertThat(store.totalExceptions()).isZero();
+    }
+
+    @Test
+    void skipsFailuresLoggedWhileServingACustomBootUiMount() {
+        ExceptionStore store = newStore();
+
+        handler(
+                        store,
+                        routingContext("/app/dev-console/api/overview"),
+                        Map.of("bootui.path", "/dev-console", "quarkus.http.root-path", "/app"))
+                .publish(failure());
+
+        assertThat(store.totalExceptions()).isZero();
+    }
+
+    @Test
+    void skipsBootUiOwnLoggers() {
+        ExceptionStore store = newStore();
+        LogRecord record = failure();
+        record.setLoggerName("io.github.jdubois.bootui.quarkus.web.OverviewResource");
+
+        handler(store, routingContext("/orders/42"), Map.of()).publish(record);
+
+        assertThat(store.totalExceptions()).isZero();
+    }
+
+    private static ExceptionStore newStore() {
+        return new ExceptionStore(10, 10, 20);
+    }
+
+    private static LogRecord failure() {
+        LogRecord record = new LogRecord(Level.SEVERE, "HTTP Request failed");
+        record.setLoggerName("io.quarkus.vertx.http.runtime.QuarkusErrorHandler");
+        record.setThrown(new IllegalStateException("boom"));
+        return record;
+    }
+
+    private static QuarkusExceptionLogHandler handler(
+            ExceptionStore store, RoutingContext rc, Map<String, String> properties) {
+        CurrentVertxRequest currentVertxRequest = mock(CurrentVertxRequest.class);
+        when(currentVertxRequest.getCurrent()).thenReturn(rc);
+        Config config = new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(properties, "test", 1000))
+                .build();
+        return new QuarkusExceptionLogHandler(
+                store,
+                new InternalPackageMatcher(List.of(
+                        "io.github.jdubois.bootui.quarkus",
+                        "io.github.jdubois.bootui.engine",
+                        "io.github.jdubois.bootui.core")),
+                null,
+                currentVertxRequest,
+                config);
+    }
+
+    private static RoutingContext routingContext(String path) {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        RoutingContext rc = mock(RoutingContext.class);
+        when(rc.normalizedPath()).thenReturn(path);
+        when(rc.request()).thenReturn(request);
+        return rc;
+    }
+}

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/QuarkusExceptionCaptureFilterTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/QuarkusExceptionCaptureFilterTest.java
@@ -1,0 +1,133 @@
+package io.github.jdubois.bootui.quarkus.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
+import io.github.jdubois.bootui.spi.TraceIdProvider;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.inject.Instance;
+import java.util.Map;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * White-box binding tests for {@link QuarkusExceptionCaptureFilter}'s self-traffic exclusion: a failure on
+ * BootUI's own surface must never reach the shared {@code ExceptionStore}, under the default root path, a
+ * non-default {@code quarkus.http.root-path}, and a custom {@code bootui.path} mount alike — while an
+ * application request failure stays captured.
+ */
+class QuarkusExceptionCaptureFilterTest {
+
+    @Test
+    void capturesApplicationRequestFailures() {
+        RoutingContext rc = mockRequest("/orders/42", new IllegalStateException("boom"));
+        ExceptionStore store = newStore();
+
+        completeRequest(filter(store, Map.of()), rc);
+
+        verify(rc).next();
+        assertThat(store.totalExceptions()).isEqualTo(1);
+        assertThat(store.groups().get(0).last().requestPath()).isEqualTo("/orders/42");
+    }
+
+    @Test
+    void ignoresRequestsThatDidNotFail() {
+        RoutingContext rc = mockRequest("/orders/42", null);
+        ExceptionStore store = newStore();
+
+        completeRequest(filter(store, Map.of()), rc);
+
+        assertThat(store.totalExceptions()).isZero();
+    }
+
+    @Test
+    void skipsBootUiFailuresUnderTheDefaultRootPath() {
+        RoutingContext rc = mockRequest("/bootui/api/overview", new IllegalStateException("boom"));
+        ExceptionStore store = newStore();
+
+        filter(store, Map.of()).handle(rc);
+
+        verify(rc).next();
+        verify(rc, never()).addBodyEndHandler(any());
+        assertThat(store.totalExceptions()).isZero();
+    }
+
+    @Test
+    void skipsBootUiFailuresUnderANonDefaultRootPath() {
+        RoutingContext rc = mockRequest("/app/bootui/api/overview", new IllegalStateException("boom"));
+        ExceptionStore store = newStore();
+
+        filter(store, Map.of("quarkus.http.root-path", "/app")).handle(rc);
+
+        verify(rc).next();
+        verify(rc, never()).addBodyEndHandler(any());
+        assertThat(store.totalExceptions()).isZero();
+    }
+
+    @Test
+    void skipsBootUiFailuresOnACustomMount() {
+        RoutingContext rc = mockRequest("/app/dev-console/api/overview", new IllegalStateException("boom"));
+        ExceptionStore store = newStore();
+
+        filter(store, Map.of("bootui.path", "/dev-console", "quarkus.http.root-path", "/app"))
+                .handle(rc);
+
+        verify(rc).next();
+        verify(rc, never()).addBodyEndHandler(any());
+        assertThat(store.totalExceptions()).isZero();
+    }
+
+    @Test
+    void stillCapturesApplicationFailuresUnderANonDefaultRootPath() {
+        RoutingContext rc = mockRequest("/app/bootui-other/status", new IllegalStateException("boom"));
+        ExceptionStore store = newStore();
+
+        completeRequest(filter(store, Map.of("quarkus.http.root-path", "/app")), rc);
+
+        assertThat(store.totalExceptions()).isEqualTo(1);
+    }
+
+    /** Runs the filter and then fires the body-end handler it registered, as Vert.x does on response end. */
+    private static void completeRequest(QuarkusExceptionCaptureFilter filter, RoutingContext rc) {
+        filter.handle(rc);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> captor = ArgumentCaptor.forClass(Handler.class);
+        verify(rc).addBodyEndHandler(captor.capture());
+        captor.getValue().handle(null);
+    }
+
+    private static ExceptionStore newStore() {
+        return new ExceptionStore(10, 10, 20);
+    }
+
+    private static QuarkusExceptionCaptureFilter filter(ExceptionStore store, Map<String, String> properties) {
+        @SuppressWarnings("unchecked")
+        Instance<TraceIdProvider> traceIdProvider = mock(Instance.class);
+        when(traceIdProvider.isResolvable()).thenReturn(false);
+        Config config = new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(properties, "test", 1000))
+                .build();
+        return new QuarkusExceptionCaptureFilter(store, traceIdProvider, config);
+    }
+
+    private static RoutingContext mockRequest(String path, Throwable failure) {
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        RoutingContext rc = mock(RoutingContext.class);
+        when(rc.normalizedPath()).thenReturn(path);
+        when(rc.request()).thenReturn(request);
+        when(rc.failure()).thenReturn(failure);
+        return rc;
+    }
+}

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/QuarkusHttpExchangeCaptureFilterTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/web/QuarkusHttpExchangeCaptureFilterTest.java
@@ -1,0 +1,126 @@
+package io.github.jdubois.bootui.quarkus.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.github.jdubois.bootui.engine.web.HttpExchangeBuffer;
+import io.github.jdubois.bootui.spi.TraceIdProvider;
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.inject.Instance;
+import java.util.Map;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * White-box binding tests for {@link QuarkusHttpExchangeCaptureFilter}'s self-traffic exclusion: BootUI's
+ * own requests must never reach the shared {@code HttpExchangeBuffer} (and therefore never reach the HTTP
+ * Exchanges panel or Live Activity correlation), under the default root path, a non-default
+ * {@code quarkus.http.root-path}, and a custom {@code bootui.path} mount alike — while application traffic
+ * stays captured.
+ */
+class QuarkusHttpExchangeCaptureFilterTest {
+
+    @Test
+    void capturesApplicationTraffic() {
+        RoutingContext rc = mockRequest("/orders/42");
+        HttpExchangeBuffer buffer = new HttpExchangeBuffer(10);
+
+        completeRequest(filter(buffer, Map.of()), rc);
+
+        verify(rc).next();
+        assertThat(buffer.snapshot()).hasSize(1);
+    }
+
+    @Test
+    void skipsBootUiTrafficUnderTheDefaultRootPath() {
+        RoutingContext rc = mockRequest("/bootui/api/overview");
+        HttpExchangeBuffer buffer = new HttpExchangeBuffer(10);
+
+        filter(buffer, Map.of()).handle(rc);
+
+        verify(rc).next();
+        verify(rc, never()).addBodyEndHandler(any());
+        assertThat(buffer.snapshot()).isEmpty();
+    }
+
+    @Test
+    void skipsBootUiTrafficUnderANonDefaultRootPath() {
+        RoutingContext rc = mockRequest("/app/bootui/api/overview");
+        HttpExchangeBuffer buffer = new HttpExchangeBuffer(10);
+
+        filter(buffer, Map.of("quarkus.http.root-path", "/app")).handle(rc);
+
+        verify(rc).next();
+        verify(rc, never()).addBodyEndHandler(any());
+        assertThat(buffer.snapshot()).isEmpty();
+    }
+
+    @Test
+    void skipsBootUiTrafficOnACustomMount() {
+        RoutingContext rc = mockRequest("/app/dev-console/api/overview");
+        HttpExchangeBuffer buffer = new HttpExchangeBuffer(10);
+
+        filter(buffer, Map.of("bootui.path", "/dev-console", "quarkus.http.root-path", "/app"))
+                .handle(rc);
+
+        verify(rc).next();
+        verify(rc, never()).addBodyEndHandler(any());
+        assertThat(buffer.snapshot()).isEmpty();
+    }
+
+    @Test
+    void stillCapturesApplicationTrafficUnderANonDefaultRootPath() {
+        RoutingContext rc = mockRequest("/app/bootui-other/status");
+        HttpExchangeBuffer buffer = new HttpExchangeBuffer(10);
+
+        completeRequest(filter(buffer, Map.of("quarkus.http.root-path", "/app")), rc);
+
+        assertThat(buffer.snapshot()).hasSize(1);
+    }
+
+    /** Runs the filter and then fires the body-end handler it registered, as Vert.x does on response end. */
+    private static void completeRequest(QuarkusHttpExchangeCaptureFilter filter, RoutingContext rc) {
+        filter.handle(rc);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Handler<Void>> captor = ArgumentCaptor.forClass(Handler.class);
+        verify(rc).addBodyEndHandler(captor.capture());
+        captor.getValue().handle(null);
+    }
+
+    private static QuarkusHttpExchangeCaptureFilter filter(HttpExchangeBuffer buffer, Map<String, String> properties) {
+        @SuppressWarnings("unchecked")
+        Instance<TraceIdProvider> traceIdProvider = mock(Instance.class);
+        when(traceIdProvider.isResolvable()).thenReturn(false);
+        Config config = new SmallRyeConfigBuilder()
+                .withSources(new PropertiesConfigSource(properties, "test", 1000))
+                .build();
+        return new QuarkusHttpExchangeCaptureFilter(buffer, traceIdProvider, config);
+    }
+
+    private static RoutingContext mockRequest(String path) {
+        HttpServerResponse response = mock(HttpServerResponse.class);
+        when(response.getStatusCode()).thenReturn(200);
+        when(response.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        HttpServerRequest request = mock(HttpServerRequest.class);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        when(request.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        when(request.absoluteURI()).thenReturn("http://localhost:8080" + path);
+        RoutingContext rc = mock(RoutingContext.class);
+        when(rc.normalizedPath()).thenReturn(path);
+        when(rc.request()).thenReturn(request);
+        when(rc.response()).thenReturn(response);
+        return rc;
+    }
+}

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -470,6 +470,13 @@ configuration fails dev/test startup. Production remains dark even if dormant pa
 always-registered production guard uses fail-closed safe defaults and suppresses both configured/default and private
 mounts without wiring data-bearing resources.
 
+BootUI's own requests are excluded from the telemetry it reports on. HTTP-exchange capture, request-failure capture,
+pre-mapping exception capture, and log-based exception capture all resolve "is this BootUI?" through one shared matcher
+that strips `quarkus.http.root-path` and matches the configured `bootui.path` / `bootui.api-path` mounts as well as the
+private `/bootui` mount. The console therefore never appears in HTTP Exchanges, Live Activity, or Exceptions under a
+custom root path or a custom mount, while application paths that merely resemble the console — `/bootui-other`, for
+instance — remain captured.
+
 ## 7. Code-sharing scorecard
 
 | Layer                                                                                                                 | Shared?          | Notes                                                                            |


### PR DESCRIPTION
Fixes #857

## Problem

With `quarkus.http.root-path=/app`, BootUI's own requests reach the capture filters as `/app/bootui/...`, but `QuarkusHttpExchangeCaptureFilter`, `QuarkusExceptionCaptureFilter`, and `QuarkusPreMappingExceptionCaptureHandler` each matched the literal `/bootui` prefix on their own. The console's polling was therefore retained as host-application traffic in HTTP Exchanges and Live Activity, and its internal failures showed up in Exceptions — while the safety and panel-access filters had already been stripping the root path correctly.

While fixing this I found the same contract broken on a fourth feeder: `QuarkusExceptionLogHandler` filters BootUI's *logger names*, but Quarkus' own `QuarkusErrorHandler` logs a failed request under a Quarkus logger, so a failure raised while serving the console still landed in the Exceptions panel — at any root path.

## Change

All four capture points now answer "is this BootUI?" through one shared matcher, `QuarkusBootUiPaths.isBootUiRequest(Config, String)`, which:

- strips `quarkus.http.root-path` with the same `QuarkusRootPath` helper `BootUiQuarkusSafetyFilter` and `QuarkusPanelAccessFilter` use, so the capture points can no longer drift from the filters guarding the same surface;
- matches the operator-configured `bootui.path` / `bootui.api-path` mounts as well as the internal `/bootui` mount, so a request is excluded before and after `BootUiPathRewriteFilter`'s reroute;
- keeps a strict `/`-delimited prefix match on the request path only, so `/bootui-other` and `/api/bootui-proxy` stay captured;
- degrades to the internal mounts instead of throwing when configuration is unusable — a capture filter must never disrupt a request, and defaulting narrowly keeps application traffic captured.

`QuarkusHttpExchangeCaptureFilter`, `QuarkusExceptionCaptureFilter`, and `QuarkusExceptionCapture` take the MicroProfile `Config` by injection; the build-time-instantiated `QuarkusPreMappingExceptionCaptureHandler` reads it through `ConfigProvider` (the config bean is `@Dependent`, and that handler has no hook to release a programmatic lookup).

## Path-handling notes

Vert.x hands filters an already-normalized path: percent-encoded unreserved characters are decoded (`/%62ootui/api` → `/bootui/api`) and `.`/`..`/`//` segments are collapsed, so neither can be used to evade the match; an encoded separator (`%2F`) is deliberately left encoded and such a request never routes to BootUI anyway. Trailing slashes, a root path given as `app`, `/app/` or `/`, and root-path boundaries (`/application/...` is not under `/app`) are all covered by tests.

## Validation

- New unit tests: `QuarkusBootUiPathsTest` (default root, non-default root, custom mount, separate API mount, false positives, root-path normalization, missing/invalid config), `QuarkusHttpExchangeCaptureFilterTest`, `QuarkusExceptionCaptureFilterTest`, `QuarkusExceptionLogHandlerTest`.
- New real-boot `@QuarkusTest`: `BootUiQuarkusHttpExchangesRootPathCaptureTest` (root path `/app`, HTTP Exchanges + Live Activity), plus a custom-mount case in `BootUiCustomPathBootTest`. Both were verified to **fail** against the previous literal-prefix logic and pass with the fix.
- `./mvnw -B -ntp spotless:check` (whole reactor) and `./mvnw -T 1C -B -ntp clean install` (whole reactor) are green.
- Environmental limitation: this machine only has JDK 26, so the JDK-gated `bootui-quarkus-integration-tests/hibernate` module and the sample app's Hibernate augmentation are skipped locally, as the reactor profile intends. Everything else, including all other Quarkus `@QuarkusTest` modules, ran.

No API, DTO, or UI contract changed.

Fixes: #858