### PR TITLE
fix(devtools): degrade restart status instead of throwing when the Restarter is unavailable

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DefaultDevToolsBridge.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DefaultDevToolsBridge.java
@@ -134,9 +134,18 @@ public class DefaultDevToolsBridge implements DevToolsBridge {
         try {
             restarter();
             return Availability.ready();
-        } catch (IllegalStateException ex) {
-            return Availability.unavailable(ex.getMessage());
+        } catch (DevToolsException ex) {
+            return Availability.unavailable(unavailableReason(ex));
         }
+    }
+
+    /**
+     * A status read must always degrade to an honest reason, so fall back to a generic explanation when the
+     * wrapped DevTools failure carries no message of its own.
+     */
+    private String unavailableReason(DevToolsException ex) {
+        String message = ex.getMessage();
+        return message == null || message.isBlank() ? "Spring Boot DevTools Restarter is not available." : message;
     }
 
     private Object restarter() {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DefaultDevToolsBridgeTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DefaultDevToolsBridgeTests.java
@@ -269,22 +269,60 @@ class DefaultDevToolsBridgeTests {
     }
 
     /**
-     * Note the asymmetry this pins down: {@code restartAvailability()} only catches {@link IllegalStateException},
-     * but {@code restarter()} wraps a failing {@code Restarter.getInstance()} in a {@link DevToolsException}, so an
-     * application that has DevTools on the classpath without an initialised Restarter surfaces the failure to the
-     * caller instead of degrading to an "unavailable" status.
+     * DevTools on the classpath without an initialised Restarter is a normal setup (a packaged jar, for
+     * instance). The status read must stay fail-closed and report an honest reason rather than propagating the
+     * failure and taking the whole DevTools panel down with it.
      */
     @Test
-    void anUninitializedRestarterFailsLoudlyRatherThanSilentlyReportingReady() throws Exception {
+    void anUninitializedRestarterDegradesToAnUnavailableStatusInsteadOfFailingTheRead() throws Exception {
         setStatic("org.springframework.boot.devtools.restart.Restarter", "failOnGetInstance", true);
         DefaultDevToolsBridge bridge = bridgeWithDevTools(null, null);
 
-        Assertions.assertThatThrownBy(bridge::status)
-                .isInstanceOf(DevToolsException.class)
-                .hasMessage("Restarter has not been initialized");
-        Assertions.assertThatThrownBy(bridge::scheduleRestart).isInstanceOf(DevToolsException.class);
+        DevToolsStatus status = bridge.status();
+        assertThat(status.restartAvailable()).isFalse();
+        assertThat(status.restartUnavailableReason()).isEqualTo("Restarter has not been initialized");
+
+        DevToolsActionResult restart = bridge.scheduleRestart();
+        assertThat(restart.action()).isEqualTo("restart");
+        assertThat(restart.status()).isEqualTo("unavailable");
+        assertThat(restart.message()).isEqualTo("Restarter has not been initialized");
         assertThat(staticValue("org.springframework.boot.devtools.restart.Restarter", "restartCount"))
                 .isEqualTo(0);
+    }
+
+    /**
+     * The other wrapping branch: the Restarter class is visible but its {@code getInstance()} method is not, so
+     * the reflective lookup fails. That must also read as an unavailable restart with a usable reason.
+     */
+    @Test
+    void aRestarterWithoutAGetInstanceMethodIsReportedAsUnavailable() throws Exception {
+        Path classes = Files.createDirectories(compiledClasses.resolve("broken-classes"));
+        Path sources = Files.createDirectories(compiledClasses.resolve("broken-sources"));
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        String source = """
+                package org.springframework.boot.devtools.restart;
+
+                public class Restarter {
+                }
+                """;
+        int result = compiler.run(
+                null,
+                null,
+                null,
+                "-d",
+                classes.toString(),
+                write(sources, "org/springframework/boot/devtools/restart/Restarter.java", source));
+        Assertions.assertThat(result).as("broken Restarter stub compilation").isZero();
+        ClassLoader brokenLoader = new URLClassLoader(new URL[] {classes.toUri().toURL()}, null);
+        ApplicationContext context = mock(ApplicationContext.class);
+        when(context.getClassLoader()).thenReturn(brokenLoader);
+        when(context.getBeansOfType(any(Class.class), anyBoolean(), anyBoolean()))
+                .thenReturn(Map.of());
+
+        DevToolsStatus status = register(new DefaultDevToolsBridge(context)).status();
+
+        assertThat(status.restartAvailable()).isFalse();
+        assertThat(status.restartUnavailableReason()).isEqualTo("Spring Boot DevTools Restarter is not available.");
     }
 
     @Test


### PR DESCRIPTION
> Stacked on #883 (`jdubois-critical-path-test-coverage`). Review that PR first; the base branch here is `jdubois-critical-path-test-coverage`, so this diff shows only the fix.

## The defect

`DefaultDevToolsBridge.restartAvailability()` guarded the Restarter lookup with:

```java
} catch (IllegalStateException ex) {
    return Availability.unavailable(ex.getMessage());
}
```

But `restarter()` in the same class wraps *every* failure in `io.github.jdubois.bootui.core.DevToolsException`:

- an `InvocationTargetException` from `Restarter.getInstance()` becomes `new DevToolsException(cause.getMessage(), cause)`
- `ReflectiveOperationException | LinkageError` becomes `new DevToolsException("Spring Boot DevTools Restarter is not available.", ex)`

`DevToolsException` extends `BootUiException` extends `RuntimeException` — it is never an `IllegalStateException`. The catch clause was dead code and the intended graceful degradation never happened.

## Real-world impact

An application with `spring-boot-devtools` on the classpath but an uninitialised `Restarter` (a packaged jar, or any context where `Restarter.getInstance()` has not been set up) made `status()` throw, taking down the whole DevTools panel status read instead of honestly reporting `restartAvailable=false` with a reason. `scheduleRestart()` inherited the same failure because it calls `restartAvailability()` first. That violates BootUI's fail-closed / honest-availability invariant: a status read must degrade, never blow up.

## The fix

- Catch `DevToolsException` in `restartAvailability()`.
- Add `unavailableReason(...)` so a null or blank wrapped message falls back to `"Spring Boot DevTools Restarter is not available."` — `restartUnavailableReason` is never null or blank when `restartAvailable` is false.

Action paths are unchanged: `triggerLiveReload()` still surfaces a `DevToolsException` when the LiveReload server genuinely fails, and `beanHandle()` already caught `ReflectiveOperationException | LinkageError` correctly. No refactoring beyond the defect, no new dependencies.

## Tests

`DefaultDevToolsBridgeTests.anUninitializedRestarterFailsLoudlyRatherThanSilentlyReportingReady` documented the buggy behaviour (asserting `status()` and `scheduleRestart()` throw). It is rewritten as `anUninitializedRestarterDegradesToAnUnavailableStatusInsteadOfFailingTheRead`, asserting:

- `status()` → `restartAvailable=false`, `restartUnavailableReason="Restarter has not been initialized"`
- `scheduleRestart()` → `("restart", "unavailable", ...)` and `restartCount` stays at 0

Added `aRestarterWithoutAGetInstanceMethodIsReportedAsUnavailable`, which compiles a `Restarter` stub with no `getInstance()` method to cover the reflective-failure wrapping branch and its fallback reason.

## Validation

- `-pl bootui-spring-autoconfigure -Dtest=DefaultDevToolsBridgeTests test` — 13 tests, 0 failures
- `-pl bootui-core,bootui-engine,bootui-spring-autoconfigure -am -DskipITs test` — 1792 tests, 0 failures
- `spotless:apply` + `spotless:check` clean

`docs/features/developer-tools.md` already states that restart actions are shown only when available, which matches the fixed behaviour, so no doc change was needed.