### PR TITLE
build: restore JaCoCo coverage in modules with a custom surefire argLine

### DIFF
--- a/bootui-engine/pom.xml
+++ b/bootui-engine/pom.xml
@@ -238,7 +238,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-quarkus-integration-tests/rabbit/pom.xml
+++ b/bootui-quarkus-integration-tests/rabbit/pom.xml
@@ -86,7 +86,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <argLine>${quarkus.test.argLine}
+                    <argLine>@{argLine} ${quarkus.test.argLine}
                         -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>

--- a/bootui-quarkus-parent/pom.xml
+++ b/bootui-quarkus-parent/pom.xml
@@ -62,7 +62,7 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
-                        <argLine>${quarkus.test.argLine}</argLine>
+                        <argLine>@{argLine} ${quarkus.test.argLine}</argLine>
                     </configuration>
                 </plugin>
             </plugins>

--- a/bootui-quarkus/pom.xml
+++ b/bootui-quarkus/pom.xml
@@ -395,7 +395,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <forkCount>1</forkCount>
-                    <argLine>${quarkus.test.argLine}
+                    <argLine>@{argLine} ${quarkus.test.argLine}
                         -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>

--- a/bootui-spring-autoconfigure/pom.xml
+++ b/bootui-spring-autoconfigure/pom.xml
@@ -407,7 +407,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-spring-sample-app/pom.xml
+++ b/bootui-spring-sample-app/pom.xml
@@ -209,7 +209,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/bootui-spring-webflux-sample-app/pom.xml
+++ b/bootui-spring-webflux-sample-app/pom.xml
@@ -142,7 +142,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-javaagent:${org.mockito:mockito-core:jar}</argLine>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,13 @@
         <node.version>v24.18.0</node.version>
         <npm.version>11.17.0</npm.version>
         <frontend.test.command>run test</frontend.test.command>
+        <!--
+            Modules that declare their own Surefire <argLine> must prefix it with the @{argLine} late-replacement
+            token, otherwise the literal value overwrites the JaCoCo agent arguments that the coverage profile's
+            prepare-agent goal publishes through this same property. This empty default keeps @{argLine} resolvable
+            in normal (non-coverage) builds, where prepare-agent never runs.
+        -->
+        <argLine></argLine>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## The bug

The `coverage` profile wires `jacoco-maven-plugin:prepare-agent`, which publishes the JaCoCo javaagent arguments through the `argLine` property that maven-surefire-plugin reads by default.

Seven modules declare their own literal surefire `<argLine>` (to attach the Mockito / Byte Buddy agent). Because those values did not carry the `@{argLine}` late-replacement token, they silently **overwrote** the JaCoCo value: the agent was never attached, and those modules produced no `jacoco.exec` at all. The `bootui-coverage` aggregate report was therefore reporting near-zero coverage.

## Measured before / after

Both runs used `./mvnw -B -ntp -Pcoverage -DskipITs -Dfrontend.skip=true -Djacoco.haltOnFailure=false verify` with all stale `jacoco*.exec` files removed first, reading `bootui-coverage/target/site/jacoco-aggregate/jacoco.csv`:

| | covered instructions | missed | overall |
|---|---|---|---|
| before | 5 453 | 232 620 | **2.29 %** |
| after | 210 826 | 27 247 | **88.56 %** |

`bootui-engine/target/jacoco.exec` and `bootui-spring-autoconfigure/target/jacoco.exec` did not exist before and are now written (334 KB / 1.1 MB). `-DskipITs` makes Quarkus classes look artificially uncovered; that is expected and unrelated.

## The fix

- Prefix every custom surefire `argLine` with the `@{argLine}` token, keeping the rest of each value byte-identical: `bootui-engine`, `bootui-spring-autoconfigure`, `bootui-quarkus`, `bootui-spring-sample-app`, `bootui-spring-webflux-sample-app`, `bootui-quarkus-parent`, `bootui-quarkus-integration-tests/rabbit`.
- Declare an empty default `<argLine></argLine>` property in the root `pom.xml`. `@{argLine}` is only defined once `prepare-agent` has run, so without a default, normal (non-coverage) builds would pass a literal `@{argLine}` to the JVM. The empty default keeps the token resolvable everywhere, and `prepare-agent` prepends its value to it under the `coverage` profile.

No Java source changed.

## Validation

- `./mvnw -pl bootui-core,bootui-engine,bootui-spring-autoconfigure -am -DskipITs test` -> 1788 tests, 0 failures (non-coverage regression check).
- Full `-Pcoverage ... verify` reactor -> BUILD SUCCESS, numbers above.
- `./mvnw spotless:apply` + `spotless:check` -> pass.