### PR TITLE
design(ui): name the 1.5rem glyph badge size as an icon step

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -90,6 +90,11 @@ typography:
     fontSize: "0.85rem"
     fontWeight: 400
     lineHeight: 1.5
+  icon:
+    fontFamily: "bootstrap-icons"
+    fontSize: "1.5rem"
+    fontWeight: 400
+    lineHeight: 1
 rounded:
   xs: "0.35rem"
   sm: "0.5rem"
@@ -210,6 +215,7 @@ The **documentation site** reuses this severity vocabulary for the check-catalog
 - **Body** (400, 1rem, line-height 1.5): explanatory prose and table cells. Cap measure at 65–75ch for prose blocks.
 - **Label / Eyebrow** (800, 0.72rem, letter-spacing 0.06em, uppercase): reserved for **sidebar nav-group headers** ("RUNTIME", "CONFIGURATION") — a scoped navigational system, not a per-section content kicker.
 - **Mono** (400, ~0.85rem): all identifiers, keys, values, code, and log output.
+- **Icon** (400, 1.5rem, line-height 1): the glyph inside the 3rem round action/status badge, and the only step that sizes an icon font rather than text. It is a fixed step, not a scale — consume it as `--bootui-icon-size` so every badge stays the same size as its neighbours.
 
 ### Named Rules
 **The Mono-Means-Machine Rule.** Anything the machine produced — a bean name, a property key, a class, a header value, a log line — is monospace. Anything BootUI wrote to *explain* it is sans. The reader can tell data from narrative without reading a word.

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1064,6 +1064,9 @@ function onGlobalKeydown(e) {
   --bootui-radius-xl: 1.25rem;
   --bootui-radius-pill: 999px;
 
+  /* Icon scale (mirrors DESIGN.md typography.icon) */
+  --bootui-icon-size: 1.5rem;
+
   /* Nav link state */
   --bootui-nav-hover-bg: rgba(25, 135, 84, 0.08);
   --bootui-nav-hover-color: #146c43;
@@ -1141,7 +1144,7 @@ function onGlobalKeydown(e) {
   border-radius: 0.85rem;
   color: var(--bootui-green);
   display: inline-flex;
-  font-size: 1.5rem;
+  font-size: var(--bootui-icon-size);
   height: 3rem;
   justify-content: center;
   width: 3rem;

--- a/bootui-ui/src/main/frontend/src/designSystem.test.js
+++ b/bootui-ui/src/main/frontend/src/designSystem.test.js
@@ -173,4 +173,26 @@ describe('BootUI design system contracts', () => {
 
     expect(offenders.map(relative)).toEqual([])
   })
+
+  // DESIGN.md typography `icon`: 1.5rem is the glyph size of the 3rem round action
+  // badge, and every Developer Tools panel renders the same badge. Each panel that
+  // copies the literal instead of the token is a panel that can silently drift away
+  // from its neighbours, and it re-opens the design finding on every edit.
+  it('routes glyph badges through the shared icon-size token', () => {
+    expect(appSource).toContain('--bootui-icon-size: 1.5rem')
+
+    const offenders = []
+
+    for (const file of [path.join(sourceRoot, 'App.vue'), ...vueFiles(viewsRoot)]) {
+      for (const style of descriptorFor(file).styles) {
+        style.content.split('\n').forEach((text, index) => {
+          if (/font-size:\s*1\.5rem/.test(text)) {
+            offenders.push(`${relative(file)}:${style.loc.start.line + index}`)
+          }
+        })
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/DevTools.vue
+++ b/bootui-ui/src/main/frontend/src/views/DevTools.vue
@@ -292,7 +292,7 @@ onUnmounted(clearReconnectTimer)
   align-items: center;
   border-radius: var(--bootui-radius-lg);
   display: inline-flex;
-  font-size: 1.5rem;
+  font-size: var(--bootui-icon-size);
   height: 3rem;
   justify-content: center;
   width: 3rem;

--- a/bootui-ui/src/main/frontend/src/views/McpServer.vue
+++ b/bootui-ui/src/main/frontend/src/views/McpServer.vue
@@ -299,7 +299,7 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: manif
   align-items: center;
   border-radius: var(--bootui-radius-lg);
   display: inline-flex;
-  font-size: 1.5rem;
+  font-size: var(--bootui-icon-size);
   height: 3rem;
   justify-content: center;
   width: 3rem;


### PR DESCRIPTION
Closes #908.

`DESIGN.md` documents a five-step type ramp; `1.5rem` was not on it, but three files used it for the round 3rem action/status glyph badge. So `design-system-font-size` fired on every edit to those files, reporting something the codebase does on purpose — and #906's Command Line panel inherited the finding on day one by copying `McpServer.vue`'s block verbatim.

## Decision

**The value is real, not incidental.** These are Bootstrap Icons glyphs, so the size genuinely *is* a font size — but it sizes an icon font, not text, which is why it never fit an existing step. Name it rather than suppress it.

- `DESIGN.md` gains an `icon` step in the `typography` block (`1.5rem`, weight 400, line-height 1) and a matching **Icon** bullet in §3 *Hierarchy*, describing it as the glyph inside the 3rem badge and the one step that sizes an icon font rather than text.
- `App.vue`'s `:global(:root)` gains `--bootui-icon-size: 1.5rem`, under the same "mirrors DESIGN.md" comment convention as the radius scale.
- All three sites — `App.vue` `.authentication-icon`, `McpServer.vue` and `DevTools.vue` `.action-icon` — consume the token. The two `.action-icon` blocks remain byte-identical.

## Recurrence guard

A new `designSystem.test.js` contract fails on any raw `font-size: 1.5rem` in a `.vue` style block. Without it, the next Developer Tools panel copy-pastes the literal back in and the finding returns; with it, `Cli.vue` from #906 lands on the token for free. Verified the guard fails on a reintroduced literal and names the offending file and line.

## Not done here

- No `.impeccable/config.json` waiver — the finding is resolved at its source, so nothing needs suppressing.
- No per-skin value: skins change typeface, not the §3 scale.
- `GitHub.vue`'s 4rem `.metric-card__icon` watermark is the same class of finding and is left as follow-up, to keep this diff reviewable.

## Validation

`npm test` in `bootui-ui/src/main/frontend` — 1026 tests across 100 files pass. `npm run format:check` clean. The design hook now reports `McpServer.vue` and `DevTools.vue` clean; `App.vue`'s remaining findings are pre-existing and unrelated.

**No rendered change** — the computed glyph size is identical at every site, so no adapter, conformance, or Playwright work applies.