### PR TITLE
fix(mcp): report a tool's client error in-band instead of "Internal error"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **An MCP tool that refuses a request now reports the status it asked for instead of `Internal error`.** MCP tools
+  delegate to the same handlers the REST API uses, and those handlers signal a client error by throwing their
+  framework's own exception — `ResponseStatusException` on Spring, `WebApplicationException` on Quarkus. The
+  framework-free `McpDispatcher` had no case for either, so they fell into its catch-all: asking for an unknown
+  exception group with `get_exception_detail` answered the agent with the detail-free JSON-RPC `-32603 Internal error`
+  and logged an internal-failure line, while the same lookup over REST correctly returned `404`. This affected every
+  tool wired to a handler that signals 4xx, on all three stacks, not just the one that surfaced it. Each adapter now
+  translates a 4xx failure into the new framework-neutral `McpToolClientException` at its tool-registration boundary,
+  and the dispatcher reports it in-band (`isError: true`) with the same reason REST returns, without reporting it as a
+  server fault. The outcome also carries the canonical status so non-MCP consumers of the same dispatch result can map
+  it. 5xx and every other failure keep their original throwable and remain a detail-free `-32603`. Covered by
+  dispatcher, per-adapter translator, and codec tests plus an MCP conformance case that pins Spring MVC, Spring WebFlux,
+  and Quarkus to identical behaviour.
+
 - **BootUI's safety filters can no longer be bypassed by a percent-encoded or matrix-parameter spelling of a BootUI URL
   on Spring MVC or Spring WebFlux.** Each guard decided whether it applied by matching the *raw* request path
   (`getRequestURI()` on the servlet stack, `pathWithinApplication().value()` on the reactive one) against `bootui.path` /

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractMcpConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractMcpConformanceTest.java
@@ -275,6 +275,49 @@ public abstract class AbstractMcpConformanceTest {
     }
 
     @Test
+    void testMcpToolClientErrorIsReportedInBandInsteadOfInternalError() {
+        assertThat(enableMcp()).as("this adapter claims MCP support").isTrue();
+        try {
+            Response listResponse = probe().request(
+                            "POST",
+                            "/bootui/api/mcp",
+                            Map.of("Content-Type", "application/json"),
+                            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}");
+            boolean advertised = false;
+            for (JsonNode tool : listResponse.json().path("result").path("tools")) {
+                if ("get_exception_detail".equals(tool.path("name").asText())) {
+                    advertised = true;
+                    break;
+                }
+            }
+            if (!advertised) {
+                return;
+            }
+
+            Response response = probe().request(
+                            "POST",
+                            "/bootui/api/mcp",
+                            Map.of("Content-Type", "application/json"),
+                            "{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"tools/call\","
+                                    + "\"params\":{\"name\":\"get_exception_detail\","
+                                    + "\"arguments\":{\"id\":\"does-not-exist\"}}}");
+
+            assertThat(response.status()).isEqualTo(200);
+            JsonNode body = response.json();
+            assertThat(body.path("error").isMissingNode())
+                    .as("an unknown id is a statement about the request, not a server fault")
+                    .isTrue();
+            JsonNode result = body.path("result");
+            assertThat(result.path("isError").asBoolean()).isTrue();
+            assertThat(result.path("content").get(0).path("text").asText())
+                    .contains("does-not-exist")
+                    .doesNotContain("Internal error");
+        } finally {
+            disableMcp();
+        }
+    }
+
+    @Test
     void testMcpPromptsWhenEnabled() {
         assertThat(enableMcp()).as("this adapter claims MCP support").isTrue();
         try {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpDispatchOutcome.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpDispatchOutcome.java
@@ -67,12 +67,25 @@ public sealed interface McpDispatchOutcome
     record ToolCallResult(Object payload) implements McpDispatchOutcome {}
 
     /**
-     * A failed {@code tools/call} reported in-band ({@code isError:true}): a refused gate, a missing or
-     * unknown tool, etc. The agent reads {@code message} as text content.
+     * A failed {@code tools/call} reported in-band ({@code isError:true}): a refused gate, a busy
+     * single-flight action, or a client error the tool itself raised. The agent reads {@code message} as
+     * text content.
+     *
+     * <p>{@code status} is metadata for non-MCP consumers of the same dispatch outcome (the BootUI CLI
+     * maps it to its own exit status). Both MCP codecs ignore it, so the JSON-RPC wire shape is
+     * identical whether or not it is present.
      *
      * @param message the human-readable failure reason
+     * @param status the canonical client-error status the tool asked for (e.g. {@code 404}), or {@code
+     *     null} when the failure has no such status
      */
-    record ToolCallError(String message) implements McpDispatchOutcome {}
+    record ToolCallError(String message, Integer status) implements McpDispatchOutcome {
+
+        /** A failure with no canonical client-error status. */
+        public ToolCallError(String message) {
+            this(message, null);
+        }
+    }
 
     /**
      * A JSON-RPC protocol error (an {@code error} envelope).

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpDispatcher.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpDispatcher.java
@@ -37,7 +37,9 @@ import org.slf4j.LoggerFactory;
  * calls {@link #dispatch(McpRequest)}, and renders the outcome back to JSON with its own
  * {@code ObjectMapper} (Jackson 3 on Spring Boot, Jackson 2 on Quarkus). The control flow here is a
  * one-to-one translation of the original Spring {@code BootUiMcpService} so both adapters answer
- * byte-identically: a refused panel gate is an in-band {@link ToolCallError} ({@code isError:true});
+ * byte-identically: a refused panel gate is an in-band {@link ToolCallError} ({@code isError:true}), as
+ * is a client error a tool raises about the request itself (an unknown resource id, a conflicting
+ * state) once the adapter has translated its framework exception into an {@link McpToolClientException};
  * malformed tool calls are JSON-RPC {@link ProtocolError}s; an unexpected failure becomes the standard,
  * detail-free JSON-RPC internal error ({@code -32603}) and is sent to the server-side diagnostic
  * reporter. Serialization of a successful payload (the only remaining Jackson step) is performed and
@@ -327,6 +329,9 @@ public final class McpDispatcher {
             Throwable cause = ex.getCause();
             if (cause instanceof ActionBusyException busy) {
                 return new ToolCallError(busy.result().message());
+            }
+            if (cause instanceof McpToolClientException clientError) {
+                return new ToolCallError(clientError.getMessage(), clientError.status());
             }
             if (cause instanceof RuntimeException runtime) {
                 throw runtime;

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolClientException.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolClientException.java
@@ -1,0 +1,44 @@
+package io.github.jdubois.bootui.engine.mcp;
+
+/**
+ * Expected control-flow signal raised when an MCP tool refuses a request because of the request itself
+ * — an unknown resource id, an unsupported argument value, a conflicting state — rather than because
+ * of a server-side fault.
+ *
+ * <p>BootUI MCP tools delegate to the same handlers the REST API uses, and those handlers report a
+ * client error by throwing their framework's own exception ({@code ResponseStatusException} on Spring,
+ * {@code WebApplicationException} on Quarkus). Neither type may reach {@code bootui-engine}, so each
+ * adapter translates a 4xx failure into this canonical exception at its tool-registration boundary and
+ * {@link McpDispatcher} turns it into an in-band {@link McpDispatchOutcome.ToolCallError} the agent can
+ * read, instead of the detail-free JSON-RPC internal error reserved for genuine server faults.
+ *
+ * <p>Only client (4xx) statuses are representable: a server-side failure must keep its original
+ * throwable so it is logged and reported as an internal error.
+ */
+public final class McpToolClientException extends RuntimeException {
+
+    private final int status;
+
+    /**
+     * @param status the canonical client-error status, in {@code [400, 500)}
+     * @param message the safe, human-readable reason already exposed over REST; a {@code null} or blank
+     *     message falls back to {@link McpProtocol#TOOL_CALL_FAILED_MESSAGE}
+     * @throws IllegalArgumentException if {@code status} is not a 4xx status
+     */
+    public McpToolClientException(int status, String message) {
+        super(
+                message == null || message.isBlank() ? McpProtocol.TOOL_CALL_FAILED_MESSAGE : message,
+                null,
+                false,
+                false);
+        if (!McpToolClientExceptions.isClientError(status)) {
+            throw new IllegalArgumentException("MCP tool client error status must be 4xx, but was: " + status);
+        }
+        this.status = status;
+    }
+
+    /** The canonical client-error status this tool asked for (e.g. {@code 404}). */
+    public int status() {
+        return status;
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolClientExceptions.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolClientExceptions.java
@@ -1,0 +1,23 @@
+package io.github.jdubois.bootui.engine.mcp;
+
+/**
+ * Shared helper for the adapter-side translation of a framework client error into {@link
+ * McpToolClientException}.
+ *
+ * <p>Each adapter catches its own framework exception ({@code ResponseStatusException} on Spring,
+ * {@code WebApplicationException} on Quarkus) and must apply the same rule about which statuses are the
+ * request's fault, so the three stacks answer identically. The rule itself carries no framework type and
+ * lives here rather than being restated per adapter.
+ */
+public final class McpToolClientExceptions {
+
+    private McpToolClientExceptions() {}
+
+    /**
+     * Whether {@code status} is a client (4xx) error, and therefore a statement about the request that
+     * should reach the agent in-band rather than an unexpected server fault.
+     */
+    public static boolean isClientError(int status) {
+        return status >= 400 && status <= 499;
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/mcp/McpDispatcherTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/mcp/McpDispatcherTests.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.mcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
 import io.github.jdubois.bootui.engine.mcp.McpDispatchOutcome.InitializeResult;
@@ -284,6 +285,55 @@ class McpDispatcherTests {
 
         release.countDown();
         winner.join(5000);
+    }
+
+    @Test
+    void toolClientErrorIsInBandErrorCarryingItsStatusAndIsNotReported() {
+        McpTool missing =
+                new McpTool("get_exception_detail", "Detail.", McpToolSchema.ID, "exceptions", false, args -> {
+                    throw new McpToolClientException(404, "exception " + args.id() + " not found");
+                });
+        McpDispatcher dispatcher =
+                new McpDispatcher(List.of(missing), List.of(), policy, "1.0", "x", 50, 20, diagnostics);
+
+        McpDispatchOutcome outcome = dispatcher.dispatch(
+                new McpRequest(JSONRPC, "tools/call", false, null, "get_exception_detail", null, null, "unknown"));
+
+        assertThat(outcome).isEqualTo(new ToolCallError("exception unknown not found", 404));
+        assertThat(diagnostics.count()).isZero();
+    }
+
+    @Test
+    void toolClientErrorWithoutMessageFallsBackToCanonicalToolFailure() {
+        McpTool refusing = new McpTool("get_overview", "Overview.", McpToolSchema.NONE, "overview", false, args -> {
+            throw new McpToolClientException(409, "  ");
+        });
+        McpDispatcher dispatcher =
+                new McpDispatcher(List.of(refusing), List.of(), policy, "1.0", "x", 50, 20, diagnostics);
+
+        assertThat(dispatcher.dispatch(call("get_overview")))
+                .isEqualTo(new ToolCallError(McpProtocol.TOOL_CALL_FAILED_MESSAGE, 409));
+        assertThat(diagnostics.count()).isZero();
+    }
+
+    @Test
+    void toolClientErrorRejectsNonClientStatus() {
+        assertThatThrownBy(() -> new McpToolClientException(500, "boom"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("500");
+        assertThat(McpToolClientExceptions.isClientError(399)).isFalse();
+        assertThat(McpToolClientExceptions.isClientError(400)).isTrue();
+        assertThat(McpToolClientExceptions.isClientError(499)).isTrue();
+        assertThat(McpToolClientExceptions.isClientError(500)).isFalse();
+    }
+
+    @Test
+    void gateRefusalCarriesNoCanonicalStatus() {
+        policy.disabled.add("overview");
+
+        assertThat(dispatcher().dispatch(call("get_overview")))
+                .isEqualTo(new ToolCallError("disabled:overview", null))
+                .isEqualTo(new ToolCallError("disabled:overview"));
     }
 
     @Test

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpToolFailures.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpToolFailures.java
@@ -1,0 +1,46 @@
+package io.github.jdubois.bootui.quarkus.mcp;
+
+import io.github.jdubois.bootui.engine.mcp.McpArguments;
+import io.github.jdubois.bootui.engine.mcp.McpToolClientException;
+import io.github.jdubois.bootui.engine.mcp.McpToolClientExceptions;
+import jakarta.ws.rs.WebApplicationException;
+import java.util.function.Function;
+
+/**
+ * Translates a JAX-RS client error raised by an MCP tool handler into the framework-neutral {@link
+ * McpToolClientException} the engine dispatcher understands. This is the Quarkus counterpart of the
+ * Spring adapter's translation, so a tool that refuses a request behaves identically on all three
+ * stacks.
+ *
+ * <p>MCP tools delegate to the same resource methods the REST API uses, and those methods report a
+ * client error by throwing {@link WebApplicationException} (typically {@code NotFoundException}) — which
+ * RESTEasy maps to the right HTTP status over REST, but which is meaningless to the framework-free
+ * dispatcher. Left untranslated it reaches the dispatcher's catch-all and an ordinary bad request is
+ * reported to the agent as the detail-free JSON-RPC internal error and logged as a server fault.
+ *
+ * <p>Only 4xx failures are translated: a 5xx {@link WebApplicationException} is a genuine server fault
+ * and keeps its original throwable so it is logged and reported as an internal error, as does every
+ * other exception.
+ */
+public final class QuarkusMcpToolFailures {
+
+    private QuarkusMcpToolFailures() {}
+
+    /**
+     * Wraps an MCP tool handler so a 4xx {@link WebApplicationException} becomes an in-band tool error
+     * carrying the status and reason the handler asked for.
+     */
+    public static Function<McpArguments, Object> translating(Function<McpArguments, Object> handler) {
+        return arguments -> {
+            try {
+                return handler.apply(arguments);
+            } catch (WebApplicationException failure) {
+                int status = failure.getResponse().getStatus();
+                if (!McpToolClientExceptions.isClientError(status)) {
+                    throw failure;
+                }
+                throw new McpToolClientException(status, failure.getMessage());
+            }
+        };
+    }
+}

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpTools.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpTools.java
@@ -657,26 +657,36 @@ public class QuarkusMcpTools {
 
     private static McpTool action(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.NONE, panelId, true, handler);
+        return new McpTool(
+                name, description, McpToolSchema.NONE, panelId, true, QuarkusMcpToolFailures.translating(handler));
     }
 
     private static McpTool read(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.NONE, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.NONE, panelId, false, QuarkusMcpToolFailures.translating(handler));
     }
 
     private static McpTool limitRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.LIMIT, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.LIMIT, panelId, false, QuarkusMcpToolFailures.translating(handler));
     }
 
     private static McpTool searchRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.QUERY_LIMIT, panelId, false, handler);
+        return new McpTool(
+                name,
+                description,
+                McpToolSchema.QUERY_LIMIT,
+                panelId,
+                false,
+                QuarkusMcpToolFailures.translating(handler));
     }
 
     private static McpTool idRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.ID, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.ID, panelId, false, QuarkusMcpToolFailures.translating(handler));
     }
 }

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpEnvelopeTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpEnvelopeTest.java
@@ -12,6 +12,7 @@ import io.github.jdubois.bootui.engine.mcp.McpTool;
 import io.github.jdubois.bootui.engine.mcp.McpToolSchema;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.github.jdubois.bootui.spi.McpPanelPolicy;
+import jakarta.ws.rs.NotFoundException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -95,6 +96,25 @@ class QuarkusMcpEnvelopeTest {
         assertThat(response.path("error").path("code").asInt()).isEqualTo(McpProtocol.INVALID_PARAMS);
         assertThat(response.path("error").path("message").asText()).isEqualTo("Unknown tool: does_not_exist");
         assertThat(diagnostics.count()).isZero();
+    }
+
+    @Test
+    void toolClientErrorIsRenderedInBandInsteadOfAnInternalError() {
+        RecordingFailureReporter diagnostics = new RecordingFailureReporter();
+        McpTool tool = tool(QuarkusMcpToolFailures.translating(args -> {
+            throw new NotFoundException("exception does-not-exist not found");
+        }));
+        QuarkusMcpEnvelope envelope = envelope(tool, diagnostics);
+
+        JsonNode response = envelope.handle(callRequest(50));
+
+        assertThat(response.path("error").isMissingNode()).isTrue();
+        JsonNode result = response.path("result");
+        assertThat(result.path("isError").asBoolean()).isTrue();
+        assertThat(result.path("content").get(0).path("text").asText()).isEqualTo("exception does-not-exist not found");
+        assertThat(diagnostics.count())
+                .as("a client error is not a server fault and must not be reported as one")
+                .isZero();
     }
 
     @Test

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpToolFailuresTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/mcp/QuarkusMcpToolFailuresTest.java
@@ -1,0 +1,71 @@
+package io.github.jdubois.bootui.quarkus.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.jdubois.bootui.engine.mcp.McpArguments;
+import io.github.jdubois.bootui.engine.mcp.McpToolClientException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class QuarkusMcpToolFailuresTest {
+
+    private static final McpArguments ARGUMENTS = McpArguments.normalize(null, null, "does-not-exist", 50);
+
+    @Test
+    void notFoundBecomesCanonicalToolClientException() {
+        Function<McpArguments, Object> handler = QuarkusMcpToolFailures.translating(args -> {
+            throw new NotFoundException("exception " + args.id() + " not found");
+        });
+
+        assertThatThrownBy(() -> handler.apply(ARGUMENTS))
+                .isInstanceOf(McpToolClientException.class)
+                .hasMessage("exception does-not-exist not found")
+                .extracting(failure -> ((McpToolClientException) failure).status())
+                .isEqualTo(404);
+    }
+
+    @Test
+    void otherClientStatusesAreTranslatedToo() {
+        Function<McpArguments, Object> handler = QuarkusMcpToolFailures.translating(args -> {
+            throw new WebApplicationException("Logs are not available for this service", Response.Status.CONFLICT);
+        });
+
+        assertThatThrownBy(() -> handler.apply(ARGUMENTS))
+                .isInstanceOf(McpToolClientException.class)
+                .extracting(failure -> ((McpToolClientException) failure).status())
+                .isEqualTo(409);
+    }
+
+    @Test
+    void serverErrorIsRethrownSoItStaysAnInternalError() {
+        WebApplicationException failure =
+                new WebApplicationException("Unable to read service logs", Response.Status.INTERNAL_SERVER_ERROR);
+        Function<McpArguments, Object> handler = QuarkusMcpToolFailures.translating(args -> {
+            throw failure;
+        });
+
+        assertThatThrownBy(() -> handler.apply(ARGUMENTS)).isSameAs(failure);
+    }
+
+    @Test
+    void unrelatedRuntimeFailureIsRethrownUnchanged() {
+        IllegalStateException failure = new IllegalStateException("boom");
+        Function<McpArguments, Object> handler = QuarkusMcpToolFailures.translating(args -> {
+            throw failure;
+        });
+
+        assertThatThrownBy(() -> handler.apply(ARGUMENTS)).isSameAs(failure);
+    }
+
+    @Test
+    void successfulHandlerIsPassedThrough() {
+        Function<McpArguments, Object> handler = QuarkusMcpToolFailures.translating(args -> Map.of("id", args.id()));
+
+        assertThat(handler.apply(ARGUMENTS)).isEqualTo(Map.of("id", "does-not-exist"));
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/mcp/BootUiMcpTools.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/mcp/BootUiMcpTools.java
@@ -745,26 +745,36 @@ public class BootUiMcpTools {
 
     private static McpTool action(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.NONE, panelId, true, handler);
+        return new McpTool(
+                name, description, McpToolSchema.NONE, panelId, true, SpringMcpToolFailures.translating(handler));
     }
 
     private static McpTool read(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.NONE, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.NONE, panelId, false, SpringMcpToolFailures.translating(handler));
     }
 
     private static McpTool limitRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.LIMIT, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.LIMIT, panelId, false, SpringMcpToolFailures.translating(handler));
     }
 
     private static McpTool searchRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.QUERY_LIMIT, panelId, false, handler);
+        return new McpTool(
+                name,
+                description,
+                McpToolSchema.QUERY_LIMIT,
+                panelId,
+                false,
+                SpringMcpToolFailures.translating(handler));
     }
 
     private static McpTool idRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.ID, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.ID, panelId, false, SpringMcpToolFailures.translating(handler));
     }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/mcp/SpringMcpToolFailures.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/mcp/SpringMcpToolFailures.java
@@ -1,0 +1,54 @@
+package io.github.jdubois.bootui.autoconfigure.mcp;
+
+import io.github.jdubois.bootui.engine.mcp.McpArguments;
+import io.github.jdubois.bootui.engine.mcp.McpToolClientException;
+import io.github.jdubois.bootui.engine.mcp.McpToolClientExceptions;
+import java.util.function.Function;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Translates a Spring client error raised by an MCP tool handler into the framework-neutral {@link
+ * McpToolClientException} the engine dispatcher understands.
+ *
+ * <p>MCP tools delegate to the same controller-support methods the REST API uses, and those methods
+ * report a client error by throwing {@link ResponseStatusException} — which Spring maps to the right
+ * HTTP status over REST, but which is meaningless to the framework-free dispatcher. Left untranslated it
+ * reaches the dispatcher's catch-all and an ordinary bad request is reported to the agent as the
+ * detail-free JSON-RPC internal error and logged as a server fault. Wrapping every registered handler
+ * here keeps that decision at the adapter boundary and out of {@code bootui-engine}.
+ *
+ * <p>Only 4xx failures are translated: a 5xx {@link ResponseStatusException} is a genuine server fault
+ * and keeps its original throwable so it is logged and reported as an internal error, as does every
+ * other exception. Both Spring stacks throw the same {@code org.springframework.web.server}
+ * exception, so Spring MVC and WebFlux share this translation.
+ */
+public final class SpringMcpToolFailures {
+
+    private SpringMcpToolFailures() {}
+
+    /**
+     * Wraps an MCP tool handler so a 4xx {@link ResponseStatusException} becomes an in-band tool error
+     * carrying the status and reason the handler asked for.
+     */
+    public static Function<McpArguments, Object> translating(Function<McpArguments, Object> handler) {
+        return arguments -> {
+            try {
+                return handler.apply(arguments);
+            } catch (ResponseStatusException failure) {
+                int status = failure.getStatusCode().value();
+                if (!McpToolClientExceptions.isClientError(status)) {
+                    throw failure;
+                }
+                throw new McpToolClientException(status, reason(failure));
+            }
+        };
+    }
+
+    private static String reason(ResponseStatusException failure) {
+        String reason = failure.getReason();
+        if (reason != null && !reason.isBlank()) {
+            return reason;
+        }
+        return failure.getBody().getDetail();
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiMcpTools.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/reactive/ReactiveBootUiMcpTools.java
@@ -8,6 +8,7 @@ import io.github.jdubois.bootui.autoconfigure.hibernate.HibernateController;
 import io.github.jdubois.bootui.autoconfigure.jms.JmsController;
 import io.github.jdubois.bootui.autoconfigure.kafka.KafkaController;
 import io.github.jdubois.bootui.autoconfigure.mail.EmailController;
+import io.github.jdubois.bootui.autoconfigure.mcp.SpringMcpToolFailures;
 import io.github.jdubois.bootui.autoconfigure.memory.MemoryController;
 import io.github.jdubois.bootui.autoconfigure.pentesting.PentestingController;
 import io.github.jdubois.bootui.autoconfigure.rabbit.RabbitController;
@@ -710,26 +711,36 @@ public class ReactiveBootUiMcpTools {
 
     private static McpTool action(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.NONE, panelId, true, handler);
+        return new McpTool(
+                name, description, McpToolSchema.NONE, panelId, true, SpringMcpToolFailures.translating(handler));
     }
 
     private static McpTool read(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.NONE, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.NONE, panelId, false, SpringMcpToolFailures.translating(handler));
     }
 
     private static McpTool limitRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.LIMIT, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.LIMIT, panelId, false, SpringMcpToolFailures.translating(handler));
     }
 
     private static McpTool searchRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.QUERY_LIMIT, panelId, false, handler);
+        return new McpTool(
+                name,
+                description,
+                McpToolSchema.QUERY_LIMIT,
+                panelId,
+                false,
+                SpringMcpToolFailures.translating(handler));
     }
 
     private static McpTool idRead(
             String name, String description, String panelId, Function<McpArguments, Object> handler) {
-        return new McpTool(name, description, McpToolSchema.ID, panelId, false, handler);
+        return new McpTool(
+                name, description, McpToolSchema.ID, panelId, false, SpringMcpToolFailures.translating(handler));
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/mcp/BootUiMcpServiceTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/mcp/BootUiMcpServiceTests.java
@@ -13,6 +13,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.node.JsonNodeFactory;
@@ -143,6 +145,34 @@ class BootUiMcpServiceTests {
         JsonNode response = service.handle(callRequest("get_overview", 6));
 
         assertThat(response.path("result").path("isError").asBoolean()).isFalse();
+    }
+
+    @Test
+    void toolClientErrorIsRenderedInBandInsteadOfAnInternalError() {
+        BootUiMcpService failing = new BootUiMcpService(
+                new BootUiMcpTools(List.of(new McpTool(
+                        "get_exception_detail",
+                        "Read one exception group's detail.",
+                        McpToolSchema.ID,
+                        BootUiPanels.EXCEPTIONS,
+                        false,
+                        SpringMcpToolFailures.translating(args -> {
+                            throw new ResponseStatusException(
+                                    HttpStatus.NOT_FOUND, "exception " + args.id() + " not found");
+                        })))),
+                properties,
+                objectMapper,
+                "1.2.3");
+        ObjectNode request = callRequest("get_exception_detail", 8);
+        ((ObjectNode) request.path("params").path("arguments")).put("id", "does-not-exist");
+
+        JsonNode response = failing.handle(request);
+
+        assertThat(response.path("error").isMissingNode()).isTrue();
+        JsonNode result = response.path("result");
+        assertThat(result.path("isError").asBoolean()).isTrue();
+        assertThat(result.path("content").get(0).path("text").asString())
+                .isEqualTo("exception does-not-exist not found");
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/mcp/SpringMcpToolFailuresTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/mcp/SpringMcpToolFailuresTests.java
@@ -1,0 +1,83 @@
+package io.github.jdubois.bootui.autoconfigure.mcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.jdubois.bootui.engine.mcp.McpArguments;
+import io.github.jdubois.bootui.engine.mcp.McpProtocol;
+import io.github.jdubois.bootui.engine.mcp.McpToolClientException;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+class SpringMcpToolFailuresTests {
+
+    private static final McpArguments ARGUMENTS = McpArguments.normalize(null, null, "does-not-exist", 50);
+
+    @Test
+    void clientErrorBecomesCanonicalToolClientException() {
+        Function<McpArguments, Object> handler = SpringMcpToolFailures.translating(args -> {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "exception " + args.id() + " not found");
+        });
+
+        assertThatThrownBy(() -> handler.apply(ARGUMENTS))
+                .isInstanceOf(McpToolClientException.class)
+                .hasMessage("exception does-not-exist not found")
+                .extracting(failure -> ((McpToolClientException) failure).status())
+                .isEqualTo(404);
+    }
+
+    @Test
+    void otherClientStatusesAreTranslatedToo() {
+        Function<McpArguments, Object> conflict = SpringMcpToolFailures.translating(args -> {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Service does not support restart");
+        });
+
+        assertThatThrownBy(() -> conflict.apply(ARGUMENTS))
+                .isInstanceOf(McpToolClientException.class)
+                .extracting(failure -> ((McpToolClientException) failure).status())
+                .isEqualTo(409);
+    }
+
+    @Test
+    void missingReasonFallsBackToProblemDetailThenCanonicalMessage() {
+        Function<McpArguments, Object> handler = SpringMcpToolFailures.translating(args -> {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+        });
+
+        assertThatThrownBy(() -> handler.apply(ARGUMENTS))
+                .isInstanceOf(McpToolClientException.class)
+                .satisfies(failure ->
+                        assertThat(failure.getMessage()).isIn("Bad Request", McpProtocol.TOOL_CALL_FAILED_MESSAGE));
+    }
+
+    @Test
+    void serverErrorIsRethrownSoItStaysAnInternalError() {
+        ResponseStatusException failure =
+                new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Unable to read service logs");
+        Function<McpArguments, Object> handler = SpringMcpToolFailures.translating(args -> {
+            throw failure;
+        });
+
+        assertThatThrownBy(() -> handler.apply(ARGUMENTS)).isSameAs(failure);
+    }
+
+    @Test
+    void unrelatedRuntimeFailureIsRethrownUnchanged() {
+        IllegalStateException failure = new IllegalStateException("boom");
+        Function<McpArguments, Object> handler = SpringMcpToolFailures.translating(args -> {
+            throw failure;
+        });
+
+        assertThatThrownBy(() -> handler.apply(ARGUMENTS)).isSameAs(failure);
+    }
+
+    @Test
+    void successfulHandlerIsPassedThrough() {
+        Function<McpArguments, Object> handler = SpringMcpToolFailures.translating(args -> Map.of("id", args.id()));
+
+        assertThat(handler.apply(ARGUMENTS)).isEqualTo(Map.of("id", "does-not-exist"));
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -2424,6 +2424,14 @@ Design rules:
   JSON-RPC internal error (`-32603`, message `Internal error`) without exception text or debug fields. The original
   throwable and stack trace are logged once on the server; expected validation, disabled-server, panel-policy, and
   unknown-method/tool errors retain their specific safe messages.
+- **Client errors are the request's fault, not the server's.** Tools delegate to the same handlers the REST API uses, and
+  those handlers signal a client error by throwing their framework's own exception (`ResponseStatusException` on Spring,
+  `WebApplicationException` on Quarkus). Each adapter translates a 4xx failure into the framework-neutral
+  `McpToolClientException` at its tool-registration boundary, and the dispatcher reports it in-band (`isError: true`)
+  with the same reason the REST API returns, carrying the canonical status for non-MCP consumers of the same outcome.
+  Such a refusal is never logged as a server failure. A 5xx failure keeps its original throwable and remains a
+  detail-free `-32603`. The translation is framework-specific but the resulting behaviour is identical on Spring MVC,
+  Spring WebFlux, and Quarkus.
 - **Reuse, don't reimplement.** Each tool delegates to the same controller/service the REST API and panels use and
   returns the existing DTO records, so contracts stay stable and masked.
 - **Single-flight parity.** Advisor action tools share the same per-scanner admission as REST. A duplicate

--- a/docs/features/developer-tools.md
+++ b/docs/features/developer-tools.md
@@ -68,6 +68,9 @@ The server inherits BootUI's full safety model:
 - Unexpected server failures return only JSON-RPC `-32603` with the message `Internal error`; exception messages, stack
   traces, paths, queries, and credentials are never included. BootUI logs the original throwable once on the server,
   while expected protocol, disabled-server, and panel-policy errors keep their actionable messages.
+- A tool that refuses a request because of the request itself — an unknown resource id, an unsupported value, a
+  conflicting state — reports that in-band (`isError: true`) with the same reason the REST API returns, and is not
+  logged as a server failure. Only genuine server faults become `-32603`.
 
 :::
 


### PR DESCRIPTION
Fixes #907.

## The problem

MCP tools delegate to the same handlers the REST API uses, and those handlers signal a client error by throwing their framework's own exception — `ResponseStatusException` on Spring, `WebApplicationException`/`NotFoundException` on Quarkus. The framework-free `McpDispatcher` had no case for either, so they fell into its catch-all:

```console
$ # MCP: get_exception_detail {"id": "does-not-exist"}
{"error":{"code":-32603,"message":"Internal error"}}
$ curl -i http://localhost:8080/bootui/api/exceptions/does-not-exist
HTTP/1.1 404
```

The agent got a detail-free internal error for an ordinary bad request, and BootUI logged it through `McpFailureReporter` as a server fault. This was never specific to `get_exception_detail` — every tool wired to a handler that signals 4xx was affected, on all three stacks.

## The fix

A canonical signal in the engine, with each framework's exception translated at that adapter's tool-registration boundary, so `bootui-engine` stays free of Spring and JAX-RS types and the three stacks behave identically:

- **`McpToolClientException`** (new, `bootui-engine`) carries a plain 4xx `int` status and a safe message, modelled on the existing `ActionBusyException` expected-control-flow signal.
- **`SpringMcpToolFailures`** (covers MVC *and* WebFlux — both throw the same `org.springframework.web.server` exception) and **`QuarkusMcpToolFailures`** translate a 4xx failure into it and rethrow everything else untouched. They are applied inside the five tool factory helpers of `BootUiMcpTools`, `ReactiveBootUiMcpTools` and `QuarkusMcpTools`, so all 15 registration paths are covered rather than only the tool that surfaced the bug.
- **`McpDispatcher`** maps it to an in-band `ToolCallError` (`isError: true`) carrying the same reason REST returns — the shape already used for panel-gate refusals and single-flight busy — and it never reaches the catch-all, so it is no longer reported as an internal failure.
- **`ToolCallError`** gained an optional `Integer status` (with a one-arg convenience constructor, so existing call sites are unchanged). Both MCP codecs ignore it, so the JSON-RPC wire shape is identical; it is there so a non-MCP consumer of the same dispatch outcome — the CLI in #906 — can map 404 to not-found rather than a generic failure.

5xx and every other throwable keep their original exception and remain a detail-free `-32603`, still reported to `McpFailureReporter`.

### Decisions

- **In-band tool error, not `-32602`.** MCP reserves JSON-RPC errors for protocol/request faults and puts execution failures in-band where the agent can read and recover.
- **Any 4xx, not only 404.** Several shared handlers already throw 400/409 (dev-services restart, security path validation), and the next one should be correct by default.

## Validation

- `McpDispatcherTests` — client error yields `ToolCallError(reason, 404)` and the failure reporter is never called; blank message falls back to the canonical text; a non-4xx status is rejected; 5xx and plain runtime failures still yield `-32603` and are still reported.
- `SpringMcpToolFailuresTests` / `QuarkusMcpToolFailuresTest` — 4xx translated, 5xx and unrelated exceptions rethrown identically, success passed through.
- `BootUiMcpServiceTests` / `QuarkusMcpEnvelopeTest` — asserted through the real codecs that the failure renders `isError: true` with the not-found text and no `error` envelope.
- **MCP conformance** — a new availability-guarded case pins Spring MVC, WebFlux and Quarkus to identical behaviour. I confirmed it is not silently skipped on any of the three, and that it fails with `[an unknown id is a statement about the request, not a server fault]` when the translation is removed.
- Full `bootui-engine` (2261), `bootui-spring-autoconfigure` (1815) and `bootui-quarkus` (434) suites, all three MCP conformance suites, and reactor-wide `spotless:check`.

Docs updated in `docs/SPECIFICATION.md` and `docs/features/developer-tools.md`, plus a CHANGELOG entry. No REST behaviour changes: the controller-support methods keep throwing exactly as before.