### PR TITLE
Add per-client MCP snippets and the bearer-header rule to the MCP panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **The MCP Server panel now shows a configuration snippet per client, and says out loud that a non-loopback agent
+  needs the bearer header.** The card carried a single VS Code `servers` block, which is not the shape Claude Code or
+  Cursor read: both use `mcpServers`, and Claude Code's normal entry point is `claude mcp add --transport http`. There
+  are now four tabs — VS Code, Claude Code, Cursor, and other clients — each with the shape that client actually
+  accepts. The header requirement was worse than undocumented: the panel decided "remote" from the browser's own
+  hostname, which is exactly wrong for an app in a container reached through a published port, where the page loads from
+  `localhost` while the agent's calls arrive from the Docker gateway and answer `401`. That silent guess is replaced by
+  an **Agent connects from another host or container** switch — still pre-set from the hostname, but now correctable
+  in one click — which adds `Authorization: Bearer …` to every snippet, next to a note explaining that the token
+  regenerates at each start and is logged once unless `bootui.authentication.token` is set. The panel never renders the
+  token itself. `docs/AI-AGENTS.md`, the MCP Server feature page, and the `bootui` agent skill carry the same
+  four shapes and the same header rule ([#928](https://github.com/jdubois/boot-ui/issues/928)).
+
 ### Fixed
 
 - **The Spring advisor and the pentest panel no longer report BootUI's own actuator default as a host

--- a/bootui-quarkus-sample-app/e2e/tests/mcp-server.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/mcp-server.spec.js
@@ -25,4 +25,21 @@ test.describe('MCP Server (Quarkus)', () => {
     await expect(toggle).not.toBeChecked()
     await expect(page.getByText('Server disabled — tools are not reachable')).toBeVisible()
   })
+
+  test('offers the same per-client configuration snippets and bearer-header switch', async ({openView, page}) => {
+    await openView('mcp-server', 'MCP Server')
+
+    await expect(page.getByRole('tablist', {name: 'MCP client'})).toHaveCount(1)
+    await expect(page.locator('#mcp-client-vscode-panel .config-block')).toContainText('"servers"')
+
+    await page.getByRole('tab', {name: 'Claude Code'}).click()
+    const claudeSnippet = page.locator('#mcp-client-claude-panel .config-block')
+    await expect(claudeSnippet).toContainText('claude mcp add --transport http bootui')
+    await expect(claudeSnippet).toContainText('/bootui/api/mcp')
+    await expect(claudeSnippet).not.toContainText('--header')
+
+    await page.locator('#mcp-remote-agent').check()
+    await expect(claudeSnippet).toContainText('--header "Authorization:')
+    await expect(page.getByText('bootui.authentication.token')).toBeVisible()
+  })
 })

--- a/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-webflux/webflux-smoke.spec.js
@@ -103,6 +103,27 @@ test.describe('BootUI on Spring WebFlux', () => {
     }
   })
 
+  test('MCP Server offers the per-client configuration snippets and the bearer-header switch', async ({page}) => {
+    await page.goto('/bootui/#/mcp-server')
+    await expect(
+      page
+        .locator('main h2')
+        .filter({hasText: /^MCP Server/})
+        .first()
+    ).toBeVisible({timeout: 15_000})
+
+    await expect(page.getByRole('tablist', {name: 'MCP client'})).toHaveCount(1)
+    await expect(page.locator('#mcp-client-vscode-panel .config-block')).toContainText('"servers"')
+
+    await page.getByRole('tab', {name: 'Claude Code'}).click()
+    const claudeSnippet = page.locator('#mcp-client-claude-panel .config-block')
+    await expect(claudeSnippet).toContainText('claude mcp add --transport http bootui')
+    await expect(claudeSnippet).not.toContainText('--header')
+
+    await page.locator('#mcp-remote-agent').check()
+    await expect(claudeSnippet).toContainText('--header "Authorization:')
+  })
+
   test("Live Activity's Live flow map renders the same contract on the reactive stack", async ({
     page,
     request,

--- a/bootui-spring-sample-app/e2e/tests/mcp-server.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/mcp-server.spec.js
@@ -1,0 +1,68 @@
+// @ts-check
+import {expect, test} from './fixtures.js'
+
+/**
+ * The MCP Server panel's client-configuration card is shared UI: one tab per MCP client, each with the
+ * shape that client actually accepts, plus the switch that adds BootUI's bearer header for an agent that
+ * does not reach the app over loopback. This spec never touches the server toggle, so it is safe to run
+ * alongside the suites that do.
+ */
+test.describe('MCP Server client configuration', () => {
+  test('offers one snippet per client and moves between them from the keyboard', async ({openView}) => {
+    const page = await openView('mcp-server', 'MCP Server')
+
+    const tablist = page.getByRole('tablist', {name: 'MCP client'})
+    await expect(tablist).toHaveCount(1)
+    const vsCode = page.getByRole('tab', {name: 'VS Code'})
+    const claude = page.getByRole('tab', {name: 'Claude Code'})
+    const other = page.getByRole('tab', {name: 'Other clients'})
+
+    // Exactly one tab is selected and reachable with Tab; the rest are removed from the tab order.
+    await expect(page.getByRole('tab', {selected: true})).toHaveCount(1)
+    await expect(vsCode).toHaveAttribute('aria-selected', 'true')
+    await expect(claude).toHaveAttribute('tabindex', '-1')
+
+    const vsCodeSnippet = page.locator('#mcp-client-vscode-panel .config-block')
+    await expect(vsCodeSnippet).toBeVisible()
+    await expect(vsCodeSnippet).toContainText('"servers"')
+    await expect(vsCodeSnippet).toContainText('/bootui/api/mcp')
+
+    await vsCode.focus()
+    await page.keyboard.press('ArrowRight')
+    await expect(claude).toHaveAttribute('aria-selected', 'true')
+    await expect(claude).toBeFocused()
+
+    const claudeSnippet = page.locator('#mcp-client-claude-panel .config-block')
+    await expect(claudeSnippet).toBeVisible()
+    await expect(claudeSnippet).toContainText('claude mcp add --transport http bootui')
+    await expect(vsCodeSnippet).toBeHidden()
+
+    await page.keyboard.press('End')
+    await expect(other).toHaveAttribute('aria-selected', 'true')
+    await expect(page.locator('#mcp-client-json-panel .config-block')).toContainText('"mcpServers"')
+    await expect(page.getByRole('tab', {selected: true})).toHaveCount(1)
+
+    // Cursor keys a remote server on `url` alone.
+    await page.getByRole('tab', {name: 'Cursor'}).click()
+    const cursorSnippet = page.locator('#mcp-client-cursor-panel .config-block')
+    await expect(cursorSnippet).toContainText('"mcpServers"')
+    await expect(cursorSnippet).not.toContainText('"type"')
+  })
+
+  test('adds the bearer header to every snippet for an agent that is not on loopback', async ({openView}) => {
+    const page = await openView('mcp-server', 'MCP Server')
+
+    const remoteAgent = page.locator('#mcp-remote-agent')
+    await expect(remoteAgent).not.toBeChecked()
+    await expect(page.locator('#mcp-client-vscode-panel .config-block')).not.toContainText('Authorization')
+
+    await remoteAgent.check()
+
+    await expect(page.locator('#mcp-client-vscode-panel .config-block')).toContainText('"Authorization"')
+    await expect(page.locator('#mcp-client-claude-panel .config-block')).toContainText('--header "Authorization:')
+    await expect(page.locator('#mcp-client-cursor-panel .config-block')).toContainText('"Authorization"')
+    await expect(page.locator('#mcp-client-json-panel .config-block')).toContainText('"Authorization"')
+
+    await expect(page.getByText('bootui.authentication.token')).toBeVisible()
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/McpServer.test.js
+++ b/bootui-ui/src/main/frontend/src/views/McpServer.test.js
@@ -41,17 +41,24 @@ function mcpStatus(overrides = {}) {
   }
 }
 
+function snippetFor(wrapper, client) {
+  return wrapper.get(`#mcp-client-${client}-panel .config-block`).text()
+}
+
 describe('McpServer', () => {
   let wrapper
+  let originalLocation
 
   beforeEach(() => {
     vi.useFakeTimers()
+    originalLocation = window.location
     Object.defineProperty(document, 'visibilityState', {configurable: true, value: 'visible'})
   })
 
   afterEach(() => {
     wrapper?.unmount()
     wrapper = null
+    Object.defineProperty(window, 'location', {configurable: true, value: originalLocation})
     vi.useRealTimers()
     vi.unstubAllGlobals()
   })
@@ -104,7 +111,7 @@ describe('McpServer', () => {
     expect(wrapper.get('#mcp-enabled-toggle').element.checked).toBe(true)
   })
 
-  it('renders a copyable MCP client configuration', async () => {
+  it('renders a copyable MCP client configuration for each supported client', async () => {
     const writeText = vi.fn().mockResolvedValue()
     vi.stubGlobal('navigator', {clipboard: {writeText}})
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(mcpStatus())))
@@ -113,11 +120,23 @@ describe('McpServer', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('Client configuration')
-    const block = wrapper.get('.config-block').text()
-    expect(block).toContain('"servers"')
-    expect(block).toContain('"bootui"')
-    expect(block).toContain('"type": "http"')
-    expect(block).toContain('/bootui/api/mcp')
+
+    const vsCode = snippetFor(wrapper, 'vscode')
+    expect(vsCode).toContain('"servers"')
+    expect(vsCode).toContain('"bootui"')
+    expect(vsCode).toContain('"type": "http"')
+    expect(vsCode).toContain('/bootui/api/mcp')
+
+    expect(snippetFor(wrapper, 'claude')).toContain('claude mcp add --transport http bootui')
+    expect(snippetFor(wrapper, 'claude')).toContain('/bootui/api/mcp')
+
+    const cursor = snippetFor(wrapper, 'cursor')
+    expect(cursor).toContain('"mcpServers"')
+    expect(cursor).not.toContain('"type"')
+
+    const generic = snippetFor(wrapper, 'json')
+    expect(generic).toContain('"mcpServers"')
+    expect(generic).toContain('"type": "http"')
 
     const copyButton = wrapper.findAll('button').find((b) => b.text().includes('Copy'))
     await copyButton.trigger('click')
@@ -128,7 +147,76 @@ describe('McpServer', () => {
     expect(writeText.mock.calls[0][0]).toContain('/bootui/api/mcp')
   })
 
-  it('adds bearer authorization guidance for remote access', async () => {
+  it('copies the snippet of the selected client tab', async () => {
+    const writeText = vi.fn().mockResolvedValue()
+    vi.stubGlobal('navigator', {clipboard: {writeText}})
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(mcpStatus())))
+
+    wrapper = mount(McpServer)
+    await flushPromises()
+
+    await wrapper.get('#mcp-client-claude-tab').trigger('click')
+    const copyButton = wrapper.findAll('button').find((b) => b.text().includes('Copy'))
+    await copyButton.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('#mcp-client-claude-tab').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('#mcp-client-vscode-tab').attributes('aria-selected')).toBe('false')
+    expect(writeText.mock.calls[0][0]).toContain('claude mcp add')
+  })
+
+  it('moves between client tabs with the arrow keys', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(mcpStatus())))
+
+    wrapper = mount(McpServer)
+    await flushPromises()
+
+    await wrapper.get('#mcp-client-vscode-tab').trigger('keydown', {key: 'ArrowRight'})
+    expect(wrapper.get('#mcp-client-claude-tab').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('#mcp-client-claude-tab').attributes('tabindex')).toBe('0')
+    expect(wrapper.get('#mcp-client-vscode-tab').attributes('tabindex')).toBe('-1')
+
+    await wrapper.get('#mcp-client-claude-tab').trigger('keydown', {key: 'End'})
+    expect(wrapper.get('#mcp-client-json-tab').attributes('aria-selected')).toBe('true')
+
+    await wrapper.get('#mcp-client-json-tab').trigger('keydown', {key: 'ArrowRight'})
+    expect(wrapper.get('#mcp-client-vscode-tab').attributes('aria-selected')).toBe('true')
+  })
+
+  it('adds the bearer header to every snippet when the agent is not on loopback', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(mcpStatus())))
+
+    wrapper = mount(McpServer)
+    await flushPromises()
+
+    expect(snippetFor(wrapper, 'vscode')).not.toContain('Authorization')
+    expect(snippetFor(wrapper, 'claude')).not.toContain('--header')
+
+    await wrapper.get('#mcp-remote-agent').setValue(true)
+
+    expect(snippetFor(wrapper, 'vscode')).toContain('"Authorization": "Bearer <BootUI authentication token>"')
+    expect(snippetFor(wrapper, 'cursor')).toContain('"Authorization": "Bearer <BootUI authentication token>"')
+    expect(snippetFor(wrapper, 'json')).toContain('"Authorization": "Bearer <BootUI authentication token>"')
+    expect(snippetFor(wrapper, 'claude')).toContain('--header "Authorization: Bearer <BootUI authentication token>"')
+
+    await wrapper.get('#mcp-remote-agent').setValue(false)
+
+    expect(snippetFor(wrapper, 'vscode')).not.toContain('Authorization')
+    expect(snippetFor(wrapper, 'claude')).not.toContain('--header')
+  })
+
+  it('always explains that a non-loopback agent needs the bearer header', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(mcpStatus())))
+
+    wrapper = mount(McpServer)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Agent connects from another host or container')
+    expect(wrapper.text()).toContain('must send BootUI')
+    expect(wrapper.text()).toContain('bootui.authentication.token')
+  })
+
+  it('pre-selects the bearer header when the browser itself is remote', async () => {
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: {origin: 'https://devbox.example.com', hostname: 'devbox.example.com'}
@@ -138,7 +226,8 @@ describe('McpServer', () => {
     wrapper = mount(McpServer)
     await flushPromises()
 
-    expect(wrapper.get('.config-block').text()).toContain('"Authorization": "Bearer <bootui authentication token>"')
+    expect(wrapper.get('#mcp-remote-agent').element.checked).toBe(true)
+    expect(snippetFor(wrapper, 'vscode')).toContain('"Authorization": "Bearer <BootUI authentication token>"')
   })
 
   it('does not toggle and warns when the panel is read-only', async () => {

--- a/bootui-ui/src/main/frontend/src/views/McpServer.vue
+++ b/bootui-ui/src/main/frontend/src/views/McpServer.vue
@@ -31,26 +31,80 @@ const endpointUrl = computed(() => {
   return origin + path
 })
 
-const remoteAccess = computed(() => {
+function browserIsRemote() {
   if (typeof window === 'undefined' || !window.location) return false
   return !['localhost', '127.0.0.1', '::1', '[::1]'].includes(window.location.hostname)
+}
+
+const AUTHORIZATION_VALUE = 'Bearer <BootUI authentication token>'
+
+const clients = [
+  {id: 'vscode', label: 'VS Code', file: '.vscode/mcp.json'},
+  {id: 'claude', label: 'Claude Code', file: 'a terminal in your project'},
+  {id: 'cursor', label: 'Cursor', file: '~/.cursor/mcp.json'},
+  {id: 'json', label: 'Other clients', file: '.mcp.json'}
+]
+
+const activeClient = ref('vscode')
+// The browser's own hostname only proves how *this page* was reached: a published container port is
+// reached on localhost while the agent still arrives from a non-loopback source. Seed the switch from
+// that guess, then let the user correct it.
+const remoteAgent = ref(browserIsRemote())
+
+const serverName = computed(() => status.value?.serverName || 'bootui')
+
+function serverEntry(withType) {
+  const server = {}
+  if (withType) server.type = status.value?.transport || 'http'
+  server.url = endpointUrl.value
+  if (remoteAgent.value) server.headers = {Authorization: AUTHORIZATION_VALUE}
+  return server
+}
+
+const vsCodeConfig = computed(() => JSON.stringify({servers: {[serverName.value]: serverEntry(true)}}, null, 2))
+
+// Cursor keys a remote server on `url` and does not use `type`.
+const cursorConfig = computed(() => JSON.stringify({mcpServers: {[serverName.value]: serverEntry(false)}}, null, 2))
+
+const genericConfig = computed(() => JSON.stringify({mcpServers: {[serverName.value]: serverEntry(true)}}, null, 2))
+
+const claudeCommand = computed(() => {
+  const transport = status.value?.transport || 'http'
+  const command = `claude mcp add --transport ${transport} ${serverName.value} ${endpointUrl.value}`
+  if (!remoteAgent.value) return command
+  return `${command} \\\n  --header "Authorization: ${AUTHORIZATION_VALUE}"`
 })
 
-const mcpConfigJson = computed(() => {
-  const server = {
-    type: status.value?.transport || 'http',
-    url: endpointUrl.value
-  }
-  if (remoteAccess.value) {
-    server.headers = {Authorization: 'Bearer <bootui authentication token>'}
-  }
-  const config = {
-    servers: {
-      [status.value?.serverName || 'bootui']: server
-    }
-  }
-  return JSON.stringify(config, null, 2)
-})
+const snippets = computed(() => ({
+  vscode: vsCodeConfig.value,
+  claude: claudeCommand.value,
+  cursor: cursorConfig.value,
+  json: genericConfig.value
+}))
+
+const activeSnippet = computed(() => snippets.value[activeClient.value])
+
+function clientTabId(id) {
+  return `mcp-client-${id}-tab`
+}
+
+function clientPanelId(id) {
+  return `mcp-client-${id}-panel`
+}
+
+function onClientTabKeydown(event, currentId) {
+  const currentIndex = clients.findIndex((client) => client.id === currentId)
+  let targetIndex = null
+  if (event.key === 'ArrowRight') targetIndex = (currentIndex + 1) % clients.length
+  else if (event.key === 'ArrowLeft') targetIndex = (currentIndex - 1 + clients.length) % clients.length
+  else if (event.key === 'Home') targetIndex = 0
+  else if (event.key === 'End') targetIndex = clients.length - 1
+  if (targetIndex === null) return
+  event.preventDefault()
+  const target = clients[targetIndex].id
+  activeClient.value = target
+  document.getElementById(clientTabId(target))?.focus()
+}
 
 async function fetchStatus() {
   try {
@@ -214,24 +268,80 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: manif
       <!-- Client configuration -->
       <div class="card mb-4">
         <div class="card-body p-4">
-          <div class="d-flex align-items-center justify-content-between gap-2 mb-2">
+          <div class="d-flex align-items-center justify-content-between gap-2 mb-3">
             <h3 class="h6 fw-bold mb-0"><i class="bi bi-filetype-json me-2"></i>Client configuration</h3>
             <button
               type="button"
               class="btn btn-sm"
               :class="copiedKey === 'mcp-config' ? 'btn-success' : 'btn-outline-secondary'"
               :title="copiedKey === 'mcp-config' ? 'Copied!' : 'Copy configuration'"
-              @click="copyToClipboard(mcpConfigJson, 'mcp-config')"
+              @click="copyToClipboard(activeSnippet, 'mcp-config')"
             >
               <i :class="['bi', copiedKey === 'mcp-config' ? 'bi-check-lg' : 'bi-clipboard', 'me-1']"></i>
               {{ copiedKey === 'mcp-config' ? 'Copied!' : 'Copy' }}
             </button>
           </div>
-          <p class="text-muted small mb-2">
-            Paste this into your AI agent's MCP configuration (for example a GitHub Copilot or Claude Code
-            <code>mcp.json</code>) to connect it to this running app.
+
+          <ul class="nav nav-tabs mb-3" role="tablist" aria-label="MCP client">
+            <li v-for="client in clients" :key="client.id" class="nav-item">
+              <button
+                :id="clientTabId(client.id)"
+                :aria-controls="clientPanelId(client.id)"
+                :aria-selected="activeClient === client.id"
+                :class="{active: activeClient === client.id}"
+                :tabindex="activeClient === client.id ? 0 : -1"
+                class="nav-link"
+                role="tab"
+                type="button"
+                @click="activeClient = client.id"
+                @keydown="onClientTabKeydown($event, client.id)"
+              >
+                {{ client.label }}
+              </button>
+            </li>
+          </ul>
+
+          <div
+            v-for="client in clients"
+            v-show="activeClient === client.id"
+            :id="clientPanelId(client.id)"
+            :key="client.id"
+            :aria-labelledby="clientTabId(client.id)"
+            role="tabpanel"
+            tabindex="0"
+          >
+            <p class="text-muted small mb-2">
+              <template v-if="client.id === 'claude'"
+                >Run this in your project directory to register this running app with Claude Code.</template
+              >
+              <template v-else-if="client.id === 'json'"
+                >The <code>mcpServers</code> shape used by Claude Code's <code>.mcp.json</code> and most other MCP
+                clients.</template
+              >
+              <template v-else
+                >Paste this into <code>{{ client.file }}</code
+                >.</template
+              >
+            </p>
+            <pre
+              class="config-block bg-light border rounded p-3 mb-0 small"
+            ><code>{{ snippets[client.id] }}</code></pre>
+          </div>
+
+          <div class="form-check remote-agent-check mt-3">
+            <input id="mcp-remote-agent" v-model="remoteAgent" class="form-check-input" type="checkbox" />
+            <label class="form-check-label small" for="mcp-remote-agent">
+              Agent connects from another host or container
+            </label>
+          </div>
+          <p class="text-muted small mb-0 mt-2">
+            A loopback agent needs no credentials. An agent that reaches this app from anywhere else — a published
+            container port, or any host allowed by <code>bootui.allow-non-localhost</code>,
+            <code>bootui.trusted-proxies</code>, or <code>bootui.trust-container-gateway</code> — must send BootUI's
+            token in the <code>Authorization</code> header, or every call answers <code>401</code>. BootUI generates
+            that token at each start and logs it once; set <code>bootui.authentication.token</code> for a value that
+            survives a restart.
           </p>
-          <pre class="config-block bg-light border rounded p-3 mb-0 small"><code>{{ mcpConfigJson }}</code></pre>
         </div>
       </div>
 
@@ -314,5 +424,20 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: manif
 .config-block {
   overflow-x: auto;
   white-space: pre;
+}
+
+/* The narrow-viewport rules grow every checkbox to a 44px touch target, which pushes a label this long
+   onto its own line. Lay the row out as flex so the label keeps its place beside the box and wraps. */
+.remote-agent-check {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  padding-left: 0;
+}
+
+.remote-agent-check .form-check-input {
+  flex: 0 0 auto;
+  float: none;
+  margin-left: 0;
 }
 </style>

--- a/docs/AI-AGENTS.md
+++ b/docs/AI-AGENTS.md
@@ -78,8 +78,10 @@ explicitly enabled, which requires authentication.
 2. **Enable the server.** Set `bootui.mcp.enabled=ON`, or flip the toggle at the top of the **MCP Server** panel
    (`/bootui/#/mcp-server`). The panel toggle overrides the property at runtime for the life of the process, so you can
    turn the server on only while you are pairing with an agent.
-3. **Point your agent at the endpoint.** The MCP Server panel shows a ready-to-copy client configuration. It is the
-   `servers` block a GitHub Copilot or Claude Code `mcp.json` expects:
+3. **Point your agent at the endpoint.** The MCP Server panel shows a ready-to-copy client configuration, with one tab
+   per client because they do not agree on a shape. Replace `8080` with your application's port.
+
+   VS Code (`.vscode/mcp.json`) uses a `servers` block:
 
    ```json
    {
@@ -92,11 +94,74 @@ explicitly enabled, which requires authentication.
    }
    ```
 
-   Replace `8080` with your application's port. No credentials are needed on loopback — the endpoint is exempt from
-   BootUI's browser-only CSRF token so a local non-browser MCP client connects with a plain HTTP config, while the
-   loopback, `Host` allow-list, and cross-site write defenses still apply. If you explicitly enable non-loopback access,
-   configure the MCP client to send the value from `bootui.authentication.token` (or the token BootUI generated at
-   startup) in the standard `Authorization` bearer header.
+   Claude Code registers the server from a terminal in your project:
+
+   ```bash
+   claude mcp add --transport http bootui http://127.0.0.1:8080/bootui/api/mcp
+   ```
+
+   Cursor (`~/.cursor/mcp.json`) keys a remote server on `url` and takes no `type`:
+
+   ```json
+   {
+     "mcpServers": {
+       "bootui": {
+         "url": "http://127.0.0.1:8080/bootui/api/mcp"
+       }
+     }
+   }
+   ```
+
+   Most other clients — including the `.mcp.json` Claude Code writes — accept the `mcpServers` shape with an
+   explicit type:
+
+   ```json
+   {
+     "mcpServers": {
+       "bootui": {
+         "type": "http",
+         "url": "http://127.0.0.1:8080/bootui/api/mcp"
+       }
+     }
+   }
+   ```
+
+   No credentials are needed on loopback — the endpoint is exempt from BootUI's browser-only CSRF token so a local
+   non-browser MCP client connects with a plain HTTP config, while the loopback, `Host` allow-list, and cross-site write
+   defenses still apply.
+
+4. **If the agent is not on loopback, send the bearer token.** An agent that reaches the app from anywhere other than
+   loopback — the common case being an app in a container reached through a published port — is a remote API caller
+   like any other, and every MCP call answers `401` until it presents BootUI's token in the standard `Authorization`
+   header.
+   Tick **Agent connects from another host or container** in the panel and the snippets gain the header. For Claude Code
+   that is:
+
+   ```bash
+   claude mcp add --transport http bootui http://localhost:8080/bootui/api/mcp \
+     --header "Authorization: Bearer <BootUI authentication token>"
+   ```
+
+   and for a JSON client, a `headers` entry beside `url`:
+
+   ```json
+   {
+     "mcpServers": {
+       "bootui": {
+         "type": "http",
+         "url": "http://localhost:8080/bootui/api/mcp",
+         "headers": {
+           "Authorization": "Bearer <BootUI authentication token>"
+         }
+       }
+     }
+   }
+   ```
+
+   The token is the value of `bootui.authentication.token`. When that property is blank, BootUI generates a new token at
+   every start and logs it once — set the property to a stable value if you do not want to re-edit the client
+   configuration after each restart. The browser console does not need this because it authenticates once and keeps an
+   HTTP-only session cookie; a non-browser MCP client has no such fallback.
 
 A `GET /bootui/api/mcp-server` status request returns the advertised tool list, which is handy for inspecting what an
 agent will see before you wire it up.

--- a/docs/features/developer-tools.md
+++ b/docs/features/developer-tools.md
@@ -75,9 +75,11 @@ The server inherits BootUI's full safety model:
 :::
 
 Connection details (transport, protocol revision, and the `bootui.mcp.max-results` cap) are shown alongside a
-ready-to-use, copyable MCP client configuration JSON pointing at this running app — the `servers` block a GitHub Copilot
-or Claude Code `mcp.json` expects. To wire it into an agent, point the client at the loopback HTTP endpoint of your
-running app:
+ready-to-use, copyable client configuration pointing at this running app, with one tab per client because they do not
+agree on a shape: **VS Code** (`.vscode/mcp.json`, a `servers` block), **Claude Code** (a `claude mcp add --transport
+http` command), **Cursor** (`~/.cursor/mcp.json`, an `mcpServers` entry keyed on `url` with no `type`), and **Other
+clients** (the `mcpServers` shape with an explicit type, which is also what Claude Code writes into `.mcp.json`). To
+wire it into an agent, point the client at the loopback HTTP endpoint of your running app:
 
 ```json
 {
@@ -89,6 +91,12 @@ running app:
   }
 }
 ```
+
+A loopback agent needs no credentials. An agent that reaches the app from anywhere else — most often an app in a
+container reached through a published port — is a remote API caller like any other, and every MCP call answers `401`
+until it sends BootUI's token in the `Authorization` header. Ticking **Agent connects from another host or container**
+adds that header to every snippet. The panel never prints the token itself: it is the value of
+`bootui.authentication.token`, and when that is blank BootUI generates a new one at each start and logs it once.
 
 See [docs/PROPERTIES.md](../PROPERTIES.md) for the `bootui.mcp.*` settings, and [AI agents](../AI-AGENTS.md) for an
 end-to-end agent workflow and how BootUI pairs with [Coffilot](https://github.com/jdubois/coffilot).

--- a/skills/bootui/SKILL.md
+++ b/skills/bootui/SKILL.md
@@ -207,7 +207,7 @@ your tool list, just call them — there is nothing to configure. For a one-off 
 guide is at `https://github.com/jdubois/boot-ui/blob/main/docs/AI-AGENTS.md`.
 
 The MCP server is opt-in. Enable it with `bootui.mcp.enabled=ON` or the MCP Server panel toggle, then configure the agent
-with the application's actual port:
+with the application's actual port. VS Code uses a `servers` block:
 
 ```json
 {
@@ -220,7 +220,13 @@ with the application's actual port:
 }
 ```
 
-Prefer `127.0.0.1` and replace `8080` when needed. No credentials are required. Verify
+Claude Code, Cursor, and most other clients use `mcpServers` instead, and Claude Code can register the server directly
+with `claude mcp add --transport http bootui http://127.0.0.1:8080/bootui/api/mcp`.
+
+Prefer `127.0.0.1` and replace `8080` when needed. A loopback agent needs no credentials. An agent that reaches the app
+from anywhere else — typically an app in a container reached through a published port — must send BootUI's token as
+`Authorization: Bearer <token>` on every call or receive `401`; the token is `bootui.authentication.token`, or the value
+BootUI generated and logged once at startup. Verify
 `GET /bootui/api/mcp-server` before debugging the client; it reports enabled state and advertised tools. Tools are
 availability-driven, so do not assume every framework exposes every tool.
 


### PR DESCRIPTION
Closes #928

## Problem

The MCP Server panel's **Client configuration** card rendered exactly one snippet, in VS Code's `servers` shape.
Claude Code and Cursor both read `mcpServers`, and Claude Code's normal entry point is
`claude mcp add --transport http`, so those users copied a block that does not work.

Worse, the header requirement was invisible until a 401 explained it. The panel derived "remote" from
`window.location.hostname` — which is exactly wrong in the reported case: an app in a container reached through a
published port serves the page on `localhost` while the agent's calls arrive from the Docker gateway and answer 401.
The browser survives because it holds the `BOOTUI_SESSION` cookie; a non-browser MCP client has no fallback.

## Change

UI and documentation only — no DTO, adapter, or engine change, so no conformance-fixture churn.

- **Tabbed client picker** — VS Code (`servers`), Claude Code (`claude mcp add --transport http …`), Cursor
  (`mcpServers` keyed on `url`, no `type`), and other clients (`.mcp.json` `mcpServers`). One shared Copy button bound
  to the active tab. Full tab ARIA: `role="tablist"`/`role="tab"`/`role="tabpanel"`, `aria-selected`, `aria-controls`,
  roving `tabindex`, and Arrow/Home/End keys, following the existing `Copilot.vue` pattern.
- **"Agent connects from another host or container" checkbox** replaces the silent hostname heuristic. It is still
  pre-set from the hostname, so today's behaviour is the default where the guess is right, but the Docker case is now
  one click away instead of being decided wrongly on the user's behalf. It injects the `Authorization` header into
  every snippet shape.
- **An always-visible note** states the rule and the token's lifecycle: BootUI generates the token at each start and
  logs it once, so set `bootui.authentication.token` for a value that survives a restart. The panel never renders the
  real token — the placeholder stays a placeholder.
- `docs/AI-AGENTS.md`, `docs/features/developer-tools.md`, and `skills/bootui/SKILL.md` carry the same four shapes and
  the same header rule, replacing the flat "No credentials are required".

## Validation

- Vitest `McpServer.test.js`: 10 tests (snippet shape per tab, header injection/removal across all shapes, Copy uses
  the active tab, keyboard navigation with wrap, note presence, remote-hostname pre-check). Full frontend suite
  1044/1044 passes.
- New Playwright spec `bootui-spring-sample-app/e2e/tests/mcp-server.spec.js` (2 tests) on Spring MVC — read-only with
  respect to server state, so it is safe under both runs.
- WebFlux `npm run test:webflux`: 12 passed, including a new MCP Server test in the smoke spec.
- Quarkus spec extended with a per-client/header test alongside the existing toggle round-trip.
- Prettier clean in `bootui-ui/src/main/frontend` and both e2e projects. No Java touched, so `spotless` is unaffected.
- Visually checked at 1200px and 320px, light and dark themes. The narrow viewport needed a scoped flex rule so the
  app-wide 44px touch-target minimum does not push the checkbox label onto its own line.

## Notes for the reviewer

- **Quarkus e2e is unverified locally** — this machine only has JDK 26 and the Quarkus sample is JDK-gated to 17/21/25,
  so augmentation is skipped. The card is shared UI and the same selectors are proven on MVC and WebFlux; CI will
  confirm.
- **`docs/images/bootui-mcp-server.webp` is now stale.** Regenerating it is a separate step, flagged rather than
  silently shipped mismatched.
- A server-side `remoteAccessConfigured` flag on `McpServerStatus` was deliberately not added: it is a cross-adapter
  contract change for a card the checkbox already resolves, and even then it would report whether *remote access is
  configured*, not whether the *agent's* source address is trusted. Worth a follow-up if the guess keeps misleading
  people.