### PR TITLE
Stop RAPI-MAP-004 judging mappings declared on an interface

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiHandlerModelBuilder.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiHandlerModelBuilder.java
@@ -289,6 +289,7 @@ final class RestApiHandlerModelBuilder {
                 classValidated,
                 hasTag,
                 hidden,
+                safeIsInterface(type),
                 handlerCount));
     }
 
@@ -342,6 +343,7 @@ final class RestApiHandlerModelBuilder {
                 classValidated,
                 hasTag,
                 hidden,
+                safeIsInterface(type),
                 handlerCount));
     }
 
@@ -1678,6 +1680,14 @@ final class RestApiHandlerModelBuilder {
     private static boolean safeIsRecord(JavaClass type) {
         try {
             return type.isRecord();
+        } catch (RuntimeException | LinkageError ex) {
+            return false;
+        }
+    }
+
+    private static boolean safeIsInterface(JavaClass type) {
+        try {
+            return type.isInterface();
         } catch (RuntimeException | LinkageError ex) {
             return false;
         }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiModel.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiModel.java
@@ -121,7 +121,15 @@ final class RestApiModel {
         static final String REST_MATRIX = "org.jboss.resteasy.reactive.RestMatrix";
     }
 
-    /** A controller class (annotated {@code @Controller} or {@code @RestController}). */
+    /**
+     * A controller class (annotated {@code @Controller} or {@code @RestController}) or a JAX-RS resource.
+     *
+     * @param declaredOnInterface whether the mappings were declared on an interface rather than on a
+     *     class. Spec-first code generators emit exactly that shape — openapi-generator's
+     *     {@code kotlin-spring} {@code interfaceOnly} output annotates the generated {@code *Api}
+     *     interface with {@code @RestController} — and an interface's mappings are inherited by every
+     *     implementation, so rules that judge how an author laid mappings out must not judge them here.
+     */
     record ControllerModel(
             String className,
             String simpleName,
@@ -130,6 +138,7 @@ final class RestApiModel {
             boolean classValidated,
             boolean hasTag,
             boolean hidden,
+            boolean declaredOnInterface,
             int handlerCount) {
 
         ControllerModel {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRules.java
@@ -544,7 +544,10 @@ final class PreferClassLevelBasePathRule extends AbstractRestApiRule {
                 RestApiCategory.ROUTING,
                 "LOW",
                 "Controllers that repeat the same leading path segment on every method but declare no type-level"
-                        + " @RequestMapping duplicate routing information.",
+                        + " @RequestMapping duplicate routing information. Mappings declared on a controller"
+                        + " interface are not evaluated: they are inherited by every implementation, so the"
+                        + " implementing author cannot restructure them, and spec-first code generators (for example"
+                        + " openapi-generator's kotlin-spring interfaceOnly output) emit exactly that layout.",
                 "Hoist the shared prefix into a class-level @RequestMapping and keep method paths relative.",
                 RestApiRuleHelp.SPRING_WEB_DOCS));
     }
@@ -559,7 +562,9 @@ final class PreferClassLevelBasePathRule extends AbstractRestApiRule {
         }
         List<String> violations = new ArrayList<>();
         for (ControllerModel controller : context.controllers()) {
-            if (!controller.typeLevelPaths().isEmpty() || controller.handlerCount() < 2) {
+            if (controller.declaredOnInterface()
+                    || !controller.typeLevelPaths().isEmpty()
+                    || controller.handlerCount() < 2) {
                 continue;
             }
             List<HandlerMethodModel> controllerHandlers = byController.getOrDefault(controller.className(), List.of());

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiHandlerModelBuilderTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiHandlerModelBuilderTests.java
@@ -18,6 +18,7 @@ class RestApiHandlerModelBuilderTests {
     private static final String PHASE3_BAD = "io.github.jdubois.bootui.engine.restapi.phase3.bad";
     private static final String PHASE3_FIXES = "io.github.jdubois.bootui.engine.restapi.phase3.fixes";
     private static final String ACCURACY = "io.github.jdubois.bootui.engine.restapi.accuracy";
+    private static final String SPEC_FIRST = "io.github.jdubois.bootui.engine.restapi.specfirst";
 
     private RestApiHandlerModelBuilder model() {
         JavaClasses classes = new ClassFileImporter().importPackages(FIXTURES);
@@ -260,5 +261,26 @@ class RestApiHandlerModelBuilderTests {
                 .findFirst()
                 .orElseThrow();
         assertThat(reactiveAdvice.hasResponseParam()).isTrue();
+    }
+
+    @Test
+    void recordsWhetherAControllerTypeIsAnInterface() {
+        JavaClasses classes = new ClassFileImporter().importPackages(SPEC_FIRST);
+        RestApiHandlerModelBuilder model = RestApiHandlerModelBuilder.build(classes);
+
+        assertThat(model.controllers())
+                .filteredOn(controller -> controller.simpleName().equals("GeneratedPaymentsGuestApi"))
+                .singleElement()
+                .satisfies(controller -> {
+                    assertThat(controller.declaredOnInterface()).isTrue();
+                    assertThat(controller.typeLevelPaths()).isEmpty();
+                    assertThat(controller.handlerCount()).isEqualTo(2);
+                });
+
+        assertThat(model.controllers())
+                .filteredOn(controller -> controller.simpleName().equals("HandWrittenRefundsController"))
+                .singleElement()
+                .satisfies(controller ->
+                        assertThat(controller.declaredOnInterface()).isFalse());
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiRulesTests.java
@@ -27,6 +27,7 @@ class RestApiRulesTests {
     private static final String RESPONSE_CONTRACTS =
             "io.github.jdubois.bootui.engine.restapi.newrules.responsecontracts";
     private static final String ACCURACY = "io.github.jdubois.bootui.engine.restapi.accuracy";
+    private static final String SPEC_FIRST = "io.github.jdubois.bootui.engine.restapi.specfirst";
 
     private RestApiContext context(boolean openApiAnnotationsPresent, String... packages) {
         return context(openApiAnnotationsPresent, false, packages);
@@ -479,5 +480,18 @@ class RestApiRulesTests {
         assertThat(status(new PathSegmentsAreKebabCaseRule(), context)).isEqualTo("PASS");
         assertThat(status(new CreatedResponsesExposeLocationRule(), context)).isEqualTo("PASS");
         assertThat(status(new ExceptionHandlersSetErrorStatusRule(), context)).isEqualTo("PASS");
+    }
+
+    @Test
+    void classLevelBasePathRuleIgnoresMappingsDeclaredOnAControllerInterface() {
+        // Issue #927: openapi-generator's kotlin-spring interfaceOnly output annotates the generated
+        // *Api interface with @RestController and repeats the full path on every method, a layout the
+        // implementing author cannot restructure. Hand-written class controllers stay reported.
+        RestApiRuleResultDto result = new PreferClassLevelBasePathRule().evaluate(context(false, SPEC_FIRST));
+
+        assertThat(result.status()).isEqualTo("VIOLATION");
+        assertThat(result.violationCount()).isEqualTo(1);
+        assertThat(result.sampleViolations()).anyMatch(violation -> violation.contains("HandWrittenRefundsController"));
+        assertThat(result.sampleViolations()).noneMatch(violation -> violation.contains("GeneratedPaymentsGuestApi"));
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/specfirst/GeneratedPaymentsGuestApi.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/specfirst/GeneratedPaymentsGuestApi.java
@@ -1,0 +1,32 @@
+package io.github.jdubois.bootui.engine.restapi.specfirst;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The shape openapi-generator emits for a spec-first API with {@code interfaceOnly=true}: the
+ * generated {@code *Api} interface carries {@code @RestController}, every method carries the full
+ * path, and there is no type-level {@code @RequestMapping} (that one is emitted only when
+ * {@code useRequestMappingOnInterface} is set).
+ *
+ * <p>The layout is the generator template's decision, not the application author's — an OpenAPI
+ * document cannot express whether a base path is hoisted onto the type — and the mappings are
+ * inherited by every implementation, so RAPI-MAP-004 must not report it.</p>
+ */
+@RestController
+public interface GeneratedPaymentsGuestApi {
+
+    @RequestMapping(
+            method = {RequestMethod.GET},
+            value = {"/api/payments/guest"},
+            produces = {"application/json"})
+    ResponseEntity<PaymentDto> getGuestPayment();
+
+    @RequestMapping(
+            method = {RequestMethod.POST},
+            value = {"/api/payments/guest/authorizations"},
+            produces = {"application/json"})
+    ResponseEntity<PaymentDto> authorizeGuestPayment();
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/specfirst/HandWrittenRefundsController.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/specfirst/HandWrittenRefundsController.java
@@ -1,0 +1,23 @@
+package io.github.jdubois.bootui.engine.restapi.specfirst;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * A hand-written class controller that repeats the same leading segment on every method. The author
+ * owns this layout and can hoist it, so RAPI-MAP-004 must keep reporting it.
+ */
+@RestController
+public class HandWrittenRefundsController {
+
+    @GetMapping("/api/refunds")
+    public PaymentDto listRefunds() {
+        return new PaymentDto("r-1", "PENDING");
+    }
+
+    @GetMapping("/api/refunds/{id}")
+    public PaymentDto getRefund(@PathVariable String id) {
+        return new PaymentDto(id, "PENDING");
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/specfirst/PaymentDto.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/specfirst/PaymentDto.java
@@ -1,0 +1,4 @@
+package io.github.jdubois.bootui.engine.restapi.specfirst;
+
+/** Minimal response payload for the spec-first fixtures. */
+public record PaymentDto(String id, String status) {}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/specfirst/PaymentsGuestController.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/specfirst/PaymentsGuestController.java
@@ -1,0 +1,22 @@
+package io.github.jdubois.bootui.engine.restapi.specfirst;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The hand-written controller that implements the generated interface. Its overriding methods carry
+ * no mapping annotations of their own, so it contributes no handlers to the model.
+ */
+@RestController
+public class PaymentsGuestController implements GeneratedPaymentsGuestApi {
+
+    @Override
+    public ResponseEntity<PaymentDto> getGuestPayment() {
+        return ResponseEntity.ok(new PaymentDto("p-1", "SETTLED"));
+    }
+
+    @Override
+    public ResponseEntity<PaymentDto> authorizeGuestPayment() {
+        return ResponseEntity.ok(new PaymentDto("p-1", "AUTHORIZED"));
+    }
+}

--- a/docs/REST-API-CHECKS.md
+++ b/docs/REST-API-CHECKS.md
@@ -116,6 +116,7 @@ Dismissed rules remove all of their findings from the score.
 
 - **Severity**: LOW
 - **Detects**: Controllers that repeat the same leading path segment on every method but declare no type-level @RequestMapping duplicate routing information.
+- **Not evaluated**: Mappings declared on a controller *interface*. An interface's mappings are inherited by every implementation, so the author of the implementing `@RestController` cannot restructure them, and whether a base path is hoisted onto the type is a decision no OpenAPI document can express — spec-first generators such as openapi-generator's `kotlin-spring` with `interfaceOnly=true` annotate the generated `*Api` interface with `@RestController` and repeat the full path on every method. The trade-off is deliberate: a hand-written controller interface that repeats a leading segment is not reported either.
 - **Recommendation**: Hoist the shared prefix into a class-level @RequestMapping and keep method paths relative.
 - **Learn more**: <https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller.html>
 


### PR DESCRIPTION
Fixes #927

## Why it fired

A spec-first application generated with openapi-generator `kotlin-spring` and `interfaceOnly=true` was reported once per generated `*Api` interface — 64 findings — for a layout its author cannot change. Verified against the upstream template (`kotlin-spring/apiInterface.mustache`):

- the generated interface carries `@RestController` (emitted unless `useFeignClient`), so `RestApiHandlerModelBuilder` models it as a controller and its methods as handlers;
- the class-level `@RequestMapping` is emitted **only** when `useRequestMappingOnInterface` is set, so `typeLevelPaths` is empty;
- every method carries `@RequestMapping(method = [...], value = ["/api/..."])` with the full path.

That is exactly RAPI-MAP-004's violation shape. The hand-written implementations contribute no handlers of their own, so the finding lands on the interface, matching the report.

## The change

Whether a shared prefix sits on the type or is repeated on every method is a code-shape decision an OpenAPI document cannot express, so it belongs to the generator template rather than the application author. A mapping declared on an interface is also inherited by every implementation, so the author of the implementing `@RestController` cannot restructure it either.

- `ControllerModel` records whether the controller type is an interface, read defensively (`safeIsInterface`) at both the Spring and JAX-RS construction sites, so generated JAX-RS resource interfaces on Quarkus get the same treatment.
- `PreferClassLevelBasePathRule` skips those controllers. Hand-written class controllers are still reported, unchanged.

Keying on "interface" rather than "generated" is what a bytecode scan can answer honestly: `@Generated` is `SOURCE`-retention (and `kotlin-spring` never emits it), and package-name heuristics would be project-specific, which the advisor deliberately avoids.

## Trade-off, stated in the rule description and the docs

A *hand-written* controller interface that repeats a leading segment is no longer reported. That is a deliberate false negative on a LOW-severity stylistic rule, chosen over dozens of unactionable findings that drown the panel's signal. Both `docs/REST-API-CHECKS.md` and the rule's own description now say so.

Deliberately out of scope: a configuration property for per-package rule opt-out (a much larger cross-adapter config surface), and modelling method-level mappings inherited by an implementing class.

## Scope

No DTO/JSON, panel, MCP, conformance or adapter changes — `ControllerModel` is a package-private engine model. Rule id, name, category and severity are unchanged, so the registry count and the UI stay as they are. Controllers-analysed and handlers-analysed counts are unaffected; only this one rule's verdict moves.

## Validation

- New `restapi.specfirst` fixtures reproduce the generated shape; the regression test was confirmed to **fail** without the fix (violation count 2, naming the interface) and pass with it (count 1, naming only the hand-written class).
- `./mvnw -B -ntp -pl bootui-engine -am test` — 2384 tests, all green.
- `./mvnw -B -ntp spotless:apply && ./mvnw -B -ntp spotless:check` — clean.