### PR TITLE
Stop three advisor rules misreading Kotlin bytecode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Three advisor rules no longer report a Kotlin application for shapes its compiler produced.** Each read bytecode as
+  if `javac` had written it, and each turned an ordinary Kotlin idiom into a finding nobody could act on.
+  `ARCH-SPRING-004` reported a self-invocation for every call that omits a default argument: Kotlin routes such a call
+  through a generated `$default` bridge, which then calls the real function, so one call in the source became a proxy
+  bypass in the report. The rule now judges both ends of a call — a bridge calling the function it exists to reach is
+  the compiler's own call and is skipped, while a call *into* a bridge is followed through to the function it
+  dispatches to, so a genuine self-invocation is still reported and named after the function you can change rather than
+  vanishing as soon as a proxied function gains a default parameter value. Only dispatch bridges are skipped, never
+  every synthetic method: a self-invocation written inside a lambda lives in a synthetic method too, and that
+  transaction really is lost. `HIB-ENTITY-005` reported every `lateinit var` as a public persistent field, though
+  Kotlin has no public fields — the compiler must leave the backing field public so the initialisation check can run,
+  while all access goes through the generated accessor pair, and the language offers no way to change it. It is now
+  exempt, recognised by that accessor pair, so a `@JvmField var` — which generates no accessors and is a real
+  encapsulation break — stays reported. `ARCH-CODE-010` asked every nested variant of an exception hierarchy to be
+  renamed, which is how a Kotlin `sealed class` hierarchy has to be written; a nested exception is now exempt when an
+  enclosing class carries the suffix, since `ClaimException.AlreadyAssigned` already says what it is at every call
+  site. That last fix is language-neutral and applies to nested Java exceptions as well.
+  ([#925](https://github.com/jdubois/boot-ui/issues/925))
+
 - **The Security Advisor no longer reports an actuator protected inside a single `anyRequest` chain as unprotected.**
   `SEC-ACT-003` decided whether the actuator was covered by looking for the base path in a chain's `securityMatcher`
   *description*. A whole-application chain renders as `any request` and never mentions `/actuator`, so an application

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
@@ -29,7 +29,6 @@ import com.tngtech.archunit.lang.EvaluationResult;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.lang.conditions.ArchConditions;
 import com.tngtech.archunit.library.GeneralCodingRules;
-import com.tngtech.archunit.library.ProxyRules;
 import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition;
 import io.github.jdubois.bootui.core.dto.ArchitectureRuleResultDto;
 import io.github.jdubois.bootui.engine.archunit.KotlinBytecode;
@@ -667,28 +666,75 @@ final class NoSelfInvocationOfProxiedMethodsRule extends AbstractArchitectureRul
 
     @Override
     ArchRule rule(ArchitectureContext context) {
-        return ProxyRules.no_classes_should_directly_call_other_methods_declared_in_the_same_class_that(
-                new DescribedPredicate<MethodCallTarget>(
-                        "are proxied through @Transactional, @Async, or @Cacheable on the method (or @Async/@Cacheable on the declaring class)") {
-                    @Override
-                    public boolean test(MethodCallTarget target) {
-                        if (isCompilerGeneratedTarget(target)) {
-                            // Kotlin routes every open suspending function through a synthetic
-                            // $suspendImpl body that inherits the annotation: the "self-invocation" is
-                            // the compiler's own call, not one the developer can refactor.
-                            return false;
-                        }
-                        return context.platform() == ArchitecturePlatform.SPRING
-                                && (SpringStereotypes.PROXIED_METHOD_ANNOTATED.test(target)
-                                        || SpringStereotypes.CLASS_LEVEL_PROXY_ANNOTATED.test(target.getOwner()));
-                    }
-                });
+        // Deliberately not ProxyRules: it only exposes the call target to its predicate, and filters origins
+        // by ACC_BRIDGE alone. Kotlin needs both ends of the call examined — see bypassesProxy below.
+        return noClasses()
+                .should(
+                        new ArchCondition<JavaClass>(
+                                "directly call other methods declared in the same class that are proxied through @Transactional, @Async, or @Cacheable on the method (or @Async/@Cacheable on the declaring class)") {
+                            @Override
+                            public void check(JavaClass javaClass, ConditionEvents events) {
+                                for (JavaMethodCall call : javaClass.getMethodCallsFromSelf()) {
+                                    events.add(new SimpleConditionEvent(
+                                            call, bypassesProxy(context, call), describe(call)));
+                                }
+                            }
+                        })
+                .because("it bypasses the proxy mechanism");
     }
 
-    private static boolean isCompilerGeneratedTarget(MethodCallTarget target) {
-        return target.resolveMember()
-                .map(ArchitectureRuleSupport::isCompilerGenerated)
-                .orElse(false);
+    /**
+     * Whether this call loses the proxy behaviour, judging both ends of it.
+     *
+     * <p>The <strong>origin</strong> must be code the developer wrote. Kotlin routes calls through
+     * generated dispatch bridges, and a bridge calling the function it exists to reach is the compiler's
+     * own call: nobody can refactor it, and reporting it says a Kotlin bean self-invokes when the source
+     * contains a single ordinary call. Only dispatch bridges are skipped, never every synthetic method,
+     * because a lambda body is synthetic too and a self-invocation inside a lambda is a genuine bypass.
+     *
+     * <p>The <strong>target</strong> must be the function the developer wrote. When a call omits a default
+     * argument, Kotlin compiles it into a call to the {@code $default} bridge, which carries none of the
+     * annotations; following that hop is what keeps a real self-invocation reported instead of silently
+     * disappearing as soon as a proxied function gains a default parameter value.
+     */
+    private static boolean bypassesProxy(ArchitectureContext context, JavaMethodCall call) {
+        if (context.platform() != ArchitecturePlatform.SPRING
+                || !call.getOriginOwner().equals(call.getTargetOwner())
+                || KotlinBytecode.isGeneratedDispatchBridge(call.getOrigin())) {
+            return false;
+        }
+        MethodCallTarget target = call.getTarget();
+        Optional<JavaMethod> resolved = target.resolveMember();
+        if (resolved.isPresent() && ArchitectureRuleSupport.isCompilerGenerated(resolved.get())) {
+            // A $default bridge stands in for a declared function, so resolve through it. Any other
+            // compiler-generated target — the $suspendImpl body of an open suspend fun, a javac bridge —
+            // is plumbing that merely inherits the annotation, and judging it invents a finding.
+            resolved = KotlinBytecode.defaultArgumentDispatchTarget(resolved.get());
+            if (resolved.isEmpty()) {
+                return false;
+            }
+        }
+        CanBeAnnotated proxied = resolved.isPresent() ? resolved.get() : target;
+        return SpringStereotypes.PROXIED_METHOD_ANNOTATED.test(proxied)
+                || SpringStereotypes.CLASS_LEVEL_PROXY_ANNOTATED.test(call.getTargetOwner());
+    }
+
+    /**
+     * The call, described by the function the developer wrote rather than by the {@code $default} bridge
+     * that stands in for it. A finding naming a method that appears in no source file cannot be acted on.
+     */
+    private static String describe(JavaMethodCall call) {
+        String description = call.getDescription();
+        if (!call.getOriginOwner().equals(call.getTargetOwner())) {
+            return description;
+        }
+        Optional<JavaMethod> bridge = call.getTarget().resolveMember();
+        if (bridge.isEmpty()) {
+            return description;
+        }
+        return KotlinBytecode.defaultArgumentDispatchTarget(bridge.get())
+                .map(declared -> description.replace(bridge.get().getFullName(), declared.getFullName()))
+                .orElse(description);
     }
 }
 
@@ -755,14 +801,47 @@ final class ExceptionsShouldBeNamedExceptionRule extends AbstractArchitectureRul
                 "Exceptions should be named ending with Exception",
                 ArchitectureCategory.CODING_PRACTICES,
                 "LOW",
-                "Detects classes extending Exception or RuntimeException that do not have names ending with 'Exception'.",
-                "Rename the class to end with 'Exception' so its purpose is immediately clear.",
+                "Detects classes extending Exception or RuntimeException that do not have names ending with 'Exception'. A nested variant of an exception hierarchy is exempt when an enclosing class carries the suffix, since it is already read as ClaimException.AlreadyAssigned at every call site.",
+                "Rename the class to end with 'Exception' so its purpose is immediately clear, or nest it inside the exception type it specialises.",
                 "https://www.archunit.org/userguide/html/000_Index.html#_naming_rules"));
     }
 
     @Override
     ArchRule rule(ArchitectureContext context) {
-        return classes().that().areAssignableTo(Exception.class).should().haveSimpleNameEndingWith("Exception");
+        return classes()
+                .that()
+                .areAssignableTo(Exception.class)
+                .should(new ArchCondition<JavaClass>("have a simple name ending with 'Exception'") {
+                    @Override
+                    public void check(JavaClass javaClass, ConditionEvents events) {
+                        events.add(new SimpleConditionEvent(
+                                javaClass,
+                                isNamedAsException(javaClass),
+                                "Class " + javaClass.getName() + " does not end with 'Exception'"));
+                    }
+                })
+                .as("Exceptions should be named ending with Exception");
+    }
+
+    /**
+     * Whether the name identifies this class as an exception, reading the enclosing chain and not only the
+     * simple name.
+     *
+     * <p>A nested variant of an exception hierarchy — the idiomatic shape of a Kotlin {@code sealed class},
+     * and common enough in Java — is already named at the point of use: {@code ClaimException.AlreadyAssigned}
+     * says what it is, and renaming it to {@code AlreadyAssignedException} would stutter as
+     * {@code ClaimException.AlreadyAssignedException}. The rule exists so an exception's purpose is clear at
+     * a glance, and here it already is.
+     */
+    private static boolean isNamedAsException(JavaClass javaClass) {
+        Optional<JavaClass> current = Optional.of(javaClass);
+        while (current.isPresent()) {
+            if (current.get().getSimpleName().endsWith("Exception")) {
+                return true;
+            }
+            current = current.get().getEnclosingClass();
+        }
+        return false;
     }
 }
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/archunit/KotlinBytecode.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/archunit/KotlinBytecode.java
@@ -5,6 +5,7 @@ import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMember;
 import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
 import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.domain.JavaParameter;
 import com.tngtech.archunit.core.domain.JavaParameterizedType;
@@ -62,6 +63,12 @@ public final class KotlinBytecode {
 
     /** Destructuring accessors generated for a {@code data class}. */
     private static final Pattern DATA_CLASS_COMPONENT = Pattern.compile("component\\d+");
+
+    /** Suffix of the bridge that applies default arguments before calling the declared function. */
+    private static final String DEFAULT_BRIDGE_SUFFIX = "$default";
+
+    /** Suffix of the static body an {@code open suspend fun} is compiled into. */
+    private static final String SUSPEND_IMPL_SUFFIX = "$suspendImpl";
 
     private KotlinBytecode() {}
 
@@ -121,6 +128,63 @@ public final class KotlinBytecode {
                     && isDataClass(member.getOwner());
         } catch (RuntimeException | LinkageError ex) {
             return false;
+        }
+    }
+
+    /**
+     * Whether this member is a dispatch bridge the compiler generated to route a call to the function the
+     * developer actually wrote: a javac/Kotlin {@code ACC_BRIDGE} method, a Kotlin {@code $default} bridge
+     * that applies default arguments, or the {@code $suspendImpl} body of an {@code open suspend fun}.
+     *
+     * <p>This is deliberately narrower than {@link #isCompilerGenerated(JavaMember)}. A rule that judges
+     * the <em>origin</em> of a call must not skip every synthetic method, because a lambda body is
+     * synthetic too — {@code lambda$process$0} on javac, {@code process$lambda$0} on Kotlin. Code inside a
+     * lambda is code the developer wrote, so a finding about it is real and actionable; only the
+     * compiler's own dispatch plumbing belongs here.
+     */
+    public static boolean isGeneratedDispatchBridge(JavaMember member) {
+        try {
+            if (member.getModifiers().contains(JavaModifier.BRIDGE)) {
+                return true;
+            }
+            if (!isKotlinClass(member.getOwner())) {
+                return false;
+            }
+            String name = member.getName();
+            return name.endsWith(DEFAULT_BRIDGE_SUFFIX) || name.endsWith(SUSPEND_IMPL_SUFFIX);
+        } catch (RuntimeException | LinkageError ex) {
+            return false;
+        }
+    }
+
+    /**
+     * The function a Kotlin {@code $default} bridge dispatches to, or empty when this method is not such a
+     * bridge.
+     *
+     * <p>A call that omits a defaulted argument is compiled into a call to the bridge rather than to the
+     * function the developer wrote, so a rule that judges the callee has to follow that one hop — otherwise
+     * it judges the annotations and modifiers of a method that appears in no source file, and a real
+     * finding disappears the moment a parameter gains a default value.
+     *
+     * <p>The hop is read from the bridge's own body, not guessed from its name: overloads share a bridge
+     * name, and only the call the bridge makes identifies which one it stands for.
+     */
+    public static Optional<JavaMethod> defaultArgumentDispatchTarget(JavaMethod bridge) {
+        try {
+            String name = bridge.getName();
+            if (!name.endsWith(DEFAULT_BRIDGE_SUFFIX) || !isKotlinClass(bridge.getOwner())) {
+                return Optional.empty();
+            }
+            String declaredName = name.substring(0, name.length() - DEFAULT_BRIDGE_SUFFIX.length());
+            for (JavaMethodCall call : bridge.getMethodCallsFromSelf()) {
+                if (call.getTargetOwner().equals(bridge.getOwner())
+                        && declaredName.equals(call.getTarget().getName())) {
+                    return call.getTarget().resolveMember();
+                }
+            }
+            return Optional.empty();
+        } catch (RuntimeException | LinkageError ex) {
+            return Optional.empty();
         }
     }
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.hibernate;
 
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
+import io.github.jdubois.bootui.engine.support.KotlinReflection;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
@@ -1852,12 +1853,42 @@ final class PublicPersistentFieldRule extends AbstractHibernateRule {
                 // fieldMember (not the "()"-suffixed name heuristic) is what actually distinguishes field
                 // access from property (getter) access; property-access entities resolve their attributes
                 // from a public getter Method, which is fully JPA/Hibernate-instrumented and not a finding.
-                if (attribute.publicMember() && attribute.fieldMember() && !attribute.isTransient()) {
+                if (attribute.publicMember()
+                        && attribute.fieldMember()
+                        && !attribute.isTransient()
+                        && !isKotlinPropertyBackingField(entity, attribute)) {
                     details.add(attribute.description() + " is exposed as a public field.");
                 }
             }
         }
         return violation(details);
+    }
+
+    /**
+     * Whether this attribute is the backing field of a Kotlin property, which the compiler must leave
+     * public even though the author declared no public field.
+     *
+     * <p>A {@code lateinit var} is reached through its generated accessors from every language that
+     * consumes it, so Hibernate's instrumentation is intact and there is nothing here to encapsulate.
+     * A field the author did expose, written {@code @JvmField var}, has no accessors and stays reported.
+     */
+    private static boolean isKotlinPropertyBackingField(
+            HibernateEntityModel entity, HibernateAttributeModel attribute) {
+        return KotlinReflection.isAccessorBackedProperty(declaringClass(entity, attribute), attribute.name());
+    }
+
+    /**
+     * The class that declares this attribute, found by walking the entity hierarchy for the name the
+     * attribute records. Null when the model carries no Java type, as hand-built models in tests do.
+     */
+    private static Class<?> declaringClass(HibernateEntityModel entity, HibernateAttributeModel attribute) {
+        for (Class<?> current = entity.javaType(); current != null && current != Object.class; ) {
+            if (current.getName().equals(attribute.entityName())) {
+                return current;
+            }
+            current = current.getSuperclass();
+        }
+        return null;
     }
 }
 

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/KotlinReflection.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/support/KotlinReflection.java
@@ -1,0 +1,107 @@
+package io.github.jdubois.bootui.engine.support;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * Kotlin-awareness for the advisors that read a host application through {@code java.lang.reflect}
+ * rather than through bytecode, so a Kotlin class is judged on what its author wrote instead of on the
+ * shape the compiler gave it.
+ *
+ * <p>This is the reflection counterpart of the ArchUnit-side {@code KotlinBytecode}, and follows the same
+ * two rules. Everything is decided from <strong>names</strong> — the runtime-retained
+ * {@code kotlin.Metadata} annotation — so {@code bootui-engine} keeps no compile-time or runtime
+ * dependency on the Kotlin standard library and behaves identically when it is absent. And every lookup
+ * is guarded, because reflection over an application's classes can fail in ways that must never abort a
+ * scan.
+ */
+public final class KotlinReflection {
+
+    /** Marker the Kotlin compiler stamps on every class it produces. */
+    private static final String METADATA_ANNOTATION = "kotlin.Metadata";
+
+    private KotlinReflection() {}
+
+    /** Whether this class was produced by the Kotlin compiler. */
+    public static boolean isKotlinClass(Class<?> type) {
+        if (type == null) {
+            return false;
+        }
+        try {
+            for (Annotation annotation : type.getAnnotations()) {
+                if (METADATA_ANNOTATION.equals(annotation.annotationType().getName())) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (RuntimeException | LinkageError ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Whether the named field is the backing field of a Kotlin property rather than a field the author
+     * exposed, recognised by the accessor pair the compiler generates alongside it.
+     *
+     * <p>Kotlin has no notion of a public field. A {@code lateinit var} is a property — read and written
+     * through {@code getX()} / {@code setX()} in every language that consumes it — but the compiler must
+     * leave its backing field public so the initialisation check can run from outside the class. Judging
+     * that field as a public field reports an encapsulation break the author cannot fix and did not make.
+     *
+     * <p>The accessor pair is the discriminator rather than an approximation of one: a genuinely exposed
+     * field, written {@code @JvmField var}, is emitted with no accessors at all, so it stays visible to
+     * the rule exactly as a Java public field would.
+     */
+    public static boolean isAccessorBackedProperty(Class<?> owner, String fieldName) {
+        if (owner == null || fieldName == null || fieldName.isEmpty() || !isKotlinClass(owner)) {
+            return false;
+        }
+        try {
+            Field field = owner.getDeclaredField(fieldName);
+            if (Modifier.isStatic(field.getModifiers())) {
+                return false;
+            }
+            return hasGetter(owner, field) && hasSetter(owner, field);
+        } catch (NoSuchFieldException | RuntimeException | LinkageError ex) {
+            return false;
+        }
+    }
+
+    private static boolean hasGetter(Class<?> owner, Field field) {
+        String name = field.getName();
+        // A property already named "isActive" keeps that name as its getter instead of gaining a "get".
+        if (isPrefixed(name)) {
+            return isAccessor(owner, name, field.getType());
+        }
+        return isAccessor(owner, "get" + capitalize(name), field.getType());
+    }
+
+    private static boolean hasSetter(Class<?> owner, Field field) {
+        String name = field.getName();
+        // ... and its setter drops that prefix: "isActive" is written through setActive.
+        String suffix = isPrefixed(name) ? name.substring(2) : capitalize(name);
+        return isAccessor(owner, "set" + suffix, Void.TYPE, field.getType());
+    }
+
+    /** Whether the name is the Kotlin {@code isXxx} boolean-property spelling. */
+    private static boolean isPrefixed(String name) {
+        return name.length() > 2 && name.startsWith("is") && Character.isUpperCase(name.charAt(2));
+    }
+
+    private static String capitalize(String name) {
+        return Character.toUpperCase(name.charAt(0)) + name.substring(1);
+    }
+
+    private static boolean isAccessor(Class<?> owner, String name, Class<?> returnType, Class<?>... parameters) {
+        try {
+            Method method = owner.getDeclaredMethod(name, parameters);
+            return method.getReturnType().equals(returnType)
+                    && !Modifier.isStatic(method.getModifiers())
+                    && !method.isSynthetic();
+        } catch (NoSuchMethodException | RuntimeException | LinkageError ex) {
+            return false;
+        }
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
@@ -549,6 +549,36 @@ class ArchitectureRulesTests {
     }
 
     @Test
+    void noSelfInvocationFlagsSelfCallMadeFromInsideALambda() {
+        ArchitectureRuleResultDto result =
+                evaluate(new NoSelfInvocationOfProxiedMethodsRule(), LambdaSelfInvokingBean.class);
+
+        // javac compiles a lambda body into a private synthetic method of the same class. Skipping every
+        // synthetic origin would silence this, and the transaction really is lost when the task runs.
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("persist"));
+    }
+
+    @Test
+    void exceptionsShouldBeNamedExceptionAllowsNestedVariantsOfAnExceptionHierarchy() {
+        ArchitectureRuleResultDto result = evaluate(
+                new ExceptionsShouldBeNamedExceptionRule(), ClaimException.class, ClaimException.AlreadyAssigned.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void exceptionsShouldBeNamedExceptionStillFlagsNestedTypesOutsideAnExceptionHierarchy() {
+        ArchitectureRuleResultDto result =
+                evaluate(new ExceptionsShouldBeNamedExceptionRule(), ClaimOutcome.Rejected.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("Rejected"));
+    }
+
+    @Test
     void liteModeBeanMethodsFlagsSiblingBeanCallInLiteClass() {
         ArchitectureRuleResultDto result =
                 evaluate(new LiteModeBeanMethodsShouldNotCallSiblingBeanMethodsRule(), LiteBeanComponent.class);
@@ -1272,6 +1302,30 @@ class ArchitectureRulesTests {
         }
 
         void inner() {}
+    }
+
+    /** A self-invocation the developer wrote inside a lambda, which javac hides in a synthetic method. */
+    @Service
+    private static class LambdaSelfInvokingBean {
+
+        Runnable persistLater(String value) {
+            return () -> persist(value);
+        }
+
+        @Transactional
+        public void persist(String value) {}
+    }
+
+    /** An exception hierarchy whose variants are nested inside the type they specialise. */
+    private static class ClaimException extends RuntimeException {
+
+        static final class AlreadyAssigned extends ClaimException {}
+    }
+
+    /** A nested exception whose enclosing class says nothing about it: still a naming finding. */
+    private static class ClaimOutcome {
+
+        static final class Rejected extends RuntimeException {}
     }
 
     @Component

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/KotlinArchitectureRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/KotlinArchitectureRulesTests.java
@@ -74,10 +74,42 @@ class KotlinArchitectureRulesTests {
     void compilerGeneratedSelfInvocationIsNotReported() {
         ArchitectureRuleResultDto result = evaluate(new NoSelfInvocationOfProxiedMethodsRule());
 
-        // Calling one's own private @Transactional function is a real finding; a suspending function
-        // dispatching to its own generated $suspendImpl body is not.
-        assertThat(result.violationCount()).isEqualTo(1);
-        assertThat(result.sampleViolations()).singleElement().asString().contains("auditOrder");
+        // Not findings: a suspending function dispatching to its own generated $suspendImpl body, and a
+        // $default bridge calling the very function it exists to reach. Both are calls the compiler makes.
+        assertThat(result.violationCount()).isEqualTo(3);
+        assertThat(result.sampleViolations()).noneMatch(violation -> violation.contains("$suspendImpl"));
+        assertThat(result.sampleViolations()).noneMatch(violation -> violation.contains("$default"));
+        assertThat(result.sampleViolations())
+                .anySatisfy(violation -> assertThat(violation).contains("auditOrder"));
+    }
+
+    @Test
+    void selfInvocationThroughADefaultArgumentBridgeIsReportedAgainstTheDeclaredFunction() {
+        ArchitectureRuleResultDto result = evaluate(new NoSelfInvocationOfProxiedMethodsRule());
+
+        // expireNow calls expire(id), which compiles into a call to the $default bridge. The finding is
+        // real and must survive the bridge, naming the function the developer can actually refactor.
+        assertThat(result.sampleViolations())
+                .anySatisfy(violation ->
+                        assertThat(violation).contains("expireNow").contains("expire(long, java.lang.String)"));
+    }
+
+    @Test
+    void selfInvocationFromInsideALambdaIsStillReported() {
+        ArchitectureRuleResultDto result = evaluate(new NoSelfInvocationOfProxiedMethodsRule());
+
+        // Kotlin puts this lambda body in a synthetic method of the same class. Skipping every synthetic
+        // origin, rather than only the compiler's dispatch bridges, would silence a real proxy bypass.
+        assertThat(result.sampleViolations())
+                .anySatisfy(violation -> assertThat(violation).contains("expireLater"));
+    }
+
+    @Test
+    void nestedVariantsOfASealedExceptionHierarchyAreNotNamingFindings() {
+        ArchitectureRuleResultDto result = evaluate(new ExceptionsShouldBeNamedExceptionRule());
+
+        // KotlinClaimException.AlreadyAssigned already says what it is; renaming it would stutter.
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
@@ -3,6 +3,9 @@ package io.github.jdubois.bootui.engine.hibernate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
+import io.github.jdubois.bootui.engine.hibernate.kotlinfixtures.KotlinJvmFieldEntity;
+import io.github.jdubois.bootui.engine.hibernate.kotlinfixtures.KotlinLateinitEntity;
+import io.github.jdubois.bootui.engine.support.KotlinReflection;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.CascadeType;
@@ -901,6 +904,44 @@ class HibernateRulesTests {
         HibernateRuleResultDto result = new PublicPersistentFieldRule().evaluate(context);
 
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void publicPersistentFieldRuleIgnoresKotlinPropertyBackingFields() {
+        HibernateRuleResultDto result =
+                new PublicPersistentFieldRule().evaluate(context(new TestEnvironment(), KotlinLateinitEntity.class));
+
+        // lateinit leaves the backing field public so the initialisation check can run from outside the
+        // class, while every access still goes through the generated accessors. Kotlin offers no way to
+        // make that field private, so the finding would ask for a change nobody can make.
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void publicPersistentFieldRuleStillFlagsKotlinJvmFieldProperties() {
+        HibernateRuleResultDto result =
+                new PublicPersistentFieldRule().evaluate(context(new TestEnvironment(), KotlinJvmFieldEntity.class));
+
+        // @JvmField is the author asking for a plain public field, and generates no accessors at all.
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample).contains("code"));
+    }
+
+    @Test
+    void kotlinAccessorPairsAreRecognisedForEveryPropertyNameShape() {
+        assertThat(KotlinReflection.isAccessorBackedProperty(KotlinLateinitEntity.class, "name"))
+                .isTrue();
+        // "isoCode" only looks like the boolean spelling: its accessors are getIsoCode / setIsoCode.
+        assertThat(KotlinReflection.isAccessorBackedProperty(KotlinLateinitEntity.class, "isoCode"))
+                .isTrue();
+        // "isActive" is the boolean spelling: isActive / setActive, with no "get" and no "setIsActive".
+        assertThat(KotlinReflection.isAccessorBackedProperty(KotlinLateinitEntity.class, "isActive"))
+                .isTrue();
+        assertThat(KotlinReflection.isAccessorBackedProperty(KotlinJvmFieldEntity.class, "code"))
+                .isFalse();
+        assertThat(KotlinReflection.isAccessorBackedProperty(PublicFieldEntity.class, "name"))
+                .isFalse();
     }
 
     @Test

--- a/bootui-engine/src/test/kotlin/io/github/jdubois/bootui/engine/architecture/kotlinfixtures/KotlinArchitectureFixtures.kt
+++ b/bootui-engine/src/test/kotlin/io/github/jdubois/bootui/engine/architecture/kotlinfixtures/KotlinArchitectureFixtures.kt
@@ -69,3 +69,43 @@ open class KotlinOrderService {
 
     fun audit(id: Long) = auditOrder(id)
 }
+
+/**
+ * Default arguments, which have no Java equivalent: `expire(id)` does not compile into a call to
+ * `expire`. The compiler emits an `expire$default` bridge that fills in the missing argument and then
+ * calls the real function, so one call written in Kotlin becomes two calls in the same class.
+ */
+@Service
+open class KotlinCartService {
+
+    companion object {
+        private val log = LoggerFactory.getLogger(KotlinCartService::class.java)
+    }
+
+    @Transactional
+    open fun expire(id: Long, reason: String = "expired") {
+        log.debug("expiring {} because {}", id, reason)
+    }
+
+    /** A real self-invocation, which the `$default` bridge must not hide. */
+    fun expireNow(id: Long) = expire(id)
+
+    /**
+     * A self-invocation from inside a lambda, which the compiler puts in a synthetic method of this
+     * class. Synthetic or not, it is code the developer wrote and a real proxy bypass. `Runnable` is a
+     * SAM type rather than a Kotlin `forEach`, whose lambda would be inlined into the caller.
+     */
+    fun expireLater(id: Long) = Runnable { expire(id, "deferred") }
+}
+
+/**
+ * The idiomatic Kotlin exception hierarchy: variants are nested inside the sealed parent so the
+ * compiler can close the hierarchy, and they are read as `KotlinClaimException.AlreadyAssigned` at
+ * every call site.
+ */
+sealed class KotlinClaimException(message: String) : RuntimeException(message) {
+
+    class AlreadyAssigned(id: Long) : KotlinClaimException("claim $id is already assigned")
+
+    class Expired(id: Long) : KotlinClaimException("claim $id has expired")
+}

--- a/bootui-engine/src/test/kotlin/io/github/jdubois/bootui/engine/hibernate/kotlinfixtures/KotlinHibernateFixtures.kt
+++ b/bootui-engine/src/test/kotlin/io/github/jdubois/bootui/engine/hibernate/kotlinfixtures/KotlinHibernateFixtures.kt
@@ -1,0 +1,46 @@
+package io.github.jdubois.bootui.engine.hibernate.kotlinfixtures
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+
+/**
+ * Kotlin fixtures for the Hibernate advisor. They are only read reflectively, never persisted, and
+ * exist so the entity rules are verified against what the Kotlin compiler actually emits for a
+ * property: a backing field plus an accessor pair, where the field's visibility is a compilation
+ * detail rather than a decision the author made.
+ */
+
+/**
+ * `lateinit var` leaves its backing field public so the initialisation check can run from outside the
+ * class, while every read and write still goes through `getName` / `setName`. Kotlin offers no way to
+ * make that field private, so reporting it asks the author for a change they cannot make.
+ */
+@Entity
+class KotlinLateinitEntity {
+
+    @Id
+    var id: Long = 0
+
+    lateinit var name: String
+
+    /** Reads as "is" but is not the boolean spelling: the accessors are `getIsoCode` / `setIsoCode`. */
+    lateinit var isoCode: String
+
+    /** The boolean spelling, whose accessors are `isActive` / `setActive`. */
+    var isActive: Boolean = false
+}
+
+/**
+ * `@JvmField` is the opposite: the author asked for a plain public field, and the compiler generates
+ * no accessors at all. That is the same encapsulation break a Java public field is, so it stays
+ * reported.
+ */
+@Entity
+class KotlinJvmFieldEntity {
+
+    @Id
+    var id: Long = 0
+
+    @JvmField
+    var code: String = ""
+}

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -208,8 +208,14 @@ Dismissed rules remove all of their instances from the score.
 
 - **Severity**: LOW
 - **Inspects**: classes that extend `Exception` or `RuntimeException`.
-- **Fires when**: an exception type's simple class name does not end with `Exception`.
-- **Recommendation**: rename exception classes to end with `Exception` so their purpose is immediately clear.
+- **Fires when**: an exception type's simple class name does not end with `Exception`, and no enclosing class does
+  either.
+- **Recommendation**: rename exception classes to end with `Exception` so their purpose is immediately clear, or nest
+  them inside the exception type they specialise.
+- **Kotlin note**: the variants of a `sealed class` hierarchy are nested inside their parent so the compiler can close
+  the hierarchy, which leaves them with names like `ClaimException.AlreadyAssigned`. Those are exempt: the enclosing
+  name already says what the type is at every call site, and adding the suffix would only make it stutter. The same
+  applies to a nested Java exception hierarchy.
 
 ### ARCH-CODE-011 - Interfaces should not have names ending with 'Interface'
 
@@ -379,8 +385,14 @@ Dismissed rules remove all of their instances from the score.
 - **Recommendation**: refactor so the call goes through the Spring proxy: move the proxied method to a separate bean, or,
   only if necessary, inject a `@Lazy` self-reference and call through it.
 - **Kotlin note**: Kotlin behaves identically — marking a function `open` does not make a `this`-call go through the
-  proxy. Calls a function makes into its own compiler-generated helpers (such as the `$suspendImpl` of an `open suspend
-  fun`) are not reported.
+  proxy. Two compiler-generated shapes are read as what the developer wrote rather than as extra self-invocations.
+  Calls a function makes into its own helpers (such as the `$suspendImpl` of an `open suspend fun`, or the `$default`
+  bridge that fills in default arguments) are not reported, because nobody can refactor a call the compiler makes.
+  Conversely, a call that omits a default argument is compiled into a call to that `$default` bridge, and it is
+  followed through to the function it dispatches to — so a genuine self-invocation stays reported, named after the
+  function you can actually change, instead of disappearing the moment a proxied function gains a default parameter
+  value. A self-invocation written inside a lambda is still reported: the compiler puts the body in a synthetic
+  method, but the code is yours and the behaviour really is lost.
 - **Quarkus/CDI note**: this rule is skipped on Quarkus. Arc deliberately supports intercepted self-invocation, unlike
   standard proxy-based Spring AOP, so reporting the Spring limitation there would be a false positive. See the
   [Quarkus CDI reference](https://quarkus.io/version/3.33/guides/cdi-reference#intercepted-self-invocation).

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -516,6 +516,11 @@ Dismissed rules remove all of their findings from the score.
 - **Why it matters**: public fields let callers bypass Hibernate's instrumentation for lazy loading and dirty tracking.
 - **Recommendation**: keep persistent fields private (or package-private) and expose mutators when needed; this
   preserves proxy substitution and bytecode-enhancer guarantees.
+- **Kotlin note**: a `lateinit var` is exempt. Kotlin has no public fields — the property is read and written through
+  its generated `getX`/`setX` pair — but the compiler must leave the backing field public so the initialisation check
+  can run from outside the class, and the language offers no way to change that. A property the author did expose,
+  written `@JvmField var`, generates no accessors at all and is still reported: that is the same encapsulation break a
+  Java public field is.
 - **Quarkus/Panache**: skipped app-wide when a Panache extension (`quarkus-hibernate-orm-panache` or
   `quarkus-hibernate-reactive-panache`) is on the runtime classpath. Panache's active-record entities are meant to be
   used with public fields; once a Panache extension is present, its build-time bytecode transformation rewrites *every*

--- a/docs/features/advisors.md
+++ b/docs/features/advisors.md
@@ -40,12 +40,20 @@ and Quarkus because it lives in the shared engine.
   filtered out, so they never appear as findings.
 - Suspending functions are judged on their declared signature: the implicit `kotlin.coroutines.Continuation` parameter
   is hidden, the real result type is read from it, and `kotlin.Unit` counts as `void`.
+- Properties are judged as properties. A `lateinit var` on an entity is not a public field finding: the compiler must
+  leave its backing field public, but every access goes through the generated accessor pair. A `@JvmField var`, which
+  has no accessors, is still reported.
+- Nested types are read with their enclosing name. The variants of a `sealed class` exception hierarchy are not
+  renaming findings, because `ClaimException.AlreadyAssigned` already says what it is.
+- Suppressing the compiler's noise never suppresses your code. A call routed through a `$default` bridge is followed
+  through to the function it dispatches to, and a self-invocation written inside a lambda stays reported even though
+  the compiler hides the body in a synthetic method.
 - Where an idiomatic Java fix does not translate, the recommendation offers the Kotlin equivalent — marking a class
   `open` or applying the `kotlin-spring` plugin instead of "remove `final`", and constructor `val` injection instead of
   an `@Autowired lateinit var`.
 
-See [Architecture checks](../ARCHITECTURE-CHECKS.md) and [REST API checks](../REST-API-CHECKS.md) for the per-rule
-notes.
+See [Architecture checks](../ARCHITECTURE-CHECKS.md), [REST API checks](../REST-API-CHECKS.md), and
+[Hibernate checks](../HIBERNATE-CHECKS.md) for the per-rule notes.
 
 ## Architecture
 


### PR DESCRIPTION
Fixes #925.

> [!NOTE]
> **Stacked on #941.** This targets `copilot/add-kotlin-support` and reuses its `KotlinBytecode` helper and Kotlin
> test toolchain. Review it after #941; the diff shown here is only this change. Retarget to `main` once #941 merges.

The advisors read compiled bytecode, so Kotlin's generated shapes were reported as if a developer had written them.
#941 built the foundation but left these three rules reporting the shapes #925 lists — it filters the compiler-generated
*target* (`refreshOrders` → `refreshOrders$suspendImpl`), while #925's `ARCH-SPRING-004` case is the reverse direction,
and it does not touch `ARCH-CODE-010` or `HibernateRules`.

## ARCH-SPRING-004 — 28 HIGH findings on `$default` bridges

A call whose **origin** is a generated dispatch bridge is no longer reported: a `$default` bridge calling the function
it exists to reach is the compiler's own call, not a self-invocation anyone can refactor.

The origin filter is deliberately narrow — `ACC_BRIDGE`, or a Kotlin owner named `…$default` / `…$suspendImpl` — and
**not** the existing `isCompilerGenerated`, which returns true for any synthetic member. Lambda bodies are synthetic
(`expireLater$lambda$0` on Kotlin, `lambda$run$0` on javac), and a `@Transactional` self-call inside a lambda is a
genuine proxy bypass. There is a test on both languages guarding that.

A same-class call *to* a `$default` bridge now resolves **through** it to the declared function, so a real Kotlin
self-invocation stays reported rather than silently disappearing the moment a proxied function gains a default
parameter value — and the finding names `expire(long, String)`, a function that exists in the source, instead of
`expire$default(…)`. Resolution walks the bridge's body rather than stripping the suffix, because overloads share a
bridge name.

Judging both ends of the call is not expressible with ArchUnit's `ProxyRules`, which only exposes the target to its
predicate, so the rule is now an equivalent custom `ArchCondition` (the same shape `ARCH-SPRING-017` already uses).
Its semantics were replicated from the decompiled `ProxyRules$1`, so Java output is byte-identical.

## ARCH-CODE-010 — 42 LOW findings on sealed variants

A nested type passes when any class in its enclosing chain is named as an exception, so
`BoosterClaimException.AlreadyAssigned` is no longer a naming finding. This is language-neutral — Java nested exception
variants get the same treatment — so no Kotlin gate is involved. A nested type inside a class *not* named as an
exception is still flagged.

## HIB-ENTITY-005 — 106 LOW findings on `lateinit var`

A public field on a Kotlin class that carries a matching accessor pair is exempt. That is the correct discriminator,
not an approximation: `lateinit var` compiles to a public field plus `getX`/`setX`, while `@JvmField` generates no
accessors at all — so a genuine Kotlin encapsulation break stays flagged. Both spellings are handled
(`isoCode` → `getIsoCode`, `isActive` → `isActive`/`setActive`), each pinned by a test against real compiled bytecode.

The Hibernate advisor reads `java.lang.reflect` rather than ArchUnit's `JavaClass`, so `KotlinBytecode` could not be
reused; `KotlinReflection` is its counterpart, in the same name-based, exception-guarded style with no Kotlin runtime
dependency.

## Tests

Real Kotlin fixtures under `src/test/kotlin`, alongside #941's, with every assertion checked against `javap` output
first. Java-side regression tests were added for the two language-neutral behaviours. No existing assertion was
weakened; the sweeping `theWholeRulesetProducesNoFindingAboutACompilerGeneratedMember` from #941 now covers `$default`
as well.

## Out of scope

`Continuation`/`Flow` awareness in the Hibernate repository rules, and `data class` entities versus the entity and
proxyability rules — judgement calls that deserve a documented position rather than a silent exemption.

## Validation

- `./mvnw -B -ntp -pl bootui-engine -am test` — 2372 tests, 0 failures
- `./mvnw -B -ntp test` — full reactor green
- `./mvnw -B -ntp spotless:check` — clean
