### PR TITLE
Match BootUI safety guards on the decoded request path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **BootUI's safety filters can no longer be bypassed by a percent-encoded or matrix-parameter spelling of a BootUI URL
+  on Spring MVC or Spring WebFlux.** Each guard decided whether it applied by matching the *raw* request path
+  (`getRequestURI()` on the servlet stack, `pathWithinApplication().value()` on the reactive one) against `bootui.path` /
+  `bootui.api-path`, while the controller behind it was selected by `PathPattern` on the *decoded* path. The two
+  disagreed, so `/%62ootui/api/**` and `/bootui;x=1/api/**` still reached the BootUI handler with the loopback check,
+  Host allow-list and DNS-rebinding defence, cross-site-write protection, bearer-token requirement, per-panel
+  enabled/read-only policy, and security headers all silently disarmed — letting a malicious page in the developer's
+  browser drive state-changing endpoints, and letting a non-loopback caller in an `allow-non-localhost` deployment reach
+  the whole API with no token. All the Spring guards now resolve the path exactly the way the handler mapping does
+  (`UrlPathHelper` on the servlet stack, a new shared `BootUiReactivePaths` built on `PathSegment#valueToMatch()` on the
+  reactive one), which is what the `#856` shell guards already did; the reactive shell guard now shares that one
+  implementation instead of keeping its own copy. Quarkus was never affected — its filters already matched on Vert.x's
+  `normalizedPath()` — so this closes a cross-adapter parity gap. Regression tests cover both encoded and
+  matrix-parameter spellings against the localhost, authentication, and panel-access filters on both Spring stacks.
+
 ## [1.15.0] - 2026-08-27
 
 Feature release that adds two panels — Fault Tolerance and WebSockets — on Spring MVC, Spring WebFlux, and Quarkus,

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/AbstractReactiveBootUiFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/AbstractReactiveBootUiFilter.java
@@ -18,7 +18,9 @@ import reactor.core.publisher.Mono;
  *
  * <p>WebFlux has no servlet context path, so path matching uses {@link ServerHttpRequest#getPath()}'s
  * already-context-relative {@code pathWithinApplication()} rather than manually stripping a context
- * path the way the servlet filters strip {@code HttpServletRequest#getContextPath()}.</p>
+ * path the way the servlet filters strip {@code HttpServletRequest#getContextPath()}. It is resolved
+ * through {@link BootUiReactivePaths} so the guards match the same decoded path the handler mapping
+ * does.</p>
  *
  * <p>There is also no {@code FilterRegistrationBean} equivalent in WebFlux: a {@link WebFilter} bean is
  * picked up and ordered automatically (via {@code @Order}/{@link org.springframework.core.Ordered}), so
@@ -62,7 +64,7 @@ public abstract class AbstractReactiveBootUiFilter implements WebFilter {
     }
 
     protected String pathWithinApplication(ServerHttpRequest request) {
-        return request.getPath().pathWithinApplication().value();
+        return BootUiReactivePaths.pathWithinApplication(request);
     }
 
     protected String escape(String value) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/BootUiReactivePaths.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/BootUiReactivePaths.java
@@ -1,0 +1,32 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import org.springframework.http.server.PathContainer;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * Resolves the context-relative request path the way WebFlux's handler mapping resolves it.
+ *
+ * <p>The path is rebuilt from {@link PathContainer.PathSegment#valueToMatch()}, which is what
+ * {@code PathPattern} matches on: percent-decoded, with matrix parameters removed. The raw
+ * {@code pathWithinApplication().value()} is neither, so a guard matching on it and a controller
+ * selected by {@code PathPattern} disagree, and {@code /%62ootui/api/**} or {@code /bootui;x=1/api/**}
+ * disarms the loopback, Host allow-list, cross-site-write, bearer-token and per-panel filters while
+ * still reaching the controller.</p>
+ *
+ * <p>Every reactive BootUI filter shares this single implementation so the guards and the shell
+ * guard cannot drift apart again.</p>
+ */
+public final class BootUiReactivePaths {
+
+    private BootUiReactivePaths() {}
+
+    public static String pathWithinApplication(ServerHttpRequest request) {
+        StringBuilder path = new StringBuilder();
+        for (PathContainer.Element element :
+                request.getPath().pathWithinApplication().elements()) {
+            path.append(
+                    element instanceof PathContainer.PathSegment segment ? segment.valueToMatch() : element.value());
+        }
+        return path.toString();
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveApiAuthenticationFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveApiAuthenticationFilter.java
@@ -94,9 +94,7 @@ public final class ReactiveApiAuthenticationFilter extends AbstractReactiveBootU
     private boolean isSessionRequest(ServerHttpRequest request) {
         return request.getMethod() != null
                 && "POST".equals(request.getMethod().name())
-                && request.getPath()
-                        .pathWithinApplication()
-                        .value()
+                && BootUiReactivePaths.pathWithinApplication(request)
                         .equals(withoutTrailingSlash(properties.getApiPath()) + SESSION_PATH);
     }
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiShellGuardFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiShellGuardFilter.java
@@ -4,7 +4,6 @@ import io.github.jdubois.bootui.engine.safety.BootUiInternalMount;
 import java.util.List;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.server.PathContainer;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -24,9 +23,10 @@ import reactor.core.publisher.Mono;
  * classpath, so touching the servlet filter class from here would raise
  * {@code NoClassDefFoundError: jakarta/servlet/Filter} on every request.</p>
  *
- * <p>The path is rebuilt from {@link PathContainer.PathSegment#valueToMatch()}, which is what
- * {@code PathPattern} matches on: it is percent-decoded and has matrix parameters removed, so
- * {@code /%62ootui/index.html} cannot slip past a guard that the resource handler would then serve.</p>
+ * <p>The path is resolved through {@link BootUiReactivePaths}, which rebuilds it from
+ * {@code PathContainer.PathSegment#valueToMatch()} &mdash; what {@code PathPattern} matches on: it is
+ * percent-decoded and has matrix parameters removed, so {@code /%62ootui/index.html} cannot slip past a
+ * guard that the resource handler would then serve. The BootUI safety filters share that same helper.</p>
  */
 public final class ReactiveBootUiShellGuardFilter implements WebFilter, Ordered {
 
@@ -43,21 +43,11 @@ public final class ReactiveBootUiShellGuardFilter implements WebFilter, Ordered 
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-        String path = decodedPathWithinApplication(exchange);
+        String path = BootUiReactivePaths.pathWithinApplication(exchange.getRequest());
         if (mounts.stream().noneMatch(mount -> BootUiInternalMount.isUnder(path, mount))) {
             return chain.filter(exchange);
         }
         exchange.getResponse().setStatusCode(HttpStatus.NOT_FOUND);
         return exchange.getResponse().setComplete();
-    }
-
-    private static String decodedPathWithinApplication(ServerWebExchange exchange) {
-        StringBuilder path = new StringBuilder();
-        for (PathContainer.Element element :
-                exchange.getRequest().getPath().pathWithinApplication().elements()) {
-            path.append(
-                    element instanceof PathContainer.PathSegment segment ? segment.valueToMatch() : element.value());
-        }
-        return path.toString();
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveLegacyBootUiPathFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveLegacyBootUiPathFilter.java
@@ -37,13 +37,13 @@ public final class ReactiveLegacyBootUiPathFilter implements WebFilter, Ordered 
     }
 
     private boolean isInternalPath(ServerWebExchange exchange) {
-        String path = exchange.getRequest().getPath().pathWithinApplication().value();
+        String path = BootUiReactivePaths.pathWithinApplication(exchange.getRequest());
         return path.equals(BootUiPathNormalizer.DEFAULT_PATH)
                 || path.startsWith(BootUiPathNormalizer.DEFAULT_PATH + "/");
     }
 
     private boolean isConfiguredApiRequest(ServerWebExchange exchange) {
-        String path = exchange.getRequest().getPath().pathWithinApplication().value();
+        String path = BootUiReactivePaths.pathWithinApplication(exchange.getRequest());
         String apiPath = properties.getApiPath();
         return path.equals(apiPath) || path.startsWith(apiPath + "/");
     }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/ApiAuthenticationFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/ApiAuthenticationFilter.java
@@ -60,11 +60,7 @@ public final class ApiAuthenticationFilter extends AbstractBootUiFilter {
     }
 
     private boolean isSessionRequest(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        String contextPath = request.getContextPath();
-        if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
+        String path = pathWithinApplication(request);
         return "POST".equalsIgnoreCase(request.getMethod())
                 && path.equals(withoutTrailingSlash(properties.getApiPath()) + SESSION_PATH);
     }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LegacyBootUiPathFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/LegacyBootUiPathFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UrlPathHelper;
 
 /**
  * Prevents Spring Boot's default static-resource handler from exposing the internal classpath mount
@@ -32,11 +33,7 @@ public final class LegacyBootUiPathFilter extends OncePerRequestFilter {
     }
 
     private boolean isConfiguredApiRequest(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        String contextPath = request.getContextPath();
-        if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
+        String path = UrlPathHelper.defaultInstance.getPathWithinApplication(request);
         String apiPath = properties.getApiPath();
         return path.equals(apiPath) || path.startsWith(apiPath + "/");
     }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/PanelAccessFilter.java
@@ -67,12 +67,7 @@ public class PanelAccessFilter extends AbstractBootUiFilter {
     }
 
     private String apiRelativePath(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        String contextPath = request.getContextPath();
-        if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-
+        String path = pathWithinApplication(request);
         String apiPath = properties.getApiPath();
         if (path.equals(apiPath)) {
             return "/";

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/SecurityHeadersFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/safety/SecurityHeadersFilter.java
@@ -65,12 +65,7 @@ public class SecurityHeadersFilter extends AbstractBootUiFilter {
     }
 
     private String contextRelativePath(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        String contextPath = request.getContextPath();
-        if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-        return path;
+        return pathWithinApplication(request);
     }
 
     /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AbstractBootUiFilter.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/AbstractBootUiFilter.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UrlPathHelper;
 
 public abstract class AbstractBootUiFilter extends OncePerRequestFilter {
 
@@ -14,24 +15,30 @@ public abstract class AbstractBootUiFilter extends OncePerRequestFilter {
         this.properties = properties;
     }
 
-    protected boolean isBootUiApiRequest(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        String contextPath = request.getContextPath();
-        if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
+    /**
+     * Returns the context-relative request path in the same form Spring's handler mapping resolves
+     * against: percent-decoded, with matrix parameters removed.
+     *
+     * <p>This must never be replaced by the raw {@code getRequestURI()}. Every BootUI safety filter
+     * decides whether it applies by matching this path against {@code bootui.path} /
+     * {@code bootui.api-path}, while the controller behind it is selected by {@code PathPattern} on the
+     * decoded path. Matching the raw URI makes the two disagree, so {@code /%62ootui/api/**} or
+     * {@code /bootui;x=1/api/**} would disarm the loopback, Host allow-list, cross-site-write, bearer
+     * token, and per-panel policy filters while still reaching the controller. The sibling
+     * {@code BootUiShellGuardFilter} resolves the path the same way for the same reason.</p>
+     */
+    protected String pathWithinApplication(HttpServletRequest request) {
+        return UrlPathHelper.defaultInstance.getPathWithinApplication(request);
+    }
 
+    protected boolean isBootUiApiRequest(HttpServletRequest request) {
+        String path = pathWithinApplication(request);
         String apiPath = properties.getApiPath();
         return path.equals(apiPath) || path.startsWith(apiPath + "/");
     }
 
     protected boolean isBootUiRequest(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        String contextPath = request.getContextPath();
-        if (contextPath != null && !contextPath.isBlank() && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length());
-        }
-
+        String path = pathWithinApplication(request);
         String basePath = properties.getPath();
         String apiPath = properties.getApiPath();
         return path.equals(basePath)

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiGuardPathMatchingTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiGuardPathMatchingTests.java
@@ -1,0 +1,96 @@
+package io.github.jdubois.bootui.autoconfigure.reactive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.engine.safety.ApiTokenAuthenticator;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive (WebFlux) sibling of {@code BootUiGuardPathMatchingTests}: the guards must match the decoded
+ * path {@code PathPattern} routes on, so {@code /%62ootui/api/**} and {@code /bootui;x=1/api/**} cannot
+ * disarm them while still reaching the BootUI handler.
+ */
+class ReactiveBootUiGuardPathMatchingTests {
+
+    private static final WebFilterChain OK_CHAIN = exchange -> {
+        exchange.getResponse().setStatusCode(HttpStatus.OK);
+        return Mono.empty();
+    };
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/%62ootui/api/config", "/bootui;x=1/api/config"})
+    void localhostGuardStillRejectsNonLoopbackSources(String uri) {
+        MockServerWebExchange exchange = exchange(uri, "10.0.0.5");
+
+        new ReactiveLocalhostOnlyFilter(new BootUiProperties())
+                .filter(exchange, OK_CHAIN)
+                .block(Duration.ofSeconds(5));
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/%62ootui/api/config", "/bootui;x=1/api/config"})
+    void bearerTokenIsStillRequiredForNonLoopbackSources(String uri) {
+        BootUiProperties properties = new BootUiProperties();
+        ReactiveApiAuthenticationFilter filter = new ReactiveApiAuthenticationFilter(
+                properties, new ApiTokenAuthenticator("test-token"), new ReactiveLocalhostOnlyFilter(properties));
+        MockServerWebExchange exchange = exchange(uri, "10.0.0.5");
+
+        filter.filter(exchange, OK_CHAIN).block(Duration.ofSeconds(5));
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/%62ootui/api/config", "/bootui;x=1/api/config"})
+    void panelPolicyStillAppliesToDisabledPanels(String uri) {
+        BootUiProperties properties = new BootUiProperties();
+        properties.panel("config").setEnabled(false);
+        MockServerWebExchange exchange = exchange(uri, "127.0.0.1");
+
+        new ReactivePanelAccessFilter(properties).filter(exchange, OK_CHAIN).block(Duration.ofSeconds(5));
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void canonicalPathsAreStillMatched() {
+        BootUiProperties properties = new BootUiProperties();
+        properties.panel("config").setEnabled(false);
+        MockServerWebExchange exchange = exchange("/bootui/api/config", "127.0.0.1");
+
+        new ReactivePanelAccessFilter(properties).filter(exchange, OK_CHAIN).block(Duration.ofSeconds(5));
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void nonBootUiRequestsAreStillLeftAlone() {
+        MockServerWebExchange exchange = exchange("/api/orders", "10.0.0.5");
+
+        new ReactiveLocalhostOnlyFilter(new BootUiProperties())
+                .filter(exchange, OK_CHAIN)
+                .block(Duration.ofSeconds(5));
+
+        assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    private static MockServerWebExchange exchange(String uri, String remoteAddress) {
+        return MockServerWebExchange.from(MockServerHttpRequest.method(HttpMethod.GET, URI.create(uri))
+                .remoteAddress(new InetSocketAddress(remoteAddress, 12345))
+                .build());
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/BootUiGuardPathMatchingTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/safety/BootUiGuardPathMatchingTests.java
@@ -1,0 +1,97 @@
+package io.github.jdubois.bootui.autoconfigure.safety;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
+import io.github.jdubois.bootui.engine.safety.ApiTokenAuthenticator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Proves the servlet safety filters decide whether they apply on the same decoded path Spring's handler
+ * mapping resolves against.
+ *
+ * <p>Servlet containers match a {@code FilterRegistrationBean} URL pattern against the decoded, normalized
+ * path, so these filters are invoked for {@code /%62ootui/api/**} and {@code /bootui;x=1/api/**} and then
+ * used to disarm themselves in {@code shouldNotFilter} by comparing the raw {@code getRequestURI()} —
+ * while {@code PathPattern} still routed the request to the BootUI controller. That turned every
+ * percent-encoded or matrix-parameter spelling of a BootUI URL into a full bypass of the loopback, Host
+ * allow-list, cross-site-write, bearer-token and per-panel policy guards.</p>
+ */
+class BootUiGuardPathMatchingTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/%62ootui/api/config", "/bootui;x=1/api/config"})
+    void localhostGuardStillRejectsNonLoopbackSources(String uri) throws Exception {
+        LocalhostOnlyFilter filter = new LocalhostOnlyFilter(new BootUiProperties());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+        request.setRequestURI(uri);
+        request.setRemoteAddr("10.0.0.5");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/%62ootui/api/config", "/bootui;x=1/api/config"})
+    void bearerTokenIsStillRequiredForNonLoopbackSources(String uri) throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        ApiAuthenticationFilter filter = new ApiAuthenticationFilter(
+                properties, new ApiTokenAuthenticator("test-token"), new LocalhostOnlyFilter(properties));
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+        request.setRequestURI(uri);
+        request.setRemoteAddr("10.0.0.5");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/%62ootui/api/config", "/bootui;x=1/api/config"})
+    void panelPolicyStillAppliesToDisabledPanels(String uri) throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        properties.panel("config").setEnabled(false);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+        request.setRequestURI(uri);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        new PanelAccessFilter(properties).doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentAsString()).contains("\"panel\":\"config\"");
+    }
+
+    @Test
+    void canonicalPathsAreStillMatched() throws Exception {
+        BootUiProperties properties = new BootUiProperties();
+        properties.panel("config").setEnabled(false);
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/bootui/api/config");
+        request.setRequestURI("/bootui/api/config");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        new PanelAccessFilter(properties).doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void nonBootUiRequestsAreStillLeftAlone() throws Exception {
+        LocalhostOnlyFilter filter = new LocalhostOnlyFilter(new BootUiProperties());
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/orders");
+        request.setRequestURI("/api/orders");
+        request.setRemoteAddr("10.0.0.5");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Makes every BootUI safety filter on Spring MVC and Spring WebFlux match the same decoded request path that Spring's handler mapping routes on, closing a bypass where `/%62ootui/api/**` and `/bootui;x=1/api/**` reached BootUI controllers with all the guards disarmed.

## Why is this change needed?

Found during a security audit of the repository.

Each guard decided whether it applied by matching the **raw** request path (`getRequestURI()` on the servlet stack, `pathWithinApplication().value()` on the reactive one) against `bootui.path` / `bootui.api-path`. The controller behind it, however, is selected by `PathPattern` on the **decoded** path, which is percent-decoded and has matrix parameters removed. The two disagreed:

| Request | Guard sees (raw) | Handler resolves to |
| --- | --- | --- |
| `/%62ootui/api/config/overrides` | `/%62ootui/...` -> not BootUI, skips | `/bootui/api/config/overrides`, controller runs |
| `/bootui;x=1/api/flyway/clean` | `/bootui;x=1/...` -> not BootUI, skips | `/bootui/api/flyway/clean`, controller runs |

Servlet containers match `FilterRegistrationBean` URL patterns against the decoded, normalized path, so the filters were invoked and then disarmed themselves in `shouldNotFilter`. The result was that `LocalhostOnlyFilter` (loopback check, Host allow-list and DNS-rebinding defence, cross-site-write protection), `ApiAuthenticationFilter` (bearer token), `PanelAccessFilter` (per-panel enabled/read-only policy), and `SecurityHeadersFilter` (CSP) were all silently skipped while the endpoint still executed.

Concretely, this let a malicious page in the developer's browser drive state-changing endpoints such as `POST /api/config/overrides`, `/api/flyway/clean`, and `/api/devtools/restart` with no cross-site-write check, defeated the Host allow-list against DNS rebinding for reads, and gave non-loopback callers in an `allow-non-localhost` or `trusted-proxies` deployment the whole API with no bearer token.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

What was actually run:

- New `BootUiGuardPathMatchingTests` and `ReactiveBootUiGuardPathMatchingTests` cover both bypass spellings against the localhost, authentication, and panel-access filters on both Spring stacks, plus canonical-path and non-BootUI-path control cases.
- Those tests were verified to be real regression tests: 12 of the 16 assertions fail against the pre-fix code and all pass after the fix.
- Full `bootui-spring-autoconfigure` suite green (1788 tests, 0 failures).
- `./mvnw spotless:apply` and `spotless:check` clean over the reactor.

The remaining boxes are unchecked because they were not run in this session, not because they are known to fail. The change is confined to path resolution inside the Spring adapter's filters.

## Screenshots (UI changes)

N/A, no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

Notes for reviewers:

- The approach is not new to the codebase. The `#856` shell guards (`BootUiShellGuardFilter`, `ReactiveBootUiShellGuardFilter`) already resolved the path this way and their javadoc calls out this exact attack; the security-critical filters simply never adopted it. This PR promotes that resolution into `AbstractBootUiFilter` (via `UrlPathHelper`) and a new shared `BootUiReactivePaths` helper (via `PathSegment#valueToMatch()`), and the reactive shell guard now uses that single implementation instead of its own private copy, so the two cannot drift apart again.
- **Quarkus was never affected.** Its filters already match on Vert.x `normalizedPath()`, so this closes a cross-adapter parity gap rather than fixing a shared design flaw. No Quarkus code changed.
- Behaviour change is fail-closed only: strictly more requests are now guarded. Canonical paths, configured custom `bootui.path` / `bootui.api-path` values, servlet context paths, and non-BootUI application routes are unaffected, and there are control tests for each.
- `CHANGELOG.md` has an entry under Unreleased describing the fix and the parity gap.
- Separately noted during the audit, not fixed here: `LocalhostGuard.isCrossSiteWrite` compares only the host of `Origin`, so any other `localhost:<port>` origin passes the cross-site-write check. That is a deliberate documented trade-off to keep the Vite dev-server proxy working, so tightening it is a product decision and belongs in its own PR.