### PR TITLE
ci(release): give Maven Central propagation a realistic wait budget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -413,14 +413,19 @@ jobs:
           )
 
           # Sonatype Central -> Maven Central propagation can lag behind a successful
-          # autoPublish, so poll until every file is downloadable (or time out).
-          DEADLINE=$(( SECONDS + 45 * 60 ))
+          # autoPublish, so poll until every file is downloadable (or time out). The budget is
+          # shared by every artifact and covers observed propagation delays well beyond an hour;
+          # it is a patience limit, not a publication deadline.
+          DEADLINE=$(( SECONDS + 120 * 60 ))
           for artifact in "${ARTIFACTS[@]}"; do
             url="${BASE}/${artifact}"
             echo "Waiting for ${url}"
             until curl -fsI "$url" >/dev/null 2>&1; do
               if (( SECONDS > DEADLINE )); then
                 echo "::error::Timed out waiting for ${url} to become available on Maven Central"
+                # Publication already succeeded; only propagation was slow. Recreating the tag or
+                # redeploying would consume the coordinate, so point at the resume path instead.
+                echo "::notice::The deployment was already published. Once the artifact appears, rerun this workflow at ${RELEASE_TAG} with an empty version, auto_publish enabled, and resume_after_publish enabled."
                 exit 1
               fi
               sleep 20


### PR DESCRIPTION
## Problem

The `Wait for Maven Central availability` step gave all ten published artifacts a **shared 45-minute** budget. During the 1.15.0 release, Sonatype Central → Maven Central propagation took longer than that, so the poll timed out on the *first* artifact ([run 33096997991](https://github.com/jdubois/boot-ui/actions/runs/33096997991)):

```
Waiting for .../bootui-parent/1.15.0/bootui-parent-1.15.0.pom   17:28:16
##[error]Timed out waiting for ...                              18:13:32
```

The deployment had published perfectly well — every artifact is public and all ten now return `200`. But because the step exits 1, it short-circuited the two steps that actually *verify* a release:

- `Smoke test published distributions` (MVC / WebFlux / Quarkus consumer checks) — skipped
- `Redeploy documentation site` — skipped, leaving the docs site advertising the previous version

So a slow CDN turned a good release into a red run with unverified artifacts and stale documentation.

## Change

- Raise the shared budget from 45 to **120 minutes**, and state in the comment that it is a patience limit for propagation, not a deadline on publication. The job sets no `timeout-minutes`, so this still fits comfortably inside the 360-minute default alongside publication (~18 min) and the smoke tests.
- On timeout, emit the recovery path as a `::notice::`. By that point the coordinate is already consumed, so redeploying or recreating the signed tag is precisely the wrong move — `resume_after_publish` from the existing tag is the supported continuation, per `.github/instructions/release.instructions.md`.

## Scope and validation

Workflow-only change, confined to the `Wait for Maven Central availability` step; no version bumps, no publication-reactor changes. `release.yml` parses as valid YAML. `RELEASE_TAG` is exported to `GITHUB_ENV` by `Resolve immutable release`, which always precedes this step, so the new message is safe under `set -euo pipefail`.

The silent-Pages-dispatch problem this same timeout exposed is addressed separately so the two changes stay reviewable independently.