### PR TITLE
build(deps): group vitest and its coverage provider in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,12 @@ updates:
         patterns:
           - 'bootstrap'
           - 'bootstrap-icons'
+      # vitest and its coverage provider peer-depend on an exact matching
+      # version, so they have to move together or npm ci fails with ERESOLVE.
+      vitest:
+        patterns:
+          - 'vitest'
+          - '@vitest/*'
 
   - package-ecosystem: npm
     directory: /


### PR DESCRIPTION
## Problem

Dependabot proposed `vitest` 4.1.10 → 4.1.11 (#889) and `@vitest/coverage-v8` 4.1.10 → 4.1.11 (#892) as two separate pull requests. Those two packages peer-depend on an *exact* matching version, so each PR fails `npm ci` on its own:

```
npm error code ERESOLVE
npm error While resolving: @vitest/coverage-v8@4.1.10
npm error Found: vitest@4.1.11
```

Neither PR can merge alone, and the pair will keep reappearing every week.

## Change

Adds a `vitest` group to the `/bootui-ui/src/main/frontend` npm ecosystem in `.github/dependabot.yml` so both packages are bumped together in one PR:

```yaml
vitest:
  patterns:
    - 'vitest'
    - '@vitest/*'
```

The `@vitest/*` wildcard also covers future companion packages (`@vitest/ui`, `@vitest/browser`, …) without another config change.

## Validation

- `.github/dependabot.yml` parses as valid YAML; the frontend ecosystem now resolves groups `vue`, `bootstrap`, `vitest`.
- Indentation and quoting style match the surrounding groups.
- Config-only change — no build, test, or runtime behavior is affected.

## Follow-up

Once this is on `main`, #889 and #892 should be closed so Dependabot can re-propose the pair as a single grouped PR.