### PR TITLE
ci: fail the release when the dispatched Pages run does not succeed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -648,7 +648,79 @@ jobs:
           # A release push made with GITHUB_TOKEN does not trigger the Pages workflow.
           # Dispatch the immutable tag, not a branch that may have advanced while Central
           # propagated the artifacts.
+          #
+          # `gh workflow run` only reports that the dispatch was accepted, so the dispatched
+          # run must be resolved and awaited explicitly. Otherwise a rejected or failing Pages
+          # deploy leaves the release green while the published documentation stays stale.
+
+          list_runs() {
+            gh run list \
+              --workflow pages.yml \
+              --event workflow_dispatch \
+              --branch "$RELEASE_TAG" \
+              --limit 50 \
+              --json databaseId \
+              --jq '.[].databaseId'
+          }
+
+          # Runs that already exist for this tag must never be mistaken for the new one.
+          if ! PRE_EXISTING_RUNS="$(list_runs)"; then
+            echo "::error::Unable to list existing Pages runs for $RELEASE_TAG"
+            exit 1
+          fi
+
           gh workflow run pages.yml --ref "$RELEASE_TAG"
+          echo "Dispatched pages.yml at $RELEASE_TAG; resolving the dispatched run."
+
+          RUN_ID=""
+          for _ in $(seq 1 30); do
+            sleep 10
+            CURRENT_RUNS="$(list_runs || true)"
+            for candidate in $CURRENT_RUNS; do
+              if ! grep -qx "$candidate" <<<"$PRE_EXISTING_RUNS"; then
+                RUN_ID="$candidate"
+                break
+              fi
+            done
+            if [[ -n "$RUN_ID" ]]; then
+              break
+            fi
+          done
+
+          if [[ -z "$RUN_ID" ]]; then
+            echo "::error::Dispatched pages.yml run for $RELEASE_TAG never became visible; documentation was not redeployed"
+            exit 1
+          fi
+
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$RUN_ID"
+          echo "Waiting for documentation deployment run: $RUN_URL"
+
+          # Bound the wait so a hung Pages run cannot block the release job indefinitely.
+          CONCLUSION=""
+          for _ in $(seq 1 120); do
+            RUN_JSON="$(gh run view "$RUN_ID" --json status,conclusion || true)"
+            if [[ -z "$RUN_JSON" ]]; then
+              sleep 15
+              continue
+            fi
+            if [[ "$(jq -r '.status' <<<"$RUN_JSON")" == "completed" ]]; then
+              CONCLUSION="$(jq -r '.conclusion' <<<"$RUN_JSON")"
+              break
+            fi
+            sleep 15
+          done
+
+          if [[ -z "$CONCLUSION" ]]; then
+            echo "::error::Timed out waiting for the documentation deployment run to complete: $RUN_URL"
+            exit 1
+          fi
+
+          if [[ "$CONCLUSION" != "success" ]]; then
+            echo "::error::Documentation deployment run concluded with '$CONCLUSION': $RUN_URL"
+            exit 1
+          fi
+
+          echo "Documentation site redeployed from $RELEASE_TAG: $RUN_URL"
 
       - name: Manual publish reminder
         if: env.CENTRAL_AUTO_PUBLISH != 'true'


### PR DESCRIPTION
## Problem

Release v1.15.0 published to Maven Central successfully, but the documentation site was never redeployed — and the release run still reported the `Redeploy documentation site` step as green.

`gh workflow run pages.yml --ref "$RELEASE_TAG"` exits 0 as soon as the *dispatch* is accepted. It never waits for, or reports, the dispatched run's outcome. In that release the dispatched Pages run was rejected (`Tag v1.15.0 is not allowed to deploy to github-pages due to environment protection rules`), yet the release job stayed green and the stale docs went unnoticed.

The `github-pages` environment policy has already been fixed out-of-band; this PR fixes the *silent failure*, so a future rejected or failing docs deploy is loud.

## Fix

Scoped entirely to the `Redeploy documentation site` step:

- Record the pre-existing `pages.yml` / `workflow_dispatch` run ids for `$RELEASE_TAG` **before** dispatching, so an older run for the same tag can never be mistaken for the new one.
- After dispatching, poll for up to 5 minutes for a run id not in that pre-existing set (dispatch-to-visible latency is real).
- Wait for that specific run to reach `completed`, bounded at 30 minutes, and fail with a clear `::error::` and the run URL on timeout.
- Fail with `::error::` and the run URL if the conclusion is anything other than `success`.

Design notes:
- `--ref "$RELEASE_TAG"` is unchanged; dispatching the immutable tag is intentional and required by the repository's immutable-release rules.
- The run URL is derived from `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$RUN_ID` so no extra API call can fail the step spuriously.
- Transient `gh` list/view failures during polling are tolerated and retried; the initial list and the final outcome are fail-closed.
- Logic is safe under `set -euo pipefail`: negated conditions wrap all non-zero-capable commands and every variable is quoted.

The `Wait for Maven Central availability` step is deliberately untouched.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` passes.
- Step body simulated locally against a stubbed `gh`: correctly selects the newly dispatched run id over the pre-existing one, exits 0 on `success`, and exits 1 with the `::error::` message on `failure`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>