### PR TITLE
Judge actuator protection by authorization, not chain shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The Security Advisor no longer reports an actuator protected inside a single `anyRequest` chain as unprotected.**
+  `SEC-ACT-003` decided whether the actuator was covered by looking for the base path in a chain's `securityMatcher`
+  *description*. A whole-application chain renders as `any request` and never mentions `/actuator`, so an application
+  following Spring Boot's own reference — one chain whose `authorizeHttpRequests` requires a role for
+  `EndpointRequest.toAnyEndpoint()` / `/actuator/**` — was reported as having "no security filter chain" for that path.
+  The rule now asks the question it is actually about: it finds the chain that matches the actuator path (a catch-all
+  chain counts, exactly as it does at runtime) and simulates an anonymous request against that chain's authorization
+  rules. A denial is protection and the rule stays silent. The check also stops passing configurations it never
+  verified: a chain that *does* match the actuator path but grants anonymous access is now reported as such, naming the
+  chain, and a chain whose authorization rules cannot be read is skipped rather than guessed at. Fixing the simulated
+  request the advisor probes with — it lacked the servlet mapping Spring dereferences while parsing a request path —
+  also restores every other path-scoped anonymous authorization simulation, which had been silently degrading to
+  "indeterminate" since Spring Security switched to `PathPatternRequestMatcher`.
+  ([#922](https://github.com/jdubois/boot-ui/issues/922))
 - **The Spring advisor and the pentest panel no longer report BootUI's own actuator default as a host
   misconfiguration.** BootUI contributes `management.endpoint.health.show-details=always` as a lowest-priority default
   so its Health panel works, and `SPRING-MGMT-003` (MEDIUM) and `PT-A05-050` (LOW) then reported that value against the

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityContext.java
@@ -212,6 +212,21 @@ record SecurityContext(
         return false;
     }
 
+    /**
+     * The configured actuator base path ({@code management.endpoints.web.base-path}), falling back to
+     * Spring Boot's own {@code /actuator} default. Resolved from the {@link Environment} so the
+     * scanner (which probes the path while building chain models) and the rules that report on it
+     * always agree.
+     */
+    static String actuatorBasePath(Environment environment) {
+        String base = environment == null ? null : environment.getProperty("management.endpoints.web.base-path");
+        return (base == null || base.isBlank()) ? "/actuator" : base.trim();
+    }
+
+    String actuatorBasePath() {
+        return actuatorBasePath(environment);
+    }
+
     String firstProperty(String... keys) {
         for (String key : keys) {
             String value = environment.getProperty(key);

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityModel.java
@@ -47,6 +47,14 @@ final class SecurityModel {
      *     {@code sessionCreationPolicy(STATELESS)} configures), {@code FALSE} when an
      *     {@code HttpSessionSecurityContextRepository} is part of it, {@code null} when the
      *     repository was absent, custom, or could not be introspected
+     * @param matchesActuatorPath {@code TRUE} when this chain's own request matcher accepts a request
+     *     for the actuator base path -- which a whole-application ({@code anyRequest}) chain does just
+     *     as much as a dedicated {@code securityMatcher("/actuator/**")} one -- {@code FALSE} when it
+     *     does not, {@code null} when the matcher could not be evaluated
+     * @param actuatorAnonymousAllowed {@code TRUE} when an anonymous request for the actuator base
+     *     path is granted by this chain's authorization rules (or the chain installs no
+     *     {@code AuthorizationFilter} at all, so nothing can deny it), {@code FALSE} when it is
+     *     denied, {@code null} when the chain's {@code AuthorizationManager} could not be introspected
      */
     record FilterChainModel(
             int index,
@@ -61,7 +69,9 @@ final class SecurityModel {
             Boolean cspReportOnly,
             Boolean authorizationRuleShadowed,
             Integer rememberMeKeyLength,
-            Boolean statelessSecurityContext) {
+            Boolean statelessSecurityContext,
+            Boolean matchesActuatorPath,
+            Boolean actuatorAnonymousAllowed) {
 
         private static final long HSTS_MIN_MAX_AGE_SECONDS = 31536000L; // HstsHeaderWriter's own 1-year default
 
@@ -103,6 +113,8 @@ final class SecurityModel {
                     null,
                     null,
                     null,
+                    null,
+                    null,
                     null);
         }
 
@@ -130,6 +142,8 @@ final class SecurityModel {
                     hstsMaxAgeSeconds,
                     hstsIncludeSubdomains,
                     cspPolicyDirectives,
+                    null,
+                    null,
                     null,
                     null,
                     null,
@@ -161,6 +175,44 @@ final class SecurityModel {
                     null,
                     authorizationRuleShadowed,
                     rememberMeKeyLength,
+                    null,
+                    null,
+                    null);
+        }
+
+        /**
+         * Convenience constructor for callers that predate the actuator-coverage fields, leaving both
+         * verdicts indeterminate so the actuator rule falls back to its matcher-string heuristic.
+         */
+        FilterChainModel(
+                int index,
+                String matcher,
+                List<String> filterNames,
+                Boolean permitsAllAnonymous,
+                Boolean sessionFixationDisabled,
+                List<String> headerWriterNames,
+                Long hstsMaxAgeSeconds,
+                Boolean hstsIncludeSubdomains,
+                String cspPolicyDirectives,
+                Boolean cspReportOnly,
+                Boolean authorizationRuleShadowed,
+                Integer rememberMeKeyLength,
+                Boolean statelessSecurityContext) {
+            this(
+                    index,
+                    matcher,
+                    filterNames,
+                    permitsAllAnonymous,
+                    sessionFixationDisabled,
+                    headerWriterNames,
+                    hstsMaxAgeSeconds,
+                    hstsIncludeSubdomains,
+                    cspPolicyDirectives,
+                    cspReportOnly,
+                    authorizationRuleShadowed,
+                    rememberMeKeyLength,
+                    statelessSecurityContext,
+                    null,
                     null);
         }
 
@@ -364,6 +416,18 @@ final class SecurityModel {
                     || normalized.contains("'/**'")
                     || normalized.contains("\"/**\"")
                     || CATCH_ALL_BRACKETED_PATTERN.matcher(normalized).find();
+        }
+
+        /**
+         * {@code true} when this chain's {@code securityMatcher} description mentions the actuator
+         * base path. Only a textual signal, used as a fallback when {@link #matchesActuatorPath()}
+         * could not be evaluated: a whole-application chain that protects the actuator through its
+         * authorization rules alone renders as {@code any request} and is not recognized here.
+         */
+        boolean matcherReferences(String basePath) {
+            return matcher != null
+                    && basePath != null
+                    && matcher.toLowerCase(Locale.ROOT).contains(basePath.toLowerCase(Locale.ROOT));
         }
 
         String describe() {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRules.java
@@ -1360,8 +1360,8 @@ final class ActuatorUnprotectedRule extends AbstractSecurityRule {
                 "Exposed actuator endpoints should be protected by a security chain",
                 SecurityCategory.ACTUATOR,
                 "MEDIUM",
-                "Detects web-exposed actuator endpoints (beyond health/info, after subtracting management.endpoints.web.exposure.exclude) when no filter chain references /actuator.",
-                "Add a SecurityFilterChain with a securityMatcher for the actuator base path that requires authentication/authorization.",
+                "Detects web-exposed actuator endpoints (beyond health/info, after subtracting management.endpoints.web.exposure.exclude) that an anonymous caller can reach: either no filter chain matches the actuator base path at all, or the chain that does match authorizes anonymous requests for it. Authorization rules are read from the chain that actually matches, so a single anyRequest chain protecting /actuator/** counts as protection just like a dedicated actuator chain does.",
+                "Require authentication/authorization for the actuator base path -- either inside the chain that matches it (e.g. requestMatchers(EndpointRequest.toAnyEndpoint()).hasRole(\"ADMIN\")) or through a dedicated SecurityFilterChain with a securityMatcher for that path.",
                 "https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.security"));
     }
 
@@ -1370,12 +1370,35 @@ final class ActuatorUnprotectedRule extends AbstractSecurityRule {
         if (!context.exposesBeyondHealthAndInfo()) {
             return pass();
         }
-        String base = context.firstProperty("management.endpoints.web.base-path");
-        String basePath = (base == null || base.isBlank()) ? "/actuator" : base.trim();
-        boolean chainReferencesActuator = context.chains().stream()
-                .anyMatch(chain -> chain.matcher() != null
-                        && chain.matcher().toLowerCase(Locale.ROOT).contains(basePath.toLowerCase(Locale.ROOT)));
-        if (chainReferencesActuator) {
+        String basePath = context.actuatorBasePath();
+        FilterChainModel matchingChain = null;
+        boolean coverageIndeterminate = false;
+        for (FilterChainModel chain : context.chains()) {
+            if (Boolean.TRUE.equals(chain.matchesActuatorPath())) {
+                // The first matching chain is the one that governs the path, mirroring how
+                // FilterChainProxy dispatches a request to the first chain that accepts it.
+                matchingChain = chain;
+                break;
+            }
+            if (chain.matchesActuatorPath() == null) {
+                coverageIndeterminate = true;
+            }
+        }
+        if (matchingChain != null) {
+            Boolean anonymousAllowed = matchingChain.actuatorAnonymousAllowed();
+            if (Boolean.FALSE.equals(anonymousAllowed)) {
+                return pass();
+            }
+            if (anonymousAllowed == null) {
+                return skipped("Authorization rules for " + basePath + " could not be read from "
+                        + matchingChain.describe() + ".");
+            }
+            return violation(List.of("Actuator endpoints are exposed at " + basePath + " but "
+                    + matchingChain.describe() + " permits anonymous access to that path."));
+        }
+        if (coverageIndeterminate && context.chains().stream().anyMatch(chain -> chain.matcherReferences(basePath))) {
+            // A chain matcher could not be evaluated; its description naming the actuator base path
+            // is the pre-existing, purely textual signal that the actuator is covered.
             return pass();
         }
         return violation(List.of(

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -11,7 +11,9 @@ import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
 import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpServletMapping;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.MappingMatch;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -281,11 +283,12 @@ final class SecurityScanner {
 
         List<String> errors = new ArrayList<>();
         List<FilterChainModel> chains = new ArrayList<>();
+        String actuatorProbePath = actuatorProbePath(environment);
         try {
             List<SecurityFilterChain> securityChains = proxy.getFilterChains();
             for (int i = 0; i < securityChains.size(); i++) {
                 try {
-                    chains.add(toChainModel(i, securityChains.get(i)));
+                    chains.add(toChainModel(i, securityChains.get(i), actuatorProbePath));
                 } catch (RuntimeException | LinkageError ex) {
                     errors.add("Chain " + i + ": " + safeMessage(ex));
                 }
@@ -340,7 +343,7 @@ final class SecurityScanner {
         return new SecurityDiscovery(context, errors);
     }
 
-    private static FilterChainModel toChainModel(int index, SecurityFilterChain chain) {
+    private static FilterChainModel toChainModel(int index, SecurityFilterChain chain, String actuatorProbePath) {
         List<Filter> filters = chain.getFilters();
         List<String> filterNames =
                 filters.stream().map(f -> f.getClass().getSimpleName()).toList();
@@ -352,6 +355,9 @@ final class SecurityScanner {
         Boolean authorizationRuleShadowed = detectAuthorizationRuleShadowed(authorizationManager);
         Integer rememberMeKeyLength = detectRememberMeKeyLength(filters);
         Boolean statelessSecurityContext = detectStatelessSecurityContext(filters);
+        Boolean matchesActuatorPath = detectMatchesActuatorPath(chain, actuatorProbePath);
+        Boolean actuatorAnonymousAllowed =
+                detectActuatorAnonymousAllowed(filters, authorizationManager, actuatorProbePath);
         return new FilterChainModel(
                 index,
                 matcher,
@@ -365,7 +371,9 @@ final class SecurityScanner {
                 headerWriters.cspReportOnly(),
                 authorizationRuleShadowed,
                 rememberMeKeyLength,
-                statelessSecurityContext);
+                statelessSecurityContext,
+                matchesActuatorPath,
+                actuatorAnonymousAllowed);
     }
 
     private static String matcherDescription(SecurityFilterChain chain) {
@@ -387,8 +395,7 @@ final class SecurityScanner {
         if (unwrappedManager == null) {
             return null;
         }
-        Authentication anonymous = new AnonymousAuthenticationToken(
-                "bootui-advisor", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+        Authentication anonymous = anonymousAuthentication();
         boolean indeterminate = false;
         for (AuthorizationProbe probe : AUTHORIZATION_PROBES) {
             try {
@@ -415,6 +422,67 @@ final class SecurityScanner {
             }
         }
         return null;
+    }
+
+    /**
+     * The path the advisor probes to reason about actuator protection: a sensitive endpoint under the
+     * configured actuator base path. Authorization is what is being probed, not endpoint existence, so
+     * the path stays representative even when {@code env} itself is not exposed -- an
+     * {@code /actuator/**} rule applies to it either way.
+     */
+    private static String actuatorProbePath(Environment environment) {
+        String basePath = SecurityContext.actuatorBasePath(environment);
+        return basePath.endsWith("/") ? basePath + "env" : basePath + "/env";
+    }
+
+    private static Authentication anonymousAuthentication() {
+        return new AnonymousAuthenticationToken(
+                "bootui-advisor", "anonymousUser", AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"));
+    }
+
+    /**
+     * {@code TRUE} when this chain's own request matcher accepts a request for the actuator path,
+     * {@code FALSE} when it does not, {@code null} when the matcher could not be evaluated. A
+     * whole-application chain matches here just as much as a dedicated
+     * {@code securityMatcher("/actuator/**")} one, which is what lets the actuator rule reason about
+     * the single-chain shape Spring Boot's reference documents.
+     */
+    private static Boolean detectMatchesActuatorPath(SecurityFilterChain chain, String actuatorProbePath) {
+        try {
+            return chain.matches(simulatedRequest("GET", actuatorProbePath));
+        } catch (RuntimeException | LinkageError ex) {
+            return null;
+        }
+    }
+
+    /**
+     * {@code TRUE} when an anonymous request for the actuator path is granted by this chain's
+     * authorization rules, {@code FALSE} when it is denied, {@code null} when an
+     * {@code AuthorizationManager} is present but could not be probed.
+     *
+     * <p>A chain with no {@code AuthorizationFilter} installs nothing that can deny the request, so it
+     * counts as granting it. An abstaining manager (a {@code null} result) is likewise treated as
+     * granting, because {@code AuthorizationFilter} only rejects an explicit denial -- reporting on a
+     * path nothing refuses keeps the rule fail-closed.</p>
+     */
+    private static Boolean detectActuatorAnonymousAllowed(
+            List<Filter> filters, AuthorizationManager<HttpServletRequest> manager, String actuatorProbePath) {
+        if (manager == null) {
+            boolean authorizationFilterPresent = filters.stream().anyMatch(AuthorizationFilter.class::isInstance);
+            return authorizationFilterPresent ? null : Boolean.TRUE;
+        }
+        AuthorizationManager<HttpServletRequest> unwrappedManager = unwrapObservationAuthorizationManager(manager);
+        if (unwrappedManager == null) {
+            return null;
+        }
+        Authentication anonymous = anonymousAuthentication();
+        try {
+            AuthorizationResult result =
+                    unwrappedManager.authorize(() -> anonymous, simulatedRequest("GET", actuatorProbePath));
+            return result == null || result.isGranted();
+        } catch (RuntimeException | LinkageError ex) {
+            return null;
+        }
     }
 
     /**
@@ -918,6 +986,36 @@ final class SecurityScanner {
         return introspectorType != null && introspectorType.isInstance(source);
     }
 
+    /**
+     * Stands in for the servlet mapping a container would attach to the request. Spring's
+     * {@code ServletRequestPathUtils} dereferences it while parsing the request path, which
+     * Spring Security's {@code PathPatternRequestMatcher} does for every path-based matcher, so
+     * without it any path-scoped simulated authorization decision would fail. {@code DEFAULT} models
+     * the root {@code "/"} mapping, i.e. no servlet path prefix to strip.
+     */
+    private static final HttpServletMapping DEFAULT_SERVLET_MAPPING = new HttpServletMapping() {
+
+        @Override
+        public String getMatchValue() {
+            return "";
+        }
+
+        @Override
+        public String getPattern() {
+            return "/";
+        }
+
+        @Override
+        public String getServletName() {
+            return "";
+        }
+
+        @Override
+        public MappingMatch getMappingMatch() {
+            return MappingMatch.DEFAULT;
+        }
+    };
+
     private static HttpServletRequest simulatedRequest(String requestMethod, String requestPath) {
         InvocationHandler handler = (proxy, method, args) -> {
             String name = method.getName();
@@ -930,6 +1028,7 @@ final class SecurityScanner {
                 case "getServerName", "getRemoteHost", "getLocalName" -> "localhost";
                 case "getRemoteAddr", "getLocalAddr" -> "127.0.0.1";
                 case "getRequestURL" -> new StringBuffer("http://localhost" + requestPath);
+                case "getHttpServletMapping" -> DEFAULT_SERVLET_MAPPING;
                 default -> defaultValue(method);
             };
         };

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRulesTests.java
@@ -234,6 +234,10 @@ class SecurityRulesTests {
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
     }
 
+    /**
+     * A chain model whose coverage verdicts are indeterminate (as models built before those fields
+     * existed are): the rule must then fall back to the purely textual matcher check.
+     */
     @Test
     void actuatorUnprotectedPassesWhenAChainMatchesTheActuatorBasePath() {
         MockEnvironment environment =
@@ -256,6 +260,124 @@ class SecurityRulesTests {
         SecurityRuleResultDto result = new ActuatorUnprotectedRule().evaluate(context(environment));
 
         assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void actuatorUnprotectedPassesWhenTheMatchingChainDeniesAnonymousAccess() {
+        // Issue #922: one anyRequest chain whose authorizeHttpRequests protects /actuator/**. Its
+        // matcher renders as "any request", so only the authorization verdict proves the actuator is
+        // covered.
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("management.endpoints.web.exposure.include", "env");
+        FilterChainModel chain =
+                actuatorChain("any request", Boolean.TRUE, /* actuatorAnonymousAllowed= */ Boolean.FALSE);
+
+        SecurityRuleResultDto result = new ActuatorUnprotectedRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void actuatorUnprotectedFiresWhenTheMatchingChainPermitsAnonymousAccess() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("management.endpoints.web.exposure.include", "env");
+        FilterChainModel chain =
+                actuatorChain("any request", Boolean.TRUE, /* actuatorAnonymousAllowed= */ Boolean.TRUE);
+
+        SecurityRuleResultDto result = new ActuatorUnprotectedRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .containsExactly("Actuator endpoints are exposed at /actuator but Chain #0 (any request) "
+                        + "permits anonymous access to that path.");
+    }
+
+    @Test
+    void actuatorUnprotectedUsesTheFirstChainThatMatchesTheActuatorPath() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("management.endpoints.web.exposure.include", "env");
+        FilterChainModel scoped = new FilterChainModel(
+                0,
+                "PathPattern [/api/**]",
+                List.of("AuthorizationFilter"),
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.FALSE,
+                Boolean.TRUE);
+        FilterChainModel catchAll = new FilterChainModel(
+                1,
+                "any request",
+                List.of("AuthorizationFilter"),
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                Boolean.TRUE,
+                Boolean.FALSE);
+
+        SecurityRuleResultDto result =
+                new ActuatorUnprotectedRule().evaluate(context(List.of(scoped, catchAll), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.PASS);
+    }
+
+    @Test
+    void actuatorUnprotectedIsSkippedWhenTheMatchingChainAuthorizationCannotBeRead() {
+        MockEnvironment environment =
+                new MockEnvironment().withProperty("management.endpoints.web.exposure.include", "env");
+        FilterChainModel chain = actuatorChain("any request", Boolean.TRUE, /* actuatorAnonymousAllowed= */ null);
+
+        SecurityRuleResultDto result = new ActuatorUnprotectedRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.SKIPPED);
+    }
+
+    @Test
+    void actuatorUnprotectedHonoursACustomActuatorBasePath() {
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("management.endpoints.web.exposure.include", "env")
+                .withProperty("management.endpoints.web.base-path", "/manage");
+        FilterChainModel chain = actuatorChain("any request", Boolean.TRUE, Boolean.TRUE);
+
+        SecurityRuleResultDto result = new ActuatorUnprotectedRule().evaluate(context(List.of(chain), environment));
+
+        assertThat(result.status()).isEqualTo(SecurityRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations()).anyMatch(detail -> detail.contains("exposed at /manage"));
+    }
+
+    /** A chain carrying the actuator-coverage verdicts the scanner probes for. */
+    private static FilterChainModel actuatorChain(
+            String matcher, Boolean matchesActuatorPath, Boolean actuatorAnonymousAllowed) {
+        return new FilterChainModel(
+                0,
+                matcher,
+                List.of("AuthorizationFilter"),
+                null,
+                null,
+                List.of(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                matchesActuatorPath,
+                actuatorAnonymousAllowed);
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -37,6 +37,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.ObjectPostProcessor;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.FilterChainProxy;
@@ -499,6 +500,110 @@ class SecurityScannerTests {
                 .build();
     }
 
+    /**
+     * Issue #922: the actuator is protected inside a single {@code anyRequest} chain, the shape
+     * Spring Boot's reference documents. The chain matcher renders as "any request" and never
+     * mentions {@code /actuator}, so SEC-ACT-003 must read the chain's authorization rules instead.
+     */
+    @Test
+    void actuatorProtectedInsideTheAnyRequestChainIsNotReportedAsUnprotected() throws Exception {
+        SecurityFilterChain chain = actuatorSecurityFilterChain(authorize -> authorize
+                .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info", "/actuator/prometheus")
+                .permitAll()
+                .requestMatchers("/actuator/**")
+                .hasRole("ADMIN")
+                .anyRequest()
+                .authenticated());
+
+        SecurityReport report = scannerFor(
+                        new FilterChainProxy(chain), new DefaultListableBeanFactory(), actuatorEnvironment())
+                .scan();
+
+        assertThat(report.filterChainsAnalyzed()).isEqualTo(1);
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-ACT-003");
+        assertThat(report.results())
+                .extracting(SecurityRuleResultDto::id)
+                .as("the exposure rules still analyze the same configuration")
+                .contains("SEC-ACT-006");
+    }
+
+    /** The same single-chain shape without an actuator rule stays a SEC-ACT-003 violation. */
+    @Test
+    void actuatorLeftOpenByTheAnyRequestChainIsReported() throws Exception {
+        SecurityFilterChain chain =
+                actuatorSecurityFilterChain(authorize -> authorize.anyRequest().permitAll());
+
+        SecurityReport report = scannerFor(
+                        new FilterChainProxy(chain), new DefaultListableBeanFactory(), actuatorEnvironment())
+                .scan();
+
+        assertThat(report.results())
+                .filteredOn(result -> result.id().equals("SEC-ACT-003"))
+                .singleElement()
+                .satisfies(result -> assertThat(result.sampleViolations())
+                        .containsExactly("Actuator endpoints are exposed at /actuator but Chain #0 (any request) "
+                                + "permits anonymous access to that path."));
+    }
+
+    /** A dedicated actuator chain that requires a role is protection, and stays silent. */
+    @Test
+    void dedicatedActuatorChainRequiringARoleIsNotReported() throws Exception {
+        SecurityFilterChain actuator = actuatorSecurityFilterChain(
+                http -> http.securityMatcher(
+                        PathPatternRequestMatcher.withDefaults().matcher("/actuator/**")),
+                authorize -> authorize.anyRequest().hasRole("ADMIN"));
+        SecurityFilterChain application =
+                actuatorSecurityFilterChain(authorize -> authorize.anyRequest().permitAll());
+
+        SecurityReport report = scannerFor(
+                        new FilterChainProxy(List.of(actuator, application)),
+                        new DefaultListableBeanFactory(),
+                        actuatorEnvironment())
+                .scan();
+
+        assertThat(report.results()).extracting(SecurityRuleResultDto::id).doesNotContain("SEC-ACT-003");
+    }
+
+    private static MockEnvironment actuatorEnvironment() {
+        return new MockEnvironment().withProperty("management.endpoints.web.exposure.include", "health,prometheus");
+    }
+
+    private static SecurityFilterChain actuatorSecurityFilterChain(
+            Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry>
+                    authorize)
+            throws Exception {
+        return actuatorSecurityFilterChain(http -> {}, authorize);
+    }
+
+    /**
+     * Builds a real chain through the {@code HttpSecurity} DSL with the given
+     * {@code authorizeHttpRequests} rules, so the actuator assertions run against the authorization
+     * manager Spring Security actually assembles rather than a hand-written model.
+     */
+    private static SecurityFilterChain actuatorSecurityFilterChain(
+            Customizer<HttpSecurity> customizer,
+            Customizer<AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry>
+                    authorize)
+            throws Exception {
+        GenericApplicationContext applicationContext = new GenericApplicationContext();
+        applicationContext.refresh();
+        ObjectPostProcessor<Object> objectPostProcessor = new ObjectPostProcessor<>() {
+            @Override
+            public <O> O postProcess(O object) {
+                return object;
+            }
+        };
+        HttpSecurity http = new HttpSecurity(
+                objectPostProcessor,
+                new AuthenticationManagerBuilder(objectPostProcessor),
+                Map.of(ApplicationContext.class, applicationContext));
+        customizer.customize(http);
+        return http.httpBasic(Customizer.withDefaults())
+                .authenticationManager(authentication -> authentication)
+                .authorizeHttpRequests(authorize)
+                .build();
+    }
+
     @Test
     void applicationCorsConfigurationStillRequiresSecurityChainIntegration() {
         AuthorizationManager<HttpServletRequest> denyAll =
@@ -672,11 +777,16 @@ class SecurityScannerTests {
 
     @SuppressWarnings("unchecked")
     private static SecurityScanner scannerFor(FilterChainProxy proxy, ListableBeanFactory beanFactory) {
+        return scannerFor(proxy, beanFactory, new MockEnvironment());
+    }
+
+    private static SecurityScanner scannerFor(
+            FilterChainProxy proxy, ListableBeanFactory beanFactory, MockEnvironment environment) {
         ObjectProvider<FilterChainProxy> filterChains = mock(ObjectProvider.class);
         ObjectProvider<ListableBeanFactory> beanFactories = mock(ObjectProvider.class);
         when(filterChains.getIfAvailable()).thenReturn(proxy);
         when(beanFactories.getIfAvailable()).thenReturn(beanFactory);
-        return new SecurityScanner(filterChains, beanFactories, new MockEnvironment(), CLOCK);
+        return new SecurityScanner(filterChains, beanFactories, environment, CLOCK);
     }
 
     private static SecurityContext hardenedContext(List<PasswordEncoderModel> encoders, MockEnvironment environment) {

--- a/bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs
+++ b/bootui-spring-sample-app/e2e/scripts/capture-docs-screenshots.mjs
@@ -2190,10 +2190,10 @@ const security = {
       'Exposed actuator endpoints should be protected by a security chain',
       'Actuator exposure',
       'MEDIUM',
-      'Detects web-exposed actuator endpoints when no filter chain references /actuator.',
+      'Detects web-exposed actuator endpoints an anonymous caller can reach.',
       1,
-      ['Actuator endpoints are exposed at /actuator but no security filter chain matches that path.'],
-      'Add a SecurityFilterChain with a securityMatcher for the actuator base path that requires authentication.'
+      ['Actuator endpoints are exposed at /actuator but Chain #2 (any request) permits anonymous access to that path.'],
+      'Require authentication for the actuator base path, in the chain that matches it or a dedicated one.'
     ),
     securityResult(
       'SEC-AUTH-005',

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -378,8 +378,8 @@ infrastructure rather than an application CORS policy and is excluded from this 
 ### SEC-ACT-003 - Exposed actuator endpoints should be protected by a security chain
 
 - **Severity**: MEDIUM
-- **Detects**: Detects web-exposed actuator endpoints (beyond health/info, after subtracting management.endpoints.web.exposure.exclude) when no filter chain references /actuator.
-- **Recommendation**: Add a SecurityFilterChain with a securityMatcher for the actuator base path that requires authentication/authorization.
+- **Detects**: Detects web-exposed actuator endpoints (beyond health/info, after subtracting management.endpoints.web.exposure.exclude) that an anonymous caller can reach: either no filter chain matches the actuator base path at all, or the chain that does match authorizes anonymous requests for it. Authorization rules are read from the chain that actually matches, so a single anyRequest chain protecting /actuator/** counts as protection just like a dedicated actuator chain does.
+- **Recommendation**: Require authentication/authorization for the actuator base path -- either inside the chain that matches it (e.g. requestMatchers(EndpointRequest.toAnyEndpoint()).hasRole("ADMIN")) or through a dedicated SecurityFilterChain with a securityMatcher for that path.
 - **Learn more**: <https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.security>
 
 ### SEC-ACT-004 - Actuator health details/components should not be exposed unconditionally


### PR DESCRIPTION
Fixes #922.

## Problem

`SEC-ACT-003` decided whether the actuator was protected by searching for the base path in a chain's `securityMatcher` **description**. A whole-application chain renders as `any request` and never mentions `/actuator`, so an application following Spring Boot's own reference — a single chain whose `authorizeHttpRequests` requires a role for `EndpointRequest.toAnyEndpoint()` / `/actuator/**` — was reported as having "no security filter chain" for that path.

The same string check passed a *dedicated* `/actuator/**` chain that permitted everything, which is a real miss.

## Change

The scanner records two tri-state facts per chain, following the pattern of the #921 fix:

- `matchesActuatorPath` — does `SecurityFilterChain.matches(...)` accept a request for the actuator base path
- `actuatorAnonymousAllowed` — does the chain's `AuthorizationManager` grant an anonymous request for it

The rule picks the first chain that matches, exactly as `FilterChainProxy` does at runtime (a catch-all chain qualifies), and passes when anonymous access is denied. A chain that matches but grants anonymous access is now reported by name. An unreadable chain is skipped rather than guessed at, and any indeterminate verdict degrades to the previous matcher-string behaviour, so introspection failure never creates a new false positive.

While spiking this, the simulated request the advisor probes with turned out to lack the servlet mapping Spring dereferences while parsing a request path, so *every* path-scoped anonymous authorization probe threw and silently degraded to "indeterminate". It now answers a default root mapping.

## Scope

Servlet/Spring MVC only. The WebFlux counterpart `SEC-RXF-ACT-003` already reasons about filter presence and does not have this false positive; Quarkus has its own catalog. Neither is touched.

## Validation

- `bootui-spring-autoconfigure` module: 1889 tests, 0 failures — including 8 new cases covering the issue's exact configuration built with the real `HttpSecurity` DSL, the anonymous-grant violation, first-matching-chain selection, the indeterminate skip, and a custom `management.endpoints.web.base-path`
- `spotless:apply` / `spotless:check` over the reactor, and `npm run format:check` for the sample app e2e scripts