### PR TITLE
Say how get_config matches, and what an empty result means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   token itself. `docs/AI-AGENTS.md`, the MCP Server feature page, and the `bootui` agent skill carry the same
   four shapes and the same header rule ([#928](https://github.com/jdubois/boot-ui/issues/928)).
 
+### Changed
+
+- **`get_config` now tells an agent how its search actually matches, and what an empty result means.** Making the
+  search relaxed-binding aware ([#939](https://github.com/jdubois/boot-ui/issues/939)) fixed the behavior but left the
+  agent-facing description asserting it was "relaxed-binding aware" without saying what that does, and an agent reads
+  the tool description, not the documentation. It now states the rule — case is ignored and `_` and `-` are treated as
+  `.`, so the dotted, kebab-case, and `UPPER_SNAKE_CASE` spellings of one property all find it — along with the two
+  things the rule does *not* cover: values are still matched literally, and each row still reports the exact name and
+  source its property source published. The same description now separates the paging counts, which was the other half
+  of the original confusion: `total` counts every property *before* filtering while `matched` counts the query hits, so
+  a large `total` beside `matched: 0` means the query found nothing rather than the property being unset. That envelope
+  is shared by every bounded read, so `docs/AI-AGENTS.md` gains a **Reading a bounded result** table defining `total`,
+  `matched`, `offset`, `limit`, `returned`, and `hasMore` once, `docs/CLI.md` gives `--json` consumers the same reading,
+  and the Configuration feature page notes that a page reports the full and matched counts separately. `bootui config
+  --help` shows the regenerated one-line summary, which no longer says "case-insensitive" now that the full rule is
+  stated where an agent reads it ([#940](https://github.com/jdubois/boot-ui/issues/940)).
+
 ### Fixed
 
 - **Configuration search now finds a property whatever spelling it was supplied in.** `get_config` with

--- a/bootui-cli/src/main/resources/bootui-tools.json
+++ b/bootui-cli/src/main/resources/bootui-tools.json
@@ -101,7 +101,7 @@
         "SPRING_MVC",
         "SPRING_WEBFLUX"
       ],
-      "summary": "Search effective configuration by case-insensitive name or displayed value and return a bounded result."
+      "summary": "Search effective configuration by name or displayed value and return a bounded result."
     },
     {
       "name": "get_crac_report",

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptions.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptions.java
@@ -76,10 +76,16 @@ public final class McpToolDescriptions {
                             + "BootUI status. Use this before interpreting other results."),
             Map.entry(
                     "get_config",
-                    "Search effective configuration by case-insensitive name or displayed value and return a bounded "
-                            + "result. Name search is relaxed-binding aware, so `bootui.mcp.enabled` also finds a value "
-                            + "supplied as the environment variable `BOOTUI_MCP_ENABLED`, which is enumerated under that "
-                            + "literal name. Secret-like configuration values are masked; prefer a narrow query."),
+                    "Search effective configuration by name or displayed value and return a bounded result. Name "
+                            + "search is relaxed-binding aware: it ignores case and treats `_` and `-` as `.`, so the "
+                            + "dotted, kebab-case, and `UPPER_SNAKE_CASE` spellings of one property all find it — "
+                            + "`bootui.mcp.enabled` also finds a value supplied as the environment variable "
+                            + "`BOOTUI_MCP_ENABLED`, which is enumerated under that literal name. Values are matched "
+                            + "literally, and each row reports the exact name and source its property source published. "
+                            + "In `page`, `total` counts every property before filtering while `matched` counts the "
+                            + "query hits, so `matched: 0` means this query found nothing, not that the property is "
+                            + "absent — retry with a shorter query before concluding it is unset. Secret-like "
+                            + "configuration values are masked; prefer a narrow query."),
             Map.entry(
                     "get_mappings",
                     "Search request routes and handlers and return a bounded result. Use a path, HTTP concept, or handler "

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptionsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/mcp/McpToolDescriptionsTests.java
@@ -2,6 +2,7 @@ package io.github.jdubois.bootui.engine.mcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
@@ -30,5 +31,24 @@ class McpToolDescriptionsTests {
                         .as(name)
                         .hasSizeGreaterThan(60)
                         .endsWith("."));
+    }
+
+    /**
+     * The Configuration search guidance is the one description agents were observed to misread: it must state the
+     * relaxed-binding rule rather than merely name it, and it must keep {@code total} (every property, before
+     * filtering) apart from {@code matched} (the query hits), so a large {@code total} beside {@code matched: 0}
+     * is not read as a missing property.
+     */
+    @Test
+    void configSearchDescriptionStatesTheMatchingRuleAndThePagingCounts() {
+        assertThat(List.of(McpToolDescriptions.spring("get_config"), McpToolDescriptions.quarkus("get_config")))
+                .allSatisfy(description -> assertThat(description)
+                        .contains("ignores case")
+                        .contains("`_` and `-` as `.`")
+                        .contains("BOOTUI_MCP_ENABLED")
+                        .contains("Values are matched literally")
+                        .contains("`total` counts every property before filtering")
+                        .contains("`matched` counts the query hits")
+                        .contains("not that the property is absent"));
     }
 }

--- a/docs/AI-AGENTS.md
+++ b/docs/AI-AGENTS.md
@@ -201,6 +201,30 @@ the classpath) are simply not advertised.
   `analyze_heap_dump`, and `trigger_devtools_livereload`. They never capture or download a heap dump, execute an HTTP
   probe, mutate a database, clear a cache, write GitHub state, restart a dev service, or run an agent command.
 
+### Reading a bounded result
+
+Every search- or list-style tool returns its rows next to the same `page` envelope, so one reading applies to all of
+them:
+
+| Field | Meaning |
+| --- | --- |
+| `total` | Every item the panel can see, **before** the query and filters are applied |
+| `matched` | How many of those the query and filters kept |
+| `offset` | Where this page starts within the matched items |
+| `limit` | The page size actually used, capped by `bootui.mcp.max-results` (`bootui.cli.max-results` from the CLI) |
+| `returned` | How many rows this response carries |
+| `hasMore` | Whether matched items remain past this page — raise `offset` to walk them |
+
+The distinction that matters is `total` versus `matched`. A large `total` beside `matched: 0` does **not** mean the
+data is missing; it means the query matched none of it. Retry with a shorter query before concluding a property,
+bean, or mapping does not exist.
+
+`get_config` additionally matches names through relaxed binding — case is ignored and `_` and `-` are treated as `.`
+— so `bootui.mcp.enabled` finds a value supplied as the environment variable `BOOTUI_MCP_ENABLED`, which every
+property source enumerates under that literal name. Values are matched literally, and each row still reports the exact
+name and source its property source published. See the [Configuration panel](features/configuration.md#configuration)
+for the panel-side behavior.
+
 ### Safety model
 
 The MCP server inherits BootUI's full safety posture, so handing it to an agent stays safe by construction:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -144,6 +144,12 @@ Advisor scans differ in how they name that array — `pentest scan` reports `fin
 advisors report `results` — so check the shape with `bootui <command> --json | jq keys` before writing a
 filter. What every scan does share is `severityCounts`, which is what the [CI](#in-ci) gate below uses.
 
+Search commands such as `bootui config --query` share a `page` envelope instead, where `total` counts everything
+the panel can see *before* the query is applied and `matched` counts what the query kept. A large `total` beside
+`matched: 0` therefore means the query found nothing, not that the data is missing — retry with a shorter query.
+See [Reading a bounded result](AI-AGENTS.md#reading-a-bounded-result) for the full envelope, including the relaxed
+name matching that lets `bootui config --query bootui.mcp.enabled` find a value supplied as `BOOTUI_MCP_ENABLED`.
+
 Auto-detection is a convenience, not a contract: on a JDK 22 or later runtime a redirected stream can still
 report a console. Pass `--json` explicitly in scripts.
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -2515,7 +2515,10 @@ Design rules:
   relevant read, correlate exception and trace identifiers, verify advisor findings before changing code, and account for
   active scan costs (`memory_scan` may trigger a full GC; `pentest_scan` sends bounded loopback probes). Tool descriptions
   state intended use, ordering, bounded/snapshot semantics, and sensitive-data caveats. Output schemas identify the
-  corresponding structured BootUI result; the existing panel DTO remains the authoritative shape.
+  corresponding structured BootUI result; the existing panel DTO remains the authoritative shape. Paged reads share one
+  envelope whose `total` counts every item before the query and filters are applied and whose `matched` counts what they
+  kept, so a non-zero `total` beside `matched: 0` is an empty query result rather than absent data; tool guidance states
+  that distinction where a narrow query would otherwise be read as a missing value.
 - **Prompt surface.** `prompts/list` advertises two argument-free workflows: `diagnose_runtime_issue` for evidence-led
   runtime diagnosis and `review_application` for a focused advisor review. `prompts/get` returns the selected workflow as
   a user message. Both prompts require agents to distinguish evidence from hypotheses, avoid blind fixes, minimize active

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -11,8 +11,9 @@ tables load in bounded server-side pages for search, source, and override-only f
 through relaxed binding — `_` and `-` are treated as `.` and case is ignored — so `bootui.mcp.enabled` also finds a
 value supplied as the environment variable `BOOTUI_MCP_ENABLED`, which Spring and Quarkus both enumerate under that
 literal name. Values, descriptions, and defaults are matched literally, and every row still reports the name and source
-its property source gave. The override property-name picker limits its datalist suggestions while narrowing against the
-full metadata catalog as you type.
+its property source gave. Each page reports the full property count and the matched count separately, so a search that
+narrows to nothing is visibly an empty result rather than an empty inventory. The override property-name picker limits
+its datalist suggestions while narrowing against the full metadata catalog as you type.
 
 ## Profile Diff
 


### PR DESCRIPTION
Closes #940.

## Scope

#940 was written as a companion to #939 and carried its own scoping clause: *"If #939 lands and makes matching relaxed-binding aware, this issue should be scoped down to documenting the normalization rule rather than the raw-name limitation."*

#939 landed as #942, so the raw-name-limitation half is obsolete. This PR closes the two documentation gaps that remain.

## What was still wrong

**The rule was not on the agent-facing surface.** #942 taught the description to say name search is "relaxed-binding aware", but an agent reads the tool description, not `docs/`. Naming the behaviour without stating the rule leaves an agent unable to predict which spellings are equivalent, unable to tell that value matching is still literal, and unable to tell that the returned `name` is the literal source key rather than the canonical one.

**`total` vs `matched` was documented nowhere.** `PagedList.from` sets `total = items.size()` — the whole inventory, *before* filtering — and `matched` to the post-filter count. That is the second half of the confusion in discussion #929: a large `total` beside `matched: 0` reads as "BootUI sees configuration but not this property", when it only means the query matched nothing. Grep found zero hits for `total`, `matched`, `returned`, or `hasMore` anywhere in `docs/`, even though every bounded read and the CLI's `--json` output carry the envelope verbatim.

## Changes

- **`McpToolDescriptions`** — `get_config` now states the rule (case ignored, `_` and `-` treated as `.`, so dotted, kebab-case, and `UPPER_SNAKE_CASE` spellings all find one property), the two things it does *not* cover (values matched literally; each row reports the exact published name and source), and the `total`/`matched` distinction with the actionable next step: retry with a shorter query.
- **`McpToolDescriptionsTests`** — the existing test only checks length and a trailing period, so nothing stopped the clarification from being edited away. A new assertion pins the rule, the environment-variable spelling, and the count distinction across all three stacks.
- **`docs/AI-AGENTS.md`** — a **Reading a bounded result** table defining `total`, `matched`, `offset`, `limit`, `returned`, and `hasMore` once, since the envelope is shared by every bounded read rather than specific to `get_config`.
- **`docs/CLI.md`** — the same reading for `--json` consumers, next to the existing note that `--json` prints exactly the bytes the MCP tool returned.
- **`docs/SPECIFICATION.md`** — the envelope's before/after-filter meaning folded into the §6.7 *Agent guidance* bullet, so it is stated contract.
- **`docs/features/configuration.md`** — one sentence noting the panel reports the full and matched counts separately.
- **`bootui-tools.json`** — regenerated, because the bundled CLI summary is the description's first sentence.

No behaviour change: `PageMetadata` and the JSON contract are untouched.

## Validation

- `McpToolDescriptionsTests` — 4/4.
- `bootui-engine` — 2358/2358.
- `bootui-cli` — 68/68, including `ToolManifestGeneratorTests`, which enforces that the checked-in manifest is not stale.
- `bootui-conformance` `BackendPanelCatalogConsistencyTest` — 8/8. This one mattered: it parses `docs/AI-AGENTS.md` between `### Tools the agent can call` and `### Safety model` to assert every MCP tool is documented, and the new subsection lands inside that range. `section()` spans to the end marker, so the tool list stays intact.
- `spotless:apply` and `spotless:check` over the full reactor — clean. No frontend or e2e changes, so no npm formatting run.