### PR TITLE
Add consent-gated Google Analytics to the docs site

### DIFF
--- a/docs/.vuepress/analytics.js
+++ b/docs/.vuepress/analytics.js
@@ -1,0 +1,136 @@
+/*
+ * Consent-gated Google Analytics.
+ *
+ * Nothing here runs on the server and nothing touches the network until the reader has explicitly
+ * accepted: the gtag.js script is injected only after a `granted` decision, so a visitor who
+ * ignores or declines the banner never has an analytics cookie written. The decision itself lives
+ * in localStorage rather than a cookie, which keeps the "remember my choice" storage strictly
+ * necessary and outside the consent requirement.
+ */
+
+export const GA_MEASUREMENT_ID = 'G-V55EF46P7M'
+
+const CONSENT_STORAGE_KEY = 'bootui-analytics-consent'
+const CONSENT_EVENT = 'bootui:analytics-consent'
+const GRANTED = 'granted'
+const DENIED = 'denied'
+
+let scriptLoaded = false
+let lastTrackedPath = null
+
+export function readConsent() {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const stored = window.localStorage.getItem(CONSENT_STORAGE_KEY)
+    return stored === GRANTED || stored === DENIED ? stored : null
+  } catch {
+    // Private browsing modes can throw on access. Treat an unreadable store as "not asked yet"
+    // rather than assuming consent.
+    return null
+  }
+}
+
+export function setConsent(consent) {
+  const normalized = consent === GRANTED ? GRANTED : DENIED
+
+  try {
+    window.localStorage.setItem(CONSENT_STORAGE_KEY, normalized)
+  } catch {
+    // A rejected write only costs the reader the banner on their next visit, so honour the choice
+    // for this session anyway.
+  }
+
+  applyConsent(normalized)
+  window.dispatchEvent(new CustomEvent(CONSENT_EVENT, {detail: normalized}))
+}
+
+export function onConsentChange(listener) {
+  if (typeof window === 'undefined') {
+    return () => {}
+  }
+
+  const handler = (event) => listener(event.detail)
+  window.addEventListener(CONSENT_EVENT, handler)
+  return () => window.removeEventListener(CONSENT_EVENT, handler)
+}
+
+export function applyConsent(consent) {
+  if (consent === GRANTED) {
+    loadGoogleAnalytics()
+    return
+  }
+
+  disableGoogleAnalytics()
+}
+
+export function trackPageView(path) {
+  if (!scriptLoaded || readConsent() !== GRANTED || path === lastTrackedPath) {
+    return
+  }
+
+  lastTrackedPath = path
+  window.gtag('event', 'page_view', {
+    page_path: path,
+    page_location: window.location.href,
+    page_title: document.title
+  })
+}
+
+function loadGoogleAnalytics() {
+  if (scriptLoaded) {
+    return
+  }
+
+  scriptLoaded = true
+  window[`ga-disable-${GA_MEASUREMENT_ID}`] = false
+  window.dataLayer = window.dataLayer || []
+  window.gtag = function gtag() {
+    // gtag.js reads `arguments` verbatim, so this cannot be a rest-parameter forward.
+    window.dataLayer.push(arguments)
+  }
+
+  window.gtag('js', new Date())
+  window.gtag('config', GA_MEASUREMENT_ID)
+  lastTrackedPath = window.location.pathname
+
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`
+  document.head.appendChild(script)
+}
+
+function disableGoogleAnalytics() {
+  // Withdrawal has to be as effective as refusal, so an already-loaded tag is muted through the
+  // opt-out flag gtag.js checks before every hit, and its cookies are removed.
+  window[`ga-disable-${GA_MEASUREMENT_ID}`] = true
+  lastTrackedPath = null
+  clearAnalyticsCookies()
+}
+
+function clearAnalyticsCookies() {
+  const names = document.cookie
+    .split(';')
+    .map((cookie) => cookie.split('=')[0].trim())
+    .filter((name) => name === '_ga' || name === '_gid' || name.startsWith('_ga_') || name.startsWith('_gat'))
+
+  const hostname = window.location.hostname
+  // The tag may have scoped its cookie to the exact host or to the registrable domain, and a
+  // mismatched delete is a silent no-op, so try every candidate.
+  const domains = new Set(['', hostname, `.${hostname}`, toRegistrableDomain(hostname)].filter(Boolean))
+  domains.add('')
+
+  names.forEach((name) => {
+    domains.forEach((domain) => {
+      const domainPart = domain ? `; domain=${domain}` : ''
+      document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT${domainPart}`
+    })
+  })
+}
+
+function toRegistrableDomain(hostname) {
+  const labels = hostname.split('.')
+  return labels.length > 2 ? `.${labels.slice(-2).join('.')}` : undefined
+}

--- a/docs/.vuepress/client.js
+++ b/docs/.vuepress/client.js
@@ -3,12 +3,17 @@ import {defineClientConfig, onContentUpdated, useRoute} from 'vuepress/client'
 import './styles/index.css'
 import ScreenshotCarousel from './components/ScreenshotCarousel.vue'
 import RuleIndex from './components/RuleIndex.vue'
+import CookieConsent from './components/CookieConsent.vue'
+import CookieSettings from './components/CookieSettings.vue'
+import {trackPageView} from './analytics.js'
 
 export default defineClientConfig({
   enhance({app}) {
     app.component('ScreenshotCarousel', ScreenshotCarousel)
     app.component('RuleIndex', RuleIndex)
+    app.component('CookieSettings', CookieSettings)
   },
+  rootComponents: [CookieConsent],
   setup() {
     const route = useRoute()
     let scheduleSidebarSync = () => {}
@@ -39,7 +44,15 @@ export default defineClientConfig({
     })
 
     onContentUpdated(syncAfterDomUpdate)
-    watch(() => route.fullPath, syncAfterDomUpdate)
+    watch(
+      () => route.fullPath,
+      () => {
+        syncAfterDomUpdate()
+        // Client-side navigation replaces the page without a document load, so gtag.js never sees
+        // it. The title is only correct once Vue has flushed, hence the nextTick.
+        void nextTick(() => trackPageView(window.location.pathname))
+      }
+    )
 
     onUnmounted(() => {
       cleanupSidebarSync()

--- a/docs/.vuepress/components/CookieConsent.vue
+++ b/docs/.vuepress/components/CookieConsent.vue
@@ -1,0 +1,164 @@
+<script setup>
+import {onMounted, onUnmounted, ref} from 'vue'
+import {applyConsent, onConsentChange, readConsent, setConsent} from '../analytics.js'
+
+const visible = ref(false)
+
+// The banner is client-only: rendering it during the static build would ship a prompt that is
+// already answered for returning readers, and would flash before hydration for everyone else.
+onMounted(() => {
+  const consent = readConsent()
+  applyConsent(consent)
+  visible.value = consent === null
+})
+
+onUnmounted(
+  onConsentChange((consent) => {
+    visible.value = consent === null
+  })
+)
+
+function accept() {
+  setConsent('granted')
+  visible.value = false
+}
+
+function decline() {
+  setConsent('denied')
+  visible.value = false
+}
+</script>
+
+<template>
+  <Transition name="bootui-consent">
+    <aside
+      v-if="visible"
+      class="bootui-consent"
+      role="region"
+      aria-labelledby="bootui-consent-title"
+      aria-describedby="bootui-consent-description"
+    >
+      <div class="bootui-consent__text">
+        <p id="bootui-consent-title" class="bootui-consent__title">Analytics cookies</p>
+        <p id="bootui-consent-description" class="bootui-consent__description">
+          BootUI would like to use Google Analytics to understand which documentation pages are useful. Nothing is set
+          unless you accept, and declining changes nothing about how the site works. See the
+          <RouteLink to="/privacy">privacy notice</RouteLink> for details or to change your mind later.
+        </p>
+      </div>
+      <div class="bootui-consent__actions">
+        <button type="button" class="bootui-consent__button" @click="decline">Decline</button>
+        <button type="button" class="bootui-consent__button bootui-consent__button--primary" @click="accept">
+          Accept
+        </button>
+      </div>
+    </aside>
+  </Transition>
+</template>
+
+<style scoped>
+.bootui-consent {
+  position: fixed;
+  z-index: 100;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem 1.5rem;
+  max-width: 62rem;
+  margin: 0 auto;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--bootui-border);
+  border-radius: 1.1rem;
+  background: var(--bootui-surface-solid);
+  box-shadow: var(--bootui-shadow-md);
+  color: var(--bootui-text);
+}
+
+.bootui-consent__text {
+  flex: 1 1 22rem;
+}
+
+.bootui-consent__title {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.bootui-consent__description {
+  margin: 0;
+  color: var(--bootui-text-muted);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.bootui-consent__actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.6rem;
+}
+
+.bootui-consent__button {
+  padding: 0.5rem 1.1rem;
+  border: 1px solid var(--bootui-border-alt);
+  border-radius: 0.75rem;
+  background: transparent;
+  color: var(--bootui-text);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.bootui-consent__button:hover {
+  border-color: var(--bootui-green);
+  background: var(--bootui-nav-hover-bg);
+}
+
+.bootui-consent__button--primary {
+  border-color: transparent;
+  background: var(--bootui-btn-primary-bg);
+  color: #ffffff;
+}
+
+.bootui-consent__button--primary:hover {
+  border-color: transparent;
+  background: var(--bootui-btn-primary-bg-hover);
+}
+
+.bootui-consent-enter-active,
+.bootui-consent-leave-active {
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.bootui-consent-enter-from,
+.bootui-consent-leave-to {
+  opacity: 0;
+  transform: translateY(0.75rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bootui-consent-enter-active,
+  .bootui-consent-leave-active {
+    transition: none;
+  }
+}
+
+@media (max-width: 40rem) {
+  .bootui-consent__actions {
+    width: 100%;
+  }
+
+  .bootui-consent__button {
+    flex: 1 1 0;
+  }
+}
+</style>

--- a/docs/.vuepress/components/CookieSettings.vue
+++ b/docs/.vuepress/components/CookieSettings.vue
@@ -1,0 +1,112 @@
+<script setup>
+import {computed, onMounted, onUnmounted, ref} from 'vue'
+import {onConsentChange, readConsent, setConsent} from '../analytics.js'
+
+const consent = ref(null)
+const hydrated = ref(false)
+
+onMounted(() => {
+  consent.value = readConsent()
+  hydrated.value = true
+})
+
+onUnmounted(
+  onConsentChange((value) => {
+    consent.value = value
+  })
+)
+
+const status = computed(() => {
+  if (consent.value === 'granted') {
+    return 'Analytics cookies are currently allowed.'
+  }
+  if (consent.value === 'denied') {
+    return 'Analytics cookies are currently refused.'
+  }
+  return 'You have not made a choice yet, so no analytics cookies are set.'
+})
+
+function choose(value) {
+  setConsent(value)
+  consent.value = value
+}
+</script>
+
+<template>
+  <div v-if="hydrated" class="bootui-cookie-settings">
+    <p class="bootui-cookie-settings__status" role="status">{{ status }}</p>
+    <div class="bootui-cookie-settings__actions">
+      <button
+        type="button"
+        class="bootui-cookie-settings__button"
+        :class="{'bootui-cookie-settings__button--active': consent === 'granted'}"
+        :aria-pressed="consent === 'granted'"
+        @click="choose('granted')"
+      >
+        Allow analytics
+      </button>
+      <button
+        type="button"
+        class="bootui-cookie-settings__button"
+        :class="{'bootui-cookie-settings__button--active': consent === 'denied'}"
+        :aria-pressed="consent === 'denied'"
+        @click="choose('denied')"
+      >
+        Refuse analytics
+      </button>
+    </div>
+  </div>
+  <p v-else class="bootui-cookie-settings__status">Loading your current preference…</p>
+</template>
+
+<style scoped>
+.bootui-cookie-settings {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--bootui-border);
+  border-radius: 1.1rem;
+  background: var(--bootui-surface-alt);
+}
+
+.bootui-cookie-settings__status {
+  margin: 0 0 0.75rem;
+  color: var(--bootui-text-muted);
+  font-size: 0.85rem;
+}
+
+.bootui-cookie-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.bootui-cookie-settings__button {
+  padding: 0.5rem 1.1rem;
+  border: 1px solid var(--bootui-border-alt);
+  border-radius: 0.75rem;
+  background: transparent;
+  color: var(--bootui-text);
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.bootui-cookie-settings__button:hover {
+  border-color: var(--bootui-green);
+  background: var(--bootui-nav-hover-bg);
+}
+
+.bootui-cookie-settings__button--active {
+  border-color: transparent;
+  background: var(--bootui-btn-primary-bg);
+  color: #ffffff;
+}
+
+.bootui-cookie-settings__button--active:hover {
+  background: var(--bootui-btn-primary-bg-hover);
+}
+</style>

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -5,8 +5,9 @@ import {toDocLink} from './doc-links.js'
 
 const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 /* JVM-TUNING-CHECKS.md is excluded from the build in config.js, so it must not fall through to the
-   "Additional docs" catch-all group either. */
-const hiddenDocs = ['README.md', 'JVM-TUNING-CHECKS.md']
+   "Additional docs" catch-all group either. PRIVACY.md is a site-legal page pinned to the bottom of
+   the sidebar by hand, so it must not be picked up by the catch-all as well. */
+const hiddenDocs = ['README.md', 'JVM-TUNING-CHECKS.md', 'PRIVACY.md']
 
 /* Sidebar labels only. Page titles stay long-form; the group heading already supplies the context
    these labels would otherwise repeat. */
@@ -105,7 +106,10 @@ export function createDocsSidebar() {
             children: remainingDocs.map((file) => toSidebarItem(file))
           }
         ]
-      : [])
+      : []),
+    // Consent stays withdrawable once the banner is gone, so the privacy page keeps a permanent
+    // entry point. It sits last, on its own, because it is site-legal rather than documentation.
+    toSidebarItem('PRIVACY.md')
   ]
 }
 
@@ -137,6 +141,13 @@ function toSidebarItem(file, trimChecksSuffix = false) {
 
 function readTitle(file) {
   const content = fs.readFileSync(path.join(docsRoot, file), 'utf8')
-  const heading = content.match(/^#\s+(.+)$/m)
+  // Frontmatter comments are also `#`-prefixed lines, so the title has to be looked for after the
+  // frontmatter block rather than from the top of the file.
+  const heading = stripFrontmatter(content).match(/^#\s+(.+)$/m)
   return heading ? heading[1].trim() : file.replace(/\.md$/, '').replaceAll('-', ' ')
+}
+
+function stripFrontmatter(content) {
+  const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n/)
+  return match ? content.slice(match[0].length) : content
 }

--- a/docs/.vuepress/styles/index.css
+++ b/docs/.vuepress/styles/index.css
@@ -321,8 +321,10 @@ body {
 }
 
 /* Page links and in-page heading links share one class, so the href fragment is what separates a
-   destination from a jump inside the page the reader is already on. */
-.vp-sidebar a.vp-sidebar-item:not([href*='#']) {
+   destination from a jump inside the page the reader is already on. A top-level entry that is a
+   link rather than a group (Privacy) is still a heading, so it must keep the eyebrow treatment
+   below instead of being pulled into the page-link ramp. */
+.vp-sidebar a.vp-sidebar-item:not([href*='#']):not(.vp-sidebar-heading) {
   font-size: 0.95rem;
   font-weight: 600;
 }
@@ -440,6 +442,15 @@ body {
   background: var(--bootui-nav-active-bg);
   box-shadow: 0 0.8rem 1.4rem rgba(25, 135, 84, 0.2);
   color: var(--bootui-nav-active-color);
+}
+
+/* A top-level entry that is a link renders as an anchor, so the theme's active treatment for page
+   links reaches it even though it is a heading: it would otherwise pick up the accent left border
+   and lighter weight that mark a nested page. Keep it matching the group headings around it. */
+.vp-sidebar a.vp-sidebar-item.vp-sidebar-heading.active {
+  border-inline-start-color: var(--bootui-border-subtle);
+  color: var(--bootui-green-dark);
+  font-weight: 800;
 }
 
 .vp-home,

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,0 +1,55 @@
+---
+# The sidebar entry for this page is a single top-level link, so its headings must not expand
+# under it: that first level is reserved for other pages everywhere else in the sidebar.
+sidebarDepth: 0
+---
+
+# Privacy
+
+This page describes what the BootUI documentation site collects, and how to change your mind at any time.
+
+## The BootUI console itself collects nothing
+
+BootUI is a local-only developer console. It runs inside your own application, binds to loopback, and never sends
+telemetry, usage data, or analytics anywhere. Nothing on this page applies to the console — only to this documentation
+website.
+
+## Analytics on this website
+
+This website can use Google Analytics 4 (measurement ID `G-V55EF46P7M`) to count page views and understand which
+documentation pages are actually read.
+
+- **Nothing is loaded until you accept.** The Google Analytics script is not requested, and no analytics cookie is
+  written, unless you choose "Accept" in the banner. Declining, or ignoring the banner, leaves the site entirely
+  free of third-party requests.
+- **What is stored if you accept:** Google Analytics sets the `_ga` and `_ga_*` cookies, which hold a randomly
+  generated identifier used to recognise a returning browser. Google receives your IP address, page URL, referrer,
+  and basic device and browser information as the data processor for these measurements.
+- **Retention:** analytics data is retained according to the Google Analytics data-retention setting for this
+  property, after which it is deleted by Google.
+- **Legal basis:** your consent, under Article 6(1)(a) GDPR and the ePrivacy Directive. You can withdraw it at any
+  time, as easily as you gave it, using the controls below.
+
+Your answer to the banner is remembered in your browser's `localStorage` under `bootui-analytics-consent`. That entry
+is strictly necessary to honour your choice, is never sent anywhere, and is not used to identify you.
+
+## Change your choice
+
+<CookieSettings />
+
+Refusing here also deletes any Google Analytics cookies already present in this browser and stops further measurement
+immediately. You can additionally remove the site's data through your browser settings, or install Google's
+[opt-out browser add-on](https://tools.google.com/dlpage/gaoptout).
+
+## Hosting
+
+The site is served as static files from GitHub Pages. GitHub processes request metadata, including IP addresses, to
+deliver the pages and protect the service, as described in the
+[GitHub Privacy Statement](https://docs.github.com/site-policy/privacy-policies/github-privacy-statement).
+
+## Your rights and contact
+
+Under GDPR you may request access to, correction of, or erasure of your personal data, object to processing, or lodge a
+complaint with your supervisory authority. For any request relating to this site, open an issue on the
+[BootUI repository](https://github.com/jdubois/boot-ui/issues) or contact the maintainer through
+[julien-dubois.com](https://www.julien-dubois.com).


### PR DESCRIPTION
## What

Adds Google Analytics 4 to the documentation site, gated behind a consent banner.

## Why

The site had no analytics. Loading GA unconditionally would set identifying cookies before the reader agrees, which GDPR and the ePrivacy Directive do not allow — and BootUI's audience is largely European, where a "cookieless GA" configuration does not exist as a compliant alternative.

## How it works

- **Nothing loads before consent.** `gtag.js` is injected only after "Accept". Declining or ignoring the banner produces no third-party request at all, rather than a degraded Consent Mode tag.
- **The choice is not itself a cookie.** It lives in `localStorage` under `bootui-analytics-consent`, keeping that storage strictly necessary and outside the consent requirement.
- **Withdrawal is as effective as refusal.** Refusing after accepting sets the `ga-disable-*` opt-out flag and deletes `_ga`, `_ga_*`, `_gid`, and `_gat` across the host and registrable domain.
- **SPA page views.** Client-side navigation is invisible to `gtag.js`, so route changes send an explicit `page_view`.
- **The banner is client-only**, so the static build ships no prompt and returning readers see no flash before hydration.

## Privacy page

`docs/PRIVACY.md` documents what is collected and carries the permanent withdraw control, since consent must stay withdrawable once the banner is gone. It sits alone at the bottom of the sidebar — it is site-legal, not documentation.

Two theme rules for page links out-specified the group-heading styling and reached that entry because it renders as an `<a>` rather than a `<p>`, giving it the wrong type ramp and an accent left border. It now keeps the heading treatment explicitly.

## Incidental fix

`readTitle()` in `sidebar.js` matched the first `#`-prefixed line in a file, but YAML frontmatter comments start with `#` too — a commented frontmatter block became the sidebar label and `aria-label`. It now strips frontmatter before looking for the title.

## Validation

Verified in a browser against the dev server:

| State | Result |
|---|---|
| Before any choice | 0 GA scripts, no cookies |
| After Accept | script loads, `_ga` set, banner dismissed |
| Navigation | exactly one `page_view` per route |
| After Refuse | cookies deleted, tag disabled |
| Reload while denied | still no script, no cookies |

Also confirmed the built `privacy.html` contains no `googletagmanager` reference, all six top-level sidebar entries render identically, and other sidebar labels are unchanged. `npm run docs:build` and Prettier pass.

No BootUI console, engine, or adapter code is touched — the console itself still sends nothing anywhere.