### PR TITLE
Teach the agent skill the command-line endpoint, not just MCP

### DIFF
--- a/docs/AI-AGENTS.md
+++ b/docs/AI-AGENTS.md
@@ -30,7 +30,8 @@ bounded shape a human would — never raw, unfiltered internals.
 ## Install the BootUI agent skill
 
 BootUI ships an agent skill that teaches GitHub Copilot how to install and configure BootUI, inspect a running
-application, turn advisor findings into focused fixes, verify those fixes, and connect to the MCP server.
+application from the [command line](CLI.md) or the MCP server, turn advisor findings into focused fixes, and verify
+those fixes.
 
 With GitHub CLI 2.90 or later, inspect the skill before installing it:
 

--- a/docs/AI-AGENTS.md
+++ b/docs/AI-AGENTS.md
@@ -30,7 +30,8 @@ bounded shape a human would — never raw, unfiltered internals.
 ## Install the BootUI agent skill
 
 BootUI ships an agent skill that teaches GitHub Copilot how to install and configure BootUI, inspect a running
-application from the [command line](CLI.md) or the MCP server, turn advisor findings into focused fixes, and verify
+application from the [command line](CLI.md) or the
+[MCP server](#connect-an-agent-to-the-bootui-mcp-server), turn advisor findings into focused fixes, and verify
 those fixes.
 
 With GitHub CLI 2.90 or later, inspect the skill before installing it:

--- a/skills/bootui/SKILL.md
+++ b/skills/bootui/SKILL.md
@@ -203,7 +203,8 @@ load; use their explicit action only when requested.
 ## Connect an agent to the MCP server
 
 Set this up only when the user asks to connect an agent or MCP client to BootUI. If BootUI MCP tools are already in
-your tool list, just call them — there is nothing to configure. For a one-off diagnostic, use the CLI instead.
+your tool list, just call them — there is nothing to configure. For a one-off diagnostic, use the CLI instead. The full
+guide is at `https://github.com/jdubois/boot-ui/blob/main/docs/AI-AGENTS.md`.
 
 The MCP server is opt-in. Enable it with `bootui.mcp.enabled=ON` or the MCP Server panel toggle, then configure the agent
 with the application's actual port:

--- a/skills/bootui/SKILL.md
+++ b/skills/bootui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootui
-description: Install, configure, and use BootUI in Spring Boot or Quarkus applications; inspect and improve a running application with BootUI panels, APIs, advisor scans, diagnostics, and its MCP server. Use when asked to add BootUI, troubleshoot its activation or access, investigate runtime behavior, optimize or fix an application using BootUI findings, or connect an AI agent to BootUI.
+description: Install, configure, and use BootUI in Spring Boot 4 or Quarkus applications; inspect and improve a running application through BootUI's command-line endpoint, MCP tools, or browser panels. Use when asked to add or troubleshoot BootUI, and when a question is about what a locally running application is actually doing — a slow or failing endpoint, an exception, SQL or Hibernate behavior, beans, mappings, configuration, health, metrics, logs, traces — or when asked for an architecture, security, memory, database, REST, pentest, GraalVM, CRaC, or vulnerability scan, or to connect an AI agent to BootUI.
 license: Apache-2.0
 ---
 
@@ -25,6 +25,9 @@ Before changing anything:
 Do not add both Spring starters. Do not add a Spring starter to Quarkus or the Quarkus extension to Spring.
 
 ## Install BootUI
+
+Add the dependency only when the user asked for BootUI or approves the change. If a diagnostic request arrives and
+BootUI is not on the classpath, say so first rather than installing it silently.
 
 Determine the latest stable BootUI version from Maven Central or the
 [BootUI releases](https://github.com/jdubois/boot-ui/releases); do not guess a version or use a snapshot unless requested.
@@ -53,8 +56,8 @@ BootUI normally opens at `http://localhost:<port>/bootui`. On Spring, `dev` or `
 cannot be forced on.
 
 After installation, verify the application starts, the BootUI banner or URL appears, and
-`GET http://127.0.0.1:<port>/bootui/api/overview` returns JSON. Do not treat an unavailable optional panel as an
-installation failure.
+`GET http://127.0.0.1:<port>/bootui/api/overview` returns JSON — `bootui overview --url http://127.0.0.1:<port>` does
+the same check when the CLI is installed. Do not treat an unavailable optional panel as an installation failure.
 
 ## Configure BootUI safely
 
@@ -64,6 +67,7 @@ Only add configuration required by the user's goal. Prefer these safe controls:
 - `bootui.panels.<panel-id>.enabled=false` to hide a panel and reject its API.
 - `bootui.panels.<panel-id>.read-only=true` to keep reads while blocking its actions.
 - `bootui.expose-values=MASKED` and `bootui.mask-secrets=true` as the normal disclosure posture.
+- `bootui.cli.enabled=false` only when the user wants the command-line endpoint off; it is enabled by default.
 - `bootui.mcp.enabled=ON` only when the user wants the MCP server enabled at startup.
 
 Never set `bootui.allow-non-localhost=true`, `bootui.expose-values=FULL`, broad trusted proxy ranges, or permissive
@@ -76,16 +80,102 @@ may require a restart. The Quarkus Configuration panel is read-only. Do not edit
 Use the full property reference at
 `https://github.com/jdubois/boot-ui/blob/main/docs/PROPERTIES.md` when a setting is not listed here.
 
+## Choose how to reach BootUI
+
+BootUI answers the same questions from one tool registry, under the same per-panel enable and read-only policy. The CLI
+and the MCP server are two spellings of that registry; the browser panels are the human-facing view of the same data.
+Pick the route already available instead of setting up another:
+
+1. **If your tool list already contains BootUI MCP tools**, call them directly. Nothing to install or enable. If one
+   answers that the MCP server is disabled, that is the one case where enabling MCP is the right move: tell the user, or
+   set `bootui.mcp.enabled=ON`, rather than abandoning the request.
+2. **Otherwise use the `bootui` command line.** Check for it with `command -v bootui` (`Get-Command bootui` in
+   PowerShell). Its endpoint is enabled by default, needs no client configuration and no restart, and returns the same
+   masked JSON.
+3. **If the CLI is not installed, call the endpoint over plain HTTP** rather than installing anything. It is ordinary
+   REST, so `curl` is enough.
+4. **Point the user at the browser panels** when a human should look, or for a screenshot.
+
+Do not enable the MCP server, edit a client configuration, or restart the application merely to run a diagnostic that
+options 2 and 3 already answer. Set MCP up as a connection when the user asks to connect an agent or MCP client to
+BootUI.
+
+## Use the command-line endpoint
+
+The CLI asks a running application one question and prints the answer. It talks to `GET /bootui/api/cli` and
+`POST /bootui/api/cli/tools/{name}`, which are enabled by default and independent of `bootui.mcp.enabled`.
+
+**Do not install anything to answer a one-off question.** The endpoint is plain REST with no JSON-RPC envelope and no
+token on loopback, so `curl` reaches the same tools under the same policy:
+
+```bash
+curl -fsS http://127.0.0.1:8080/bootui/api/cli                       # the catalog
+curl -fsS -X POST -H 'Content-Type: application/json' -d '{}' \
+  http://127.0.0.1:8080/bootui/api/cli/tools/get_overview
+curl -fsS -X POST -H 'Content-Type: application/json' -d '{"limit": 20}' \
+  http://127.0.0.1:8080/bootui/api/cli/tools/get_http_exchanges
+```
+
+Always send `Content-Type: application/json` and a body, `{}` when the tool takes no argument, exactly as the CLI does.
+Add `-H "Authorization: Bearer $BOOTUI_TOKEN"` when `bootui.authentication.token` is set. The tool names are the MCP
+tool names; `bootui tools` and the catalog both list them. On this path the outcome is the HTTP status rather than an
+exit code: `403` is the panel refusing, the same condition the CLI reports as `2`.
+
+Install the `bootui` command only when the user wants it, or when repeated calls make it worth it — and ask first,
+because it writes an executable to their machine. It needs a JDK 17 or later. Prefer a source the user can verify:
+[JBang](https://www.jbang.dev) resolves it from Maven Central with `jbang app install bootui@jdubois/boot-ui`, and the
+jar can be downloaded from `repo1.maven.org` and run with `java -jar`. The
+[installer scripts](https://github.com/jdubois/boot-ui/blob/main/docs/CLI.md#install) are a third option; do not pipe
+one into a shell on the user's behalf without their explicit agreement.
+
+Once it is on the `PATH`:
+
+```bash
+bootui tools                                   # what this application actually exposes
+bootui --url http://127.0.0.1:8080 overview
+bootui hibernate scan --json | jq '.severityCounts'
+bootui exceptions show <id> --json
+```
+
+- `--url` (or `BOOTUI_URL`) defaults to `http://localhost:8080`; pass the application's real port.
+- `--api-path` is only needed when `bootui.api-path` is customised, `--token` only when
+  `bootui.authentication.token` is set, and `--timeout` raises the 60-second wait for a slow scan.
+- **Always pass `--json` when parsing.** The human table rendering is not a contract, and terminal auto-detection is
+  unreliable on JDK 22 or later.
+- `bootui tools` prints a human table whose `status` column reads `ready`, `action`, `read-only`, or `panel disabled`.
+  With `--json` it prints the endpoint's own document instead, where each entry in `tools` carries `name`, `panel`,
+  `action`, `arguments`, `panelEnabled`, and `panelReadOnly` — but no `status` or `command` field. Derive availability
+  from those: `panelEnabled: false` means unavailable, `action: true` with `panelReadOnly: true` means the call would be
+  refused. Read this before concluding a stack or panel lacks a capability.
+- Exit codes: `0` answered, `1` usage error or unreachable application or a request the tool rejected, `2` BootUI
+  declined because the panel is disabled or read-only. Treat `2` as "not available here", not as a failure to work
+  around by loosening configuration.
+- Prefer the `BOOTUI_TOKEN` environment variable over `--token`, which exposes the token to shell history and process
+  listings. Never echo a token or copy it into a report.
+- Scan payloads differ: `pentest scan` names its array `findings`, the rule-based advisors name it `results`. Every scan
+  shares `severityCounts`, so prefer that for thresholds, and check the shape with `--json | jq keys` first.
+
+In CI, capture the exit code (`bootui … --json > report.json || status=$?`) so a non-zero exit does not abort the step
+before the application is stopped.
+
+The full command table is at `https://github.com/jdubois/boot-ui/blob/main/docs/CLI.md`; each command maps to the MCP
+tool of the same behavior.
+
 ## Use BootUI on a running application
 
-Prefer BootUI's browser panels or MCP tools over raw framework internals because BootUI returns bounded, masked DTOs.
+Prefer BootUI's CLI, MCP tools, or browser panels over raw framework internals because BootUI returns bounded, masked
+DTOs.
 
-1. Confirm the process, port, framework, and BootUI availability.
-2. Read Overview and Health first.
+1. Confirm the process, port, framework, and BootUI availability, then run `bootui tools` to see what this application
+   really exposes.
+2. Read Overview and Health when the application's identity or overall state matters (`bootui overview`,
+   `bootui health`, or `get_overview` and `get_health`); go straight to the relevant read when the question is specific.
 3. Use Live Activity to correlate recent requests, SQL, exceptions, security events, scheduled work, messaging, and mail.
-4. Open the dedicated diagnostic panel for full detail.
-5. Run only relevant advisor scans. Scans and network-backed actions must be explicit, not triggered just by opening a
-   panel.
+4. Open the dedicated diagnostic command or panel for full detail.
+5. Answer with read commands where you can. Do not run a tool the catalog marks as an action — every `… scan`,
+   `clear`, `pause`, `resume`, and heap analysis — unless the user asked for it or approves after you name it. Prefer
+   an existing `… report` over a fresh scan, and treat `vulnerabilities scan` as always requiring approval because it
+   queries OSV.dev over the network.
 6. Record a baseline: finding identifiers and severities, health, failing request, exception, and relevant metrics.
 
 Treat unavailable panels honestly. Their backing library, capability, configuration, or adapter support may be absent.
@@ -110,7 +200,10 @@ Ask before destructive or state-changing actions such as clearing caches, changi
 running migrations, deleting data, or capturing heap dumps. Never run vulnerability or external-network scans on page
 load; use their explicit action only when requested.
 
-## Connect and use the MCP server
+## Connect an agent to the MCP server
+
+Set this up only when the user asks to connect an agent or MCP client to BootUI. If BootUI MCP tools are already in
+your tool list, just call them — there is nothing to configure. For a one-off diagnostic, use the CLI instead.
 
 The MCP server is opt-in. Enable it with `bootui.mcp.enabled=ON` or the MCP Server panel toggle, then configure the agent
 with the application's actual port:
@@ -152,6 +245,14 @@ paginated reads are capped by `bootui.mcp.max-results`.
 - **403 non-loopback/host rejection:** use `127.0.0.1` or `localhost`; inspect the rejection reason before changing safety
   configuration.
 - **403 panel access:** check the panel's `enabled` and `read-only` settings and the global `bootui.read-only` setting.
+- **`bootui` command not found:** do not install it to answer one question — `curl` the same endpoint as shown above.
+  Install it only with the user's agreement.
+- **CLI cannot reach the application:** it defaults to `http://localhost:8080`; pass the real port with `--url`, and
+  `--api-path` when `bootui.api-path` is customised. Add `-v` to see the underlying failure.
+- **CLI exits `2`, or `curl` returns `403`:** the panel is disabled or read-only on that application. Report it; do not
+  loosen configuration.
+- **`curl` returns `503`:** `bootui.cli.enabled=false` is set in configuration. It is not revocable or restorable from
+  the browser; the property has to change.
 - **MCP endpoint disabled:** enable it in the MCP Server panel or set `bootui.mcp.enabled=ON`, then restart if the property
   changed.
 - **Tool not advertised:** check the backing panel's availability and required application capability.


### PR DESCRIPTION
## What does this PR do?

Teaches the `bootui` agent skill about the command-line endpoint, which it did not know existed, and reorders the routes it offers so an agent uses whatever is already available instead of setting up MCP.

## Why is this change needed?

The skill predates #906. It told agents that the MCP server was the only way to reach BootUI from outside the browser, which is the most expensive route on offer: MCP is off by default and needs client configuration plus, usually, a restart. The command-line endpoint is on by default, answers the same tool registry under the same per-panel enable and read-only policy, and needs neither.

The skill now orders routes by what costs nothing:

1. BootUI MCP tools already in the agent's tool list, called directly.
2. The `bootui` command, when it is on the PATH.
3. Plain `curl` against `POST /bootui/api/cli/tools/{name}`, so no install is needed to answer one question.
4. The browser panels, when a human should look.

MCP stays first-class and is still what an agent sets up when the user asks to connect one; the skill also now enables it when an advertised tool reports the server is disabled, instead of giving up.

## Notable details

Three points came out of review and are worth a reviewer's attention:

- **No piped installer.** The skill does not tell an agent to run `curl ... | sh` on a user's machine. It prefers JBang or the Maven Central jar, points at `docs/CLI.md#install` for the scripts, and requires the user's agreement first.
- **`bootui tools --json` has no `status` field.** The `status` column (`ready`, `action`, `read-only`, `panel disabled`) is synthesized by `CliContext.status` for the human table only. With `--json` the CLI prints the endpoint's own document, so the skill tells agents to derive availability from `panelEnabled` and `panelReadOnly`.
- **The raw HTTP examples match `BootUiClient`.** They send `Content-Type: application/json` and a `{}` body, because the controller binds `@RequestBody(required = false) Map`, and they document `403` as the refusal that the CLI reports as exit code `2` and `503` as `bootui.cli.enabled=false`.

Also adds action-consent guardrails the CLI makes newly reachable: approval before any tool the catalog marks as an action, `BOOTUI_TOKEN` in preference to `--token`, and `--json` rather than parsing the rendered table.

Docs get the matching links: `AI-AGENTS.md` links its own MCP section next to the CLI guide, and the skill's MCP section links back to `AI-AGENTS.md` the way it already linked `CLI.md`.

## How was it tested?

Documentation only, no code paths touched, so the build and conformance suites are not affected.

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [ ] Ran the affected Playwright suite(s) for browser-facing changes
- [ ] Added or updated tests where applicable

Every factual claim added to the skill was verified against source rather than against the docs: `bootui.cli.enabled` defaulting to `true` in `BootUiProperties` and `BootUiCliProducer`, the endpoint methods in `BootUiCliController`, the option defaults in `BootUiClientOptions` and `GlobalOptions`, the exit codes in `ExitCodes`, the status strings in `CliContext`, the JSON catalog fields in `BootUiCatalog`, and the HTTP status mapping in `CliStatus`.

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed