### PR TITLE
Make configuration name search relaxed-binding aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Configuration search now finds a property whatever spelling it was supplied in.** `get_config` with
+  `{"query": "bootui.mcp.enabled"}` answered `matched: 0` on a value that was set, effective, and visibly working,
+  because it came from the environment variable `BOOTUI_MCP_ENABLED`: relaxed binding applies when a name is looked up,
+  never when a property source is enumerated, so the inventory carries the raw `UPPER_SNAKE_CASE` key and a literal
+  substring search could not reach it. The engine now compares canonicalized names — case-insensitive, with `_` and `-`
+  treated as `.` — so the dotted, kebab-case, and environment-variable spellings of one property all find it, in the
+  Configuration panel's search box as well as over MCP and the CLI. Values, descriptions, and defaults keep matching
+  literally, so a relaxed query never widens the search into unrelated values, and each row still reports the exact name
+  and source its property source gave. Fixed once in `bootui-engine`, so Spring MVC, WebFlux, and Quarkus behave
+  identically ([#939](https://github.com/jdubois/boot-ui/issues/939)).
+
 - **The Security Advisor no longer reports an actuator protected inside a single `anyRequest` chain as unprotected.**
   `SEC-ACT-003` decided whether the actuator was covered by looking for the base path in a chain's `securityMatcher`
   *description*. A whole-application chain renders as `any request` and never mentions `/actuator`, so an application

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
@@ -1419,6 +1419,35 @@ public abstract class AbstractBootUiApiConformanceTest {
     }
 
     /**
+     * A property is enumerated under the literal name its source uses: an environment variable stays
+     * {@code UPPER_SNAKE_CASE} on Spring and on Quarkus alike, because relaxed binding applies on lookup and
+     * never on enumeration. Free-text search must therefore compare canonicalized names, so the dotted,
+     * kebab-case and {@code UPPER_SNAKE_CASE} spellings of one property all find it on every stack.
+     */
+    @Test
+    void configSearchFindsAPropertyThroughItsRelaxedBindingNameForms() {
+        assumeTrue(isPanelUsableInLiveManifest("config"), "config panel is not available in this environment");
+
+        String key = "bootui.conformance.api-token";
+        String rawSecret = "conformance-raw-secret-value";
+        Response response = probe().get(api("/config?q=BOOTUI_CONFORMANCE_API_TOKEN&limit=10"));
+        assertThat(response.status()).as("relaxed config query status").isEqualTo(200);
+        assertThat(response.body()).as("raw secret must never be serialized").doesNotContain(rawSecret);
+
+        JsonNode matching = null;
+        for (JsonNode property : response.json().path("properties")) {
+            if (key.equals(property.path("name").asText())) {
+                matching = property;
+                break;
+            }
+        }
+        assertThat(matching)
+                .as("an UPPER_SNAKE_CASE query must find the dotted property, as relaxed binding would")
+                .isNotNull();
+        assertThat(matching.path("masked").asBoolean()).isTrue();
+    }
+
+    /**
      * SQL Trace rankings and route attribution must present the same bounded, self-describing shape on
      * Spring MVC, Spring WebFlux and Quarkus. Values differ per runtime and per workload; the contract does
      * not. In particular the response must always say which correlation tiers it could use, so a stack with

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/config/ConfigService.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/config/ConfigService.java
@@ -8,6 +8,7 @@ import io.github.jdubois.bootui.core.dto.ConfigReport;
 import io.github.jdubois.bootui.core.dto.ProfileSourceDto;
 import io.github.jdubois.bootui.core.dto.ProfilesReport;
 import io.github.jdubois.bootui.engine.support.PagedList;
+import io.github.jdubois.bootui.engine.support.RelaxedNames;
 import io.github.jdubois.bootui.spi.ConfigEntry;
 import io.github.jdubois.bootui.spi.ConfigProvider;
 import io.github.jdubois.bootui.spi.ExposurePolicy;
@@ -29,6 +30,12 @@ import java.util.Map;
  * (masked) value and never reveals a secret. The Configuration panel masks the raw {@code Object} value and
  * Profile Diff masks {@code String.valueOf(value)} — exactly as the two controllers did — so value-pattern
  * masking stays identical for both.</p>
+ *
+ * <p>Free-text matching on the property <em>name</em> is relaxed-binding aware ({@link RelaxedNames}): a
+ * property supplied as the environment variable {@code BOOTUI_MCP_ENABLED} is enumerated under that literal
+ * name by both Spring and Quarkus, and must still be found by the dotted query {@code bootui.mcp.enabled}.
+ * Value, description and default matching stays literal, and the reported {@code name} and {@code source}
+ * are always the ones the property source gave.</p>
  */
 public final class ConfigService {
 
@@ -57,12 +64,13 @@ public final class ConfigService {
         sorted.sort(Comparator.comparing(ConfigPropertyDto::name));
 
         String normalizedQuery = PagedList.normalize(query);
+        String canonicalQuery = RelaxedNames.canonicalize(normalizedQuery);
         String normalizedSource = sourceFilter == null ? "" : sourceFilter.trim();
         PagedList.Result<ConfigPropertyDto> page = PagedList.from(
                 sorted,
                 property -> matchesSource(property, normalizedSource)
                         && matchesOverrideFilter(property, overridesOnly)
-                        && matchesQuery(property, normalizedQuery),
+                        && matchesQuery(property, normalizedQuery, canonicalQuery),
                 offset,
                 limit);
         return new ConfigReport(
@@ -137,8 +145,8 @@ public final class ConfigService {
         return !overridesOnly || property.override();
     }
 
-    private boolean matchesQuery(ConfigPropertyDto property, String query) {
-        return PagedList.contains(property.name(), query)
+    private boolean matchesQuery(ConfigPropertyDto property, String query, String canonicalQuery) {
+        return RelaxedNames.contains(property.name(), canonicalQuery)
                 || PagedList.contains(text(property.value()), query)
                 || PagedList.contains(property.description(), query)
                 || PagedList.contains(text(property.defaultValue()), query);

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptions.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptions.java
@@ -77,7 +77,9 @@ public final class McpToolDescriptions {
             Map.entry(
                     "get_config",
                     "Search effective configuration by case-insensitive name or displayed value and return a bounded "
-                            + "result. Secret-like configuration values are masked; prefer a narrow query."),
+                            + "result. Name search is relaxed-binding aware, so `bootui.mcp.enabled` also finds a value "
+                            + "supplied as the environment variable `BOOTUI_MCP_ENABLED`, which is enumerated under that "
+                            + "literal name. Secret-like configuration values are masked; prefer a narrow query."),
             Map.entry(
                     "get_mappings",
                     "Search request routes and handlers and return a bounded result. Use a path, HTTP concept, or handler "

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/RelaxedNames.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/RelaxedNames.java
@@ -1,0 +1,48 @@
+package io.github.jdubois.bootui.engine.support;
+
+import java.util.Locale;
+
+/**
+ * Relaxed-binding-aware matching for configuration property names, shared by every BootUI adapter.
+ *
+ * <p>Property sources enumerate their names verbatim: Spring's {@code SystemEnvironmentPropertySource} and
+ * Quarkus/MicroProfile both report an environment variable as {@code BOOTUI_MCP_ENABLED}, because relaxed
+ * binding only applies when a name is <em>looked up</em>, never when the source is enumerated. A literal
+ * substring search therefore cannot find {@code bootui.mcp.enabled} in an env-only property.
+ *
+ * <p>{@link #canonicalize(String)} maps both sides of a name comparison onto one form — lower case, with
+ * {@code _} and {@code -} treated as {@code .} — so the dotted, kebab-case and {@code UPPER_SNAKE_CASE}
+ * spellings of the same property all compare equal. The mapping is per character and length preserving, so
+ * canonical containment is a superset of literal containment: every query that matched a name before still
+ * matches it. Only names are canonicalized; values, descriptions and defaults keep literal matching.
+ */
+public final class RelaxedNames {
+
+    private RelaxedNames() {}
+
+    /**
+     * The canonical form used to compare property names: lower case, with {@code _} and {@code -} normalized
+     * to {@code .}. Returns {@code null} for a {@code null} input.
+     */
+    public static String canonicalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        return value.toLowerCase(Locale.ROOT).replace('_', '.').replace('-', '.');
+    }
+
+    /**
+     * Whether {@code name} contains {@code canonicalQuery} once both are canonicalized. An empty query
+     * matches everything, mirroring {@link PagedList#contains(String, String)}.
+     *
+     * @param name the literal property name, as reported by the property source
+     * @param canonicalQuery a query already run through {@link #canonicalize(String)}
+     */
+    public static boolean contains(String name, String canonicalQuery) {
+        if (canonicalQuery == null || canonicalQuery.isEmpty()) {
+            return true;
+        }
+        String canonicalName = canonicalize(name);
+        return canonicalName != null && canonicalName.contains(canonicalQuery);
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/config/ConfigServiceTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/config/ConfigServiceTests.java
@@ -66,6 +66,63 @@ class ConfigServiceTests {
     }
 
     @Test
+    void dottedQueryFindsAnEnvironmentVariableStyleName() {
+        FakeProvider provider = new FakeProvider().entry("BOOTUI_MCP_ENABLED", "true", "systemEnvironment");
+        ConfigService service = new ConfigService(provider, exposure(ValueExposure.FULL, true));
+
+        ConfigReport report = service.list("bootui.mcp.enabled", null, false, null, null);
+
+        assertThat(report.properties()).hasSize(1);
+        ConfigPropertyDto property = report.properties().get(0);
+        assertThat(property.name()).isEqualTo("BOOTUI_MCP_ENABLED");
+        assertThat(property.source()).isEqualTo("systemEnvironment");
+    }
+
+    @Test
+    void environmentVariableStyleQueryFindsADottedName() {
+        FakeProvider provider = new FakeProvider().entry("bootui.mcp.enabled", "true", "application.properties");
+        ConfigService service = new ConfigService(provider, exposure(ValueExposure.FULL, true));
+
+        assertThat(service.list("BOOTUI_MCP_ENABLED", null, false, null, null).properties())
+                .extracting(ConfigPropertyDto::name)
+                .containsExactly("bootui.mcp.enabled");
+    }
+
+    @Test
+    void kebabAndDottedSeparatorsAreInterchangeableInNameSearch() {
+        FakeProvider provider = new FakeProvider().entry("bootui.conformance.api-token", "x", "app");
+        ConfigService service = new ConfigService(provider, exposure(ValueExposure.FULL, false));
+
+        assertThat(service.list("bootui.conformance.api.token", null, false, null, null)
+                        .properties())
+                .hasSize(1);
+        assertThat(service.list("bootui.conformance.api-token", null, false, null, null)
+                        .properties())
+                .hasSize(1);
+    }
+
+    @Test
+    void relaxedNameMatchingDoesNotWidenValueOrMetadataMatching() {
+        FakeProvider provider = new FakeProvider()
+                .entry("app.name", "demo_value", "app")
+                .suggestion("app.name", "The app_name shown in the header.", "demo_default");
+        ConfigService service = new ConfigService(provider, exposure(ValueExposure.FULL, false));
+
+        assertThat(service.list("demo_value", null, false, null, null).properties())
+                .hasSize(1);
+        assertThat(service.list("app_name shown", null, false, null, null).properties())
+                .hasSize(1);
+        assertThat(service.list("demo_default", null, false, null, null).properties())
+                .hasSize(1);
+        assertThat(service.list("demo.value", null, false, null, null).properties())
+                .isEmpty();
+        assertThat(service.list("app.name shown", null, false, null, null).properties())
+                .isEmpty();
+        assertThat(service.list("demo.default", null, false, null, null).properties())
+                .isEmpty();
+    }
+
+    @Test
     void metadataOnlyExposureHidesAllValues() {
         FakeProvider provider = new FakeProvider().entry("app.name", "demo", "app");
         ConfigService service = new ConfigService(provider, exposure(ValueExposure.METADATA_ONLY, true));
@@ -114,6 +171,7 @@ class ConfigServiceTests {
         private final List<String> sources = new java.util.ArrayList<>();
         private final List<ConfigEntry> entries = new java.util.ArrayList<>();
         private final List<ProfileSource> profileSources = new java.util.ArrayList<>();
+        private final List<ConfigPropertySuggestionDto> suggestions = new java.util.ArrayList<>();
         private String overrideSource;
 
         FakeProvider activeProfiles(String... p) {
@@ -128,6 +186,11 @@ class ConfigServiceTests {
 
         FakeProvider entry(String name, Object value, String source) {
             entries.add(new ConfigEntry(name, value, source));
+            return this;
+        }
+
+        FakeProvider suggestion(String name, String description, Object defaultValue) {
+            suggestions.add(new ConfigPropertySuggestionDto(name, "java.lang.String", description, defaultValue));
             return this;
         }
 
@@ -168,7 +231,7 @@ class ConfigServiceTests {
 
         @Override
         public List<ConfigPropertySuggestionDto> suggestions() {
-            return List.of();
+            return suggestions;
         }
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/RelaxedNamesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/support/RelaxedNamesTests.java
@@ -1,0 +1,58 @@
+package io.github.jdubois.bootui.engine.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the relaxed-binding-aware name matching used by the Configuration panel and the {@code get_config}
+ * MCP tool. Property sources enumerate environment variables under their raw {@code UPPER_SNAKE_CASE} names,
+ * so a dotted query has to reach them through canonicalization rather than a literal substring test.
+ */
+class RelaxedNamesTests {
+
+    @Test
+    void canonicalizeLowercasesAndNormalizesSeparators() {
+        assertThat(RelaxedNames.canonicalize("BOOTUI_MCP_ENABLED")).isEqualTo("bootui.mcp.enabled");
+        assertThat(RelaxedNames.canonicalize("bootui.conformance.api-token")).isEqualTo("bootui.conformance.api.token");
+        assertThat(RelaxedNames.canonicalize("bootui.mcp.enabled")).isEqualTo("bootui.mcp.enabled");
+    }
+
+    @Test
+    void canonicalizePreservesNullAndEmpty() {
+        assertThat(RelaxedNames.canonicalize(null)).isNull();
+        assertThat(RelaxedNames.canonicalize("")).isEmpty();
+    }
+
+    @Test
+    void canonicalizeIsLengthPreservingSoLiteralMatchesAreNeverLost() {
+        String name = "Spring_Datasource-URL";
+        assertThat(RelaxedNames.canonicalize(name)).hasSameSizeAs(name);
+        assertThat(RelaxedNames.contains(name, RelaxedNames.canonicalize("datasource")))
+                .isTrue();
+    }
+
+    @Test
+    void containsMatchesAcrossSeparatorAndCaseSpellings() {
+        assertThat(RelaxedNames.contains("BOOTUI_MCP_ENABLED", "bootui.mcp.enabled"))
+                .isTrue();
+        assertThat(RelaxedNames.contains("bootui.mcp.enabled", RelaxedNames.canonicalize("BOOTUI_MCP_ENABLED")))
+                .isTrue();
+        assertThat(RelaxedNames.contains("spring.datasource.url", RelaxedNames.canonicalize("spring-datasource")))
+                .isTrue();
+    }
+
+    @Test
+    void containsRejectsUnrelatedNamesAndToleratesNulls() {
+        assertThat(RelaxedNames.contains("bootui.mcp.enabled", "bootui.cli.enabled"))
+                .isFalse();
+        assertThat(RelaxedNames.contains(null, "bootui")).isFalse();
+    }
+
+    @Test
+    void anEmptyOrNullQueryMatchesEverything() {
+        assertThat(RelaxedNames.contains("bootui.mcp.enabled", "")).isTrue();
+        assertThat(RelaxedNames.contains(null, "")).isTrue();
+        assertThat(RelaxedNames.contains("bootui.mcp.enabled", null)).isTrue();
+    }
+}

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -445,6 +445,8 @@ Data sources:
 Features:
 
 - List and search all Spring Boot configuration properties visible to the application.
+- Match property names through relaxed binding, so a dotted query also finds a property supplied as an
+  `UPPER_SNAKE_CASE` environment variable, which every property source enumerates under its literal name.
 - Show effective value.
 - Show source property source.
 - Show active profiles.

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -7,8 +7,12 @@
 The Configuration panel shows effective configuration properties, sources, metadata descriptions, defaults when known,
 active profiles, and masked values. It can create, update, and delete local runtime overrides persisted to
 `.bootui/application-bootui.properties`, with restart and rebinding caveats shown for every mutation. Large property
-tables load in bounded server-side pages for search, source, and override-only filters. The override property-name
-picker limits its datalist suggestions while narrowing against the full metadata catalog as you type.
+tables load in bounded server-side pages for search, source, and override-only filters. Search matches property names
+through relaxed binding — `_` and `-` are treated as `.` and case is ignored — so `bootui.mcp.enabled` also finds a
+value supplied as the environment variable `BOOTUI_MCP_ENABLED`, which Spring and Quarkus both enumerate under that
+literal name. Values, descriptions, and defaults are matched literally, and every row still reports the name and source
+its property source gave. The override property-name picker limits its datalist suggestions while narrowing against the
+full metadata catalog as you type.
 
 ## Profile Diff
 


### PR DESCRIPTION
Closes #939.

## Problem

`get_config` with `{"query": "bootui.mcp.enabled"}` returned `matched: 0` on a value that was set, effective and visibly working, because it was supplied as the environment variable `BOOTUI_MCP_ENABLED`. Relaxed binding applies when a name is *looked up*, never when a property source is *enumerated*, so the inventory carries the raw `UPPER_SNAKE_CASE` key and `ConfigService`'s literal substring test could not reach it. The Configuration panel's search box had the same blind spot, on all three stacks.

## Change

- New `RelaxedNames` helper in `bootui-engine/.../support/`: canonical form is lower case with `_` and `-` mapped to `.`. JDK-only, sibling of `PagedList`.
- `ConfigService.matchesQuery` uses it for the **name arm only**. The mapping is per character and length preserving, so canonical containment is a strict superset of literal containment — nothing that matched before stops matching.
- Value, description and default matching stays literal, so a relaxed query never widens the search into unrelated (or masked) values. Every row still reports the exact `name` and `source` its property source gave.
- Fixed once in the engine, so Spring MVC, WebFlux and Quarkus behave identically. No UI change: the Configuration table filter is already server-side.

| Stored name | Query | Before | After |
| --- | --- | --- | --- |
| `BOOTUI_MCP_ENABLED` | `bootui.mcp.enabled` | no match | match |
| `bootui.mcp.enabled` | `BOOTUI_MCP_ENABLED` | no match | match |
| `spring.datasource.url` | `spring-datasource` | no match | match |
| value `demo_value` | `demo.value` | no match | no match (values stay literal) |

## Out of scope

Associating configuration-metadata `description`/`defaultValue` with env-style names, deduplicating an env entry against its dotted twin, and relaxing the loggers/beans/mappings searches. Those change displayed content rather than search reach.

## Validation

- `ConfigServiceTests` (dotted query → env-style name, env-style query → dotted name, kebab/dotted equivalence, values and metadata not relaxed) and new `RelaxedNamesTests`; full `bootui-engine` suite green (2357 tests).
- New conformance test `configSearchFindsAPropertyThroughItsRelaxedBindingNameForms` runs — not skipped — on Spring MVC (29/29), WebFlux (29/29) and Quarkus (29 run, 4 pre-existing skips), asserting the property is found by its `UPPER_SNAKE_CASE` spelling, still masked, raw secret absent from the body.
- `spotless:check` clean over the reactor; `bootui-conformance` catalog consistency tests green.