### PR TITLE
Block the packaged BootUI shell on Spring MVC and WebFlux when activation is disabled

### DIFF
--- a/.github/instructions/spring-adapter.instructions.md
+++ b/.github/instructions/spring-adapter.instructions.md
@@ -8,7 +8,9 @@ applyTo: "bootui-spring-autoconfigure/**,bootui-spring-boot-starter/**,bootui-sp
   compatibility is out of scope.
 - Keep controllers thin. They inject engine services, translate Spring request types, and return stable core DTOs.
 - Four autoconfigurations are registered in `AutoConfiguration.imports`: servlet and reactive BootUI configurations,
-  plus their Spring Security companions. They are registered, not component-scanned.
+  plus their Spring Security companions. They are registered, not component-scanned. A fifth,
+  `BootUiShellGuardAutoConfiguration`, is the inverse: it is gated by `BootUiInactiveCondition` and exists only while
+  BootUI is off, to keep the packaged `/bootui` classpath shell a plain 404 on both stacks.
 - Register shared controllers in both `BootUiAutoConfiguration` and `BootUiReactiveAutoConfiguration`. Put genuinely
   stack-specific bindings in the servlet or `...autoconfigure.reactive` package and its matching import list.
 - Activation is fail-closed through the shared `BootUiActivationCondition`: `bootui.enabled=ON|OFF` wins; otherwise an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,18 @@ and strengthens release verification against the artifacts consumers actually do
 
 ### Fixed
 
+- **The packaged BootUI shell is no longer reachable on Spring MVC or Spring WebFlux when BootUI is inactive.**
+  Deactivating BootUI (a `prod`/`production` profile, `bootui.enabled=OFF`, an invalid `bootui.enabled` value, or simply
+  no enabling profile) already unwired every BootUI route, but `bootui-ui` ships the compiled console at
+  `META-INF/resources/bootui/`, one of Spring Boot's default static-resource locations, so `GET /bootui/index.html` and
+  every asset under it still answered `200` with an empty shell. A new `BootUiShellGuardAutoConfiguration`, gated by the
+  exact negation of the activation condition and by the presence of the packaged shell, answers `404` for the reserved
+  `/bootui` namespace on both stacks, matching the Quarkus adapter's production shell guard. It matches the decoded
+  request path (so `/%62ootui/index.html` and matrix-parameter spellings cannot slip through) and follows relocated
+  static handling (`spring.mvc.servlet.path`, `spring.mvc.static-path-pattern`, `spring.webflux.static-path-pattern`),
+  under which the same bundle otherwise surfaced at, for example, `/app/static/bootui/index.html`. Requests outside the
+  reserved `/bootui` namespace are passed through untouched; a host application that served its own routes there while
+  shipping BootUI now receives `404` for them while BootUI is inactive (#856).
 - **Spring native images can start with the sample application's Hibernate second-level JCache configuration.**
   Runtime hints now retain the reflectively created `JCacheRegionFactory` constructor together with Caffeine's
   `application.conf` and default `reference.conf` cache configuration resources (#832, #835).

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/safety/BootUiInternalMount.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/safety/BootUiInternalMount.java
@@ -1,0 +1,48 @@
+package io.github.jdubois.bootui.engine.safety;
+
+import io.github.jdubois.bootui.core.BootUiPathNormalizer;
+
+/**
+ * The reserved internal {@code /bootui} classpath mount, as a framework-neutral request-path predicate.
+ *
+ * <p>{@code bootui-ui} packages the compiled Vue bundle at {@code META-INF/resources/bootui/}, a
+ * location every supported runtime serves from its own built-in static-resource handling, independently
+ * of anything BootUI registers. {@code bootui.path} moves the console's routes but never that classpath
+ * location, so {@code /bootui} stays reserved and adapters need one agreed answer to "is this request
+ * addressing the packaged mount?".</p>
+ *
+ * <p>Deliberately free of any framework type: the Spring MVC binding is a servlet {@code Filter} and the
+ * Spring WebFlux binding is a {@code WebFilter}, and a reactive-only application has no servlet API on
+ * its classpath at all, so neither binding may reach into the other for this decision.</p>
+ *
+ * <p>Callers must pass a <strong>decoded</strong> application-relative path — the same form the
+ * framework's own handler mapping matches on. Comparing raw request URIs would let {@code /%62ootui/...}
+ * slip past a guard while still resolving to the bundle.</p>
+ */
+public final class BootUiInternalMount {
+
+    private BootUiInternalMount() {}
+
+    /**
+     * Returns {@code true} for the reserved mount itself and everything below it.
+     *
+     * @param path a decoded, application-relative request path
+     */
+    public static boolean covers(String path) {
+        return isUnder(path, BootUiPathNormalizer.DEFAULT_PATH);
+    }
+
+    /**
+     * Returns {@code true} when {@code path} addresses {@code mount} itself or anything below it.
+     *
+     * <p>Adapters use this for the additional prefixes under which their framework may expose the same
+     * packaged bundle &mdash; a Spring {@code spring.mvc.servlet.path} or static path pattern, for
+     * example &mdash; without teaching the engine about framework-specific configuration.</p>
+     *
+     * @param path a decoded, application-relative request path
+     * @param mount an absolute mount path with no trailing slash
+     */
+    public static boolean isUnder(String path, String mount) {
+        return path != null && mount != null && (path.equals(mount) || path.startsWith(mount + "/"));
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/safety/BootUiInternalMountTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/safety/BootUiInternalMountTests.java
@@ -1,0 +1,31 @@
+package io.github.jdubois.bootui.engine.safety;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the shared definition of the reserved {@code /bootui} classpath mount that the Spring MVC and
+ * Spring WebFlux shell guards both match on (issue #856).
+ */
+class BootUiInternalMountTests {
+
+    @Test
+    void coversTheMountAndEverythingBelowIt() {
+        assertThat(BootUiInternalMount.covers("/bootui")).isTrue();
+        assertThat(BootUiInternalMount.covers("/bootui/")).isTrue();
+        assertThat(BootUiInternalMount.covers("/bootui/index.html")).isTrue();
+        assertThat(BootUiInternalMount.covers("/bootui/assets/index-abc123.js")).isTrue();
+        assertThat(BootUiInternalMount.covers("/bootui/api/overview")).isTrue();
+    }
+
+    @Test
+    void doesNotCoverAdjacentOrUnrelatedPaths() {
+        assertThat(BootUiInternalMount.covers("/bootuix")).isFalse();
+        assertThat(BootUiInternalMount.covers("/bootui-console/index.html")).isFalse();
+        assertThat(BootUiInternalMount.covers("/console")).isFalse();
+        assertThat(BootUiInternalMount.covers("/")).isFalse();
+        assertThat(BootUiInternalMount.covers("")).isFalse();
+        assertThat(BootUiInternalMount.covers(null)).isFalse();
+    }
+}

--- a/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
+++ b/bootui-quarkus-deployment/src/main/java/io/github/jdubois/bootui/quarkus/deployment/BootUiQuarkusProcessor.java
@@ -146,8 +146,9 @@ import org.jboss.jandex.Type;
  * {@code /bootui} and any {@code /bootui/**} path (the static shell, {@code /bootui/api/**}, everything);
  * in every other launch mode it is an immediate no-op pass-through, so dev/{@code @QuarkusTest} behavior is
  * entirely unaffected. Net effect: {@code /bootui}/{@code /bootui/**} is a plain 404 in production, at
- * parity with the Spring adapter (which never registers any BootUI route when inactive, so nothing is
- * reachable there either).</p>
+ * parity with the Spring adapter, whose {@code BootUiShellGuardAutoConfiguration} answers the same 404 for
+ * the same reserved mount whenever BootUI's activation condition resolves to disabled (#856: Spring Boot's
+ * default static-resource handling served the packaged shell there too, for exactly the same reason).</p>
  *
  * <p>In dev/test, the static handler only answers the directory index {@code /bootui/} (trailing slash);
  * {@code /bootui} without the trailing slash previously 404'd, so {@code QuarkusIndexResource} — a

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiProdShellGuardFilter.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiProdShellGuardFilter.java
@@ -21,8 +21,9 @@ import org.eclipse.microprofile.config.Config;
  * Quarkus offers no build-time mechanism to exclude a single path from it (see
  * {@code BootUiQuarkusProcessor}'s class Javadoc for the full investigation). Left alone, that would leave
  * the empty SPA shell's {@code index.html}/JS/CSS reachable in production, just with no working API behind
- * it — this filter is what turns that into a plain 404, at parity with the Spring adapter (which never
- * registers any BootUI route when inactive, so nothing is reachable there either).
+ * it — this filter is what turns that into a plain 404, at parity with the Spring adapter, where
+ * {@code BootUiShellGuardAutoConfiguration} answers the same 404 for the same reserved mount whenever
+ * BootUI's activation condition resolves to disabled (#856).
  *
  * <p>This bean is registered by its own, deliberately <strong>always-on</strong> build step
  * ({@code BootUiQuarkusProcessor#registerProdShellGuard}) — unlike every other BootUI bean/resource, which

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiInactiveCondition.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiInactiveCondition.java
@@ -1,0 +1,23 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Exact negation of {@link BootUiActivationCondition}: matches when BootUI resolves to
+ * <em>inactive</em> for the current environment.
+ *
+ * <p>Both conditions delegate to the same {@link BootUiActivationCondition#resolve} call, so there is
+ * a single activation decision and no way for the two polarities to drift apart. This is what
+ * {@link BootUiShellGuardAutoConfiguration} uses to wire the only piece of BootUI that must exist
+ * while the console is switched off.</p>
+ */
+public class BootUiInactiveCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return !BootUiActivationCondition.resolve(context.getEnvironment(), context.getClassLoader())
+                .enabled();
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiShellGuardAutoConfiguration.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiShellGuardAutoConfiguration.java
@@ -1,0 +1,85 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiShellGuardFilter;
+import io.github.jdubois.bootui.autoconfigure.safety.BootUiShellGuardFilter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnResource;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * The one piece of BootUI that is wired while BootUI is <strong>off</strong>.
+ *
+ * <p>{@link BootUiAutoConfiguration} and {@link BootUiReactiveAutoConfiguration} register nothing when
+ * {@link BootUiActivationCondition} does not match, which makes the whole JSON API unreachable. It does
+ * not make the console unreachable: {@code bootui-ui} packages the compiled Vue bundle at
+ * {@code META-INF/resources/bootui/}, and {@code classpath:/META-INF/resources/} is a default
+ * static-resource location for both {@code WebMvcAutoConfiguration} and {@code WebFluxAutoConfiguration}.
+ * A production deployment therefore still answered {@code GET /bootui/index.html} (and every asset under
+ * it) with {@code 200} — an empty shell with no API behind it, but reachable (#856).</p>
+ *
+ * <p>This auto-configuration closes that gap with a filter that answers {@code 404} for the reserved
+ * {@code /bootui} classpath mount, on Spring MVC and Spring WebFlux alike. It mirrors the Quarkus
+ * adapter's always-registered {@code BootUiProdShellGuardFilter}, with the difference that Spring can
+ * express the decision as a bean condition: {@link BootUiInactiveCondition} is the exact negation of the
+ * activation condition and delegates to the same {@code resolve} call, so the guard exists precisely
+ * when the console does not and the two polarities cannot drift apart.</p>
+ *
+ * <p>{@link ConditionalOnResource} keeps the guard honest: it only claims the mount when the packaged
+ * shell it is guarding is actually on the classpath, so an application that depends on
+ * {@code bootui-spring-autoconfigure} without {@code bootui-ui} keeps {@code /bootui} for itself.</p>
+ *
+ * <p>Scope is the reserved {@code /bootui} namespace, plus the same namespace under whatever prefixes
+ * {@link BootUiShellGuardMounts} derives from the host's static-resource configuration. Everything
+ * outside those mounts is passed through untouched.</p>
+ */
+@AutoConfiguration
+@Conditional(BootUiInactiveCondition.class)
+@ConditionalOnResource(resources = "classpath:/META-INF/resources/bootui/index.html")
+public class BootUiShellGuardAutoConfiguration {
+
+    /**
+     * Servlet binding. Registered at {@link Integer#MIN_VALUE} so the guard runs before any host filter
+     * chain can act on a request BootUI is about to reject, and mapped to every derived mount rather
+     * than only {@code /bootui/*}.
+     */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+    @ConditionalOnClass(name = "org.springframework.web.servlet.DispatcherServlet")
+    static class ServletShellGuardConfiguration {
+
+        @Bean
+        BootUiShellGuardFilter bootUiShellGuardFilter(Environment environment) {
+            return new BootUiShellGuardFilter(BootUiShellGuardMounts.servlet(environment));
+        }
+
+        @Bean
+        FilterRegistrationBean<BootUiShellGuardFilter> bootUiShellGuardFilterRegistration(
+                BootUiShellGuardFilter filter, Environment environment) {
+            FilterRegistrationBean<BootUiShellGuardFilter> registration = new FilterRegistrationBean<>(filter);
+            for (String mount : BootUiShellGuardMounts.servlet(environment)) {
+                registration.addUrlPatterns(mount + "/*");
+            }
+            registration.setOrder(Integer.MIN_VALUE);
+            registration.setName("bootUiShellGuardFilter");
+            return registration;
+        }
+    }
+
+    /** WebFlux binding. {@code WebFilter} beans are ordered by {@code Ordered}, not by a registration. */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+    @ConditionalOnClass(name = "org.springframework.web.reactive.DispatcherHandler")
+    static class ReactiveShellGuardConfiguration {
+
+        @Bean
+        ReactiveBootUiShellGuardFilter bootUiReactiveShellGuardFilter(Environment environment) {
+            return new ReactiveBootUiShellGuardFilter(BootUiShellGuardMounts.reactive(environment));
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiShellGuardMounts.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiShellGuardMounts.java
@@ -1,0 +1,102 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import io.github.jdubois.bootui.core.BootUiPathNormalizer;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.core.env.Environment;
+
+/**
+ * Resolves the application-relative prefixes under which Spring Boot's own static-resource mapping can
+ * serve the packaged BootUI bundle.
+ *
+ * <p>The bundle lives at the fixed classpath location {@code META-INF/resources/bootui/}, but the URL it
+ * surfaces at is not fixed: the static-resource handler sits behind the DispatcherServlet mapping
+ * ({@code spring.mvc.servlet.path}) and behind a configurable pattern
+ * ({@code spring.mvc.static-path-pattern} / {@code spring.webflux.static-path-pattern}). With
+ * {@code spring.mvc.servlet.path=/app} the shell answers at {@code /app/bootui/index.html}; with
+ * {@code spring.mvc.static-path-pattern=/static/**} it answers at {@code /static/bootui/index.html}.
+ * A guard pinned to {@code /bootui/**} alone would miss both.</p>
+ *
+ * <p>A prefix is only derived when the configured pattern can actually reach a nested resource — that
+ * is, when it ends in a multi-segment wildcard. {@code /resources/*} matches a single segment and can
+ * never serve {@code /resources/bootui/index.html}, so claiming that namespace would block host routes
+ * for no security benefit.</p>
+ *
+ * <p>The reserved {@code /bootui} mount is always included, so the namespace BootUI claims stays claimed
+ * regardless of how the host has moved its static handling. Values are read once at startup: these are
+ * static Spring Boot properties, not live-overridable BootUI configuration.</p>
+ *
+ * <p>This covers Spring Boot's static-resource <em>mapping</em>, not arbitrary resource-location
+ * aliasing. A host that deliberately points {@code spring.web.resources.static-locations} inside
+ * BootUI's classpath directory is republishing those files under a URL of its own choosing; that is
+ * host-controlled and out of scope here.</p>
+ */
+public final class BootUiShellGuardMounts {
+
+    private BootUiShellGuardMounts() {}
+
+    /** Mounts to guard in a servlet (Spring MVC) application. */
+    public static List<String> servlet(Environment environment) {
+        return mounts(
+                pathPrefix(environment.getProperty("spring.mvc.servlet.path", "/")),
+                nestedPatternPrefix(environment.getProperty("spring.mvc.static-path-pattern", "/**")));
+    }
+
+    /** Mounts to guard in a reactive (Spring WebFlux) application. */
+    public static List<String> reactive(Environment environment) {
+        return mounts("", nestedPatternPrefix(environment.getProperty("spring.webflux.static-path-pattern", "/**")));
+    }
+
+    private static List<String> mounts(String servletPrefix, String staticPrefix) {
+        Set<String> mounts = new LinkedHashSet<>();
+        mounts.add(BootUiPathNormalizer.DEFAULT_PATH);
+        if (staticPrefix != null) {
+            mounts.add(servletPrefix + staticPrefix + BootUiPathNormalizer.DEFAULT_PATH);
+        }
+        return List.copyOf(mounts);
+    }
+
+    /** Normalizes a configured path prefix to either {@code ""} or a value like {@code "/app"}. */
+    private static String pathPrefix(String value) {
+        if (value == null) {
+            return "";
+        }
+        String trimmed = value.strip();
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        if (trimmed.isEmpty()) {
+            return "";
+        }
+        return trimmed.startsWith("/") ? trimmed : "/" + trimmed;
+    }
+
+    /**
+     * Returns the literal prefix of a resource pattern that can serve nested resources
+     * ({@code /static/**} yields {@code /static}), or {@code null} when the pattern cannot reach
+     * {@code bootui/**} at all.
+     */
+    private static String nestedPatternPrefix(String pattern) {
+        if (pattern == null || !matchesNestedPaths(pattern)) {
+            return null;
+        }
+        int wildcard = indexOfWildcard(pattern);
+        return pathPrefix(pattern.substring(0, wildcard));
+    }
+
+    /** A pattern reaches nested resources only through {@code **} or a capture-all {@code {*name}}. */
+    private static boolean matchesNestedPaths(String pattern) {
+        return pattern.contains("**") || pattern.contains("{*");
+    }
+
+    private static int indexOfWildcard(String pattern) {
+        for (int i = 0; i < pattern.length(); i++) {
+            char c = pattern.charAt(i);
+            if (c == '*' || c == '?' || c == '{') {
+                return i;
+            }
+        }
+        return pattern.length();
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiShellGuardFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiShellGuardFilter.java
@@ -1,0 +1,63 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import io.github.jdubois.bootui.engine.safety.BootUiInternalMount;
+import java.util.List;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.PathContainer;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive (WebFlux) sibling of {@code BootUiShellGuardFilter}: answers {@code 404} for the packaged
+ * BootUI mount while BootUI is inactive.
+ *
+ * <p>WebFlux has the same exposure as Spring MVC. {@code WebFluxAutoConfiguration} serves
+ * {@code classpath:/META-INF/resources/} by default, so the compiled Vue bundle shipped by
+ * {@code bootui-ui} answers {@code GET /bootui/index.html} with {@code 200} even though no BootUI bean is
+ * wired (#856). See {@code BootUiShellGuardFilter} for the full rationale.</p>
+ *
+ * <p>Both stacks agree on scope through the framework-neutral {@link BootUiInternalMount} predicate
+ * rather than by one filter calling the other: a reactive-only application has no servlet API on its
+ * classpath, so touching the servlet filter class from here would raise
+ * {@code NoClassDefFoundError: jakarta/servlet/Filter} on every request.</p>
+ *
+ * <p>The path is rebuilt from {@link PathContainer.PathSegment#valueToMatch()}, which is what
+ * {@code PathPattern} matches on: it is percent-decoded and has matrix parameters removed, so
+ * {@code /%62ootui/index.html} cannot slip past a guard that the resource handler would then serve.</p>
+ */
+public final class ReactiveBootUiShellGuardFilter implements WebFilter, Ordered {
+
+    private final List<String> mounts;
+
+    public ReactiveBootUiShellGuardFilter(List<String> mounts) {
+        this.mounts = List.copyOf(mounts);
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String path = decodedPathWithinApplication(exchange);
+        if (mounts.stream().noneMatch(mount -> BootUiInternalMount.isUnder(path, mount))) {
+            return chain.filter(exchange);
+        }
+        exchange.getResponse().setStatusCode(HttpStatus.NOT_FOUND);
+        return exchange.getResponse().setComplete();
+    }
+
+    private static String decodedPathWithinApplication(ServerWebExchange exchange) {
+        StringBuilder path = new StringBuilder();
+        for (PathContainer.Element element :
+                exchange.getRequest().getPath().pathWithinApplication().elements()) {
+            path.append(
+                    element instanceof PathContainer.PathSegment segment ? segment.valueToMatch() : element.value());
+        }
+        return path.toString();
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/BootUiShellGuardFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/BootUiShellGuardFilter.java
@@ -1,0 +1,64 @@
+package io.github.jdubois.bootui.autoconfigure.safety;
+
+import io.github.jdubois.bootui.engine.safety.BootUiInternalMount;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UrlPathHelper;
+
+/**
+ * Keeps the packaged BootUI shell dark while BootUI is inactive.
+ *
+ * <p>When {@code BootUiActivationCondition} resolves to disabled &mdash; a {@code prod}/{@code production}
+ * profile, {@code bootui.enabled=OFF}, an invalid {@code bootui.enabled} value, or simply no enabling
+ * profile &mdash; no BootUI controller, resource handler, or safety filter is registered at all. The API
+ * is therefore already unreachable. The compiled Vue bundle is not: {@code bootui-ui} ships it on the
+ * classpath at {@code META-INF/resources/bootui/}, and {@code classpath:/META-INF/resources/} is one of
+ * Spring Boot's <strong>default</strong> static-resource locations, wired by
+ * {@code WebMvcAutoConfiguration} independently of BootUI. Left alone, {@code GET /bootui/index.html} and
+ * every asset below it answer {@code 200} in production with no working API behind them (#856).</p>
+ *
+ * <p>This filter turns that into a {@code 404}, at parity with the Quarkus adapter's
+ * {@code BootUiProdShellGuardFilter}. It is registered by {@code BootUiShellGuardAutoConfiguration} under
+ * {@code BootUiInactiveCondition}, the exact negation of the activation condition, so it exists only
+ * while the console is off and can never shadow a live BootUI mount.</p>
+ *
+ * <p>Two details make the match honest rather than approximate:</p>
+ * <ul>
+ *   <li>It compares the <strong>decoded</strong> application path from {@link UrlPathHelper}, the same
+ *       form Spring's handler mapping resolves against. Matching the raw {@code getRequestURI()} would
+ *       let {@code /%62ootui/index.html} and {@code /bootui;x=1/index.html} through while they still
+ *       resolved to the bundle.</li>
+ *   <li>It checks every mount {@code BootUiShellGuardMounts} derives, not only {@code /bootui}: Spring
+ *       Boot serves static resources behind {@code spring.mvc.servlet.path} and
+ *       {@code spring.mvc.static-path-pattern}, so the same bundle can surface at, say,
+ *       {@code /app/bootui/**} or {@code /static/bootui/**}.</li>
+ * </ul>
+ *
+ * <p>The rejection uses {@code sendError} rather than a bare status so the response is the host
+ * application's own {@code 404} &mdash; exactly what any unknown URL produces there, which is the point.
+ * This also matches the sibling {@link LegacyBootUiPathFilter}.</p>
+ */
+public final class BootUiShellGuardFilter extends OncePerRequestFilter {
+
+    private final List<String> mounts;
+
+    public BootUiShellGuardFilter(List<String> mounts) {
+        this.mounts = List.copyOf(mounts);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String path = UrlPathHelper.defaultInstance.getPathWithinApplication(request);
+        if (mounts.stream().noneMatch(mount -> BootUiInternalMount.isUnder(path, mount))) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/bootui-spring-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -2,3 +2,4 @@ io.github.jdubois.bootui.autoconfigure.BootUiAutoConfiguration
 io.github.jdubois.bootui.autoconfigure.BootUiReactiveAutoConfiguration
 io.github.jdubois.bootui.autoconfigure.BootUiSpringSecurityAutoConfiguration
 io.github.jdubois.bootui.autoconfigure.BootUiReactiveSpringSecurityAutoConfiguration
+io.github.jdubois.bootui.autoconfigure.BootUiShellGuardAutoConfiguration

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiShellGuardAutoConfigurationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiShellGuardAutoConfigurationTests.java
@@ -1,0 +1,243 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.github.jdubois.bootui.autoconfigure.reactive.ReactiveBootUiShellGuardFilter;
+import io.github.jdubois.bootui.autoconfigure.safety.BootUiShellGuardFilter;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.webflux.autoconfigure.HttpHandlerAutoConfiguration;
+import org.springframework.boot.webflux.autoconfigure.WebFluxAutoConfiguration;
+import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
+import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Tests for {@link BootUiShellGuardAutoConfiguration} (issue #856).
+ *
+ * <p>The console's API is already unreachable when {@link BootUiActivationCondition} does not match,
+ * because nothing is registered. The compiled Vue bundle was not: it ships at
+ * {@code META-INF/resources/bootui/}, one of Spring Boot's default static-resource locations, so both
+ * {@code WebMvcAutoConfiguration} and {@code WebFluxAutoConfiguration} served it regardless of BootUI's
+ * activation state. {@code shellIsReachableWithoutTheGuard*} pins that underlying exposure so these
+ * tests keep proving something real, and the rest assert the guard closes it on both stacks.</p>
+ */
+class BootUiShellGuardAutoConfigurationTests {
+
+    private static final ClassPathResource PACKAGED_SHELL =
+            new ClassPathResource("META-INF/resources/bootui/index.html");
+
+    @Test
+    void registersServletGuardWhenBootUiIsInactive() {
+        servletRunner()
+                .run(context -> assertThat(context)
+                        .hasSingleBean(BootUiShellGuardAutoConfiguration.class)
+                        .hasSingleBean(BootUiShellGuardFilter.class));
+    }
+
+    @Test
+    void registersServletGuardForEveryDisablingReason() {
+        servletRunner()
+                .withPropertyValues("spring.profiles.active=prod")
+                .run(context -> assertThat(context).hasSingleBean(BootUiShellGuardFilter.class));
+        servletRunner()
+                .withPropertyValues("spring.profiles.active=dev", "bootui.enabled=OFF")
+                .run(context -> assertThat(context).hasSingleBean(BootUiShellGuardFilter.class));
+        // Fail-closed: an unparseable bootui.enabled disables BootUI, so the shell must go dark too.
+        servletRunner()
+                .withPropertyValues("spring.profiles.active=dev", "bootui.enabled=maybe")
+                .run(context -> assertThat(context).hasSingleBean(BootUiShellGuardFilter.class));
+    }
+
+    @Test
+    void doesNotRegisterServletGuardWhenBootUiIsActive() {
+        servletRunner()
+                .withPropertyValues("bootui.enabled=ON")
+                .run(context -> assertThat(context)
+                        .doesNotHaveBean(BootUiShellGuardAutoConfiguration.class)
+                        .doesNotHaveBean(BootUiShellGuardFilter.class));
+        servletRunner()
+                .withPropertyValues("spring.profiles.active=dev")
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiShellGuardFilter.class));
+        // bootui.enabled=ON wins over a disabled profile, and so must the guard's polarity.
+        servletRunner()
+                .withPropertyValues("spring.profiles.active=prod", "bootui.enabled=ON")
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiShellGuardFilter.class));
+    }
+
+    @Test
+    void registersTheServletFilterForTheReservedMountOnly() {
+        servletRunner().run(context -> {
+            FilterRegistrationBean<?> registration =
+                    context.getBean("bootUiShellGuardFilterRegistration", FilterRegistrationBean.class);
+            assertThat(registration.getUrlPatterns()).containsExactly("/bootui/*");
+            assertThat(registration.getOrder()).isEqualTo(Integer.MIN_VALUE);
+        });
+    }
+
+    @Test
+    void doesNotRegisterAGuardWithoutThePackagedShellOnTheClasspath() {
+        // bootui-spring-autoconfigure without bootui-ui: there is no shell to leak, so /bootui stays
+        // the host application's to use.
+        servletRunner()
+                .withClassLoader(new FilteredClassLoader(PACKAGED_SHELL))
+                .run(context -> assertThat(context).doesNotHaveBean(BootUiShellGuardFilter.class));
+    }
+
+    @Test
+    void doesNotRegisterAnyGuardInANonWebApplication() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(BootUiShellGuardAutoConfiguration.class))
+                .run(context -> assertThat(context)
+                        .doesNotHaveBean(BootUiShellGuardFilter.class)
+                        .doesNotHaveBean(ReactiveBootUiShellGuardFilter.class));
+    }
+
+    @Test
+    void shellIsReachableWithoutTheGuardOnSpringMvc() {
+        // Regression anchor: this is exactly what #856 reported.
+        servletRunner().run(context -> {
+            MockMvc mvc = MockMvcBuilders.webAppContextSetup(
+                            (WebApplicationContext) context.getSourceApplicationContext())
+                    .build();
+            mvc.perform(get("/bootui/index.html")).andExpect(status().isOk());
+            // The encoded spelling resolves to the same bundle entry, which is why the guard has to
+            // match the decoded path rather than the raw request URI.
+            mvc.perform(get(URI.create("/%62ootui/index.html"))).andExpect(status().isOk());
+        });
+    }
+
+    @Test
+    void guardBlocksTheShellOnSpringMvc() {
+        servletRunner().run(context -> {
+            MockMvc mvc = MockMvcBuilders.webAppContextSetup(
+                            (WebApplicationContext) context.getSourceApplicationContext())
+                    .addFilters(context.getBean(BootUiShellGuardFilter.class))
+                    .build();
+            mvc.perform(get("/bootui/index.html")).andExpect(status().isNotFound());
+            mvc.perform(get("/bootui/assets/index-abc123.js")).andExpect(status().isNotFound());
+            mvc.perform(get("/bootui")).andExpect(status().isNotFound());
+        });
+    }
+
+    @Test
+    void guardBlocksAnEncodedSpellingOfTheMountOnSpringMvc() {
+        // Spring resolves the resource against the decoded path, so a guard that compared the raw
+        // request URI would pass this straight through to the packaged bundle.
+        servletRunner().run(context -> {
+            MockMvc mvc = MockMvcBuilders.webAppContextSetup(
+                            (WebApplicationContext) context.getSourceApplicationContext())
+                    .addFilters(context.getBean(BootUiShellGuardFilter.class))
+                    .build();
+            mvc.perform(get(URI.create("/%62ootui/index.html"))).andExpect(status().isNotFound());
+        });
+    }
+
+    @Test
+    void registersReactiveGuardWhenBootUiIsInactive() {
+        reactiveRunner()
+                .run(context -> assertThat(context)
+                        .hasSingleBean(BootUiShellGuardAutoConfiguration.class)
+                        .hasSingleBean(ReactiveBootUiShellGuardFilter.class)
+                        .doesNotHaveBean(BootUiShellGuardFilter.class));
+    }
+
+    @Test
+    void doesNotRegisterReactiveGuardWhenBootUiIsActive() {
+        reactiveRunner()
+                .withPropertyValues("bootui.enabled=ON")
+                .run(context -> assertThat(context).doesNotHaveBean(ReactiveBootUiShellGuardFilter.class));
+    }
+
+    @Test
+    void shellIsReachableWithoutTheGuardOnWebFlux() {
+        new ReactiveWebApplicationContextRunner()
+                .withConfiguration(
+                        AutoConfigurations.of(HttpHandlerAutoConfiguration.class, WebFluxAutoConfiguration.class))
+                .run(context -> {
+                    WebTestClient client = WebTestClient.bindToApplicationContext(context.getSourceApplicationContext())
+                            .build();
+                    client.get()
+                            .uri("/bootui/index.html")
+                            .exchange()
+                            .expectStatus()
+                            .isOk();
+                    // Same point as on Spring MVC: the encoded spelling reaches the bundle too.
+                    client.get()
+                            .uri(URI.create("/%62ootui/index.html"))
+                            .exchange()
+                            .expectStatus()
+                            .isOk();
+                });
+    }
+
+    @Test
+    void guardBlocksTheShellOnWebFlux() {
+        reactiveRunner().run(context -> {
+            WebTestClient client = WebTestClient.bindToApplicationContext(context.getSourceApplicationContext())
+                    .build();
+            client.get().uri("/bootui/index.html").exchange().expectStatus().isNotFound();
+            client.get()
+                    .uri("/bootui/assets/index-abc123.js")
+                    .exchange()
+                    .expectStatus()
+                    .isNotFound();
+            client.get().uri("/bootui").exchange().expectStatus().isNotFound();
+            client.get()
+                    .uri(URI.create("/%62ootui/index.html"))
+                    .exchange()
+                    .expectStatus()
+                    .isNotFound();
+        });
+    }
+
+    @Test
+    void reactiveGuardWorksWithoutTheServletApiOnTheClasspath() {
+        // A WebFlux-only application has no jakarta.servlet at all. An earlier revision of the guard had
+        // the reactive filter call a static on its servlet sibling, which raised
+        // NoClassDefFoundError: jakarta/servlet/Filter on *every* request (not only BootUI's), leaving
+        // Netty to close the connection with no response.
+        reactiveRunner()
+                .withClassLoader(new FilteredClassLoader(jakarta.servlet.Filter.class))
+                .run(context -> {
+                    WebTestClient client = WebTestClient.bindToApplicationContext(context.getSourceApplicationContext())
+                            .build();
+                    client.get()
+                            .uri("/bootui/index.html")
+                            .exchange()
+                            .expectStatus()
+                            .isNotFound();
+                    client.get().uri("/api/orders").exchange().expectStatus().isNotFound();
+                });
+    }
+
+    private static WebApplicationContextRunner servletRunner() {
+        return new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        DispatcherServletAutoConfiguration.class,
+                        WebMvcAutoConfiguration.class,
+                        BootUiAutoConfiguration.class,
+                        BootUiShellGuardAutoConfiguration.class));
+    }
+
+    private static ReactiveWebApplicationContextRunner reactiveRunner() {
+        return new ReactiveWebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        HttpHandlerAutoConfiguration.class,
+                        WebFluxAutoConfiguration.class,
+                        BootUiReactiveAutoConfiguration.class,
+                        BootUiShellGuardAutoConfiguration.class));
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiShellGuardMountsTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiShellGuardMountsTests.java
@@ -1,0 +1,74 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Pins the derivation of every prefix under which Spring can serve the packaged BootUI bundle, which is
+ * what keeps the shell guard from being defeated by a host's static-resource configuration (#856).
+ */
+class BootUiShellGuardMountsTests {
+
+    @Test
+    void defaultsToTheReservedMountOnly() {
+        assertThat(BootUiShellGuardMounts.servlet(new MockEnvironment())).containsExactly("/bootui");
+        assertThat(BootUiShellGuardMounts.reactive(new MockEnvironment())).containsExactly("/bootui");
+    }
+
+    @Test
+    void addsTheDispatcherServletPathPrefix() {
+        MockEnvironment environment = new MockEnvironment().withProperty("spring.mvc.servlet.path", "/app");
+
+        assertThat(BootUiShellGuardMounts.servlet(environment)).containsExactly("/bootui", "/app/bootui");
+    }
+
+    @Test
+    void addsTheStaticPathPatternPrefix() {
+        MockEnvironment servlet = new MockEnvironment().withProperty("spring.mvc.static-path-pattern", "/static/**");
+        MockEnvironment reactive =
+                new MockEnvironment().withProperty("spring.webflux.static-path-pattern", "/static/**");
+
+        assertThat(BootUiShellGuardMounts.servlet(servlet)).containsExactly("/bootui", "/static/bootui");
+        assertThat(BootUiShellGuardMounts.reactive(reactive)).containsExactly("/bootui", "/static/bootui");
+    }
+
+    @Test
+    void combinesTheServletPathAndTheStaticPathPattern() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.mvc.servlet.path", "/app")
+                .withProperty("spring.mvc.static-path-pattern", "/static/**");
+
+        assertThat(BootUiShellGuardMounts.servlet(environment)).containsExactly("/bootui", "/app/static/bootui");
+    }
+
+    @Test
+    void normalizesTrailingSlashesAndMissingLeadingSlashes() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.mvc.servlet.path", "app/")
+                .withProperty("spring.mvc.static-path-pattern", "/resources/**");
+
+        assertThat(BootUiShellGuardMounts.servlet(environment)).containsExactly("/bootui", "/app/resources/bootui");
+    }
+
+    @Test
+    void ignoresPatternsThatCannotReachNestedResources() {
+        // "/resources/*" matches exactly one segment, so it can never serve
+        // "/resources/bootui/index.html". Claiming that namespace would block host routes for nothing.
+        MockEnvironment singleSegment =
+                new MockEnvironment().withProperty("spring.mvc.static-path-pattern", "/resources/*");
+        MockEnvironment literal = new MockEnvironment().withProperty("spring.mvc.static-path-pattern", "/resources");
+
+        assertThat(BootUiShellGuardMounts.servlet(singleSegment)).containsExactly("/bootui");
+        assertThat(BootUiShellGuardMounts.servlet(literal)).containsExactly("/bootui");
+    }
+
+    @Test
+    void handlesCaptureAllPatterns() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("spring.webflux.static-path-pattern", "/static/{*resource}");
+
+        assertThat(BootUiShellGuardMounts.reactive(environment)).containsExactly("/bootui", "/static/bootui");
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiShellGuardFilterTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiShellGuardFilterTests.java
@@ -1,0 +1,81 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.core.BootUiPathNormalizer;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+
+/**
+ * WebFlux twin of {@code BootUiShellGuardFilterTests}: the reactive guard must block exactly the same
+ * surface, including under a {@code spring.webflux.base-path} and for encoded spellings of the mount.
+ */
+class ReactiveBootUiShellGuardFilterTests {
+
+    private static final List<String> DEFAULT_MOUNTS = List.of(BootUiPathNormalizer.DEFAULT_PATH);
+
+    private static final WebFilterChain OK_CHAIN = exchange -> {
+        exchange.getResponse().setStatusCode(HttpStatus.OK);
+        return exchange.getResponse().setComplete();
+    };
+
+    @Test
+    void blocksThePackagedShellAndItsAssets() {
+        assertThat(status("/bootui/index.html", null)).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(status("/bootui/assets/index-abc123.js", null)).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(status("/bootui/", null)).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(status("/bootui", null)).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(status("/bootui/api/overview", null)).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void blocksPercentEncodedAndMatrixParameterSpellingsOfTheMount() {
+        // PathPattern matches on the decoded segment value, so these reach the packaged bundle.
+        assertThat(status("/%62ootui/index.html", null)).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(status("/boot%75i/index.html", null)).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(status("/bootui;version=1/index.html", null)).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void blocksTheMountUnderAHostBasePath() {
+        assertThat(status("/host/bootui/index.html", "/host")).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void blocksEveryConfiguredMount() {
+        List<String> mounts = List.of("/bootui", "/static/bootui");
+        assertThat(status(mounts, "/static/bootui/index.html", null)).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(status(mounts, "/bootui/index.html", null)).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(status(mounts, "/static/other.js", null)).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void leavesHostApplicationRoutesUntouched() {
+        assertThat(status("/api/orders", null)).isEqualTo(HttpStatus.OK);
+        assertThat(status("/bootui-console/index.html", null)).isEqualTo(HttpStatus.OK);
+        assertThat(status("/host/console/bootui", "/host")).isEqualTo(HttpStatus.OK);
+    }
+
+    private static HttpStatus status(String uri, String contextPath) {
+        return status(DEFAULT_MOUNTS, uri, contextPath);
+    }
+
+    private static HttpStatus status(List<String> mounts, String uri, String contextPath) {
+        // method(HttpMethod, URI) rather than get(String): the String overload re-encodes the template,
+        // which would turn "%62" into "%2562" and quietly defeat the encoded-path assertions.
+        MockServerHttpRequest.BaseBuilder<?> builder = MockServerHttpRequest.method(HttpMethod.GET, URI.create(uri));
+        if (contextPath != null) {
+            builder = builder.contextPath(contextPath);
+        }
+        MockServerWebExchange exchange = MockServerWebExchange.from(builder);
+        new ReactiveBootUiShellGuardFilter(mounts).filter(exchange, OK_CHAIN).block(Duration.ofSeconds(5));
+        return HttpStatus.valueOf(exchange.getResponse().getStatusCode().value());
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/BootUiShellGuardFilterTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/BootUiShellGuardFilterTests.java
@@ -1,0 +1,84 @@
+package io.github.jdubois.bootui.autoconfigure.safety;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.core.BootUiPathNormalizer;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * White-box coverage for the servlet shell guard: what it blocks, what it must never touch, how it
+ * behaves under a host {@code server.servlet.context-path}, and that it matches the decoded path rather
+ * than the raw request URI.
+ */
+class BootUiShellGuardFilterTests {
+
+    private static final List<String> DEFAULT_MOUNTS = List.of(BootUiPathNormalizer.DEFAULT_PATH);
+
+    @Test
+    void blocksThePackagedShellAndItsAssets() throws Exception {
+        assertThat(status("/bootui/index.html", "")).isEqualTo(404);
+        assertThat(status("/bootui/assets/index-abc123.js", "")).isEqualTo(404);
+        assertThat(status("/bootui/assets/index-abc123.css", "")).isEqualTo(404);
+        assertThat(status("/bootui/", "")).isEqualTo(404);
+        assertThat(status("/bootui", "")).isEqualTo(404);
+    }
+
+    @Test
+    void blocksTheApiMountToo() throws Exception {
+        // Nothing serves it while BootUI is inactive, but the guard must not carve out an exception
+        // that a future change could turn into a hole.
+        assertThat(status("/bootui/api/overview", "")).isEqualTo(404);
+    }
+
+    @Test
+    void blocksPercentEncodedAndMatrixParameterSpellingsOfTheMount() throws Exception {
+        // Spring resolves handlers against the decoded path, so these all reach the packaged bundle.
+        assertThat(status("/%62ootui/index.html", "")).isEqualTo(404);
+        assertThat(status("/boot%75i/index.html", "")).isEqualTo(404);
+        assertThat(status("/bootui;version=1/index.html", "")).isEqualTo(404);
+    }
+
+    @Test
+    void blocksTheMountUnderAHostContextPath() throws Exception {
+        assertThat(status("/host/bootui/index.html", "/host")).isEqualTo(404);
+    }
+
+    @Test
+    void blocksEveryConfiguredMount() throws Exception {
+        // What BootUiShellGuardMounts derives for spring.mvc.servlet.path=/app plus
+        // spring.mvc.static-path-pattern=/static/**.
+        List<String> mounts = List.of("/bootui", "/app/static/bootui");
+        assertThat(status(mounts, "/app/static/bootui/index.html", "")).isEqualTo(404);
+        assertThat(status(mounts, "/bootui/index.html", "")).isEqualTo(404);
+        assertThat(status(mounts, "/app/static/other.js", "")).isEqualTo(200);
+    }
+
+    @Test
+    void leavesHostApplicationRoutesUntouched() throws Exception {
+        assertThat(status("/", "")).isEqualTo(200);
+        assertThat(status("/api/orders", "")).isEqualTo(200);
+        // Adjacent paths that merely share the "/bootui" prefix are not under the mount.
+        assertThat(status("/bootui-console/index.html", "")).isEqualTo(200);
+        assertThat(status("/bootuix", "")).isEqualTo(200);
+        // A host route that happens to sit at the same-named path under a different context.
+        assertThat(status("/host/console/bootui", "/host")).isEqualTo(200);
+    }
+
+    private static int status(String uri, String contextPath) throws Exception {
+        return status(DEFAULT_MOUNTS, uri, contextPath);
+    }
+
+    private static int status(List<String> mounts, String uri, String contextPath) throws Exception {
+        BootUiShellGuardFilter filter = new BootUiShellGuardFilter(mounts);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+        request.setRequestURI(uri);
+        request.setContextPath(contextPath);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        filter.doFilter(request, response, new MockFilterChain());
+        return response.getStatus();
+    }
+}

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiInactiveShellIntegrationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiInactiveShellIntegrationTests.java
@@ -1,0 +1,77 @@
+package io.github.jdubois.bootui.sample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+/**
+ * Regression test for issue #856, on a real embedded Tomcat with the real {@code bootui-ui} jar on the
+ * classpath.
+ *
+ * <p>{@code bootui.enabled=OFF} reproduces the production-dark state (the same
+ * {@code BootUiActivationCondition} verdict a {@code prod} profile produces) while keeping the sample
+ * app's own configuration untouched. Every BootUI route is then unregistered — but the compiled Vue
+ * bundle ships at {@code META-INF/resources/bootui/}, which Spring Boot's default static-resource
+ * handler serves regardless, so {@code GET /bootui/index.html} used to answer {@code 200} with the empty
+ * shell. {@code BootUiShellGuardAutoConfiguration} turns the whole mount into a plain {@code 404}.</p>
+ */
+@SpringBootTest(
+        classes = BootUiSampleApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.profiles.active=dev",
+            "bootui.enabled=OFF",
+            "bootui.show-banner=false",
+            "bootui.overrides-file=target/bootui-inactive-shell-test-overrides.properties"
+        })
+class BootUiInactiveShellIntegrationTests {
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void packagedShellAndAssetsAreNotServedWhenBootUiIsInactive() throws Exception {
+        assertThat(status("/bootui/index.html")).isEqualTo(404);
+        assertThat(status("/bootui/")).isEqualTo(404);
+        assertThat(status("/bootui")).isEqualTo(404);
+        assertThat(status("/bootui/api/overview")).isEqualTo(404);
+        // A real, content-hashed bundle entry resolved from the packaged jar: proves the 404 is the
+        // guard rejecting an asset that genuinely exists, not just a missing file.
+        assertThat(status("/bootui/assets/" + packagedAssetName())).isEqualTo(404);
+        // Spring resolves static resources against the decoded path, so the encoded spellings reach
+        // the same bundle entry and must be rejected too.
+        assertThat(status("/%62ootui/index.html")).isEqualTo(404);
+        assertThat(status("/bootui;version=1/index.html")).isEqualTo(404);
+    }
+
+    static String packagedAssetName() throws Exception {
+        Resource[] assets = new PathMatchingResourcePatternResolver()
+                .getResources("classpath:/META-INF/resources/bootui/assets/index-*.js");
+        assertThat(assets).isNotEmpty();
+        return assets[0].getFilename();
+    }
+
+    @Test
+    void hostApplicationKeepsServingItsOwnStaticResources() throws Exception {
+        assertThat(status("/")).isEqualTo(200);
+        assertThat(status("/index.html")).isEqualTo(200);
+    }
+
+    private int status(String path) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + path))
+                .GET()
+                .build();
+        return HttpClient.newHttpClient()
+                .send(request, HttpResponse.BodyHandlers.ofString())
+                .statusCode();
+    }
+}

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiInactiveShellStaticMappingIntegrationTests.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/BootUiInactiveShellStaticMappingIntegrationTests.java
@@ -1,0 +1,62 @@
+package io.github.jdubois.bootui.sample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/**
+ * Companion to {@link BootUiInactiveShellIntegrationTests} for issue #856: the URL that exposes the
+ * packaged bundle is not fixed at {@code /bootui/**}.
+ *
+ * <p>Spring Boot's static-resource handler sits behind the DispatcherServlet mapping
+ * ({@code spring.mvc.servlet.path}) and behind a configurable pattern
+ * ({@code spring.mvc.static-path-pattern}). With both moved, the shell surfaces at
+ * {@code /app/static/bootui/index.html}, which a guard pinned to {@code /bootui/*} would sail past.
+ * {@code BootUiShellGuardMounts} derives that prefix, and this test proves the derivation matches the
+ * real URL on a real embedded Tomcat.</p>
+ */
+@SpringBootTest(
+        classes = BootUiSampleApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.profiles.active=dev",
+            "bootui.enabled=OFF",
+            "bootui.show-banner=false",
+            "bootui.overrides-file=target/bootui-inactive-shell-mapping-test-overrides.properties",
+            "spring.mvc.servlet.path=/app",
+            "spring.mvc.static-path-pattern=/static/**"
+        })
+class BootUiInactiveShellStaticMappingIntegrationTests {
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void relocatedStaticHandlingStillServesTheHostBundleButNotBootUi() throws Exception {
+        // The host application's own static resource proves the handler really is mounted here, so the
+        // 404 below is the guard rejecting the request rather than an unmapped URL.
+        assertThat(status("/app/static/index.html")).isEqualTo(200);
+
+        assertThat(status("/app/static/bootui/index.html")).isEqualTo(404);
+        assertThat(status("/app/static/bootui/assets/" + BootUiInactiveShellIntegrationTests.packagedAssetName()))
+                .isEqualTo(404);
+        // The reserved namespace stays claimed at its canonical location as well.
+        assertThat(status("/bootui/index.html")).isEqualTo(404);
+    }
+
+    private int status(String path) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + path))
+                .GET()
+                .build();
+        return HttpClient.newHttpClient()
+                .send(request, HttpResponse.BodyHandlers.ofString())
+                .statusCode();
+    }
+}

--- a/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxInactiveShellIntegrationTest.java
+++ b/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxInactiveShellIntegrationTest.java
@@ -1,0 +1,76 @@
+package io.github.jdubois.bootui.webfluxsample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+/**
+ * WebFlux twin of the servlet sample app's {@code BootUiInactiveShellIntegrationTests} (issue #856),
+ * on a real embedded Netty with the real {@code bootui-ui} jar on the classpath.
+ *
+ * <p>{@code WebFluxAutoConfiguration} serves {@code classpath:/META-INF/resources/} by default just as
+ * {@code WebMvcAutoConfiguration} does, so the packaged shell was reachable on this stack too while
+ * BootUI was inactive. The reactive shell guard closes it identically.</p>
+ */
+@SpringBootTest(
+        classes = BootUiWebfluxSampleApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.profiles.active=dev",
+            "bootui.enabled=OFF",
+            "bootui.show-banner=false",
+            "bootui.overrides-file=target/bootui-inactive-shell-test-overrides.properties"
+        })
+class WebFluxInactiveShellIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void packagedShellAndAssetsAreNotServedWhenBootUiIsInactive() throws Exception {
+        assertThat(status("/bootui/index.html")).isEqualTo(404);
+        assertThat(status("/bootui/")).isEqualTo(404);
+        assertThat(status("/bootui")).isEqualTo(404);
+        assertThat(status("/bootui/api/overview")).isEqualTo(404);
+        // A real, content-hashed bundle entry resolved from the packaged jar: proves the 404 is the
+        // guard rejecting an asset that genuinely exists, not just a missing file.
+        assertThat(status("/bootui/assets/" + packagedAssetName())).isEqualTo(404);
+        // PathPattern matches decoded segments, so the encoded spellings reach the same entry.
+        assertThat(status("/%62ootui/index.html")).isEqualTo(404);
+        assertThat(status("/bootui;version=1/index.html")).isEqualTo(404);
+    }
+
+    static String packagedAssetName() throws Exception {
+        Resource[] assets = new PathMatchingResourcePatternResolver()
+                .getResources("classpath:/META-INF/resources/bootui/assets/index-*.js");
+        assertThat(assets).isNotEmpty();
+        return assets[0].getFilename();
+    }
+
+    @Test
+    void hostApplicationRoutesAreUntouched() throws Exception {
+        // The guard sits at HIGHEST_PRECEDENCE, ahead of Spring Security, so this also proves it does
+        // not swallow requests outside the reserved mount: /api/** is permitAll and still answers,
+        // and / still reaches the sample's security chain (401) rather than the guard's 404.
+        assertThat(status("/api/greetings/bootui")).isEqualTo(200);
+        assertThat(status("/")).isEqualTo(401);
+    }
+
+    private int status(String path) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + path))
+                .GET()
+                .build();
+        return HttpClient.newHttpClient()
+                .send(request, HttpResponse.BodyHandlers.ofString())
+                .statusCode();
+    }
+}

--- a/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxInactiveShellStaticMappingIntegrationTest.java
+++ b/bootui-spring-webflux-sample-app/src/test/java/io/github/jdubois/bootui/webfluxsample/WebFluxInactiveShellStaticMappingIntegrationTest.java
@@ -1,0 +1,56 @@
+package io.github.jdubois.bootui.webfluxsample;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/**
+ * WebFlux twin of the servlet sample app's {@code BootUiInactiveShellStaticMappingIntegrationTests}
+ * (issue #856): {@code spring.webflux.static-path-pattern} relocates the handler that exposes the
+ * packaged bundle, so the shell guard has to follow it there.
+ */
+@SpringBootTest(
+        classes = BootUiWebfluxSampleApplication.class,
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = {
+            "spring.profiles.active=dev",
+            "bootui.enabled=OFF",
+            "bootui.show-banner=false",
+            "bootui.overrides-file=target/bootui-inactive-shell-mapping-test-overrides.properties",
+            "spring.webflux.static-path-pattern=/static/**"
+        })
+class WebFluxInactiveShellStaticMappingIntegrationTest {
+
+    @LocalServerPort
+    int port;
+
+    @Test
+    void relocatedStaticHandlingDoesNotExposeTheShell() throws Exception {
+        // The sample app authenticates everything outside /api/**, /greeting/** and /actuator/**, so a
+        // relocated host resource answers 401. The BootUI mount answers 404 instead: the guard runs
+        // ahead of the security chain and rejects the request outright, which is exactly the
+        // discriminator that shows the guard — not the security filter — handled it.
+        assertThat(status("/static/index.html")).isEqualTo(401);
+
+        assertThat(status("/static/bootui/index.html")).isEqualTo(404);
+        assertThat(status("/static/bootui/assets/" + WebFluxInactiveShellIntegrationTest.packagedAssetName()))
+                .isEqualTo(404);
+        assertThat(status("/bootui/index.html")).isEqualTo(404);
+    }
+
+    private int status(String path) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + path))
+                .GET()
+                .build();
+        return HttpClient.newHttpClient()
+                .send(request, HttpResponse.BodyHandlers.ofString())
+                .statusCode();
+    }
+}

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -419,8 +419,10 @@ advisor endpoints, and the shell-chrome `GET /bootui/api/overview` endpoint is s
   step in the extension), whose `handle()` method reads a CDI-injected `LaunchMode` and answers a plain `404` for
   the configured UI/API surface and the private `/bootui` classpath mount only when it is `LaunchMode.NORMAL` — an
   immediate no-op pass-through otherwise, so dev/`@QuarkusTest` behavior is unaffected. Net effect: the public and
-  internal BootUI paths are plain 404s in production, at parity with the Spring adapter (which never registers any BootUI
-  route when inactive, so nothing is reachable there either).
+  internal BootUI paths are plain 404s in production, at parity with the Spring adapter, whose
+  `BootUiShellGuardAutoConfiguration` answers the same 404 for the same reserved `/bootui` mount whenever BootUI's
+  activation condition resolves to disabled — Spring Boot's default static-resource handling exposed the packaged shell
+  there for exactly the same reason (#856).
   Proven by a genuine `LaunchMode.NORMAL` build+run via `QuarkusProdModeTest`
   (`BootUiQuarkusProdShellGuardBootTest`, in the dedicated `bootui-quarkus-prod-shell-guard-integration-tests`
   module — kept separate from every `@QuarkusTest`-based module because Quarkus's own test framework refuses to mix

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -100,6 +100,26 @@ Default activation rules:
 `bootui.enabled=AUTO` is the default. BootUI must fail closed: if no enabled profile is active and DevTools is not on
 the classpath, it should not expose the UI.
 
+Failing closed covers the packaged console itself, not only its API. When BootUI is inactive no controller, resource
+handler, or safety filter is registered, but `bootui-ui` still ships the compiled shell on the classpath at
+`META-INF/resources/bootui/`, which every supported runtime serves from its own built-in static-resource handling. Each
+adapter therefore keeps a guard that answers `404` for the reserved internal `/bootui` namespace while the console is
+off: `BootUiShellGuardAutoConfiguration` on Spring MVC and Spring WebFlux (registered under the exact negation of the
+activation condition, and only when the packaged shell is actually on the classpath), `BootUiProdShellGuardFilter` on
+Quarkus (always registered, active in `LaunchMode.NORMAL`). A custom `bootui.path` moves the console's routes but never
+the classpath location of the bundle.
+
+The URL that reaches that classpath location is not fixed, so the Spring guard resolves it rather than assuming it. It
+matches the decoded application path, the same form the framework's handler mapping resolves against, so encoded and
+matrix-parameter spellings such as `/%62ootui/index.html` cannot slip past it. It also follows Spring Boot's relocatable
+static handling — `spring.mvc.servlet.path`, `spring.mvc.static-path-pattern`, and `spring.webflux.static-path-pattern`
+— under which the same bundle surfaces at, for example, `/app/static/bootui/index.html`. A prefix is only claimed when
+the configured pattern can actually reach a nested resource, so a single-segment pattern such as `/resources/*` never
+costs the host a namespace it could not have exposed. Requests outside the reserved `/bootui` namespace and its derived
+prefixes are passed through untouched; the namespace itself is reserved, so a host application must not serve its own
+routes there. Republishing BootUI's classpath directory under a URL of the host's own choosing (by pointing
+`spring.web.resources.static-locations` inside it) is host-controlled and unsupported.
+
 When BootUI is active, the starter should contribute low-precedence Actuator defaults for the local panels, including
 `beans`, `conditions`, `configprops`, `env`, `loggers`, `mappings`, `metrics`, `startup`, and `scheduledtasks`. Host
 applications can override those `management.*` settings explicitly.

--- a/docs/WEBFLUX-SUPPORT.md
+++ b/docs/WEBFLUX-SUPPORT.md
@@ -71,6 +71,15 @@ both, so exactly one of the two autoconfigurations activates.
   `bootui.disabled-profiles`, `spring-boot-devtools` on the classpath), plus
   `@ConditionalOnWebApplication(REACTIVE)` and `@ConditionalOnClass(DispatcherHandler)`. There is no separate
   "reactive mode" flag to opt into — BootUI simply detects which stack Spring Boot picked and binds accordingly.
+- **Same dark shell when inactive.** `WebFluxAutoConfiguration` serves `classpath:/META-INF/resources/` by default, so
+  the packaged Vue bundle would stay reachable at `/bootui/**` even with every BootUI bean unwired.
+  `BootUiShellGuardAutoConfiguration` registers `ReactiveBootUiShellGuardFilter` under the exact negation of the
+  activation condition, answering `404` for the reserved namespace; the servlet adapter gets the identical treatment
+  from the same auto-configuration. The reactive filter matches on `PathContainer.PathSegment.valueToMatch()` — the
+  decoded value `PathPattern` itself matches — and covers the prefix `spring.webflux.static-path-pattern` introduces,
+  mirroring the servlet guard's handling of `spring.mvc.servlet.path` and `spring.mvc.static-path-pattern`. Both filters
+  share the framework-neutral `BootUiInternalMount` predicate rather than calling into each other, because a
+  WebFlux-only application has no servlet API on its classpath at all.
 - **Same `LocalhostGuard`, ported to `WebFilter`.** `ReactiveLocalhostOnlyFilter` is a thin `WebFilter` binding over
   the exact same framework-neutral `io.github.jdubois.bootui.engine.safety.LocalhostGuard` the servlet
   `LocalhostOnlyFilter` uses — same loopback-source trust, `Host` allow-list, cross-site-write/CSRF defense, same


### PR DESCRIPTION
Fixes #856.

## The problem

Deactivating BootUI (a `prod`/`production` profile, `bootui.enabled=OFF`, an invalid `bootui.enabled` value, or simply no enabling profile) unwires every BootUI controller, resource handler, and safety filter — so the JSON API is unreachable. It did **not** make the console unreachable.

`bootui-ui` ships the compiled Vue bundle at `META-INF/resources/bootui/`, and `classpath:/META-INF/resources/` is a **default** static-resource location for both `WebMvcAutoConfiguration` and `WebFluxAutoConfiguration`. Reproduced on both stacks before the fix:

```
SERVLET  /bootui/index.html -> 200
REACTIVE /bootui/index.html -> 200
```

An empty shell with no API behind it, but reachable. Quarkus already closed the equivalent hole with `BootUiProdShellGuardFilter`; Spring had no counterpart.

## The fix

`BootUiShellGuardAutoConfiguration` — the one piece of BootUI wired while BootUI is *off*:

- Gated by `BootUiInactiveCondition`, the exact negation of `BootUiActivationCondition`, delegating to the same `resolve(...)` call so the two polarities cannot drift apart.
- Gated by `@ConditionalOnResource` on the packaged shell, so an app using `bootui-spring-autoconfigure` without `bootui-ui` keeps `/bootui` for itself.
- Nested `@ConditionalOnWebApplication` configurations register `BootUiShellGuardFilter` (servlet, `Integer.MIN_VALUE`) and `ReactiveBootUiShellGuardFilter` (WebFlux, `HIGHEST_PRECEDENCE`), both answering `404` for the reserved `/bootui` namespace.

Two details make the match honest rather than approximate:

- **Decoded paths.** Spring resolves resources against the decoded path, so `/%62ootui/index.html` and `/bootui;version=1/index.html` reach the same bundle entry. The servlet filter matches `UrlPathHelper.getPathWithinApplication`; the reactive filter rebuilds the path from `PathContainer.PathSegment.valueToMatch()`, the value `PathPattern` itself matches on.
- **Relocatable static handling.** Spring Boot serves static resources behind `spring.mvc.servlet.path` and `spring.mvc.static-path-pattern` / `spring.webflux.static-path-pattern`, so the same bundle surfaces at e.g. `/app/static/bootui/index.html`. `BootUiShellGuardMounts` derives those prefixes — and only when the configured pattern can actually reach a nested resource, so a single-segment pattern like `/resources/*` costs the host nothing.

The shared mount predicate lives in the framework-neutral engine (`BootUiInternalMount`): a WebFlux-only application has no servlet API on its classpath, so the reactive filter must not reach into its servlet sibling. An earlier revision that did raised `NoClassDefFoundError: jakarta/servlet/Filter` on *every* request; there is now a `FilteredClassLoader(jakarta.servlet.Filter.class)` regression test for it.

Rejections use `sendError(404)` so the response is the host application's own 404 — exactly what any unknown URL produces there — matching the sibling `LegacyBootUiPathFilter`.

## Compatibility

`/bootui/**` was already reserved (`BootUiPathNormalizer` rejects nesting under it, `LegacyBootUiPathFilter` claims it when a custom `bootui.path` is active, Quarkus 404s it in production). It is now also claimed while BootUI is inactive, so a host application that served its own routes there while shipping BootUI will receive 404 for them. Called out in `CHANGELOG.md` and `docs/SPECIFICATION.md` §4.1. Requests outside the reserved namespace and its derived prefixes pass through untouched.

## Tests

- `BootUiShellGuardAutoConfigurationTests` — activation polarity for every disabling/enabling reason, registration mounts and order, non-web and missing-shell cases, the WebFlux-only classloader regression, and **controls asserting the shell (including `/%62ootui/index.html`) returns 200 *without* the guard**, so the 404 assertions cannot pass vacuously.
- `BootUiShellGuardFilterTests`, `ReactiveBootUiShellGuardFilterTests`, `BootUiShellGuardMountsTests`, `BootUiInternalMountTests`.
- Real-server `@SpringBootTest(RANDOM_PORT)` coverage on both sample apps (`BootUiInactiveShellIntegrationTests`, `WebFluxInactiveShellIntegrationTest`, plus `...StaticMappingIntegrationTests` twins for relocated static handling), asserting 404 for the shell, a real content-hashed asset resolved from the packaged jar, and the encoded spellings — while the host's own resources still answer.

## Validation

`./mvnw -B -ntp -Pcoverage clean install` (full reactor, serial, JDK 26): **BUILD SUCCESS**, including Quarkus integration tests and conformance. `spotless:check` and the frontend `format:check` pass.

Honest note: an earlier `-T 1C` run of the same command failed in two Quarkus integration-test modules with `Port already bound: 8081` and a Quarkus test-classloader `LinkageError` on `ServiceMapSources` — both parallelism artifacts on this machine, unrelated to this change (each module passes standalone, including with `-Pcoverage`). The serial run is clean.

The implementation was also put through an explicit rubber-duck critique, which found two real bypasses (raw-vs-decoded path matching, and relocatable static mappings); both are fixed above and covered by tests.