### PR TITLE
Stop reporting BootUI's own health show-details default as a host finding (SPRING-MGMT-003, PT-A05-050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Spring advisor and the pentest panel no longer report BootUI's own actuator default as a host
+  misconfiguration.** BootUI contributes `management.endpoint.health.show-details=always` as a lowest-priority default
+  so its Health panel works, and `SPRING-MGMT-003` (MEDIUM) and `PT-A05-050` (LOW) then reported that value against the
+  application — a "security finding" BootUI had created itself, in an application whose configuration never mentions
+  the property. `SPRING-MGMT-003` now reads the property the same host-aware way `SEC-ACT-004` already did, and the
+  pentest collector's host lookup no longer misses the filter: it skips Spring Boot's attached
+  `configurationProperties` property source, which sits in front of every other source and resolves through them, so
+  BootUI's contribution was returned under the wrong source name and slipped past the check the panel documented. All
+  four call sites now share one implementation, so the two cannot drift apart again. What BootUI injects, and its
+  lowest-priority precedence, are unchanged (#923).
+
 ## [1.16.0] - 2026-09-03
 
 Feature release that takes BootUI's diagnostics out of the browser and the agent: a `bootui` command-line interface with

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiContributedProperties.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/config/BootUiContributedProperties.java
@@ -1,0 +1,89 @@
+package io.github.jdubois.bootui.autoconfigure.config;
+
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.env.DefaultPropertiesPropertySource;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+
+/**
+ * Resolves the value the <em>host application</em> configured for a property, ignoring the actuator
+ * defaults {@link BootUiActuatorDefaultsEnvironmentPostProcessor} contributes on BootUI's behalf.
+ *
+ * <p>BootUI widens {@code management.endpoints.web.exposure.include} and sets
+ * {@code management.endpoint.health.show-details=always} (among others) so its local panels work. Advisor
+ * rules, the Security scanner, and the pentest checks all report host misconfiguration, so they must not
+ * see BootUI's own contribution as if the application had chosen it &mdash; otherwise every BootUI user is
+ * shown a finding BootUI created.</p>
+ *
+ * <p>Two properties of the lookup matter and are easy to get wrong when duplicated per call site:</p>
+ * <ul>
+ *   <li>Spring Boot attaches a {@code configurationProperties} {@link PropertySource} at the front of the
+ *       environment which resolves through every other source. Iterating property sources without skipping
+ *       it returns BootUI's value under the wrong source name, defeating the filter entirely.</li>
+ *   <li>BootUI's defaults are merged into the shared {@code defaultProperties} source (so any host value
+ *       wins), which is therefore the only source a BootUI contribution can come from.</li>
+ * </ul>
+ *
+ * <p>Known limitation: a host that sets the exact same value BootUI would contribute, through its own
+ * {@code defaultProperties} source (for example {@code SpringApplication.setDefaultProperties}), is
+ * indistinguishable from BootUI here and is treated as BootUI's contribution.</p>
+ */
+public final class BootUiContributedProperties {
+
+    private BootUiContributedProperties() {}
+
+    /**
+     * Returns the trimmed value the host configured for {@code key}, or {@code null} when the key is unset,
+     * blank, or set only by BootUI's own actuator defaults.
+     */
+    public static String hostProperty(Environment environment, String key) {
+        if (environment == null || key == null) {
+            return null;
+        }
+        if (!(environment instanceof ConfigurableEnvironment configurableEnvironment)) {
+            String value = environment.getProperty(key);
+            return value == null || value.isBlank() ? null : value.trim();
+        }
+        for (PropertySource<?> propertySource : configurableEnvironment.getPropertySources()) {
+            if (ConfigurationPropertySources.isAttachedConfigurationPropertySource(propertySource)) {
+                continue;
+            }
+            Object value = propertySource.getProperty(key);
+            if (value == null) {
+                continue;
+            }
+            String text = value.toString().trim();
+            if (text.isBlank()) {
+                continue;
+            }
+            if (isBootUiContribution(propertySource, key, text)) {
+                continue;
+            }
+            return text;
+        }
+        return null;
+    }
+
+    /**
+     * Returns the first host-configured value among {@code keys}, or {@code null} when none is set outside
+     * BootUI's own actuator defaults.
+     */
+    public static String firstHostProperty(Environment environment, String... keys) {
+        if (keys == null) {
+            return null;
+        }
+        for (String key : keys) {
+            String value = hostProperty(environment, key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isBootUiContribution(PropertySource<?> propertySource, String key, String value) {
+        return DefaultPropertiesPropertySource.NAME.equals(propertySource.getName())
+                && BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(key, value);
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentesting/SpringPentestingObservationCollector.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/pentesting/SpringPentestingObservationCollector.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.autoconfigure.pentesting;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.config.BootUiActuatorDefaultsEnvironmentPostProcessor;
+import io.github.jdubois.bootui.autoconfigure.config.BootUiContributedProperties;
 import io.github.jdubois.bootui.engine.pentesting.PentestingConfigSnapshot;
 import io.github.jdubois.bootui.engine.pentesting.PentestingEndpointInventory;
 import io.github.jdubois.bootui.engine.pentesting.PentestingObservation;
@@ -14,7 +15,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.env.DefaultPropertiesPropertySource;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.EnumerablePropertySource;
@@ -190,29 +190,7 @@ public class SpringPentestingObservationCollector {
     }
 
     private String hostProperty(String propertyName) {
-        if (!(environment instanceof ConfigurableEnvironment configurableEnvironment)) {
-            return environment.getProperty(propertyName);
-        }
-        for (PropertySource<?> propertySource : configurableEnvironment.getPropertySources()) {
-            Object value = propertySource.getProperty(propertyName);
-            if (value == null) {
-                continue;
-            }
-            String text = value.toString().trim();
-            if (text.isBlank()) {
-                continue;
-            }
-            if (isBootUiActuatorDefault(propertySource, propertyName, text)) {
-                continue;
-            }
-            return text;
-        }
-        return null;
-    }
-
-    private boolean isBootUiActuatorDefault(PropertySource<?> propertySource, String propertyName, String value) {
-        return DefaultPropertiesPropertySource.NAME.equals(propertySource.getName())
-                && BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(propertyName, value);
+        return BootUiContributedProperties.hostProperty(environment, propertyName);
     }
 
     private String httpFirewallType() {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
@@ -1,6 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.security;
 
-import io.github.jdubois.bootui.autoconfigure.config.BootUiActuatorDefaultsEnvironmentPostProcessor;
+import io.github.jdubois.bootui.autoconfigure.config.BootUiContributedProperties;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.CorsConfigModel;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.FilterChainModel;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.PasswordEncoderModel;
@@ -233,42 +233,7 @@ record SecurityContext(
     }
 
     String firstHostProperty(String... keys) {
-        if (!(environment instanceof ConfigurableEnvironment configurableEnvironment)) {
-            return firstProperty(keys);
-        }
-        for (String key : keys) {
-            String value = hostProperty(configurableEnvironment, key);
-            if (value != null) {
-                return value;
-            }
-        }
-        return null;
-    }
-
-    private String hostProperty(ConfigurableEnvironment configurableEnvironment, String key) {
-        for (PropertySource<?> propertySource : configurableEnvironment.getPropertySources()) {
-            if (ConfigurationPropertySources.isAttachedConfigurationPropertySource(propertySource)) {
-                continue;
-            }
-            Object value = propertySource.getProperty(key);
-            if (value == null) {
-                continue;
-            }
-            String text = value.toString().trim();
-            if (text.isBlank()) {
-                continue;
-            }
-            if (isBootUiActuatorDefault(propertySource, key, text)) {
-                continue;
-            }
-            return text;
-        }
-        return null;
-    }
-
-    private boolean isBootUiActuatorDefault(PropertySource<?> propertySource, String key, String value) {
-        return DefaultPropertiesPropertySource.NAME.equals(propertySource.getName())
-                && BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(key, value);
+        return BootUiContributedProperties.firstHostProperty(environment, keys);
     }
 
     String[] activeProfiles() {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollector.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SpringReactiveSecurityObservationCollector.java
@@ -1,6 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.security;
 
-import io.github.jdubois.bootui.autoconfigure.config.BootUiActuatorDefaultsEnvironmentPostProcessor;
+import io.github.jdubois.bootui.autoconfigure.config.BootUiContributedProperties;
 import io.github.jdubois.bootui.engine.reactivesecurity.CorsConfigObservation;
 import io.github.jdubois.bootui.engine.reactivesecurity.ReactiveSecurityEnvironmentSnapshot;
 import io.github.jdubois.bootui.engine.reactivesecurity.ReactiveSecurityObservation;
@@ -589,42 +589,7 @@ public final class SpringReactiveSecurityObservationCollector {
     }
 
     private String firstHostProperty(String... keys) {
-        if (!(environment instanceof ConfigurableEnvironment configurableEnvironment)) {
-            return firstProperty(keys);
-        }
-        for (String key : keys) {
-            String value = hostProperty(configurableEnvironment, key);
-            if (value != null) {
-                return value;
-            }
-        }
-        return null;
-    }
-
-    private String hostProperty(ConfigurableEnvironment configurableEnvironment, String key) {
-        for (PropertySource<?> propertySource : configurableEnvironment.getPropertySources()) {
-            if (ConfigurationPropertySources.isAttachedConfigurationPropertySource(propertySource)) {
-                continue;
-            }
-            Object value = propertySource.getProperty(key);
-            if (value == null) {
-                continue;
-            }
-            String text = value.toString().trim();
-            if (text.isBlank()) {
-                continue;
-            }
-            if (isBootUiActuatorDefault(propertySource, key, text)) {
-                continue;
-            }
-            return text;
-        }
-        return null;
-    }
-
-    private boolean isBootUiActuatorDefault(PropertySource<?> propertySource, String key, String value) {
-        return DefaultPropertiesPropertySource.NAME.equals(propertySource.getName())
-                && BootUiActuatorDefaultsEnvironmentPostProcessor.isBootUiActuatorDefault(key, value);
+        return BootUiContributedProperties.firstHostProperty(environment, keys);
     }
 
     /**

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringContext.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.spring;
 
+import io.github.jdubois.bootui.autoconfigure.config.BootUiContributedProperties;
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.BeanRef;
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.CacheManagerRef;
 import java.time.Duration;
@@ -67,6 +68,14 @@ record SpringContext(
             }
         }
         return null;
+    }
+
+    /**
+     * Like {@link #firstProperty}, but ignores the actuator defaults BootUI contributes itself, so a rule
+     * reports only what the host application configured.
+     */
+    String firstHostProperty(String... keys) {
+        return BootUiContributedProperties.firstHostProperty(environment, keys);
     }
 
     Integer firstIntegerProperty(String... keys) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
@@ -1335,13 +1335,15 @@ final class ActuatorShowValuesAlwaysRule extends AbstractSpringRule {
     SpringRuleResultDto evaluateRule(SpringContext context) {
         List<String> findings = new ArrayList<>();
         for (String id : VALUE_ENDPOINTS) {
-            String showValues = context.firstProperty("management.endpoint." + id + ".show-values");
+            // Host-configured values only: BootUI contributes its own actuator defaults (including
+            // show-details=always) so its local panels work, and must not report them against the host.
+            String showValues = context.firstHostProperty("management.endpoint." + id + ".show-values");
             if ("always".equalsIgnoreCase(showValues) && ActuatorExposure.isReadable(context, id)) {
                 findings.add("management.endpoint." + id + ".show-values=ALWAYS reveals full '" + id
                         + "' values to every caller; use WHEN_AUTHORIZED.");
             }
         }
-        String showDetails = context.firstProperty("management.endpoint.health.show-details");
+        String showDetails = context.firstHostProperty("management.endpoint.health.show-details");
         if ("always".equalsIgnoreCase(showDetails) && ActuatorExposure.isReadable(context, "health")) {
             findings.add("management.endpoint.health.show-details=always exposes internal health probe details to"
                     + " every caller; use when-authorized.");

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiContributedPropertiesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/config/BootUiContributedPropertiesTests.java
@@ -1,0 +1,99 @@
+package io.github.jdubois.bootui.autoconfigure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+
+/** Coverage for the shared "what did the host actually configure?" property lookup. */
+class BootUiContributedPropertiesTests {
+
+    private static final String SHOW_DETAILS = "management.endpoint.health.show-details";
+
+    @Test
+    void ignoresBootUiActuatorDefaultContributedThroughDefaultProperties() {
+        MockEnvironment environment = new MockEnvironment();
+        environment
+                .getPropertySources()
+                .addLast(new MapPropertySource("defaultProperties", Map.of(SHOW_DETAILS, "always")));
+
+        assertThat(BootUiContributedProperties.hostProperty(environment, SHOW_DETAILS))
+                .isNull();
+    }
+
+    @Test
+    void ignoresBootUiActuatorDefaultWhenConfigurationPropertiesSourceIsAttached() {
+        // Regression for #923: Spring Boot attaches a "configurationProperties" source at the front of the
+        // environment that resolves through every other source. Without skipping it, BootUI's own default
+        // is returned under that source's name and reported as host configuration.
+        StandardEnvironment environment = new StandardEnvironment();
+        environment
+                .getPropertySources()
+                .addLast(new MapPropertySource("defaultProperties", Map.of(SHOW_DETAILS, "always")));
+        ConfigurationPropertySources.attach(environment);
+
+        assertThat(BootUiContributedProperties.hostProperty(environment, SHOW_DETAILS))
+                .isNull();
+    }
+
+    @Test
+    void returnsHostValueEvenWhenConfigurationPropertiesSourceIsAttached() {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("application", Map.of(SHOW_DETAILS, "always")));
+        ConfigurationPropertySources.attach(environment);
+
+        assertThat(BootUiContributedProperties.hostProperty(environment, SHOW_DETAILS))
+                .isEqualTo("always");
+    }
+
+    @Test
+    void returnsHostValueThatDiffersFromTheBootUiDefaultInDefaultProperties() {
+        MockEnvironment environment = new MockEnvironment();
+        environment
+                .getPropertySources()
+                .addLast(new MapPropertySource("defaultProperties", Map.of(SHOW_DETAILS, "when-authorized")));
+
+        assertThat(BootUiContributedProperties.hostProperty(environment, SHOW_DETAILS))
+                .isEqualTo("when-authorized");
+    }
+
+    @Test
+    void skipsBlankAndMissingValues() {
+        MockEnvironment environment = new MockEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource("application", Map.of(SHOW_DETAILS, "  ")));
+
+        assertThat(BootUiContributedProperties.hostProperty(environment, SHOW_DETAILS))
+                .isNull();
+        assertThat(BootUiContributedProperties.hostProperty(environment, "management.endpoint.health.show-components"))
+                .isNull();
+    }
+
+    @Test
+    void firstHostPropertyReturnsTheFirstKeySetByTheHost() {
+        MockEnvironment environment = new MockEnvironment();
+        environment
+                .getPropertySources()
+                .addLast(new MapPropertySource("defaultProperties", Map.of(SHOW_DETAILS, "always")));
+        environment
+                .getPropertySources()
+                .addFirst(new MapPropertySource(
+                        "application", Map.of("management.endpoint.health.show-components", "always")));
+
+        assertThat(BootUiContributedProperties.firstHostProperty(
+                        environment, SHOW_DETAILS, "management.endpoint.health.show-components"))
+                .isEqualTo("always");
+    }
+
+    @Test
+    void toleratesNullArguments() {
+        assertThat(BootUiContributedProperties.hostProperty(null, SHOW_DETAILS)).isNull();
+        assertThat(BootUiContributedProperties.hostProperty(new MockEnvironment(), null))
+                .isNull();
+        assertThat(BootUiContributedProperties.firstHostProperty(new MockEnvironment(), (String[]) null))
+                .isNull();
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/pentesting/SpringPentestingObservationCollectorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/pentesting/SpringPentestingObservationCollectorTests.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
@@ -459,11 +460,26 @@ class SpringPentestingObservationCollectorTests {
                 .getPropertySources()
                 .addLast(new MapPropertySource(
                         "defaultProperties", Map.of("management.endpoint.health.show-details", "always")));
+        // Regression for #923: a real application has Spring Boot's "configurationProperties" source
+        // attached at the front, and it resolves through every other source.
+        ConfigurationPropertySources.attach(environment);
 
         PentestingReport report =
                 scanner(new CapturingLocalHttpClient(), environment).scan();
 
         assertThat(report.findings()).extracting(PentestingFindingDto::id).doesNotContain("PT-A05-050");
+    }
+
+    @Test
+    void healthDetailsCheckStillReportsHostConfiguredValue() {
+        MockEnvironment environment = environment();
+        environment.setProperty("management.endpoint.health.show-details", "always");
+        ConfigurationPropertySources.attach(environment);
+
+        PentestingReport report =
+                scanner(new CapturingLocalHttpClient(), environment).scan();
+
+        assertThat(report.findings()).extracting(PentestingFindingDto::id).contains("PT-A05-050");
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
@@ -2,11 +2,15 @@ package io.github.jdubois.bootui.autoconfigure.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.jdubois.bootui.autoconfigure.config.BootUiActuatorDefaultsEnvironmentPostProcessor;
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.BeanRef;
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.CacheManagerRef;
 import io.github.jdubois.bootui.core.dto.SpringRuleResultDto;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
 /** Focused coverage for the rules added or corrected during the Spring Advisor audit. */
@@ -901,6 +905,35 @@ class SpringRulesTests {
                                 .build())
                         .status())
                 .isEqualTo("PASS");
+    }
+
+    @Test
+    void actuatorShowDetailsAlwaysIgnoresBootUiOwnDefault() {
+        // Regression for #923: BootUiActuatorDefaultsEnvironmentPostProcessor contributes
+        // show-details=always into the lowest-priority defaultProperties source whenever BootUI is active,
+        // and a real application also has Spring Boot's attached "configurationProperties" source in front
+        // of it. Neither must be reported as host misconfiguration.
+        ActuatorShowValuesAlwaysRule rule = new ActuatorShowValuesAlwaysRule();
+
+        MockEnvironment bootUiContributed = env();
+        bootUiContributed
+                .getPropertySources()
+                .addLast(new MapPropertySource(
+                        "defaultProperties",
+                        Map.of(
+                                "management.endpoint.health.show-details",
+                                "always",
+                                "management.endpoints.web.exposure.include",
+                                BootUiActuatorDefaultsEnvironmentPostProcessor.REQUIRED_ENDPOINTS)));
+        ConfigurationPropertySources.attach(bootUiContributed);
+
+        assertThat(rule.evaluate(context(bootUiContributed).build()).status()).isEqualTo("PASS");
+
+        // A host that configures the same value itself is still reported.
+        MockEnvironment hostConfigured = env().withProperty("management.endpoint.health.show-details", "always");
+        ConfigurationPropertySources.attach(hostConfigured);
+
+        assertThat(rule.evaluate(context(hostConfigured).build()).status()).isEqualTo("VIOLATION");
     }
 
     // ── SPRING-MGMT-004: shutdown / heapdump reachable ───────────────────────────

--- a/docs/SPRING-CHECKS.md
+++ b/docs/SPRING-CHECKS.md
@@ -304,6 +304,7 @@ The access-aware rules resolve Spring Boot 4 endpoint-specific and global `acces
 
 - **Severity**: MEDIUM
 - **Detects**: management.endpoint.env.show-values=ALWAYS or management.endpoint.configprops.show-values=ALWAYS on readable endpoints, or management.endpoint.health.show-details=always while health is readable. Property values, including credentials, and internal health probe details are then returned to every caller.
+- **Only host configuration**: BootUI contributes `management.endpoint.health.show-details=always` itself, as a lowest-priority default, so its own Health panel works. That contribution is ignored here, so the rule reports only what the application configured.
 - **Recommendation**: Use show-values=WHEN_AUTHORIZED and show-details=when-authorized so sensitive values and health details are only revealed to authenticated, authorized users.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.sanitization>
 


### PR DESCRIPTION
## Problem

BootUI's `BootUiActuatorDefaultsEnvironmentPostProcessor` contributes `management.endpoint.health.show-details=always` into the lowest-priority `defaultProperties` source whenever BootUI is active and the host has not set the key. Two BootUI checks then reported that value as a *host* misconfiguration, in applications whose configuration never mentions the property:

- **`SPRING-MGMT-003`** (MEDIUM) read the property through `context.firstProperty(...)`, a plain `Environment.getProperty` — the Spring Advisor context had no host-aware lookup at all.
- **`PT-A05-050`** (LOW) *did* try to filter BootUI's contribution, but its `hostProperty` loop did not skip Spring Boot's attached `configurationProperties` property source. That source sits first in a real application's `MutablePropertySources` and resolves through every other source, so BootUI's value was returned under the name `configurationProperties` rather than `defaultProperties` and never matched the filter. The existing unit test only passed because `MockEnvironment` has no attached source, and `docs/PENTEST-CHECKS.md` already documented the behaviour the code did not deliver.

The same ~15-line filter existed in three copies (`SecurityContext`, `SpringReactiveSecurityObservationCollector`, `SpringPentestingObservationCollector`) and one had drifted.

## Fix

- New `BootUiContributedProperties` in the `config` package, next to the post-processor that creates the ambiguity: one `hostProperty` / `firstHostProperty` lookup that skips the attached source, blank values, and BootUI's own defaults in `defaultProperties`.
- All three existing copies now delegate to it — this is the actual `PT-A05-050` fix and removes the possibility of the copies diverging again.
- New `SpringContext.firstHostProperty(...)`, used by `ActuatorShowValuesAlwaysRule` — the `SPRING-MGMT-003` fix. The `ActuatorExposure.isReadable` gate is unchanged.

What BootUI injects, and its lowest-priority precedence, are unchanged. Quarkus reports `null` for `healthShowDetails`, so no adapter change there; MVC and WebFlux share the fixed collector.

## Verification

Each new test was confirmed to fail against the un-fixed lookup:

```
BootUiContributedPropertiesTests.ignoresBootUiActuatorDefaultWhenConfigurationPropertiesSourceIsAttached  FAILED
SpringPentestingObservationCollectorTests.healthDetailsCheckIgnoresBootUiActuatorDefault                  FAILED
SpringRulesTests.actuatorShowDetailsAlwaysIgnoresBootUiOwnDefault                                         FAILED
```

With the fix: `bootui-spring-autoconfigure` — 1859 tests, 0 failures. `spotless:check` passes over the reactor.

Fixes #923