### PR TITLE
Complete the 1.15.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.15.0] - 2026-08-24
+## [1.15.0] - 2026-08-26
 
 Feature release that adds two panels — Fault Tolerance and WebSockets — on Spring MVC, Spring WebFlux, and Quarkus,
 explains where every meter comes from in the Metrics panel, ranks retained SQL and attributes it to request routes,
 catalogues the application's declared error contract in the REST API panel, and discloses cache tiers and native hit
-ratios. It also closes several masking, activation, and input-bounding gaps found by review.
+ratios. It also closes several masking, activation, and input-bounding gaps found by review, and rebuilds the
+documentation site around what readers actually came for.
 
 ### Added
 
@@ -96,8 +97,25 @@ ratios. It also closes several masking, activation, and input-bounding gaps foun
   filtering, contrast, and responsive presentation issues resolved across the console. The confirmation dialog and the
   Bootstrap collapse code are now deferred until the surfaces that need them are used, with deferred dialog state
   synchronized on mount so no confirmation is missed while the chunk loads.
+- **The documentation site is organized around what readers came for.** Local, service-free search now indexes the whole
+  site including advisor rule ids such as `SEC-AUTH-001`; the single 27k-word features page is split into one page per
+  console menu group under `/features`, with the group index still at the unchanged `/features` route; the twelve
+  diagnostic check catalogues gained an id/title/category search with a severity filter that collapses the page body to
+  match; the setup guide is four steps again, with WebFlux, Quarkus, Docker, command-line, activation-policy, and
+  troubleshooting material moved to focused pages under `/setup`; and the sidebar is regrouped into Get started,
+  Features, Reference, Diagnostic checks, Framework support, and Contributing. Markdown remains the single source of
+  truth — the check catalogues are still parsed from it at build time — and the feature, route, and conformance tests
+  that read the docs structurally were updated with it (#875).
+- **The documentation site measures traffic only after you agree.** Google Analytics is injected only once a reader
+  accepts; declining or ignoring the banner issues no third-party request at all, the decision is stored in
+  `localStorage` rather than a cookie, and withdrawing consent mutes an already-loaded tag and deletes its cookies.
+  Client-side route changes send an explicit `page_view`, and a new privacy page states what is collected (#876).
 
 ### Fixed
+
+- **A failed load of the REST API panel's declared error contract shows the reason instead of `[object Object]`.** The
+  panel passed the paged-list error descriptor straight into a string prop, so the failure rendered as the object's
+  default string form behind a Vue prop warning; it now uses the same error-formatting convention as every other panel.
 
 - **HTTP Probe input is explicitly bounded on Spring MVC, Spring WebFlux, and Quarkus.** The probe capped only the
   response body, so an oversized request body, path or header collection was bound by the adapter and forwarded to the


### PR DESCRIPTION
## What does this PR do?

Finishes the drafted `## [1.15.0]` changelog section so it matches what actually landed in the cycle, and moves the release date to 2026-08-26.

## Why is this change needed?

The 1.15.0 notes were written on 2026-08-24, before three more merged PRs landed on main, so the section documented neither the documentation-site work nor a UI fix, and carried a date that had already passed.

Added:

- **Changed** entry for the documentation-site restructure (#875): local service-free search that indexes advisor rule ids, the features guide split into one page per console menu group, an id/title/category search with severity filter over the twelve diagnostic check catalogues, the setup guide cut back to four steps with the rest moved under `/setup`, and a regrouped sidebar.
- **Changed** entry for consent-gated analytics on the documentation site (#876): no third-party request before Accept, the decision stored in `localStorage` rather than a cookie, withdrawal muting an already-loaded tag and deleting its cookies.
- **Fixed** entry for the REST API panel rendering a failed declared-error-contract load as `[object Object]`.

I also audited release readiness while writing this, and found nothing to fix: the 57 panels in `BootUiPanels.java` line up exactly with the panel ids in `docs/PROPERTIES.md`, every panel has a screenshot refreshed on 2026-08-25, the new endpoints and advisor rules (`DB-RUNTIME-001`, `RAPI-ERR-009/010/011`) are documented, and `BackendPanelCatalogConsistencyTest` passes, which is what contract-checks docs headings, access properties, read endpoints, MCP tools, and screenshot embeds.

Two minor pre-existing observations, deliberately not changed here: `pages.yml` syncs only the Maven spring-starter version while `release.yml` handles the reactive/Quarkus/Gradle coordinates, and `README.md` no longer contains dependency snippets, so its version rewrite in both workflows is now a no-op.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests (`BackendPanelCatalogConsistencyTest`, 8 tests, as part of the readiness audit)
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [ ] Added or updated tests where applicable

Documentation-only change, so no build or runtime behaviour is affected.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed