### PR TITLE
Report vulnerability scan coverage and resolve coordinates from the SBOM

### DIFF
--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
@@ -864,6 +864,31 @@ public abstract class AbstractBootUiApiConformanceTest {
         assertThat(report.path("total").isInt())
                 .as("$.total must be an integer")
                 .isTrue();
+        assertThat(report.path("scan").path("packagesSkipped").isInt())
+                .as("$.scan.packagesSkipped must be an integer")
+                .isTrue();
+        // Coverage tells the caller how much of the application the inventory actually accounts for, so a
+        // clean report can never be mistaken for a full-coverage scan. Every adapter must report it.
+        JsonNode coverage = report.path("coverage");
+        assertThat(coverage.isObject()).as("$.coverage must be an object").isTrue();
+        assertThat(coverage.path("status").asText())
+                .as("$.coverage.status must be one of the canonical states")
+                .isIn("COMPLETE", "INCOMPLETE", "UNAVAILABLE");
+        assertThat(coverage.path("archivesFound").isInt())
+                .as("$.coverage.archivesFound must be an integer")
+                .isTrue();
+        assertThat(coverage.path("archivesIdentified").isInt())
+                .as("$.coverage.archivesIdentified must be an integer")
+                .isTrue();
+        assertThat(coverage.path("archivesUnidentified").isInt())
+                .as("$.coverage.archivesUnidentified must be an integer")
+                .isTrue();
+        assertThat(coverage.path("unidentifiedArchives").isArray())
+                .as("$.coverage.unidentifiedArchives must be an array")
+                .isTrue();
+        assertThat(coverage.path("unidentifiedArchivesTruncated").isBoolean())
+                .as("$.coverage.unidentifiedArchivesTruncated must be a boolean")
+                .isTrue();
     }
 
     @Test

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependenciesReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependenciesReport.java
@@ -4,6 +4,10 @@ import java.util.List;
 
 /**
  * Top-level report for dependency inventory and vulnerability findings.
+ *
+ * @param total the number of resolved dependency coordinates in the inventory
+ * @param coverage how much of the application's real JAR set that inventory accounts for; never
+ *     {@code null}, so a caller can always tell a complete inventory from a partial one
  */
 public record DependenciesReport(
         boolean scanningEnabled,
@@ -11,11 +15,13 @@ public record DependenciesReport(
         int vulnerable,
         List<DependencySeverityCountDto> severityCounts,
         DependencyScanStatusDto scan,
+        DependencyCoverageDto coverage,
         List<DependencyDto> dependencies) {
 
     public DependenciesReport {
         severityCounts = DtoCollections.immutableCopy(severityCounts);
         dependencies = DtoCollections.immutableCopy(dependencies);
+        coverage = coverage == null ? DependencyCoverageDto.unavailable() : coverage;
     }
 
     public String status() {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyCoverageDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyCoverageDto.java
@@ -1,0 +1,90 @@
+package io.github.jdubois.bootui.core.dto;
+
+import java.util.List;
+
+/**
+ * How much of the running application's real JAR set the dependency inventory actually accounts for.
+ *
+ * <p>The inventory is coordinate-based: a JAR only enters it when a {@code groupId:artifactId:version} can
+ * be resolved for it. Many widely-used artifacts ship no Maven descriptor at all (Spring Framework,
+ * {@code tomcat-embed-*}, {@code hibernate-core}, {@code kotlin-stdlib}, the PostgreSQL driver, and others
+ * are built without {@code META-INF/maven/.../pom.properties}), and no manifest header carries a groupId, so
+ * without this record a repackaged application could report a green "0 vulnerable" summary while a large
+ * part of its classpath was never scanned at all. This record makes that gap explicit instead.</p>
+ *
+ * @param status {@code COMPLETE} when every enumerated archive resolved to coordinates, {@code INCOMPLETE}
+ *     when some did not, or {@code UNAVAILABLE} when the archive census itself could not run (an unknown or
+ *     synthetic classpath, for example a native image) and coverage is therefore unknown rather than claimed
+ * @param archivesFound the number of JAR archives enumerated from the running application
+ * @param archivesIdentified how many of them resolved to a Maven coordinate and are in the inventory
+ * @param archivesUnidentified how many of them did not, and are therefore not scannable
+ * @param unidentifiedArchives the unresolved archive file names, bounded for transport
+ * @param unidentifiedArchivesTruncated whether {@code unidentifiedArchives} omits some names because the
+ *     transport bound was hit
+ */
+public record DependencyCoverageDto(
+        String status,
+        int archivesFound,
+        int archivesIdentified,
+        int archivesUnidentified,
+        List<String> unidentifiedArchives,
+        boolean unidentifiedArchivesTruncated) {
+
+    /** Coverage could not be determined; the caller could not enumerate the application's archives. */
+    public static final String UNAVAILABLE = "UNAVAILABLE";
+
+    /** Every enumerated archive resolved to a Maven coordinate. */
+    public static final String COMPLETE = "COMPLETE";
+
+    /** At least one enumerated archive could not be resolved to a Maven coordinate. */
+    public static final String INCOMPLETE = "INCOMPLETE";
+
+    public DependencyCoverageDto {
+        unidentifiedArchives = DtoCollections.immutableCopy(unidentifiedArchives);
+    }
+
+    /**
+     * Coverage for a provider that cannot enumerate the application's archives, so it can neither claim nor
+     * deny full coverage.
+     */
+    public static DependencyCoverageDto unavailable() {
+        return new DependencyCoverageDto(UNAVAILABLE, 0, 0, 0, List.of(), false);
+    }
+
+    /**
+     * Coverage for a provider whose inventory is authoritative by construction &mdash; for example Quarkus,
+     * which reads the fully-resolved build-time application model rather than probing the classpath.
+     *
+     * @param identified the number of resolved dependencies in the inventory
+     */
+    public static DependencyCoverageDto complete(int identified) {
+        int count = Math.max(0, identified);
+        return new DependencyCoverageDto(COMPLETE, count, count, 0, List.of(), false);
+    }
+
+    /**
+     * Coverage derived from a completed archive census. The status is {@link #COMPLETE} only when no archive
+     * was left unidentified.
+     *
+     * <p>{@code unidentifiedArchives} may be shorter than {@code archivesUnidentified} because the name list
+     * is bounded for transport; the counts are always the true totals, so a truncated list never
+     * under-reports the size of the gap.</p>
+     *
+     * @param archivesFound the number of archives enumerated
+     * @param archivesUnidentified how many of them did not resolve to a Maven coordinate
+     * @param unidentifiedArchives the unresolved archive file names, already bounded
+     */
+    public static DependencyCoverageDto of(
+            int archivesFound, int archivesUnidentified, List<String> unidentifiedArchives) {
+        int found = Math.max(0, archivesFound);
+        int unidentified = Math.min(found, Math.max(0, archivesUnidentified));
+        int listed = unidentifiedArchives == null ? 0 : unidentifiedArchives.size();
+        return new DependencyCoverageDto(
+                unidentified == 0 ? COMPLETE : INCOMPLETE,
+                found,
+                found - unidentified,
+                unidentified,
+                unidentifiedArchives,
+                listed < unidentified);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyScanStatusDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyScanStatusDto.java
@@ -2,6 +2,17 @@ package io.github.jdubois.bootui.core.dto;
 
 /**
  * Metadata about the dependency vulnerability scan.
+ *
+ * @param packagesScanned how many distinct packages were actually submitted to the scanner and completed
+ * @param packagesSkipped how many inventory packages were dropped before the scan because the configured
+ *     {@code bootui.vulnerabilities.max-packages} bound was reached; a non-zero value means
+ *     {@code packagesScanned} is not full coverage of the inventory
  */
 public record DependencyScanStatusDto(
-        String scanner, String status, String message, Long scannedAt, int packagesScanned, int vulnerabilitiesFound) {}
+        String scanner,
+        String status,
+        String message,
+        Long scannedAt,
+        int packagesScanned,
+        int packagesSkipped,
+        int vulnerabilitiesFound) {}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptions.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptions.java
@@ -87,7 +87,9 @@ public final class McpToolDescriptions {
                     "Actively query OSV.dev for known vulnerabilities in this application's dependencies and return "
                             + "severity-ranked findings. This makes outbound network calls to a public advisory database; "
                             + "run only when needed and verify a finding's affected version range before changing a "
-                            + "dependency."),
+                            + "dependency. Check `coverage` and `scan.packagesSkipped` before treating a clean result as "
+                            + "proof: JARs published without Maven coordinates cannot be scanned and are reported there "
+                            + "instead of being silently dropped."),
             Map.entry(
                     "get_loggers",
                     "Search configured loggers by case-insensitive name and return their configured and effective "
@@ -137,7 +139,9 @@ public final class McpToolDescriptions {
             Map.entry(
                     "get_vulnerabilities_report",
                     "Return the cached vulnerability report, or the local dependency inventory before the first scan, "
-                            + "without contacting OSV.dev or any other network service."),
+                            + "without contacting OSV.dev or any other network service. `coverage` states how many of "
+                            + "the application's JARs the inventory actually accounts for, so a clean report is not "
+                            + "mistaken for full coverage."),
             Map.entry(
                     "get_metrics",
                     "Search the current application metrics inventory and return a bounded page of local meter values. "

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/ArchiveNames.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/ArchiveNames.java
@@ -1,0 +1,70 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import java.util.Locale;
+
+/**
+ * File-name policy for attributing a classpath JAR archive to a resolved Maven coordinate.
+ *
+ * <p>The dependency inventory resolves coordinates from Maven descriptors and the application's SBOM, but
+ * those sources say nothing about <em>which</em> archives they failed to cover. Comparing the resolved
+ * coordinates against the real archive census is what turns "201 packages scanned" into "201 of 325 JARs
+ * identified", so the panel can never present a partial scan as full coverage.</p>
+ *
+ * <p>Maven's repository layout names an artifact {@code <artifactId>-<version>[-<classifier>].jar}, which is
+ * also how Spring Boot's repackaging writes {@code BOOT-INF/lib/} entries. That is a naming convention
+ * rather than a guarantee, so it is used only for attribution &mdash; an archive that fails to match is
+ * reported as unidentified, never silently dropped.</p>
+ */
+public final class ArchiveNames {
+
+    private static final String JAR_SUFFIX = ".jar";
+
+    private ArchiveNames() {}
+
+    private static boolean isJar(String name) {
+        return name != null
+                && name.length() > JAR_SUFFIX.length()
+                && name.toLowerCase(Locale.ROOT).endsWith(JAR_SUFFIX);
+    }
+
+    /**
+     * Returns the bare file name of a JAR path or archive entry name, or {@code null} when the path does not
+     * name a JAR.
+     *
+     * <p>Handles both {@code /} and the platform separator, so it works on a {@code java.class.path} entry
+     * and on a {@code BOOT-INF/lib/...} archive entry alike.</p>
+     */
+    public static String jarFileName(String path) {
+        if (path == null) {
+            return null;
+        }
+        String value = path.trim();
+        int slash = Math.max(value.lastIndexOf('/'), value.lastIndexOf('\\'));
+        String name = slash < 0 ? value : value.substring(slash + 1);
+        return isJar(name) ? name : null;
+    }
+
+    /**
+     * Whether {@code archiveFileName} is the archive Maven would publish for {@code artifactId}/
+     * {@code version}, either as the main artifact or as one of its classified artifacts.
+     *
+     * @param archiveFileName a bare JAR file name, as returned by {@link #jarFileName(String)}
+     */
+    public static boolean matches(String archiveFileName, String artifactId, String version) {
+        if (archiveFileName == null || artifactId == null || version == null) {
+            return false;
+        }
+        if (artifactId.isBlank() || version.isBlank()) {
+            return false;
+        }
+        String base = artifactId + "-" + version;
+        if (archiveFileName.equalsIgnoreCase(base + JAR_SUFFIX)) {
+            return true;
+        }
+        // artifactId-version-classifier.jar; the classifier must be non-empty.
+        String classified = base + "-";
+        return archiveFileName.length() > classified.length() + JAR_SUFFIX.length()
+                && archiveFileName.regionMatches(true, 0, classified, 0, classified.length())
+                && isJar(archiveFileName);
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyInventory.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyInventory.java
@@ -1,0 +1,28 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import io.github.jdubois.bootui.core.dto.DependencyCoverageDto;
+import io.github.jdubois.bootui.core.dto.DependencyDto;
+import java.util.List;
+
+/**
+ * A dependency provider's resolved inventory together with how much of the running application's real JAR
+ * set that inventory accounts for.
+ *
+ * <p>Kept separate from the bare {@link DependencyProvider#dependencies()} list so a provider that
+ * <em>can</em> enumerate the application's archives (the Spring classpath catalogue) reports its blind spot,
+ * while one whose inventory is authoritative by construction (the Quarkus build-time application model)
+ * simply reports complete coverage.</p>
+ */
+public record DependencyInventory(List<DependencyDto> dependencies, DependencyCoverageDto coverage) {
+
+    public DependencyInventory {
+        dependencies = dependencies == null ? List.of() : List.copyOf(dependencies);
+        coverage = coverage == null ? DependencyCoverageDto.unavailable() : coverage;
+    }
+
+    /** An inventory that is complete by construction: every dependency is known, nothing was probed. */
+    public static DependencyInventory complete(List<DependencyDto> dependencies) {
+        List<DependencyDto> resolved = dependencies == null ? List.of() : dependencies;
+        return new DependencyInventory(resolved, DependencyCoverageDto.complete(resolved.size()));
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyProvider.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyProvider.java
@@ -6,4 +6,16 @@ import java.util.List;
 public interface DependencyProvider {
 
     List<DependencyDto> dependencies();
+
+    /**
+     * The resolved inventory plus its coverage over the application's real JAR set.
+     *
+     * <p>Defaults to treating {@link #dependencies()} as complete, which is correct for a provider reading a
+     * fully-resolved build-time dependency model. A provider that probes the classpath &mdash; where
+     * artifacts published without a Maven descriptor are invisible &mdash; must override this and report the
+     * archives it could not identify, so the panel never presents a partial inventory as full coverage.</p>
+     */
+    default DependencyInventory inventory() {
+        return DependencyInventory.complete(dependencies());
+    }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.vulnerabilities;
 
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
+import io.github.jdubois.bootui.core.dto.DependencyCoverageDto;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencyScanStatusDto;
 import io.github.jdubois.bootui.core.dto.DependencySeverityCountDto;
@@ -61,6 +62,35 @@ public final class DependencyReports {
             Long scannedAt,
             int packagesScanned,
             List<DependencyDto> dependencies) {
+        return report(
+                scanningEnabled,
+                status,
+                message,
+                scannedAt,
+                packagesScanned,
+                0,
+                dependencies,
+                DependencyCoverageDto.unavailable());
+    }
+
+    /**
+     * Assembles a report that states its own coverage on both axes a green summary could otherwise hide:
+     * {@code coverage} says how many of the application's real JAR archives the inventory accounts for, and
+     * {@code packagesSkipped} says how many inventory packages the configured scan bound dropped before the
+     * scanner ever ran.
+     *
+     * @param packagesSkipped inventory packages dropped by the {@code max-packages} bound
+     * @param coverage the inventory's coverage of the application's archives; {@code null} means unknown
+     */
+    public static DependenciesReport report(
+            boolean scanningEnabled,
+            String status,
+            String message,
+            Long scannedAt,
+            int packagesScanned,
+            int packagesSkipped,
+            List<DependencyDto> dependencies,
+            DependencyCoverageDto coverage) {
         List<DependencyDto> orderedDependencies =
                 dependencies.stream().sorted(DEPENDENCY_ORDER).toList();
         int vulnerabilitiesFound = orderedDependencies.stream()
@@ -74,7 +104,14 @@ public final class DependencyReports {
                         .count(),
                 severityCounts(orderedDependencies),
                 new DependencyScanStatusDto(
-                        "OSV.dev", status, message, scannedAt, packagesScanned, vulnerabilitiesFound),
+                        "OSV.dev",
+                        status,
+                        message,
+                        scannedAt,
+                        packagesScanned,
+                        Math.max(0, packagesSkipped),
+                        vulnerabilitiesFound),
+                coverage,
                 orderedDependencies);
     }
 
@@ -233,9 +270,16 @@ public final class DependencyReports {
                         scan.message(),
                         scan.scannedAt(),
                         scan.packagesScanned(),
+                        scan.packagesSkipped(),
                         vulnerabilitiesFound);
         return new DependenciesReport(
-                report.scanningEnabled(), report.total(), vulnerable, severityCounts(marked), updatedScan, marked);
+                report.scanningEnabled(),
+                report.total(),
+                vulnerable,
+                severityCounts(marked),
+                updatedScan,
+                report.coverage(),
+                marked);
     }
 
     private static DependencyDto markDismissals(DependencyDto dependency, Set<String> dismissedIds) {
@@ -306,6 +350,15 @@ public final class DependencyReports {
             distinct.add(dependency.packageName() + ":" + dependency.version());
         }
         return distinct.size();
+    }
+
+    /**
+     * How many distinct package/version inputs {@link #scanCandidates(List, int)} drops for the same
+     * {@code maxPackages} bound. Reported alongside {@code packagesScanned} so a bounded scan is visibly
+     * partial rather than reading as full coverage of the inventory.
+     */
+    public static int skippedCandidateCount(List<DependencyDto> dependencies, int maxPackages) {
+        return Math.max(0, scanCandidateCount(dependencies) - Math.max(1, maxPackages));
     }
 
     /**

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/PackageUrls.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/PackageUrls.java
@@ -1,0 +1,88 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Parses Maven coordinates out of a <a href="https://github.com/package-url/purl-spec">package URL</a>.
+ *
+ * <p>A CycloneDX SBOM identifies every component by {@code purl}, and for the Maven ecosystem that is
+ * exactly {@code pkg:maven/<groupId>/<artifactId>@<version>} &mdash; the {@code groupId} that no JAR
+ * manifest header carries. That makes an application's embedded SBOM the only local source able to identify
+ * the many artifacts published without {@code META-INF/maven/.../pom.properties}.</p>
+ *
+ * <p>Parsing lives in the engine so every adapter that can read an SBOM applies the same rules; reading the
+ * JSON itself stays in the adapters, which own a JSON library (the engine deliberately does not).</p>
+ */
+public final class PackageUrls {
+
+    private static final String MAVEN_PREFIX = "pkg:maven/";
+
+    private PackageUrls() {}
+
+    /**
+     * Parses a Maven package URL into its coordinates.
+     *
+     * <p>Per the purl specification the type is case-insensitive, the optional {@code ?qualifiers} and
+     * {@code #subpath} segments are ignored here (BootUI scans by {@code groupId:artifactId:version}, so a
+     * classifier or packaging qualifier does not change the OSV query), and percent-encoded characters are
+     * decoded. Any purl of another type, or one missing a namespace, name, or version, yields {@code null}
+     * rather than a half-populated coordinate.
+     *
+     * @param purl the package URL, possibly {@code null}
+     * @return the coordinates, or {@code null} when {@code purl} is not a complete Maven package URL
+     */
+    public static MavenCoordinates mavenCoordinates(String purl) {
+        if (purl == null) {
+            return null;
+        }
+        String value = purl.trim();
+        if (value.length() <= MAVEN_PREFIX.length()
+                || !value.regionMatches(true, 0, MAVEN_PREFIX, 0, MAVEN_PREFIX.length())) {
+            return null;
+        }
+        value = value.substring(MAVEN_PREFIX.length());
+        value = stripAfter(stripAfter(value, '#'), '?');
+
+        int at = value.lastIndexOf('@');
+        if (at <= 0 || at == value.length() - 1) {
+            return null;
+        }
+        String version = decode(value.substring(at + 1));
+        String path = value.substring(0, at);
+
+        int lastSlash = path.lastIndexOf('/');
+        if (lastSlash <= 0 || lastSlash == path.length() - 1) {
+            return null;
+        }
+        // A Maven namespace is a single segment, but decode defensively rather than assume it.
+        String groupId = decode(path.substring(0, lastSlash).replace('/', '.'));
+        String artifactId = decode(path.substring(lastSlash + 1));
+        if (groupId.isEmpty() || artifactId.isEmpty() || version.isEmpty()) {
+            return null;
+        }
+        return new MavenCoordinates(groupId, artifactId, version);
+    }
+
+    private static String stripAfter(String value, char delimiter) {
+        int index = value.indexOf(delimiter);
+        return index < 0 ? value : value.substring(0, index);
+    }
+
+    private static String decode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8).trim();
+        } catch (IllegalArgumentException ex) {
+            // Malformed percent-encoding: keep the raw text rather than dropping the component entirely.
+            return value.trim();
+        }
+    }
+
+    /** A resolved {@code groupId:artifactId:version} triple. */
+    public record MavenCoordinates(String groupId, String artifactId, String version) {
+
+        public String packageName() {
+            return groupId + ":" + artifactId;
+        }
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/VulnerabilityScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/VulnerabilityScanner.java
@@ -1,10 +1,15 @@
 package io.github.jdubois.bootui.engine.vulnerabilities;
 
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
-import io.github.jdubois.bootui.core.dto.DependencyDto;
-import java.util.List;
 
 public interface VulnerabilityScanner {
 
-    DependenciesReport scan(List<DependencyDto> dependencies);
+    /**
+     * Scans the resolved inventory.
+     *
+     * <p>Takes the whole {@link DependencyInventory} rather than a bare dependency list so the scanner can
+     * carry the inventory's coverage into every report it produces &mdash; including the error and partial
+     * paths. Without it, a scan of a partially-resolved classpath would render as a complete result.</p>
+     */
+    DependenciesReport scan(DependencyInventory inventory);
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/ArchiveNamesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/ArchiveNamesTests.java
@@ -1,0 +1,75 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ArchiveNamesTests {
+
+    @Test
+    void extractsTheFileNameFromAnArchiveEntry() {
+        assertThat(ArchiveNames.jarFileName("BOOT-INF/lib/spring-core-7.0.9.jar"))
+                .isEqualTo("spring-core-7.0.9.jar");
+    }
+
+    @Test
+    void extractsTheFileNameFromAWindowsClasspathEntry() {
+        assertThat(ArchiveNames.jarFileName("C:\\repo\\org\\example\\sample-1.0.0.jar"))
+                .isEqualTo("sample-1.0.0.jar");
+    }
+
+    @Test
+    void acceptsABareFileName() {
+        assertThat(ArchiveNames.jarFileName("sample-1.0.0.jar")).isEqualTo("sample-1.0.0.jar");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"BOOT-INF/classes/", "/path/to/classes", "app.war", ".jar", "/path/to/.jar"})
+    void returnsNullWhenThePathDoesNotNameAJar(String path) {
+        assertThat(ArchiveNames.jarFileName(path)).isNull();
+    }
+
+    @Test
+    void matchesTheMainArtifactArchive() {
+        assertThat(ArchiveNames.matches("spring-core-7.0.9.jar", "spring-core", "7.0.9"))
+                .isTrue();
+    }
+
+    @Test
+    void matchesAClassifiedArchive() {
+        assertThat(ArchiveNames.matches(
+                        "netty-transport-native-epoll-4.2.7-linux-x86_64.jar", "netty-transport-native-epoll", "4.2.7"))
+                .isTrue();
+    }
+
+    @Test
+    void doesNotMatchADifferentVersionOfTheSameArtifact() {
+        assertThat(ArchiveNames.matches("spring-core-7.0.9.jar", "spring-core", "7.0.10"))
+                .isFalse();
+    }
+
+    @Test
+    void doesNotMatchAnArtifactWhoseNameIsAPrefixOfTheArchive() {
+        // spring-core-7.0.9.jar must not be attributed to the "spring" artifact.
+        assertThat(ArchiveNames.matches("spring-core-7.0.9.jar", "spring", "7.0.9"))
+                .isFalse();
+    }
+
+    @Test
+    void requiresANonEmptyClassifier() {
+        assertThat(ArchiveNames.matches("sample-1.0.0-.jar", "sample", "1.0.0")).isFalse();
+    }
+
+    @Test
+    void rejectsBlankOrMissingCoordinates() {
+        assertThat(ArchiveNames.matches("sample-1.0.0.jar", null, "1.0.0")).isFalse();
+        assertThat(ArchiveNames.matches("sample-1.0.0.jar", "sample", null)).isFalse();
+        assertThat(ArchiveNames.matches(null, "sample", "1.0.0")).isFalse();
+        assertThat(ArchiveNames.matches("sample-1.0.0.jar", " ", "1.0.0")).isFalse();
+        assertThat(ArchiveNames.matches("sample-1.0.0.jar", "sample", " ")).isFalse();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
@@ -3,6 +3,7 @@ package io.github.jdubois.bootui.engine.vulnerabilities;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
+import io.github.jdubois.bootui.core.dto.DependencyCoverageDto;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
@@ -349,6 +350,54 @@ class DependencyReportsTests {
 
         assertThat(enriched.get(0).vulnerabilities().get(0).epssScore()).isEqualTo(0.25d);
         assertThat(enriched.get(0).vulnerabilities().get(0).epssPercentile()).isEqualTo(0.75d);
+    }
+
+    @Test
+    void skippedCandidateCountReportsWhatTheMaxPackagesBoundDroppedRatherThanHidingIt() {
+        DependencyDto first = dependency("org.example", "first", "1.0.0");
+        DependencyDto duplicate = dependency("org.example", "first", "1.0.0");
+        DependencyDto second = dependency("org.example", "second", "2.0.0");
+        DependencyDto third = dependency("org.example", "third", "3.0.0");
+        List<DependencyDto> dependencies = List.of(first, duplicate, second, third);
+
+        // Deduplication happens before the bound, so the duplicate is not counted as skipped.
+        assertThat(DependencyReports.skippedCandidateCount(dependencies, 2)).isEqualTo(1);
+        assertThat(DependencyReports.skippedCandidateCount(dependencies, 3)).isZero();
+        assertThat(DependencyReports.skippedCandidateCount(dependencies, 500)).isZero();
+        // scanCandidates clamps a non-positive bound to 1, and the skipped count must agree with it.
+        assertThat(DependencyReports.skippedCandidateCount(dependencies, 0)).isEqualTo(2);
+        assertThat(DependencyReports.scanCandidates(dependencies, 0)).hasSize(1);
+    }
+
+    @Test
+    void reportDefaultsToUnavailableCoverageWhenTheAdapterCannotDescribeIt() {
+        DependenciesReport report =
+                DependencyReports.report(true, "SCANNED", "done", 1L, 1, List.of(dependency("org.example", "a", "1")));
+
+        assertThat(report.coverage().status()).isEqualTo("UNAVAILABLE");
+        assertThat(report.scan().packagesSkipped()).isZero();
+    }
+
+    @Test
+    void applyDismissalsPreservesCoverageAndSkippedPackages() {
+        DependencyCoverageDto coverage = DependencyCoverageDto.of(3, 1, List.of("mystery-1.0.0.jar"));
+        DependenciesReport report = DependencyReports.report(
+                true,
+                "SCANNED",
+                "done",
+                1L,
+                2,
+                7,
+                List.of(vulnerableDependency("org.example", "lib", "1.0.0", "CRITICAL")),
+                coverage);
+
+        DependenciesReport updated = DependencyReports.applyDismissals(
+                report, Set.of(DependencyReports.dismissalKey("V-lib", "org.example:lib")));
+
+        assertThat(updated.scan().packagesSkipped()).isEqualTo(7);
+        assertThat(updated.coverage()).isEqualTo(coverage);
+        assertThat(updated.coverage().status()).isEqualTo("INCOMPLETE");
+        assertThat(updated.coverage().archivesIdentified()).isEqualTo(2);
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/PackageUrlsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/PackageUrlsTests.java
@@ -1,0 +1,89 @@
+package io.github.jdubois.bootui.engine.vulnerabilities;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.engine.vulnerabilities.PackageUrls.MavenCoordinates;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PackageUrlsTests {
+
+    @Test
+    void parsesAMavenPackageUrl() {
+        MavenCoordinates coordinates = PackageUrls.mavenCoordinates("pkg:maven/org.springframework/spring-core@7.0.9");
+
+        assertThat(coordinates).isNotNull();
+        assertThat(coordinates.groupId()).isEqualTo("org.springframework");
+        assertThat(coordinates.artifactId()).isEqualTo("spring-core");
+        assertThat(coordinates.version()).isEqualTo("7.0.9");
+        assertThat(coordinates.packageName()).isEqualTo("org.springframework:spring-core");
+    }
+
+    @Test
+    void ignoresQualifiersAndSubpath() {
+        MavenCoordinates coordinates = PackageUrls.mavenCoordinates(
+                "pkg:maven/org.postgresql/postgresql@42.7.13?type=jar&classifier=sources#some/sub/path");
+
+        assertThat(coordinates).isNotNull();
+        assertThat(coordinates.artifactId()).isEqualTo("postgresql");
+        assertThat(coordinates.version()).isEqualTo("42.7.13");
+    }
+
+    @Test
+    void acceptsAVersionContainingAQualifierSuffix() {
+        MavenCoordinates coordinates =
+                PackageUrls.mavenCoordinates("pkg:maven/org.hibernate.orm/hibernate-core@7.4.5.Final");
+
+        assertThat(coordinates).isNotNull();
+        assertThat(coordinates.groupId()).isEqualTo("org.hibernate.orm");
+        assertThat(coordinates.version()).isEqualTo("7.4.5.Final");
+    }
+
+    @Test
+    void treatsThePurlTypeAsCaseInsensitive() {
+        assertThat(PackageUrls.mavenCoordinates("PKG:MAVEN/org.example/sample@1.0.0"))
+                .isEqualTo(new MavenCoordinates("org.example", "sample", "1.0.0"));
+    }
+
+    @Test
+    void decodesPercentEncodedSegments() {
+        MavenCoordinates coordinates = PackageUrls.mavenCoordinates("pkg:maven/org.example/sample@1.0.0%2Bbuild.7");
+
+        assertThat(coordinates).isNotNull();
+        assertThat(coordinates.version()).isEqualTo("1.0.0+build.7");
+    }
+
+    @Test
+    void keepsRawTextWhenPercentEncodingIsMalformed() {
+        MavenCoordinates coordinates = PackageUrls.mavenCoordinates("pkg:maven/org.example/sam%ZZple@1.0.0");
+
+        assertThat(coordinates).isNotNull();
+        assertThat(coordinates.artifactId()).isEqualTo("sam%ZZple");
+    }
+
+    @Test
+    void flattensAMultiSegmentNamespaceIntoAGroupId() {
+        // Maven namespaces are single-segment in practice, but a producer may still slash-separate them.
+        assertThat(PackageUrls.mavenCoordinates("pkg:maven/org/example/sample@1.0.0"))
+                .isEqualTo(new MavenCoordinates("org.example", "sample", "1.0.0"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(
+            strings = {
+                "pkg:npm/left-pad@1.3.0",
+                "pkg:maven/org.example/sample",
+                "pkg:maven/sample@1.0.0",
+                "pkg:maven/org.example/@1.0.0",
+                "pkg:maven//sample@1.0.0",
+                "pkg:maven/org.example/sample@",
+                "pkg:maven/",
+                "not a purl"
+            })
+    void returnsNullForAnythingThatIsNotACompleteMavenPurl(String purl) {
+        assertThat(PackageUrls.mavenCoordinates(purl)).isNull();
+    }
+}

--- a/bootui-quarkus-sample-app/e2e/tests/vulnerabilities.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/vulnerabilities.spec.js
@@ -24,6 +24,14 @@ test.describe('Vulnerabilities (Quarkus)', () => {
 
     // The fixture-backed server is configured with max-packages=3, below the real inventory size.
     await expect(page.getByText('Partial scan', {exact: true})).toBeVisible()
+    // A truncated scan must say so rather than letting the result read as a complete one.
+    const truncationWarning = page.locator('.alert-warning', {hasText: 'not sent to OSV.dev'})
+    await expect(truncationWarning).toBeVisible()
+    await expect(truncationWarning).toContainText('bootui.vulnerabilities.max-packages')
+    // Quarkus resolves every coordinate from its build-time application model, so coverage is complete.
+    const coverageMetric = page.locator('.advisor-summary__metric', {hasText: 'Unidentified JARs'})
+    await expect(coverageMetric.locator('dd')).toHaveText('0')
+    await expect(page.getByText('could not be identified and were not scanned')).toHaveCount(0)
 
     const scannerMetric = page.locator('.advisor-summary__metric', {hasText: 'Scanner'})
     await expect(scannerMetric.locator('dd')).toHaveText('OSV.dev')

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
@@ -3,8 +3,10 @@ package io.github.jdubois.bootui.quarkus;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
+import io.github.jdubois.bootui.core.dto.DependencyCoverageDto;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyInventory;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import io.github.jdubois.bootui.engine.vulnerabilities.EpssScore;
 import io.github.jdubois.bootui.engine.vulnerabilities.VulnerabilityScanner;
@@ -251,13 +253,23 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     }
 
     @Override
-    public DependenciesReport scan(List<DependencyDto> dependencies) {
+    public DependenciesReport scan(DependencyInventory inventory) {
+        List<DependencyDto> dependencies = inventory.dependencies();
+        DependencyCoverageDto coverage = inventory.coverage();
         long scannedAt = Instant.now().toEpochMilli();
         List<DependencyDto> packages = DependencyReports.scanCandidates(dependencies, settings.maxPackages());
+        int packagesSkipped = DependencyReports.skippedCandidateCount(dependencies, settings.maxPackages());
         int packagesScanned = 0;
         if (packages.isEmpty()) {
             return DependencyReports.report(
-                    true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
+                    true,
+                    "SCANNED",
+                    "No Maven dependencies were discovered to scan.",
+                    scannedAt,
+                    0,
+                    packagesSkipped,
+                    dependencies,
+                    coverage);
         }
         try {
             QueryBatchResult queryResult = queryBatch(packages);
@@ -284,14 +296,30 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                             fetched.failedFetches()),
                     scannedAt,
                     packagesScanned,
-                    enriched);
+                    packagesSkipped,
+                    enriched,
+                    coverage);
         } catch (IOException ex) {
             return DependencyReports.report(
-                    true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packagesScanned, dependencies);
+                    true,
+                    "ERROR",
+                    "OSV scan failed: " + ex.getMessage(),
+                    scannedAt,
+                    packagesScanned,
+                    packagesSkipped,
+                    dependencies,
+                    coverage);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             return DependencyReports.report(
-                    true, "ERROR", "OSV scan was interrupted", scannedAt, packagesScanned, dependencies);
+                    true,
+                    "ERROR",
+                    "OSV scan was interrupted",
+                    scannedAt,
+                    packagesScanned,
+                    packagesSkipped,
+                    dependencies,
+                    coverage);
         }
     }
 

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusVulnerabilitySettings.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/QuarkusVulnerabilitySettings.java
@@ -11,7 +11,7 @@ import org.eclipse.microprofile.config.Config;
  * record" extraction template (rather than a live-policy SPI): the adapter factory maps the
  * {@code bootui.vulnerabilities.*} properties onto this record inline when producing the scanner, matching
  * the Spring adapter's {@code BootUiProperties.Vulnerabilities} defaults (osv-enabled=true,
- * request-timeout=10s, max-packages=250, max-advisories=200). The base URI defaults to the public OSV.dev
+ * request-timeout=10s, max-packages=500, max-advisories=200). The base URI defaults to the public OSV.dev
  * endpoint and is overridable (notably so the integration test can point it at a loopback stub).</p>
  */
 public record QuarkusVulnerabilitySettings(
@@ -36,7 +36,7 @@ public record QuarkusVulnerabilitySettings(
                 config.getOptionalValue("bootui.vulnerabilities.request-timeout", Duration.class)
                         .orElse(Duration.ofSeconds(10)),
                 config.getOptionalValue("bootui.vulnerabilities.max-packages", Integer.class)
-                        .orElse(250),
+                        .orElse(500),
                 config.getOptionalValue("bootui.vulnerabilities.max-advisories", Integer.class)
                         .orElse(200),
                 config.getOptionalValue("bootui.vulnerabilities.osv-base-uri", String.class)

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/VulnerabilitiesResource.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/web/VulnerabilitiesResource.java
@@ -1,10 +1,10 @@
 package io.github.jdubois.bootui.quarkus.web;
 
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
-import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
 import io.github.jdubois.bootui.engine.advisor.DismissedRulesStore;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyInventory;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import io.github.jdubois.bootui.quarkus.OsvVulnerabilityScanner;
 import io.github.jdubois.bootui.quarkus.QuarkusDependencyProvider;
@@ -15,7 +15,6 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-import java.util.List;
 import org.eclipse.microprofile.config.Config;
 
 /**
@@ -76,14 +75,16 @@ public class VulnerabilitiesResource {
         if (cached != null) {
             return DependencyReports.applyDismissals(cached, dismissedRules.load());
         }
-        List<DependencyDto> dependencies = dependencyProvider.dependencies();
+        DependencyInventory inventory = dependencyProvider.inventory();
         DependenciesReport report = DependencyReports.report(
                 osvEnabled(),
                 "NOT_SCANNED",
                 "Dependency inventory loaded. Click Scan with OSV.dev to check for known vulnerabilities.",
                 null,
                 0,
-                dependencies);
+                0,
+                inventory.dependencies(),
+                inventory.coverage());
         return DependencyReports.applyDismissals(report, dismissedRules.load());
     }
 
@@ -91,7 +92,7 @@ public class VulnerabilitiesResource {
     @Path("/scan")
     @Produces(MediaType.APPLICATION_JSON)
     public DependenciesReport scan() {
-        List<DependencyDto> dependencies = dependencyProvider.dependencies();
+        DependencyInventory inventory = dependencyProvider.inventory();
         DependenciesReport report;
         if (!osvEnabled()) {
             report = DependencyReports.report(
@@ -100,10 +101,12 @@ public class VulnerabilitiesResource {
                     "OSV scanning is disabled. Set bootui.vulnerabilities.osv-enabled=true to allow on-demand scans.",
                     null,
                     0,
-                    dependencies);
+                    0,
+                    inventory.dependencies(),
+                    inventory.coverage());
         } else {
-            report = singleFlight.run(
-                    ActionOperations.VULNERABILITIES_SCAN, () -> vulnerabilityScanner.scan(dependencies));
+            report =
+                    singleFlight.run(ActionOperations.VULNERABILITIES_SCAN, () -> vulnerabilityScanner.scan(inventory));
         }
         if (!"DISABLED".equals(report.status())) {
             this.lastScanReport = report;

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
@@ -10,6 +10,7 @@ import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyInventory;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import java.io.IOException;
 import java.io.InputStream;
@@ -142,8 +143,8 @@ class OsvVulnerabilityScannerTest {
         });
 
         DependenciesReport report = scanner(250, 200)
-                .scan(List.of(
-                        dependency("org.acme", "widget", "1.2.3"), dependency("io.quarkus", "quarkus-arc", "3.20.0")));
+                .scan(DependencyInventory.complete(List.of(
+                        dependency("org.acme", "widget", "1.2.3"), dependency("io.quarkus", "quarkus-arc", "3.20.0"))));
 
         assertThat(report.status()).isEqualTo("SCANNED");
         assertThat(report.scan().vulnerabilitiesFound()).isEqualTo(1);
@@ -183,7 +184,7 @@ class OsvVulnerabilityScannerTest {
         });
         DependencyDto duplicate = dependency("org.acme", "widget", "1.0.0");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(duplicate, duplicate));
+        DependenciesReport report = scanner(250, 200).scan(DependencyInventory.complete(List.of(duplicate, duplicate)));
 
         assertThat(queryCount).hasValue(1);
         assertThat(capturedRequest
@@ -223,7 +224,8 @@ class OsvVulnerabilityScannerTest {
                 "{\"id\":\"GHSA-alpha-critical\",\"database_specific\":{\"severity\":\"CRITICAL\"}}");
 
         DependenciesReport report = scanner(250, 200)
-                .scan(List.of(dependency("org.zeta", "low", "1.0.0"), dependency("org.alpha", "critical", "1.0.0")));
+                .scan(DependencyInventory.complete(
+                        List.of(dependency("org.zeta", "low", "1.0.0"), dependency("org.alpha", "critical", "1.0.0"))));
 
         assertThat(report.dependencies())
                 .extracting(DependencyDto::packageName)
@@ -241,7 +243,8 @@ class OsvVulnerabilityScannerTest {
         handle("/v1/querybatch", "{\"results\":[{}]}");
 
         DependenciesReport report = scanner(1, 200)
-                .scan(List.of(dependency("org.acme", "widget", "1.0.0"), dependency("org.acme", "gadget", "1.0.0")));
+                .scan(DependencyInventory.complete(
+                        List.of(dependency("org.acme", "widget", "1.0.0"), dependency("org.acme", "gadget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("PARTIAL");
         assertThat(report.scan().packagesScanned()).isEqualTo(1);
@@ -254,7 +257,7 @@ class OsvVulnerabilityScannerTest {
         server.createContext("/v1/querybatch", exchange -> respond(exchange, 500, "boom"));
 
         List<DependencyDto> inventory = List.of(dependency("org.acme", "widget", "1.0.0"));
-        DependenciesReport report = scanner(250, 200).scan(inventory);
+        DependenciesReport report = scanner(250, 200).scan(DependencyInventory.complete(inventory));
 
         assertThat(report.status()).isEqualTo("ERROR");
         assertThat(report.scan().message()).contains("OSV");
@@ -267,7 +270,8 @@ class OsvVulnerabilityScannerTest {
         handle("/v1/querybatch", "{\"results\":[{}]}");
 
         DependenciesReport report = scanner(250, 200)
-                .scan(List.of(dependency("org.acme", "first", "1.0.0"), dependency("org.acme", "second", "1.0.0")));
+                .scan(DependencyInventory.complete(
+                        List.of(dependency("org.acme", "first", "1.0.0"), dependency("org.acme", "second", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("ERROR");
         assertThat(report.scan().packagesScanned()).isZero();
@@ -279,7 +283,8 @@ class OsvVulnerabilityScannerTest {
     void reportsErrorWhenQuerybatchContainsAVulnerabilityWithoutAnId() {
         handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{}]}]}");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("ERROR");
         assertThat(report.scan().packagesScanned()).isZero();
@@ -300,7 +305,8 @@ class OsvVulnerabilityScannerTest {
         });
         handle("/v1/vulns/V-MISMATCH", "{\"id\":\"V-OTHER\",\"database_specific\":{\"severity\":\"CRITICAL\"}}");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains("1 advisory fetch failed");
@@ -323,8 +329,8 @@ class OsvVulnerabilityScannerTest {
         });
 
         List<DependencyDto> inventory = List.of(dependency("org.acme", "widget", "1.0.0"));
-        DependenciesReport report =
-                new OsvVulnerabilityScanner(settings(Duration.ofMillis(50), 250, 200)).scan(inventory);
+        DependenciesReport report = new OsvVulnerabilityScanner(settings(Duration.ofMillis(50), 250, 200))
+                .scan(DependencyInventory.complete(inventory));
 
         assertThat(report.status()).isEqualTo("ERROR");
         assertThat(report.scan().message()).contains("OSV");
@@ -336,14 +342,15 @@ class OsvVulnerabilityScannerTest {
     void reportsErrorOnMalformedJson() {
         handle("/v1/querybatch", "{ this is not json ");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("ERROR");
     }
 
     @Test
     void reportsScannedWithNoFindingsWhenInventoryIsEmpty() {
-        DependenciesReport report = scanner(250, 200).scan(List.of());
+        DependenciesReport report = scanner(250, 200).scan(DependencyInventory.complete(List.of()));
 
         assertThat(report.status()).isEqualTo("SCANNED");
         assertThat(report.scan().message()).contains("No Maven dependencies");
@@ -367,7 +374,8 @@ class OsvVulnerabilityScannerTest {
                                 // Real CVSS v3.1 vector verified against the FIRST.org spec: base score 5.4 -> MEDIUM.
                                 + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N\"}]}"));
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.dependencies().get(0).highestSeverity()).isEqualTo("MEDIUM");
         assertThat(severityCount(report, "MEDIUM")).isEqualTo(1);
@@ -387,7 +395,8 @@ class OsvVulnerabilityScannerTest {
             respond(exchange, 200, "{\"id\":\"" + id + "\",\"database_specific\":{\"severity\":\"HIGH\"}}");
         });
 
-        DependenciesReport report = scanner(250, 1).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report =
+                scanner(250, 1).scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("PARTIAL");
         assertThat(fetched)
@@ -413,7 +422,8 @@ class OsvVulnerabilityScannerTest {
                                 + "\"severity\":[{\"type\":\"CVSS_V4\","
                                 + "\"score\":\"CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N\"}]}"));
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         DependencyVulnerabilityDto vulnerability =
                 report.dependencies().get(0).vulnerabilities().get(0);
@@ -433,7 +443,7 @@ class OsvVulnerabilityScannerTest {
                         + "{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"}]}");
 
         DependencyVulnerabilityDto vulnerability = scanner(250, 200)
-                .scan(List.of(dependency("org.acme", "widget", "1.0.0")))
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))))
                 .dependencies()
                 .get(0)
                 .vulnerabilities()
@@ -456,7 +466,8 @@ class OsvVulnerabilityScannerTest {
                         "{\"id\":\"GHSA-withdrawn\",\"withdrawn\":\"2024-01-01T00:00:00Z\","
                                 + "\"database_specific\":{\"severity\":\"CRITICAL\"}}"));
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         // A withdrawn advisory is intentionally dropped -- this is correct, expected behavior, not a
         // failure, so it must not degrade the scan status to PARTIAL/ERROR.
@@ -477,7 +488,8 @@ class OsvVulnerabilityScannerTest {
                 exchange -> respond(exchange, 200, "{\"id\":\"V-OK\",\"database_specific\":{\"severity\":\"HIGH\"}}"));
         server.createContext("/v1/vulns/V-FAIL", exchange -> respond(exchange, 503, "boom"));
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         // The advisory that failed to fetch must not discard the one that succeeded, nor abort the
         // whole scan to ERROR the way a single-advisory IOException used to.
@@ -501,7 +513,8 @@ class OsvVulnerabilityScannerTest {
                         + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"},"
                         + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H\"}]}]}");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         DependencyVulnerabilityDto vulnerability =
                 report.dependencies().get(0).vulnerabilities().get(0);
@@ -518,7 +531,8 @@ class OsvVulnerabilityScannerTest {
                         + "\"severity\":[{\"type\":\"CVSS_V3\",\"score\":\"CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N\"}],"
                         + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"}}]}");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         DependencyVulnerabilityDto vulnerability =
                 report.dependencies().get(0).vulnerabilities().get(0);
@@ -542,7 +556,8 @@ class OsvVulnerabilityScannerTest {
         handle("/v1/vulns/GHSA-page-1", "{\"id\":\"GHSA-page-1\",\"database_specific\":{\"severity\":\"HIGH\"}}");
         handle("/v1/vulns/GHSA-page-2", "{\"id\":\"GHSA-page-2\",\"database_specific\":{\"severity\":\"LOW\"}}");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         // Both pages must be merged into the final result, and pagination completing within the safety
         // bound must not degrade the scan status.
@@ -570,7 +585,8 @@ class OsvVulnerabilityScannerTest {
             respond(exchange, 200, "{\"id\":\"" + id + "\",\"database_specific\":{\"severity\":\"LOW\"}}");
         });
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains("paginated");
@@ -605,7 +621,7 @@ class OsvVulnerabilityScannerTest {
             dependencies.add(dependency("org.acme", "widget" + i, "1.0.0"));
         }
 
-        DependenciesReport report = scanner(1500, 200).scan(dependencies);
+        DependenciesReport report = scanner(1500, 200).scan(DependencyInventory.complete(dependencies));
 
         // 1500 packages must be partitioned into 2 requests of <=1000 each (OSV's hard per-request cap),
         // not sent as a single oversized batch that OSV.dev would reject with HTTP 400.
@@ -626,7 +642,7 @@ class OsvVulnerabilityScannerTest {
             dependencies.add(dependency("org.acme", "widget" + i, "1.0.0"));
         }
 
-        DependenciesReport report = scanner(1001, 200).scan(dependencies);
+        DependenciesReport report = scanner(1001, 200).scan(DependencyInventory.complete(dependencies));
 
         assertThat(queryBatchCalls).hasValue(2);
         assertThat(report.status()).isEqualTo("PARTIAL");
@@ -649,7 +665,8 @@ class OsvVulnerabilityScannerTest {
                     "{\"data\":[{\"cve\":\"CVE-2021-44228\",\"epss\":\"0.944500000\",\"percentile\":\"0.999900000\"}]}");
         });
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         DependencyVulnerabilityDto vulnerability =
                 report.dependencies().get(0).vulnerabilities().get(0);
@@ -681,7 +698,8 @@ class OsvVulnerabilityScannerTest {
                     "{\"data\":[{\"cve\":\"CVE-2024-1234\",\"epss\":\"0.125\",\"percentile\":\"0.75\"}]}");
         });
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(epssCalls).hasValue(2);
         DependencyVulnerabilityDto cveFinding = report.dependencies().get(0).vulnerabilities().stream()
@@ -700,7 +718,8 @@ class OsvVulnerabilityScannerTest {
                 "{\"id\":\"GHSA-epss-down\",\"aliases\":[\"CVE-2021-44228\"],\"database_specific\":{\"severity\":\"CRITICAL\"}}");
         server.createContext("/data/v1/epss", exchange -> respond(exchange, 503, "boom"));
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("SCANNED");
         DependencyVulnerabilityDto vulnerability =
@@ -724,8 +743,8 @@ class OsvVulnerabilityScannerTest {
 
         QuarkusVulnerabilitySettings settings =
                 new QuarkusVulnerabilitySettings(true, Duration.ofSeconds(5), 250, 200, baseUri, false, baseUri);
-        DependenciesReport report =
-                new OsvVulnerabilityScanner(settings).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = new OsvVulnerabilityScanner(settings)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(epssCalls.get()).isZero();
         assertThat(report.dependencies().get(0).vulnerabilities().get(0).epssScore())
@@ -741,7 +760,8 @@ class OsvVulnerabilityScannerTest {
                         + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"},"
                         + "\"ranges\":[{\"events\":[{\"introduced\":\"0\"},{\"last_affected\":\"1.0.0\"}]}]}]}");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         DependencyVulnerabilityDto vulnerability =
                 report.dependencies().get(0).vulnerabilities().get(0);
@@ -762,7 +782,7 @@ class OsvVulnerabilityScannerTest {
                         + "]}]}");
 
         DependencyVulnerabilityDto vulnerability = scanner(250, 200)
-                .scan(List.of(dependency("org.acme", "widget", "0.9")))
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "0.9"))))
                 .dependencies()
                 .get(0)
                 .vulnerabilities()
@@ -781,7 +801,8 @@ class OsvVulnerabilityScannerTest {
                         + "\"ranges\":[{\"events\":[{\"introduced\":\"0\"},{\"fixed\":\"1.0.0\"}]}]}]}");
 
         // Dependency is already at version 1.2.0, above the advertised "fixed" 1.0.0.
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.2.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.2.0"))));
 
         DependencyVulnerabilityDto vulnerability =
                 report.dependencies().get(0).vulnerabilities().get(0);
@@ -802,7 +823,8 @@ class OsvVulnerabilityScannerTest {
                         + "{\"type\":\"REPORT\",\"url\":\"https://example.com/report\"}],"
                         + "\"affected\":[{\"package\":{\"ecosystem\":\"Maven\",\"name\":\"org.acme:widget\"}}]}");
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         DependencyVulnerabilityDto vulnerability =
                 report.dependencies().get(0).vulnerabilities().get(0);
@@ -838,7 +860,8 @@ class OsvVulnerabilityScannerTest {
                     "{\"id\":\"" + id + "\",\"database_specific\":{\"severity\":\"" + severity + "\"}}");
         }
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("SCANNED");
         assertThat(report.dependencies().get(0).vulnerabilities()).hasSize(advisoryCount);
@@ -870,7 +893,8 @@ class OsvVulnerabilityScannerTest {
             }
         }
 
-        DependenciesReport report = scanner(250, 200).scan(List.of(dependency("org.acme", "widget", "1.0.0")));
+        DependenciesReport report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
 
         assertThat(report.status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains(failingCount + " advisory fetches failed");

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiProperties.java
@@ -782,9 +782,11 @@ public class BootUiProperties {
         private Duration requestTimeout = Duration.ofSeconds(10);
 
         /**
-         * Maximum number of dependency packages included in one OSV batch query.
+         * Maximum number of dependency packages included in one OSV batch query. Packages beyond this bound
+         * are reported as {@code scan.packagesSkipped} rather than silently dropped. The default is sized to
+         * cover a typical Spring Boot application's full JAR set, which commonly exceeds 300 dependencies.
          */
-        private int maxPackages = 250;
+        private int maxPackages = 500;
 
         /**
          * Maximum number of advisory details fetched after the package query.

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
@@ -40,6 +40,13 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
     /** Maven metadata scanned by {@code DependencyCatalog} for the Vulnerabilities panel. */
     private static final String MAVEN_POM_PROPERTIES_PATTERN = "META-INF/maven/*/*/pom.properties";
 
+    /**
+     * CycloneDX SBOM locations read by {@code DependencyCatalog}. Without these the Vulnerabilities panel
+     * loses its only source of coordinates for artifacts published with no Maven descriptor, which is most
+     * of a typical application's classpath.
+     */
+    private static final String[] SBOM_RESOURCES = {"META-INF/sbom/application.cdx.json", "META-INF/sbom/bom.json"};
+
     /** Configuration metadata scanned by {@code ConfigMetadataCatalog} for the Config panel. */
     private static final String CONFIGURATION_METADATA_RESOURCE = "META-INF/spring-configuration-metadata.json";
 
@@ -81,6 +88,9 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
                 .registerPattern(MAVEN_POM_PROPERTIES_PATTERN)
                 .registerPattern(CONFIGURATION_METADATA_RESOURCE)
                 .registerPattern(BOOTUI_VERSION_RESOURCE);
+        for (String sbomResource : SBOM_RESOURCES) {
+            hints.resources().registerPattern(sbomResource);
+        }
 
         registerDtoBindingHints(hints, classLoader);
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalog.java
@@ -1,14 +1,22 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
+import io.github.jdubois.bootui.core.dto.DependencyCoverageDto;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.engine.support.BlankStrings;
+import io.github.jdubois.bootui.engine.vulnerabilities.ArchiveNames;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyInventory;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyProvider;
+import io.github.jdubois.bootui.engine.vulnerabilities.PackageUrls;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -19,14 +27,69 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
+/**
+ * Resolves the running Spring application's dependency inventory, and reports how much of its real JAR set
+ * that inventory actually covers.
+ *
+ * <p>Coordinates are resolved from three local sources, in decreasing order of authority:</p>
+ *
+ * <ol>
+ *   <li>the application's embedded <a href="https://cyclonedx.org/">CycloneDX</a> SBOM
+ *       ({@code META-INF/sbom/application.cdx.json}, the file Spring Boot's {@code /actuator/sbom} serves),
+ *       whose {@code purl} values carry the {@code groupId};</li>
+ *   <li>{@code META-INF/maven/*}{@code /*}{@code /pom.properties} descriptors on the classpath;</li>
+ *   <li>the {@code java.class.path} entries, read through the Maven repository directory layout or an
+ *       adjacent {@code .pom}.</li>
+ * </ol>
+ *
+ * <p>The SBOM matters because sources 2 and 3 leave a large, security-relevant hole. Many artifacts are
+ * published with no Maven descriptor at all (Spring Framework, Spring Boot, Spring Security,
+ * {@code tomcat-embed-*}, {@code hibernate-core}, {@code kotlin-stdlib}, the PostgreSQL driver, and the
+ * {@code opentelemetry-*} and {@code micrometer-*} families among them), and inside a repackaged fat JAR
+ * source 3 is dead too, because {@code java.class.path} is then just the application archive. No JAR
+ * manifest header carries a {@code groupId} &mdash; {@code Implementation-Title} is a display name as often
+ * as an artifact id, and {@code Implementation-Vendor-Id} is not a group id &mdash; so an application
+ * without an SBOM genuinely cannot resolve those artifacts locally.</p>
+ *
+ * <p>That is why the catalogue also takes a census of the application's real archives ({@code BOOT-INF/lib/}
+ * entries inside a repackaged JAR or WAR, classpath JARs otherwise) and reports every archive it could not
+ * attribute to a resolved coordinate as {@link DependencyCoverageDto#INCOMPLETE} coverage. A scan covering
+ * part of the classpath is then visibly partial instead of rendering as a green, full-coverage result. When
+ * the census itself cannot run &mdash; a blank or synthetic {@code java.class.path}, as under a native image
+ * &mdash; coverage is reported {@link DependencyCoverageDto#UNAVAILABLE} rather than assumed complete.</p>
+ *
+ * <p>Every source fails soft: an unreadable descriptor, a malformed SBOM, or an unreadable archive is logged
+ * and skipped without discarding the entries that did resolve.</p>
+ */
 final class DependencyCatalog implements DependencyProvider {
 
     private static final String MAVEN_PROPERTIES_PATTERN = "classpath*:META-INF/maven/*/*/pom.properties";
 
+    /** The two SBOM locations Spring Boot's {@code SbomEndpoint} recognizes for the application BOM. */
+    static final List<String> SBOM_PATTERNS =
+            List.of("classpath*:META-INF/sbom/application.cdx.json", "classpath*:META-INF/sbom/bom.json");
+
+    private static final String MAVEN_METADATA_MARKER = "!/META-INF/maven/";
+
+    /** Manifest attribute Spring Boot's repackaging writes, naming the nested library directory. */
+    private static final String SPRING_BOOT_LIB_ATTRIBUTE = "Spring-Boot-Lib";
+
+    private static final List<String> DEFAULT_NESTED_LIBRARY_PREFIXES = List.of("BOOT-INF/lib/", "WEB-INF/lib/");
+
+    /** Upper bound on the archive names carried in the report; the reported counts stay exact regardless. */
+    static final int MAX_UNIDENTIFIED_ARCHIVES = 200;
+
+    /** Upper bound on SBOM components read, so a pathological BOM cannot stall a panel load. */
+    private static final int MAX_SBOM_COMPONENTS = 10_000;
+
     private static final System.Logger LOGGER = System.getLogger(DependencyCatalog.class.getName());
 
     private final ResourcePatternResolver resolver;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     DependencyCatalog() {
         this(new PathMatchingResourcePatternResolver());
@@ -38,28 +101,288 @@ final class DependencyCatalog implements DependencyProvider {
 
     @Override
     public List<DependencyDto> dependencies() {
+        return inventory().dependencies();
+    }
+
+    @Override
+    public DependencyInventory inventory() {
         Map<String, DependencyDto> dependencies = new LinkedHashMap<>();
-        for (Resource resource : mavenPomProperties()) {
+        Set<String> identifiedArchives = new LinkedHashSet<>();
+
+        for (DependencyDto dependency : sbomDependencies()) {
+            dependencies.putIfAbsent(key(dependency), dependency);
+        }
+        for (Resource resource : resources(MAVEN_PROPERTIES_PATTERN)) {
             DependencyDto dependency = dependency(resource);
             if (dependency != null) {
-                dependencies.putIfAbsent(dependency.packageName() + ":" + dependency.version(), dependency);
+                dependencies.putIfAbsent(key(dependency), dependency);
+                String owner = owningArchive(resource);
+                if (owner != null) {
+                    identifiedArchives.add(owner);
+                }
             }
         }
         for (DependencyDto dependency : javaClassPathDependencies()) {
-            dependencies.putIfAbsent(dependency.packageName() + ":" + dependency.version(), dependency);
+            dependencies.putIfAbsent(key(dependency), dependency);
         }
-        return dependencies.values().stream()
+
+        List<DependencyDto> resolved = dependencies.values().stream()
                 .sorted(Comparator.comparing(DependencyDto::packageName).thenComparing(DependencyDto::version))
                 .toList();
+        return new DependencyInventory(resolved, coverage(resolved, identifiedArchives));
     }
 
-    private Resource[] mavenPomProperties() {
+    private static String key(DependencyDto dependency) {
+        return dependency.packageName() + ":" + dependency.version();
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Coverage
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Compares the resolved coordinates against the application's real archive census. An archive counts as
+     * identified when a Maven descriptor was read from inside it, or when its file name is the one Maven
+     * would publish for a resolved coordinate.
+     */
+    private DependencyCoverageDto coverage(List<DependencyDto> resolved, Set<String> identifiedArchives) {
+        List<String> archives = archiveCensus();
+        if (archives.isEmpty()) {
+            return DependencyCoverageDto.unavailable();
+        }
+        List<String> unidentified = new ArrayList<>();
+        for (String archive : archives) {
+            if (!identifiedArchives.contains(archive) && !isIdentified(archive, resolved)) {
+                unidentified.add(archive);
+            }
+        }
+        unidentified.sort(String.CASE_INSENSITIVE_ORDER);
+        return DependencyCoverageDto.of(
+                archives.size(),
+                unidentified.size(),
+                unidentified.stream().limit(MAX_UNIDENTIFIED_ARCHIVES).toList());
+    }
+
+    private static boolean isIdentified(String archive, List<DependencyDto> resolved) {
+        for (DependencyDto dependency : resolved) {
+            if (ArchiveNames.matches(archive, dependency.artifactId(), dependency.version())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The distinct JAR archives the application actually runs with, or an empty list when they cannot be
+     * enumerated (a blank {@code java.class.path}, as under a native image or a non-standard launcher),
+     * which is reported as unknown coverage rather than as a clean bill of health.
+     */
+    private List<String> archiveCensus() {
+        String classPath = System.getProperty("java.class.path", "");
+        if (classPath.isBlank()) {
+            return List.of();
+        }
+        Set<String> archives = new LinkedHashSet<>();
+        for (String entry : classPath.split(Pattern.quote(File.pathSeparator))) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            List<String> nested = nestedLibraries(trimmed);
+            if (nested != null) {
+                // A repackaged archive is the application's own, not a third-party dependency: its nested
+                // libraries are the real dependency set, and the outer archive is deliberately not counted.
+                // This is also why the entry is inspected before its extension is considered: an executable
+                // WAR is a classpath entry that is not itself a JAR.
+                archives.addAll(nested);
+                continue;
+            }
+            String archive = ArchiveNames.jarFileName(trimmed);
+            if (archive != null) {
+                archives.add(archive);
+            }
+        }
+        return List.copyOf(archives);
+    }
+
+    /**
+     * The {@code BOOT-INF/lib/} (or {@code WEB-INF/lib/}) archive names of a repackaged Spring Boot archive,
+     * or {@code null} when {@code entry} is an ordinary library JAR, is unreadable, or does not exist.
+     *
+     * <p>Only the archive's central directory and manifest are read; nothing is extracted or decompressed,
+     * and nesting is not recursed into, matching how Spring Boot repackaging actually lays an archive
+     * out.</p>
+     */
+    private List<String> nestedLibraries(String entry) {
+        File file = new File(entry);
+        if (!file.isFile()) {
+            return null;
+        }
+        try (JarFile jarFile = new JarFile(file)) {
+            List<String> prefixes = nestedLibraryPrefixes(jarFile);
+            List<String> nested = new ArrayList<>();
+            Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry jarEntry = entries.nextElement();
+                if (jarEntry.isDirectory()) {
+                    continue;
+                }
+                String name = jarEntry.getName();
+                for (String prefix : prefixes) {
+                    if (name.startsWith(prefix) && name.indexOf('/', prefix.length()) < 0) {
+                        String archive = ArchiveNames.jarFileName(name);
+                        if (archive != null) {
+                            nested.add(archive);
+                        }
+                        break;
+                    }
+                }
+            }
+            return nested.isEmpty() ? null : nested;
+        } catch (IOException | RuntimeException ex) {
+            LOGGER.log(
+                    System.Logger.Level.DEBUG,
+                    "Could not inspect classpath archive {0} for nested libraries: {1}",
+                    entry,
+                    ex.getMessage());
+            return null;
+        }
+    }
+
+    private static List<String> nestedLibraryPrefixes(JarFile jarFile) {
         try {
-            return resolver.getResources(MAVEN_PROPERTIES_PATTERN);
-        } catch (IOException ex) {
+            Manifest manifest = jarFile.getManifest();
+            String declared = manifest == null
+                    ? null
+                    : BlankStrings.blankToNullTrimmed(
+                            manifest.getMainAttributes().getValue(SPRING_BOOT_LIB_ATTRIBUTE));
+            if (declared != null) {
+                return List.of(declared.endsWith("/") ? declared : declared + "/");
+            }
+        } catch (IOException | RuntimeException ex) {
+            // Fall through to the conventional prefixes; an unreadable manifest is not an error here.
+        }
+        return DEFAULT_NESTED_LIBRARY_PREFIXES;
+    }
+
+    /**
+     * The archive a classpath descriptor was read from, parsed out of its resource URL, or {@code null} for
+     * a descriptor on an exploded directory classpath. This attributes a descriptor to its archive exactly,
+     * rather than inferring it from coordinates that a shaded archive may not match.
+     */
+    private String owningArchive(Resource resource) {
+        String location = location(resource);
+        if (location == null) {
+            return null;
+        }
+        int marker = location.indexOf(MAVEN_METADATA_MARKER);
+        if (marker < 0) {
+            return null;
+        }
+        return ArchiveNames.jarFileName(location.substring(0, marker));
+    }
+
+    /**
+     * The resource's location as text. Spring Boot 3.2+ addresses a descriptor inside a repackaged archive
+     * with a {@code jar:nested:} URL, which only resolves as a {@code URL} while Boot's protocol handler is
+     * registered; falling back to the URI keeps attribution working regardless.
+     */
+    private static String location(Resource resource) {
+        try {
+            return resource.getURL().toString();
+        } catch (IOException | RuntimeException ex) {
+            // Not URL-addressable; try the URI below.
+        }
+        try {
+            return resource.getURI().toString();
+        } catch (IOException | RuntimeException ex) {
+            return null;
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // CycloneDX SBOM
+    // -----------------------------------------------------------------------------------------------
+
+    /**
+     * Reads the application's embedded CycloneDX SBOM, taking one dependency per Maven {@code purl}. This is
+     * the only local source able to resolve the {@code groupId} of an artifact published without a Maven
+     * descriptor, so it is what closes the classpath gap on a repackaged application.
+     */
+    private List<DependencyDto> sbomDependencies() {
+        Map<String, DependencyDto> dependencies = new LinkedHashMap<>();
+        for (String pattern : SBOM_PATTERNS) {
+            for (Resource resource : resources(pattern)) {
+                readSbom(resource, dependencies);
+            }
+        }
+        return List.copyOf(dependencies.values());
+    }
+
+    private void readSbom(Resource resource, Map<String, DependencyDto> dependencies) {
+        JsonNode root;
+        try (InputStream input = resource.getInputStream()) {
+            root = objectMapper.readTree(input);
+        } catch (IOException | RuntimeException ex) {
             LOGGER.log(
                     System.Logger.Level.WARNING,
-                    "Could not inspect classpath Maven metadata; continuing with java.class.path: {0}",
+                    "Could not read the CycloneDX SBOM from {0}; continuing without it: {1}",
+                    resource.getDescription(),
+                    ex.getMessage());
+            return;
+        }
+        if (root == null || !root.isObject()) {
+            return;
+        }
+        // The BOM's own metadata.component is the application itself, not one of its dependencies, so only
+        // the components array is read.
+        collectSbomComponents(root.get("components"), dependencies);
+    }
+
+    private void collectSbomComponents(JsonNode components, Map<String, DependencyDto> dependencies) {
+        if (components == null || !components.isArray()) {
+            return;
+        }
+        for (JsonNode component : components) {
+            if (dependencies.size() >= MAX_SBOM_COMPONENTS) {
+                return;
+            }
+            if (!component.isObject()) {
+                continue;
+            }
+            JsonNode purl = component.get("purl");
+            PackageUrls.MavenCoordinates coordinates =
+                    purl == null || !purl.isString() ? null : PackageUrls.mavenCoordinates(purl.stringValue());
+            if (coordinates != null) {
+                dependencies.putIfAbsent(
+                        coordinates.packageName() + ":" + coordinates.version(),
+                        new DependencyDto(
+                                coordinates.groupId(),
+                                coordinates.artifactId(),
+                                coordinates.version(),
+                                coordinates.packageName(),
+                                "CycloneDX SBOM",
+                                0,
+                                "NONE",
+                                List.of()));
+            }
+            // CycloneDX allows a component to nest the components it in turn assembles.
+            collectSbomComponents(component.get("components"), dependencies);
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Maven descriptors and the java.class.path
+    // -----------------------------------------------------------------------------------------------
+
+    private Resource[] resources(String pattern) {
+        try {
+            return resolver.getResources(pattern);
+        } catch (IOException | RuntimeException ex) {
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "Could not resolve {0} from the classpath; continuing without it: {1}",
+                    pattern,
                     ex.getMessage());
             return new Resource[0];
         }
@@ -92,7 +415,7 @@ final class DependencyCatalog implements DependencyProvider {
         if (classPath.isBlank()) {
             return List.of();
         }
-        return List.of(classPath.split(java.util.regex.Pattern.quote(File.pathSeparator))).stream()
+        return List.of(classPath.split(Pattern.quote(File.pathSeparator))).stream()
                 .map(this::dependencyFromClassPathEntry)
                 .filter(dependency -> dependency != null)
                 .toList();

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -2,8 +2,10 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
+import io.github.jdubois.bootui.core.dto.DependencyCoverageDto;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.core.dto.DependencyVulnerabilityDto;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyInventory;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import io.github.jdubois.bootui.engine.vulnerabilities.EpssScore;
 import io.github.jdubois.bootui.engine.vulnerabilities.VulnerabilityScanner;
@@ -229,13 +231,23 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     }
 
     @Override
-    public DependenciesReport scan(List<DependencyDto> dependencies) {
+    public DependenciesReport scan(DependencyInventory inventory) {
+        List<DependencyDto> dependencies = inventory.dependencies();
+        DependencyCoverageDto coverage = inventory.coverage();
         long scannedAt = Instant.now().toEpochMilli();
         List<DependencyDto> packages = DependencyReports.scanCandidates(dependencies, properties.getMaxPackages());
+        int packagesSkipped = DependencyReports.skippedCandidateCount(dependencies, properties.getMaxPackages());
         int packagesScanned = 0;
         if (packages.isEmpty()) {
             return DependencyReports.report(
-                    true, "SCANNED", "No Maven dependencies were discovered to scan.", scannedAt, 0, dependencies);
+                    true,
+                    "SCANNED",
+                    "No Maven dependencies were discovered to scan.",
+                    scannedAt,
+                    0,
+                    packagesSkipped,
+                    dependencies,
+                    coverage);
         }
         try {
             QueryBatchResult queryResult = queryBatch(packages);
@@ -262,14 +274,30 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                             fetched.failedFetches()),
                     scannedAt,
                     packagesScanned,
-                    enriched);
+                    packagesSkipped,
+                    enriched,
+                    coverage);
         } catch (IOException | JacksonException ex) {
             return DependencyReports.report(
-                    true, "ERROR", "OSV scan failed: " + ex.getMessage(), scannedAt, packagesScanned, dependencies);
+                    true,
+                    "ERROR",
+                    "OSV scan failed: " + ex.getMessage(),
+                    scannedAt,
+                    packagesScanned,
+                    packagesSkipped,
+                    dependencies,
+                    coverage);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
             return DependencyReports.report(
-                    true, "ERROR", "OSV scan was interrupted", scannedAt, packagesScanned, dependencies);
+                    true,
+                    "ERROR",
+                    "OSV scan was interrupted",
+                    scannedAt,
+                    packagesScanned,
+                    packagesSkipped,
+                    dependencies,
+                    coverage);
         }
     }
 

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilitiesController.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilitiesController.java
@@ -2,14 +2,13 @@ package io.github.jdubois.bootui.autoconfigure.web;
 
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
-import io.github.jdubois.bootui.core.dto.DependencyDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
 import io.github.jdubois.bootui.engine.advisor.DismissedRulesStore;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyInventory;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyProvider;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import io.github.jdubois.bootui.engine.vulnerabilities.VulnerabilityScanner;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,20 +65,22 @@ public class VulnerabilitiesController {
         if (cached != null) {
             return DependencyReports.applyDismissals(cached, dismissedRules.load());
         }
-        List<DependencyDto> dependencies = dependencyProvider.dependencies();
+        DependencyInventory inventory = dependencyProvider.inventory();
         DependenciesReport report = DependencyReports.report(
                 properties.getVulnerabilities().isOsvEnabled(),
                 "NOT_SCANNED",
                 "Dependency inventory loaded. Click Scan with OSV.dev to check for known vulnerabilities.",
                 null,
                 0,
-                dependencies);
+                0,
+                inventory.dependencies(),
+                inventory.coverage());
         return DependencyReports.applyDismissals(report, dismissedRules.load());
     }
 
     @PostMapping("/scan")
     public DependenciesReport scan() {
-        List<DependencyDto> dependencies = dependencyProvider.dependencies();
+        DependencyInventory inventory = dependencyProvider.inventory();
         DependenciesReport report;
         if (!properties.getVulnerabilities().isOsvEnabled()) {
             report = DependencyReports.report(
@@ -88,10 +89,12 @@ public class VulnerabilitiesController {
                     "OSV scanning is disabled. Set bootui.vulnerabilities.osv-enabled=true to allow on-demand scans.",
                     null,
                     0,
-                    dependencies);
+                    0,
+                    inventory.dependencies(),
+                    inventory.coverage());
         } else {
-            report = singleFlight.run(
-                    ActionOperations.VULNERABILITIES_SCAN, () -> vulnerabilityScanner.scan(dependencies));
+            report =
+                    singleFlight.run(ActionOperations.VULNERABILITIES_SCAN, () -> vulnerabilityScanner.scan(inventory));
         }
         if (!"DISABLED".equals(report.status())) {
             this.lastScanReport = report;

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiPropertiesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiPropertiesTests.java
@@ -146,9 +146,11 @@ class BootUiPropertiesTests {
     }
 
     @Test
-    void defaultVulnerabilitiesMaxPackagesIs250() {
+    void defaultVulnerabilitiesMaxPackagesCoversATypicalApplicationsFullJarSet() {
+        // A typical Spring Boot application ships well over 250 JARs, and the old default silently dropped
+        // the remainder from the scan.
         BootUiProperties props = new BootUiProperties();
-        assertThat(props.getVulnerabilities().getMaxPackages()).isEqualTo(250);
+        assertThat(props.getVulnerabilities().getMaxPackages()).isEqualTo(500);
     }
 
     // -------------------------------------------------------------------------

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
@@ -26,6 +26,12 @@ class BootUiRuntimeHintsTests {
                 .accepts(hints);
         assertThat(RuntimeHintsPredicates.resource().forResource("bootui-version.properties"))
                 .accepts(hints);
+        // The Vulnerabilities panel reads the application's CycloneDX SBOM; without these the native image
+        // loses the only source of coordinates for JARs published with no Maven descriptor.
+        assertThat(RuntimeHintsPredicates.resource().forResource("META-INF/sbom/application.cdx.json"))
+                .accepts(hints);
+        assertThat(RuntimeHintsPredicates.resource().forResource("META-INF/sbom/bom.json"))
+                .accepts(hints);
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/DependencyCatalogTests.java
@@ -1,15 +1,26 @@
 package io.github.jdubois.bootui.autoconfigure.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
+import io.github.jdubois.bootui.core.dto.DependencyCoverageDto;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyInventory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.io.ByteArrayResource;
@@ -21,51 +32,22 @@ class DependencyCatalogTests {
     @TempDir
     Path tempDir;
 
-    private static ResourcePatternResolver emptyResolver() {
-        return new ResourcePatternResolver() {
-            @Override
-            public Resource[] getResources(String locationPattern) {
-                return new Resource[0];
-            }
-
-            @Override
-            public Resource getResource(String location) {
-                return new ByteArrayResource(new byte[0]);
-            }
-
-            @Override
-            public ClassLoader getClassLoader() {
-                return DependencyCatalogTests.class.getClassLoader();
-            }
-        };
-    }
+    // -----------------------------------------------------------------------------------------------
+    // Coordinate resolution
+    // -----------------------------------------------------------------------------------------------
 
     @Test
     void discoversMavenCoordinatesFromJavaClassPathJarsWithoutPomProperties() {
-        String previousClassPath = System.getProperty("java.class.path");
-        try {
-            System.setProperty(
-                    "java.class.path",
-                    String.join(
-                            File.pathSeparator,
-                            "/home/user/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/11.0.21/tomcat-embed-core-11.0.21.jar",
-                            "/home/user/.m2/repository/org/postgresql/postgresql/42.7.10/postgresql-42.7.10.jar"));
+        List<DependencyDto> dependencies = withClassPath(
+                emptyResolver(),
+                "/home/user/.m2/repository/org/apache/tomcat/embed/tomcat-embed-core/11.0.21/tomcat-embed-core-11.0.21.jar",
+                "/home/user/.m2/repository/org/postgresql/postgresql/42.7.10/postgresql-42.7.10.jar");
 
-            List<DependencyDto> dependencies = new DependencyCatalog(emptyResolver()).dependencies();
-
-            assertThat(dependencies)
-                    .extracting(DependencyDto::packageName, DependencyDto::version)
-                    .contains(
-                            org.assertj.core.api.Assertions.tuple(
-                                    "org.apache.tomcat.embed:tomcat-embed-core", "11.0.21"),
-                            org.assertj.core.api.Assertions.tuple("org.postgresql:postgresql", "42.7.10"));
-        } finally {
-            if (previousClassPath == null) {
-                System.clearProperty("java.class.path");
-            } else {
-                System.setProperty("java.class.path", previousClassPath);
-            }
-        }
+        assertThat(dependencies)
+                .extracting(DependencyDto::packageName, DependencyDto::version)
+                .contains(
+                        tuple("org.apache.tomcat.embed:tomcat-embed-core", "11.0.21"),
+                        tuple("org.postgresql:postgresql", "42.7.10"));
     }
 
     @Test
@@ -82,12 +64,11 @@ class DependencyCatalogTests {
                 </project>
                 """);
 
-        List<DependencyDto> dependencies = withClassPath(jar.toString());
+        List<DependencyDto> dependencies = withClassPath(emptyResolver(), jar.toString());
 
         assertThat(dependencies)
                 .extracting(DependencyDto::packageName, DependencyDto::version, DependencyDto::source)
-                .containsExactly(org.assertj.core.api.Assertions.tuple(
-                        "com.acme.libs:acme-widget", "2.1.0", "Adjacent Maven POM"));
+                .containsExactly(tuple("com.acme.libs:acme-widget", "2.1.0", "Adjacent Maven POM"));
     }
 
     @Test
@@ -96,31 +77,22 @@ class DependencyCatalogTests {
         Files.createDirectories(versionDirectory);
         Path jar = Files.createFile(versionDirectory.resolve("acme-widget-2.1.0.jar"));
 
-        assertThat(withClassPath(jar.toString())).isEmpty();
+        assertThat(withClassPath(emptyResolver(), jar.toString())).isEmpty();
     }
 
     @Test
     void skipsUnreadableMavenMetadataWithoutDiscardingReadableEntries() {
         Resource readable = new ByteArrayResource(
                 "groupId=com.acme\nartifactId=widget\nversion=1.2.3\n".getBytes(StandardCharsets.UTF_8));
-        Resource unreadable = new ByteArrayResource(new byte[0]) {
-            @Override
-            public InputStream getInputStream() throws IOException {
-                throw new IOException("unreadable");
-            }
-
-            @Override
-            public String getDescription() {
-                return "unreadable pom.properties";
-            }
-        };
-        ResourcePatternResolver resolver = resolver(readable, unreadable);
+        Resource unreadable = failingResource("unreadable pom.properties");
+        ResourcePatternResolver resolver =
+                patternResolver(Map.of("classpath*:META-INF/maven/*/*/pom.properties", List.of(readable, unreadable)));
 
         List<DependencyDto> dependencies = new DependencyCatalog(resolver).dependencies();
 
         assertThat(dependencies)
                 .extracting(DependencyDto::packageName, DependencyDto::version)
-                .contains(org.assertj.core.api.Assertions.tuple("com.acme:widget", "1.2.3"));
+                .contains(tuple("com.acme:widget", "1.2.3"));
     }
 
     @Test
@@ -129,14 +101,262 @@ class DependencyCatalogTests {
         Files.createDirectories(versionDirectory);
         Path wrongVersionJar = Files.createFile(versionDirectory.resolve("widget-1.0.1.jar"));
 
-        assertThat(withClassPath(wrongVersionJar.toString())).isEmpty();
+        assertThat(withClassPath(emptyResolver(), wrongVersionJar.toString())).isEmpty();
     }
 
-    private List<DependencyDto> withClassPath(String classPath) {
+    // -----------------------------------------------------------------------------------------------
+    // CycloneDX SBOM
+    // -----------------------------------------------------------------------------------------------
+
+    @Test
+    void resolvesCoordinatesFromTheEmbeddedCycloneDxSbom() {
+        ResourcePatternResolver resolver = sbomResolver("""
+                {
+                  "bomFormat": "CycloneDX",
+                  "metadata": {"component": {"purl": "pkg:maven/com.example/demo-app@0.0.1"}},
+                  "components": [
+                    {"purl": "pkg:maven/org.springframework/spring-core@7.0.9"},
+                    {"purl": "pkg:maven/org.hibernate.orm/hibernate-core@7.4.5.Final"},
+                    {"purl": "pkg:npm/left-pad@1.3.0"},
+                    {"name": "no purl at all"}
+                  ]
+                }
+                """);
+
+        List<DependencyDto> dependencies = withClassPath(resolver, "");
+
+        assertThat(dependencies)
+                .extracting(DependencyDto::packageName, DependencyDto::version, DependencyDto::source)
+                .containsExactly(
+                        tuple("org.hibernate.orm:hibernate-core", "7.4.5.Final", "CycloneDX SBOM"),
+                        tuple("org.springframework:spring-core", "7.0.9", "CycloneDX SBOM"));
+    }
+
+    @Test
+    void sbomCoordinatesTakePrecedenceOverOtherSourcesForTheSameArtifact() {
+        Resource pomProperties =
+                new ByteArrayResource("groupId=org.springframework\nartifactId=spring-core\nversion=7.0.9\n"
+                        .getBytes(StandardCharsets.UTF_8));
+        ResourcePatternResolver resolver = patternResolver(Map.of(
+                "classpath*:META-INF/sbom/application.cdx.json",
+                List.of(sbomResource("""
+                        {"components": [{"purl": "pkg:maven/org.springframework/spring-core@7.0.9"}]}
+                        """)),
+                "classpath*:META-INF/maven/*/*/pom.properties",
+                List.of(pomProperties)));
+
+        List<DependencyDto> dependencies = withClassPath(resolver, "");
+
+        assertThat(dependencies)
+                .extracting(DependencyDto::packageName, DependencyDto::source)
+                .containsExactly(tuple("org.springframework:spring-core", "CycloneDX SBOM"));
+    }
+
+    @Test
+    void aMalformedSbomIsSkippedWithoutDiscardingTheRestOfTheInventory() {
+        Resource pomProperties = new ByteArrayResource(
+                "groupId=com.acme\nartifactId=widget\nversion=1.2.3\n".getBytes(StandardCharsets.UTF_8));
+        ResourcePatternResolver resolver = patternResolver(Map.of(
+                "classpath*:META-INF/sbom/application.cdx.json",
+                List.of(sbomResource("{ this is not json")),
+                "classpath*:META-INF/sbom/bom.json",
+                List.of(failingResource("unreadable bom.json")),
+                "classpath*:META-INF/maven/*/*/pom.properties",
+                List.of(pomProperties)));
+
+        List<DependencyDto> dependencies = withClassPath(resolver, "");
+
+        assertThat(dependencies).extracting(DependencyDto::packageName).containsExactly("com.acme:widget");
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Coverage
+    // -----------------------------------------------------------------------------------------------
+
+    @Test
+    void reportsUnidentifiedNestedLibrariesOfARepackagedArchiveInsteadOfHidingThem() throws Exception {
+        Path fatJar = repackagedJar(
+                "app.jar", "BOOT-INF/lib/", List.of("resolved-1.0.0.jar", "mystery-2.0.0.jar", "other-3.0.0.jar"));
+        ResourcePatternResolver resolver = sbomResolver("""
+                {"components": [{"purl": "pkg:maven/com.example/resolved@1.0.0"}]}
+                """);
+
+        DependencyInventory inventory = withClassPathInventory(resolver, fatJar.toString());
+
+        assertThat(inventory.dependencies())
+                .extracting(DependencyDto::packageName)
+                .containsExactly("com.example:resolved");
+        DependencyCoverageDto coverage = inventory.coverage();
+        assertThat(coverage.status()).isEqualTo(DependencyCoverageDto.INCOMPLETE);
+        assertThat(coverage.archivesFound()).isEqualTo(3);
+        assertThat(coverage.archivesIdentified()).isEqualTo(1);
+        assertThat(coverage.archivesUnidentified()).isEqualTo(2);
+        assertThat(coverage.unidentifiedArchives()).containsExactly("mystery-2.0.0.jar", "other-3.0.0.jar");
+        assertThat(coverage.unidentifiedArchivesTruncated()).isFalse();
+        // The outer application archive is not a dependency, so it is never counted as an unscanned JAR.
+        assertThat(coverage.unidentifiedArchives()).doesNotContain("app.jar");
+    }
+
+    @Test
+    void reportsCompleteCoverageWhenEveryNestedLibraryResolves() throws Exception {
+        Path fatJar = repackagedJar("app.jar", "BOOT-INF/lib/", List.of("resolved-1.0.0.jar", "other-3.0.0.jar"));
+        ResourcePatternResolver resolver = sbomResolver("""
+                {"components": [
+                  {"purl": "pkg:maven/com.example/resolved@1.0.0"},
+                  {"purl": "pkg:maven/com.example/other@3.0.0"}
+                ]}
+                """);
+
+        DependencyCoverageDto coverage =
+                withClassPathInventory(resolver, fatJar.toString()).coverage();
+
+        assertThat(coverage.status()).isEqualTo(DependencyCoverageDto.COMPLETE);
+        assertThat(coverage.archivesFound()).isEqualTo(2);
+        assertThat(coverage.archivesUnidentified()).isZero();
+        assertThat(coverage.unidentifiedArchives()).isEmpty();
+    }
+
+    @Test
+    void honoursTheSpringBootLibManifestAttributeWhenLocatingNestedLibraries() throws Exception {
+        Path warLikeJar = repackagedJar("app.war", "WEB-INF/lib/", List.of("mystery-2.0.0.jar"));
+
+        DependencyCoverageDto coverage =
+                withClassPathInventory(emptyResolver(), warLikeJar.toString()).coverage();
+
+        assertThat(coverage.status()).isEqualTo(DependencyCoverageDto.INCOMPLETE);
+        assertThat(coverage.unidentifiedArchives()).containsExactly("mystery-2.0.0.jar");
+    }
+
+    @Test
+    void countsPlainClasspathJarsWhenTheApplicationRunsExploded() throws Exception {
+        Path resolvedJar = plainJar("resolved-1.0.0.jar");
+        Path mysteryJar = plainJar("mystery-2.0.0.jar");
+        ResourcePatternResolver resolver = sbomResolver("""
+                {"components": [{"purl": "pkg:maven/com.example/resolved@1.0.0"}]}
+                """);
+
+        DependencyCoverageDto coverage = withClassPathInventory(
+                        resolver,
+                        resolvedJar.toString(),
+                        mysteryJar.toString(),
+                        tempDir.resolve("classes").toString())
+                .coverage();
+
+        assertThat(coverage.archivesFound()).isEqualTo(2);
+        assertThat(coverage.unidentifiedArchives()).containsExactly("mystery-2.0.0.jar");
+    }
+
+    @Test
+    void attributesAnArchiveByTheDescriptorReadFromInsideItEvenWhenTheNameDoesNotMatch() throws Exception {
+        // A shaded archive's file name need not match the coordinates of the descriptor inside it, so
+        // attribution follows the descriptor's owning-archive location rather than guessing from the name.
+        Path fatJar = repackagedJar("app.jar", "BOOT-INF/lib/", List.of("shaded-bundle-9.9.9.jar"));
+        Resource descriptor = descriptorAtUrl(
+                "jar:file:/app/app.jar!/BOOT-INF/lib/shaded-bundle-9.9.9.jar!/META-INF/maven/com.acme/widget/pom.properties");
+        ResourcePatternResolver resolver =
+                patternResolver(Map.of("classpath*:META-INF/maven/*/*/pom.properties", List.of(descriptor)));
+
+        DependencyCoverageDto coverage =
+                withClassPathInventory(resolver, fatJar.toString()).coverage();
+
+        assertThat(coverage.status()).isEqualTo(DependencyCoverageDto.COMPLETE);
+        assertThat(coverage.archivesIdentified()).isEqualTo(1);
+    }
+
+    @Test
+    void attributesAnArchiveFromABoot32NestedResourceUri() throws Exception {
+        // Spring Boot 3.2+ addresses nested entries with jar:nested:, which is only URL-resolvable while
+        // Boot's protocol handler is registered, so attribution must also work from the URI alone.
+        Path fatJar = repackagedJar("app.jar", "BOOT-INF/lib/", List.of("shaded-bundle-9.9.9.jar"));
+        Resource descriptor = descriptorAtUri(
+                "jar:nested:/app/app.jar/!BOOT-INF/lib/shaded-bundle-9.9.9.jar!/META-INF/maven/com.acme/widget/pom.properties");
+        ResourcePatternResolver resolver =
+                patternResolver(Map.of("classpath*:META-INF/maven/*/*/pom.properties", List.of(descriptor)));
+
+        DependencyCoverageDto coverage =
+                withClassPathInventory(resolver, fatJar.toString()).coverage();
+
+        assertThat(coverage.status()).isEqualTo(DependencyCoverageDto.COMPLETE);
+    }
+
+    @Test
+    void reportsUnavailableCoverageWhenTheArchivesCannotBeEnumerated() {
+        DependencyCoverageDto coverage =
+                withClassPathInventory(emptyResolver(), "").coverage();
+
+        assertThat(coverage.status()).isEqualTo(DependencyCoverageDto.UNAVAILABLE);
+        assertThat(coverage.archivesFound()).isZero();
+        assertThat(coverage.unidentifiedArchives()).isEmpty();
+    }
+
+    @Test
+    void anUnreadableArchiveIsCountedRatherThanSilentlyDropped() throws Exception {
+        Path corrupt = Files.writeString(tempDir.resolve("corrupt-1.0.0.jar"), "not a zip file");
+
+        DependencyCoverageDto coverage =
+                withClassPathInventory(emptyResolver(), corrupt.toString()).coverage();
+
+        assertThat(coverage.status()).isEqualTo(DependencyCoverageDto.INCOMPLETE);
+        assertThat(coverage.unidentifiedArchives()).containsExactly("corrupt-1.0.0.jar");
+    }
+
+    @Test
+    void boundsTheReportedArchiveNamesWhileKeepingTheCountExact() throws Exception {
+        int total = DependencyCatalog.MAX_UNIDENTIFIED_ARCHIVES + 5;
+        List<String> nested = new java.util.ArrayList<>();
+        for (int i = 0; i < total; i++) {
+            nested.add("mystery-%04d-1.0.0.jar".formatted(i));
+        }
+        Path fatJar = repackagedJar("app.jar", "BOOT-INF/lib/", nested);
+
+        DependencyCoverageDto coverage =
+                withClassPathInventory(emptyResolver(), fatJar.toString()).coverage();
+
+        assertThat(coverage.archivesUnidentified()).isEqualTo(total);
+        assertThat(coverage.unidentifiedArchives()).hasSize(DependencyCatalog.MAX_UNIDENTIFIED_ARCHIVES);
+        assertThat(coverage.unidentifiedArchivesTruncated()).isTrue();
+    }
+
+    // -----------------------------------------------------------------------------------------------
+    // Fixtures
+    // -----------------------------------------------------------------------------------------------
+
+    private Path repackagedJar(String name, String libraryPrefix, List<String> nestedArchives) throws IOException {
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+        manifest.getMainAttributes().putValue("Spring-Boot-Lib", libraryPrefix);
+        Path jar = tempDir.resolve(name);
+        try (OutputStream out = Files.newOutputStream(jar);
+                JarOutputStream jarOut = new JarOutputStream(out, manifest)) {
+            jarOut.putNextEntry(new ZipEntry("BOOT-INF/classes/com/example/App.class"));
+            jarOut.closeEntry();
+            for (String nested : nestedArchives) {
+                jarOut.putNextEntry(new ZipEntry(libraryPrefix + nested));
+                jarOut.closeEntry();
+            }
+        }
+        return jar;
+    }
+
+    private Path plainJar(String name) throws IOException {
+        Path jar = tempDir.resolve(name);
+        try (OutputStream out = Files.newOutputStream(jar);
+                JarOutputStream jarOut = new JarOutputStream(out, new Manifest())) {
+            jarOut.putNextEntry(new ZipEntry("com/example/Library.class"));
+            jarOut.closeEntry();
+        }
+        return jar;
+    }
+
+    private List<DependencyDto> withClassPath(ResourcePatternResolver resolver, String... entries) {
+        return withClassPathInventory(resolver, entries).dependencies();
+    }
+
+    private DependencyInventory withClassPathInventory(ResourcePatternResolver resolver, String... entries) {
         String previousClassPath = System.getProperty("java.class.path");
         try {
-            System.setProperty("java.class.path", classPath);
-            return new DependencyCatalog(emptyResolver()).dependencies();
+            System.setProperty("java.class.path", String.join(File.pathSeparator, entries));
+            return new DependencyCatalog(resolver).inventory();
         } finally {
             if (previousClassPath == null) {
                 System.clearProperty("java.class.path");
@@ -146,11 +366,65 @@ class DependencyCatalogTests {
         }
     }
 
-    private static ResourcePatternResolver resolver(Resource... resources) {
+    private static final byte[] WIDGET_DESCRIPTOR =
+            "groupId=com.acme\nartifactId=widget\nversion=1.2.3\n".getBytes(StandardCharsets.UTF_8);
+
+    private static Resource descriptorAtUrl(String url) {
+        return new ByteArrayResource(WIDGET_DESCRIPTOR) {
+            @Override
+            public URL getURL() throws IOException {
+                return URI.create(url).toURL();
+            }
+        };
+    }
+
+    private static Resource descriptorAtUri(String uri) {
+        return new ByteArrayResource(WIDGET_DESCRIPTOR) {
+            @Override
+            public URI getURI() {
+                return URI.create(uri);
+            }
+        };
+    }
+
+    private static Resource sbomResource(String json) {
+        return new ByteArrayResource(json.getBytes(StandardCharsets.UTF_8), "application.cdx.json");
+    }
+
+    private static Resource failingResource(String description) {
+        return new ByteArrayResource(new byte[0]) {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                throw new IOException("unreadable");
+            }
+
+            @Override
+            public String getDescription() {
+                return description;
+            }
+        };
+    }
+
+    private static ResourcePatternResolver sbomResolver(String json) {
+        return patternResolver(Map.of("classpath*:META-INF/sbom/application.cdx.json", List.of(sbomResource(json))));
+    }
+
+    private static ResourcePatternResolver emptyResolver() {
+        return patternResolver(Map.of());
+    }
+
+    /**
+     * A resolver that answers per pattern. The catalogue now queries several patterns, so a resolver that
+     * returned the same resources for every pattern would feed SBOM bytes to the Maven-descriptor reader and
+     * vice versa, testing something the runtime never does.
+     */
+    private static ResourcePatternResolver patternResolver(Map<String, List<Resource>> resourcesByPattern) {
         return new ResourcePatternResolver() {
             @Override
             public Resource[] getResources(String locationPattern) {
-                return resources;
+                return resourcesByPattern
+                        .getOrDefault(locationPattern, List.of())
+                        .toArray(new Resource[0]);
             }
 
             @Override

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -6,6 +6,7 @@ import com.sun.net.httpserver.HttpServer;
 import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.core.dto.DependenciesReport;
 import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.engine.vulnerabilities.DependencyInventory;
 import io.github.jdubois.bootui.engine.vulnerabilities.DependencyReports;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -91,7 +92,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("SCANNED");
         assertThat(report.vulnerable()).isEqualTo(1);
@@ -131,7 +133,7 @@ class OsvVulnerabilityScannerTests {
                 URI.create("http://localhost:" + server.getAddress().getPort()));
         DependencyDto duplicate = dependency("org.example", "sample", "1.0.0");
 
-        DependenciesReport report = scanner.scan(List.of(duplicate, duplicate));
+        DependenciesReport report = scanner.scan(DependencyInventory.complete(List.of(duplicate, duplicate)));
 
         assertThat(queryCount).hasValue(1);
         assertThat(report.scan().packagesScanned()).isEqualTo(1);
@@ -163,7 +165,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.dependencies().get(0).vulnerabilities())
                 .extracting("severity")
@@ -200,7 +203,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("ERROR");
         assertThat(report.dependencies()).hasSize(1);
@@ -225,8 +229,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(
-                List.of(dependency("org.example", "first", "1.0.0"), dependency("org.example", "second", "1.0.0")));
+        DependenciesReport report = scanner.scan(DependencyInventory.complete(
+                List.of(dependency("org.example", "first", "1.0.0"), dependency("org.example", "second", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("ERROR");
         assertThat(report.scan().packagesScanned()).isZero();
@@ -252,7 +256,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("ERROR");
         assertThat(report.scan().packagesScanned()).isZero();
@@ -301,7 +306,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains("1 advisory fetch failed");
@@ -357,7 +363,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.score()).isEqualTo(9.8d);
@@ -404,7 +411,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.score()).isNull();
@@ -448,7 +456,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        var vulnerability = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")))
+        var vulnerability = scanner.scan(
+                        DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))))
                 .dependencies()
                 .get(0)
                 .vulnerabilities()
@@ -493,7 +502,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         // A withdrawn advisory is intentionally dropped -- this is correct, expected behavior, not a
         // failure, so it must not degrade the scan status to PARTIAL/ERROR.
@@ -532,7 +542,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         // The advisory that failed to fetch must not discard the one that succeeded, nor abort the whole
         // scan to ERROR the way a single-advisory IOException used to.
@@ -577,7 +588,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains("1 advisory fetch failed");
@@ -627,7 +639,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
@@ -671,7 +684,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.severity()).isEqualTo("MEDIUM");
@@ -712,7 +726,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         // Both pages must be merged into the final result, and pagination completing within the safety
         // bound must not degrade the scan status.
@@ -758,7 +773,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains("paginated");
@@ -810,7 +826,7 @@ class OsvVulnerabilityScannerTests {
             dependencies.add(dependency("org.example", "sample" + i, "1.0.0"));
         }
 
-        DependenciesReport report = scanner.scan(dependencies);
+        DependenciesReport report = scanner.scan(DependencyInventory.complete(dependencies));
 
         // 1500 packages must be partitioned into 2 requests of <=1000 each (OSV's hard per-request cap),
         // not sent as a single oversized batch that OSV.dev would reject with HTTP 400.
@@ -857,7 +873,7 @@ class OsvVulnerabilityScannerTests {
             dependencies.add(dependency("org.example", "sample" + i, "1.0.0"));
         }
 
-        DependenciesReport report = scanner.scan(dependencies);
+        DependenciesReport report = scanner.scan(DependencyInventory.complete(dependencies));
 
         assertThat(calls).hasValue(2);
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
@@ -908,7 +924,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.epssScore()).isEqualTo(0.9445d);
@@ -961,7 +978,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(epssCalls).hasValue(2);
         var cveFinding = report.dependencies().get(0).vulnerabilities().stream()
@@ -1010,7 +1028,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("SCANNED");
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
@@ -1061,7 +1080,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(epssCalls.get()).isZero();
         assertThat(report.dependencies().get(0).vulnerabilities().get(0).epssScore())
@@ -1108,7 +1128,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.fixedVersions()).isEmpty();
@@ -1154,7 +1175,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        var vulnerability = scanner.scan(List.of(dependency("org.example", "sample", "0.9")))
+        var vulnerability = scanner.scan(
+                        DependencyInventory.complete(List.of(dependency("org.example", "sample", "0.9"))))
                 .dependencies()
                 .get(0)
                 .vulnerabilities()
@@ -1204,7 +1226,8 @@ class OsvVulnerabilityScannerTests {
                 // Dependency is already at version 1.2.0, above the advertised "fixed" 1.0.0.
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.2.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.2.0"))));
 
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.fixedVersions()).containsExactly("1.0.0");
@@ -1254,7 +1277,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         var vulnerability = report.dependencies().get(0).vulnerabilities().get(0);
         // ADVISORY sorts first (the canonical page), FIX second, then WEB/REPORT keep OSV's original order.
@@ -1300,7 +1324,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("SCANNED");
         assertThat(report.dependencies().get(0).vulnerabilities()).hasSize(advisoryCount);
@@ -1358,7 +1383,8 @@ class OsvVulnerabilityScannerTests {
                 new ObjectMapper(),
                 URI.create("http://localhost:" + server.getAddress().getPort()));
 
-        DependenciesReport report = scanner.scan(List.of(dependency("org.example", "sample", "1.0.0")));
+        DependenciesReport report =
+                scanner.scan(DependencyInventory.complete(List.of(dependency("org.example", "sample", "1.0.0"))));
 
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains(failingCount + " advisory fetches failed");

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilitiesControllerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/VulnerabilitiesControllerTests.java
@@ -59,7 +59,8 @@ class VulnerabilitiesControllerTests {
         MockMvc mvc = standaloneSetup(new VulnerabilitiesController(
                         new BootUiProperties(),
                         () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                        dependencies -> DependencyReports.report(true, "SCANNED", "unused", 1L, 1, dependencies),
+                        inventory ->
+                                DependencyReports.report(true, "SCANNED", "unused", 1L, 1, inventory.dependencies()),
                         emptyDismissedRulesStore()))
                 .build();
 
@@ -77,7 +78,7 @@ class VulnerabilitiesControllerTests {
         MockMvc mvc = standaloneSetup(new VulnerabilitiesController(
                         new BootUiProperties(),
                         () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                        dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, dependencies),
+                        inventory -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, inventory.dependencies()),
                         emptyDismissedRulesStore()))
                 .build();
 
@@ -96,7 +97,7 @@ class VulnerabilitiesControllerTests {
         VulnerabilitiesController controller = new VulnerabilitiesController(
                 new BootUiProperties(),
                 () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                dependencies -> {
+                inventory -> {
                     scans.incrementAndGet();
                     entered.countDown();
                     try {
@@ -107,7 +108,7 @@ class VulnerabilitiesControllerTests {
                         Thread.currentThread().interrupt();
                         throw new IllegalStateException(ex);
                     }
-                    return DependencyReports.report(true, "SCANNED", "done", 1L, 1, dependencies);
+                    return DependencyReports.report(true, "SCANNED", "done", 1L, 1, inventory.dependencies());
                 },
                 emptyDismissedRulesStore());
         MockMvc mvc = standaloneSetup(controller)
@@ -153,7 +154,8 @@ class VulnerabilitiesControllerTests {
         MockMvc mvc = standaloneSetup(new VulnerabilitiesController(
                         properties,
                         () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                        dependencies -> DependencyReports.report(true, "SCANNED", "unused", 1L, 1, dependencies),
+                        inventory ->
+                                DependencyReports.report(true, "SCANNED", "unused", 1L, 1, inventory.dependencies()),
                         emptyDismissedRulesStore()))
                 .build();
 
@@ -169,7 +171,7 @@ class VulnerabilitiesControllerTests {
         MockMvc mvc = standaloneSetup(new VulnerabilitiesController(
                         new BootUiProperties(),
                         () -> List.of(dependency("org.example", "sample", "1.0.0")),
-                        dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, dependencies),
+                        inventory -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, inventory.dependencies()),
                         emptyDismissedRulesStore()))
                 .build();
 
@@ -192,7 +194,7 @@ class VulnerabilitiesControllerTests {
         VulnerabilitiesController controller = new VulnerabilitiesController(
                 new BootUiProperties(),
                 () -> List.of(vulnerable),
-                dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, List.of(vulnerable)),
+                inventory -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, List.of(vulnerable)),
                 dismissedRules);
         MockMvc mvc = standaloneSetup(controller).build();
         // Populate the cached lastScanReport so GET serves it (mirroring dependenciesReturnsLastScanReportAfterScan).
@@ -216,7 +218,7 @@ class VulnerabilitiesControllerTests {
         VulnerabilitiesController controller = new VulnerabilitiesController(
                 new BootUiProperties(),
                 () -> List.of(vulnerable),
-                dependencies -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, List.of(vulnerable)),
+                inventory -> DependencyReports.report(true, "SCANNED", "done", 1L, 1, List.of(vulnerable)),
                 dismissedRules);
         MockMvc mvc = standaloneSetup(controller).build();
 

--- a/bootui-spring-sample-app/e2e/tests/vulnerabilities.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/vulnerabilities.spec.js
@@ -18,8 +18,10 @@ const inventoryReport = {
     message: 'Dependency inventory loaded.',
     scannedAt: null,
     packagesScanned: 0,
+    packagesSkipped: 0,
     vulnerabilitiesFound: 0
   },
+  coverage: coverage(),
   dependencies: [
     dependency('org.springframework.boot', 'spring-boot', '4.0.6'),
     dependency('org.zeta', 'critical-lib', '1.0.0'),
@@ -44,6 +46,7 @@ const scannedReport = {
     message: 'Scan completed against OSV.dev.',
     scannedAt: Date.now(),
     packagesScanned: 4,
+    packagesSkipped: 0,
     vulnerabilitiesFound: 4
   },
   dependencies: [
@@ -121,7 +124,52 @@ test.describe('Vulnerabilities view', () => {
     await expect(page.getByText('1 of 4 dependencies')).toBeVisible()
     await expect(page.locator('tbody tr', {hasText: 'org.example:vulnerable-lib'})).toBeVisible()
   })
+
+  test('warns that unidentified JARs were not scanned instead of reading as a clean result', async ({
+    openView,
+    page
+  }) => {
+    const incompleteReport = {
+      ...inventoryReport,
+      coverage: {
+        status: 'INCOMPLETE',
+        archivesFound: 325,
+        archivesIdentified: 186,
+        archivesUnidentified: 139,
+        unidentifiedArchives: ['spring-core-7.0.9.jar', 'tomcat-embed-core-11.0.24.jar'],
+        unidentifiedArchivesTruncated: true
+      }
+    }
+    await page.route(
+      (url) => url.pathname === '/bootui/api/vulnerabilities',
+      async (route) => {
+        await route.fulfill({contentType: 'application/json', body: JSON.stringify(incompleteReport)})
+      }
+    )
+
+    await openView('vulnerabilities', /^Vulnerabilities/)
+    await expect(page.getByText('139 of 325 JARs could not be identified and were not scanned')).toBeVisible()
+    const coverageMetric = page.locator('.advisor-summary__metric', {hasText: 'Unidentified JARs'})
+    await expect(coverageMetric.locator('dd')).toHaveText('139')
+    // The archive names stay out of the scannable dependency table until explicitly requested.
+    await expect(page.getByText('spring-core-7.0.9.jar')).toHaveCount(0)
+
+    await page.getByRole('button', {name: 'Show unidentified JARs'}).click()
+    await expect(page.getByText('spring-core-7.0.9.jar')).toBeVisible()
+    await expect(page.getByText('Only the first 2 names are listed.')).toBeVisible()
+  })
 })
+
+function coverage() {
+  return {
+    status: 'COMPLETE',
+    archivesFound: 4,
+    archivesIdentified: 4,
+    archivesUnidentified: 0,
+    unidentifiedArchives: [],
+    unidentifiedArchivesTruncated: false
+  }
+}
 
 function dependency(groupId, artifactId, version) {
   return {

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
@@ -34,12 +34,25 @@ function dependency(packageName, version, vulnerabilities, highestSeverity) {
   }
 }
 
+function coverage(overrides = {}) {
+  return {
+    status: 'COMPLETE',
+    archivesFound: 0,
+    archivesIdentified: 0,
+    archivesUnidentified: 0,
+    unidentifiedArchives: [],
+    unidentifiedArchivesTruncated: false,
+    ...overrides
+  }
+}
+
 function report(
   dependencies,
   vulnerable = dependencies.filter((d) => d.vulnerabilityCount > 0).length,
-  status = 'SCANNED'
+  status = 'SCANNED',
+  overrides = {}
 ) {
-  return {
+  const base = {
     scanningEnabled: true,
     total: dependencies.length,
     vulnerable,
@@ -55,10 +68,13 @@ function report(
       message: 'Scan completed against OSV.dev.',
       scannedAt: 1_700_000_000_000,
       packagesScanned: dependencies.length,
+      packagesSkipped: 0,
       vulnerabilitiesFound: dependencies.reduce((sum, d) => sum + d.vulnerabilityCount, 0)
     },
+    coverage: coverage({archivesFound: dependencies.length, archivesIdentified: dependencies.length}),
     dependencies
   }
+  return {...base, ...overrides, scan: {...base.scan, ...(overrides.scan || {})}}
 }
 
 /**
@@ -341,6 +357,94 @@ describe('Vulnerabilities', () => {
     expect(wrapper.text()).toContain('No newer fixed version reported by OSV (reported: 1.5.0)')
     expect(wrapper.text()).not.toContain('already on a fixed version')
     expect(wrapper.text()).not.toContain('No fixed version reported by OSV')
+  })
+
+  it('warns that unidentified JARs were not scanned instead of presenting a clean result', async () => {
+    const clean = dependency('org.example:clean', '1.0.0', [], 'NONE')
+    const {wrapper} = await mountWithReports([
+      report([clean], 0, 'SCANNED', {
+        coverage: coverage({
+          status: 'INCOMPLETE',
+          archivesFound: 325,
+          archivesIdentified: 186,
+          archivesUnidentified: 139,
+          unidentifiedArchives: ['spring-core-7.0.9.jar', 'tomcat-embed-core-11.0.24.jar']
+        })
+      })
+    ])
+
+    expect(wrapper.text()).toContain('139 of 325 JARs could not be identified and were not scanned')
+    expect(wrapper.text()).toContain('Unidentified JARs')
+    expect(wrapper.text()).toContain('cyclonedx-maven-plugin')
+    // The jar names stay collapsed until asked for, and out of the scannable dependency table.
+    expect(wrapper.text()).not.toContain('spring-core-7.0.9.jar')
+
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Show unidentified JARs'))
+      .trigger('click')
+
+    expect(wrapper.text()).toContain('spring-core-7.0.9.jar')
+    expect(wrapper.text()).toContain('tomcat-embed-core-11.0.24.jar')
+    expect(wrapper.findAll('table tbody tr').map((row) => row.text())).not.toContain('spring-core-7.0.9.jar')
+  })
+
+  it('says the unidentified JAR list is bounded when the report truncated it', async () => {
+    const {wrapper} = await mountWithReports([
+      report([], 0, 'SCANNED', {
+        coverage: coverage({
+          status: 'INCOMPLETE',
+          archivesFound: 400,
+          archivesIdentified: 0,
+          archivesUnidentified: 400,
+          unidentifiedArchives: ['mystery-1.0.0.jar'],
+          unidentifiedArchivesTruncated: true
+        })
+      })
+    ])
+
+    await wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Show unidentified JARs'))
+      .trigger('click')
+
+    expect(wrapper.text()).toContain('Only the first 1 names are listed.')
+  })
+
+  it('does not claim coverage it could not determine', async () => {
+    const clean = dependency('org.example:clean', '1.0.0', [], 'NONE')
+    const {wrapper} = await mountWithReports([
+      report([clean], 0, 'SCANNED', {coverage: coverage({status: 'UNAVAILABLE'})})
+    ])
+
+    expect(wrapper.text()).toContain("could not enumerate this application's JARs")
+    expect(wrapper.text()).not.toContain('could not be identified and were not scanned')
+  })
+
+  it('stays silent about coverage when every JAR was identified', async () => {
+    const clean = dependency('org.example:clean', '1.0.0', [], 'NONE')
+    const {wrapper} = await mountWithReports([report([clean])])
+
+    expect(wrapper.text()).not.toContain('could not be identified and were not scanned')
+    expect(wrapper.text()).not.toContain("could not enumerate this application's JARs")
+  })
+
+  it('renders without a coverage block, for a report produced before coverage existed', async () => {
+    const clean = dependency('org.example:clean', '1.0.0', [], 'NONE')
+    const legacy = report([clean])
+    delete legacy.coverage
+    const {wrapper} = await mountWithReports([legacy])
+
+    expect(wrapper.text()).toContain('org.example:clean')
+    expect(wrapper.text()).not.toContain('Unidentified JARs')
+  })
+
+  it('warns when the max-packages limit stopped some packages from being scanned', async () => {
+    const clean = dependency('org.example:clean', '1.0.0', [], 'NONE')
+    const {wrapper} = await mountWithReports([report([clean], 0, 'PARTIAL', {scan: {packagesSkipped: 75}})])
+
+    expect(wrapper.text()).toContain('75 packages were not sent to OSV.dev')
+    expect(wrapper.text()).toContain('bootui.vulnerabilities.max-packages')
   })
 
   it('links a CVE alias to NVD and a GHSA alias to GitHub Advisories', async () => {

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -122,6 +122,49 @@ const maxSeverityCount = computed(() => {
 
 const hasScanData = computed(() => hasScanResult(data.value?.scan?.status))
 
+// Coverage answers "how much of the application did we actually look at?". Without it a green
+// "0 vulnerable" summary reads as full coverage even when the inventory missed most of the
+// classpath, which is exactly the failure this panel used to hide.
+const coverage = computed(() => data.value?.coverage ?? null)
+
+const coverageIncomplete = computed(() => coverage.value?.status === 'INCOMPLETE')
+
+const coverageUnavailable = computed(() => coverage.value?.status === 'UNAVAILABLE')
+
+const unidentifiedArchiveCount = computed(() => (coverageIncomplete.value ? coverage.value.archivesUnidentified : 0))
+
+const unidentifiedArchives = computed(() => coverage.value?.unidentifiedArchives ?? [])
+
+const packagesSkipped = computed(() => data.value?.scan?.packagesSkipped ?? 0)
+
+const coverageMetric = computed(() => {
+  if (coverageUnavailable.value) {
+    return {
+      label: 'Unidentified JARs',
+      value: '—',
+      hint: 'BootUI could not enumerate the JARs on this classpath, so scan coverage is unknown.'
+    }
+  }
+  if (!coverage.value) return null
+  return {
+    label: 'Unidentified JARs',
+    value: coverage.value.archivesUnidentified,
+    hint: `${coverage.value.archivesIdentified} of ${coverage.value.archivesFound} JARs resolved to Maven coordinates.`
+  }
+})
+
+const summaryMetrics = computed(() => {
+  const metrics = [
+    {label: 'Dependencies', value: data.value.total},
+    {label: 'Vulnerable', value: data.value.vulnerable}
+  ]
+  if (coverageMetric.value) metrics.push(coverageMetric.value)
+  metrics.push({label: 'Scanner', value: data.value.scan.scanner, hint: data.value.scan.message})
+  return metrics
+})
+
+const showUnidentifiedArchives = ref(false)
+
 function severityClass(severity) {
   return severityClasses[severity] || 'text-bg-light'
 }
@@ -285,12 +328,47 @@ onMounted(loadDependencies)
         :scan-status-label="scanStatusLabel(data.scan.status)"
         :scan-status-class="scanStatusBadgeClass(data.scan.status)"
         :scan-time="scanTime()"
-        :metrics="[
-          {label: 'Dependencies', value: data.total},
-          {label: 'Vulnerable', value: data.vulnerable},
-          {label: 'Scanner', value: data.scan.scanner, hint: data.scan.message}
-        ]"
+        :metrics="summaryMetrics"
       />
+
+      <div v-if="coverageIncomplete" class="alert alert-warning" role="status">
+        <div class="fw-semibold">
+          <i class="bi bi-exclamation-triangle me-1"></i>
+          {{ unidentifiedArchiveCount }} of {{ coverage.archivesFound }} JARs could not be identified and were not
+          scanned
+        </div>
+        <div class="small">
+          These archives carry no Maven coordinates, so OSV.dev cannot be queried for them. Results below cover the
+          {{ coverage.archivesIdentified }} identified JARs only. Adding the <code>cyclonedx-maven-plugin</code> or
+          <code>cyclonedx-gradle-plugin</code> to your build embeds an SBOM that BootUI reads to resolve them.
+        </div>
+        <button
+          v-if="unidentifiedArchives.length"
+          class="btn btn-sm btn-outline-secondary mt-2"
+          type="button"
+          @click="showUnidentifiedArchives = !showUnidentifiedArchives"
+        >
+          {{ showUnidentifiedArchives ? 'Hide' : 'Show' }} unidentified JARs
+        </button>
+        <ul v-if="showUnidentifiedArchives" class="small mt-2 mb-0 unidentified-archives">
+          <li v-for="archive in unidentifiedArchives" :key="archive">{{ archive }}</li>
+        </ul>
+        <div v-if="showUnidentifiedArchives && coverage.unidentifiedArchivesTruncated" class="small text-muted mt-1">
+          Only the first {{ unidentifiedArchives.length }} names are listed.
+        </div>
+      </div>
+
+      <div v-if="coverageUnavailable" class="alert alert-warning" role="status">
+        <i class="bi bi-exclamation-triangle me-1"></i>
+        BootUI could not enumerate this application's JARs, so it cannot confirm that every dependency was scanned.
+      </div>
+
+      <div v-if="packagesSkipped > 0" class="alert alert-warning" role="status">
+        <i class="bi bi-exclamation-triangle me-1"></i>
+        {{ packagesSkipped }} {{ packagesSkipped === 1 ? 'package was' : 'packages were' }} not sent to OSV.dev because
+        the scan reached the <code>bootui.vulnerabilities.max-packages</code> limit. Raise that property to scan the
+        full inventory.
+      </div>
 
       <div class="card mb-3">
         <div class="card-header"><h3>Severity breakdown</h3></div>
@@ -449,5 +527,10 @@ onMounted(loadDependencies)
 
 .vulnerability-list {
   max-width: 48rem;
+}
+
+.unidentified-archives {
+  max-height: 14rem;
+  overflow-y: auto;
 }
 </style>

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -645,7 +645,7 @@ The JMS panel is a dedicated view over the same bounded Spring JMS capture that 
 | `bootui.panels.vulnerabilities.read-only` | `false` | Disable on-demand OSV scan requests.                    |
 | `bootui.vulnerabilities.osv-enabled`         | `true`  | Additional action gate for OSV.dev scans.               |
 | `bootui.vulnerabilities.request-timeout`     | `10s`   | Timeout for each OSV request.                           |
-| `bootui.vulnerabilities.max-packages`        | `250`   | Maximum packages included in one OSV batch query.       |
+| `bootui.vulnerabilities.max-packages`        | `500`   | Maximum packages included in one OSV batch query; the excess is reported as `scan.packagesSkipped`. |
 | `bootui.vulnerabilities.max-advisories`      | `200`   | Maximum advisory details fetched after a package query. |
 | `bootui.vulnerabilities.osv-base-uri`        | `https://api.osv.dev` | Base URI of the OSV.dev API queried during a scan. Mainly useful for pointing scans at a local stub in tests. |
 | `bootui.vulnerabilities.epss-enabled`        | `true`  | Enrich CVE-aliased advisories with FIRST.org EPSS probability and percentile data during the user-initiated scan. EPSS failure never discards OSV results. |

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -50,7 +50,7 @@ The repository already separates "what the data means" (framework-neutral) from 
 | The advisor **engines** are framework-neutral    | `bootui-engine` advisor packages contain no Spring imports; framework collection and base-package discovery live in the adapters                                                                        |
 | Hibernate analysis already uses neutral APIs      | `HibernateScanner` consumes `jakarta.persistence.EntityManagerFactory` / `Metamodel`, which Quarkus also provides                                                                                       |
 | Safety decision logic is already Spring-free      | `CidrRange` and `ContainerGatewayDetector` carry no Spring dependency; only `LocalhostOnlyFilter` / `PanelAccessFilter` bind to `jakarta.servlet`                                                       |
-| Several data sources are framework-neutral today  | OSV scanner, OTLP receiver + `TelemetryStore`, `DependencyCatalog` (reads `META-INF/maven/*/pom.properties` + `java.class.path`), JVM MXBean readers, GitHub `HttpClient`, Copilot/Claude log readers   |
+| Several data sources are framework-neutral today  | OSV scanner, OTLP receiver + `TelemetryStore`, `DependencyCatalog` (reads the CycloneDX SBOM + `META-INF/maven/*/pom.properties` + `java.class.path`), JVM MXBean readers, GitHub `HttpClient`, Copilot/Claude log readers   |
 
 The coupling that remains is concentrated in: the web layer (`@RestController`), the Actuator/`ApplicationContext`/
 `Environment` data readers, the servlet safety filters, and the `EnvironmentPostProcessor`-based config plumbing. That is
@@ -185,7 +185,7 @@ Logic lives entirely in `bootui-core` + `bootui-engine`; the Quarkus adapter add
 | `Metrics`                                             | Micrometer — same API                                                             |
 | `Hibernate` advisor                                   | Same 72-rule registry/report contract; mapping and configuration rules port, while Spring Data query rules skip when repository metadata is unavailable |
 | `Hibernate Statistics`                                | Standalone Database-section panel over `org.hibernate.stat.Statistics`, gated on the same Hibernate ORM capability as the advisor; its runtime-enable action has the same read-only and cross-site-write protection as Spring |
-| `Vulnerabilities`                                     | Classpath Maven metadata + OSV                                                    |
+| `Vulnerabilities`                                     | Classpath SBOM/Maven metadata + OSV                                               |
 | `HTTP Probe`                                          | Local HTTP probing                                                                |
 | `AI Framework`                                        | —                                                                                 |
 | `Traces`                                              | OTLP — a standard; Quarkus/LangChain4j export it                                  |

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -730,7 +730,11 @@ Purpose: answer "Which runtime JAR dependencies are present, and do any have kno
 
 Data sources:
 
+- The application's embedded CycloneDX SBOM (`META-INF/sbom/application.cdx.json` or `META-INF/sbom/bom.json`, the
+  files Spring Boot's `/actuator/sbom` serves), whose `purl` values carry the `groupId`.
 - Maven metadata (`META-INF/maven/*/*/pom.properties`) discovered from the running application's classpath.
+- The `java.class.path` entries, read through the Maven repository directory layout or an adjacent `.pom`.
+- Quarkus instead uses its build-time resolved application model, which already carries every coordinate.
 - OSV.dev Maven vulnerability data for explicit on-demand scans.
 
 Features:
@@ -774,6 +778,13 @@ Features:
   that OSV reported no `fixed` event: a range may instead end with `last_affected`, which names the final vulnerable
   version but does not identify the first non-vulnerable upgrade target. The UI must not conflate that state with proof
   that no fix exists.
+- Report scan coverage: enumerate the application's real JAR archives (the `BOOT-INF/lib/`/`WEB-INF/lib/` entries of a
+  repackaged archive, the classpath JARs otherwise), attribute each to a resolved coordinate, and report the remainder
+  as `coverage.status=INCOMPLETE` with the unidentified archive names (bounded for transport, with exact counts). Report
+  `COMPLETE` only when every enumerated archive resolved, and `UNAVAILABLE` when the census itself could not run
+  (a blank or synthetic classpath, for example under a native image) rather than assuming full coverage.
+- Report packages dropped by the `bootui.vulnerabilities.max-packages` bound as `scan.packagesSkipped` rather than
+  letting `packagesScanned` present a truncated scan as a complete one.
 - Support disabling OSV scans with `bootui.vulnerabilities.osv-enabled=false`.
 - Allow dismissing/restoring an individual vulnerability finding for a specific dependency, excluding it from the
   vulnerable count and severity rollups until restored, consistent with the dismiss/restore workflow shared by every
@@ -788,14 +799,24 @@ Acceptance criteria:
   inventory; a failure fetching one advisory's details does not discard advisories that were already fetched
   successfully, degrading the scan to a partial-success status instead of an outright error.
 - Scan size is bounded by configuration so large classpaths remain responsive.
-- Initial/error/partial UI states must not label an empty advisory list as a clean "None found" result.
-- An unreadable Spring `pom.properties` resource is logged and skipped without discarding readable inventory entries;
-  Quarkus continues to use its build-time resolved runtime dependency model and fails soft on malformed entries.
+- Initial/error/partial UI states must not label an empty advisory list as a clean "None found" result, and a report
+  with unidentified archives or skipped packages must never render as full coverage.
+- An unreadable Spring `pom.properties` resource, a malformed or unreadable SBOM, and an unreadable classpath archive
+  are each logged and skipped without discarding entries that did resolve; Quarkus continues to use its build-time
+  resolved runtime dependency model and fails soft on malformed entries.
 
-Known limitation: the dependency inventory on both adapters is coordinate-based (one resolved JAR = one artifact
-coordinate). A vulnerable library relocated/repackaged inside a shaded or uber JAR has no `pom.properties`/build-time
-coordinate of its own, so it is invisible to the inventory and cannot be flagged — the same reduced-fidelity honesty
-precedent already documented for other panels (for example Cache, Beans). Direct-vs-transitive dependency provenance
+Known limitation: the dependency inventory is coordinate-based (one resolved JAR = one artifact coordinate), and no JAR
+manifest header carries a `groupId` — `Implementation-Title` is a display name as often as an artifact id, and
+`Implementation-Vendor-Id` is not a group id. An application built without a CycloneDX SBOM therefore cannot resolve
+coordinates for the many artifacts published with no Maven descriptor (Spring Framework, Spring Boot, Spring Security,
+`tomcat-embed-*`, `hibernate-core`, `kotlin-stdlib`, the PostgreSQL driver, and the `opentelemetry-*` and
+`micrometer-*` families among them), and inside a repackaged fat JAR the `java.class.path` fallback is dead too. Those
+archives are reported through `coverage` as explicitly unscanned rather than dropped, and the panel points at the SBOM
+plugin as the fix. Resolving the remaining coordinates by SHA-1 lookup against Maven Central would work but adds a new
+outbound service and configuration surface, so it is deliberately not done. Separately, a vulnerable library
+relocated/repackaged inside a shaded or uber JAR has no coordinate of its own, so it is invisible to the inventory and
+cannot be flagged — the same reduced-fidelity honesty precedent already documented for other panels (for example Cache,
+Beans). Direct-vs-transitive dependency provenance
 ("introduced through") is not yet tracked on either adapter; Quarkus could source it from its build-time application
 dependency graph, but Spring's classpath-based inventory has no equivalent graph today, so this is deferred rather than
 shipped asymmetrically.
@@ -2312,7 +2333,7 @@ Initial properties:
 | `bootui.email.dev-trap`                      | `false`                                 | Capture outgoing email without handing it to the real mail transport (MailDev/GreenMail-style trap). |
 | `bootui.vulnerabilities.osv-enabled`            | `true`                                  | Allow the user-initiated OSV.dev vulnerability scan action.                                       |
 | `bootui.vulnerabilities.request-timeout`        | `10s`                                   | Timeout applied to each OSV request.                                                              |
-| `bootui.vulnerabilities.max-packages`           | `250`                                   | Maximum packages sent in one OSV batch query.                                                     |
+| `bootui.vulnerabilities.max-packages`           | `500`                                   | Maximum packages sent in one OSV batch query; the excess is reported as `scan.packagesSkipped`.   |
 | `bootui.vulnerabilities.max-advisories`         | `200`                                   | Maximum advisory detail documents fetched after a query.                                          |
 | `bootui.vulnerabilities.epss-enabled`           | `true`                                  | Allow the batched FIRST.org EPSS exploit-probability lookup during a scan.                        |
 | `bootui.vulnerabilities.epss-base-uri`          | `https://api.first.org`                | Base URI of the FIRST.org EPSS API queried during a scan.                                         |

--- a/docs/features/advisors.md
+++ b/docs/features/advisors.md
@@ -558,14 +558,45 @@ fresh deterministic ordering from the recomputed active severity. Dismiss/restor
 read-only.
 
 ::: details How Spring discovers dependencies
-The Spring adapter scans the classpath for `META-INF/maven/*/pom.properties`, which is unreliable under the Quarkus
-runtime classloader. For JARs without embedded metadata, Spring also reads an adjacent Maven POM (including in
-nonstandard local-repository paths), and only falls back to path-derived coordinates when a literal `repository`
-directory makes the group path unambiguous; it never guesses a group id from an arbitrary cache path. Unreadable
-individual `pom.properties` resources are logged and skipped instead of failing the whole inventory, and classpath JAR
-filenames must match the resolved artifact/version exactly (with an optional classifier) rather than merely sharing a
-version prefix.
+The Spring adapter resolves coordinates from three sources, in decreasing order of authority:
+
+1. **The application's embedded CycloneDX SBOM** (`META-INF/sbom/application.cdx.json` or `META-INF/sbom/bom.json`, the
+   files Spring Boot's `/actuator/sbom` serves). Each Maven `purl` is exactly `pkg:maven/<groupId>/<artifactId>@<version>`
+   — the `groupId` no manifest header carries. This is what identifies artifacts published without a Maven descriptor.
+2. **`META-INF/maven/*/*/pom.properties`** descriptors on the classpath, which Spring's resolver also sees inside a
+   repackaged archive's nested JARs.
+3. **`java.class.path` entries**, read through the Maven repository directory layout or an adjacent Maven POM (including
+   in nonstandard local-repository paths). A group id is only derived from a path when a literal `repository` directory
+   makes it unambiguous; it is never guessed from an arbitrary cache path. Classpath JAR filenames must match the
+   resolved artifact/version exactly (with an optional classifier) rather than merely sharing a version prefix. Inside a
+   repackaged fat JAR this source is dead, because `java.class.path` is then just the application archive.
+
+Unreadable `pom.properties` resources, a malformed or unreadable SBOM, and unreadable classpath archives are each logged
+and skipped instead of failing the whole inventory.
 :::
+
+### Coverage
+
+A coordinate-based inventory can only scan what it can name, so the panel also reports what it *couldn't*. Alongside the
+inventory, BootUI takes a census of the application's real archives — the `BOOT-INF/lib/`/`WEB-INF/lib/` entries of a
+repackaged JAR or WAR, or the classpath JARs when running exploded — and attributes each to a resolved coordinate. The
+result is one of three honest states:
+
+| `coverage.status` | Meaning |
+| --- | --- |
+| `COMPLETE` | Every enumerated archive resolved to a Maven coordinate and is in the scannable inventory. |
+| `INCOMPLETE` | Some archives did not; they are counted and named, and the panel warns that they were not scanned. |
+| `UNAVAILABLE` | The census itself could not run (a blank or synthetic classpath, for example under a native image), so coverage is unknown rather than claimed. |
+
+When coverage is incomplete the panel shows an "Unidentified JARs" metric and a warning naming the gap
+("139 of 325 JARs could not be identified and were not scanned"), with a collapsible list of the archive names and a
+pointer to adding the CycloneDX plugin to the build. Unidentified archives deliberately stay out of the scannable
+dependency table — they have no coordinates to show. Only the archives' central directories and manifests are read;
+nothing is decompressed or extracted.
+
+The scan status reports the same kind of gap for the `bootui.vulnerabilities.max-packages` bound: packages beyond it are
+counted in `scan.packagesSkipped` and surfaced as a warning, instead of letting `packagesScanned` present a truncated
+scan as a complete one. The default bound is `500`, sized to cover a typical Spring Boot application's full JAR set.
 
 ::: details On Quarkus
 
@@ -574,14 +605,23 @@ same report contract, CVSS/withdrawn/partial-failure handling, pagination/batch-
 dismiss/restore workflow. `bootui.vulnerabilities.osv-enabled=false` / `bootui.vulnerabilities.epss-enabled=false`
 disable on-demand scanning / EPSS enrichment on both adapters. The one platform difference is dependency discovery: the
 Quarkus inventory is captured at **build time** from the application's resolved runtime dependency model and read back at
-runtime (mirroring the Architecture panel's build-time base-package discovery).
+runtime (mirroring the Architecture panel's build-time base-package discovery). Because that model is already fully
+resolved, Quarkus reports `coverage.status=COMPLETE` and has no SBOM-shaped gap to close.
 
 :::
 
 ### Known limitations
 
-Two limitations are documented honestly rather than hidden:
+Three limitations are documented honestly rather than hidden — and, where a gap remains, it is reported through
+`coverage` rather than left silent:
 
+- **Without an SBOM, some JARs cannot be identified.** No JAR manifest header carries a `groupId`
+  (`Implementation-Title` is a display name as often as an artifact id, and `Implementation-Vendor-Id` is not a group
+  id), so an application built without a CycloneDX SBOM cannot resolve coordinates for artifacts published with no Maven
+  descriptor — Spring Framework, Spring Boot, Spring Security, `tomcat-embed-*`, `hibernate-core`, `kotlin-stdlib`, the
+  PostgreSQL driver, and the `opentelemetry-*`/`micrometer-*` families among them. Those archives are reported as
+  unidentified rather than dropped. Resolving them by SHA-1 lookup against Maven Central would work but adds a new
+  outbound service and configuration surface, so it is deliberately not done.
 - **Shaded/uber JARs are invisible.** The inventory on both adapters is coordinate-based (one resolved JAR = one Maven
   `groupId:artifactId:version`), so a vulnerable library relocated or repackaged inside a shaded/uber JAR carries no
   `pom.properties`/build-time coordinate of its own and is invisible — the same reduced-fidelity honesty precedent


### PR DESCRIPTION
Fixes #920.

## The problem

`DependencyCatalog` built the Vulnerabilities inventory from exactly two sources: `classpath*:META-INF/maven/*/*/pom.properties`, and a `java.class.path` walk that recovers coordinates from the `~/.m2/repository` layout. Inside a repackaged Spring Boot fat jar the second source is dead (`java.class.path` is just `app.jar`), so the inventory was whatever the first source happened to find. Every JAR published without Maven descriptors — all of Spring Framework/Boot/Security, `tomcat-embed-*`, `hibernate-core`, `postgresql`, `kotlin-stdlib`, the `micrometer-*` and `opentelemetry-*` families — was dropped in silence. The reporter saw `total: 201` against 325 JARs in `BOOT-INF/lib`, under a green "0 vulnerable" summary that reads as full coverage.

## Why not the manifest

The issue proposed falling back to manifest headers. Checked against real artifacts, that cannot work:

| jar | `Implementation-Title` | `Implementation-Vendor-Id` | real groupId |
| --- | --- | --- | --- |
| `postgresql-42.7.13.jar` | `PostgreSQL JDBC Driver` | `org.postgresql` | `org.postgresql` |
| `hibernate-core-7.4.5.Final.jar` | `hibernate-core` | `org.hibernate` | `org.hibernate.orm` |
| `tomcat-embed-core-11.0.24.jar` | `Apache Tomcat` | `Apache Software Foundation` | `org.apache.tomcat.embed` |
| `spring-core-7.0.9.jar` | `spring-core` | *(absent)* | `org.springframework` |

`Implementation-Title` is a display name as often as an artifactId, `Implementation-Vendor-Id` is not a groupId, and **no manifest header carries a groupId at all** — so the manifest can never produce a scannable `groupId:artifactId`. This is recorded in the docs so it isn't re-litigated.

## What this does instead

**Resolve what is resolvable.** The embedded CycloneDX SBOM carries `pkg:maven/<group>/<artifact>@<version>` purls — build-resolved coordinates, groupId included. `DependencyCatalog` now reads `META-INF/sbom/application.cdx.json` and `META-INF/sbom/bom.json` (the two names Spring Boot's `SbomEndpoint` recognizes) ahead of the existing sources. A malformed or unreadable SBOM logs at WARNING and leaves the rest of the inventory intact.

**Make the residue visible.** The catalog enumerates the real archive census — nested `BOOT-INF/lib` / `WEB-INF/lib` entries inside a fat jar, classpath jars otherwise — attributes each archive to a resolved coordinate (by owning-archive URL, then by `artifactId-version` file name), and publishes a new `coverage` block:

- `COMPLETE` — every enumerated archive resolved.
- `INCOMPLETE` — `unidentifiedArchives` names the remainder (bounded at 200, with a truncation flag).
- `UNAVAILABLE` — the census itself could not run; coverage is reported as unknown rather than claimed.

The panel gains an "Unidentified JARs" metric and a warning reading "N of M JARs could not be identified and were not scanned", with a collapsible name list and a pointer to enabling the CycloneDX plugin. Unidentified archives stay out of the scannable dependency table.

**Same bug, second instance.** `bootui.vulnerabilities.max-packages` silently truncated the scan while `packagesScanned` reported the truncated number as if it were the whole story. The default moves 250 → 500 and the dropped count is reported as `scan.packagesSkipped` with its own warning.

Deliberately out of scope: resolving a groupId by SHA-1 lookup against Maven Central. It would work, but it adds an outbound service and config surface; it is recorded as a follow-up in the docs' known-limitations section.

## Two production bugs the new tests caught

- `archiveCensus()` checked the file extension before looking inside, so an executable `app.war` was skipped entirely and coverage collapsed to `UNAVAILABLE`. It now inspects nested libraries first.
- `owningArchive()` used only `resource.getURL()`, which throws for the Boot 3.2+ `jar:nested:` scheme outside a running Boot app. It now falls back to `getURI()`. Both URL forms are covered by tests.

## Contract and scope

Additive only — `DependenciesReport` gains `coverage`, `DependencyScanStatusDto` gains `packagesSkipped`; nothing is renamed or removed. `DependencyProvider` gains a `default inventory()`, so Quarkus and any third-party provider stay source-compatible; Quarkus reads a fully-resolved build-time model and reports `COMPLETE`. MVC and WebFlux share one controller. `BootUiRuntimeHints` registers the two SBOM resource patterns for native image. MCP tool descriptions mention the new fields.

## Validation

- `bootui-core,bootui-engine,bootui-spring-autoconfigure` — 1871 tests
- `bootui-quarkus` — 435 tests
- `bootui-ui` frontend — 1046 tests / 101 files
- Spring, WebFlux, and Quarkus conformance suites — 28 each; the canonical-shape test now pins `coverage` and `scan.packagesSkipped` across all three adapters
- Spring sample-app Playwright `vulnerabilities.spec.js`, including a new case for the incomplete-coverage warning — 2 passed against a live server
- `spotless:check` and `prettier --check` clean across the reactor, the UI, and both e2e folders

New unit tests: `PackageUrlsTests` (17), `ArchiveNamesTests` (16), a rewritten `DependencyCatalogTests` (17) that builds synthetic fat jars in a `@TempDir`, plus `DependencyReportsTests` and `Vulnerabilities.test.js` additions.

The Quarkus sample-app e2e assertion added here could not run locally (JDK 26 skips Quarkus augmentation); it runs in CI on a supported JDK.