### PR TITLE
Resolve DataSource wrappers instead of skipping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Database Advisor and SQL Trace no longer go blind when the pool is wrapped in a `DataSource` proxy.** Spring
+  Boot 4.1's `spring.datasource.connection-fetch: lazy` replaces the `dataSource` bean with a
+  `LazyConnectionDataSourceProxy`, so the Hikari pool inside it is not a bean at all. BootUI skipped every Spring
+  wrapper on the assumption that it forwards to another `DataSource` bean that is discovered on its own — true for a
+  hand-declared wrapper, false here. The Database Advisor answered `DISABLED, "No DataSource beans were found to
+  inspect."` while the Connection Pools panel, which unwraps, showed the very same pool; SQL Trace silently recorded
+  nothing for the same reason. Wrappers are now *resolved* instead of ignored. The advisor skips one only when the pool
+  behind it is a bean of its own, introspects the wrapper itself when it is not, expands a routing datasource into its
+  resolved targets as `beanName[lookupKey]`, and reports a wrapper that will not describe its target as an unreadable
+  datasource rather than dropping it — so `"No DataSource beans were found"` now means exactly that. SQL Trace traces
+  the pool *inside* such a wrapper in place, leaving the bean and its concrete type untouched so by-type injection and
+  Spring Boot's own pool lookups keep resolving, and still skips a target that was already traced so nothing is
+  double-counted. ([#924](https://github.com/jdubois/boot-ui/issues/924))
+
 ## [1.16.0] - 2026-09-03
 
 Feature release that takes BootUI's diagnostics out of the browser and the agent: a `bootui` command-line interface with

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/databaseadvisor/SpringDatabaseAdvisorDataSourceProvider.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/databaseadvisor/SpringDatabaseAdvisorDataSourceProvider.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.databaseadvisor;
 
+import io.github.jdubois.bootui.autoconfigure.datasource.DelegatingDataSources;
 import io.github.jdubois.bootui.spi.DatabaseAdvisorDataSourceProvider;
 import io.github.jdubois.bootui.spi.NamedDataSource;
 import java.sql.SQLException;
@@ -7,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.sql.DataSource;
 import org.springframework.beans.BeansException;
@@ -15,25 +17,39 @@ import org.springframework.beans.factory.ObjectProvider;
 
 /**
  * Spring binding of the {@link DatabaseAdvisorDataSourceProvider} SPI: discovers the application's
- * {@code DataSource} beans directly, skipping Spring's delegating/routing {@code DataSource} wrappers
- * (which forward to another {@code DataSource} bean that is discovered on its own) the same way SQL
- * Trace's {@code SqlTraceDataSourceBeanPostProcessor} skips them, so a wrapped datasource is never
- * introspected twice under two different names.
+ * {@code DataSource} beans, resolving Spring's delegating and routing {@code DataSource} wrappers down to the
+ * physical pools behind them so the same database is introspected exactly once, under one name.
  *
- * <p>De-duplication is by <em>physical</em> identity: a bean wrapped by BootUI's own SQL Trace proxy is
- * reduced to the pool behind it (through the JDBC {@code unwrap} contract the proxy delegates) before being
- * compared, so a traced datasource and the same pool exposed under a second bean name are introspected once,
- * not twice — which would otherwise double every finding in the report.</p>
+ * <p>Discovery runs in two passes. Plain {@code DataSource} beans are taken first, so a wrapper never claims a
+ * name a real bean could have carried. Wrapper beans are then resolved:</p>
+ *
+ * <ul>
+ *   <li>A single-target wrapper ({@code DelegatingDataSource}, most often Spring Boot's
+ *       {@code LazyConnectionDataSourceProxy} for {@code spring.datasource.connection-fetch=lazy}) is
+ *       <em>skipped only when the pool it forwards to is a bean of its own</em>, which is the case it was always
+ *       meant to cover. When the wrapper owns the only reference to that pool the wrapper itself is introspected,
+ *       because opening a connection and reading {@code DatabaseMetaData} through it reaches the same physical
+ *       database. Reporting nothing there was issue #924.</li>
+ *   <li>A routing wrapper ({@code AbstractRoutingDataSource}) is expanded into its already-resolved targets, named
+ *       {@code beanName[lookupKey]}, since the wrapper itself cannot answer {@code getConnection()} without a live
+ *       lookup key. Targets that are beans in their own right are de-duplicated away.</li>
+ * </ul>
+ *
+ * <p>De-duplication is by <em>physical</em> identity: a candidate is reduced through BootUI's own SQL Trace proxy
+ * (via the JDBC {@code unwrap} contract the proxy delegates) and through nested single-target wrappers before being
+ * compared, so a traced datasource and the same pool exposed under a second bean name are introspected once, not
+ * twice — which would otherwise double every finding in the report.</p>
+ *
+ * <p>When a wrapper refuses to describe its target, it is reported rather than dropped, so the scan says the
+ * physical schema could not be read instead of claiming the application has no {@code DataSource} bean at all.</p>
  */
 public final class SpringDatabaseAdvisorDataSourceProvider implements DatabaseAdvisorDataSourceProvider {
 
     private static final String TRACED_DATA_SOURCE_MARKER =
             "io.github.jdubois.bootui.engine.sqltrace.SqlTracedDataSource";
 
-    private static final String[] DELEGATING_WRAPPERS = {
-        "org.springframework.jdbc.datasource.DelegatingDataSource",
-        "org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource"
-    };
+    /** Bound on wrapper nesting, so a mis-configured cyclic wrapper chain cannot spin here. */
+    private static final int MAX_WRAPPER_DEPTH = 16;
 
     private final ObjectProvider<ListableBeanFactory> beanFactoryProvider;
 
@@ -47,19 +63,66 @@ public final class SpringDatabaseAdvisorDataSourceProvider implements DatabaseAd
         if (factory == null) {
             return List.of();
         }
+        List<Candidate> candidates = candidates(factory);
         List<NamedDataSource> dataSources = new ArrayList<>();
         Set<DataSource> seen = Collections.newSetFromMap(new IdentityHashMap<>());
-        for (String beanName : beanNamesForType(factory)) {
-            DataSource dataSource = bean(factory, beanName);
-            if (dataSource == null || isDelegatingWrapper(dataSource.getClass())) {
-                continue;
+        for (Candidate candidate : candidates) {
+            if (!candidate.wrapper()) {
+                add(dataSources, seen, candidate.name(), candidate.dataSource());
             }
-            if (!seen.add(physicalDataSource(dataSource))) {
-                continue;
+        }
+        for (Candidate candidate : candidates) {
+            if (candidate.wrapper()) {
+                addWrapper(dataSources, seen, candidate.name(), candidate.dataSource());
             }
-            dataSources.add(new NamedDataSource(strip(beanName), dataSource));
         }
         return dataSources;
+    }
+
+    /** One {@code DataSource} bean, pre-classified as a Spring wrapper or a plain datasource. */
+    private record Candidate(String name, DataSource dataSource, boolean wrapper) {}
+
+    private static List<Candidate> candidates(ListableBeanFactory factory) {
+        List<Candidate> candidates = new ArrayList<>();
+        for (String beanName : beanNamesForType(factory)) {
+            DataSource dataSource = bean(factory, beanName);
+            if (dataSource != null) {
+                candidates.add(new Candidate(
+                        strip(beanName), dataSource, DelegatingDataSources.isWrapper(dataSource.getClass())));
+            }
+        }
+        return candidates;
+    }
+
+    private static void addWrapper(
+            List<NamedDataSource> dataSources, Set<DataSource> seen, String beanName, DataSource wrapper) {
+        if (DelegatingDataSources.isRouting(wrapper.getClass())) {
+            Map<Object, DataSource> targets = DelegatingDataSources.routingTargets(wrapper);
+            if (targets.isEmpty()) {
+                add(dataSources, seen, beanName, wrapper);
+                return;
+            }
+            for (Map.Entry<Object, DataSource> target : targets.entrySet()) {
+                add(dataSources, seen, beanName + "[" + target.getKey() + "]", target.getValue());
+            }
+            return;
+        }
+        DataSource target = DelegatingDataSources.target(wrapper);
+        if (target == null) {
+            add(dataSources, seen, beanName, wrapper);
+            return;
+        }
+        // The wrapper is what gets introspected, but the pool behind it is what decides whether it is a duplicate.
+        if (seen.add(physicalDataSource(target))) {
+            dataSources.add(new NamedDataSource(beanName, wrapper));
+        }
+    }
+
+    private static void add(
+            List<NamedDataSource> dataSources, Set<DataSource> seen, String name, DataSource dataSource) {
+        if (seen.add(physicalDataSource(dataSource))) {
+            dataSources.add(new NamedDataSource(name, dataSource));
+        }
     }
 
     private static String[] beanNamesForType(ListableBeanFactory factory) {
@@ -79,35 +142,40 @@ public final class SpringDatabaseAdvisorDataSourceProvider implements DatabaseAd
         }
     }
 
-    /** The pool behind a BootUI SQL Trace proxy; anything else is already its own physical datasource. */
+    /**
+     * The physical datasource behind a BootUI SQL Trace proxy and any nesting of Spring's single-target wrappers;
+     * anything else (including a routing wrapper, which has no single physical target) is its own identity.
+     */
     private static DataSource physicalDataSource(DataSource dataSource) {
-        if (!isTracingProxy(dataSource)) {
-            return dataSource;
+        DataSource current = dataSource;
+        for (int depth = 0; depth < MAX_WRAPPER_DEPTH; depth++) {
+            DataSource next = unwrapOnce(current);
+            if (next == null || next == current) {
+                return current;
+            }
+            current = next;
         }
-        try {
-            DataSource unwrapped = dataSource.unwrap(DataSource.class);
-            return unwrapped == null ? dataSource : unwrapped;
-        } catch (SQLException | RuntimeException ex) {
-            return dataSource;
+        return current;
+    }
+
+    private static DataSource unwrapOnce(DataSource dataSource) {
+        if (isTracingProxy(dataSource)) {
+            try {
+                return dataSource.unwrap(DataSource.class);
+            } catch (SQLException | RuntimeException ex) {
+                return null;
+            }
         }
+        if (DelegatingDataSources.isSingleTarget(dataSource.getClass())) {
+            return DelegatingDataSources.target(dataSource);
+        }
+        return null;
     }
 
     private static boolean isTracingProxy(DataSource dataSource) {
         for (Class<?> interfaceType : dataSource.getClass().getInterfaces()) {
             if (TRACED_DATA_SOURCE_MARKER.equals(interfaceType.getName())) {
                 return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isDelegatingWrapper(Class<?> type) {
-        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
-            String name = current.getName();
-            for (String wrapper : DELEGATING_WRAPPERS) {
-                if (wrapper.equals(name)) {
-                    return true;
-                }
             }
         }
         return false;

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/datasource/DelegatingDataSources.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/datasource/DelegatingDataSources.java
@@ -1,0 +1,124 @@
+package io.github.jdubois.bootui.autoconfigure.datasource;
+
+import java.lang.reflect.Method;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+
+/**
+ * Reflective access to Spring's two {@code DataSource} wrapper shapes — the single-target
+ * {@code org.springframework.jdbc.datasource.DelegatingDataSource} (whose best-known subclass is
+ * {@code LazyConnectionDataSourceProxy}) and the multi-target
+ * {@code org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource}.
+ *
+ * <p>Everything here is done <em>by class name</em>, never by import: {@code spring-boot-jdbc} (and therefore
+ * {@code spring-jdbc}) is an optional dependency of this module, so an always-loaded class must not link those
+ * types.</p>
+ *
+ * <p>Target resolution deliberately does not use the JDBC {@code unwrap} contract. {@code
+ * DelegatingDataSource.unwrap(DataSource.class)} returns the <em>wrapper</em> — {@code iface.isInstance(this)}
+ * holds — so it can never reveal the pool behind it. Only the public {@code getTargetDataSource()} and
+ * {@code getResolvedDataSources()} accessors can, and neither of them opens a connection.</p>
+ */
+public final class DelegatingDataSources {
+
+    private static final String DELEGATING = "org.springframework.jdbc.datasource.DelegatingDataSource";
+    private static final String ROUTING = "org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource";
+
+    private DelegatingDataSources() {}
+
+    /** Whether {@code type} is either of Spring's delegating or routing {@code DataSource} wrappers. */
+    public static boolean isWrapper(Class<?> type) {
+        return isSingleTarget(type) || isRouting(type);
+    }
+
+    /** Whether {@code type} forwards to exactly one target {@code DataSource} it exposes. */
+    public static boolean isSingleTarget(Class<?> type) {
+        return declaringClass(type, DELEGATING) != null;
+    }
+
+    /** Whether {@code type} routes to one of several targets chosen per call from a lookup key. */
+    public static boolean isRouting(Class<?> type) {
+        return declaringClass(type, ROUTING) != null;
+    }
+
+    /** The single target of a delegating wrapper, or {@code null} when it cannot be read. */
+    public static DataSource target(DataSource wrapper) {
+        return invokeDataSource(wrapper, DELEGATING, "getTargetDataSource");
+    }
+
+    /**
+     * Replaces the single target of a delegating wrapper in place, reporting whether it worked. Used by SQL Trace
+     * to insert its proxy underneath a wrapper that owns the only reference to a pool.
+     */
+    public static boolean replaceTarget(DataSource wrapper, DataSource replacement) {
+        Class<?> declaring = declaringClass(wrapper.getClass(), DELEGATING);
+        if (declaring == null) {
+            return false;
+        }
+        try {
+            Method setter = declaring.getMethod("setTargetDataSource", DataSource.class);
+            setter.invoke(wrapper, replacement);
+            return true;
+        } catch (ReflectiveOperationException | LinkageError | RuntimeException ex) {
+            return false;
+        }
+    }
+
+    /**
+     * The already-resolved targets of a routing wrapper, keyed by lookup key and ordered by the key's string form
+     * so the report is stable (Spring resolves them into a plain {@code HashMap}), with the default target added
+     * last under the {@code "default"} key when it is not one of them. Never calls the wrapper's own
+     * {@code determineCurrentLookupKey()}, which would need a live request thread.
+     */
+    public static Map<Object, DataSource> routingTargets(DataSource wrapper) {
+        Map<Object, DataSource> targets = new LinkedHashMap<>();
+        Class<?> declaring = declaringClass(wrapper.getClass(), ROUTING);
+        if (declaring == null) {
+            return targets;
+        }
+        try {
+            Object resolved = declaring.getMethod("getResolvedDataSources").invoke(wrapper);
+            if (resolved instanceof Map<?, ?> map) {
+                map.entrySet().stream()
+                        .filter(entry -> entry.getKey() != null && entry.getValue() instanceof DataSource)
+                        .sorted(Comparator.comparing(entry -> String.valueOf(entry.getKey())))
+                        .forEach(entry -> targets.put(entry.getKey(), (DataSource) entry.getValue()));
+            }
+        } catch (ReflectiveOperationException | LinkageError | RuntimeException ex) {
+            // A routing wrapper that will not describe its targets is reported through its own bean instead.
+        }
+        DataSource defaultTarget = invokeDataSource(wrapper, ROUTING, "getResolvedDefaultDataSource");
+        if (defaultTarget != null && !targets.containsValue(defaultTarget)) {
+            targets.put("default", defaultTarget);
+        }
+        return targets;
+    }
+
+    private static DataSource invokeDataSource(DataSource wrapper, String wrapperType, String method) {
+        Class<?> declaring = declaringClass(wrapper.getClass(), wrapperType);
+        if (declaring == null) {
+            return null;
+        }
+        try {
+            Object value = declaring.getMethod(method).invoke(wrapper);
+            return value instanceof DataSource dataSource && dataSource != wrapper ? dataSource : null;
+        } catch (ReflectiveOperationException | LinkageError | RuntimeException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * The class named {@code wrapperType} in {@code type}'s hierarchy, so reflective calls are made against the
+     * public Spring class rather than a possibly package-private application subclass.
+     */
+    private static Class<?> declaringClass(Class<?> type, String wrapperType) {
+        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
+            if (wrapperType.equals(current.getName())) {
+                return current;
+            }
+        }
+        return null;
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceDataSourceBeanPostProcessor.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceDataSourceBeanPostProcessor.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure.sqltrace;
 
+import io.github.jdubois.bootui.autoconfigure.datasource.DelegatingDataSources;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTracedDataSource;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTracingProxies;
@@ -40,18 +41,26 @@ import org.springframework.util.ClassUtils;
  * unregistered interface set throws an {@link Error} rather than a
  * {@code RuntimeException}; the catch is deliberately broad (only re-throwing
  * {@link VirtualMachineError}) so tracing simply stays off instead of breaking
- * startup. Spring's delegating/routing {@code DataSource} wrappers are skipped
- * because they forward to another {@code DataSource} bean that is wrapped on its
- * own, which would otherwise double-count executions.</p>
+ * startup.</p>
+ *
+ * <p>Spring's {@code DataSource} wrappers are never replaced, because the bean's
+ * concrete type is part of the application's contract and because their targets
+ * are usually beans that get wrapped on their own — wrapping both would
+ * double-count executions. A wrapper that owns the only reference to a pool is
+ * still traced, though: this post-processor runs after Spring's own
+ * {@code LazyConnectionDataSourceBeanPostProcessor}, so under
+ * {@code spring.datasource.connection-fetch=lazy} the single {@code dataSource}
+ * bean <em>is</em> a {@code LazyConnectionDataSourceProxy} and the pool inside it
+ * is not a bean at all. For a single-target wrapper whose target is neither
+ * already traced nor itself a wrapper, the target is wrapped and re-injected in
+ * place with {@code setTargetDataSource}, and the untouched wrapper bean is
+ * returned. Routing wrappers are left alone entirely: replacing their resolved
+ * targets means re-running {@code initialize()}, and those targets are in
+ * practice beans that are traced individually (issue #924).</p>
  */
 public final class SqlTraceDataSourceBeanPostProcessor implements BeanPostProcessor {
 
     private static final Logger log = LoggerFactory.getLogger(SqlTraceDataSourceBeanPostProcessor.class);
-
-    private static final String[] DELEGATING_WRAPPERS = {
-        "org.springframework.jdbc.datasource.DelegatingDataSource",
-        "org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource"
-    };
 
     private final ObjectProvider<SqlTraceRecorder> recorderProvider;
 
@@ -61,21 +70,22 @@ public final class SqlTraceDataSourceBeanPostProcessor implements BeanPostProces
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        if (!(bean instanceof DataSource dataSource)
-                || bean instanceof SqlTracedDataSource
-                || isDelegatingWrapper(bean.getClass())) {
+        if (!(bean instanceof DataSource dataSource) || bean instanceof SqlTracedDataSource) {
             return bean;
         }
         SqlTraceRecorder recorder = recorderProvider.getIfAvailable();
         if (recorder == null || !recorder.isEnabled()) {
             return bean;
         }
+        if (DelegatingDataSources.isRouting(dataSource.getClass())) {
+            return bean;
+        }
+        if (DelegatingDataSources.isSingleTarget(dataSource.getClass())) {
+            traceTargetInPlace(dataSource, beanName, recorder);
+            return bean;
+        }
         try {
-            Class<?>[] vendorInterfaces = vendorInterfaces(dataSource.getClass());
-            DataSource traced = vendorInterfaces.length == 0
-                    ? SqlTracingProxies.wrap(dataSource, recorder)
-                    : SqlTracingProxies.wrap(
-                            dataSource, recorder, SqlTracingProxies.dataSourceInterfaces(vendorInterfaces));
+            DataSource traced = trace(dataSource, recorder);
             recorder.registerDataSource(beanName);
             return traced;
         } catch (Throwable ex) {
@@ -86,6 +96,41 @@ public final class SqlTraceDataSourceBeanPostProcessor implements BeanPostProces
                     "BootUI could not enable SQL tracing for DataSource bean '{}'; leaving it unwrapped", beanName, ex);
             return bean;
         }
+    }
+
+    /**
+     * Traces the pool a single-target wrapper forwards to, when that pool is not a {@code DataSource} bean of its
+     * own and so would otherwise never be wrapped. A target that is already traced, or is itself one of Spring's
+     * wrappers, is left alone so no execution is recorded twice.
+     */
+    private static void traceTargetInPlace(DataSource wrapper, String beanName, SqlTraceRecorder recorder) {
+        DataSource target = DelegatingDataSources.target(wrapper);
+        if (target == null
+                || target instanceof SqlTracedDataSource
+                || DelegatingDataSources.isWrapper(target.getClass())) {
+            return;
+        }
+        try {
+            if (DelegatingDataSources.replaceTarget(wrapper, trace(target, recorder))) {
+                recorder.registerDataSource(beanName);
+            }
+        } catch (Throwable ex) {
+            if (ex instanceof VirtualMachineError vme) {
+                throw vme;
+            }
+            log.warn(
+                    "BootUI could not enable SQL tracing for the DataSource behind bean '{}'; leaving it unwrapped",
+                    beanName,
+                    ex);
+        }
+    }
+
+    private static DataSource trace(DataSource dataSource, SqlTraceRecorder recorder) {
+        Class<?>[] vendorInterfaces = vendorInterfaces(dataSource.getClass());
+        return vendorInterfaces.length == 0
+                ? SqlTracingProxies.wrap(dataSource, recorder)
+                : SqlTracingProxies.wrap(
+                        dataSource, recorder, SqlTracingProxies.dataSourceInterfaces(vendorInterfaces));
     }
 
     /**
@@ -104,17 +149,5 @@ public final class SqlTraceDataSourceBeanPostProcessor implements BeanPostProces
         Set<Class<?>> extra = new LinkedHashSet<>(ClassUtils.getAllInterfacesForClassAsSet(dataSourceClass));
         extra.removeAll(Arrays.asList(SqlTracingProxies.dataSourceInterfaces()));
         return extra.toArray(new Class<?>[0]);
-    }
-
-    private static boolean isDelegatingWrapper(Class<?> type) {
-        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
-            String name = current.getName();
-            for (String wrapper : DELEGATING_WRAPPERS) {
-                if (wrapper.equals(name)) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/databaseadvisor/LazyConnectionDataSourceAdvisorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/databaseadvisor/LazyConnectionDataSourceAdvisorTests.java
@@ -1,0 +1,81 @@
+package io.github.jdubois.bootui.autoconfigure.databaseadvisor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.autoconfigure.BootUiAutoConfiguration;
+import io.github.jdubois.bootui.autoconfigure.web.HikariDataSourceDiscovery;
+import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
+import io.github.jdubois.bootui.engine.sqltrace.SqlTracedDataSource;
+import java.sql.Connection;
+import java.sql.Statement;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+/**
+ * End-to-end reproduction of issue #924 against a real Spring Boot context.
+ *
+ * <p>With {@code spring.datasource.connection-fetch=lazy}, Spring Boot's own bean post-processor replaces the
+ * {@code dataSource} bean with a {@link LazyConnectionDataSourceProxy} and the Hikari pool inside it is no longer
+ * a bean at all. BootUI used to skip every Spring wrapper on the assumption that it forwards to another
+ * {@code DataSource} bean, so the Database Advisor reported "No DataSource beans were found to inspect." while
+ * the Connection Pools panel — which unwraps — happily showed the pool. This test pins all three behaviours
+ * together: the advisor scans, SQL Trace still wraps the pool, and pool discovery keeps working.</p>
+ */
+class LazyConnectionDataSourceAdvisorTests {
+
+    private final WebApplicationContextRunner runner = new WebApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(BootUiAutoConfiguration.class, DataSourceAutoConfiguration.class))
+            .withPropertyValues(
+                    "bootui.enabled=ON",
+                    "bootui.sql-trace.enabled=true",
+                    "spring.datasource.url=jdbc:h2:mem:bootui-issue-924;DB_CLOSE_DELAY=-1",
+                    "spring.datasource.driver-class-name=org.h2.Driver",
+                    "spring.datasource.connection-fetch=lazy");
+
+    @Test
+    void scansThePoolWrappedInALazyConnectionDataSourceProxy() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context.getBean(DataSource.class)).isInstanceOf(LazyConnectionDataSourceProxy.class);
+
+            var report = context.getBean(DatabaseAdvisorController.class).scan();
+
+            assertThat(report.scan().status()).isNotEqualTo("DISABLED");
+            assertThat(report.dataSourceNames()).containsExactly("dataSource");
+            assertThat(report.dataSources()).singleElement().satisfies(dataSource -> {
+                assertThat(dataSource.name()).isEqualTo("dataSource");
+                assertThat(dataSource.status()).isEqualTo("AVAILABLE");
+            });
+        });
+    }
+
+    @Test
+    void tracesThePoolWrappedInALazyConnectionDataSourceProxy() {
+        runner.run(context -> {
+            LazyConnectionDataSourceProxy lazy = (LazyConnectionDataSourceProxy) context.getBean(DataSource.class);
+            assertThat(lazy.getTargetDataSource()).isInstanceOf(SqlTracedDataSource.class);
+
+            try (Connection connection = lazy.getConnection();
+                    Statement statement = connection.createStatement()) {
+                statement.execute("SELECT 1");
+            }
+
+            SqlTraceRecorder recorder = context.getBean(SqlTraceRecorder.class);
+            assertThat(recorder.dataSourceNames()).contains("dataSource");
+            assertThat(recorder.recent())
+                    .extracting(SqlTraceRecorder.CapturedStatement::sql)
+                    .contains("SELECT 1");
+        });
+    }
+
+    @Test
+    void keepsResolvingTheHikariPoolBehindTheProxy() {
+        runner.run(context -> assertThat(HikariDataSourceDiscovery.discover(context.getBeanFactory()))
+                .singleElement()
+                .satisfies(entry -> assertThat(entry.beanName()).isEqualTo("dataSource")));
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/databaseadvisor/SpringDatabaseAdvisorDataSourceProviderTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/databaseadvisor/SpringDatabaseAdvisorDataSourceProviderTests.java
@@ -8,17 +8,22 @@ import io.github.jdubois.bootui.spi.NamedDataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.jdbc.datasource.DelegatingDataSource;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 
 /**
  * Discovery rules for the Spring binding: a wrapped datasource must be introspected exactly once, under one
- * name, because every duplicate would double every finding the Database Advisor reports.
+ * name, because every duplicate would double every finding the Database Advisor reports — and a wrapper that
+ * owns the only reference to a pool must still be introspected rather than skipped (issue #924).
  */
 class SpringDatabaseAdvisorDataSourceProviderTests {
 
@@ -51,11 +56,40 @@ class SpringDatabaseAdvisorDataSourceProviderTests {
                 .containsExactly("dataSource");
     }
 
+    /**
+     * Spring Boot's {@code spring.datasource.connection-fetch=lazy} replaces the {@code dataSource} bean with a
+     * {@link LazyConnectionDataSourceProxy}, so the pool is not a bean at all and skipping the wrapper left the
+     * advisor with nothing to inspect.
+     */
+    @Test
+    void introspectsALazyConnectionProxyWhoseTargetIsNotABeanOfItsOwn() {
+        DataSource pool = new StubDataSource();
+        LazyConnectionDataSourceProxy lazy = new LazyConnectionDataSourceProxy(pool);
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.registerSingleton("dataSource", lazy);
+
+        List<NamedDataSource> dataSources = providerFor(factory).dataSources();
+
+        assertThat(dataSources).hasSize(1);
+        assertThat(dataSources.get(0).name()).isEqualTo("dataSource");
+        assertThat(dataSources.get(0).dataSource()).isSameAs(lazy);
+    }
+
+    @Test
+    void collapsesNestedWrappersOverTheSamePoolToOneDatasource() {
+        DataSource pool = new StubDataSource();
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.registerSingleton("dataSource", new DelegatingDataSource(new LazyConnectionDataSourceProxy(pool)));
+
+        assertThat(providerFor(factory).dataSources())
+                .extracting(NamedDataSource::name)
+                .containsExactly("dataSource");
+    }
+
     @Test
     void introspectsATracedDataSourceAndItsUnderlyingPoolOnlyOnce() {
         DataSource real = new StubDataSource();
-        DataSource traced =
-                SqlTracingProxies.wrap(real, new SqlTraceRecorder(false, false, false, false, 100, 100, 256, 128, 5));
+        DataSource traced = SqlTracingProxies.wrap(real, recorder());
         DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
         factory.registerSingleton("dataSource", traced);
         factory.registerSingleton("rawDataSource", real);
@@ -64,6 +98,78 @@ class SpringDatabaseAdvisorDataSourceProviderTests {
 
         assertThat(dataSources).hasSize(1);
         assertThat(dataSources.get(0).name()).isEqualTo("dataSource");
+    }
+
+    /** SQL Trace inserts its proxy underneath a lazy wrapper, which must not make the pool look like a second one. */
+    @Test
+    void introspectsATracedPoolBehindALazyProxyOnlyOnce() {
+        DataSource pool = new StubDataSource();
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.registerSingleton("rawDataSource", pool);
+        factory.registerSingleton(
+                "dataSource", new LazyConnectionDataSourceProxy(SqlTracingProxies.wrap(pool, recorder())));
+
+        assertThat(providerFor(factory).dataSources())
+                .extracting(NamedDataSource::name)
+                .containsExactly("rawDataSource");
+    }
+
+    @Test
+    void expandsARoutingDataSourceIntoItsResolvedTargets() {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.registerSingleton("routingDataSource", routing(new StubDataSource(), new StubDataSource()));
+
+        assertThat(providerFor(factory).dataSources())
+                .extracting(NamedDataSource::name)
+                .containsExactly("routingDataSource[primary]", "routingDataSource[replica]");
+    }
+
+    @Test
+    void doesNotDuplicateRoutingTargetsThatAreBeansOfTheirOwn() {
+        DataSource primary = new StubDataSource();
+        DataSource replica = new StubDataSource();
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.registerSingleton("primaryDataSource", primary);
+        factory.registerSingleton("replicaDataSource", replica);
+        factory.registerSingleton("routingDataSource", routing(primary, replica));
+
+        assertThat(providerFor(factory).dataSources())
+                .extracting(NamedDataSource::name)
+                .containsExactly("primaryDataSource", "replicaDataSource");
+    }
+
+    /**
+     * A wrapper that will not name its target is reported, so the scan explains a read failure instead of claiming
+     * the application has no {@code DataSource} bean.
+     */
+    @Test
+    void reportsAWrapperWhoseTargetCannotBeResolved() {
+        DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+        factory.registerSingleton("dataSource", new DelegatingDataSource());
+
+        assertThat(providerFor(factory).dataSources())
+                .extracting(NamedDataSource::name)
+                .containsExactly("dataSource");
+    }
+
+    private static SqlTraceRecorder recorder() {
+        return new SqlTraceRecorder(false, false, false, false, 100, 100, 256, 128, 5);
+    }
+
+    private static AbstractRoutingDataSource routing(DataSource primary, DataSource replica) {
+        Map<Object, Object> targets = new LinkedHashMap<>();
+        targets.put("primary", primary);
+        targets.put("replica", replica);
+        AbstractRoutingDataSource routing = new AbstractRoutingDataSource() {
+            @Override
+            protected Object determineCurrentLookupKey() {
+                return "primary";
+            }
+        };
+        routing.setTargetDataSources(targets);
+        routing.setDefaultTargetDataSource(primary);
+        routing.afterPropertiesSet();
+        return routing;
     }
 
     /** Minimal {@link ObjectProvider} over a fixed bean factory. */

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceDataSourceBeanPostProcessorTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/sqltrace/SqlTraceDataSourceBeanPostProcessorTests.java
@@ -6,16 +6,21 @@ import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTracedDataSource;
 import java.io.PrintWriter;
 import java.sql.Connection;
+import java.util.Map;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.jdbc.datasource.DelegatingDataSource;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 
 /**
  * Verifies that {@link SqlTraceDataSourceBeanPostProcessor} preserves a vendor-specific
  * {@code DataSource} interface (such as Oracle UCP's {@code PoolDataSource}) on the traced proxy, so
  * by-type/by-interface injection of the vendor contract keeps resolving after SQL tracing wraps the
- * bean (see issue #762).
+ * bean (see issue #762) — and that a Spring wrapper owning the only reference to a pool still gets that
+ * pool traced, in place, without replacing the bean (see issue #924).
  */
 class SqlTraceDataSourceBeanPostProcessorTests {
 
@@ -45,6 +50,72 @@ class SqlTraceDataSourceBeanPostProcessorTests {
 
     private static SqlTraceRecorder enabledRecorder() {
         return new SqlTraceRecorder(true, true, true, false, 100, 100, 256, 128, 5);
+    }
+
+    /**
+     * Under {@code spring.datasource.connection-fetch=lazy} this post-processor sees the
+     * {@link LazyConnectionDataSourceProxy} Spring Boot already substituted, and the pool inside it is not a bean
+     * of its own — so tracing has to be inserted underneath the wrapper rather than around it (issue #924).
+     */
+    @Test
+    void tracesThePoolInsideALazyConnectionProxyAndLeavesTheBeanItself() {
+        SqlTraceRecorder recorder = enabledRecorder();
+        SqlTraceDataSourceBeanPostProcessor bpp = new SqlTraceDataSourceBeanPostProcessor(provider(recorder));
+        LazyConnectionDataSourceProxy lazy = new LazyConnectionDataSourceProxy(new VendorPoolDataSource());
+
+        Object result = bpp.postProcessAfterInitialization(lazy, "dataSource");
+
+        assertThat(result).isSameAs(lazy);
+        assertThat(lazy.getTargetDataSource()).isInstanceOf(SqlTracedDataSource.class);
+        assertThat(recorder.dataSourceNames()).contains("dataSource");
+    }
+
+    @Test
+    void leavesAWrapperAloneWhenItsTargetIsAlreadyTraced() {
+        SqlTraceRecorder recorder = enabledRecorder();
+        SqlTraceDataSourceBeanPostProcessor bpp = new SqlTraceDataSourceBeanPostProcessor(provider(recorder));
+        DataSource traced = (DataSource) bpp.postProcessAfterInitialization(new VendorPoolDataSource(), "dataSource");
+        DelegatingDataSource wrapper = new DelegatingDataSource(traced);
+
+        Object result = bpp.postProcessAfterInitialization(wrapper, "delegatingDataSource");
+
+        assertThat(result).isSameAs(wrapper);
+        assertThat(wrapper.getTargetDataSource()).isSameAs(traced);
+        assertThat(recorder.dataSourceNames()).doesNotContain("delegatingDataSource");
+    }
+
+    @Test
+    void leavesARoutingDataSourceAndItsTargetsAlone() {
+        SqlTraceRecorder recorder = enabledRecorder();
+        SqlTraceDataSourceBeanPostProcessor bpp = new SqlTraceDataSourceBeanPostProcessor(provider(recorder));
+        DataSource primary = new VendorPoolDataSource();
+        AbstractRoutingDataSource routing = new AbstractRoutingDataSource() {
+            @Override
+            protected Object determineCurrentLookupKey() {
+                return "primary";
+            }
+        };
+        routing.setTargetDataSources(Map.of("primary", primary));
+        routing.afterPropertiesSet();
+
+        Object result = bpp.postProcessAfterInitialization(routing, "routingDataSource");
+
+        assertThat(result).isSameAs(routing);
+        assertThat(routing.getResolvedDataSources().get("primary")).isSameAs(primary);
+        assertThat(recorder.dataSourceNames()).doesNotContain("routingDataSource");
+    }
+
+    @Test
+    void leavesAWrapperUntouchedWhenTracingDisabled() {
+        SqlTraceRecorder recorder = new SqlTraceRecorder(false, false, false, false, 100, 100, 256, 128, 5);
+        SqlTraceDataSourceBeanPostProcessor bpp = new SqlTraceDataSourceBeanPostProcessor(provider(recorder));
+        DataSource pool = new VendorPoolDataSource();
+        LazyConnectionDataSourceProxy lazy = new LazyConnectionDataSourceProxy(pool);
+
+        Object result = bpp.postProcessAfterInitialization(lazy, "dataSource");
+
+        assertThat(result).isSameAs(lazy);
+        assertThat(lazy.getTargetDataSource()).isSameAs(pool);
     }
 
     private static <T> ObjectProvider<T> provider(T value) {

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1746,8 +1746,13 @@ Features:
   foreign key matching tolerates the physical constraint's own column order but requires the same child-to-parent
   pairing, and an association explicitly declaring `@ForeignKey(ConstraintMode.NO_CONSTRAINT)` is excluded from the
   missing-constraint check.
-- Discover datasources through the same proxy-aware mechanism as Database Connection Pools and SQL Trace so delegating
-  or routing wrappers do not cause the same physical datasource to be scanned twice.
+- Discover datasources through the same proxy-aware mechanism as Database Connection Pools and SQL Trace, resolving
+  Spring's delegating and routing `DataSource` wrappers down to the physical pool behind them so the same datasource is
+  never scanned twice. A wrapper is skipped only when the pool it forwards to is a bean of its own; when the wrapper
+  owns the only reference to that pool — as `spring.datasource.connection-fetch=lazy` does with
+  `LazyConnectionDataSourceProxy` — the wrapper itself is introspected, and a routing wrapper is expanded into its
+  resolved targets named `beanName[lookupKey]`. A wrapper that cannot describe its target is reported as an unreadable
+  datasource rather than dropped.
 - Report findings by severity and rule, with bounded sample evidence and remediation guidance, and cache the latest
   report until the next explicit scan.
 

--- a/docs/features/advisors.md
+++ b/docs/features/advisors.md
@@ -174,9 +174,12 @@ The Database panel introspects the physical schema of every discovered applicati
 of deterministic, low-false-positive structural checks. It never executes DDL and never queries application data. See
 [DATABASE-ADVISOR-CHECKS.md](../DATABASE-ADVISOR-CHECKS.md) for the full catalogue and remediation links.
 
-It reuses the same proxy-aware datasource discovery as Database Connection Pools and SQL Trace, skipping Spring's
-delegating/routing `DataSource` wrappers and de-duplicating by the physical pool behind BootUI's own SQL Trace proxy, so
-a wrapped datasource is never introspected twice.
+It reuses the same proxy-aware datasource discovery as Database Connection Pools and SQL Trace, de-duplicating by the
+physical pool behind BootUI's own SQL Trace proxy so a wrapped datasource is never introspected twice. Spring's
+delegating and routing `DataSource` wrappers are resolved rather than ignored: one is skipped only when the pool it
+forwards to is a bean of its own, so the pool inside a `LazyConnectionDataSourceProxy` (what
+`spring.datasource.connection-fetch=lazy` installs) is still inspected, and a routing datasource is expanded into its
+resolved targets, named `beanName[lookupKey]`.
 
 ::: details The generic structural checks
 - A missing primary key.

--- a/docs/features/database.md
+++ b/docs/features/database.md
@@ -46,7 +46,10 @@ BootUI transparently wraps each `DataSource` bean and intercepts statement execu
 `Connection`/`Statement`/`PreparedStatement`/`CallableStatement` objects, recording the SQL text, statement type, SQL
 category (`SELECT`/`INSERT`/`UPDATE`/`DELETE`/`DDL`/`OTHER`), wall-clock duration, affected-row counts, batch size,
 originating connection, executing thread, the call site that triggered it (when call-site capture is enabled), and any
-failure. Spring's delegating/routing `DataSource` wrappers are skipped so executions are not double-counted, and wrapping
+failure. A Spring `DataSource` wrapper is never replaced, because its concrete type is part of your application's
+contract: instead, when it owns the only reference to a pool — as `spring.datasource.connection-fetch=lazy` does with
+`LazyConnectionDataSourceProxy` — the pool inside it is traced in place, and when its target is a bean that was traced
+on its own it is left alone so executions are not double-counted. Wrapping
 **fails open**: if a `DataSource` cannot be proxied it is left untouched so application database access is never
 compromised.
 


### PR DESCRIPTION
Fixes #924.

## The bug

Spring Boot 4.1's `spring.datasource.connection-fetch: lazy` installs a bean post-processor (order `0`) that **replaces** the `dataSource` bean with a `LazyConnectionDataSourceProxy`. The Hikari pool inside it is not a bean at all — there is exactly one `DataSource` bean and it is a `DelegatingDataSource` subclass.

Two BootUI components blanket-skipped `DelegatingDataSource` / `AbstractRoutingDataSource` on the assumption that a wrapper always forwards to *another* `DataSource` bean discovered on its own. That assumption no longer holds:

- **Database Advisor** reported `DISABLED, "No DataSource beans were found to inspect."` while the Connection Pools panel — which unwraps — happily showed `HikariPool-1` from the very same bean. This is the reported symptom.
- **SQL Trace** hit the same wall. Its post-processor declares no `Ordered`, so it runs *after* Spring's lazy BPP, sees the proxy, and skips it: **statements were silently not recorded at all** under `connection-fetch: lazy`. Found while scoping the fix and included here at the maintainer's request.

## The fix

A new `DelegatingDataSources` helper reads Spring's public accessors (`getTargetDataSource`, `getResolvedDataSources`, `setTargetDataSource`) **by class name via reflection** — `spring-boot-jdbc` is `optional` in this module, so an always-loaded class must not link those types. It deliberately does not use JDBC `unwrap`: `DelegatingDataSource.unwrap(DataSource.class)` returns *the wrapper* (`iface.isInstance(this)` holds), so it can never reveal the pool.

**Advisor discovery** now runs in two passes — plain beans first, so a wrapper never claims a name a real bean could have carried, then wrappers *resolved* rather than ignored:

| Case | Before | After |
| --- | --- | --- |
| Wrapper over a pool that is its own bean | skipped | skipped (unchanged — that was the case it was written for) |
| Wrapper owning the only reference to a pool | **dropped** | the wrapper is introspected under its bean name |
| Routing datasource with inline targets | **dropped** | expanded to `beanName[lookupKey]`, deduped against beans |
| Wrapper that will not describe its target | **dropped** | reported as an unreadable datasource |

De-duplication is still by *physical* identity, now resolved recursively (depth-bounded) through BootUI's SQL Trace proxy and nested single-target wrappers, so a wrapped datasource is never introspected twice — a duplicate would double every finding in the report.

Because an unresolvable wrapper is now surfaced instead of dropped, the scanner's existing `ERROR` path covers it and `"No DataSource beans were found"` is reserved for a genuinely empty bean set. That satisfies the issue's second ask without adding a status.

**SQL Trace** keeps the BPP unordered — reordering it would make later `instanceof HikariDataSource` post-processors (`HikariJdbcConnectionDetailsBeanPostProcessor`, `DataSourceCheckpointRestoreConfiguration$Hikari`) stop matching. Instead it wraps the *target* of a single-target wrapper and re-injects it with `setTargetDataSource`, returning the original bean untouched so its concrete type, by-type injection, and Spring Boot's own pool lookups keep resolving. A target that is already traced, or is itself a wrapper, is left alone so nothing is double-counted. Routing wrappers stay untouched (replacing their resolved targets means re-running `initialize()`, and those targets are in practice beans traced individually); the asymmetry with the advisor is documented in the class Javadoc.

Resulting graph: `dataSource` = `LazyConnectionDataSourceProxy` -> `SqlTracedDataSource` -> `HikariDataSource`, which keeps `unwrap(HikariDataSource.class)` working for the pool panel.

## Verification

`LazyConnectionDataSourceAdvisorTests` boots a real context with H2 + Hikari and `spring.datasource.connection-fetch=lazy`, then pins all three behaviours together: the advisor scans and reports `dataSource` as `AVAILABLE`, a `SELECT 1` executed through the lazy proxy lands in the SQL Trace recorder, and `HikariDataSourceDiscovery` still resolves the pool.

Against the pre-fix `src/main`, the new and existing tests produce **7 failures**; with the fix, 0. Full reactor build green (`bootui-core` 368, `bootui-spring-autoconfigure` 1863), `spotless:check` and frontend `format:check` clean.

## Scope

No DTO, JSON contract, panel-availability, MCP, or UI change — the Quarkus provider and the WebFlux contract are untouched (WebFlux shares this autoconfigure module and gets the fix for free). Docs updated in `SPECIFICATION.md`, `features/advisors.md`, `features/database.md`, plus a `CHANGELOG.md` Unreleased entry.