### PR TITLE
build(deps): restore canonical registry URLs and sha512 integrity in lockfiles

### DIFF
--- a/bootui-ui/src/main/frontend/package-lock.json
+++ b/bootui-ui/src/main/frontend/package-lock.json
@@ -187,7 +187,7 @@
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
-      "integrity": "sha1-u+EtyltO+YOg0K9LB7m8kOoKuro=",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1198,7 +1198,7 @@
     "node_modules/ast-v8-to-istanbul": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
-      "integrity": "sha1-cIuutvXIeSJtESo0H/qCHEOIHS0=",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1210,7 +1210,7 @@
     "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha1-Z8PlSexAKkh7T8GT0ZU6UkdSNA0=",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1220,7 +1220,7 @@
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
-      "integrity": "sha1-3/51mbSou3/jCv+NAjUjTf+3mDE=",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1556,7 +1556,7 @@
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1585,7 +1585,7 @@
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1606,7 +1606,7 @@
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-      "integrity": "sha1-LRZsSwZE1Do58Ev2wu3R5YXzF1Y=",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1616,7 +1616,7 @@
     "node_modules/istanbul-lib-report": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-      "integrity": "sha1-kIMFusmlvRdaxqdEier9D8JEWn0=",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1631,7 +1631,7 @@
     "node_modules/istanbul-reports": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
-      "integrity": "sha1-y0U1FitXhKpiPO4hpyUs8sgHrJM=",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2074,7 +2074,7 @@
     "node_modules/magicast": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
-      "integrity": "sha1-u+ON/WA3ZwBX8zq/IriqedXpnQo=",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2086,7 +2086,7 @@
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
-      "integrity": "sha1-w8IwencSd82WODBfkVwprnQbYU4=",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2567,7 +2567,7 @@
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2820,8 +2820,8 @@
     },
     "node_modules/@vuepress/plugin-slimsearch": {
       "version": "2.0.0-rc.131",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vuepress/plugin-slimsearch/-/plugin-slimsearch-2.0.0-rc.131.tgz",
-      "integrity": "sha1-qYKdocGL7ILW1US0RMK5yxPQO2k=",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-slimsearch/-/plugin-slimsearch-2.0.0-rc.131.tgz",
+      "integrity": "sha512-QVCxtrbAxGLUuMK9bssxfwZ+eFAMiAXXlD70Py5tn24lCWg9XGVeUxzFRjQzCHrgxmOiqlAYdLAhxyhIz9n0Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6648,8 +6648,8 @@
     },
     "node_modules/slimsearch": {
       "version": "2.3.0",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/slimsearch/-/slimsearch-2.3.0.tgz",
-      "integrity": "sha1-TSiuzaiSz1ROzzIcKEcFgmO8TkE=",
+      "resolved": "https://registry.npmjs.org/slimsearch/-/slimsearch-2.3.0.tgz",
+      "integrity": "sha512-e0L+ke+DGxptl2os/9DshoGVB+XkD2u1nSnRH4Jh0MNIfqkRUmLFLjvwVJiDT7grAYhpCEfHRv5nBNvcADZ4pw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Problem

Fourteen entries across the two `package-lock.json` files carry metadata written by a **local corporate npm proxy** rather than the public registry:

| Symptom | Count | Where |
|---|---|---|
| `resolved` points at `ms-feed-25.pkgs.visualstudio.com` | 2 | root (`@vuepress/plugin-slimsearch`, `slimsearch`) |
| `integrity` is a **sha1** hash instead of sha512 | 14 | 2 root + 12 in `bootui-ui/src/main/frontend` |

The frontend entries are all coverage tooling: `@bcoe/v8-coverage`, `ast-v8-to-istanbul` (plus its nested `estree-walker` and `js-tokens`), `has-flag`, `html-escaper`, `istanbul-lib-coverage`, `istanbul-lib-report`, `istanbul-reports`, `magicast`, `make-dir`, `supports-color`.

### Root cause

The proxy strips `dist.integrity` from its metadata responses. When npm doesn't receive an integrity value it computes one itself from the downloaded tarball — and falls back to **sha1**, npm's legacy algorithm. It also records the proxy's own tarball URL in `resolved`. A plain `npm install` behind such a proxy therefore silently downgrades supply-chain verification for every entry it touches.

This is pre-existing contamination from an earlier local install, not something introduced by a recent dependency bump.

### Why it matters

- **sha1 is cryptographically broken.** Chosen-prefix collisions against SHA-1 are practical (SHAttered, 2017; Leurent–Peyrin, 2020). An integrity hash is precisely the setting where collision resistance is the property being relied on, so these entries provide materially weaker tamper-evidence than the sha512 used by the other 750 entries.
- **The internal URLs aren't resolvable** outside the corporate network, making those two entries a portability hazard for CI and outside contributors.

## What changed

Only the `resolved` and `integrity` fields of the 14 affected entries. **No package versions changed** — verified by diffing the full `{path: version}` map of both lockfiles before and after:

```
package-lock.json: versions unchanged
bootui-ui/src/main/frontend/package-lock.json: versions unchanged
```

```
 bootui-ui/src/main/frontend/package-lock.json | 24 ++++++++++++------------
 package-lock.json                             |  8 ++++----
 2 files changed, 16 insertions(+), 16 deletions(-)
```

The 12 frontend entries change one line each (integrity only — their URLs were already correct); the 2 root entries change two lines each (URL + integrity).

## How it was regenerated

`registry.npmjs.org` is **not directly reachable** from the machine this was authored on, so canonical hashes could not be obtained or verified locally — running `npm install` here would only have reproduced the contamination.

Instead the repair ran **inside GitHub Actions**, which has clean public registry access, via a temporary workflow. For each affected entry it fetched `registry.npmjs.org/<name>/<exact-version>` and took `dist.tarball` and `dist.integrity` verbatim. The script asserted, and would have failed the build otherwise, that:

- the registry returned an integrity value actually beginning with `sha512-`;
- the tarball host was `registry.npmjs.org`;
- after rewriting, **no** entry anywhere in either file retained a non-sha512 integrity or a foreign host.

The temporary workflow was used only to produce the artifact and is deliberately **not** part of this PR — the diff is lockfiles only.

## Validation

- Repair job green; both assertions passed and the post-rewrite scan found zero residual weak or foreign entries.
- `npm ci` run in **both** directories against the repaired lockfiles inside the same job — npm re-verifies every tarball against its recorded integrity on install, so this is a genuine end-to-end check that the new sha512 values match the real tarball bytes.
- Re-scanned locally after applying the artifact: `539 entries | weak-integrity=0 foreign-host=0` (root) and `225 entries | weak-integrity=0 foreign-host=0` (frontend).
- Re-serialisation is diff-safe: `JSON.stringify(JSON.parse(content), null, 2) + "\n"` round-trips **byte-identically** on both files at `main`, confirmed before the repair, so the diff contains no incidental reformatting.

## Note for maintainers

Anyone whose npm is configured against a rewriting proxy will silently reintroduce this the next time they run `npm install`. `npm ci` is unaffected — it never writes the lockfile. Worth keeping in mind when hand-editing dependencies rather than letting Dependabot do it.