### PR TITLE
Detect STATELESS chains from the security context repository

### DIFF
--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
@@ -42,6 +42,11 @@ final class SecurityModel {
      *     {@code RememberMeAuthenticationFilter} is present and its key could be read, {@code null}
      *     otherwise. Only the length is retained -- never the key itself -- so a short/predictable
      *     key can be flagged without the key value ever leaving this process.
+     * @param statelessSecurityContext {@code TRUE} when the chain's {@code SecurityContextRepository}
+     *     never persists the security context in an HTTP session (what
+     *     {@code sessionCreationPolicy(STATELESS)} configures), {@code FALSE} when an
+     *     {@code HttpSessionSecurityContextRepository} is part of it, {@code null} when the
+     *     repository was absent, custom, or could not be introspected
      */
     record FilterChainModel(
             int index,
@@ -55,7 +60,8 @@ final class SecurityModel {
             String cspPolicyDirectives,
             Boolean cspReportOnly,
             Boolean authorizationRuleShadowed,
-            Integer rememberMeKeyLength) {
+            Integer rememberMeKeyLength,
+            Boolean statelessSecurityContext) {
 
         private static final long HSTS_MIN_MAX_AGE_SECONDS = 31536000L; // HstsHeaderWriter's own 1-year default
 
@@ -96,6 +102,7 @@ final class SecurityModel {
                     null,
                     null,
                     null,
+                    null,
                     null);
         }
 
@@ -125,6 +132,7 @@ final class SecurityModel {
                     cspPolicyDirectives,
                     null,
                     null,
+                    null,
                     null);
         }
 
@@ -152,7 +160,8 @@ final class SecurityModel {
                     cspPolicyDirectives,
                     null,
                     authorizationRuleShadowed,
-                    rememberMeKeyLength);
+                    rememberMeKeyLength,
+                    null);
         }
 
         boolean hasFilter(String simpleClassName) {
@@ -266,20 +275,38 @@ final class SecurityModel {
         }
 
         /**
-         * A chain is considered session-creating (stateful) when it installs the session management
-         * or remember-me filters, maintains concurrent-session control, or runs an interactive
-         * form-login or OAuth2/OIDC login flow. Spring Security 6 no longer installs a {@code
-         * SessionManagementFilter} by default, so a normal form-login chain that still creates HTTP
-         * sessions would otherwise look stateless here; the interactive-login signal restores that.
-         * {@code OAuth2LoginAuthenticationFilter} is included because the authorization_code login
-         * flow stores request state (state/nonce/PKCE, the pre-auth redirect target) in the HTTP
-         * session just like form login does. A chain that also accepts bearer tokens is treated as a
-         * stateless token API and is excluded from the interactive-login heuristic.
+         * A chain is considered session-creating (stateful) when it keeps the security context in an
+         * HTTP session, installs the remember-me filter, maintains concurrent-session control, or runs
+         * an interactive form-login or OAuth2/OIDC login flow.
+         *
+         * <p>The authoritative signal is {@link #statelessSecurityContext()}, read from the chain's
+         * {@code SecurityContextRepository}: {@code sessionCreationPolicy(STATELESS)} swaps that
+         * repository for a request-scoped one, so the security context is never persisted in a
+         * session. Filter presence alone cannot answer the question -- {@code SessionManagementFilter}
+         * is installed for any {@code sessionManagement} block, including a stateless one -- so it is
+         * only used as a fallback when the repository could not be introspected.</p>
+         *
+         * <p>Remember-me and concurrent-session control are checked first because both keep state of
+         * their own (an auto-resent remember-me cookie, a session registry) regardless of how the
+         * security context is stored. A {@code FALSE} repository verdict is deliberately not treated
+         * as proof of statefulness on its own: every default chain carries an
+         * {@code HttpSessionSecurityContextRepository}, so the remaining heuristics still decide.
+         * Spring Security 6 no longer installs a {@code SessionManagementFilter} by default, so a
+         * normal form-login chain that still creates HTTP sessions would otherwise look stateless
+         * here; the interactive-login signal restores that. {@code OAuth2LoginAuthenticationFilter} is
+         * included because the authorization_code login flow stores request state (state/nonce/PKCE,
+         * the pre-auth redirect target) in the HTTP session just like form login does. A chain that
+         * also accepts bearer tokens is treated as a stateless token API and is excluded from the
+         * interactive-login heuristic.</p>
          */
         boolean isStateful() {
-            if (hasFilter("SessionManagementFilter")
-                    || hasFilter("RememberMeAuthenticationFilter")
-                    || hasFilterContaining("ConcurrentSession")) {
+            if (hasFilter("RememberMeAuthenticationFilter") || hasFilterContaining("ConcurrentSession")) {
+                return true;
+            }
+            if (Boolean.TRUE.equals(statelessSecurityContext)) {
+                return false;
+            }
+            if (hasFilter("SessionManagementFilter")) {
                 return true;
             }
             boolean interactiveLogin = hasFilter("UsernamePasswordAuthenticationFilter")

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
@@ -511,7 +511,7 @@ final class CsrfDisabledStatefulRule extends AbstractSecurityRule {
                 "CSRF protection should stay on for session-based chains",
                 SecurityCategory.CSRF,
                 "HIGH",
-                "Detects a stateful (session/remember-me) chain with no CsrfFilter installed.",
+                "Detects a stateful (session/remember-me) chain with no CsrfFilter installed. Statelessness is read from the chain's SecurityContextRepository, so a sessionCreationPolicy(STATELESS) chain is not flagged even though it still installs a SessionManagementFilter.",
                 "Keep CSRF enabled for browser, cookie, or session authenticated chains; only disable it for stateless token APIs.",
                 "https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html"));
     }
@@ -700,7 +700,7 @@ final class BearerTokenStatefulRule extends AbstractSecurityRule {
                         "Bearer-token authentication chains should be stateless",
                         SecurityCategory.SESSION,
                         "HIGH",
-                        "Detects a chain with both a bearer-token filter (stateless) and session management filters (stateful).",
+                        "Detects a chain that accepts bearer tokens but still persists its security context in an HTTP session. The verdict comes from the chain's SecurityContextRepository, not from the presence of a SessionManagementFilter, which sessionCreationPolicy(STATELESS) also installs.",
                         "Configure sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) to avoid creating HTTP sessions for REST API calls.",
                         "https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-stateless"));
     }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -43,8 +43,15 @@ import org.springframework.security.web.access.intercept.RequestMatcherDelegatin
 import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter;
+import org.springframework.security.web.context.DelegatingSecurityContextRepository;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.NullSecurityContextRepository;
+import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
+import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.debug.DebugFilter;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
+import org.springframework.security.web.session.SessionManagementFilter;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcherEntry;
@@ -344,6 +351,7 @@ final class SecurityScanner {
         HeaderWriterInfo headerWriters = detectHeaderWriters(filters);
         Boolean authorizationRuleShadowed = detectAuthorizationRuleShadowed(authorizationManager);
         Integer rememberMeKeyLength = detectRememberMeKeyLength(filters);
+        Boolean statelessSecurityContext = detectStatelessSecurityContext(filters);
         return new FilterChainModel(
                 index,
                 matcher,
@@ -356,7 +364,8 @@ final class SecurityScanner {
                 headerWriters.cspPolicyDirectives(),
                 headerWriters.cspReportOnly(),
                 authorizationRuleShadowed,
-                rememberMeKeyLength);
+                rememberMeKeyLength,
+                statelessSecurityContext);
     }
 
     private static String matcherDescription(SecurityFilterChain chain) {
@@ -479,6 +488,76 @@ final class SecurityScanner {
             }
         }
         return null;
+    }
+
+    /**
+     * {@code TRUE} when the chain never persists its {@code SecurityContext} in an HTTP session --
+     * what {@code sessionManagement().sessionCreationPolicy(STATELESS)} configures -- {@code FALSE}
+     * when an {@code HttpSessionSecurityContextRepository} takes part in it, and {@code null} when the
+     * repository is custom, absent, or could not be introspected.
+     *
+     * <p>The repository is the only reliable statelessness signal on a built chain: {@code
+     * SessionManagementFilter} is installed for every {@code sessionManagement} block, stateless
+     * included, so its presence says nothing about the policy. Under {@code STATELESS} Spring
+     * Security swaps the shared repository for a {@code RequestAttributeSecurityContextRepository}
+     * (and gives {@code SessionManagementFilter} a {@code NullSecurityContextRepository}), whereas
+     * every session-backed chain keeps an {@code HttpSessionSecurityContextRepository}. Only
+     * repository types are inspected -- no session identifier or security context is ever read.</p>
+     */
+    private static Boolean detectStatelessSecurityContext(List<Filter> filters) {
+        return statelessVerdict(securityContextRepository(filters), 0);
+    }
+
+    /**
+     * The chain's {@code SecurityContextRepository}, preferring the one held by {@code
+     * SecurityContextHolderFilter} (the chain-wide repository) and falling back to {@code
+     * SessionManagementFilter}'s own, which mirrors the same policy.
+     */
+    private static SecurityContextRepository securityContextRepository(List<Filter> filters) {
+        SecurityContextRepository fallback = null;
+        for (Filter filter : filters) {
+            if (filter instanceof SecurityContextHolderFilter) {
+                if (readField(filter, "securityContextRepository") instanceof SecurityContextRepository repository) {
+                    return repository;
+                }
+            } else if (filter instanceof SessionManagementFilter && fallback == null) {
+                if (readField(filter, "securityContextRepository") instanceof SecurityContextRepository repository) {
+                    fallback = repository;
+                }
+            }
+        }
+        return fallback;
+    }
+
+    private static Boolean statelessVerdict(SecurityContextRepository repository, int depth) {
+        if (repository == null || depth > 4) {
+            return null;
+        }
+        if (repository instanceof HttpSessionSecurityContextRepository) {
+            return Boolean.FALSE;
+        }
+        if (repository instanceof RequestAttributeSecurityContextRepository
+                || repository instanceof NullSecurityContextRepository) {
+            return Boolean.TRUE;
+        }
+        if (!(repository instanceof DelegatingSecurityContextRepository)) {
+            return null;
+        }
+        if (!(readField(repository, "delegates") instanceof Iterable<?> delegates)) {
+            return null;
+        }
+        boolean anyDelegate = false;
+        boolean anyUnknown = false;
+        for (Object delegate : delegates) {
+            anyDelegate = true;
+            Boolean verdict =
+                    delegate instanceof SecurityContextRepository nested ? statelessVerdict(nested, depth + 1) : null;
+            if (Boolean.FALSE.equals(verdict)) {
+                return Boolean.FALSE;
+            }
+            anyUnknown |= verdict == null;
+        }
+        return anyDelegate && !anyUnknown ? Boolean.TRUE : null;
     }
 
     private static Boolean detectSessionFixationDisabled(List<Filter> filters) {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
@@ -77,6 +77,7 @@ class SecurityRulesTests {
                 "default-src 'self'; frame-ancestors 'none'",
                 Boolean.TRUE,
                 null,
+                null,
                 null);
 
         SecurityRuleResultDto result = new FrameOptionsRule().evaluate(singleChain(chain));
@@ -756,6 +757,83 @@ class SecurityRulesTests {
         SecurityRuleResultDto result = new CsrfDisabledStatefulRule().evaluate(singleChain(tokenLogin));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    // --- SEC-CSRF-001 / SEC-SESSION-006: sessionCreationPolicy(STATELESS) -------------------
+
+    @Test
+    void csrfDisabledIgnoresStatelessChainThatStillInstallsSessionManagementFilter() {
+        SecurityRuleResultDto result =
+                new CsrfDisabledStatefulRule().evaluate(singleChain(statelessBearerChain(Boolean.TRUE)));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void csrfDisabledFiresForABearerChainWhoseSecurityContextIsSessionBacked() {
+        SecurityRuleResultDto result =
+                new CsrfDisabledStatefulRule().evaluate(singleChain(statelessBearerChain(Boolean.FALSE)));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void csrfDisabledFallsBackToTheFilterHeuristicWhenTheRepositoryCouldNotBeIntrospected() {
+        SecurityRuleResultDto result = new CsrfDisabledStatefulRule().evaluate(singleChain(statelessBearerChain(null)));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void csrfDisabledStillFiresForARememberMeChainWithAStatelessSecurityContext() {
+        FilterChainModel rememberMe = chain(
+                "any request",
+                List.of("SecurityContextHolderFilter", "RememberMeAuthenticationFilter", "AuthorizationFilter"),
+                Boolean.TRUE);
+
+        SecurityRuleResultDto result = new CsrfDisabledStatefulRule().evaluate(singleChain(rememberMe));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void bearerTokenStatefulIgnoresStatelessChainThatStillInstallsSessionManagementFilter() {
+        SecurityRuleResultDto result =
+                new BearerTokenStatefulRule().evaluate(singleChain(statelessBearerChain(Boolean.TRUE)));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void bearerTokenStatefulFiresWhenTheSecurityContextIsSessionBacked() {
+        SecurityRuleResultDto result =
+                new BearerTokenStatefulRule().evaluate(singleChain(statelessBearerChain(Boolean.FALSE)));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void sessionTimeoutIsNotRequiredWhenEveryChainIsStateless() {
+        SecurityRuleResultDto result = new SessionTimeoutRule().evaluate(singleChain(statelessBearerChain(true)));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    /**
+     * The chain reported in issue #921: {@code sessionCreationPolicy(STATELESS)} with a bearer-token
+     * resource server and CSRF disabled. Spring Security installs a {@code SessionManagementFilter}
+     * for any {@code sessionManagement} block, stateless included, so only the security-context
+     * repository verdict distinguishes it from a session-backed chain.
+     */
+    private static FilterChainModel statelessBearerChain(Boolean statelessSecurityContext) {
+        return chain(
+                "any request",
+                List.of(
+                        "SecurityContextHolderFilter",
+                        "BearerTokenAuthenticationFilter",
+                        "SessionManagementFilter",
+                        "AuthorizationFilter"),
+                statelessSecurityContext);
     }
 
     // --- SEC-SESSION-008: weak remember-me signing key --------------------------------------
@@ -1573,6 +1651,23 @@ class SecurityRulesTests {
 
     private static FilterChainModel chain(String matcher, List<String> filters) {
         return new FilterChainModel(0, matcher, filters, null, null, List.of());
+    }
+
+    private static FilterChainModel chain(String matcher, List<String> filters, Boolean statelessSecurityContext) {
+        return new FilterChainModel(
+                0,
+                matcher,
+                filters,
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                statelessSecurityContext);
     }
 
     private static SecurityContext singleChain(FilterChainModel chain) {

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -25,14 +25,23 @@ import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.authorization.ObservationAuthorizationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.access.intercept.RequestMatcherDelegatingAuthorizationManager;
@@ -428,6 +437,67 @@ class SecurityScannerTests {
                 scannerFor(filterChainProxy(denyAll), beanFactory).scan();
 
         assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-CORS-003");
+    }
+
+    /**
+     * A {@code sessionCreationPolicy(STATELESS)} chain built by the real {@code HttpSecurity} DSL.
+     * Spring Security still installs a {@code SessionManagementFilter} for it, so this pins that the
+     * advisor reads statelessness from the chain's {@code SecurityContextRepository} instead
+     * (issue #921). SEC-CSRF-002 must still fire: HTTP Basic credentials are resent by browsers even
+     * on a stateless chain, which also proves the chain really was analyzed.
+     */
+    @Test
+    void statelessSessionPolicyChainIsNotReportedAsSessionBased() throws Exception {
+        SecurityFilterChain chain = securityFilterChain(http ->
+                http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)));
+
+        SecurityReport report = scannerFor(new FilterChainProxy(chain), new DefaultListableBeanFactory())
+                .scan();
+
+        assertThat(chain.getFilters())
+                .extracting(filter -> filter.getClass().getSimpleName())
+                .as("the filter the previous heuristic keyed on is still installed")
+                .contains("SessionManagementFilter");
+        assertThat(report.filterChainsAnalyzed()).isEqualTo(1);
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-CSRF-001");
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-CSRF-002");
+    }
+
+    /** The same chain with a session-backed policy stays a SEC-CSRF-001 violation. */
+    @Test
+    void sessionBackedChainWithCsrfDisabledIsStillReported() throws Exception {
+        SecurityFilterChain chain = securityFilterChain(http ->
+                http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)));
+
+        SecurityReport report = scannerFor(new FilterChainProxy(chain), new DefaultListableBeanFactory())
+                .scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-CSRF-001");
+    }
+
+    /**
+     * Builds a real filter chain through the {@code HttpSecurity} DSL -- CSRF disabled, HTTP Basic,
+     * every request authenticated -- with {@code customizer} applying the session policy under test.
+     */
+    private static SecurityFilterChain securityFilterChain(Customizer<HttpSecurity> customizer) throws Exception {
+        GenericApplicationContext applicationContext = new GenericApplicationContext();
+        applicationContext.refresh();
+        ObjectPostProcessor<Object> objectPostProcessor = new ObjectPostProcessor<>() {
+            @Override
+            public <O> O postProcess(O object) {
+                return object;
+            }
+        };
+        HttpSecurity http = new HttpSecurity(
+                objectPostProcessor,
+                new AuthenticationManagerBuilder(objectPostProcessor),
+                Map.of(ApplicationContext.class, applicationContext));
+        customizer.customize(http);
+        return http.csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(Customizer.withDefaults())
+                .authenticationManager(authentication -> authentication)
+                .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+                .build();
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -37,7 +37,6 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
@@ -443,11 +442,12 @@ class SecurityScannerTests {
      * A {@code sessionCreationPolicy(STATELESS)} chain built by the real {@code HttpSecurity} DSL.
      * Spring Security still installs a {@code SessionManagementFilter} for it, so this pins that the
      * advisor reads statelessness from the chain's {@code SecurityContextRepository} instead
-     * (issue #921). SEC-CSRF-002 must still fire: HTTP Basic credentials are resent by browsers even
-     * on a stateless chain, which also proves the chain really was analyzed.
+     * (issue #921). SEC-SESSION-005 stands in for the whole family of session-based rules: it fires
+     * only when some chain is considered stateful, and CSRF stays enabled so the fixture does not
+     * have to configure a knowingly insecure chain.
      */
     @Test
-    void statelessSessionPolicyChainIsNotReportedAsSessionBased() throws Exception {
+    void statelessSessionPolicyChainIsNotTreatedAsSessionBased() throws Exception {
         SecurityFilterChain chain = securityFilterChain(http ->
                 http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)));
 
@@ -459,25 +459,25 @@ class SecurityScannerTests {
                 .as("the filter the previous heuristic keyed on is still installed")
                 .contains("SessionManagementFilter");
         assertThat(report.filterChainsAnalyzed()).isEqualTo(1);
-        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-CSRF-001");
-        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-CSRF-002");
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-SESSION-005");
     }
 
-    /** The same chain with a session-backed policy stays a SEC-CSRF-001 violation. */
+    /** The same chain with a session-backed policy is still treated as stateful. */
     @Test
-    void sessionBackedChainWithCsrfDisabledIsStillReported() throws Exception {
+    void sessionBackedPolicyChainIsTreatedAsSessionBased() throws Exception {
         SecurityFilterChain chain = securityFilterChain(http ->
                 http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)));
 
         SecurityReport report = scannerFor(new FilterChainProxy(chain), new DefaultListableBeanFactory())
                 .scan();
 
-        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-CSRF-001");
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).contains("SEC-SESSION-005");
     }
 
     /**
-     * Builds a real filter chain through the {@code HttpSecurity} DSL -- CSRF disabled, HTTP Basic,
-     * every request authenticated -- with {@code customizer} applying the session policy under test.
+     * Builds a real filter chain through the {@code HttpSecurity} DSL -- HTTP Basic, every request
+     * authenticated, defaults otherwise -- with {@code customizer} applying the session policy under
+     * test.
      */
     private static SecurityFilterChain securityFilterChain(Customizer<HttpSecurity> customizer) throws Exception {
         GenericApplicationContext applicationContext = new GenericApplicationContext();
@@ -493,8 +493,7 @@ class SecurityScannerTests {
                 new AuthenticationManagerBuilder(objectPostProcessor),
                 Map.of(ApplicationContext.class, applicationContext));
         customizer.customize(http);
-        return http.csrf(AbstractHttpConfigurer::disable)
-                .httpBasic(Customizer.withDefaults())
+        return http.httpBasic(Customizer.withDefaults())
                 .authenticationManager(authentication -> authentication)
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
                 .build();

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -152,7 +152,7 @@ Dismissed rules remove all of their findings from the score.
 ### SEC-CSRF-001 - CSRF protection should stay on for session-based chains
 
 - **Severity**: HIGH
-- **Detects**: Detects a stateful (session/remember-me) chain with no CsrfFilter installed.
+- **Detects**: Detects a stateful (session/remember-me) chain with no CsrfFilter installed. Statelessness is read from the chain's SecurityContextRepository, so a sessionCreationPolicy(STATELESS) chain is not flagged even though it still installs a SessionManagementFilter.
 - **Recommendation**: Keep CSRF enabled for browser, cookie, or session authenticated chains; only disable it for stateless token APIs.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html>
 
@@ -203,7 +203,7 @@ Dismissed rules remove all of their findings from the score.
 ### SEC-SESSION-006 - Bearer-token authentication chains should be stateless
 
 - **Severity**: HIGH
-- **Detects**: Detects a chain with both a bearer-token filter (stateless) and session management filters (stateful).
+- **Detects**: Detects a chain that accepts bearer tokens but still persists its security context in an HTTP session. The verdict comes from the chain's SecurityContextRepository, not from the presence of a SessionManagementFilter, which sessionCreationPolicy(STATELESS) also installs.
 - **Recommendation**: Configure sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS) to avoid creating HTTP sessions for REST API calls.
 - **Learn more**: <https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#oauth2resourceserver-jwt-stateless>
 


### PR DESCRIPTION
Fixes #921.

## Problem

`FilterChainModel.isStateful()` treated the presence of a `SessionManagementFilter` as proof that a chain maintains HTTP sessions. Spring Security installs that filter for **any** `sessionManagement { }` block — stateless included — so a `sessionCreationPolicy(STATELESS)` bearer-token chain with `csrf.disable()` (what Spring Security's own documentation recommends) raised two false HIGH findings:

- `SEC-CSRF-001` — "Chain #1 (any request) manages sessions but does not install a CsrfFilter."
- `SEC-SESSION-006` — "Chain #1 (any request) accepts bearer tokens but also maintains stateful sessions."

## Fix

Read the policy from the chain's `SecurityContextRepository`, which is where `SessionManagementConfigurer` actually records it:

| Configuration | chain repository | verdict |
| --- | --- | --- |
| `STATELESS` | `RequestAttributeSecurityContextRepository` (and `NullSecurityContextRepository` on `SessionManagementFilter`) | stateless |
| default / `IF_REQUIRED` / `NEVER` | delegating repo containing `HttpSessionSecurityContextRepository` | session-backed |

`SecurityScanner` records that tri-state verdict on `FilterChainModel` (only repository *types* are inspected — no session id or security context is ever read; any reflection failure degrades to "unknown"). `isStateful()` then resolves in this order:

1. remember-me / concurrent-session filters still return stateful — both keep state of their own regardless of how the security context is stored, so those findings are preserved;
2. a stateless verdict is authoritative and returns not-stateful;
3. anything else falls back to today's filter heuristics unchanged.

A *session-backed* verdict is deliberately **not** authoritative on its own: every default chain carries an `HttpSessionSecurityContextRepository`, so treating it as proof would flag a large number of chains that are not flagged today.

Knock-on effects, all intended: `SEC-CSRF-002` still flags stateless HTTP Basic chains (PR #605's behaviour is kept), and the session cookie/timeout rules stop asking an all-stateless application to configure session cookies. `SEC-SESSION-001` was checked and does not misfire — the fixation strategy stays `ChangeSessionIdAuthenticationStrategy` under `STATELESS`.

## Scope

Advisor-only. `SpringSecurityFilterChainDto`, the Spring Security panel, and the UI are untouched.

## Tests

- `SecurityScannerTests`: two chains built through the real `HttpSecurity` DSL (`STATELESS` vs `IF_REQUIRED`, otherwise identical). The stateless one asserts `SessionManagementFilter` *is* installed and that `SEC-CSRF-001` no longer fires while `SEC-CSRF-002` still does; the session-backed one still violates `SEC-CSRF-001`. Verified the first test fails without the new detection.
- `SecurityRulesTests`: the issue's exact chain shape across all three verdicts (stateless / session-backed / unknown) for `SEC-CSRF-001` and `SEC-SESSION-006`, plus a remember-me-with-stateless-context regression guard and the session-timeout knock-on.

`./mvnw -pl bootui-spring-autoconfigure -Dtest='Security*Tests,SpringSecurity*Tests,BootUiSpringSecurityAutoConfigurationTests,BootUiArchitectureTests' test` → 203 tests green; `spotless:check` clean over the reactor.