### PR TITLE
Suggest an override name typed as an environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The Configuration panel's override name picker now suggests a property typed the way a container spells it.** The
+  free-text search above it was made relaxed-binding aware in
+  [#939](https://github.com/jdubois/boot-ui/issues/939), so `bootui.mcp.enabled` finds a value supplied as
+  `BOOTUI_MCP_ENABLED` — but the name box for a new override still matched its datalist literally against the metadata
+  catalog, which only ever publishes canonical dotted names. Typing `BOOTUI_MCP`, the spelling you read off the
+  environment and the spelling the search on the same panel had just started accepting, offered nothing. The picker now
+  canonicalizes both sides of the match exactly as the engine does — case ignored, `_` and `-` treated as `.` — so the
+  environment spelling narrows to the dotted property. That is more than a convenience: a name saved as
+  `BOOTUI_MCP_ENABLED` is written verbatim to `.bootui/application-bootui.properties`, where relaxed binding does not
+  rescue it, because a key from a file — unlike one from the environment — is adapted by dropping its separators and so
+  never reaches `bootui.mcp.enabled`. Suggesting the canonical name is what steers the override to a spelling that
+  binds, and accepting a suggestion writes that name. The mapping is length preserving, so the existing
+  prefix-before-contains ranking and suggestion cap are untouched and nothing that matched before stops matching. The
+  hint under the input still requires an exact name, since describing a property the file will not bind would assert
+  the opposite of what happens ([#945](https://github.com/jdubois/boot-ui/issues/945)).
+
 - **Three advisor rules no longer report a Kotlin application for shapes its compiler produced.** Each read bytecode as
   if `javac` had written it, and each turned an ordinary Kotlin idiom into a finding nobody could act on.
   `ARCH-SPRING-004` reported a self-invocation for every call that omits a default argument: Kotlin routes such a call

--- a/bootui-ui/src/main/frontend/src/utils/relaxedNames.js
+++ b/bootui-ui/src/main/frontend/src/utils/relaxedNames.js
@@ -1,0 +1,13 @@
+/**
+ * Relaxed-binding-aware matching for configuration property names, mirroring the engine's
+ * `io.github.jdubois.bootui.engine.support.RelaxedNames` so the browser narrows a name the same way the server does.
+ *
+ * Both sides are mapped onto one canonical form — lower case, with `_` and `-` treated as `.` — so the dotted,
+ * kebab-case and UPPER_SNAKE_CASE spellings of one property all compare equal. The mapping is per character and
+ * length preserving, so canonical matching is a superset of literal matching: nothing that matched before stops
+ * matching, and a prefix stays a prefix.
+ */
+export function canonicalizeName(value) {
+  if (typeof value !== 'string') return ''
+  return value.toLowerCase().replace(/[_-]/g, '.')
+}

--- a/bootui-ui/src/main/frontend/src/utils/relaxedNames.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/relaxedNames.test.js
@@ -1,0 +1,23 @@
+import {describe, expect, it} from 'vitest'
+import {canonicalizeName} from './relaxedNames.js'
+
+describe('canonicalizeName', () => {
+  it('maps the dotted, kebab-case and UPPER_SNAKE_CASE spellings of one property onto the same form', () => {
+    expect(canonicalizeName('BOOTUI_MCP_ENABLED')).toBe('bootui.mcp.enabled')
+    expect(canonicalizeName('bootui.mcp.enabled')).toBe('bootui.mcp.enabled')
+    expect(canonicalizeName('spring.datasource.hikari.maximum-pool-size')).toBe(
+      canonicalizeName('SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE')
+    )
+  })
+
+  it('preserves length, so a literal prefix stays a prefix once canonicalized', () => {
+    const name = 'bootui.mcp.max-results'
+    expect(canonicalizeName(name)).toHaveLength(name.length)
+    expect(canonicalizeName(name).startsWith(canonicalizeName('BOOTUI_MCP'))).toBe(true)
+  })
+
+  it('returns an empty string for a missing name rather than throwing', () => {
+    expect(canonicalizeName(null)).toBe('')
+    expect(canonicalizeName(undefined)).toBe('')
+  })
+})

--- a/bootui-ui/src/main/frontend/src/views/Config.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Config.test.js
@@ -174,4 +174,46 @@ describe('Config', () => {
     )
     expect(fetchMock.mock.calls.some(([, init]) => init?.method === 'DELETE')).toBe(false)
   })
+
+  it('suggests the canonical property name when the override name is typed as an environment variable', async () => {
+    const config = {
+      ...EMPTY_CONFIG,
+      propertySuggestions: [
+        {name: 'bootui.mcp.enabled', type: 'java.lang.Boolean', description: 'Whether the MCP server is enabled.'},
+        {name: 'bootui.mcp.max-results', type: 'java.lang.Integer', description: null},
+        {name: 'spring.application.name', type: 'java.lang.String', description: null}
+      ]
+    }
+    const fetchMock = vi.fn(() => Promise.resolve(new Response(JSON.stringify(config), {status: 200})))
+    const wrapper = await mountConfig(undefined, fetchMock)
+    await wrapper.get('button.btn-success').trigger('click')
+    const nameInput = wrapper.get('input[list="bootPropertySuggestions"]')
+
+    await nameInput.setValue('BOOTUI_MCP')
+
+    expect(wrapper.findAll('#bootPropertySuggestions option').map((option) => option.attributes('value'))).toEqual([
+      'bootui.mcp.enabled',
+      'bootui.mcp.max-results'
+    ])
+  })
+
+  it('keeps narrowing override suggestions by the literal name that was typed', async () => {
+    const config = {
+      ...EMPTY_CONFIG,
+      propertySuggestions: [
+        {name: 'bootui.mcp.max-results', type: 'java.lang.Integer', description: null},
+        {name: 'spring.application.name', type: 'java.lang.String', description: null}
+      ]
+    }
+    const fetchMock = vi.fn(() => Promise.resolve(new Response(JSON.stringify(config), {status: 200})))
+    const wrapper = await mountConfig(undefined, fetchMock)
+    await wrapper.get('button.btn-success').trigger('click')
+    const nameInput = wrapper.get('input[list="bootPropertySuggestions"]')
+
+    await nameInput.setValue('bootui.mcp.max-results')
+
+    expect(wrapper.findAll('#bootPropertySuggestions option').map((option) => option.attributes('value'))).toEqual([
+      'bootui.mcp.max-results'
+    ])
+  })
 })

--- a/bootui-ui/src/main/frontend/src/views/Config.vue
+++ b/bootui-ui/src/main/frontend/src/views/Config.vue
@@ -3,6 +3,7 @@ import {apiFetch} from '../api.js'
 import {computed, inject, nextTick, onMounted, ref, watch} from 'vue'
 import {formatLoadError} from '../utils/loadError.js'
 import {panelProps, usePanelState} from '../utils/panelState.js'
+import {canonicalizeName} from '../utils/relaxedNames.js'
 import {useConfirm} from '../utils/useConfirm.js'
 import {useServerPagedList} from '../utils/useServerPagedList.js'
 import {useFlashMessage} from '../utils/useFlashMessage.js'
@@ -68,11 +69,11 @@ const {
 
 const propertySuggestions = computed(() => data.value?.propertySuggestions || [])
 
-const propertySuggestionQuery = computed(() => (newRowName.value || '').trim().toLowerCase())
+const propertySuggestionQuery = computed(() => canonicalizeName((newRowName.value || '').trim()))
 
 function propertySuggestionMatches(suggestion, query) {
   if (!query) return true
-  return (suggestion.name || '').toLowerCase().includes(query)
+  return canonicalizeName(suggestion.name).includes(query)
 }
 
 const matchingPropertySuggestionCount = computed(
@@ -87,7 +88,7 @@ const visiblePropertySuggestions = computed(() => {
   if (!query) return propertySuggestions.value.slice(0, MAX_PROPERTY_SUGGESTIONS)
   const prefixMatches = []
   for (const suggestion of propertySuggestions.value) {
-    const name = (suggestion.name || '').toLowerCase()
+    const name = canonicalizeName(suggestion.name)
     if (name.startsWith(query)) {
       prefixMatches.push(suggestion)
     }
@@ -95,7 +96,7 @@ const visiblePropertySuggestions = computed(() => {
   }
   const containsMatches = []
   for (const suggestion of propertySuggestions.value) {
-    const name = (suggestion.name || '').toLowerCase()
+    const name = canonicalizeName(suggestion.name)
     if (!name.startsWith(query) && name.includes(query)) {
       containsMatches.push(suggestion)
     }

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -11,8 +11,10 @@ tables load in bounded server-side pages for search, source, and override-only f
 through relaxed binding — `_` and `-` are treated as `.` and case is ignored — so `bootui.mcp.enabled` also finds a
 value supplied as the environment variable `BOOTUI_MCP_ENABLED`, which Spring and Quarkus both enumerate under that
 literal name. Values, descriptions, and defaults are matched literally, and every row still reports the name and source
-its property source gave. The override property-name picker limits its datalist suggestions while narrowing against the
-full metadata catalog as you type.
+its property source gave. The override property-name picker narrows the same way — typing `BOOTUI_MCP` suggests
+`bootui.mcp.enabled` — and each suggestion carries the canonical dotted name, so accepting one writes a name the
+framework binds rather than the environment spelling it was typed as. The datalist is limited to the first matches
+against the full metadata catalog as you type.
 
 ## Profile Diff
 


### PR DESCRIPTION
Closes #945. Follow-up to #939, found while analysing discussion #929.

## Problem

#939 made the Configuration panel's free-text search relaxed-binding aware, so `bootui.mcp.enabled` finds a value supplied as `BOOTUI_MCP_ENABLED`. The **override property-name picker** on the same panel was left behind: it matched its datalist with a plain `toLowerCase().includes()` against the metadata catalog, which only ever publishes canonical dotted names. Typing `BOOTUI_MCP` — the spelling you read off a container environment, and the spelling the search directly above had just started accepting — offered no suggestion at all. Two name inputs on one panel, different answers to the same text.

## Why it is more than a convenience

A name saved as `BOOTUI_MCP_ENABLED` is written verbatim to `.bootui/application-bootui.properties`, and relaxed binding does **not** rescue it there. I verified this against Spring Boot 4 rather than assuming it:

| Property source holding `BOOTUI_MCP_ENABLED` | `Binder.bind("bootui.mcp.enabled").isBound()` |
| --- | --- |
| `SystemEnvironmentPropertySource` | `true` |
| file-style `MapPropertySource` | `false` |

An environment source is mapped by `SystemEnvironmentPropertyMapper`; every other source goes through `DefaultPropertyMapper`, which adapts the key by dropping its separators, so it lands on `bootuimcpenabled` and never reaches the property. The override would have been written and silently done nothing. Offering the canonical suggestion is what steers the name to a spelling that binds, since accepting a suggestion writes the suggestion's own dotted name.

## Change

- New `src/utils/relaxedNames.js` — `canonicalizeName()`, mirroring the engine's `io.github.jdubois.bootui.engine.support.RelaxedNames` (lower case, `_` and `-` treated as `.`).
- `Config.vue` canonicalizes both sides of the suggestion match. The mapping is per character and length preserving, so the existing prefix-before-contains ranking and the `MAX_PROPERTY_SUGGESTIONS` cap are untouched, and nothing that matched before stops matching.
- The metadata hint below the input (`selectedNewSuggestion`) deliberately still requires an exact name: showing type and description for a property the file will not bind would assert the opposite of what happens.
- `docs/features/configuration.md` says the picker narrows the same way the search does, and why the canonical name is the one that gets written.

UI only — no API, DTO, or engine change, so conformance is unaffected.

## Validation

- `npx vitest run` — 1055 tests, 102 files, all passing, including three new `relaxedNames` cases and two new `Config` cases (env-style query surfaces the dotted suggestions; a literal dotted query still narrows to exactly one).
- `npm run format` + `npm run format:check` clean.

## Note for merge order

This touches the same paragraph of `docs/features/configuration.md` as #944, so whichever lands second will need a one-hunk textual resolution. No behavioral overlap.