### PR TITLE
fix(masking): mask URI credentials and sanitize REST-client errors

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restclienttrace/RestClientTraceRecorder.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restclienttrace/RestClientTraceRecorder.java
@@ -6,7 +6,11 @@ import io.github.jdubois.bootui.core.dto.RestClientTraceEntryDto;
 import io.github.jdubois.bootui.core.dto.RestClientTraceGroupDto;
 import io.github.jdubois.bootui.core.dto.RestClientTraceReport;
 import io.github.jdubois.bootui.core.dto.RestClientTraceStatsDto;
+import io.github.jdubois.bootui.engine.support.CredentialRedaction;
+import io.github.jdubois.bootui.engine.support.DetailText;
+import io.github.jdubois.bootui.engine.support.SensitiveNames;
 import io.github.jdubois.bootui.engine.support.StackFramePrefixes;
+import io.github.jdubois.bootui.engine.support.UriMasking;
 import io.github.jdubois.bootui.spi.IdleReclaimable;
 import io.github.jdubois.bootui.spi.TraceIdProvider;
 import java.util.ArrayDeque;
@@ -40,23 +44,21 @@ import java.util.stream.Stream;
  * {@code bootui.mask-secrets} is reflected immediately, including for already-captured calls. Only
  * capturing headers at all is opt-in ({@link #isCaptureHeaders()}); request/response bodies are never
  * captured.</p>
+ *
+ * <p>Two things are sanitized before storage rather than at display time, because no exposure setting ever
+ * reveals them: URI authority user-info credentials, and the client {@code errorMessage}, which is flattened,
+ * credential-redacted, and length-bounded since a transport exception can quote a whole request URL.</p>
  */
 public final class RestClientTraceRecorder implements IdleReclaimable {
 
     static final int TOP_CALLS_LIMIT = 20;
 
     /**
-     * Header names treated as sensitive even though {@link SecretMasker#isSecret(String)} doesn't
-     * recognize them by keyword (mirrors {@code HttpExchangesService}'s allow-list for inbound
-     * exchanges).
-     */
-    private static final Set<String> SENSITIVE_HEADER_NAMES =
-            Set.of("authorization", "proxy-authorization", "cookie", "set-cookie", "x-xsrf-token", "x-csrf-token");
-
-    /**
      * A single immutable captured outbound HTTP call. Query parameter values in {@code uri} and header
      * values in {@code requestHeaders} are truncated but otherwise raw; masking is applied at display time
-     * (see the class-level docs), not when this record is created.
+     * (see the class-level docs), not when this record is created. URI user-info credentials and
+     * {@code errorMessage} are the exceptions: both are sanitized before they ever reach this record, since
+     * neither is a value the exposure policy can ever widen.
      */
     public record CapturedCall(
             long id,
@@ -99,7 +101,6 @@ public final class RestClientTraceRecorder implements IdleReclaimable {
     private final Set<String> clientTypes = new ConcurrentSkipListSet<>();
     private final CopyOnWriteArrayList<Runnable> listeners = new CopyOnWriteArrayList<>();
     private volatile TraceIdProvider traceIdProvider = RestClientTraceRecorder::mdcTraceId;
-    private final SecretMasker masker = new SecretMasker();
 
     public RestClientTraceRecorder(
             boolean enabled,
@@ -188,8 +189,9 @@ public final class RestClientTraceRecorder implements IdleReclaimable {
 
     /**
      * Records one outbound call, truncating oversized URIs/header values and evicting the oldest entry
-     * when full. Values are stored raw (unmasked); masking is applied per-name at report time so it can
-     * honor the live exposure policy (see the class-level docs).
+     * when full. Query and header values are stored raw (unmasked) so masking can honor the live exposure
+     * policy at report time (see the class-level docs); URI user-info credentials and the client error
+     * message are sanitized here instead, because no exposure setting ever reveals them.
      */
     public void record(
             String method,
@@ -278,13 +280,13 @@ public final class RestClientTraceRecorder implements IdleReclaimable {
                 sequence.incrementAndGet(),
                 System.currentTimeMillis(),
                 method,
-                truncate(uri, maxUriLength),
+                truncate(UriMasking.maskUserInfo(uri), maxUriLength),
                 host,
                 truncate(path, maxUriLength),
                 status,
                 Math.max(0, durationMillis),
                 success,
-                errorMessage,
+                sanitizeErrorMessage(errorMessage),
                 clientType,
                 captureHeaders ? truncateHeaderValues(headers) : Map.of(),
                 thread,
@@ -474,11 +476,11 @@ public final class RestClientTraceRecorder implements IdleReclaimable {
                 entry.method(),
                 displayUri(entry.uri(), maskSecrets, exposure),
                 entry.host(),
-                entry.path(),
+                UriMasking.maskPath(entry.path(), maskSecrets, exposure),
                 entry.status(),
                 entry.durationMillis(),
                 entry.success(),
-                entry.errorMessage(),
+                displayErrorMessage(entry.errorMessage(), exposure),
                 isSlow(entry.durationMillis()),
                 entry.clientType(),
                 displayHeaders(entry.requestHeaders(), maskSecrets, exposure),
@@ -488,45 +490,40 @@ public final class RestClientTraceRecorder implements IdleReclaimable {
     }
 
     /**
-     * Displays the (already length-bounded) stored URI, dropping the whole query string under {@link
-     * ValueExposure#METADATA_ONLY} and otherwise masking each query parameter value by name (mirrors
-     * {@code HttpExchangesService#displayUri}). Malformed query strings (no {@code =}) are passed through
-     * unmodified rather than dropped. The base URI and parameter names are never masked.
+     * Displays the (already user-info-redacted and length-bounded) stored URI, dropping the whole query string
+     * under {@link ValueExposure#METADATA_ONLY} and otherwise masking each query or fragment parameter value by
+     * name. Shared with the HTTP Exchanges panel through {@link UriMasking}, so inbound and outbound URIs are
+     * masked identically. Parameter names and the base URI are never masked; a value-less parameter whose name
+     * itself looks sensitive is replaced wholesale.
      */
     private String displayUri(String uri, boolean maskSecrets, ValueExposure exposure) {
-        if (uri == null) {
-            return null;
-        }
-        int queryIndex = uri.indexOf('?');
-        if (queryIndex < 0) {
-            return uri;
-        }
-        if (exposure == ValueExposure.METADATA_ONLY) {
-            return uri.substring(0, queryIndex);
-        }
-        if (queryIndex == uri.length() - 1) {
-            return uri;
-        }
-        String base = uri.substring(0, queryIndex);
-        String[] pairs = uri.substring(queryIndex + 1).split("&");
-        StringBuilder display = new StringBuilder(base).append('?');
-        for (int i = 0; i < pairs.length; i++) {
-            if (i > 0) {
-                display.append('&');
-            }
-            display.append(displayQueryPart(pairs[i], maskSecrets, exposure));
-        }
-        return display.toString();
+        return UriMasking.maskUri(uri, maskSecrets, exposure);
     }
 
-    private String displayQueryPart(String pair, boolean maskSecrets, ValueExposure exposure) {
-        int eq = pair.indexOf('=');
-        if (eq < 0) {
-            return pair;
+    /**
+     * Bounds and sanitizes a client error message before it is buffered: newlines are flattened, URL credentials
+     * and sensitive query values echoed by the exception are redacted ({@link CredentialRedaction}), and the
+     * result is truncated to {@link DetailText#DEFAULT_MAX_CHARS}. Blank messages become {@code null} so the
+     * panel and Live Activity render "no detail" rather than an empty string.
+     */
+    private static String sanitizeErrorMessage(String errorMessage) {
+        if (errorMessage == null) {
+            return null;
         }
-        String name = pair.substring(0, eq);
-        String value = displayValue(name, pair.substring(eq + 1), maskSecrets, exposure);
-        return name + '=' + value;
+        String flattened = errorMessage.replaceAll("[\\r\\n\\t]+", " ").strip();
+        if (flattened.isEmpty()) {
+            return null;
+        }
+        return truncate(CredentialRedaction.redactMessage(flattened), DetailText.DEFAULT_MAX_CHARS);
+    }
+
+    /**
+     * Applies the live exposure policy to the stored error message: {@link ValueExposure#METADATA_ONLY} hides it
+     * (the failure itself still shows through {@code success}/{@code status}), every other mode keeps the
+     * already-sanitized text so a transport failure stays diagnosable.
+     */
+    private static String displayErrorMessage(String errorMessage, ValueExposure exposure) {
+        return exposure == ValueExposure.METADATA_ONLY ? null : errorMessage;
     }
 
     /**
@@ -566,10 +563,7 @@ public final class RestClientTraceRecorder implements IdleReclaimable {
     }
 
     private boolean shouldMask(String name, boolean maskSecrets) {
-        if (name == null || name.isBlank()) {
-            return false;
-        }
-        return maskSecrets && (masker.isSecret(name) || SENSITIVE_HEADER_NAMES.contains(name.toLowerCase(Locale.ROOT)));
+        return maskSecrets && SensitiveNames.isSensitive(name);
     }
 
     /** Bounds each stored header value's length without masking; masking happens at display time. */

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/CredentialRedaction.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/CredentialRedaction.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.support;
 
 import io.github.jdubois.bootui.core.SecretMasker;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -22,6 +23,8 @@ public final class CredentialRedaction {
             Pattern.compile("([a-z][a-z0-9+.-]*://)([^:/@\\s]+):([^@\\s]+)@", Pattern.CASE_INSENSITIVE);
     private static final Pattern URL_CREDENTIAL_PARAMS =
             Pattern.compile("([?&;](?:user|username|password|passwd|pwd)=)([^&;\\s]*)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern URL_USER_INFO = Pattern.compile("(//)[^/?#\\s]*@");
+    private static final Pattern QUERY_PARAM = Pattern.compile("[?&;#]([^?&;#=\\s]{1,128})=([^&;#\\s]*)");
 
     private CredentialRedaction() {}
 
@@ -32,5 +35,37 @@ public final class CredentialRedaction {
         }
         String redacted = URL_CREDENTIALS.matcher(value).replaceAll("$1" + SecretMasker.MASKED_VALUE + "@");
         return URL_CREDENTIAL_PARAMS.matcher(redacted).replaceAll("$1" + SecretMasker.MASKED_VALUE);
+    }
+
+    /**
+     * {@link #redact(String)} widened for free-form text that may quote a whole request URL — most importantly an
+     * HTTP client exception message. On top of the connection-string patterns it removes <em>any</em> authority
+     * user-info (including a percent-encoded {@code user%3Apass@host} or a scheme-relative {@code //user:pass@host}
+     * that {@link #redact(String)} does not recognize) and masks the value of every embedded query, matrix, or
+     * fragment parameter whose name looks sensitive per {@link SensitiveNames}. An echoed
+     * {@code ?access_token=...} therefore leaks no more than the same parameter would in the panel's URI column.
+     *
+     * <p>Like {@link #redact(String)} this is unconditional: an exception message is not a value the developer
+     * asked to see, so it is never widened by {@code bootui.expose-values}.</p>
+     */
+    public static String redactMessage(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        String redacted = URL_USER_INFO
+                .matcher(redact(value))
+                .replaceAll("$1" + Matcher.quoteReplacement(SecretMasker.MASKED_VALUE) + "@");
+        Matcher matcher = QUERY_PARAM.matcher(redacted);
+        StringBuilder result = new StringBuilder(redacted.length());
+        int copiedTo = 0;
+        while (matcher.find()) {
+            if (!SensitiveNames.isSensitive(matcher.group(1))) {
+                continue;
+            }
+            int valueStart = matcher.start(2);
+            result.append(redacted, copiedTo, valueStart).append(SecretMasker.MASKED_VALUE);
+            copiedTo = matcher.end(2);
+        }
+        return result.append(redacted, copiedTo, redacted.length()).toString();
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/CredentialRedaction.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/CredentialRedaction.java
@@ -24,7 +24,13 @@ public final class CredentialRedaction {
     private static final Pattern URL_CREDENTIAL_PARAMS =
             Pattern.compile("([?&;](?:user|username|password|passwd|pwd)=)([^&;\\s]*)", Pattern.CASE_INSENSITIVE);
     private static final Pattern URL_USER_INFO = Pattern.compile("(//)[^/?#\\s]*@");
-    private static final Pattern QUERY_PARAM = Pattern.compile("[?&;#]([^?&;#=\\s]{1,128})=([^&;#\\s]*)");
+    private static final Pattern QUERY_PARAM = Pattern.compile("[?&;#]([^?&;#=\\s]+)=([^&;#\\s]*)");
+
+    /**
+     * How many layers of nested (percent-encoded) URL a value is inspected through before giving up. Three is far
+     * past anything a real redirect chain carries, and bounds the work done per captured error message.
+     */
+    private static final int MAX_NESTED_URL_DEPTH = 3;
 
     private CredentialRedaction() {}
 
@@ -42,13 +48,27 @@ public final class CredentialRedaction {
      * HTTP client exception message. On top of the connection-string patterns it removes <em>any</em> authority
      * user-info (including a percent-encoded {@code user%3Apass@host} or a scheme-relative {@code //user:pass@host}
      * that {@link #redact(String)} does not recognize) and masks the value of every embedded query, matrix, or
-     * fragment parameter whose name looks sensitive per {@link SensitiveNames}. An echoed
+     * fragment parameter that either has a sensitive name ({@link SensitiveNames}) or itself
+     * {@linkplain #carriesCredentials(String) carries a nested credential-bearing URL}. An echoed
      * {@code ?access_token=...} therefore leaks no more than the same parameter would in the panel's URI column.
      *
      * <p>Like {@link #redact(String)} this is unconditional: an exception message is not a value the developer
      * asked to see, so it is never widened by {@code bootui.expose-values}.</p>
      */
     public static String redactMessage(String value) {
+        return redactMessage(value, MAX_NESTED_URL_DEPTH);
+    }
+
+    /**
+     * True when a value embeds a URL that itself carries credentials — a nested {@code user:secret@host} or a
+     * nested sensitive parameter — as a percent-encoded {@code redirect=} target commonly does. Inspected both as
+     * captured and percent-decoded, through at most {@link #MAX_NESTED_URL_DEPTH} layers of encoding.
+     */
+    public static boolean carriesCredentials(String value) {
+        return carriesCredentials(value, MAX_NESTED_URL_DEPTH);
+    }
+
+    private static String redactMessage(String value, int depth) {
         if (value == null || value.isEmpty()) {
             return value;
         }
@@ -59,7 +79,7 @@ public final class CredentialRedaction {
         StringBuilder result = new StringBuilder(redacted.length());
         int copiedTo = 0;
         while (matcher.find()) {
-            if (!SensitiveNames.isSensitive(matcher.group(1))) {
+            if (!SensitiveNames.isSensitive(matcher.group(1)) && !carriesCredentials(matcher.group(2), depth - 1)) {
                 continue;
             }
             int valueStart = matcher.start(2);
@@ -67,5 +87,16 @@ public final class CredentialRedaction {
             copiedTo = matcher.end(2);
         }
         return result.append(redacted, copiedTo, redacted.length()).toString();
+    }
+
+    private static boolean carriesCredentials(String value, int depth) {
+        if (value == null || value.isEmpty() || depth <= 0) {
+            return false;
+        }
+        if (!redactMessage(value, depth - 1).equals(value)) {
+            return true;
+        }
+        String decoded = SensitiveNames.decodeQueryComponent(value);
+        return !decoded.equals(value) && !redactMessage(decoded, depth - 1).equals(decoded);
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/SensitiveNames.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/SensitiveNames.java
@@ -1,7 +1,7 @@
 package io.github.jdubois.bootui.engine.support;
 
 import io.github.jdubois.bootui.core.SecretMasker;
-import java.net.URLDecoder;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Set;
@@ -51,8 +51,9 @@ public final class SensitiveNames {
 
     /**
      * Percent-decodes a query-string component, treating {@code +} as an encoded space the way an
-     * {@code application/x-www-form-urlencoded} reader does. Malformed escapes are returned unchanged rather
-     * than raising, so masking never fails on hand-written input.
+     * {@code application/x-www-form-urlencoded} reader does. Decoding is lenient and per-escape: a malformed
+     * sequence such as {@code %ZZ} is preserved literally while the valid escapes around it are still decoded, so
+     * an encoded sensitive name cannot hide behind one bad escape. Never raises.
      */
     public static String decodeQueryComponent(String value) {
         return decode(value, true);
@@ -70,15 +71,47 @@ public final class SensitiveNames {
         if (value == null || value.isEmpty()) {
             return value;
         }
-        boolean encoded = value.indexOf('%') >= 0 || (formEncoded && value.indexOf('+') >= 0);
-        if (!encoded) {
+        if (value.indexOf('%') < 0 && !(formEncoded && value.indexOf('+') >= 0)) {
             return value;
         }
-        try {
-            String input = formEncoded ? value : value.replace("+", "%2B");
-            return URLDecoder.decode(input, StandardCharsets.UTF_8);
-        } catch (RuntimeException malformedEncoding) {
-            return value;
+        StringBuilder decoded = new StringBuilder(value.length());
+        ByteArrayOutputStream pending = new ByteArrayOutputStream();
+        int index = 0;
+        while (index < value.length()) {
+            char current = value.charAt(index);
+            int escaped = current == '%' ? decodeEscape(value, index) : -1;
+            if (escaped >= 0) {
+                pending.write(escaped);
+                index += 3;
+                continue;
+            }
+            flush(pending, decoded);
+            decoded.append(formEncoded && current == '+' ? ' ' : current);
+            index++;
         }
+        flush(pending, decoded);
+        return decoded.toString();
+    }
+
+    /** The byte encoded by the {@code %XX} escape at {@code index}, or {@code -1} when it is malformed. */
+    private static int decodeEscape(String value, int index) {
+        if (index + 2 >= value.length()) {
+            return -1;
+        }
+        int high = Character.digit(value.charAt(index + 1), 16);
+        int low = Character.digit(value.charAt(index + 2), 16);
+        return high < 0 || low < 0 ? -1 : (high << 4) + low;
+    }
+
+    /**
+     * Appends the buffered escape bytes as UTF-8. Invalid byte sequences become the replacement character rather
+     * than raising, because masking must never fail on hand-written or corrupted input.
+     */
+    private static void flush(ByteArrayOutputStream pending, StringBuilder decoded) {
+        if (pending.size() == 0) {
+            return;
+        }
+        decoded.append(pending.toString(StandardCharsets.UTF_8));
+        pending.reset();
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/SensitiveNames.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/SensitiveNames.java
@@ -1,0 +1,84 @@
+package io.github.jdubois.bootui.engine.support;
+
+import io.github.jdubois.bootui.core.SecretMasker;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Single decision point for "does this header, query-parameter, or attribute name look sensitive?".
+ *
+ * <p>Every telemetry surface that masks a value <em>by name</em> — inbound HTTP exchanges, outbound REST-client
+ * calls, and the Quarkus capture filter — used to carry its own copy of the {@link SecretMasker} keyword check
+ * plus the same hardcoded header allow-list. Keeping one copy here is what makes masking indistinguishable
+ * across Spring MVC, Spring WebFlux, and Quarkus.</p>
+ *
+ * <p>Names are matched both as captured and percent-decoded, so a URL-encoded parameter such as
+ * {@code %61pi%2Dkey} cannot evade the keyword check that plain {@code api-key} triggers.</p>
+ */
+public final class SensitiveNames {
+
+    /**
+     * Names treated as sensitive even though {@link SecretMasker#isSecret(String)} does not recognize them by
+     * keyword.
+     */
+    private static final Set<String> SENSITIVE_HEADER_NAMES =
+            Set.of("authorization", "proxy-authorization", "cookie", "set-cookie", "x-xsrf-token", "x-csrf-token");
+
+    private static final SecretMasker MASKER = new SecretMasker();
+
+    private SensitiveNames() {}
+
+    /**
+     * Returns true when {@code name} looks sensitive either as captured or once percent-decoded. A {@code null}
+     * or blank name is never sensitive.
+     */
+    public static boolean isSensitive(String name) {
+        if (name == null || name.isBlank()) {
+            return false;
+        }
+        if (matches(name)) {
+            return true;
+        }
+        String decoded = decodeQueryComponent(name);
+        return !decoded.equals(name) && matches(decoded);
+    }
+
+    private static boolean matches(String name) {
+        return MASKER.isSecret(name) || SENSITIVE_HEADER_NAMES.contains(name.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Percent-decodes a query-string component, treating {@code +} as an encoded space the way an
+     * {@code application/x-www-form-urlencoded} reader does. Malformed escapes are returned unchanged rather
+     * than raising, so masking never fails on hand-written input.
+     */
+    public static String decodeQueryComponent(String value) {
+        return decode(value, true);
+    }
+
+    /**
+     * Percent-decodes a path component. Unlike {@link #decodeQueryComponent(String)} a literal {@code +} stays a
+     * {@code +}, because it carries no special meaning in a path.
+     */
+    public static String decodePathComponent(String value) {
+        return decode(value, false);
+    }
+
+    private static String decode(String value, boolean formEncoded) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        boolean encoded = value.indexOf('%') >= 0 || (formEncoded && value.indexOf('+') >= 0);
+        if (!encoded) {
+            return value;
+        }
+        try {
+            String input = formEncoded ? value : value.replace("+", "%2B");
+            return URLDecoder.decode(input, StandardCharsets.UTF_8);
+        } catch (RuntimeException malformedEncoding) {
+            return value;
+        }
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/UriMasking.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/UriMasking.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.engine.support;
 
 import io.github.jdubois.bootui.core.SecretMasker;
 import io.github.jdubois.bootui.core.ValueExposure;
+import java.util.function.UnaryOperator;
 
 /**
  * Shared display-time masking for a captured request URI, used identically by the HTTP Exchanges panel
@@ -79,19 +80,60 @@ public final class UriMasking {
         if (exposure == ValueExposure.METADATA_ONLY) {
             return null;
         }
-        return maskParameterList(rawQuery, maskSecrets && exposure != ValueExposure.FULL);
+        return maskParameterList(rawQuery, masksByPolicy(maskSecrets, exposure));
     }
 
     /**
      * Masks {@code ;name=value} matrix parameters carried by a URI path per the live exposure policy. Path
      * segments themselves are preserved, since a path is the request's identity rather than one of its values —
-     * including under {@link ValueExposure#METADATA_ONLY}, where the sensitive matrix values are still masked.
+     * including under {@link ValueExposure#METADATA_ONLY}, which drops query and fragment values outright and so
+     * masks matrix values regardless of {@code maskSecrets}.
      */
     public static String maskPath(String path, boolean maskSecrets, ValueExposure exposure) {
         if (path == null || path.indexOf(';') < 0) {
             return path;
         }
-        return maskMatrixParameters(path, maskSecrets && exposure != ValueExposure.FULL);
+        return maskMatrixParameters(path, masksByPolicy(maskSecrets, exposure));
+    }
+
+    /**
+     * Applies {@code parameterMasker} to each {@code &}/{@code ;}-separated parameter of {@code parameters},
+     * preserving the original separators. Exposed so an adapter that sanitizes before storage — the Quarkus REST
+     * Client filter, which applies a stricter value-aware rule — splits parameters exactly the way display-time
+     * masking does instead of keeping its own splitter.
+     */
+    public static String maskParameters(String parameters, UnaryOperator<String> parameterMasker) {
+        if (parameters == null || parameters.isEmpty()) {
+            return parameters;
+        }
+        StringBuilder masked = new StringBuilder(parameters.length());
+        int start = 0;
+        for (int i = 0; i <= parameters.length(); i++) {
+            if (i < parameters.length() && parameters.charAt(i) != '&' && parameters.charAt(i) != ';') {
+                continue;
+            }
+            masked.append(parameterMasker.apply(parameters.substring(start, i)));
+            if (i < parameters.length()) {
+                masked.append(parameters.charAt(i));
+            }
+            start = i + 1;
+        }
+        return masked.toString();
+    }
+
+    /**
+     * Applies {@code parameterMasker} to the {@code ;name=value} matrix parameters of every segment of
+     * {@code path}, leaving each segment's own name untouched.
+     */
+    public static String maskPathMatrixParameters(String path, UnaryOperator<String> parameterMasker) {
+        if (path == null || path.indexOf(';') < 0) {
+            return path;
+        }
+        String[] segments = path.split("/", -1);
+        for (int i = 0; i < segments.length; i++) {
+            segments[i] = maskSegmentMatrixParameters(segments[i], parameterMasker);
+        }
+        return String.join("/", segments);
     }
 
     /**
@@ -103,7 +145,7 @@ public final class UriMasking {
         if (uri == null) {
             return null;
         }
-        boolean policyMasking = maskSecrets && exposure != ValueExposure.FULL;
+        boolean policyMasking = masksByPolicy(maskSecrets, exposure);
         int fragmentIndex = uri.indexOf('#');
         String beforeFragment = fragmentIndex < 0 ? uri : uri.substring(0, fragmentIndex);
         String fragment = fragmentIndex < 0 ? null : uri.substring(fragmentIndex + 1);
@@ -126,6 +168,18 @@ public final class UriMasking {
         return display.toString();
     }
 
+    /**
+     * Whether the live policy masks secret-named values right now. {@link ValueExposure#METADATA_ONLY} always
+     * does — it hides values wholesale — while {@link ValueExposure#FULL} never does and
+     * {@link ValueExposure#MASKED} defers to {@code bootui.mask-secrets}.
+     */
+    private static boolean masksByPolicy(boolean maskSecrets, ValueExposure exposure) {
+        if (exposure == ValueExposure.METADATA_ONLY) {
+            return true;
+        }
+        return maskSecrets && exposure != ValueExposure.FULL;
+    }
+
     /** Index at which the path begins, i.e. just past the {@code //authority} component when there is one. */
     private static int pathStart(String base) {
         int separator = base.indexOf("//");
@@ -140,31 +194,26 @@ public final class UriMasking {
     }
 
     private static String maskMatrixParameters(String path, boolean policyMasking) {
-        if (path.indexOf(';') < 0) {
-            return path;
+        return maskPathMatrixParameters(path, parameter -> maskParameter(parameter, policyMasking));
+    }
+
+    /**
+     * Masks one path segment's matrix parameters. The segment name before the first {@code ;} is left alone: a
+     * path segment is part of the request's identity, so a route such as {@code /api/token/refresh} must stay
+     * readable even though {@code token} is a sensitive <em>parameter</em> name.
+     */
+    private static String maskSegmentMatrixParameters(String segment, UnaryOperator<String> parameterMasker) {
+        int firstSemicolon = segment.indexOf(';');
+        if (firstSemicolon < 0) {
+            return segment;
         }
-        String[] segments = path.split("/", -1);
-        for (int i = 0; i < segments.length; i++) {
-            segments[i] = maskParameterList(segments[i], policyMasking);
-        }
-        return String.join("/", segments);
+        return segment.substring(0, firstSemicolon + 1)
+                + maskParameters(segment.substring(firstSemicolon + 1), parameterMasker);
     }
 
     /** Masks each {@code &}/{@code ;}-separated {@code name=value} parameter, preserving the separators used. */
     private static String maskParameterList(String parameters, boolean policyMasking) {
-        StringBuilder masked = new StringBuilder(parameters.length());
-        int start = 0;
-        for (int i = 0; i <= parameters.length(); i++) {
-            if (i < parameters.length() && parameters.charAt(i) != '&' && parameters.charAt(i) != ';') {
-                continue;
-            }
-            masked.append(maskParameter(parameters.substring(start, i), policyMasking));
-            if (i < parameters.length()) {
-                masked.append(parameters.charAt(i));
-            }
-            start = i + 1;
-        }
-        return masked.toString();
+        return maskParameters(parameters, parameter -> maskParameter(parameter, policyMasking));
     }
 
     private static String maskParameter(String parameter, boolean policyMasking) {
@@ -175,27 +224,9 @@ public final class UriMasking {
         }
         String value = parameter.substring(equalsIndex + 1);
         boolean sensitiveByName = policyMasking && SensitiveNames.isSensitive(name);
-        if (sensitiveByName || carriesCredentials(value)) {
+        if (sensitiveByName || CredentialRedaction.carriesCredentials(value)) {
             return name + '=' + SecretMasker.MASKED_VALUE;
         }
         return parameter;
-    }
-
-    /**
-     * True when a parameter value embeds a URL that itself carries credentials — a nested {@code user:secret@host}
-     * or a sensitive nested parameter — as it commonly does in a percent-encoded {@code redirect=} target. Checked
-     * both as captured and percent-decoded, and masked on the same unconditional footing as authority user-info,
-     * because a nested credential is never the value the developer meant to inspect.
-     */
-    private static boolean carriesCredentials(String value) {
-        if (value.isEmpty()) {
-            return false;
-        }
-        if (!CredentialRedaction.redactMessage(value).equals(value)) {
-            return true;
-        }
-        String decoded = SensitiveNames.decodeQueryComponent(value);
-        return !decoded.equals(value)
-                && !CredentialRedaction.redactMessage(decoded).equals(decoded);
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/UriMasking.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/UriMasking.java
@@ -1,0 +1,201 @@
+package io.github.jdubois.bootui.engine.support;
+
+import io.github.jdubois.bootui.core.SecretMasker;
+import io.github.jdubois.bootui.core.ValueExposure;
+
+/**
+ * Shared display-time masking for a captured request URI, used identically by the HTTP Exchanges panel
+ * (inbound) and the REST Client panel (outbound) so the two never drift.
+ *
+ * <p>Two different rules apply, deliberately:</p>
+ *
+ * <ul>
+ *   <li><strong>Authority user-info is removed unconditionally.</strong> A {@code user:secret@host} credential is
+ *       never a value the developer asked BootUI to display, so — like {@link CredentialRedaction} — it is
+ *       stripped regardless of {@code bootui.mask-secrets} and even under {@link ValueExposure#FULL}. Host and
+ *       port survive, because they are the useful part. A parameter value that itself carries a nested URL with
+ *       credentials (commonly a percent-encoded {@code redirect=} target) is masked on the same unconditional
+ *       footing.</li>
+ *   <li><strong>Query, matrix, and fragment parameters follow the live exposure policy.</strong> Values whose name
+ *       looks sensitive ({@link SensitiveNames}) are masked under {@link ValueExposure#MASKED}, every query and
+ *       fragment value is dropped under {@link ValueExposure#METADATA_ONLY}, and nothing is masked under
+ *       {@link ValueExposure#FULL}. Parameter names are always preserved, so the shape of the request stays
+ *       diagnosable. Both {@code &} and the legacy {@code ;} separate parameters, and {@code ;name=value} matrix
+ *       parameters inside path segments are masked the same way.</li>
+ * </ul>
+ *
+ * <p>Everything works on the raw (still percent-encoded) URI text: captured URIs may be truncated, relative, or
+ * malformed, and re-parsing them is not a precondition for masking them safely. Percent-decoding is used only to
+ * decide whether something is sensitive, never to produce the displayed value.</p>
+ */
+public final class UriMasking {
+
+    private UriMasking() {}
+
+    /**
+     * Removes the authority user-info from a raw URI or URI prefix, replacing {@code user:secret@} with
+     * {@link SecretMasker#MASKED_VALUE}{@code @} and leaving host, port, path, query, and fragment untouched.
+     * Returns the input unchanged when it has no authority component or no user-info.
+     */
+    public static String maskUserInfo(String uri) {
+        if (uri == null || uri.isEmpty()) {
+            return uri;
+        }
+        int separator = uri.indexOf("//");
+        if (separator < 0 || (separator > 0 && uri.charAt(separator - 1) != ':')) {
+            return uri;
+        }
+        int authorityStart = separator + 2;
+        int authorityEnd = uri.length();
+        for (int i = authorityStart; i < uri.length(); i++) {
+            char c = uri.charAt(i);
+            if (c == '/' || c == '?' || c == '#') {
+                authorityEnd = i;
+                break;
+            }
+        }
+        String authority = uri.substring(authorityStart, authorityEnd);
+        int userInfoEnd = authority.lastIndexOf('@');
+        if (userInfoEnd < 0) {
+            return uri;
+        }
+        return uri.substring(0, authorityStart)
+                + SecretMasker.MASKED_VALUE
+                + '@'
+                + authority.substring(userInfoEnd + 1)
+                + uri.substring(authorityEnd);
+    }
+
+    /**
+     * Masks a raw query string (or a query-shaped fragment) per the live exposure policy. Returns {@code null}
+     * under {@link ValueExposure#METADATA_ONLY} so callers can drop the component entirely, and {@code null} for
+     * a {@code null} input. Parameters are separated by {@code &} or the legacy {@code ;}; the original separators
+     * are preserved.
+     */
+    public static String maskQueryString(String rawQuery, boolean maskSecrets, ValueExposure exposure) {
+        if (rawQuery == null) {
+            return null;
+        }
+        if (exposure == ValueExposure.METADATA_ONLY) {
+            return null;
+        }
+        return maskParameterList(rawQuery, maskSecrets && exposure != ValueExposure.FULL);
+    }
+
+    /**
+     * Masks {@code ;name=value} matrix parameters carried by a URI path per the live exposure policy. Path
+     * segments themselves are preserved, since a path is the request's identity rather than one of its values —
+     * including under {@link ValueExposure#METADATA_ONLY}, where the sensitive matrix values are still masked.
+     */
+    public static String maskPath(String path, boolean maskSecrets, ValueExposure exposure) {
+        if (path == null || path.indexOf(';') < 0) {
+            return path;
+        }
+        return maskMatrixParameters(path, maskSecrets && exposure != ValueExposure.FULL);
+    }
+
+    /**
+     * Masks a whole raw URI: user-info unconditionally, query, matrix, and fragment parameters per the live
+     * exposure policy. A value-less parameter whose name itself looks sensitive (for example a bare
+     * {@code ?api_key}) is replaced wholesale, since there is no name/value split to preserve.
+     */
+    public static String maskUri(String uri, boolean maskSecrets, ValueExposure exposure) {
+        if (uri == null) {
+            return null;
+        }
+        boolean policyMasking = maskSecrets && exposure != ValueExposure.FULL;
+        int fragmentIndex = uri.indexOf('#');
+        String beforeFragment = fragmentIndex < 0 ? uri : uri.substring(0, fragmentIndex);
+        String fragment = fragmentIndex < 0 ? null : uri.substring(fragmentIndex + 1);
+        int queryIndex = beforeFragment.indexOf('?');
+        String base = queryIndex < 0 ? beforeFragment : beforeFragment.substring(0, queryIndex);
+        String rawQuery = queryIndex < 0 ? null : beforeFragment.substring(queryIndex + 1);
+
+        String maskedBase = maskUserInfo(base);
+        int pathStart = pathStart(maskedBase);
+        StringBuilder display = new StringBuilder(maskedBase.substring(0, pathStart))
+                .append(maskMatrixParameters(maskedBase.substring(pathStart), policyMasking));
+        String maskedQuery = maskQueryString(rawQuery, maskSecrets, exposure);
+        if (maskedQuery != null) {
+            display.append('?').append(maskedQuery);
+        }
+        String maskedFragment = maskQueryString(fragment, maskSecrets, exposure);
+        if (maskedFragment != null) {
+            display.append('#').append(maskedFragment);
+        }
+        return display.toString();
+    }
+
+    /** Index at which the path begins, i.e. just past the {@code //authority} component when there is one. */
+    private static int pathStart(String base) {
+        int separator = base.indexOf("//");
+        if (separator < 0 || (separator > 0 && base.charAt(separator - 1) != ':')) {
+            return 0;
+        }
+        int index = separator + 2;
+        while (index < base.length() && base.charAt(index) != '/') {
+            index++;
+        }
+        return index;
+    }
+
+    private static String maskMatrixParameters(String path, boolean policyMasking) {
+        if (path.indexOf(';') < 0) {
+            return path;
+        }
+        String[] segments = path.split("/", -1);
+        for (int i = 0; i < segments.length; i++) {
+            segments[i] = maskParameterList(segments[i], policyMasking);
+        }
+        return String.join("/", segments);
+    }
+
+    /** Masks each {@code &}/{@code ;}-separated {@code name=value} parameter, preserving the separators used. */
+    private static String maskParameterList(String parameters, boolean policyMasking) {
+        StringBuilder masked = new StringBuilder(parameters.length());
+        int start = 0;
+        for (int i = 0; i <= parameters.length(); i++) {
+            if (i < parameters.length() && parameters.charAt(i) != '&' && parameters.charAt(i) != ';') {
+                continue;
+            }
+            masked.append(maskParameter(parameters.substring(start, i), policyMasking));
+            if (i < parameters.length()) {
+                masked.append(parameters.charAt(i));
+            }
+            start = i + 1;
+        }
+        return masked.toString();
+    }
+
+    private static String maskParameter(String parameter, boolean policyMasking) {
+        int equalsIndex = parameter.indexOf('=');
+        String name = equalsIndex >= 0 ? parameter.substring(0, equalsIndex) : parameter;
+        if (equalsIndex < 0) {
+            return policyMasking && SensitiveNames.isSensitive(name) ? SecretMasker.MASKED_VALUE : parameter;
+        }
+        String value = parameter.substring(equalsIndex + 1);
+        boolean sensitiveByName = policyMasking && SensitiveNames.isSensitive(name);
+        if (sensitiveByName || carriesCredentials(value)) {
+            return name + '=' + SecretMasker.MASKED_VALUE;
+        }
+        return parameter;
+    }
+
+    /**
+     * True when a parameter value embeds a URL that itself carries credentials — a nested {@code user:secret@host}
+     * or a sensitive nested parameter — as it commonly does in a percent-encoded {@code redirect=} target. Checked
+     * both as captured and percent-decoded, and masked on the same unconditional footing as authority user-info,
+     * because a nested credential is never the value the developer meant to inspect.
+     */
+    private static boolean carriesCredentials(String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        if (!CredentialRedaction.redactMessage(value).equals(value)) {
+            return true;
+        }
+        String decoded = SensitiveNames.decodeQueryComponent(value);
+        return !decoded.equals(value)
+                && !CredentialRedaction.redactMessage(decoded).equals(decoded);
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpExchangesService.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/web/HttpExchangesService.java
@@ -6,6 +6,8 @@ import io.github.jdubois.bootui.core.dto.HttpExchangeDto;
 import io.github.jdubois.bootui.core.dto.HttpExchangesReport;
 import io.github.jdubois.bootui.core.dto.HttpHeaderDto;
 import io.github.jdubois.bootui.engine.support.PagedList;
+import io.github.jdubois.bootui.engine.support.SensitiveNames;
+import io.github.jdubois.bootui.engine.support.UriMasking;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -14,7 +16,6 @@ import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Framework-neutral assembly, masking, trace-id extraction, self-exclusion and paging for the HTTP
@@ -23,11 +24,6 @@ import java.util.Set;
  * Boot and Quarkus because every transformation lives here. Pure functions over core DTOs and the JDK.
  */
 public final class HttpExchangesService {
-
-    private static final Set<String> SENSITIVE_HEADER_NAMES =
-            Set.of("authorization", "proxy-authorization", "cookie", "set-cookie", "x-xsrf-token", "x-csrf-token");
-
-    private final SecretMasker masker = new SecretMasker();
 
     /**
      * Builds the report from already-captured exchanges. The {@code selfFilter} hides BootUI's own
@@ -75,7 +71,7 @@ public final class HttpExchangesService {
         java.net.URI requestUri = exchange.uri();
         String method = exchange.method();
         String uri = requestUri == null ? null : displayUri(requestUri, maskSecrets, exposure);
-        String path = requestUri == null ? null : requestUri.getPath();
+        String path = requestUri == null ? null : UriMasking.maskPath(requestUri.getPath(), maskSecrets, exposure);
         String query = requestUri == null ? null : displayQuery(requestUri.getRawQuery(), maskSecrets, exposure);
         int status = exchange.status();
         Long durationMs = exchange.durationMs();
@@ -158,58 +154,19 @@ public final class HttpExchangesService {
     }
 
     private boolean shouldMask(String name, boolean maskSecrets) {
-        if (name == null) {
-            return false;
-        }
-        return maskSecrets && (masker.isSecret(name) || SENSITIVE_HEADER_NAMES.contains(name.toLowerCase(Locale.ROOT)));
+        return maskSecrets && SensitiveNames.isSensitive(name);
     }
 
+    /**
+     * Renders the request URI for display: the authority's user-info credentials are removed unconditionally,
+     * and query/fragment parameter values follow the live exposure policy (see {@link UriMasking}).
+     */
     private String displayUri(java.net.URI uri, boolean maskSecrets, ValueExposure exposure) {
-        String rawQuery = uri.getRawQuery();
-        if (rawQuery == null) {
-            return uri.toString();
-        }
-        StringBuilder builder = new StringBuilder();
-        if (uri.getScheme() != null) {
-            builder.append(uri.getScheme()).append(':');
-        }
-        if (uri.getRawAuthority() != null) {
-            builder.append("//").append(uri.getRawAuthority());
-        }
-        if (uri.getRawPath() != null) {
-            builder.append(uri.getRawPath());
-        }
-        String displayQuery = displayQuery(rawQuery, maskSecrets, exposure);
-        if (displayQuery != null) {
-            builder.append('?').append(displayQuery);
-        }
-        if (uri.getRawFragment() != null) {
-            builder.append('#').append(uri.getRawFragment());
-        }
-        return builder.toString();
+        return UriMasking.maskUri(uri.toString(), maskSecrets, exposure);
     }
 
     private String displayQuery(String rawQuery, boolean maskSecrets, ValueExposure exposure) {
-        if (rawQuery == null) {
-            return null;
-        }
-        if (exposure == ValueExposure.METADATA_ONLY) {
-            return null;
-        }
-        String[] parts = rawQuery.split("&", -1);
-        for (int i = 0; i < parts.length; i++) {
-            parts[i] = displayQueryPart(parts[i], maskSecrets, exposure);
-        }
-        return String.join("&", parts);
-    }
-
-    private String displayQueryPart(String part, boolean maskSecrets, ValueExposure exposure) {
-        int equalsIndex = part.indexOf('=');
-        String name = equalsIndex >= 0 ? part.substring(0, equalsIndex) : part;
-        if (!shouldMask(name, maskSecrets) || exposure == ValueExposure.FULL) {
-            return part;
-        }
-        return equalsIndex >= 0 ? name + "=" + SecretMasker.MASKED_VALUE : SecretMasker.MASKED_VALUE;
+        return UriMasking.maskQueryString(rawQuery, maskSecrets, exposure);
     }
 
     private Long responseSizeBytes(List<HttpHeaderDto> responseHeaders) {

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restclienttrace/RestClientTraceRecorderTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restclienttrace/RestClientTraceRecorderTests.java
@@ -10,6 +10,7 @@ import io.github.jdubois.bootui.core.dto.RestClientTraceEntryDto;
 import io.github.jdubois.bootui.core.dto.RestClientTraceGroupDto;
 import io.github.jdubois.bootui.core.dto.RestClientTraceReport;
 import io.github.jdubois.bootui.core.dto.RestClientTraceStatsDto;
+import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -540,5 +541,119 @@ class RestClientTraceRecorderTests {
         RestClientTraceReport report = recorder.report(true, ValueExposure.MASKED);
         assertThat(report.warnings()).anyMatch(w -> w.contains("paused"));
         assertThat(report.warnings()).anyMatch(w -> w.contains("headers are captured"));
+    }
+
+    private RestClientTraceRecorder recordCall(String uri, String errorMessage) {
+        RestClientTraceRecorder recorder = recorder(true, 10, 100);
+        recorder.record(
+                "GET",
+                uri,
+                "api.example.com",
+                "/orders",
+                errorMessage == null ? 200 : null,
+                1,
+                errorMessage == null,
+                errorMessage,
+                "RestClient",
+                Map.of(),
+                "main");
+        return recorder;
+    }
+
+    @Test
+    void removesUriUserInfoCredentialsBeforeTheyAreBuffered() {
+        RestClientTraceRecorder recorder = recordCall("https://alice:s3cr3t@api.example.com/orders", null);
+        assertThat(recorder.recent().get(0).uri())
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com/orders");
+    }
+
+    @Test
+    void removesUriUserInfoCredentialsEvenUnderFullExposure() {
+        RestClientTraceRecorder recorder =
+                recordCall("https://alice:s3cr3t@api.example.com/orders?apiKey=verysecretvalue", null);
+        RestClientTraceEntryDto entry =
+                recorder.report(true, ValueExposure.FULL).entries().get(0);
+        assertThat(entry.uri())
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com/orders?apiKey=verysecretvalue");
+        assertThat(entry.uri()).doesNotContain("s3cr3t");
+    }
+
+    @Test
+    void masksPercentEncodedSensitiveQueryNames() {
+        RestClientTraceRecorder recorder = recordCall("https://api.example.com/orders?%70assword=hunter2&page=2", null);
+        RestClientTraceEntryDto entry =
+                recorder.report(true, ValueExposure.MASKED).entries().get(0);
+        assertThat(entry.uri())
+                .isEqualTo("https://api.example.com/orders?%70assword=" + SecretMasker.MASKED_VALUE + "&page=2");
+    }
+
+    @Test
+    void masksSensitiveFragmentParameters() {
+        RestClientTraceRecorder recorder =
+                recordCall("https://api.example.com/callback#access_token=abc&state=x", null);
+        RestClientTraceEntryDto entry =
+                recorder.report(true, ValueExposure.MASKED).entries().get(0);
+        assertThat(entry.uri())
+                .isEqualTo("https://api.example.com/callback#access_token=" + SecretMasker.MASKED_VALUE + "&state=x");
+    }
+
+    @Test
+    void redactsCredentialsAndSensitiveQueryValuesFromTheErrorMessage() {
+        RestClientTraceRecorder recorder = recordCall(
+                "https://api.example.com/orders",
+                "I/O error on GET request for \"https://alice:s3cr3t@api.example.com/orders"
+                        + "?apiKey=verysecretvalue\": Connection refused");
+
+        String stored = recorder.recent().get(0).errorMessage();
+        assertThat(stored)
+                .doesNotContain("s3cr3t")
+                .doesNotContain("verysecretvalue")
+                .contains("Connection refused");
+        assertThat(recorder.report(true, ValueExposure.MASKED).entries().get(0).errorMessage())
+                .isEqualTo(stored);
+    }
+
+    @Test
+    void flattensAndBoundsTheErrorMessage() {
+        String message = "Connection reset\n\tat com.example.Client.call(Client.java:42)\n" + "x".repeat(1000);
+        RestClientTraceRecorder recorder = recordCall("https://api.example.com/orders", message);
+
+        String stored = recorder.recent().get(0).errorMessage();
+        assertThat(stored).doesNotContain("\n").doesNotContain("\t");
+        assertThat(stored).hasSizeLessThanOrEqualTo(DetailText.DEFAULT_MAX_CHARS + 1);
+        assertThat(stored).startsWith("Connection reset at com.example.Client.call(Client.java:42)");
+    }
+
+    @Test
+    void normalizesBlankErrorMessagesToNull() {
+        assertThat(recordCall("https://api.example.com/orders", "   \n  ")
+                        .recent()
+                        .get(0)
+                        .errorMessage())
+                .isNull();
+        assertThat(recordCall("https://api.example.com/orders", null)
+                        .recent()
+                        .get(0)
+                        .errorMessage())
+                .isNull();
+    }
+
+    @Test
+    void hidesTheErrorMessageUnderMetadataOnlyExposure() {
+        RestClientTraceRecorder recorder = recordCall("https://api.example.com/orders", "Connection refused");
+        RestClientTraceEntryDto entry =
+                recorder.report(true, ValueExposure.METADATA_ONLY).entries().get(0);
+        assertThat(entry.errorMessage()).isNull();
+        assertThat(entry.success()).isFalse();
+    }
+
+    @Test
+    void leavesAnOrdinaryErrorMessageAndUriIntact() {
+        RestClientTraceRecorder recorder =
+                recordCall("https://api.example.com/orders?page=2&sort=asc", "Connection refused");
+        RestClientTraceEntryDto entry =
+                recorder.report(true, ValueExposure.MASKED).entries().get(0);
+        assertThat(entry.uri()).isEqualTo("https://api.example.com/orders?page=2&sort=asc");
+        assertThat(entry.errorMessage()).isEqualTo("Connection refused");
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/CredentialRedactionTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/CredentialRedactionTests.java
@@ -101,4 +101,53 @@ class CredentialRedactionTests {
         String message = "404 for https://host/users/alice@example.com";
         assertThat(CredentialRedaction.redactMessage(message)).isEqualTo(message);
     }
+
+    @Test
+    void redactMessageMasksASensitiveNameLongerThanAnyMatcherBound() {
+        String name = "a".repeat(200) + "password";
+        assertThat(CredentialRedaction.redactMessage("failed https://h/x?" + name + "=secret"))
+                .isEqualTo("failed https://h/x?" + name + "=******");
+    }
+
+    @Test
+    void redactMessageMasksAnEncodedNestedCredentialUrl() {
+        assertThat(CredentialRedaction.redactMessage(
+                        "failed https://h/x?redirect=https%3A%2F%2Falice%3Apw%40host%2Fcb"))
+                .isEqualTo("failed https://h/x?redirect=******");
+    }
+
+    @Test
+    void redactMessageMasksAnEncodedNestedSensitiveParameter() {
+        assertThat(CredentialRedaction.redactMessage(
+                        "failed https://h/x?redirect=https%3A%2F%2Fevil%2Fcb%3Faccess_token%3Dnested"))
+                .isEqualTo("failed https://h/x?redirect=******");
+    }
+
+    @Test
+    void redactMessageMasksAnEncodedSensitiveNameCarryingAMalformedEscape() {
+        assertThat(CredentialRedaction.redactMessage("failed https://h/x?%70assword%ZZ=secret"))
+                .isEqualTo("failed https://h/x?%70assword%ZZ=******");
+    }
+
+    @Test
+    void redactMessageMasksASecretAfterAnHtmlEscapedAmpersand() {
+        assertThat(CredentialRedaction.redactMessage("failed https://h/x?page=2&amp;access_token=secret"))
+                .isEqualTo("failed https://h/x?page=2&amp;access_token=******");
+    }
+
+    @Test
+    void redactMessageLeavesAnOrdinaryNestedRedirectVisible() {
+        String message = "failed https://h/x?redirect=https%3A%2F%2Fexample.com%2Fhome";
+        assertThat(CredentialRedaction.redactMessage(message)).isEqualTo(message);
+    }
+
+    @Test
+    void carriesCredentialsDetectsNestedCredentialsAndIgnoresOrdinaryValues() {
+        assertThat(CredentialRedaction.carriesCredentials("https%3A%2F%2Falice%3Apw%40host%2Fcb"))
+                .isTrue();
+        assertThat(CredentialRedaction.carriesCredentials("https://example.com/home"))
+                .isFalse();
+        assertThat(CredentialRedaction.carriesCredentials("")).isFalse();
+        assertThat(CredentialRedaction.carriesCredentials(null)).isFalse();
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/CredentialRedactionTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/CredentialRedactionTests.java
@@ -34,4 +34,71 @@ class CredentialRedactionTests {
         assertThat(CredentialRedaction.redact(null)).isNull();
         assertThat(CredentialRedaction.redact("")).isEmpty();
     }
+
+    @Test
+    void redactMessageAlsoMasksSensitiveQueryValuesByName() {
+        String message = "I/O error on GET request for \"https://api.example.com/orders"
+                + "?apiKey=verysecretvalue&page=2\": Connection refused";
+        assertThat(CredentialRedaction.redactMessage(message))
+                .doesNotContain("verysecretvalue")
+                .contains("apiKey=******")
+                .contains("page=2")
+                .contains("Connection refused");
+    }
+
+    @Test
+    void redactMessageMasksPercentEncodedSensitiveQueryNames() {
+        assertThat(CredentialRedaction.redactMessage("failed: https://api/x?%70assword=hunter2&page=2"))
+                .isEqualTo("failed: https://api/x?%70assword=******&page=2");
+    }
+
+    @Test
+    void redactMessageMasksSeveralParametersInOneMessage() {
+        assertThat(CredentialRedaction.redactMessage("GET https://api/x?token=a&page=2&client_secret=b failed"))
+                .isEqualTo("GET https://api/x?token=******&page=2&client_secret=****** failed");
+    }
+
+    @Test
+    void redactMessageStillRedactsUrlCredentials() {
+        assertThat(CredentialRedaction.redactMessage("Connect to https://alice:hunter2@api.example.com failed"))
+                .isEqualTo("Connect to https://******@api.example.com failed");
+    }
+
+    @Test
+    void redactMessageLeavesOrdinaryTextUnchanged() {
+        String message = "Connection refused: connect to api.example.com:443?page=2";
+        assertThat(CredentialRedaction.redactMessage(message)).isEqualTo(message);
+        assertThat(CredentialRedaction.redactMessage(null)).isNull();
+        assertThat(CredentialRedaction.redactMessage("")).isEmpty();
+    }
+
+    @Test
+    void redactMessageRemovesPercentEncodedUserInfo() {
+        assertThat(CredentialRedaction.redactMessage("failed https://alice%3As3cr3t@host/x"))
+                .isEqualTo("failed https://******@host/x");
+    }
+
+    @Test
+    void redactMessageRemovesUserInfoFromASchemeRelativeAuthority() {
+        assertThat(CredentialRedaction.redactMessage("failed //alice:s3cr3t@host/x"))
+                .isEqualTo("failed //******@host/x");
+    }
+
+    @Test
+    void redactMessageMasksSensitiveFragmentParameters() {
+        assertThat(CredentialRedaction.redactMessage("failed https://host/x#access_token=fragsecret"))
+                .isEqualTo("failed https://host/x#access_token=******");
+    }
+
+    @Test
+    void redactMessageMasksAQueryParameterFollowedByAFragment() {
+        assertThat(CredentialRedaction.redactMessage("failed https://host/x?token=a#state=b"))
+                .isEqualTo("failed https://host/x?token=******#state=b");
+    }
+
+    @Test
+    void redactMessageDoesNotMistakeAnEmailAddressInAPathForUserInfo() {
+        String message = "404 for https://host/users/alice@example.com";
+        assertThat(CredentialRedaction.redactMessage(message)).isEqualTo(message);
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/SensitiveNamesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/SensitiveNamesTests.java
@@ -71,4 +71,28 @@ class SensitiveNamesTests {
         assertThat(SensitiveNames.decodeQueryComponent("%2570assword")).isEqualTo("%70assword");
         assertThat(SensitiveNames.isSensitive("%2570assword")).isFalse();
     }
+
+    @Test
+    void decodesValidEscapesEvenWhenAMalformedSequenceIsPresent() {
+        assertThat(SensitiveNames.decodeQueryComponent("%70assword%ZZ")).isEqualTo("password%ZZ");
+        assertThat(SensitiveNames.isSensitive("%70assword%ZZ")).isTrue();
+        assertThat(SensitiveNames.isSensitive("api%2Dkey%")).isTrue();
+    }
+
+    @Test
+    void decodesAValueEndingInATruncatedEscape() {
+        assertThat(SensitiveNames.decodeQueryComponent("%70assword%7")).isEqualTo("password%7");
+        assertThat(SensitiveNames.isSensitive("%70assword%7")).isTrue();
+    }
+
+    @Test
+    void replacesInvalidUtf8BytesInsteadOfRaising() {
+        assertThat(SensitiveNames.decodeQueryComponent("%FF")).isEqualTo("\uFFFD");
+        assertThat(SensitiveNames.isSensitive("%FF")).isFalse();
+    }
+
+    @Test
+    void acceptsBothHexCases() {
+        assertThat(SensitiveNames.decodeQueryComponent("%2f%2F")).isEqualTo("//");
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/SensitiveNamesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/SensitiveNamesTests.java
@@ -1,0 +1,74 @@
+package io.github.jdubois.bootui.engine.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SensitiveNamesTests {
+
+    @Test
+    void recognizesKeywordNamesAndTheHeaderAllowList() {
+        assertThat(SensitiveNames.isSensitive("apiKey")).isTrue();
+        assertThat(SensitiveNames.isSensitive("access_token")).isTrue();
+        assertThat(SensitiveNames.isSensitive("Authorization")).isTrue();
+        assertThat(SensitiveNames.isSensitive("Set-Cookie")).isTrue();
+        assertThat(SensitiveNames.isSensitive("X-XSRF-TOKEN")).isTrue();
+    }
+
+    @Test
+    void leavesOrdinaryNamesAlone() {
+        assertThat(SensitiveNames.isSensitive("page")).isFalse();
+        assertThat(SensitiveNames.isSensitive("X-Trace")).isFalse();
+        assertThat(SensitiveNames.isSensitive("content-length")).isFalse();
+    }
+
+    @Test
+    void treatsNullAndBlankNamesAsNotSensitive() {
+        assertThat(SensitiveNames.isSensitive(null)).isFalse();
+        assertThat(SensitiveNames.isSensitive("")).isFalse();
+        assertThat(SensitiveNames.isSensitive("   ")).isFalse();
+    }
+
+    @Test
+    void recognizesPercentEncodedNames() {
+        assertThat(SensitiveNames.isSensitive("%70assword")).isTrue();
+        assertThat(SensitiveNames.isSensitive("api%2Dkey")).isTrue();
+        assertThat(SensitiveNames.isSensitive("%41uthorization")).isTrue();
+        assertThat(SensitiveNames.isSensitive("client%5Fsecret")).isTrue();
+    }
+
+    @Test
+    void recognizesNamesHiddenBehindNonAsciiEncoding() {
+        // A zero-width space in front of the keyword still decodes to a name containing "password".
+        assertThat(SensitiveNames.isSensitive("%E2%80%8Bpassword")).isTrue();
+    }
+
+    @Test
+    void treatsPlusAsSpaceInQueryNamesButNotInPathSegments() {
+        assertThat(SensitiveNames.decodeQueryComponent("api+key")).isEqualTo("api key");
+        assertThat(SensitiveNames.decodePathComponent("api+key")).isEqualTo("api+key");
+    }
+
+    @Test
+    void survivesMalformedPercentEscapes() {
+        assertThat(SensitiveNames.decodeQueryComponent("%")).isEqualTo("%");
+        assertThat(SensitiveNames.decodeQueryComponent("%zz")).isEqualTo("%zz");
+        assertThat(SensitiveNames.decodeQueryComponent("token%")).isEqualTo("token%");
+        assertThat(SensitiveNames.isSensitive("token%")).isTrue();
+        assertThat(SensitiveNames.isSensitive("%zz")).isFalse();
+    }
+
+    @Test
+    void handlesNullAndEmptyDecodeInput() {
+        assertThat(SensitiveNames.decodeQueryComponent(null)).isNull();
+        assertThat(SensitiveNames.decodePathComponent(null)).isNull();
+        assertThat(SensitiveNames.decodeQueryComponent("")).isEmpty();
+    }
+
+    @Test
+    void doesNotDoubleDecode() {
+        // %2570assword is literally "%70assword" to the server, not "password".
+        assertThat(SensitiveNames.decodeQueryComponent("%2570assword")).isEqualTo("%70assword");
+        assertThat(SensitiveNames.isSensitive("%2570assword")).isFalse();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/UriMaskingTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/UriMaskingTests.java
@@ -1,0 +1,228 @@
+package io.github.jdubois.bootui.engine.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.core.SecretMasker;
+import io.github.jdubois.bootui.core.ValueExposure;
+import org.junit.jupiter.api.Test;
+
+class UriMaskingTests {
+
+    @Test
+    void removesAuthorityUserInfoButKeepsHostAndPort() {
+        assertThat(UriMasking.maskUserInfo("https://alice:s3cr3t@api.example.com:8443/orders"))
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com:8443/orders");
+    }
+
+    @Test
+    void removesUserInfoThatContainsNoPassword() {
+        assertThat(UriMasking.maskUserInfo("https://alice@api.example.com/orders"))
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com/orders");
+    }
+
+    @Test
+    void removesUserInfoFromIpv6AndProtocolRelativeAuthorities() {
+        assertThat(UriMasking.maskUserInfo("http://alice:s3cr3t@[::1]:8080/x"))
+                .isEqualTo("http://" + SecretMasker.MASKED_VALUE + "@[::1]:8080/x");
+        assertThat(UriMasking.maskUserInfo("//alice:s3cr3t@api.example.com/x"))
+                .isEqualTo("//" + SecretMasker.MASKED_VALUE + "@api.example.com/x");
+    }
+
+    @Test
+    void removesUserInfoWhenTheAuthorityIsFollowedDirectlyByAQueryOrFragment() {
+        assertThat(UriMasking.maskUserInfo("https://alice:s3cr3t@api.example.com?page=2"))
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com?page=2");
+        assertThat(UriMasking.maskUserInfo("https://alice:s3cr3t@api.example.com#top"))
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com#top");
+    }
+
+    @Test
+    void leavesOrdinaryUrisUntouched() {
+        assertThat(UriMasking.maskUserInfo("https://api.example.com/orders?page=2#top"))
+                .isEqualTo("https://api.example.com/orders?page=2#top");
+        assertThat(UriMasking.maskUserInfo("/orders/42")).isEqualTo("/orders/42");
+        assertThat(UriMasking.maskUserInfo("")).isEmpty();
+        assertThat(UriMasking.maskUserInfo(null)).isNull();
+    }
+
+    @Test
+    void doesNotMistakeAnAtSignInThePathForUserInfo() {
+        assertThat(UriMasking.maskUserInfo("https://api.example.com/users/alice@example.com"))
+                .isEqualTo("https://api.example.com/users/alice@example.com");
+        assertThat(UriMasking.maskUserInfo("/a//alice@example.com/b")).isEqualTo("/a//alice@example.com/b");
+    }
+
+    @Test
+    void masksSensitiveQueryValuesByNameAndKeepsTheRest() {
+        assertThat(UriMasking.maskQueryString("apiKey=s3cr3t&page=2", true, ValueExposure.MASKED))
+                .isEqualTo("apiKey=" + SecretMasker.MASKED_VALUE + "&page=2");
+    }
+
+    @Test
+    void masksPercentEncodedSensitiveQueryNames() {
+        assertThat(UriMasking.maskQueryString("%70assword=s3cr3t&page=2", true, ValueExposure.MASKED))
+                .isEqualTo("%70assword=" + SecretMasker.MASKED_VALUE + "&page=2");
+        assertThat(UriMasking.maskQueryString("api%2Dkey=s3cr3t", true, ValueExposure.MASKED))
+                .isEqualTo("api%2Dkey=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void masksAValuelessSensitiveParameterWholesale() {
+        assertThat(UriMasking.maskQueryString("access_token&page=2", true, ValueExposure.MASKED))
+                .isEqualTo(SecretMasker.MASKED_VALUE + "&page=2");
+        assertThat(UriMasking.maskQueryString("verbose&page=2", true, ValueExposure.MASKED))
+                .isEqualTo("verbose&page=2");
+    }
+
+    @Test
+    void keepsEmptyParametersAndPreservesParameterOrder() {
+        assertThat(UriMasking.maskQueryString("a=1&&b=2", true, ValueExposure.MASKED))
+                .isEqualTo("a=1&&b=2");
+        assertThat(UriMasking.maskQueryString("", true, ValueExposure.MASKED)).isEmpty();
+        assertThat(UriMasking.maskQueryString(null, true, ValueExposure.MASKED)).isNull();
+    }
+
+    @Test
+    void honorsTheExposurePolicy() {
+        assertThat(UriMasking.maskQueryString("apiKey=s3cr3t", false, ValueExposure.MASKED))
+                .isEqualTo("apiKey=s3cr3t");
+        assertThat(UriMasking.maskQueryString("apiKey=s3cr3t", true, ValueExposure.FULL))
+                .isEqualTo("apiKey=s3cr3t");
+        assertThat(UriMasking.maskQueryString("apiKey=s3cr3t", true, ValueExposure.METADATA_ONLY))
+                .isNull();
+    }
+
+    @Test
+    void masksUserInfoQueryAndFragmentTogether() {
+        String masked = UriMasking.maskUri(
+                "https://alice:s3cr3t@api.example.com/orders?apiKey=abc&page=2#access_token=xyz",
+                true,
+                ValueExposure.MASKED);
+        assertThat(masked)
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com/orders?apiKey="
+                        + SecretMasker.MASKED_VALUE + "&page=2#access_token=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void keepsUserInfoMaskedEvenUnderFullExposure() {
+        assertThat(UriMasking.maskUri(
+                        "https://alice:s3cr3t@api.example.com/orders?apiKey=abc", true, ValueExposure.FULL))
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com/orders?apiKey=abc");
+        assertThat(UriMasking.maskUri("https://alice:s3cr3t@api.example.com/orders", false, ValueExposure.FULL))
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com/orders");
+    }
+
+    @Test
+    void dropsQueryAndFragmentUnderMetadataOnlyExposure() {
+        assertThat(UriMasking.maskUri(
+                        "https://api.example.com/orders?page=2#section", true, ValueExposure.METADATA_ONLY))
+                .isEqualTo("https://api.example.com/orders");
+    }
+
+    @Test
+    void keepsANonSensitiveFragment() {
+        assertThat(UriMasking.maskUri("https://api.example.com/docs#installation", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/docs#installation");
+    }
+
+    @Test
+    void treatsEverythingAfterTheFirstHashAsFragmentAndStillMasksSecretsInIt() {
+        assertThat(UriMasking.maskUri("https://api.example.com/docs#a?token=abc", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/docs#a?token=" + SecretMasker.MASKED_VALUE);
+        assertThat(UriMasking.maskUri("https://api.example.com/docs#a?page=2", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/docs#a?page=2");
+    }
+
+    @Test
+    void leavesOrdinaryAndRelativeUrisUnchanged() {
+        assertThat(UriMasking.maskUri("https://api.example.com/orders", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/orders");
+        assertThat(UriMasking.maskUri("/orders?page=2", true, ValueExposure.MASKED))
+                .isEqualTo("/orders?page=2");
+        assertThat(UriMasking.maskUri("https://api.example.com/orders?", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/orders?");
+        assertThat(UriMasking.maskUri(null, true, ValueExposure.MASKED)).isNull();
+    }
+
+    @Test
+    void masksATruncatedUriWithoutFailing() {
+        assertThat(UriMasking.maskUri(
+                        "https://alice:s3cr3t@api.example.com/orders?apiKey=abc…", true, ValueExposure.MASKED))
+                .isEqualTo("https://" + SecretMasker.MASKED_VALUE + "@api.example.com/orders?apiKey="
+                        + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void masksParametersSeparatedByTheLegacySemicolon() {
+        assertThat(UriMasking.maskUri(
+                        "https://api.example.com/orders?page=2;token=qsecret", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/orders?page=2;token=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void preservesTheOriginalParameterSeparators() {
+        assertThat(UriMasking.maskQueryString("a=1;b=2&c=3", true, ValueExposure.MASKED))
+                .isEqualTo("a=1;b=2&c=3");
+    }
+
+    @Test
+    void masksSensitiveMatrixParametersInThePath() {
+        assertThat(UriMasking.maskUri(
+                        "https://api.example.com/orders;token=pathsecret/42?page=2", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/orders;token=" + SecretMasker.MASKED_VALUE + "/42?page=2");
+    }
+
+    @Test
+    void masksSensitiveMatrixParametersEvenUnderMetadataOnlyExposure() {
+        assertThat(UriMasking.maskUri(
+                        "https://api.example.com/orders;token=pathsecret?page=2", true, ValueExposure.METADATA_ONLY))
+                .isEqualTo("https://api.example.com/orders;token=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void doesNotMistakeAHostPortForAMatrixParameter() {
+        assertThat(UriMasking.maskUri("https://api.example.com:8443/orders", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com:8443/orders");
+    }
+
+    @Test
+    void masksPathMatrixParametersThroughMaskPath() {
+        assertThat(UriMasking.maskPath("/orders;token=abc/42", true, ValueExposure.MASKED))
+                .isEqualTo("/orders;token=" + SecretMasker.MASKED_VALUE + "/42");
+        assertThat(UriMasking.maskPath("/orders/42", true, ValueExposure.MASKED))
+                .isEqualTo("/orders/42");
+        assertThat(UriMasking.maskPath("/orders;token=abc", true, ValueExposure.FULL))
+                .isEqualTo("/orders;token=abc");
+        assertThat(UriMasking.maskPath(null, true, ValueExposure.MASKED)).isNull();
+    }
+
+    @Test
+    void masksAParameterValueCarryingANestedEncodedCredentialUrl() {
+        assertThat(UriMasking.maskUri(
+                        "https://api.example.com/go?redirect=https%3A%2F%2Fevil%2Fcb%3Faccess_token%3Dnestedsecret",
+                        true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/go?redirect=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void masksAParameterValueCarryingNestedUserInfo() {
+        assertThat(UriMasking.maskUri(
+                        "https://api.example.com/go?next=https://alice:s3cr3t@evil/cb", true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/go?next=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void masksNestedCredentialsEvenUnderFullExposure() {
+        assertThat(UriMasking.maskUri(
+                        "https://api.example.com/go?next=https://alice:s3cr3t@evil/cb", true, ValueExposure.FULL))
+                .isEqualTo("https://api.example.com/go?next=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void leavesAnOrdinaryNestedRedirectUrlVisible() {
+        assertThat(UriMasking.maskUri(
+                        "https://api.example.com/go?redirect=https%3A%2F%2Fexample.com%2Fhome",
+                        true, ValueExposure.MASKED))
+                .isEqualTo("https://api.example.com/go?redirect=https%3A%2F%2Fexample.com%2Fhome");
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/UriMaskingTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/UriMaskingTests.java
@@ -225,4 +225,52 @@ class UriMaskingTests {
                         true, ValueExposure.MASKED))
                 .isEqualTo("https://api.example.com/go?redirect=https%3A%2F%2Fexample.com%2Fhome");
     }
+
+    @Test
+    void masksMatrixValuesUnderMetadataOnlyEvenWhenMaskSecretsIsOff() {
+        assertThat(UriMasking.maskUri("https://h/orders;token=secret", false, ValueExposure.METADATA_ONLY))
+                .isEqualTo("https://h/orders;token=" + SecretMasker.MASKED_VALUE);
+        assertThat(UriMasking.maskPath("/orders;token=secret", false, ValueExposure.METADATA_ONLY))
+                .isEqualTo("/orders;token=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void keepsMatrixValuesVisibleUnderMaskedExposureWhenMaskSecretsIsOff() {
+        assertThat(UriMasking.maskUri("https://h/orders;token=secret", false, ValueExposure.MASKED))
+                .isEqualTo("https://h/orders;token=secret");
+    }
+
+    @Test
+    void neverMasksAPathSegmentThatSharesASensitiveParameterName() {
+        assertThat(UriMasking.maskUri("https://h/api/token/refresh;v=1", true, ValueExposure.MASKED))
+                .isEqualTo("https://h/api/token/refresh;v=1");
+        assertThat(UriMasking.maskPath("/api/token/refresh;v=1", true, ValueExposure.MASKED))
+                .isEqualTo("/api/token/refresh;v=1");
+    }
+
+    @Test
+    void masksAnEncodedSensitiveNameCarryingAMalformedEscape() {
+        assertThat(UriMasking.maskUri("https://h/x?%70assword%ZZ=secret", true, ValueExposure.MASKED))
+                .isEqualTo("https://h/x?%70assword%ZZ=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void masksANestedCredentialUrlEndingInAMalformedEscape() {
+        assertThat(UriMasking.maskUri(
+                        "https://h/x?redirect=https%3A%2F%2Falice%3Apw%40host%2Fcb%ZZ", true, ValueExposure.MASKED))
+                .isEqualTo("https://h/x?redirect=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void masksASensitiveNameLongerThanAnyMatcherBound() {
+        String name = "a".repeat(200) + "password";
+        assertThat(UriMasking.maskUri("https://h/x?" + name + "=secret", true, ValueExposure.MASKED))
+                .isEqualTo("https://h/x?" + name + "=" + SecretMasker.MASKED_VALUE);
+    }
+
+    @Test
+    void masksASecretAfterAnHtmlEscapedAmpersandBecauseBothCharactersSeparate() {
+        assertThat(UriMasking.maskUri("https://h/x?page=2&amp;access_token=secret", true, ValueExposure.MASKED))
+                .isEqualTo("https://h/x?page=2&amp;access_token=" + SecretMasker.MASKED_VALUE);
+    }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpExchangesServiceTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/web/HttpExchangesServiceTests.java
@@ -128,4 +128,77 @@ class HttpExchangesServiceTests {
         buffer.suspendForIdle();
         assertThat(buffer.snapshot()).isEmpty();
     }
+
+    private HttpExchangeDto reportedExchange(URI uri, boolean maskSecrets, ValueExposure exposure) {
+        CapturedHttpExchange captured = new CapturedHttpExchange(
+                Instant.parse("2024-01-01T00:00:00Z"),
+                "GET",
+                uri,
+                200,
+                12L,
+                "127.0.0.1",
+                "alice",
+                "S1",
+                Map.of(),
+                Map.of("Content-Length", List.of("42")),
+                null);
+        return service.report(List.of(captured), u -> false, maskSecrets, exposure, null, null, null, null, null)
+                .exchanges()
+                .get(0);
+    }
+
+    @Test
+    void removesUriUserInfoCredentialsWhenThereIsNoQueryString() {
+        HttpExchangeDto dto =
+                reportedExchange(URI.create("https://alice:s3cr3t@api.example.com/orders"), true, ValueExposure.MASKED);
+        assertThat(dto.uri()).isEqualTo("https://******@api.example.com/orders");
+        assertThat(dto.uri()).doesNotContain("s3cr3t");
+    }
+
+    @Test
+    void removesUriUserInfoCredentialsAlongsideAQueryString() {
+        HttpExchangeDto dto = reportedExchange(
+                URI.create("https://alice:s3cr3t@api.example.com/orders?token=abc&page=2"), true, ValueExposure.MASKED);
+        assertThat(dto.uri()).isEqualTo("https://******@api.example.com/orders?token=******&page=2");
+    }
+
+    @Test
+    void removesUriUserInfoCredentialsEvenUnderFullExposure() {
+        HttpExchangeDto dto = reportedExchange(
+                URI.create("https://alice:s3cr3t@api.example.com/orders?token=abc"), true, ValueExposure.FULL);
+        assertThat(dto.uri()).isEqualTo("https://******@api.example.com/orders?token=abc");
+    }
+
+    @Test
+    void masksPercentEncodedSensitiveQueryNames() {
+        HttpExchangeDto dto = reportedExchange(
+                URI.create("https://api.example.com/orders?%70assword=hunter2&page=2"), true, ValueExposure.MASKED);
+        assertThat(dto.uri()).isEqualTo("https://api.example.com/orders?%70assword=******&page=2");
+        assertThat(dto.query()).isEqualTo("%70assword=******&page=2");
+    }
+
+    @Test
+    void masksSensitiveFragmentParameters() {
+        HttpExchangeDto dto = reportedExchange(
+                URI.create("https://api.example.com/callback#access_token=abc&state=xyz"), true, ValueExposure.MASKED);
+        assertThat(dto.uri()).isEqualTo("https://api.example.com/callback#access_token=******&state=xyz");
+    }
+
+    @Test
+    void dropsQueryAndFragmentUnderMetadataOnlyExposure() {
+        HttpExchangeDto dto = reportedExchange(
+                URI.create("https://api.example.com/callback?page=2#access_token=abc"),
+                true,
+                ValueExposure.METADATA_ONLY);
+        assertThat(dto.uri()).isEqualTo("https://api.example.com/callback");
+        assertThat(dto.query()).isNull();
+    }
+
+    @Test
+    void leavesAnOrdinaryUriUnchanged() {
+        HttpExchangeDto dto = reportedExchange(
+                URI.create("https://api.example.com/orders?page=2&sort=asc#results"), true, ValueExposure.MASKED);
+        assertThat(dto.uri()).isEqualTo("https://api.example.com/orders?page=2&sort=asc#results");
+        assertThat(dto.path()).isEqualTo("/orders");
+    }
 }

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/restclienttrace/QuarkusRestClientTraceFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/restclienttrace/QuarkusRestClientTraceFilter.java
@@ -2,7 +2,9 @@ package io.github.jdubois.bootui.quarkus.restclienttrace;
 
 import io.github.jdubois.bootui.core.SecretMasker;
 import io.github.jdubois.bootui.engine.restclienttrace.RestClientTraceRecorder;
+import io.github.jdubois.bootui.engine.support.CredentialRedaction;
 import io.github.jdubois.bootui.engine.support.SensitiveNames;
+import io.github.jdubois.bootui.engine.support.UriMasking;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.client.ClientResponseContext;
@@ -116,40 +118,64 @@ public final class QuarkusRestClientTraceFilter implements ClientRequestFilter, 
         return new CapturedUri(value.toString(), uri.getHost(), path);
     }
 
+    /**
+     * Sanitizes a path before storage: a segment whose own name looks like a secret is masked, and each segment's
+     * {@code ;name=value} matrix parameters are sanitized like query parameters (the segment name itself is never
+     * treated as a parameter). Splitting matches display-time masking through {@link UriMasking}.
+     */
     private static String sanitizePath(String rawPath) {
         if (rawPath == null || rawPath.isEmpty()) {
             return rawPath;
         }
         String[] segments = rawPath.split("/", -1);
         for (int i = 0; i < segments.length; i++) {
-            if (SECRET_MASKER.shouldMask("path-segment", decode(segments[i], false))) {
-                segments[i] = SecretMasker.MASKED_VALUE;
-            }
+            segments[i] = sanitizeSegment(segments[i]);
         }
         return String.join("/", segments);
     }
 
+    private static String sanitizeSegment(String segment) {
+        int firstSemicolon = segment.indexOf(';');
+        String name = firstSemicolon < 0 ? segment : segment.substring(0, firstSemicolon);
+        String sanitizedName =
+                SECRET_MASKER.shouldMask("path-segment", decode(name, false)) ? SecretMasker.MASKED_VALUE : name;
+        if (firstSemicolon < 0) {
+            return sanitizedName;
+        }
+        return sanitizedName
+                + ';'
+                + UriMasking.maskParameters(
+                        segment.substring(firstSemicolon + 1), QuarkusRestClientTraceFilter::sanitizeParameter);
+    }
+
+    /**
+     * Sanitizes a query before storage. Parameters are split on {@code &} and the legacy {@code ;} through
+     * {@link UriMasking}, so a semicolon-separated secret cannot reach the recorder raw.
+     */
     private static String sanitizeQuery(String rawQuery) {
         if (rawQuery == null || rawQuery.isEmpty()) {
             return rawQuery;
         }
-        String[] parameters = rawQuery.split("&", -1);
-        for (int i = 0; i < parameters.length; i++) {
-            int equals = parameters[i].indexOf('=');
-            if (equals < 0) {
-                String decoded = decode(parameters[i], true);
-                if (SECRET_MASKER.shouldMask(decoded, decoded)) {
-                    parameters[i] = SecretMasker.MASKED_VALUE;
-                }
-                continue;
-            }
-            String rawName = parameters[i].substring(0, equals);
-            String rawValue = parameters[i].substring(equals + 1);
-            if (SECRET_MASKER.shouldMask(decode(rawName, true), decode(rawValue, true))) {
-                parameters[i] = rawName + '=' + SecretMasker.MASKED_VALUE;
-            }
+        return UriMasking.maskParameters(rawQuery, QuarkusRestClientTraceFilter::sanitizeParameter);
+    }
+
+    /**
+     * Sanitizes one {@code name=value} parameter. Unlike display-time masking this also inspects the value, since
+     * Quarkus never retains a secret it could later reveal under {@code bootui.expose-values=FULL}.
+     */
+    private static String sanitizeParameter(String parameter) {
+        int equals = parameter.indexOf('=');
+        if (equals < 0) {
+            String decoded = decode(parameter, true);
+            return SECRET_MASKER.shouldMask(decoded, decoded) ? SecretMasker.MASKED_VALUE : parameter;
         }
-        return String.join("&", parameters);
+        String rawName = parameter.substring(0, equals);
+        String rawValue = parameter.substring(equals + 1);
+        if (SECRET_MASKER.shouldMask(decode(rawName, true), decode(rawValue, true))
+                || CredentialRedaction.carriesCredentials(rawValue)) {
+            return rawName + '=' + SecretMasker.MASKED_VALUE;
+        }
+        return parameter;
     }
 
     private static String decode(String value, boolean formEncoded) {

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/restclienttrace/QuarkusRestClientTraceFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/restclienttrace/QuarkusRestClientTraceFilter.java
@@ -2,13 +2,12 @@ package io.github.jdubois.bootui.quarkus.restclienttrace;
 
 import io.github.jdubois.bootui.core.SecretMasker;
 import io.github.jdubois.bootui.engine.restclienttrace.RestClientTraceRecorder;
+import io.github.jdubois.bootui.engine.support.SensitiveNames;
 import jakarta.ws.rs.client.ClientRequestContext;
 import jakarta.ws.rs.client.ClientRequestFilter;
 import jakarta.ws.rs.client.ClientResponseContext;
 import jakarta.ws.rs.client.ClientResponseFilter;
 import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.jboss.logging.Logger;
@@ -154,12 +153,7 @@ public final class QuarkusRestClientTraceFilter implements ClientRequestFilter, 
     }
 
     private static String decode(String value, boolean formEncoded) {
-        try {
-            String encoded = formEncoded ? value : value.replace("+", "%2B");
-            return URLDecoder.decode(encoded, StandardCharsets.UTF_8);
-        } catch (IllegalArgumentException malformedEncoding) {
-            return value;
-        }
+        return formEncoded ? SensitiveNames.decodeQueryComponent(value) : SensitiveNames.decodePathComponent(value);
     }
 
     private static void logCaptureFailure(RuntimeException failure) {

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/restclienttrace/QuarkusRestClientTraceFilterTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/restclienttrace/QuarkusRestClientTraceFilterTest.java
@@ -45,6 +45,55 @@ class QuarkusRestClientTraceFilterTest {
     }
 
     @Test
+    void sanitizesSemicolonSeparatedAndMatrixParametersBeforeStorage() {
+        RestClientTraceRecorder recorder = recorder(false);
+        QuarkusRestClientTraceFilter filter = new QuarkusRestClientTraceFilter(recorder);
+        ClientRequestContext request = request(
+                "GET", URI.create("https://example.test/orders;token=pathsecret/42?page=2;api_key=querysecret"));
+
+        filter.filter(request);
+        filter.filter(request, response(200));
+
+        assertThat(recorder.recent()).singleElement().satisfies(call -> {
+            assertThat(call.uri())
+                    .isEqualTo("https://example.test/orders;token=******/42?page=2;api_key=******")
+                    .doesNotContain("pathsecret", "querysecret");
+            assertThat(call.path()).isEqualTo("/orders;token=******/42");
+        });
+    }
+
+    @Test
+    void keepsAPathSegmentThatSharesASensitiveParameterName() {
+        RestClientTraceRecorder recorder = recorder(false);
+        QuarkusRestClientTraceFilter filter = new QuarkusRestClientTraceFilter(recorder);
+        ClientRequestContext request = request("GET", URI.create("https://example.test/api/token/refresh;v=1"));
+
+        filter.filter(request);
+        filter.filter(request, response(200));
+
+        assertThat(recorder.recent())
+                .singleElement()
+                .satisfies(call -> assertThat(call.path()).isEqualTo("/api/token/refresh;v=1"));
+    }
+
+    @Test
+    void sanitizesANestedCredentialBearingRedirectBeforeStorage() {
+        RestClientTraceRecorder recorder = recorder(false);
+        QuarkusRestClientTraceFilter filter = new QuarkusRestClientTraceFilter(recorder);
+        ClientRequestContext request =
+                request("GET", URI.create("https://example.test/go?redirect=https%3A%2F%2Falice%3Apw%40host%2Fcb"));
+
+        filter.filter(request);
+        filter.filter(request, response(200));
+
+        assertThat(recorder.recent())
+                .singleElement()
+                .satisfies(call -> assertThat(call.uri())
+                        .isEqualTo("https://example.test/go?redirect=******")
+                        .doesNotContain("alice", "pw"));
+    }
+
+    @Test
     void captureFailuresNeverEscapeIntoTheApplicationCall() {
         RestClientTraceRecorder recorder = recorder(false);
         QuarkusRestClientTraceFilter filter = new QuarkusRestClientTraceFilter(recorder);

--- a/bootui-ui/src/main/frontend/src/views/RestClientTrace.test.js
+++ b/bootui-ui/src/main/frontend/src/views/RestClientTrace.test.js
@@ -206,6 +206,50 @@ describe('RestClientTrace', () => {
     expect(toggle.attributes('aria-expanded')).toBe('false')
   })
 
+  it('renders a placeholder for a failed call whose message metadata-only hid', async () => {
+    const failed = traceReport()
+    failed.entries = [
+      {
+        ...failed.entries[0],
+        id: 3,
+        status: null,
+        success: false,
+        errorMessage: null
+      }
+    ]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(failed)))
+
+    wrapper = mount(RestClientTrace, {props: {panel: {id: 'rest-client-trace'}}})
+    await flushPromises()
+
+    await wrapper.get('tr.rest-row button.rest-row-toggle').trigger('click')
+    const details = wrapper.get('tr.rest-detail-row').text()
+    expect(details).toContain('Error')
+    expect(details).toContain('—')
+  })
+
+  it('renders the sanitized error message for a failed call when it is present', async () => {
+    const failed = traceReport()
+    failed.entries = [
+      {
+        ...failed.entries[0],
+        id: 4,
+        status: null,
+        success: false,
+        errorMessage: 'I/O error on GET request for "https://******@api.example.com/orders"'
+      }
+    ]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(failed)))
+
+    wrapper = mount(RestClientTrace, {props: {panel: {id: 'rest-client-trace'}}})
+    await flushPromises()
+
+    await wrapper.get('tr.rest-row button.rest-row-toggle').trigger('click')
+    const details = wrapper.get('tr.rest-detail-row').text()
+    expect(details).toContain('I/O error on GET request')
+    expect(details).toContain('******@api.example.com')
+  })
+
   it('filters calls by URI text', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(traceReport())))
 

--- a/bootui-ui/src/main/frontend/src/views/RestClientTrace.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestClientTrace.vue
@@ -490,7 +490,7 @@ function clearTrace() {
                         </dd>
                         <template v-if="!entry.success">
                           <dt class="col-sm-2 text-danger">Error</dt>
-                          <dd class="col-sm-10 text-danger">{{ entry.errorMessage }}</dd>
+                          <dd class="col-sm-10 text-danger">{{ entry.errorMessage || '—' }}</dd>
                         </template>
                       </dl>
                     </td>

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1569,7 +1569,10 @@ toggle, or free text across URI, host, method, client, and thread. Local-only **
 you stop recording without removing the client instrumentation, or empty the buffer.
 
 The panel is read-mostly and privacy-conscious. On Spring, the URI is retained and query values are masked **by name**
-(the same `SecretMasker` rules the Config and HTTP Exchanges panels use); request headers are withheld by default, and
+(the same `SecretMasker` rules the Config and HTTP Exchanges panels use, matched percent-decoded so a URL-encoded
+parameter name cannot slip through); URI authority credentials such as `user:secret@host` are removed before the call is
+ever buffered, and the client error message is flattened, credential-redacted, and truncated for the same reason — a
+transport exception routinely quotes the whole request URL. Request headers are withheld by default, and
 `bootui.rest-client-trace.capture-headers=true` opts into bounded, exposure-aware header capture. Quarkus is deliberately
 stricter: it is always metadata-only, ignores that header property, never reads or retains request/response bodies,
 arbitrary headers, authorization, cookies, credentials, or tokens, and strips URI user-info/fragments plus masks

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -905,7 +905,11 @@ Features:
 Acceptance criteria:
 
 - The recorder is bounded by `bootui.http-exchanges.max-exchanges`, defaulting to 200.
-- Secret-like headers and query parameters are masked unless value exposure is explicitly set to `FULL`.
+- Secret-like headers and query parameters are masked unless value exposure is explicitly set to `FULL`. Sensitive
+  parameter names are matched percent-decoded, so a URL-encoded name cannot evade masking, and the same masking applies
+  to a query-shaped URI fragment.
+- URI authority user-info credentials (`user:secret@host`) are removed unconditionally, including under `FULL`: host and
+  port survive, the credential never reaches the browser.
 - The panel is read-only and returns a stable unavailable DTO when no `HttpExchangeRepository` is available.
 - Copy as cURL performs no request and changes no state; it shows the command before copying, keeps query-parameter
   names but replaces every value with a placeholder, copies only allowlisted unmasked request headers, POSIX-quotes
@@ -1346,6 +1350,12 @@ Acceptance criteria:
   `bootui.rest-client-trace.capture-headers=true`. Quarkus is always metadata-only: it never reads or retains bodies,
   arbitrary headers, credentials, cookies, or tokens, and removes URI user-info/fragments plus sensitive path/query
   values before storage.
+- Every adapter shares one URI masking policy with HTTP Exchanges: authority user-info credentials are removed before
+  storage and never revealed by any exposure setting, sensitive parameter names are matched percent-decoded, and a
+  query-shaped fragment is masked like a query string.
+- The client error message is flattened, credential-redacted (URL credentials plus sensitive query values echoed by the
+  exception), and truncated before it is buffered; value exposure `METADATA_ONLY` hides it entirely, with the failure
+  still visible through the call's success flag and status.
 - Calls are grouped by method, host, and normalized path (numeric/UUID segments collapsed to `{id}`) and a group at or
   above `bootui.rest-client-trace.chatty-call-threshold` is flagged as a **chatty** (repeated-call) pattern, for calls
   of any HTTP method.


### PR DESCRIPTION
Fixes #858

## Problem

HTTP Exchange and REST-client URI handling masked query parameter *values* but copied the URI authority verbatim, so a `user:secret@host` credential reached the browser. On top of that:

- URL-encoded sensitive parameter names (`%70assword`, `api%2Dkey`) evaded the keyword check.
- URI fragments were appended raw and never masked, so an OAuth-style `#access_token=…` leaked.
- The REST-client `errorMessage` was serialized unbounded and unsanitized, even though a transport exception routinely quotes the whole request URL.

## Approach

Two new engine helpers, shared by both panels so inbound and outbound URI masking can no longer drift apart:

**`SensitiveNames`** — the single "is this name sensitive?" decision. It matches a name both as captured and percent-decoded, and owns the sensitive-header allow-list that `HttpExchangesService`, `RestClientTraceRecorder`, and the Quarkus capture filter each carried their own copy of. Decoding is lenient (malformed escapes pass through) and used *only* for the matching decision, never for output.

**`UriMasking`** — applies two deliberately different rules:

| | Rule |
|---|---|
| Authority user-info | Removed **unconditionally**, even under `FULL` — same footing as `CredentialRedaction`. Host and port survive. |
| Query / matrix / fragment parameters | Follow the live exposure policy. Names always preserved. |

Both `&` and the legacy `;` separate parameters (the original separators are preserved), `;name=value` matrix parameters inside path segments are masked, and a parameter value carrying a nested credential-bearing URL (typically a percent-encoded `redirect=` target) is masked unconditionally.

`CredentialRedaction.redactMessage` widens free-text redaction to any authority user-info — including percent-encoded (`alice%3As3cr3t@`) and scheme-relative (`//alice:pw@host`) forms that the existing connection-string regex misses — and to sensitive query, matrix, and fragment parameter values.

The REST-client error message is flattened, credential-redacted, and truncated to `DetailText.DEFAULT_MAX_CHARS` **before it is buffered**, and hidden under `METADATA_ONLY`; the failure itself stays visible through the success flag and status.

## Behavior changes worth flagging

- URI user-info is now masked even under `bootui.expose-values=FULL`. This matches the issue's "never expose URI authority user-info" and the existing `CredentialRedaction` policy ("a driver error message is never a property value the user asked to see").
- URI fragments are now masked and are dropped under `METADATA_ONLY`, alongside the query.
- The REST-client error message is `null` under `METADATA_ONLY`.
- A value-less sensitive parameter (`?api_key`) is now masked wholesale on the REST-client side too, matching what HTTP Exchanges already did.

## Validation

- Full `./mvnw install` reactor green, including all Quarkus integration tests (engine 2156 tests, Spring auto-configuration 1734 tests, UI 561 view tests).
- New focused regression coverage for URI user-info (including IPv6, scheme-relative, `@` in path, multiple `@`), encoded query keys, `+` vs `%2B`, malformed escapes, double encoding, fragments, `;` separators, matrix parameters, nested encoded credential URLs, exception text, truncation, and ordinary URLs that must stay untouched.
- `spotless:check` and frontend `format:check` clean.
- An internal rubber-duck critique surfaced three bypasses (semicolon/matrix parameters, encoded and scheme-relative user-info plus fragment credentials in message text, nested encoded URLs); all three are fixed and covered by tests in this PR.

The only Quarkus change is a small de-duplication: `QuarkusRestClientTraceFilter` now delegates its percent-decoding to the shared `SensitiveNames` helper instead of keeping a third copy. It is unrelated to the Quarkus root-path work in #857.

Fixes: #857