### PR TITLE
Rename the DevTools panel to Spring DevTools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **The `DevTools` panel is now called `Spring DevTools`.** The old name sat inside the *Developer tools* navigation
+  group and read like a generic developer-tooling panel or the browser's own DevTools, while it has always been
+  specifically about Spring Boot DevTools — classpath presence, the LiveReload server, and the restart bridge (it is
+  reported *not applicable* on Quarkus). Only the display title changes: the `devtools` panel id, the `/devtools`
+  route, the `bootui.panels.devtools.*` properties, and the `/bootui/api/devtools` contract are untouched.
+
 ### Fixed
 
 - **BootUI's safety filters can no longer be bypassed by a percent-encoded or matrix-parameter spelling of a BootUI URL

--- a/bootui-conformance/src/main/resources/io/github/jdubois/bootui/conformance/expected-panels-quarkus.json
+++ b/bootui-conformance/src/main/resources/io/github/jdubois/bootui/conformance/expected-panels-quarkus.json
@@ -38,7 +38,7 @@
     { "id": "http-probe", "title": "HTTP Probe", "actionCapable": true },
     { "id": "architecture", "title": "Architecture", "actionCapable": true },
     { "id": "vulnerabilities", "title": "Vulnerabilities", "actionCapable": true },
-    { "id": "devtools", "title": "DevTools", "actionCapable": true },
+    { "id": "devtools", "title": "Spring DevTools", "actionCapable": true },
     { "id": "dev-services", "title": "Dev Services", "actionCapable": true },
     { "id": "copilot", "title": "Copilot", "actionCapable": false },
     { "id": "claude-code", "title": "Claude Code", "actionCapable": false },

--- a/bootui-conformance/src/main/resources/io/github/jdubois/bootui/conformance/expected-panels-spring.json
+++ b/bootui-conformance/src/main/resources/io/github/jdubois/bootui/conformance/expected-panels-spring.json
@@ -38,7 +38,7 @@
     { "id": "http-probe", "title": "HTTP Probe", "actionCapable": true },
     { "id": "architecture", "title": "Architecture", "actionCapable": true },
     { "id": "vulnerabilities", "title": "Vulnerabilities", "actionCapable": true },
-    { "id": "devtools", "title": "DevTools", "actionCapable": true },
+    { "id": "devtools", "title": "Spring DevTools", "actionCapable": true },
     { "id": "dev-services", "title": "Dev Services", "actionCapable": true },
     { "id": "copilot", "title": "Copilot", "actionCapable": false },
     { "id": "claude-code", "title": "Claude Code", "actionCapable": false },

--- a/bootui-conformance/src/main/resources/io/github/jdubois/bootui/conformance/expected-panels-webflux.json
+++ b/bootui-conformance/src/main/resources/io/github/jdubois/bootui/conformance/expected-panels-webflux.json
@@ -38,7 +38,7 @@
     { "id": "http-probe", "title": "HTTP Probe", "actionCapable": true },
     { "id": "architecture", "title": "Architecture", "actionCapable": true },
     { "id": "vulnerabilities", "title": "Vulnerabilities", "actionCapable": true },
-    { "id": "devtools", "title": "DevTools", "actionCapable": true },
+    { "id": "devtools", "title": "Spring DevTools", "actionCapable": true },
     { "id": "dev-services", "title": "Dev Services", "actionCapable": true },
     { "id": "copilot", "title": "Copilot", "actionCapable": false },
     { "id": "claude-code", "title": "Claude Code", "actionCapable": false },

--- a/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
+++ b/bootui-conformance/src/test/java/io/github/jdubois/bootui/conformance/BackendPanelCatalogConsistencyTest.java
@@ -145,7 +145,10 @@ class BackendPanelCatalogConsistencyTest {
                         section(readDocumentation("AI-AGENTS.md"), "### Tools the agent can call", "### Safety model")),
                 new DocumentationSection(
                         "docs/features/developer-tools.md",
-                        section(readDocumentation("features/developer-tools.md"), "## MCP Server", "## DevTools")),
+                        section(
+                                readDocumentation("features/developer-tools.md"),
+                                "## MCP Server",
+                                "## Spring DevTools")),
                 new DocumentationSection(
                         "docs/SPECIFICATION.md",
                         section(

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/panel/BootUiPanels.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/panel/BootUiPanels.java
@@ -118,7 +118,7 @@ public final class BootUiPanels {
             new Panel(HTTP_PROBE, "HTTP Probe", true, "/http-probe"),
             new Panel(ARCHITECTURE, "Architecture", true, "/architecture"),
             new Panel(VULNERABILITIES, "Vulnerabilities", true, "/vulnerabilities"),
-            new Panel(DEVTOOLS, "DevTools", true, "/devtools"),
+            new Panel(DEVTOOLS, "Spring DevTools", true, "/devtools"),
             new Panel(DEV_SERVICES, "Dev Services", true, "/dev-services"),
             new Panel(COPILOT, "Copilot", false, "/copilot"),
             new Panel(CLAUDE_CODE, "Claude Code", false, "/claude-code"),

--- a/bootui-quarkus-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/app-shell.spec.js
@@ -7,7 +7,7 @@ import {expect, test} from './fixtures.js'
  *
  * The navigation test below only consults an entry when the Quarkus adapter actually reports that
  * panel available, so Spring-only panels that are unavailable on Quarkus (Spring Data, Spring
- * Security, GraalVM, CRaC, Conditions, Startup Timeline, HTTP Sessions, DevTools) are simply
+ * Security, GraalVM, CRaC, Conditions, Startup Timeline, HTTP Sessions, Spring DevTools) are simply
  * skipped — they are covered by not-applicable.spec.js instead.
  */
 const PANEL_HEADINGS = {
@@ -62,7 +62,7 @@ const PANEL_HEADINGS = {
   'rest-api': /^REST API/,
   spring: /^Quarkus/,
   'mcp-server': /^MCP Server/,
-  devtools: /^DevTools/,
+  devtools: /^Spring DevTools/,
   'dev-services': /^Dev Services/,
   copilot: /^Copilot/,
   'claude-code': /^Claude Code/

--- a/bootui-quarkus-sample-app/e2e/tests/not-applicable.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/not-applicable.spec.js
@@ -8,7 +8,7 @@ import {expect, test} from './fixtures.js'
  * breaks on Quarkus.
  */
 const NOT_APPLICABLE = [
-  {id: 'devtools', label: 'DevTools'},
+  {id: 'devtools', label: 'Spring DevTools'},
   {id: 'conditions', label: 'Conditions'},
   {id: 'http-sessions', label: 'HTTP Sessions'},
   {id: 'graalvm', label: 'GraalVM'},
@@ -36,10 +36,10 @@ test.describe('Spring-only panels degrade honestly on Quarkus', () => {
     await expect(toggle).toBeVisible()
     await expect(toggle).toHaveAttribute('aria-expanded', 'false')
 
-    // DevTools is Spring-only, so it must not be visible until the disabled group is expanded.
-    await expect(page.locator('aside .nav-link', {hasText: 'DevTools'})).not.toBeVisible()
+    // Spring DevTools is Spring-only, so it must not be visible until the disabled group is expanded.
+    await expect(page.locator('aside .nav-link', {hasText: 'Spring DevTools'})).not.toBeVisible()
 
     await toggle.click()
-    await expect(page.locator('aside .nav-link', {hasText: 'DevTools'})).toBeVisible()
+    await expect(page.locator('aside .nav-link', {hasText: 'Spring DevTools'})).toBeVisible()
   })
 })

--- a/bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -107,7 +107,7 @@ const panelOrder = [
   ['rest-api', 'REST API'],
   ['database-advisor', 'Database'],
   ['mcp-server', 'MCP Server'],
-  ['devtools', 'DevTools'],
+  ['devtools', 'Spring DevTools'],
   ['dev-services', 'Dev Services'],
   ['copilot', 'Copilot'],
   ['claude-code', 'Claude Code']
@@ -5525,7 +5525,7 @@ const screenshots = [
   ['spring', 'Spring', 'bootui-spring.webp', waitForText('Prefer RestClient over RestTemplate')],
   ['memory', 'Memory', 'bootui-memory.webp', waitForText('Old generation is near its maximum')],
   ['mcp-server', 'MCP Server', 'bootui-mcp-server.webp', waitForText('Client configuration')],
-  ['devtools', 'DevTools', 'bootui-devtools.webp', waitForText('Trigger LiveReload')],
+  ['devtools', 'Spring DevTools', 'bootui-devtools.webp', waitForText('Trigger LiveReload')],
   ['dev-services', 'Dev Services', 'bootui-dev-services.webp', waitForText('postgres')],
   [
     'copilot',

--- a/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/app-shell.spec.js
@@ -53,7 +53,7 @@ const allPanelLinks = [
   {id: 'architecture', title: 'Architecture', heading: /^Architecture/},
   {id: 'rest-api', title: 'REST API', heading: /^REST API/},
   {id: 'mcp-server', title: 'MCP Server', heading: /^MCP Server/},
-  {id: 'devtools', title: 'DevTools', heading: /^DevTools/},
+  {id: 'devtools', title: 'Spring DevTools', heading: /^Spring DevTools/},
   {id: 'dev-services', title: 'Dev Services', heading: /^Dev Services/},
   {id: 'copilot', title: 'Copilot', heading: /^Copilot/},
   {id: 'claude-code', title: 'Claude Code', heading: /^Claude Code/}

--- a/bootui-spring-sample-app/e2e/tests/devtools.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/devtools.spec.js
@@ -48,7 +48,7 @@ test.describe('Spring DevTools view', () => {
       }
     )
 
-    await openView('devtools', /^DevTools/)
+    await openView('devtools', /^Spring DevTools/)
 
     await expect(page.getByText('LiveReload port:')).toBeVisible()
     await expect(page.getByText('Connected clients:')).toBeVisible()
@@ -90,7 +90,7 @@ test.describe('Spring DevTools view', () => {
       }
     )
 
-    await openView('devtools', /^DevTools/)
+    await openView('devtools', /^Spring DevTools/)
 
     const liveReloadCard = page.locator('.card', {hasText: 'Trigger LiveReload'})
     await expect(liveReloadCard).toContainText('No browsers are connected to the LiveReload server')

--- a/bootui-spring-sample-app/e2e/tests/devtools.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/devtools.spec.js
@@ -1,9 +1,9 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
 
-test.describe('DevTools view', () => {
+test.describe('Spring DevTools view', () => {
   test('renders LiveReload and restart status cards without triggering restart', async ({openView, page}) => {
-    await openView('devtools', 'DevTools')
+    await openView('devtools', 'Spring DevTools')
 
     const liveReloadCard = page.locator('.card', {hasText: 'Trigger LiveReload'})
     const restartCard = page.locator('.card', {hasText: 'Restart application'})

--- a/bootui-ui/src/main/frontend/src/routes.js
+++ b/bootui-ui/src/main/frontend/src/routes.js
@@ -934,9 +934,17 @@ export const routes = [
     meta: {
       group: groups.developerTools,
       icon: 'bi-lightning-charge',
-      title: 'DevTools',
+      title: 'Spring DevTools',
       shortcut: 'dt',
-      keywords: ['devtools', 'livereload', 'restart', 'hot reload', 'auto restart']
+      keywords: [
+        'devtools',
+        'spring devtools',
+        'spring-boot-devtools',
+        'livereload',
+        'restart',
+        'hot reload',
+        'auto restart'
+      ]
     }
   },
   {

--- a/bootui-ui/src/main/frontend/src/routes.test.js
+++ b/bootui-ui/src/main/frontend/src/routes.test.js
@@ -310,7 +310,7 @@ describe('routes', () => {
       'HTTP Exchanges',
       'HTTP Probe',
       'MCP Server',
-      'DevTools',
+      'Spring DevTools',
       'Dev Services',
       'Copilot',
       'Claude Code'

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -39,7 +39,7 @@ async function fetchStatus() {
     status.value = await getJson('api/devtools')
     lastFetched.value = Date.now()
   } catch (e) {
-    flash(formatLoadError(e, 'Could not load DevTools status'), 'danger')
+    flash(formatLoadError(e, 'Could not load Spring DevTools status'), 'danger')
   }
 }
 
@@ -144,7 +144,7 @@ onUnmounted(clearReconnectTimer)
   <div>
     <PanelHeader
       icon="bi-lightning-charge"
-      title="DevTools"
+      title="Spring DevTools"
       subtitle="Trigger Spring Boot DevTools LiveReload notifications or restart the local application."
       :loading="loading || restarting"
       :last-fetched="lastFetched"
@@ -154,7 +154,7 @@ onUnmounted(clearReconnectTimer)
 
     <FlashBanner :message="banner" with-icon @dismiss="clear" />
 
-    <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">DevTools actions are read-only.</ReadOnlyNotice>
+    <ReadOnlyNotice v-if="readOnly" :reason="readOnlyReason">Spring DevTools actions are read-only.</ReadOnlyNotice>
 
     <div v-if="restarting" class="alert alert-primary d-flex align-items-start gap-3">
       <div class="spinner-border spinner-border-sm mt-1" role="status"></div>
@@ -278,7 +278,7 @@ onUnmounted(clearReconnectTimer)
 
     <UnavailableState
       v-else
-      message="DevTools status is unavailable. The app may be restarting or unreachable — retry or refresh this panel."
+      message="Spring DevTools status is unavailable. The app may be restarting or unreachable — retry or refresh this panel."
     />
   </div>
 </template>

--- a/docs/FRAMEWORK-SUPPORT.md
+++ b/docs/FRAMEWORK-SUPPORT.md
@@ -38,7 +38,7 @@ covered by something else:
 | **GraalVM**, **CRaC**                   | Quarkus is native-first and starts fast by design. Use its own native build.        |
 | **Conditions**, **Startup Timeline**    | Quarkus resolves wiring at build time, so there is no runtime graph or step timeline. |
 | **Spring Security**, **Spring Data**    | Quarkus uses Elytron/OIDC and Panache. Use the Quarkus Security advisor and the Hibernate advisor. |
-| **DevTools**                            | Quarkus dev mode already owns live reload.                                          |
+| **Spring DevTools**                     | Quarkus dev mode already owns live reload.                                          |
 | **HTTP Sessions**                       | Reactive and stateless by default, as on WebFlux.                                   |
 | **Transactions**                        | Boundary capture needs a Spring hook that Narayana and CDI do not expose.            |
 

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -207,7 +207,7 @@ Enforced identically on Spring and Quarkus (`PanelAccessFilter` / `QuarkusPanelA
 | Diagnostics     | HTTP Exchanges            | `http-exchanges`            | `bootui.panels.http-exchanges.enabled`            | Not applicable; view-only.                |
 | Diagnostics     | HTTP Probe                | `http-probe`                | `bootui.panels.http-probe.enabled`                | `bootui.panels.http-probe.read-only`      |
 | Developer tools | MCP Server                | `mcp-server`                | `bootui.panels.mcp-server.enabled`                | `bootui.panels.mcp-server.read-only`      |
-| Developer tools | DevTools                  | `devtools`                  | `bootui.panels.devtools.enabled`                  | `bootui.panels.devtools.read-only`        |
+| Developer tools | Spring DevTools           | `devtools`                  | `bootui.panels.devtools.enabled`                  | `bootui.panels.devtools.read-only`        |
 | Developer tools | Dev Services              | `dev-services`              | `bootui.panels.dev-services.enabled`              | `bootui.panels.dev-services.read-only`    |
 | Developer tools | Copilot                   | `copilot`                   | `bootui.panels.copilot.enabled`                   | Not applicable; view-only.                |
 | Developer tools | Claude Code               | `claude-code`               | `bootui.panels.claude-code.enabled`               | Not applicable; view-only.                |
@@ -694,7 +694,7 @@ The JMS panel is a dedicated view over the same bounded Spring JMS capture that 
 | `bootui.panels.crac.enabled`   | `true`  | Show the CRaC (Coordinated Restore at Checkpoint) readiness panel and its latest report.                       |
 | `bootui.panels.crac.read-only` | `false` | Disable the on-demand readiness scan and the Dockerfile/entrypoint install actions (downloads stay available). |
 
-### DevTools
+### Spring DevTools
 
 | Property                           | Default | Description                                                         |
 | ---------------------------------- | ------- | ------------------------------------------------------------------- |

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -165,7 +165,7 @@ those fields so the same UI build renders the correct sidebar and status on each
 > (capture/analyze/delete/download), Threads (download), the advisor scans, Loggers (set level), HTTP Probe, Cache
 > (clear), Flyway (migrate/clean), Liquibase (update), Traces (clear), Email (clear), Kafka (clear), RabbitMQ (clear),
 > REST Client Reactive (clear + recording toggle), and the MCP Server toggle. Eight panels — **GraalVM**, **CRaC**,
-> **Conditions**, **Startup Timeline**, **HTTP Sessions**, **Spring Data**, **Spring Security**, and **DevTools** — are
+> **Conditions**, **Startup Timeline**, **HTTP Sessions**, **Spring Data**, **Spring Security**, and **Spring DevTools** — are
 > intentionally unavailable with a panel-specific not-applicable reason (§5.5). **JMS** is the sole panel that is not yet
 > available on Quarkus (§5.6). The per-panel `**Implemented**` markers below and `docs/features/` carry the authoritative,
 > current per-platform detail.
@@ -482,7 +482,7 @@ No equivalent, low value, or superseded by Quarkus's own tooling:
   - `GraalVM` readiness — Quarkus is native-first with its own build.
   - `CRaC` — BootUI's advisor and generated assets depend on Spring `LifecycleProcessor`, Spring scheduling, Spring Boot
     Hikari integration, and `spring.context.checkpoint=onRefresh`, so partial reuse would be misleading.
-  - `DevTools` (**Implemented as `NOT_APPLICABLE`**) — Quarkus has built-in dev-mode live reload, so there is no
+  - `Spring DevTools` (**Implemented as `NOT_APPLICABLE`**) — Quarkus has built-in dev-mode live reload, so there is no
     Spring-style DevTools restart/LiveReload to expose; the panel reports *not applicable* rather than *not yet*.
 - **No comparable capture hook:** `Transactions` — capture relies on Spring Framework's `TransactionExecutionListener`,
   registered against `ConfigurableTransactionManager` beans. Quarkus's transaction management goes through Narayana's
@@ -498,7 +498,7 @@ No equivalent, low value, or superseded by Quarkus's own tooling:
 
 **Result:** 47 of the 57 panels ship on Quarkus: 26 are statically available and 21 are capability/detector-gated. The
 remaining 10 panels do not ship: 9 are intentionally not applicable (GraalVM, CRaC, Conditions, Startup Timeline, HTTP
-Sessions, Spring Data, Spring Security, DevTools, Transactions), and 1 (`JMS`) is not yet available. By portability
+Sessions, Spring Data, Spring Security, Spring DevTools, Transactions), and 1 (`JMS`) is not yet available. By portability
 strategy, the 47 shipped panels comprise 19 ported as-is, 12 source-swapped, 13 capture-rebuilt, and 3 replaced with a
 Quarkus-native panel. The Overview dashboard panel is available (its scoring dashboard renders client-side from the
 advisor endpoints, and the shell-chrome `GET /bootui/api/overview` endpoint is served on both adapters).
@@ -746,7 +746,7 @@ Pentesting, HTTP Probe, MCP Server) need no special ingredients — they work ag
 | Security            | **done**    | Replace | Quarkus security ruleset         | Quarkus-native checks (OIDC/auth/TLS/CORS/annotations); see QUARKUS-CHECKS.md |
 | GraalVM             | **done**    | Drop    | —                                | Quarkus native-first; `NOT_APPLICABLE`      |
 | CRaC                | **done**    | Drop    | —                                | Spring lifecycle-specific; `NOT_APPLICABLE` |
-| DevTools            | **done**    | Drop    | —                                | Quarkus live reload built in; `NOT_APPLICABLE` |
+| Spring DevTools     | **done**    | Drop    | —                                | Quarkus live reload built in; `NOT_APPLICABLE` |
 | Conditions          | spring-only | Drop    | —                                | no runtime conditions report                |
 | Startup Timeline    | spring-only | Drop    | —                                | not applicable: build-time augmentation, no runtime per-step buffer |
 | Spring Security     | spring-only | Drop    | —                                | Elytron/OIDC, different model               |

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,4 +68,4 @@ is unavailable, BootUI returns stable empty responses or shows an actionable emp
   services.
 - Diagnostics and security panels for traces, logs, HTTP exchanges, local probes, architecture checks, GraalVM readiness,
   dependency vulnerabilities, Spring Security, and security advisors.
-- Developer tooling dashboards for DevTools, GitHub, Copilot, and Claude Code local activity.
+- Developer tooling dashboards for Spring DevTools, GitHub, Copilot, and Claude Code local activity.

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -582,7 +582,7 @@ Acceptance criteria:
 - Runtime level changes work when Actuator supports them.
 - UI clearly states changes are runtime-only and not persisted.
 
-### 5.7.1 DevTools Controls
+### 5.7.1 Spring DevTools Controls
 
 Purpose: answer "Can I trigger local LiveReload or restart this app from the console?"
 
@@ -2547,7 +2547,7 @@ Top-level navigation:
   - HTTP Probe.
 - Developer tools:
   - MCP Server.
-  - DevTools.
+  - Spring DevTools.
   - Dev Services.
   - Copilot.
   - Claude Code.

--- a/docs/WEBFLUX-SUPPORT.md
+++ b/docs/WEBFLUX-SUPPORT.md
@@ -153,7 +153,7 @@ were already framework-neutral in practice, not just in the engine underneath th
 | Overview, GitHub, Beans, Conditions, Configuration, Mappings, Health, Loggers, Startup Timeline, Spring Data |
 | Database, Hibernate, Hibernate Statistics, Flyway, Liquibase, Database Connection Pools, Cache, Dev Services |
 | Vulnerabilities, Scheduled Tasks, Fault Tolerance, HTTP Probe, Pentesting, Heap Dump, Architecture, REST API advisor |
-| Profile Diff, Spring advisor[^spring-advisor-reactive], Live Memory, JVM Tuning, Metrics, DevTools, Traces, AI Framework |
+| Profile Diff, Spring advisor[^spring-advisor-reactive], Live Memory, JVM Tuning, Metrics, Spring DevTools, Traces, AI Framework |
 | GraalVM, CRaC, Threads, Memory, Email, Kafka, RabbitMQ, JMS |
 
 These controllers keep their synchronous servlet-facing signatures. On WebFlux, the centralized

--- a/docs/features/developer-tools.md
+++ b/docs/features/developer-tools.md
@@ -105,11 +105,11 @@ surface, including `security_scan` through the shared reactive advisor service. 
 panel/read-only gating, payload/concurrency limits, and response envelopes are otherwise identical across all three
 adapters.
 
-## DevTools
+## Spring DevTools
 
-![BootUI DevTools panel](../images/bootui-devtools.webp)
+![BootUI Spring DevTools panel](../images/bootui-devtools.webp)
 
-The DevTools panel reports Spring Boot DevTools availability, LiveReload status, and restart support. Restart actions
+The Spring DevTools panel reports Spring Boot DevTools availability, LiveReload status, and restart support. Restart actions
 are shown only when available and require explicit confirmation before execution. When DevTools is on the classpath but
 the LiveReload server is not running, the panel shows a tip to set `spring.devtools.livereload.enabled=true` (Spring
 Boot 4 disables LiveReload by default).


### PR DESCRIPTION
## What does this PR do?

Renames the `DevTools` panel's display title to `Spring DevTools` across the backend catalog, UI, conformance fixtures, docs, and browser specs, leaving the panel id, route, properties, and API contract untouched.

## Why is this change needed?

The menu item was hard to understand. Sitting inside the **Developer tools** navigation group, a bare `DevTools` entry reads either like a category duplicate or like the browser's own DevTools, when the panel has always been specifically about Spring Boot DevTools: `spring-boot-devtools` classpath presence, the LiveReload server on port 35729 (including connected browser count), and the restart bridge. It is reported *not applicable* on Quarkus, which owns live reload through its own dev mode. Naming it `Spring DevTools` makes that scope obvious from the sidebar.

Closes #

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Details:

- `BackendPanelCatalogConsistencyTest` passes (8/8). This is the test that pins `BootUiPanels` titles against the three `expected-panels-*.json` fixtures, the `docs/features/` headings, and the `docs/PROPERTIES.md` panel access matrix.
- Full frontend unit suite passes (1025 tests, 100 files). `routes.test.js` independently derives the expected titles from `BootUiPanels.java`, the conformance manifests, `docs/features/`, `docs/FRAMEWORK-SUPPORT.md`, and the `docs/SPECIFICATION.md` navigation inventory, so every doc surface listed below is machine-checked.
- Spring Playwright `devtools.spec.js` (3 passed) and `app-shell.spec.js` (15 passed) run locally against the booted sample app.
- `./mvnw spotless:check` and `format:check` in `bootui-ui/src/main/frontend`, `bootui-spring-sample-app/e2e`, and `bootui-quarkus-sample-app/e2e` are clean.

### Note on the second commit

The first commit updated the string-form panel titles but missed three regex-form heading matchers that still expected `/^DevTools/`. Two of them, in the Spring devtools spec, failed the Spring end-to-end job on the first CI run. The third, in the Quarkus app-shell heading map, was latent: that loop only visits panels the adapter reports available, and `devtools` is not applicable on Quarkus, so the stale pattern was never exercised. The follow-up commit fixes all three, and the Playwright specs above were then run locally rather than reasoned about.

## Screenshots (UI changes)

N/A. The only visual delta is the sidebar entry and panel heading text changing from "DevTools" to "Spring DevTools".

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed

### What is intentionally unchanged

Nothing programmatic depends on the new string. The `devtools` panel id, the `/devtools` UI route, the `bootui.panels.devtools.enabled` / `.read-only` properties, and the `GET|POST /bootui/api/devtools*` contract all keep their existing names. The `title` field of `/bootui/api/panels` is a display string and now returns `Spring DevTools` on all three adapters, which is why the conformance fixtures move together.

### Surfaces updated

- Backend: `BootUiPanels`, the Spring, WebFlux, and Quarkus `expected-panels-*.json` fixtures, and the conformance test's docs section boundary.
- UI: route metadata (plus `spring devtools` and `spring-boot-devtools` search keywords so the old mental model still finds the panel), the `PanelHeader` title, and the read-only, unavailable-state, and load-error strings that name the panel.
- Docs: `features/developer-tools.md`, `SPECIFICATION.md` (section 5.7.1 and the 7.1 navigation inventory), `PROPERTIES.md` (panel access matrix and per-panel section), `FRAMEWORK-SUPPORT.md`, `QUARKUS-SUPPORT.md`, `WEBFLUX-SUPPORT.md`, `docs/README.md`, and a CHANGELOG entry.
- Tests and tooling: `routes.test.js`, the Spring `app-shell` and `devtools` Playwright specs, the Quarkus `app-shell` and `not-applicable` specs, and the docs screenshot capture manifest.
