### PR TITLE
Make core DTO collection fields defensively immutable

### DIFF
--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ActivationStatus.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ActivationStatus.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Reason why BootUI activated, plus current safety settings.
  */
-public record ActivationStatus(boolean enabled, boolean localhostOnly, String reason, List<String> warnings) {}
+public record ActivationStatus(boolean enabled, boolean localhostOnly, String reason, List<String> warnings) {
+
+    public ActivationStatus {
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiChatDetailDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiChatDetailDto.java
@@ -12,4 +12,12 @@ public record AiChatDetailDto(
         List<SpanAttributeDto> attributes,
         List<SpanEventDto> events,
         boolean contentCaptured,
-        String contentBanner) {}
+        String contentBanner) {
+
+    public AiChatDetailDto {
+        toolCalls = DtoCollections.immutableCopy(toolCalls);
+        vectorOperations = DtoCollections.immutableCopy(vectorOperations);
+        attributes = DtoCollections.immutableCopy(attributes);
+        events = DtoCollections.immutableCopy(events);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiOverviewDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiOverviewDto.java
@@ -21,4 +21,11 @@ public record AiOverviewDto(
         int vectorOperationCount,
         int embeddingCount,
         List<AiChatSummaryDto> recent,
-        String contentBanner) {}
+        String contentBanner) {
+
+    public AiOverviewDto {
+        tokensByModel = DtoCollections.immutableCopy(tokensByModel);
+        callsByModel = DtoCollections.immutableCopy(callsByModel);
+        recent = DtoCollections.immutableCopy(recent);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiTokenSeriesDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AiTokenSeriesDto.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Token usage time series payload.
  */
-public record AiTokenSeriesDto(int minutes, List<AiTokenBucketDto> buckets) {}
+public record AiTokenSeriesDto(int minutes, List<AiTokenBucketDto> buckets) {
+
+    public AiTokenSeriesDto {
+        buckets = DtoCollections.immutableCopy(buckets);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ArchitectureReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ArchitectureReport.java
@@ -16,4 +16,12 @@ public record ArchitectureReport(
         List<ArchitectureSeverityCountDto> severityCounts,
         ArchitectureScanStatusDto scan,
         List<ArchitectureRuleResultDto> results,
-        List<ArchitectureRuleResultDto> analysisErrors) {}
+        List<ArchitectureRuleResultDto> analysisErrors) {
+
+    public ArchitectureReport {
+        basePackages = DtoCollections.immutableCopy(basePackages);
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        results = DtoCollections.immutableCopy(results);
+        analysisErrors = DtoCollections.immutableCopy(analysisErrors);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ArchitectureRuleResultDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ArchitectureRuleResultDto.java
@@ -18,6 +18,10 @@ public record ArchitectureRuleResultDto(
         String learnMoreUrl,
         boolean dismissed) {
 
+    public ArchitectureRuleResultDto {
+        sampleViolations = DtoCollections.immutableCopy(sampleViolations);
+    }
+
     public ArchitectureRuleResultDto(
             String id,
             String name,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/BeanList.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/BeanList.java
@@ -3,6 +3,11 @@ package io.github.jdubois.bootui.core.dto;
 import java.util.List;
 
 public record BeanList(int total, List<BeanSummary> beans, PageMetadata page) {
+
+    public BeanList {
+        beans = DtoCollections.immutableCopy(beans);
+    }
+
     public BeanList(int total, List<BeanSummary> beans) {
         this(total, beans, new PageMetadata(total, beans.size(), 0, beans.size(), beans.size(), false));
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/BeanSummary.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/BeanSummary.java
@@ -12,4 +12,10 @@ public record BeanSummary(
         String resource,
         List<String> dependencies,
         List<String> aliases,
-        String classification) {}
+        String classification) {
+
+    public BeanSummary {
+        dependencies = DtoCollections.immutableCopy(dependencies);
+        aliases = DtoCollections.immutableCopy(aliases);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheClearResult.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheClearResult.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Result of a cache clear operation.
  */
-public record CacheClearResult(String status, String message, int clearedCaches, List<String> caches) {}
+public record CacheClearResult(String status, String message, int clearedCaches, List<String> caches) {
+
+    public CacheClearResult {
+        caches = DtoCollections.immutableCopy(caches);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheDto.java
@@ -24,4 +24,9 @@ public record CacheDto(
         boolean opaque,
         String opaqueReason,
         List<CacheTierDto> tiers,
-        CacheStatisticsDto statistics) {}
+        CacheStatisticsDto statistics) {
+
+    public CacheDto {
+        tiers = DtoCollections.immutableCopy(tiers);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheManagerDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheManagerDto.java
@@ -23,4 +23,10 @@ public record CacheManagerDto(
         String composition,
         String dynamicCaches,
         List<String> delegateTypes,
-        List<CacheDto> caches) {}
+        List<CacheDto> caches) {
+
+    public CacheManagerDto {
+        delegateTypes = DtoCollections.immutableCopy(delegateTypes);
+        caches = DtoCollections.immutableCopy(caches);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheOperationDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheOperationDto.java
@@ -15,4 +15,9 @@ public record CacheOperationDto(
         String condition,
         String unless,
         boolean allEntries,
-        boolean beforeInvocation) {}
+        boolean beforeInvocation) {
+
+    public CacheOperationDto {
+        caches = DtoCollections.immutableCopy(caches);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CacheReport.java
@@ -26,4 +26,11 @@ public record CacheReport(
         boolean truncated,
         List<CacheManagerDto> managers,
         List<CacheOperationDto> operations,
-        List<String> warnings) {}
+        List<String> warnings) {
+
+    public CacheReport {
+        managers = DtoCollections.immutableCopy(managers);
+        operations = DtoCollections.immutableCopy(operations);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ConditionsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ConditionsReport.java
@@ -9,6 +9,14 @@ public record ConditionsReport(
         List<String> exclusions,
         PageMetadata page,
         ConditionCounts counts) {
+
+    public ConditionsReport {
+        positiveMatches = DtoCollections.immutableCopy(positiveMatches);
+        negativeMatches = DtoCollections.immutableCopy(negativeMatches);
+        unconditionalClasses = DtoCollections.immutableCopy(unconditionalClasses);
+        exclusions = DtoCollections.immutableCopy(exclusions);
+    }
+
     public ConditionsReport(
             List<ConditionEntry> positiveMatches,
             List<ConditionEntry> negativeMatches,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ConfigPropertyDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ConfigPropertyDto.java
@@ -11,4 +11,10 @@ public record ConfigPropertyDto(
         boolean masked,
         boolean override,
         String description,
-        Object defaultValue) {}
+        Object defaultValue) {
+
+    public ConfigPropertyDto {
+        value = DtoCollections.immutableValue(value);
+        defaultValue = DtoCollections.immutableValue(defaultValue);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ConfigPropertySuggestionDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ConfigPropertySuggestionDto.java
@@ -3,4 +3,9 @@ package io.github.jdubois.bootui.core.dto;
 /**
  * A known configuration property that can be used for new overrides.
  */
-public record ConfigPropertySuggestionDto(String name, String type, String description, Object defaultValue) {}
+public record ConfigPropertySuggestionDto(String name, String type, String description, Object defaultValue) {
+
+    public ConfigPropertySuggestionDto {
+        defaultValue = DtoCollections.immutableValue(defaultValue);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ConfigReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ConfigReport.java
@@ -9,6 +9,14 @@ public record ConfigReport(
         List<ConfigPropertySuggestionDto> propertySuggestions,
         PageMetadata page,
         int overrideCount) {
+
+    public ConfigReport {
+        activeProfiles = DtoCollections.immutableCopy(activeProfiles);
+        sources = DtoCollections.immutableCopy(sources);
+        properties = DtoCollections.immutableCopy(properties);
+        propertySuggestions = DtoCollections.immutableCopy(propertySuggestions);
+    }
+
     public ConfigReport(
             List<String> activeProfiles,
             List<String> sources,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotDashboardDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotDashboardDto.java
@@ -28,4 +28,15 @@ public record CopilotDashboardDto(
         List<CopilotActivityBucket> activityBuckets,
         List<CopilotActivityBucket> dailyActivityBuckets,
         List<CopilotSessionSummary> recentSessions,
-        List<String> warnings) {}
+        List<String> warnings) {
+
+    public CopilotDashboardDto {
+        categoryCounts = DtoCollections.immutableCopy(categoryCounts);
+        modelCounts = DtoCollections.immutableCopy(modelCounts);
+        topTools = DtoCollections.immutableCopy(topTools);
+        activityBuckets = DtoCollections.immutableCopy(activityBuckets);
+        dailyActivityBuckets = DtoCollections.immutableCopy(dailyActivityBuckets);
+        recentSessions = DtoCollections.immutableCopy(recentSessions);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotEventListDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotEventListDto.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Paginated/filtered events for a single session.
  */
-public record CopilotEventListDto(String sessionId, int total, int returned, List<CopilotActivityEvent> events) {}
+public record CopilotEventListDto(String sessionId, int total, int returned, List<CopilotActivityEvent> events) {
+
+    public CopilotEventListDto {
+        events = DtoCollections.immutableCopy(events);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotInsightCounts.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotInsightCounts.java
@@ -6,4 +6,9 @@ import java.util.Map;
  * Aggregate counters across a Copilot session's events.
  */
 public record CopilotInsightCounts(
-        int total, Map<String, Integer> byCategory, int errors, Long lastActivityEpochMillis) {}
+        int total, Map<String, Integer> byCategory, int errors, Long lastActivityEpochMillis) {
+
+    public CopilotInsightCounts {
+        byCategory = DtoCollections.immutableCopy(byCategory);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotSessionDetail.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotSessionDetail.java
@@ -11,4 +11,12 @@ public record CopilotSessionDetail(
         List<CopilotTurn> turns,
         List<CopilotActivityEvent> recentEvents,
         List<CopilotActivityEvent> failureEvents,
-        List<String> warnings) {}
+        List<String> warnings) {
+
+    public CopilotSessionDetail {
+        turns = DtoCollections.immutableCopy(turns);
+        recentEvents = DtoCollections.immutableCopy(recentEvents);
+        failureEvents = DtoCollections.immutableCopy(failureEvents);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotSessionListDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CopilotSessionListDto.java
@@ -13,4 +13,10 @@ public record CopilotSessionListDto(
         int returned,
         int maxSessions,
         List<CopilotSessionSummary> sessions,
-        List<String> warnings) {}
+        List<String> warnings) {
+
+    public CopilotSessionListDto {
+        sessions = DtoCollections.immutableCopy(sessions);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CracFindingDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CracFindingDto.java
@@ -16,4 +16,9 @@ public record CracFindingDto(
         int occurrenceCount,
         List<String> sampleOccurrences,
         String recommendation,
-        String learnMoreUrl) {}
+        String learnMoreUrl) {
+
+    public CracFindingDto {
+        sampleOccurrences = DtoCollections.immutableCopy(sampleOccurrences);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CracReadinessReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CracReadinessReport.java
@@ -25,6 +25,14 @@ public record CracReadinessReport(
         List<String> warnings,
         List<CracGeneratedFileDto> generatedFiles) {
 
+    public CracReadinessReport {
+        basePackages = DtoCollections.immutableCopy(basePackages);
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        findings = DtoCollections.immutableCopy(findings);
+        warnings = DtoCollections.immutableCopy(warnings);
+        generatedFiles = DtoCollections.immutableCopy(generatedFiles);
+    }
+
     /** Returns a copy of this report with the generated container assets attached. */
     public CracReadinessReport withGeneratedFiles(List<CracGeneratedFileDto> generatedFiles) {
         return new CracReadinessReport(

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CracRuntimeStatusDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/CracRuntimeStatusDto.java
@@ -29,4 +29,10 @@ public record CracRuntimeStatusDto(
         String restoreFrom,
         List<String> cracJvmArgs,
         String summary,
-        List<String> restoreCaveats) {}
+        List<String> restoreCaveats) {
+
+    public CracRuntimeStatusDto {
+        cracJvmArgs = DtoCollections.immutableCopy(cracJvmArgs);
+        restoreCaveats = DtoCollections.immutableCopy(restoreCaveats);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DatabaseAdvisorReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DatabaseAdvisorReport.java
@@ -30,4 +30,13 @@ public record DatabaseAdvisorReport(
         List<DatabaseAdvisorSeverityCountDto> severityCounts,
         DatabaseAdvisorScanStatusDto scan,
         List<DatabaseAdvisorRuleResultDto> results,
-        List<DatabaseAdvisorDiagnosticDto> diagnostics) {}
+        List<DatabaseAdvisorDiagnosticDto> diagnostics) {
+
+    public DatabaseAdvisorReport {
+        dataSourceNames = DtoCollections.immutableCopy(dataSourceNames);
+        dataSources = DtoCollections.immutableCopy(dataSources);
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        results = DtoCollections.immutableCopy(results);
+        diagnostics = DtoCollections.immutableCopy(diagnostics);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DatabaseAdvisorRuleResultDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DatabaseAdvisorRuleResultDto.java
@@ -19,6 +19,10 @@ public record DatabaseAdvisorRuleResultDto(
         String learnMoreUrl,
         boolean dismissed) {
 
+    public DatabaseAdvisorRuleResultDto {
+        sampleViolations = DtoCollections.immutableCopy(sampleViolations);
+    }
+
     public DatabaseAdvisorRuleResultDto(
             String id,
             String name,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependenciesReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependenciesReport.java
@@ -13,6 +13,11 @@ public record DependenciesReport(
         DependencyScanStatusDto scan,
         List<DependencyDto> dependencies) {
 
+    public DependenciesReport {
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        dependencies = DtoCollections.immutableCopy(dependencies);
+    }
+
     public String status() {
         return scan == null ? null : scan.status();
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyDto.java
@@ -13,4 +13,9 @@ public record DependencyDto(
         String source,
         int vulnerabilityCount,
         String highestSeverity,
-        List<DependencyVulnerabilityDto> vulnerabilities) {}
+        List<DependencyVulnerabilityDto> vulnerabilities) {
+
+    public DependencyDto {
+        vulnerabilities = DtoCollections.immutableCopy(vulnerabilities);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyVulnerabilityDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyVulnerabilityDto.java
@@ -33,6 +33,12 @@ public record DependencyVulnerabilityDto(
         Double epssPercentile,
         boolean dismissed) {
 
+    public DependencyVulnerabilityDto {
+        aliases = DtoCollections.immutableCopy(aliases);
+        references = DtoCollections.immutableCopy(references);
+        fixedVersions = DtoCollections.immutableCopy(fixedVersions);
+    }
+
     public DependencyVulnerabilityDto(
             String id,
             String summary,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DevServiceDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DevServiceDto.java
@@ -18,4 +18,10 @@ public record DevServiceDto(
         Map<String, Object> connectionDetails,
         boolean restartable,
         boolean logsAvailable,
-        String note) {}
+        String note) {
+
+    public DevServiceDto {
+        ports = DtoCollections.immutableCopy(ports);
+        connectionDetails = DtoCollections.immutableCopy(connectionDetails);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DevServicesReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DevServicesReport.java
@@ -13,6 +13,11 @@ public record DevServicesReport(
         List<DevServiceDto> services,
         List<String> warnings) {
 
+    public DevServicesReport {
+        services = DtoCollections.immutableCopy(services);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+
     public DevServicesReport(
             boolean dockerComposePresent,
             boolean testcontainersPresent,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DismissedRulesDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DismissedRulesDto.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * The set of advisor rule IDs that have been dismissed by the developer.
  */
-public record DismissedRulesDto(List<String> dismissed) {}
+public record DismissedRulesDto(List<String> dismissed) {
+
+    public DismissedRulesDto {
+        dismissed = DtoCollections.immutableCopy(dismissed);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DtoCollections.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DtoCollections.java
@@ -1,0 +1,69 @@
+package io.github.jdubois.bootui.core.dto;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defensive-copy helpers shared by the core DTO records.
+ *
+ * <p>Core DTOs are documented as immutable, so every collection component is copied in the record's
+ * compact constructor. Without the copy a caller could keep a reference to the collection it passed
+ * in, or mutate the collection returned by an accessor, and change a report after it was published.</p>
+ *
+ * <p>The copies deliberately do not use {@link List#copyOf(java.util.Collection)} or
+ * {@link Map#copyOf(Map)}:</p>
+ *
+ * <ul>
+ *   <li>{@code Map.copyOf} produces a hash-ordered map whose iteration order is not the insertion
+ *       order and is randomized per JVM run, which would make the serialized JSON key order unstable
+ *       and different between Jackson 2 and Jackson 3 runs. A {@link LinkedHashMap} copy keeps the
+ *       caller's order, so the emitted bytes stay identical across both Jackson generations.</li>
+ *   <li>Both {@code copyOf} methods reject {@code null} elements, values, and keys. Panel data is
+ *       assembled from JVM and framework sources that can legitimately yield a {@code null} element,
+ *       and a DTO constructor is the wrong place to turn that into a request failure.</li>
+ * </ul>
+ *
+ * <p>{@code null} is normalized to an empty collection: no core DTO documents a nullable collection
+ * component, and the existing DTOs already used that convention.</p>
+ *
+ * <p>The copies are shallow. Elements are themselves immutable DTO records, boxed scalars, or
+ * strings, so a shallow copy is enough for every typed component. The only exception is a
+ * {@code Map<String, Object>} value supplied by a framework, which BootUI does not attempt to
+ * deep-copy.</p>
+ */
+final class DtoCollections {
+
+    private DtoCollections() {}
+
+    /**
+     * Returns an unmodifiable copy of {@code values}, preserving iteration order.
+     *
+     * @param values the caller-owned list, possibly {@code null}
+     * @param <T> the element type
+     * @return an immutable list, empty when {@code values} is {@code null} or empty
+     */
+    static <T> List<T> immutableCopy(List<T> values) {
+        if (values == null || values.isEmpty()) {
+            return List.of();
+        }
+        return Collections.unmodifiableList(new ArrayList<>(values));
+    }
+
+    /**
+     * Returns an unmodifiable copy of {@code values}, preserving iteration order.
+     *
+     * @param values the caller-owned map, possibly {@code null}
+     * @param <K> the key type
+     * @param <V> the value type
+     * @return an immutable map, empty when {@code values} is {@code null} or empty
+     */
+    static <K, V> Map<K, V> immutableCopy(Map<K, V> values) {
+        if (values == null || values.isEmpty()) {
+            return Map.of();
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(values));
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DtoCollections.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DtoCollections.java
@@ -1,6 +1,8 @@
 package io.github.jdubois.bootui.core.dto;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -29,10 +31,13 @@ import java.util.Map;
  * <p>{@code null} is normalized to an empty collection: no core DTO documents a nullable collection
  * component, and the existing DTOs already used that convention.</p>
  *
- * <p>The copies are shallow. Elements are themselves immutable DTO records, boxed scalars, or
- * strings, so a shallow copy is enough for every typed component. The only exception is a
- * {@code Map<String, Object>} value supplied by a framework, which BootUI does not attempt to
- * deep-copy.</p>
+ * <p>The copies are deep with respect to JSON-shaped payloads. Typed components hold immutable DTO
+ * records, boxed scalars, or strings, so element copying is a no-op for them, but the DTO surface
+ * also exposes a few {@code Object}-typed components ({@code ConfigPropertyDto.value},
+ * {@code HealthNodeDto.details}, {@code SpanAttributeDto.value}, and the values of
+ * {@code DevServiceDto.connectionDetails}) that receive framework-supplied maps, collections, and
+ * arrays. Those are snapshotted recursively through {@link #immutableValue(Object)}; a nested
+ * payload is otherwise still caller-owned and can change a published report.</p>
  */
 final class DtoCollections {
 
@@ -45,11 +50,16 @@ final class DtoCollections {
      * @param <T> the element type
      * @return an immutable list, empty when {@code values} is {@code null} or empty
      */
+    @SuppressWarnings("unchecked")
     static <T> List<T> immutableCopy(List<T> values) {
         if (values == null || values.isEmpty()) {
             return List.of();
         }
-        return Collections.unmodifiableList(new ArrayList<>(values));
+        List<T> copy = new ArrayList<>(values.size());
+        for (T value : values) {
+            copy.add((T) immutableValue(value));
+        }
+        return Collections.unmodifiableList(copy);
     }
 
     /**
@@ -60,10 +70,52 @@ final class DtoCollections {
      * @param <V> the value type
      * @return an immutable map, empty when {@code values} is {@code null} or empty
      */
+    @SuppressWarnings("unchecked")
     static <K, V> Map<K, V> immutableCopy(Map<K, V> values) {
         if (values == null || values.isEmpty()) {
             return Map.of();
         }
-        return Collections.unmodifiableMap(new LinkedHashMap<>(values));
+        Map<K, V> copy = new LinkedHashMap<>();
+        for (Map.Entry<K, V> entry : values.entrySet()) {
+            copy.put(entry.getKey(), (V) immutableValue(entry.getValue()));
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+
+    /**
+     * Returns an immutable snapshot of a loosely typed, JSON-shaped value.
+     *
+     * <p>Maps, collections, and arrays are copied recursively; a collection or array becomes an
+     * unmodifiable list, which Jackson serializes to the same JSON array as the original. Anything
+     * else is returned unchanged, because the remaining values BootUI puts behind an {@code Object}
+     * component are strings, boxed scalars, and immutable DTO records.</p>
+     *
+     * @param value the caller-owned value, possibly {@code null}
+     * @return an immutable equivalent of {@code value}
+     */
+    static Object immutableValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<Object, Object> copy = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                copy.put(entry.getKey(), immutableValue(entry.getValue()));
+            }
+            return Collections.unmodifiableMap(copy);
+        }
+        if (value instanceof Collection<?> values) {
+            List<Object> copy = new ArrayList<>(values.size());
+            for (Object element : values) {
+                copy.add(immutableValue(element));
+            }
+            return Collections.unmodifiableList(copy);
+        }
+        if (value != null && value.getClass().isArray()) {
+            int length = Array.getLength(value);
+            List<Object> copy = new ArrayList<>(length);
+            for (int i = 0; i < length; i++) {
+                copy.add(immutableValue(Array.get(value, i)));
+            }
+            return Collections.unmodifiableList(copy);
+        }
+        return value;
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/EmailMessageDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/EmailMessageDto.java
@@ -49,9 +49,9 @@ public record EmailMessageDto(
         String thread) {
 
     public EmailMessageDto {
-        to = to == null ? List.of() : List.copyOf(to);
-        cc = cc == null ? List.of() : List.copyOf(cc);
-        bcc = bcc == null ? List.of() : List.copyOf(bcc);
-        attachments = attachments == null ? List.of() : List.copyOf(attachments);
+        to = DtoCollections.immutableCopy(to);
+        cc = DtoCollections.immutableCopy(cc);
+        bcc = DtoCollections.immutableCopy(bcc);
+        attachments = DtoCollections.immutableCopy(attachments);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/EmailsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/EmailsReport.java
@@ -22,7 +22,7 @@ public record EmailsReport(
         List<EmailMessageDto> messages) {
 
     public EmailsReport {
-        messages = messages == null ? List.of() : List.copyOf(messages);
+        messages = DtoCollections.immutableCopy(messages);
     }
 
     public static EmailsReport unavailable(String reason, int maxEntries) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ErrorContractEntryDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ErrorContractEntryDto.java
@@ -51,6 +51,6 @@ public record ErrorContractEntryDto(
         List<String> produces) {
 
     public ErrorContractEntryDto {
-        produces = produces == null ? List.of() : List.copyOf(produces);
+        produces = DtoCollections.immutableCopy(produces);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ErrorContractReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ErrorContractReport.java
@@ -27,6 +27,10 @@ public record ErrorContractReport(
         List<ErrorContractEntryDto> entries,
         PageMetadata page) {
 
+    public ErrorContractReport {
+        entries = DtoCollections.immutableCopy(entries);
+    }
+
     /** The unavailable report for a stack with no error-contract backend. */
     public static ErrorContractReport unavailable(String reason, int maxEntries) {
         return new ErrorContractReport(

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ExceptionCauseDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ExceptionCauseDto.java
@@ -9,4 +9,9 @@ import java.util.List;
  * exception, so the UI can render the familiar {@code ... N more} suffix.</p>
  */
 public record ExceptionCauseDto(
-        String exceptionClassName, String message, List<ExceptionFrameDto> frames, int commonFrames) {}
+        String exceptionClassName, String message, List<ExceptionFrameDto> frames, int commonFrames) {
+
+    public ExceptionCauseDto {
+        frames = DtoCollections.immutableCopy(frames);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ExceptionDetailDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ExceptionDetailDto.java
@@ -10,4 +10,11 @@ public record ExceptionDetailDto(
         ExceptionGroupDto group,
         List<ExceptionFrameDto> frames,
         List<ExceptionCauseDto> causes,
-        List<ExceptionOccurrenceDto> occurrences) {}
+        List<ExceptionOccurrenceDto> occurrences) {
+
+    public ExceptionDetailDto {
+        frames = DtoCollections.immutableCopy(frames);
+        causes = DtoCollections.immutableCopy(causes);
+        occurrences = DtoCollections.immutableCopy(occurrences);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ExceptionsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ExceptionsReport.java
@@ -13,6 +13,10 @@ public record ExceptionsReport(
         long totalExceptions,
         List<ExceptionGroupDto> groups) {
 
+    public ExceptionsReport {
+        groups = DtoCollections.immutableCopy(groups);
+    }
+
     public static ExceptionsReport unavailable(String reason, int maxGroups) {
         return new ExceptionsReport(false, reason, maxGroups, 0L, List.of());
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FaultTolerancePolicyDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FaultTolerancePolicyDto.java
@@ -39,4 +39,9 @@ public record FaultTolerancePolicyDto(
         String target,
         String state,
         List<FaultTolerancePolicySettingDto> settings,
-        FaultTolerancePolicyMetricsDto metrics) {}
+        FaultTolerancePolicyMetricsDto metrics) {
+
+    public FaultTolerancePolicyDto {
+        settings = DtoCollections.immutableCopy(settings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FaultToleranceReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FaultToleranceReport.java
@@ -35,6 +35,14 @@ public record FaultToleranceReport(
         int maxEvents,
         List<String> warnings) {
 
+    public FaultToleranceReport {
+        providers = DtoCollections.immutableCopy(providers);
+        policies = DtoCollections.immutableCopy(policies);
+        policyCountsByType = DtoCollections.immutableCopy(policyCountsByType);
+        events = DtoCollections.immutableCopy(events);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+
     /** An empty report explaining why no supported fault tolerance library is reporting. */
     public static FaultToleranceReport unavailable(String reason, int maxEvents) {
         return new FaultToleranceReport(

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FlywayActionResult.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FlywayActionResult.java
@@ -13,4 +13,11 @@ public record FlywayActionResult(
         List<String> schemasCleaned,
         List<String> schemasDropped,
         String migrationPath,
-        List<String> warnings) {}
+        List<String> warnings) {
+
+    public FlywayActionResult {
+        schemasCleaned = DtoCollections.immutableCopy(schemasCleaned);
+        schemasDropped = DtoCollections.immutableCopy(schemasDropped);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FlywayDatabaseDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FlywayDatabaseDto.java
@@ -15,4 +15,9 @@ public record FlywayDatabaseDto(
         boolean migrateEnabled,
         String migrateDisabledReason,
         boolean cleanEnabled,
-        String cleanDisabledReason) {}
+        String cleanDisabledReason) {
+
+    public FlywayDatabaseDto {
+        migrations = DtoCollections.immutableCopy(migrations);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FlywayReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/FlywayReport.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Top-level Flyway migration report.
  */
-public record FlywayReport(boolean flywayPresent, int total, List<FlywayDatabaseDto> databases) {}
+public record FlywayReport(boolean flywayPresent, int total, List<FlywayDatabaseDto> databases) {
+
+    public FlywayReport {
+        databases = DtoCollections.immutableCopy(databases);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubDashboardReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubDashboardReport.java
@@ -24,4 +24,17 @@ public record GitHubDashboardReport(
         List<GitHubIssueDto> issues,
         List<GitHubSecuritySignalDto> securitySignals,
         GitHubCopilotUsageDto copilotUsage,
-        List<String> warnings) {}
+        List<String> warnings) {
+
+    public GitHubDashboardReport {
+        metrics = DtoCollections.immutableCopy(metrics);
+        quotas = DtoCollections.immutableCopy(quotas);
+        pullRequests = DtoCollections.immutableCopy(pullRequests);
+        workflowRuns = DtoCollections.immutableCopy(workflowRuns);
+        workflows = DtoCollections.immutableCopy(workflows);
+        issueBuckets = DtoCollections.immutableCopy(issueBuckets);
+        issues = DtoCollections.immutableCopy(issues);
+        securitySignals = DtoCollections.immutableCopy(securitySignals);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubIssueDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubIssueDto.java
@@ -14,4 +14,9 @@ public record GitHubIssueDto(
         Long createdAt,
         Long updatedAt,
         int comments,
-        List<String> labels) {}
+        List<String> labels) {
+
+    public GitHubIssueDto {
+        labels = DtoCollections.immutableCopy(labels);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubPullRequestDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubPullRequestDto.java
@@ -14,4 +14,9 @@ public record GitHubPullRequestDto(
         Long updatedAt,
         String reviewDecision,
         String checksConclusion,
-        List<String> labels) {}
+        List<String> labels) {
+
+    public GitHubPullRequestDto {
+        labels = DtoCollections.immutableCopy(labels);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubSecuritySignalDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GitHubSecuritySignalDto.java
@@ -9,6 +9,10 @@ import java.util.List;
 public record GitHubSecuritySignalDto(
         String label, String status, Integer count, String unavailableReason, List<GitHubDependabotAlertDto> alerts) {
 
+    public GitHubSecuritySignalDto {
+        alerts = DtoCollections.immutableCopy(alerts);
+    }
+
     public GitHubSecuritySignalDto(String label, String status, Integer count, String unavailableReason) {
         this(label, status, count, unavailableReason, List.of());
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GraalVmFindingDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GraalVmFindingDto.java
@@ -16,4 +16,9 @@ public record GraalVmFindingDto(
         int occurrenceCount,
         List<String> sampleOccurrences,
         String recommendation,
-        String learnMoreUrl) {}
+        String learnMoreUrl) {
+
+    public GraalVmFindingDto {
+        sampleOccurrences = DtoCollections.immutableCopy(sampleOccurrences);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GraalVmReadinessReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/GraalVmReadinessReport.java
@@ -37,6 +37,14 @@ public record GraalVmReadinessReport(
         String metadataDirectory,
         GraalVmDockerfileDto dockerfile) {
 
+    public GraalVmReadinessReport {
+        basePackages = DtoCollections.immutableCopy(basePackages);
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        findings = DtoCollections.immutableCopy(findings);
+        dependencies = DtoCollections.immutableCopy(dependencies);
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+
     /** Returns a copy of this report with the install target resolution filled in. */
     public GraalVmReadinessReport withInstallTarget(boolean installable, String installPath, String metadataDirectory) {
         return new GraalVmReadinessReport(

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HealthNodeDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HealthNodeDto.java
@@ -15,6 +15,11 @@ public record HealthNodeDto(
         String guidanceReason,
         List<HealthSetupStepDto> setup) {
 
+    public HealthNodeDto {
+        components = DtoCollections.immutableCopy(components);
+        setup = DtoCollections.immutableCopy(setup);
+    }
+
     public HealthNodeDto(String name, String status, Object details, List<HealthNodeDto> components) {
         this(name, status, details, components, true, null, null, List.of());
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HealthNodeDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HealthNodeDto.java
@@ -16,6 +16,7 @@ public record HealthNodeDto(
         List<HealthSetupStepDto> setup) {
 
     public HealthNodeDto {
+        details = DtoCollections.immutableValue(details);
         components = DtoCollections.immutableCopy(components);
         setup = DtoCollections.immutableCopy(setup);
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HealthSetupStepDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HealthSetupStepDto.java
@@ -2,4 +2,9 @@ package io.github.jdubois.bootui.core.dto;
 
 import java.util.List;
 
-public record HealthSetupStepDto(String title, String description, List<String> snippets) {}
+public record HealthSetupStepDto(String title, String description, List<String> snippets) {
+
+    public HealthSetupStepDto {
+        snippets = DtoCollections.immutableCopy(snippets);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HeapDumpReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HeapDumpReport.java
@@ -21,4 +21,10 @@ public record HeapDumpReport(
         List<HeapDumpFileDto> dumps,
         long histogramTotalInstances,
         long histogramTotalBytes,
-        List<HeapClassHistogramEntryDto> topClasses) {}
+        List<HeapClassHistogramEntryDto> topClasses) {
+
+    public HeapDumpReport {
+        dumps = DtoCollections.immutableCopy(dumps);
+        topClasses = DtoCollections.immutableCopy(topClasses);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HibernateReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HibernateReport.java
@@ -15,4 +15,11 @@ public record HibernateReport(
         int violationsFound,
         List<HibernateSeverityCountDto> severityCounts,
         HibernateScanStatusDto scan,
-        List<HibernateRuleResultDto> results) {}
+        List<HibernateRuleResultDto> results) {
+
+    public HibernateReport {
+        entityPackages = DtoCollections.immutableCopy(entityPackages);
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        results = DtoCollections.immutableCopy(results);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HibernateRuleResultDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HibernateRuleResultDto.java
@@ -18,6 +18,10 @@ public record HibernateRuleResultDto(
         String learnMoreUrl,
         boolean dismissed) {
 
+    public HibernateRuleResultDto {
+        sampleViolations = DtoCollections.immutableCopy(sampleViolations);
+    }
+
     public HibernateRuleResultDto(
             String id,
             String name,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HibernateStatisticsDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HibernateStatisticsDto.java
@@ -43,6 +43,6 @@ public record HibernateStatisticsDto(
         List<HibernateCacheRegionStatisticsDto> secondLevelCacheRegions) {
 
     public HibernateStatisticsDto {
-        secondLevelCacheRegions = secondLevelCacheRegions == null ? List.of() : List.copyOf(secondLevelCacheRegions);
+        secondLevelCacheRegions = DtoCollections.immutableCopy(secondLevelCacheRegions);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HikariPoolsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HikariPoolsReport.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Top-level database connection-pool report.
  */
-public record HikariPoolsReport(boolean hikariPresent, int total, List<HikariPoolDto> pools) {}
+public record HikariPoolsReport(boolean hikariPresent, int total, List<HikariPoolDto> pools) {
+
+    public HikariPoolsReport {
+        pools = DtoCollections.immutableCopy(pools);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpExchangeDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpExchangeDto.java
@@ -19,4 +19,10 @@ public record HttpExchangeDto(
         String sessionId,
         String traceId,
         List<HttpHeaderDto> requestHeaders,
-        List<HttpHeaderDto> responseHeaders) {}
+        List<HttpHeaderDto> responseHeaders) {
+
+    public HttpExchangeDto {
+        requestHeaders = DtoCollections.immutableCopy(requestHeaders);
+        responseHeaders = DtoCollections.immutableCopy(responseHeaders);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpExchangesReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpExchangesReport.java
@@ -9,6 +9,11 @@ public record HttpExchangesReport(
         List<HttpExchangeDto> exchanges,
         PageMetadata page,
         String unavailableReason) {
+
+    public HttpExchangesReport {
+        exchanges = DtoCollections.immutableCopy(exchanges);
+    }
+
     public static HttpExchangesReport unavailable(String reason) {
         return new HttpExchangesReport(0, 0, 0, List.of(), new PageMetadata(0, 0, 0, 0, 0, false), reason);
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpHeaderDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpHeaderDto.java
@@ -2,4 +2,9 @@ package io.github.jdubois.bootui.core.dto;
 
 import java.util.List;
 
-public record HttpHeaderDto(String name, List<String> values, boolean masked) {}
+public record HttpHeaderDto(String name, List<String> values, boolean masked) {
+
+    public HttpHeaderDto {
+        values = DtoCollections.immutableCopy(values);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpProbeRequest.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpProbeRequest.java
@@ -5,4 +5,9 @@ import java.util.Map;
 /**
  * Request from the browser to probe a local HTTP endpoint.
  */
-public record HttpProbeRequest(String method, String path, String body, Map<String, String> headers) {}
+public record HttpProbeRequest(String method, String path, String body, Map<String, String> headers) {
+
+    public HttpProbeRequest {
+        headers = DtoCollections.immutableCopy(headers);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpProbeResponse.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpProbeResponse.java
@@ -17,4 +17,9 @@ public record HttpProbeResponse(
         String body,
         long durationMs,
         String error,
-        boolean truncated) {}
+        boolean truncated) {
+
+    public HttpProbeResponse {
+        headers = DtoCollections.immutableCopy(headers);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpSessionDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpSessionDto.java
@@ -16,4 +16,9 @@ public record HttpSessionDto(
         Long idleSeconds,
         int maxInactiveIntervalSeconds,
         int attributeCount,
-        List<HttpSessionAttributeDto> attributes) {}
+        List<HttpSessionAttributeDto> attributes) {
+
+    public HttpSessionDto {
+        attributes = DtoCollections.immutableCopy(attributes);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpSessionsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HttpSessionsReport.java
@@ -16,6 +16,10 @@ public record HttpSessionsReport(
         String valueExposure,
         List<HttpSessionDto> sessions) {
 
+    public HttpSessionsReport {
+        sessions = DtoCollections.immutableCopy(sessions);
+    }
+
     public static HttpSessionsReport unavailable(
             String reason, int limit, boolean actionEnabled, String valueExposure) {
         return new HttpSessionsReport(false, reason, 0, 0, limit, false, actionEnabled, valueExposure, List.of());

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/JmsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/JmsReport.java
@@ -25,7 +25,7 @@ public record JmsReport(
         List<JmsMessageDto> messages) {
 
     public JmsReport {
-        messages = messages == null ? List.of() : List.copyOf(messages);
+        messages = DtoCollections.immutableCopy(messages);
     }
 
     public static JmsReport unavailable(String reason, int maxEntries) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/KafkaReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/KafkaReport.java
@@ -33,7 +33,7 @@ public record KafkaReport(
         List<KafkaMessageDto> messages) {
 
     public KafkaReport {
-        messages = messages == null ? List.of() : List.copyOf(messages);
+        messages = DtoCollections.immutableCopy(messages);
     }
 
     public static KafkaReport unavailable(String reason, int maxEntries) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/KubernetesMemoryRecommendationDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/KubernetesMemoryRecommendationDto.java
@@ -26,4 +26,9 @@ public record KubernetesMemoryRecommendationDto(
         double initialRamPercentage,
         String javaToolOptions,
         boolean burstableEnabled,
-        boolean healthProbesEnabled) {}
+        boolean healthProbesEnabled) {
+
+    public KubernetesMemoryRecommendationDto {
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiquibaseActionResult.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiquibaseActionResult.java
@@ -12,4 +12,9 @@ public record LiquibaseActionResult(
         Integer pendingBefore,
         Integer pendingAfter,
         Integer changeSetsApplied,
-        List<String> warnings) {}
+        List<String> warnings) {
+
+    public LiquibaseActionResult {
+        warnings = DtoCollections.immutableCopy(warnings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiquibaseChangeSetDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiquibaseChangeSetDto.java
@@ -18,4 +18,10 @@ public record LiquibaseChangeSetDto(
         String tag,
         String deploymentId,
         List<String> contexts,
-        List<String> labels) {}
+        List<String> labels) {
+
+    public LiquibaseChangeSetDto {
+        contexts = DtoCollections.immutableCopy(contexts);
+        labels = DtoCollections.immutableCopy(labels);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiquibaseDatabaseDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiquibaseDatabaseDto.java
@@ -12,4 +12,9 @@ public record LiquibaseDatabaseDto(
         int total,
         List<LiquibaseChangeSetDto> changeSets,
         boolean updateEnabled,
-        String updateDisabledReason) {}
+        String updateDisabledReason) {
+
+    public LiquibaseDatabaseDto {
+        changeSets = DtoCollections.immutableCopy(changeSets);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiquibaseReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiquibaseReport.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Top-level Liquibase migration report.
  */
-public record LiquibaseReport(boolean liquibasePresent, int total, List<LiquibaseDatabaseDto> databases) {}
+public record LiquibaseReport(boolean liquibasePresent, int total, List<LiquibaseDatabaseDto> databases) {
+
+    public LiquibaseReport {
+        databases = DtoCollections.immutableCopy(databases);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiveActivityReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiveActivityReport.java
@@ -28,10 +28,10 @@ public record LiveActivityReport(
         ActivityPersistenceOptionDto persistenceOption) {
 
     public LiveActivityReport {
-        entries = entries == null ? List.of() : List.copyOf(entries);
-        typeCounts = typeCounts == null ? Map.of() : Map.copyOf(typeCounts);
-        sources = sources == null ? List.of() : List.copyOf(sources);
-        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        entries = DtoCollections.immutableCopy(entries);
+        typeCounts = DtoCollections.immutableCopy(typeCounts);
+        sources = DtoCollections.immutableCopy(sources);
+        warnings = DtoCollections.immutableCopy(warnings);
     }
 
     /** Convenience constructor for callers that have a page info but no persistence option yet. */

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiveMemoryReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LiveMemoryReport.java
@@ -12,4 +12,10 @@ public record LiveMemoryReport(
         List<String> jvmInputArguments,
         String suggestedJvmOptions,
         MemoryCalculationDto calculation,
-        KubernetesMemoryRecommendationDto kubernetes) {}
+        KubernetesMemoryRecommendationDto kubernetes) {
+
+    public LiveMemoryReport {
+        pools = DtoCollections.immutableCopy(pools);
+        jvmInputArguments = DtoCollections.immutableCopy(jvmInputArguments);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LoggersReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/LoggersReport.java
@@ -3,6 +3,12 @@ package io.github.jdubois.bootui.core.dto;
 import java.util.List;
 
 public record LoggersReport(List<String> availableLevels, List<LoggerDto> loggers, PageMetadata page) {
+
+    public LoggersReport {
+        availableLevels = DtoCollections.immutableCopy(availableLevels);
+        loggers = DtoCollections.immutableCopy(loggers);
+    }
+
     public LoggersReport(List<String> availableLevels, List<LoggerDto> loggers) {
         this(
                 availableLevels,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MappingsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MappingsReport.java
@@ -3,6 +3,11 @@ package io.github.jdubois.bootui.core.dto;
 import java.util.List;
 
 public record MappingsReport(int total, List<MappingDto> mappings, PageMetadata page) {
+
+    public MappingsReport {
+        mappings = DtoCollections.immutableCopy(mappings);
+    }
+
     public MappingsReport(int total, List<MappingDto> mappings) {
         this(total, mappings, new PageMetadata(total, mappings.size(), 0, mappings.size(), mappings.size(), false));
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/McpServerStatus.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/McpServerStatus.java
@@ -41,6 +41,10 @@ public record McpServerStatus(
         int toolCount,
         List<McpToolInfo> tools) {
 
+    public McpServerStatus {
+        tools = DtoCollections.immutableCopy(tools);
+    }
+
     public McpServerStatus(
             boolean enabled,
             String configuredMode,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MemoryReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MemoryReport.java
@@ -19,4 +19,11 @@ public record MemoryReport(
         List<MemorySeverityCountDto> severityCounts,
         MemoryScanStatusDto scan,
         List<MemoryRuleResultDto> results,
-        List<MemoryRuleResultDto> analysisErrors) {}
+        List<MemoryRuleResultDto> analysisErrors) {
+
+    public MemoryReport {
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        results = DtoCollections.immutableCopy(results);
+        analysisErrors = DtoCollections.immutableCopy(analysisErrors);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MemoryRuleResultDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MemoryRuleResultDto.java
@@ -19,6 +19,10 @@ public record MemoryRuleResultDto(
         String learnMoreUrl,
         boolean dismissed) {
 
+    public MemoryRuleResultDto {
+        sampleViolations = DtoCollections.immutableCopy(sampleViolations);
+    }
+
     public MemoryRuleResultDto(
             String id,
             String name,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricAvailableTagDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricAvailableTagDto.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Available values for one Micrometer meter tag key.
  */
-public record MetricAvailableTagDto(String key, List<String> values, boolean truncated) {}
+public record MetricAvailableTagDto(String key, List<String> values, boolean truncated) {
+
+    public MetricAvailableTagDto {
+        values = DtoCollections.immutableCopy(values);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricDetailDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricDetailDto.java
@@ -19,6 +19,12 @@ public record MetricDetailDto(
         boolean samplesTruncated,
         MetricProvenanceDto provenance) {
 
+    public MetricDetailDto {
+        measurements = DtoCollections.immutableCopy(measurements);
+        availableTags = DtoCollections.immutableCopy(availableTags);
+        samples = DtoCollections.immutableCopy(samples);
+    }
+
     public MetricDetailDto(
             boolean metricsAvailable,
             String name,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricGroupDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricGroupDto.java
@@ -19,4 +19,11 @@ public record MetricGroupDto(
         int describedMeterCount,
         List<String> families,
         List<String> commonTagKeys,
-        List<String> baseUnits) {}
+        List<String> baseUnits) {
+
+    public MetricGroupDto {
+        families = DtoCollections.immutableCopy(families);
+        commonTagKeys = DtoCollections.immutableCopy(commonTagKeys);
+        baseUnits = DtoCollections.immutableCopy(baseUnits);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricMeterDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricMeterDto.java
@@ -16,6 +16,10 @@ public record MetricMeterDto(
         List<MetricAvailableTagDto> availableTags,
         MetricProvenanceDto provenance) {
 
+    public MetricMeterDto {
+        availableTags = DtoCollections.immutableCopy(availableTags);
+    }
+
     public MetricMeterDto(
             String name, String description, String baseUnit, String type, List<MetricAvailableTagDto> availableTags) {
         this(name, description, baseUnit, type, availableTags, null);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricSampleDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricSampleDto.java
@@ -5,4 +5,10 @@ import java.util.List;
 /**
  * One concrete tagged Micrometer meter sample.
  */
-public record MetricSampleDto(List<MetricTagDto> tags, List<MetricMeasurementDto> measurements) {}
+public record MetricSampleDto(List<MetricTagDto> tags, List<MetricMeasurementDto> measurements) {
+
+    public MetricSampleDto {
+        tags = DtoCollections.immutableCopy(tags);
+        measurements = DtoCollections.immutableCopy(measurements);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MetricsReport.java
@@ -18,6 +18,12 @@ public record MetricsReport(
         List<MetricGroupDto> groups,
         String catalogueVersion) {
 
+    public MetricsReport {
+        meters = DtoCollections.immutableCopy(meters);
+        availableTypes = DtoCollections.immutableCopy(availableTypes);
+        groups = DtoCollections.immutableCopy(groups);
+    }
+
     public MetricsReport(
             boolean metricsAvailable,
             int total,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/OverviewDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/OverviewDto.java
@@ -20,4 +20,10 @@ public record OverviewDto(
         String contextPath,
         Long startupTimeMillis,
         ActivationStatus activation,
-        String openApiUrl) {}
+        String openApiUrl) {
+
+    public OverviewDto {
+        activeProfiles = DtoCollections.immutableCopy(activeProfiles);
+        defaultProfiles = DtoCollections.immutableCopy(defaultProfiles);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/PanelsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/PanelsReport.java
@@ -12,6 +12,10 @@ import java.util.List;
  */
 public record PanelsReport(String platform, List<PanelDto> panels) {
 
+    public PanelsReport {
+        panels = DtoCollections.immutableCopy(panels);
+    }
+
     /** Platform value reported by the Spring Boot autoconfigure adapter running on the servlet (Spring MVC) stack. */
     public static final String PLATFORM_SPRING_BOOT = "spring-boot";
 

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/PentestingReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/PentestingReport.java
@@ -13,4 +13,11 @@ public record PentestingReport(
         List<PentestingSeverityCountDto> severityCounts,
         PentestingScanStatusDto scan,
         List<PentestingCoverageDto> coverage,
-        List<PentestingFindingDto> findings) {}
+        List<PentestingFindingDto> findings) {
+
+    public PentestingReport {
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        coverage = DtoCollections.immutableCopy(coverage);
+        findings = DtoCollections.immutableCopy(findings);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ProfileSourceDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ProfileSourceDto.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Properties contributed by a single profile-specific property source.
  */
-public record ProfileSourceDto(String sourceName, String profile, List<ConfigPropertyDto> properties) {}
+public record ProfileSourceDto(String sourceName, String profile, List<ConfigPropertyDto> properties) {
+
+    public ProfileSourceDto {
+        properties = DtoCollections.immutableCopy(properties);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ProfilesReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ProfilesReport.java
@@ -5,4 +5,10 @@ import java.util.List;
 /**
  * Profile-aware view of the active configuration.
  */
-public record ProfilesReport(List<String> activeProfiles, List<ProfileSourceDto> profileSources) {}
+public record ProfilesReport(List<String> activeProfiles, List<ProfileSourceDto> profileSources) {
+
+    public ProfilesReport {
+        activeProfiles = DtoCollections.immutableCopy(activeProfiles);
+        profileSources = DtoCollections.immutableCopy(profileSources);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RabbitReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RabbitReport.java
@@ -33,7 +33,7 @@ public record RabbitReport(
         List<RabbitMessageDto> messages) {
 
     public RabbitReport {
-        messages = messages == null ? List.of() : List.copyOf(messages);
+        messages = DtoCollections.immutableCopy(messages);
     }
 
     public static RabbitReport unavailable(String reason, int maxEntries) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RepositoriesReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RepositoriesReport.java
@@ -2,4 +2,9 @@ package io.github.jdubois.bootui.core.dto;
 
 import java.util.List;
 
-public record RepositoriesReport(boolean springDataPresent, int total, List<RepositoryDto> repositories) {}
+public record RepositoriesReport(boolean springDataPresent, int total, List<RepositoryDto> repositories) {
+
+    public RepositoriesReport {
+        repositories = DtoCollections.immutableCopy(repositories);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RepositoryDetailDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RepositoryDetailDto.java
@@ -13,4 +13,10 @@ public record RepositoryDetailDto(
         String storeModule,
         String customImplementation,
         List<RepositoryMethodDto> methods,
-        List<String> fragments) {}
+        List<String> fragments) {
+
+    public RepositoryDetailDto {
+        methods = DtoCollections.immutableCopy(methods);
+        fragments = DtoCollections.immutableCopy(fragments);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RequestProfileDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RequestProfileDto.java
@@ -37,11 +37,11 @@ public record RequestProfileDto(
         List<String> notes) {
 
     public RequestProfileDto {
-        sql = sql == null ? List.of() : List.copyOf(sql);
-        sqlGroups = sqlGroups == null ? List.of() : List.copyOf(sqlGroups);
-        exceptions = exceptions == null ? List.of() : List.copyOf(exceptions);
-        security = security == null ? List.of() : List.copyOf(security);
-        notes = notes == null ? List.of() : List.copyOf(notes);
+        sql = DtoCollections.immutableCopy(sql);
+        sqlGroups = DtoCollections.immutableCopy(sqlGroups);
+        exceptions = DtoCollections.immutableCopy(exceptions);
+        security = DtoCollections.immutableCopy(security);
+        notes = DtoCollections.immutableCopy(notes);
     }
 
     public static RequestProfileDto unavailable(String reason) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestApiReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestApiReport.java
@@ -16,4 +16,11 @@ public record RestApiReport(
         int violationsFound,
         List<RestApiSeverityCountDto> severityCounts,
         RestApiScanStatusDto scan,
-        List<RestApiRuleResultDto> results) {}
+        List<RestApiRuleResultDto> results) {
+
+    public RestApiReport {
+        basePackages = DtoCollections.immutableCopy(basePackages);
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        results = DtoCollections.immutableCopy(results);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestApiRuleResultDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestApiRuleResultDto.java
@@ -18,6 +18,10 @@ public record RestApiRuleResultDto(
         String learnMoreUrl,
         boolean dismissed) {
 
+    public RestApiRuleResultDto {
+        sampleViolations = DtoCollections.immutableCopy(sampleViolations);
+    }
+
     public RestApiRuleResultDto(
             String id,
             String name,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestClientTraceEntryDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestClientTraceEntryDto.java
@@ -57,6 +57,6 @@ public record RestClientTraceEntryDto(
         String callSite) {
 
     public RestClientTraceEntryDto {
-        requestHeaders = requestHeaders == null ? Map.of() : Map.copyOf(requestHeaders);
+        requestHeaders = DtoCollections.immutableCopy(requestHeaders);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestClientTraceGroupDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestClientTraceGroupDto.java
@@ -31,6 +31,6 @@ public record RestClientTraceGroupDto(
         List<String> callSites) {
 
     public RestClientTraceGroupDto {
-        callSites = callSites == null ? List.of() : List.copyOf(callSites);
+        callSites = DtoCollections.immutableCopy(callSites);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestClientTraceReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestClientTraceReport.java
@@ -34,10 +34,10 @@ public record RestClientTraceReport(
         List<String> warnings) {
 
     public RestClientTraceReport {
-        clientTypes = clientTypes == null ? List.of() : List.copyOf(clientTypes);
-        entries = entries == null ? List.of() : List.copyOf(entries);
-        topCalls = topCalls == null ? List.of() : List.copyOf(topCalls);
-        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        clientTypes = DtoCollections.immutableCopy(clientTypes);
+        entries = DtoCollections.immutableCopy(entries);
+        topCalls = DtoCollections.immutableCopy(topCalls);
+        warnings = DtoCollections.immutableCopy(warnings);
     }
 
     public static RestClientTraceReport unavailable(String reason) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ScheduledReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ScheduledReport.java
@@ -2,4 +2,9 @@ package io.github.jdubois.bootui.core.dto;
 
 import java.util.List;
 
-public record ScheduledReport(boolean schedulingPresent, int total, List<ScheduledTaskDto> tasks) {}
+public record ScheduledReport(boolean schedulingPresent, int total, List<ScheduledTaskDto> tasks) {
+
+    public ScheduledReport {
+        tasks = DtoCollections.immutableCopy(tasks);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityLogEventDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityLogEventDto.java
@@ -13,4 +13,9 @@ import java.util.List;
  *     instead (see {@code ActivityEntryDto.parentId}).
  */
 public record SecurityLogEventDto(
-        String timestamp, String principal, String type, List<SecurityLogDataDto> data, String traceId) {}
+        String timestamp, String principal, String type, List<SecurityLogDataDto> data, String traceId) {
+
+    public SecurityLogEventDto {
+        data = DtoCollections.immutableCopy(data);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityLogsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityLogsReport.java
@@ -13,6 +13,11 @@ public record SecurityLogsReport(
         List<SecurityLogEventDto> events,
         PageMetadata page) {
 
+    public SecurityLogsReport {
+        typeSummaries = DtoCollections.immutableCopy(typeSummaries);
+        events = DtoCollections.immutableCopy(events);
+    }
+
     public static SecurityLogsReport unavailable(String reason, int maxLogs) {
         return new SecurityLogsReport(
                 false, reason, maxLogs, List.of(), List.of(), new PageMetadata(0, 0, 0, 0, 0, false));

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityReport.java
@@ -16,4 +16,12 @@ public record SecurityReport(
         List<SecuritySeverityCountDto> severityCounts,
         SecurityScanStatusDto scan,
         List<SecurityRuleResultDto> results,
-        List<SecurityRuleResultDto> analysisErrors) {}
+        List<SecurityRuleResultDto> analysisErrors) {
+
+    public SecurityReport {
+        filterChains = DtoCollections.immutableCopy(filterChains);
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        results = DtoCollections.immutableCopy(results);
+        analysisErrors = DtoCollections.immutableCopy(analysisErrors);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityRuleResultDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityRuleResultDto.java
@@ -19,6 +19,10 @@ public record SecurityRuleResultDto(
         String learnMoreUrl,
         boolean dismissed) {
 
+    public SecurityRuleResultDto {
+        sampleViolations = DtoCollections.immutableCopy(sampleViolations);
+    }
+
     public SecurityRuleResultDto(
             String id,
             String name,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ServiceMapEdgeDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ServiceMapEdgeDto.java
@@ -37,6 +37,6 @@ public record ServiceMapEdgeDto(
         List<ServiceMapInteractionDto> recentInteractions) {
 
     public ServiceMapEdgeDto {
-        recentInteractions = recentInteractions == null ? List.of() : List.copyOf(recentInteractions);
+        recentInteractions = DtoCollections.immutableCopy(recentInteractions);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ServiceMapReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ServiceMapReport.java
@@ -36,9 +36,9 @@ public record ServiceMapReport(
         List<String> warnings) {
 
     public ServiceMapReport {
-        nodes = nodes == null ? List.of() : List.copyOf(nodes);
-        edges = edges == null ? List.of() : List.copyOf(edges);
-        sources = sources == null ? List.of() : List.copyOf(sources);
-        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        nodes = DtoCollections.immutableCopy(nodes);
+        edges = DtoCollections.immutableCopy(edges);
+        sources = DtoCollections.immutableCopy(sources);
+        warnings = DtoCollections.immutableCopy(warnings);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpanAttributeDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpanAttributeDto.java
@@ -3,4 +3,9 @@ package io.github.jdubois.bootui.core.dto;
 /**
  * Summary describing a span attribute, normalized to a JSON-friendly value type.
  */
-public record SpanAttributeDto(String key, String type, Object value) {}
+public record SpanAttributeDto(String key, String type, Object value) {
+
+    public SpanAttributeDto {
+        value = DtoCollections.immutableValue(value);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpanDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpanDto.java
@@ -19,4 +19,10 @@ public record SpanDto(
         String statusCode,
         String statusMessage,
         List<SpanAttributeDto> attributes,
-        List<SpanEventDto> events) {}
+        List<SpanEventDto> events) {
+
+    public SpanDto {
+        attributes = DtoCollections.immutableCopy(attributes);
+        events = DtoCollections.immutableCopy(events);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpanEventDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpanEventDto.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Discrete event recorded inside a span.
  */
-public record SpanEventDto(String name, long timeOffsetNanos, List<SpanAttributeDto> attributes) {}
+public record SpanEventDto(String name, long timeOffsetNanos, List<SpanAttributeDto> attributes) {
+
+    public SpanEventDto {
+        attributes = DtoCollections.immutableCopy(attributes);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringReport.java
@@ -16,4 +16,12 @@ public record SpringReport(
         List<SpringSeverityCountDto> severityCounts,
         SpringScanStatusDto scan,
         List<SpringRuleResultDto> results,
-        List<SpringRuleResultDto> analysisErrors) {}
+        List<SpringRuleResultDto> analysisErrors) {
+
+    public SpringReport {
+        inspected = DtoCollections.immutableCopy(inspected);
+        severityCounts = DtoCollections.immutableCopy(severityCounts);
+        results = DtoCollections.immutableCopy(results);
+        analysisErrors = DtoCollections.immutableCopy(analysisErrors);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringRuleResultDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringRuleResultDto.java
@@ -18,6 +18,10 @@ public record SpringRuleResultDto(
         String learnMoreUrl,
         boolean dismissed) {
 
+    public SpringRuleResultDto {
+        sampleViolations = DtoCollections.immutableCopy(sampleViolations);
+    }
+
     public SpringRuleResultDto(
             String id,
             String name,

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityAuthDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityAuthDto.java
@@ -6,4 +6,10 @@ import java.util.List;
  * Authentication and user-details summary.
  */
 public record SpringSecurityAuthDto(
-        List<String> authenticationProviderTypes, List<String> userDetailsServiceTypes, String configuredUsername) {}
+        List<String> authenticationProviderTypes, List<String> userDetailsServiceTypes, String configuredUsername) {
+
+    public SpringSecurityAuthDto {
+        authenticationProviderTypes = DtoCollections.immutableCopy(authenticationProviderTypes);
+        userDetailsServiceTypes = DtoCollections.immutableCopy(userDetailsServiceTypes);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityEndpointDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityEndpointDto.java
@@ -30,4 +30,9 @@ public record SpringSecurityEndpointDto(
         Integer chainIndex,
         String matcherDescription,
         String description,
-        boolean bestEffort) {}
+        boolean bestEffort) {
+
+    public SpringSecurityEndpointDto {
+        roles = DtoCollections.immutableCopy(roles);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityEndpointsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityEndpointsReport.java
@@ -9,4 +9,9 @@ public record SpringSecurityEndpointsReport(
         boolean springSecurityPresent,
         boolean handlerMappingAvailable,
         int total,
-        List<SpringSecurityEndpointDto> endpoints) {}
+        List<SpringSecurityEndpointDto> endpoints) {
+
+    public SpringSecurityEndpointsReport {
+        endpoints = DtoCollections.immutableCopy(endpoints);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityExplainDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityExplainDto.java
@@ -10,4 +10,9 @@ import java.util.List;
  * session-based matchers.</p>
  */
 public record SpringSecurityExplainDto(
-        boolean matched, boolean bestEffort, Integer chainIndex, String matcherDescription, List<String> filters) {}
+        boolean matched, boolean bestEffort, Integer chainIndex, String matcherDescription, List<String> filters) {
+
+    public SpringSecurityExplainDto {
+        filters = DtoCollections.immutableCopy(filters);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityFilterChainDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityFilterChainDto.java
@@ -12,4 +12,9 @@ public record SpringSecurityFilterChainDto(
         List<String> filters,
         boolean csrfEnabled,
         boolean corsEnabled,
-        boolean sessionManagementPresent) {}
+        boolean sessionManagementPresent) {
+
+    public SpringSecurityFilterChainDto {
+        filters = DtoCollections.immutableCopy(filters);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringSecurityReport.java
@@ -6,4 +6,9 @@ import java.util.List;
  * Top-level Spring Security report.
  */
 public record SpringSecurityReport(
-        boolean springSecurityPresent, List<SpringSecurityFilterChainDto> chains, SpringSecurityAuthDto auth) {}
+        boolean springSecurityPresent, List<SpringSecurityFilterChainDto> chains, SpringSecurityAuthDto auth) {
+
+    public SpringSecurityReport {
+        chains = DtoCollections.immutableCopy(chains);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlRouteAttributionDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlRouteAttributionDto.java
@@ -41,9 +41,9 @@ public record SqlRouteAttributionDto(
         List<String> notes) {
 
     public SqlRouteAttributionDto {
-        supportedCorrelations = supportedCorrelations == null ? List.of() : List.copyOf(supportedCorrelations);
-        routes = routes == null ? List.of() : List.copyOf(routes);
-        notes = notes == null ? List.of() : List.copyOf(notes);
+        supportedCorrelations = DtoCollections.immutableCopy(supportedCorrelations);
+        routes = DtoCollections.immutableCopy(routes);
+        notes = DtoCollections.immutableCopy(notes);
         unattributed = unattributed == null ? SqlAttributionBucketDto.empty(null) : unattributed;
         ambiguous = ambiguous == null ? SqlAttributionBucketDto.empty(null) : ambiguous;
     }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlRouteRankingDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlRouteRankingDto.java
@@ -57,7 +57,7 @@ public record SqlRouteRankingDto(
         List<Long> entryIds) {
 
     public SqlRouteRankingDto {
-        topStatements = topStatements == null ? List.of() : List.copyOf(topStatements);
-        entryIds = entryIds == null ? List.of() : List.copyOf(entryIds);
+        topStatements = DtoCollections.immutableCopy(topStatements);
+        entryIds = DtoCollections.immutableCopy(entryIds);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlStatementRankingDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlStatementRankingDto.java
@@ -57,8 +57,8 @@ public record SqlStatementRankingDto(
         boolean entryIdsTruncated) {
 
     public SqlStatementRankingDto {
-        topFor = topFor == null ? List.of() : List.copyOf(topFor);
-        callSites = callSites == null ? List.of() : List.copyOf(callSites);
-        entryIds = entryIds == null ? List.of() : List.copyOf(entryIds);
+        topFor = DtoCollections.immutableCopy(topFor);
+        callSites = DtoCollections.immutableCopy(callSites);
+        entryIds = DtoCollections.immutableCopy(entryIds);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlTraceEntryDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlTraceEntryDto.java
@@ -50,6 +50,6 @@ public record SqlTraceEntryDto(
         String callSite) {
 
     public SqlTraceEntryDto {
-        parameters = parameters == null ? List.of() : List.copyOf(parameters);
+        parameters = DtoCollections.immutableCopy(parameters);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlTraceGroupDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlTraceGroupDto.java
@@ -26,6 +26,6 @@ public record SqlTraceGroupDto(
         List<String> callSites) {
 
     public SqlTraceGroupDto {
-        callSites = callSites == null ? List.of() : List.copyOf(callSites);
+        callSites = DtoCollections.immutableCopy(callSites);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlTraceInsightsReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlTraceInsightsReport.java
@@ -41,9 +41,9 @@ public record SqlTraceInsightsReport(
 
     public SqlTraceInsightsReport {
         window = window == null ? SqlTraceWindowDto.empty() : window;
-        statements = statements == null ? List.of() : List.copyOf(statements);
+        statements = DtoCollections.immutableCopy(statements);
         attribution = attribution == null ? SqlRouteAttributionDto.unavailable(null) : attribution;
-        notes = notes == null ? List.of() : List.copyOf(notes);
+        notes = DtoCollections.immutableCopy(notes);
     }
 
     public static SqlTraceInsightsReport unavailable(String reason) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlTraceReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SqlTraceReport.java
@@ -33,10 +33,10 @@ public record SqlTraceReport(
         List<String> warnings) {
 
     public SqlTraceReport {
-        dataSources = dataSources == null ? List.of() : List.copyOf(dataSources);
-        entries = entries == null ? List.of() : List.copyOf(entries);
-        topStatements = topStatements == null ? List.of() : List.copyOf(topStatements);
-        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        dataSources = DtoCollections.immutableCopy(dataSources);
+        entries = DtoCollections.immutableCopy(entries);
+        topStatements = DtoCollections.immutableCopy(topStatements);
+        warnings = DtoCollections.immutableCopy(warnings);
     }
 
     public static SqlTraceReport unavailable(String reason) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/StartupReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/StartupReport.java
@@ -2,4 +2,9 @@ package io.github.jdubois.bootui.core.dto;
 
 import java.util.List;
 
-public record StartupReport(List<StartupStepDto> steps) {}
+public record StartupReport(List<StartupStepDto> steps) {
+
+    public StartupReport {
+        steps = DtoCollections.immutableCopy(steps);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/StartupStepDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/StartupStepDto.java
@@ -2,4 +2,9 @@ package io.github.jdubois.bootui.core.dto;
 
 import java.util.List;
 
-public record StartupStepDto(long id, Long parentId, String name, long durationMs, List<TagDto> tags) {}
+public record StartupStepDto(long id, Long parentId, String name, long durationMs, List<TagDto> tags) {
+
+    public StartupStepDto {
+        tags = DtoCollections.immutableCopy(tags);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ThreadDumpReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ThreadDumpReport.java
@@ -26,9 +26,9 @@ public record ThreadDumpReport(
         PageMetadata page) {
 
     public ThreadDumpReport {
-        deadlockedThreadIds = deadlockedThreadIds == null ? List.of() : List.copyOf(deadlockedThreadIds);
-        stateCounts = stateCounts == null ? List.of() : List.copyOf(stateCounts);
-        threads = threads == null ? List.of() : List.copyOf(threads);
+        deadlockedThreadIds = DtoCollections.immutableCopy(deadlockedThreadIds);
+        stateCounts = DtoCollections.immutableCopy(stateCounts);
+        threads = DtoCollections.immutableCopy(threads);
     }
 
     /**

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ThreadInfoDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ThreadInfoDto.java
@@ -29,6 +29,6 @@ public record ThreadInfoDto(
         List<String> stackTrace) {
 
     public ThreadInfoDto {
-        stackTrace = stackTrace == null ? List.of() : List.copyOf(stackTrace);
+        stackTrace = DtoCollections.immutableCopy(stackTrace);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TraceDetailDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TraceDetailDto.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Top-level Trace detail payload.
  */
-public record TraceDetailDto(String traceId, List<SpanDto> spans) {}
+public record TraceDetailDto(String traceId, List<SpanDto> spans) {
+
+    public TraceDetailDto {
+        spans = DtoCollections.immutableCopy(spans);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TraceSummaryDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TraceSummaryDto.java
@@ -15,4 +15,9 @@ public record TraceSummaryDto(
         long durationNanos,
         int spanCount,
         boolean hasError,
-        boolean hasAi) {}
+        boolean hasAi) {
+
+    public TraceSummaryDto {
+        services = DtoCollections.immutableCopy(services);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TracesReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TracesReport.java
@@ -5,4 +5,9 @@ import java.util.List;
 /**
  * Top-level Traces list payload.
  */
-public record TracesReport(boolean enabled, int retained, int capacity, List<TraceSummaryDto> traces) {}
+public record TracesReport(boolean enabled, int retained, int capacity, List<TraceSummaryDto> traces) {
+
+    public TracesReport {
+        traces = DtoCollections.immutableCopy(traces);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TransactionReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/TransactionReport.java
@@ -31,8 +31,8 @@ public record TransactionReport(
         List<String> warnings) {
 
     public TransactionReport {
-        entries = entries == null ? List.of() : List.copyOf(entries);
-        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        entries = DtoCollections.immutableCopy(entries);
+        warnings = DtoCollections.immutableCopy(warnings);
     }
 
     public static TransactionReport unavailable(String reason) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/WebSocketEndpointDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/WebSocketEndpointDto.java
@@ -42,9 +42,9 @@ public record WebSocketEndpointDto(
         boolean captureInstalled) {
 
     public WebSocketEndpointDto {
-        subprotocols = subprotocols == null ? List.of() : List.copyOf(subprotocols);
-        allowedOrigins = allowedOrigins == null ? List.of() : List.copyOf(allowedOrigins);
-        interceptors = interceptors == null ? List.of() : List.copyOf(interceptors);
-        callbacks = callbacks == null ? List.of() : List.copyOf(callbacks);
+        subprotocols = DtoCollections.immutableCopy(subprotocols);
+        allowedOrigins = DtoCollections.immutableCopy(allowedOrigins);
+        interceptors = DtoCollections.immutableCopy(interceptors);
+        callbacks = DtoCollections.immutableCopy(callbacks);
     }
 }

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/WebSocketReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/WebSocketReport.java
@@ -65,15 +65,14 @@ public record WebSocketReport(
         List<String> warnings) {
 
     public WebSocketReport {
-        brokerPrefixes = brokerPrefixes == null ? List.of() : List.copyOf(brokerPrefixes);
-        applicationDestinationPrefixes =
-                applicationDestinationPrefixes == null ? List.of() : List.copyOf(applicationDestinationPrefixes);
-        endpoints = endpoints == null ? List.of() : List.copyOf(endpoints);
-        sessions = sessions == null ? List.of() : List.copyOf(sessions);
-        subscriptions = subscriptions == null ? List.of() : List.copyOf(subscriptions);
-        activity = activity == null ? List.of() : List.copyOf(activity);
+        brokerPrefixes = DtoCollections.immutableCopy(brokerPrefixes);
+        applicationDestinationPrefixes = DtoCollections.immutableCopy(applicationDestinationPrefixes);
+        endpoints = DtoCollections.immutableCopy(endpoints);
+        sessions = DtoCollections.immutableCopy(sessions);
+        subscriptions = DtoCollections.immutableCopy(subscriptions);
+        activity = DtoCollections.immutableCopy(activity);
         stats = stats == null ? WebSocketStatsDto.empty() : stats;
-        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        warnings = DtoCollections.immutableCopy(warnings);
     }
 
     public static WebSocketReport unavailable(String reason) {

--- a/bootui-core/src/test/java/io/github/jdubois/bootui/core/dto/CoreDtoImmutabilityTests.java
+++ b/bootui-core/src/test/java/io/github/jdubois/bootui/core/dto/CoreDtoImmutabilityTests.java
@@ -1,0 +1,321 @@
+package io.github.jdubois.bootui.core.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+/**
+ * Contract tests over every public record in {@code io.github.jdubois.bootui.core.dto}.
+ *
+ * <p>The DTO package is discovered reflectively rather than spot-checked, so a newly added DTO that
+ * forgets its defensive copy fails here instead of silently shipping a mutable "immutable" record.</p>
+ */
+class CoreDtoImmutabilityTests {
+
+    private static final String PROBE = "probe";
+    private static final String MUTATION = "mutation";
+
+    /**
+     * Guards the discovery itself: if the class scan silently found nothing, every generated test
+     * would vacuously pass.
+     */
+    @Test
+    void discoversTheDtoRecordsThatCarryCollections() {
+        List<Class<?>> records = dtoRecords();
+
+        assertThat(records).hasSizeGreaterThanOrEqualTo(200);
+        assertThat(records.stream().filter(CoreDtoImmutabilityTests::hasCollectionComponent))
+                .hasSizeGreaterThanOrEqualTo(130);
+        assertThat(records)
+                .contains(
+                        OverviewDto.class,
+                        RepositoriesReport.class,
+                        PanelsReport.class,
+                        MemoryReport.class,
+                        ConfigReport.class);
+    }
+
+    @TestFactory
+    Stream<DynamicTest> everyCollectionComponentIsDefensivelyCopied() {
+        return dtoRecords().stream()
+                .filter(CoreDtoImmutabilityTests::hasCollectionComponent)
+                .map(type -> DynamicTest.dynamicTest(type.getSimpleName(), () -> assertDefensivelyCopied(type)));
+    }
+
+    @TestFactory
+    Stream<DynamicTest> everyCollectionComponentIsNeverNull() {
+        return dtoRecords().stream()
+                .filter(CoreDtoImmutabilityTests::hasCollectionComponent)
+                .map(type ->
+                        DynamicTest.dynamicTest(type.getSimpleName(), () -> assertNullCollectionsBecomeEmpty(type)));
+    }
+
+    @Test
+    void nestedReportCollectionsStayImmutableThroughEveryLevel() {
+        List<String> stackTrace = new ArrayList<>(List.of("com.example.Boom.run(Boom.java:1)"));
+        ThreadInfoDto thread = new ThreadInfoDto(
+                1L,
+                "main",
+                "RUNNABLE",
+                5,
+                false,
+                false,
+                null,
+                null,
+                0L,
+                0L,
+                false,
+                false,
+                false,
+                null,
+                null,
+                null,
+                stackTrace);
+        List<Long> deadlocked = new ArrayList<>(List.of(1L));
+        List<ThreadInfoDto> threads = new ArrayList<>(List.of(thread));
+        ThreadDumpReport report = new ThreadDumpReport(
+                true, null, 1L, 1, 0, 1, 1L, true, true, false, deadlocked, new ArrayList<>(), threads, null);
+
+        stackTrace.clear();
+        deadlocked.clear();
+        threads.clear();
+
+        assertThat(report.threads()).hasSize(1);
+        assertThat(report.deadlockedThreadIds()).containsExactly(1L);
+        ThreadInfoDto held = report.threads().get(0);
+        assertThat(held.stackTrace()).containsExactly("com.example.Boom.run(Boom.java:1)");
+        assertThatThrownBy(() -> report.threads().clear()).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> report.deadlockedThreadIds().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> held.stackTrace().clear()).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void mapComponentsKeepInsertionOrderSoSerializationStaysStable() {
+        Map<String, String> headers = new LinkedHashMap<>();
+        headers.put("zeta", "1");
+        headers.put("alpha", "2");
+        headers.put("mid", "3");
+
+        HttpProbeRequest request = new HttpProbeRequest("GET", "/api", null, headers);
+        headers.put("added", "4");
+
+        assertThat(request.headers().keySet()).containsExactly("zeta", "alpha", "mid");
+        assertThatThrownBy(() -> request.headers().put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void defensiveCopiesPreserveRecordEqualityAndHashCode() {
+        List<String> profiles = new ArrayList<>(List.of("dev", "local"));
+        OverviewDto first = new OverviewDto(
+                "1",
+                "app",
+                "Spring Boot",
+                "4.0",
+                "17",
+                "vendor",
+                profiles,
+                List.of(),
+                "SERVLET",
+                8080,
+                null,
+                "/",
+                1L,
+                null,
+                null);
+        OverviewDto second = new OverviewDto(
+                "1",
+                "app",
+                "Spring Boot",
+                "4.0",
+                "17",
+                "vendor",
+                List.of("dev", "local"),
+                new ArrayList<>(),
+                "SERVLET",
+                8080,
+                null,
+                "/",
+                1L,
+                null,
+                null);
+
+        assertThat(first).isEqualTo(second);
+        assertThat(first).hasSameHashCodeAs(second);
+        assertThat(first.toString()).isEqualTo(second.toString());
+    }
+
+    private static void assertDefensivelyCopied(Class<?> type) throws Exception {
+        RecordComponent[] components = type.getRecordComponents();
+        Object[] arguments = new Object[components.length];
+        for (int i = 0; i < components.length; i++) {
+            arguments[i] = probeValue(components[i].getType());
+        }
+
+        Object instance = canonicalConstructor(type).newInstance(arguments);
+
+        for (int i = 0; i < components.length; i++) {
+            RecordComponent component = components[i];
+            if (!isCollection(component.getType())) {
+                continue;
+            }
+            String where = type.getSimpleName() + "." + component.getName() + "()";
+            mutate(arguments[i], MUTATION);
+            Object held = component.getAccessor().invoke(instance);
+
+            assertThat(held).as(where + " must not be null").isNotNull();
+            assertThat(sizeOf(held))
+                    .as(where + " must not observe mutation of the caller-owned collection")
+                    .isEqualTo(1);
+            assertThatThrownBy(() -> mutate(held, MUTATION))
+                    .as(where + " must reject mutation of the accessor-returned collection")
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    private static void assertNullCollectionsBecomeEmpty(Class<?> type) throws Exception {
+        RecordComponent[] components = type.getRecordComponents();
+        Object[] arguments = new Object[components.length];
+        for (int i = 0; i < components.length; i++) {
+            Class<?> componentType = components[i].getType();
+            arguments[i] = isCollection(componentType) ? null : probeValue(componentType);
+        }
+
+        Object instance = canonicalConstructor(type).newInstance(arguments);
+
+        for (RecordComponent component : components) {
+            if (!isCollection(component.getType())) {
+                continue;
+            }
+            Object held = component.getAccessor().invoke(instance);
+            assertThat(held)
+                    .as(type.getSimpleName() + "." + component.getName() + "() must normalize null to empty")
+                    .isNotNull();
+            assertThat(sizeOf(held)).isZero();
+        }
+    }
+
+    private static Constructor<?> canonicalConstructor(Class<?> type) throws NoSuchMethodException {
+        Class<?>[] parameterTypes = Stream.of(type.getRecordComponents())
+                .map(RecordComponent::getType)
+                .toArray(Class<?>[]::new);
+        Constructor<?> constructor = type.getDeclaredConstructor(parameterTypes);
+        constructor.setAccessible(true);
+        return constructor;
+    }
+
+    private static boolean hasCollectionComponent(Class<?> type) {
+        return Stream.of(type.getRecordComponents()).anyMatch(component -> isCollection(component.getType()));
+    }
+
+    private static boolean isCollection(Class<?> type) {
+        return Collection.class.isAssignableFrom(type) || Map.class.isAssignableFrom(type);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static void mutate(Object collection, String value) {
+        if (collection instanceof Map map) {
+            map.put(value, value);
+        } else {
+            ((Collection) collection).add(value);
+        }
+    }
+
+    private static int sizeOf(Object collection) {
+        return collection instanceof Map<?, ?> map ? map.size() : ((Collection<?>) collection).size();
+    }
+
+    private static Object probeValue(Class<?> type) {
+        if (Map.class.isAssignableFrom(type)) {
+            Map<Object, Object> map = new LinkedHashMap<>();
+            map.put(PROBE, PROBE);
+            return map;
+        }
+        if (Collection.class.isAssignableFrom(type)) {
+            List<Object> list = new ArrayList<>();
+            list.add(PROBE);
+            return list;
+        }
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == char.class) {
+            return ' ';
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0f;
+        }
+        return 0d;
+    }
+
+    private static List<Class<?>> dtoRecords() {
+        Path root;
+        try {
+            root = Path.of(CoreDtoImmutabilityTests.class
+                    .getProtectionDomain()
+                    .getCodeSource()
+                    .getLocation()
+                    .toURI());
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
+        Path packageRoot = root.resolveSibling("classes")
+                .resolve(DtoCollections.class.getPackageName().replace('.', '/'));
+        if (!Files.isDirectory(packageRoot)) {
+            return fail("Could not locate the compiled DTO package at " + packageRoot);
+        }
+        try (Stream<Path> files = Files.list(packageRoot)) {
+            return files.map(path -> path.getFileName().toString())
+                    .filter(fileName -> fileName.endsWith(".class") && !fileName.contains("$"))
+                    .map(fileName -> fileName.substring(0, fileName.length() - ".class".length()))
+                    .map(simpleName -> loadClass(DtoCollections.class.getPackageName() + "." + simpleName))
+                    .filter(Class::isRecord)
+                    .filter(type -> Modifier.isPublic(type.getModifiers()))
+                    .sorted(java.util.Comparator.comparing(Class::getName))
+                    .collect(java.util.stream.Collectors.toList());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Class<?> loadClass(String name) {
+        try {
+            return Class.forName(name);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/bootui-core/src/test/java/io/github/jdubois/bootui/core/dto/CoreDtoImmutabilityTests.java
+++ b/bootui-core/src/test/java/io/github/jdubois/bootui/core/dto/CoreDtoImmutabilityTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.TestFactory;
  * <p>The DTO package is discovered reflectively rather than spot-checked, so a newly added DTO that
  * forgets its defensive copy fails here instead of silently shipping a mutable "immutable" record.</p>
  */
+@SuppressWarnings("unchecked")
 class CoreDtoImmutabilityTests {
 
     private static final String PROBE = "probe";
@@ -56,7 +57,7 @@ class CoreDtoImmutabilityTests {
     @TestFactory
     Stream<DynamicTest> everyCollectionComponentIsDefensivelyCopied() {
         return dtoRecords().stream()
-                .filter(CoreDtoImmutabilityTests::hasCollectionComponent)
+                .filter(CoreDtoImmutabilityTests::hasCollectionCarryingComponent)
                 .map(type -> DynamicTest.dynamicTest(type.getSimpleName(), () -> assertDefensivelyCopied(type)));
     }
 
@@ -163,6 +164,58 @@ class CoreDtoImmutabilityTests {
         assertThat(first.toString()).isEqualTo(second.toString());
     }
 
+    @Test
+    void collectionsCarriedByLooselyTypedComponentsAreSnapshotted() {
+        List<String> attributeValue = new ArrayList<>(List.of("a", "b"));
+        SpanAttributeDto attribute = new SpanAttributeDto("http.methods", "ARRAY", attributeValue);
+
+        Map<String, Object> details = new LinkedHashMap<>();
+        List<String> nested = new ArrayList<>(List.of("db1"));
+        details.put("databases", nested);
+        HealthNodeDto node = new HealthNodeDto("db", "UP", details, List.of());
+
+        List<String> defaultValue = new ArrayList<>(List.of("INFO"));
+        ConfigPropertyDto property = new ConfigPropertyDto(
+                "logging.level", new ArrayList<>(List.of("DEBUG")), "env", null, false, false, null, defaultValue);
+
+        attributeValue.add("mutated");
+        nested.add("mutated");
+        details.put("mutated", "mutated");
+        defaultValue.add("mutated");
+
+        assertThat((List<Object>) attribute.value()).containsExactly("a", "b");
+        assertThatThrownBy(() -> ((List<Object>) attribute.value()).add("x"))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        Map<String, Object> heldDetails = (Map<String, Object>) node.details();
+        assertThat(heldDetails).containsOnlyKeys("databases");
+        assertThat((List<Object>) heldDetails.get("databases")).containsExactly("db1");
+        assertThatThrownBy(() -> ((List<Object>) heldDetails.get("databases")).add("x"))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        assertThat((List<Object>) property.defaultValue()).containsExactly("INFO");
+        assertThat((List<Object>) property.value()).containsExactly("DEBUG");
+    }
+
+    @Test
+    void arraysCarriedByLooselyTypedComponentsBecomeImmutableLists() {
+        String[] values = {"a", "b"};
+
+        SpanAttributeDto attribute = new SpanAttributeDto("http.methods", "ARRAY", values);
+        values[0] = "mutated";
+
+        assertThat((List<Object>) attribute.value()).containsExactly("a", "b");
+        assertThatThrownBy(() -> ((List<Object>) attribute.value()).add("x"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void scalarsBehindLooselyTypedComponentsArePassedThroughUnchanged() {
+        assertThat(new SpanAttributeDto("http.status", "LONG", 200L).value()).isEqualTo(200L);
+        assertThat(new SpanAttributeDto("http.route", "STRING", "/a").value()).isEqualTo("/a");
+        assertThat(new SpanAttributeDto("missing", "NULL", null).value()).isNull();
+    }
+
     private static void assertDefensivelyCopied(Class<?> type) throws Exception {
         RecordComponent[] components = type.getRecordComponents();
         Object[] arguments = new Object[components.length];
@@ -174,7 +227,7 @@ class CoreDtoImmutabilityTests {
 
         for (int i = 0; i < components.length; i++) {
             RecordComponent component = components[i];
-            if (!isCollection(component.getType())) {
+            if (!carriesCollection(component.getType())) {
                 continue;
             }
             String where = type.getSimpleName() + "." + component.getName() + "()";
@@ -226,8 +279,20 @@ class CoreDtoImmutabilityTests {
         return Stream.of(type.getRecordComponents()).anyMatch(component -> isCollection(component.getType()));
     }
 
+    private static boolean hasCollectionCarryingComponent(Class<?> type) {
+        return Stream.of(type.getRecordComponents()).anyMatch(component -> carriesCollection(component.getType()));
+    }
+
     private static boolean isCollection(Class<?> type) {
         return Collection.class.isAssignableFrom(type) || Map.class.isAssignableFrom(type);
+    }
+
+    /**
+     * A loosely typed {@code Object} component carries framework-supplied JSON payloads, so it has to
+     * snapshot a collection just like a declared collection component does.
+     */
+    private static boolean carriesCollection(Class<?> type) {
+        return isCollection(type) || type == Object.class;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -250,6 +315,11 @@ class CoreDtoImmutabilityTests {
             return map;
         }
         if (Collection.class.isAssignableFrom(type)) {
+            List<Object> list = new ArrayList<>();
+            list.add(PROBE);
+            return list;
+        }
+        if (type == Object.class) {
             List<Object> list = new ArrayList<>();
             list.add(PROBE);
             return list;

--- a/bootui-core/src/test/java/io/github/jdubois/bootui/core/dto/DtoCollectionsTests.java
+++ b/bootui-core/src/test/java/io/github/jdubois/bootui/core/dto/DtoCollectionsTests.java
@@ -1,0 +1,119 @@
+package io.github.jdubois.bootui.core.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the shared defensive-copy helper behind every core DTO collection component.
+ */
+class DtoCollectionsTests {
+
+    @Test
+    void nullListBecomesEmptyImmutableList() {
+        List<String> copy = DtoCollections.immutableCopy((List<String>) null);
+
+        assertThat(copy).isEmpty();
+        assertThatThrownBy(() -> copy.add("x")).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void nullMapBecomesEmptyImmutableMap() {
+        Map<String, String> copy = DtoCollections.immutableCopy((Map<String, String>) null);
+
+        assertThat(copy).isEmpty();
+        assertThatThrownBy(() -> copy.put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void emptyCollectionsBecomeEmptyImmutableCollections() {
+        List<String> list = DtoCollections.immutableCopy(new ArrayList<String>());
+        Map<String, String> map = DtoCollections.immutableCopy(new LinkedHashMap<String, String>());
+
+        assertThat(list).isEmpty();
+        assertThat(map).isEmpty();
+        assertThatThrownBy(() -> list.add("x")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> map.put("k", "v")).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void listCopyIsDetachedFromTheCallerList() {
+        List<String> source = new ArrayList<>(List.of("a", "b"));
+
+        List<String> copy = DtoCollections.immutableCopy(source);
+        source.add("c");
+        source.set(0, "mutated");
+
+        assertThat(copy).containsExactly("a", "b");
+    }
+
+    @Test
+    void mapCopyIsDetachedFromTheCallerMap() {
+        Map<String, Integer> source = new LinkedHashMap<>();
+        source.put("a", 1);
+
+        Map<String, Integer> copy = DtoCollections.immutableCopy(source);
+        source.put("b", 2);
+        source.put("a", 99);
+
+        assertThat(copy).containsExactly(Map.entry("a", 1));
+    }
+
+    @Test
+    void returnedCollectionsRejectMutation() {
+        List<String> list = DtoCollections.immutableCopy(new ArrayList<>(List.of("a")));
+        Map<String, String> map = DtoCollections.immutableCopy(new LinkedHashMap<>(Map.of("k", "v")));
+
+        assertThatThrownBy(() -> list.add("b")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> list.remove(0)).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> list.set(0, "b")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(list::clear).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> map.put("k2", "v2")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> map.remove("k")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(map::clear).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> map.keySet().remove("k")).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> map.values().clear()).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> map.entrySet().clear()).isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void nullElementsAreToleratedUnlikeListCopyOf() {
+        List<String> source = new ArrayList<>(Arrays.asList("a", null));
+        Map<String, String> mapSource = new LinkedHashMap<>();
+        mapSource.put("present", "value");
+        mapSource.put("absent", null);
+
+        assertThat(DtoCollections.immutableCopy(source)).containsExactly("a", null);
+        assertThat(DtoCollections.immutableCopy(mapSource))
+                .containsOnlyKeys("present", "absent")
+                .containsEntry("present", "value")
+                .containsEntry("absent", null);
+    }
+
+    @Test
+    void mapCopyKeepsCallerIterationOrderSoSerializedKeyOrderIsStable() {
+        Map<String, Integer> source = new LinkedHashMap<>();
+        source.put("zeta", 1);
+        source.put("alpha", 2);
+        source.put("mid", 3);
+
+        assertThat(DtoCollections.immutableCopy(source).keySet()).containsExactly("zeta", "alpha", "mid");
+    }
+
+    @Test
+    void copiesKeepValueSemanticsForEqualsAndHashCode() {
+        List<String> list = DtoCollections.immutableCopy(new ArrayList<>(List.of("a", "b")));
+        Map<String, Integer> map = DtoCollections.immutableCopy(new LinkedHashMap<>(Map.of("k", 1)));
+
+        assertThat(list).isEqualTo(List.of("a", "b"));
+        assertThat(list).hasSameHashCodeAs(List.of("a", "b"));
+        assertThat(map).isEqualTo(Map.of("k", 1));
+        assertThat(map).hasSameHashCodeAs(Map.of("k", 1));
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -2062,6 +2062,13 @@ Dependency direction is one-way: `bootui-engine` depends on `bootui-core`, and e
 The shared `core`, `engine`, `conformance`, and UI modules never depend on Spring or Quarkus. JSON parsing and
 serialization stay in the adapters because Spring Boot and Quarkus use incompatible Jackson major versions.
 
+Core DTO immutability is enforced, not just documented. Every collection component of a `bootui-core` record is
+defensively copied in the record's compact constructor, so a caller cannot change a published report by mutating the
+collection it passed in or the collection an accessor returned, and a `null` collection is normalized to an empty one.
+The copies preserve the caller's iteration order — in particular map components are copied into a `LinkedHashMap` rather
+than through `Map.copyOf`, whose hash order is randomized per JVM run — so the serialized JSON stays byte-identical
+across Jackson 3 and Jackson 2.
+
 The Maven build installs the configured Node.js and npm versions, builds the frontend before Java resources are
 packaged, and produces adapter artifacts that already contain the compiled UI. Consumers only add the matching Spring
 starter or Quarkus extension; they do not run a frontend build.


### PR DESCRIPTION
Fixes #855

## Problem

`bootui-core` records are documented as immutable, but most of them stored the caller's `List` or `Map` reference directly. A caller could keep the collection it passed to the constructor, or mutate the collection an accessor returned, and change a report after it had been published.

## Change

- New package-private `DtoCollections` helper in `io.github.jdubois.bootui.core.dto`.
- Every collection component of every core DTO record is now defensively copied in the record's compact constructor: **263 components across 131 records**. This includes rewriting the 26 records that already used the ad-hoc `x == null ? List.of() : List.copyOf(x)` convention, so there is now a single approach.
- `null` normalizes to an empty immutable collection, matching the convention those 26 records already used. No core DTO documents a nullable collection component, and no production call site passes `null` for one, so no emitted JSON changes.
- **Loosely typed components are covered too.** Copying only the declared `List`/`Map` components left a hole: six `Object`-typed components receive framework-supplied JSON payloads whose nested collections stayed caller-owned — `SpanAttributeDto.value` (decoded OTLP lists), `HealthNodeDto.details` (the actuator / SmallRye detail map), `ConfigPropertyDto.value` / `.defaultValue` and `ConfigPropertySuggestionDto.defaultValue` (Jackson-converted values), and the values nested inside `DevServiceDto.connectionDetails`. `DtoCollections.immutableValue` snapshots these recursively, and the list/map copies route through it so nested payloads are covered as well. A collection or array becomes an unmodifiable list, which serializes to the same JSON array; scalars pass through unchanged.

### Why not `List.copyOf` / `Map.copyOf`

- `Map.copyOf` returns a hash-ordered map whose iteration order is randomized per JVM run. The two records that already used it (`LiveActivityReport.typeCounts`, `RestClientTraceEntryDto.requestHeaders`) therefore had unstable serialized key order. A `LinkedHashMap` copy keeps the caller's order, so the bytes stay identical across Jackson 3 (Spring) and Jackson 2 (Quarkus).
- Both `copyOf` methods reject `null` elements, values, and keys. Panel data is assembled from JVM and framework sources that can legitimately yield a `null`, and a DTO constructor is the wrong place to turn that into a request failure.

The DTO package has no arrays, no `Optional`, no `Set`/`SortedMap`, and no nested generic collections such as `Map<String, List<..>>` as declared component types, and `bootui-core` has no records outside the DTO package.

## Tests

- `DtoCollectionsTests` — helper semantics: null/empty handling, detachment from the caller collection, rejection of every mutation entry point (including `keySet`/`values`/`entrySet` and iterator removal), null-element tolerance, insertion-order preservation, and `equals`/`hashCode` value semantics.
- `CoreDtoImmutabilityTests` — discovers the DTO package reflectively instead of spot-checking, and generates per-record dynamic tests asserting that mutating the caller-owned collection does not change the DTO, that the accessor-returned collection rejects mutation, and that `null` components normalize to empty. An `Object` component is treated as collection-carrying, so a future DTO that exposes a mutable payload behind `Object` fails the build too. Plus explicit nested-structure, `Object`-payload, array, scalar-passthrough, map-ordering, and record-equality tests.
- I verified the reflective test actually bites: temporarily removing the `SpanAttributeDto` snapshot fails it with `SpanAttributeDto.value() must not observe mutation of the caller-owned collection`.

`bootui-core` goes from 92 to 364 tests.

## Validation

- `./mvnw install` over the full 31-module reactor with tests: **BUILD SUCCESS**, including the Spring MVC, Spring WebFlux, and Quarkus conformance and integration suites.
- `./mvnw spotless:apply` / `spotless:check` clean.
- Audited all `new <Dto>(...)` call sites in `bootui-core`, `bootui-engine`, `bootui-spring-autoconfigure`, `bootui-quarkus`, and `bootui-quarkus-deployment`: none passes `null` at a collection position.
- Audited `bootui-ui` for code that distinguishes `null` from `[]`/`{}` on a collection field: none.
- Audited every cast of the `Object`-typed accessors across engine, adapters, and tests: all remain valid (a `Map` stays a `Map`; list equality is unaffected).

## Notes

Architecture invariants are preserved: no new dependencies, no new public API (the helper is package-private), DTOs stay annotation-free records, and `bootui-core <- bootui-engine <- adapters` is untouched. `docs/SPECIFICATION.md` §6.2 documents the guarantee.

`HttpProbeRequest.headers` receives the same defensive copy as every other core DTO map; this PR adds no probe input bounds, which are tracked separately in #860.