### PR TITLE
test(ui): raise Vitest timeout for whole-codebase contract suites

### DIFF
--- a/bootui-ui/src/main/frontend/vite.config.js
+++ b/bootui-ui/src/main/frontend/vite.config.js
@@ -95,6 +95,11 @@ export default defineConfig(({command}) => ({
     restoreMocks: true,
     reporters: process.env.CI ? ['default', 'junit'] : 'default',
     outputFile: {junit: './test-results/vitest-junit.xml'},
+    // The design-system, accessibility, motion, and contrast contract suites parse
+    // every `.vue` file under `src/views`. On CI that runs under V8 coverage while
+    // vue-tsc (vite-plugin-checker) competes for the same cores, so Vitest's 5s
+    // default intermittently trips on the first test.
+    testTimeout: 30000,
     coverage: {
       provider: 'v8',
       reportsDirectory: './coverage',


### PR DESCRIPTION
## Problem

`bootui-ui/src/main/frontend/src/designSystem.test.js` intermittently fails on GitHub Actions with a 5s Vitest timeout on its *first* test:

```
FAIL  src/designSystem.test.js > BootUI design system contracts > keeps uppercase tracked labels out of panel content
Error: Test timed out in 5000ms.
Tests  1 failed | 1024 passed (1025)
```

This is environment-timing dependent, not an assertion failure. It blocked Dependabot PR #888, whose only change is a one-line `spring-boot.version` bump in the root `pom.xml` — it failed twice in a row there while passing on other PRs.

## Root cause

That test synchronously walks `src/views` and runs `@vue/compiler-sfc` `parse()` over 78 `.vue` files (~1.9MB).

Measured locally:

- 195ms standalone
- 753ms for the whole `designSystem.test.js` file under coverage
- ~13s for the full suite via `npm run test:coverage`, 1025/1025 passing

CI is far slower: a 2-core runner, V8 coverage instrumentation, and `vite-plugin-checker` running `vue-tsc` concurrently (`checker({vueTsc: true})` in `vite.config.js`). Under that contention the cold first test exceeds the limit. `vite.config.js` set no `testTimeout`, so Vitest's 5000ms default applied.

## Why a timeout rather than caching

Memoizing or caching the SFC parses would not help: the test that times out is the *first* one, so it pays the cold parse cost regardless of any cache.

Three sibling suites perform the same 78-file scan and carry the same latent risk — `src/accessibility.test.js`, `src/responsiveMotion.test.js`, and `src/themeContrast.test.js`. Fixing this at config level covers all four instead of leaving one-off inline timeouts scattered across suites.

## Change

One line plus a short comment in the existing `test: { ... }` block of `bootui-ui/src/main/frontend/vite.config.js`:

```js
testTimeout: 30000,
```

No test files, assertions, caching, or `checker({vueTsc: true})` configuration were touched.

## Validation

From `bootui-ui/src/main/frontend`:

- `npm run test:coverage` — **1025/1025 passing**, 100 test files, coverage thresholds still hold (statements 80.66%, branches 71.49%, functions 77.37%, lines 83.26%)
- `npm run format` and `npm run format:check` — clean

Full Maven reactor was not run; this is a frontend-config-only change and the targeted Vitest run is the correct smallest validation.

## Follow-up

Once this merges, PR #888 should be re-run.