### PR TITLE
Exempt post-commit transactional event listeners from ARCH-SPRING-019

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`ARCH-SPRING-019` no longer reports every Spring Modulith event listener.** `@ApplicationModuleListener` composes
+  `@Async`, `@Transactional(propagation = REQUIRES_NEW)` and `@TransactionalEventListener`, so a Modulith application
+  collected one MEDIUM finding per cross-module listener — telling it that the caller's transaction does not propagate,
+  which is precisely the shape's purpose: the listener runs after the publisher committed, so there is no transaction
+  left to join. The rule now reads the listener's transaction phase rather than the two annotations in isolation. A
+  post-commit listener — `AFTER_COMMIT`, `AFTER_ROLLBACK` or `AFTER_COMPLETION` — is silent, recognised on the method
+  itself, through any composed annotation (a project's own meta-annotation is exempt too), and by name for
+  `@ApplicationModuleListener` in both its current `org.springframework.modulith.events` package and the Spring
+  Modulith 1.x one, so the exemption holds even where that annotation type cannot be resolved. What is not silenced is
+  the case that is genuinely broken: `@TransactionalEventListener(phase = BEFORE_COMMIT)` with `@Async` still reports,
+  now naming the phase, because there the publishing transaction is still open while the listener runs on another
+  thread. Plain `@Async` plus `@Transactional` is reported exactly as before. BootUI gains no Spring Modulith
+  dependency: the annotations are matched by name.
+  ([#926](https://github.com/jdubois/boot-ui/issues/926))
 - **Three advisor rules no longer report a Kotlin application for shapes its compiler produced.** Each read bytecode as
   if `javac` had written it, and each turned an ordinary Kotlin idiom into a finding nobody could act on.
   `ARCH-SPRING-004` reported a self-invocation for every call that omits a default argument: Kotlin routes such a call

--- a/bootui-engine/pom.xml
+++ b/bootui-engine/pom.xml
@@ -232,6 +232,22 @@
         </dependency>
 
         <!--
+          Test-scope only: ARCH-SPRING-019 must stay silent for Spring Modulith's @ApplicationModuleListener,
+          which composes @Async + @Transactional(REQUIRES_NEW) + @TransactionalEventListener. The fixture uses
+          the real annotation so the exemption is pinned against Modulith's own composition rather than a
+          hand-written imitation of it. The version is pinned directly (spring-boot-dependencies does not manage
+          Spring Modulith) but is otherwise inert: the fixture is only statically bytecode-scanned by ArchUnit,
+          never executed, and production code matches the annotation by name, so BootUI adds no Spring Modulith
+          dependency to a host application.
+        -->
+        <dependency>
+            <groupId>org.springframework.modulith</groupId>
+            <artifactId>spring-modulith-events-api</artifactId>
+            <version>2.1.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
           Test-scope only: JdbcActivityStoreTests exercises the plain-JDBC Live Activity persistence
           store against a real, disposable database rather than mocking java.sql.*. H2's version is
           managed by the imported spring-boot-dependencies BOM.

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRules.java
@@ -15,6 +15,7 @@ import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.domain.JavaConstructor;
 import com.tngtech.archunit.core.domain.JavaConstructorCall;
+import com.tngtech.archunit.core.domain.JavaEnumConstant;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaFieldAccess;
 import com.tngtech.archunit.core.domain.JavaMethod;
@@ -103,6 +104,11 @@ final class SpringStereotypes {
     static final String CACHING = "org.springframework.cache.annotation.Caching";
     static final String SCHEDULED = "org.springframework.scheduling.annotation.Scheduled";
     static final String EVENT_LISTENER = "org.springframework.context.event.EventListener";
+    static final String TRANSACTIONAL_EVENT_LISTENER =
+            "org.springframework.transaction.event.TransactionalEventListener";
+    static final String APPLICATION_MODULE_LISTENER = "org.springframework.modulith.events.ApplicationModuleListener";
+    // Spring Modulith 1.x carried the same annotation directly under org.springframework.modulith.
+    static final String LEGACY_APPLICATION_MODULE_LISTENER = "org.springframework.modulith.ApplicationModuleListener";
     static final String CONFIGURATION_PROPERTIES =
             "org.springframework.boot.context.properties.ConfigurationProperties";
     static final String BEAN = "org.springframework.context.annotation.Bean";
@@ -1713,8 +1719,21 @@ final class LifecycleCallbacksShouldNotBeProxyDrivenRule extends AbstractArchite
  * on the async worker thread, so the caller's transaction and security context do not propagate and
  * the returned {@code Future} completes outside the transaction boundary; the combination is usually
  * unintended.
+ *
+ * <p>A transactional event listener that runs after the publishing transaction completed is the
+ * exception: {@code @Async} plus {@code @Transactional(propagation = REQUIRES_NEW)} plus
+ * {@code @TransactionalEventListener} is exactly what Spring Modulith's
+ * {@code @ApplicationModuleListener} composes, and not joining the publisher's transaction is the
+ * point of that shape — by the time the listener runs there is no transaction left to join. Such
+ * methods are not reported. A {@code BEFORE_COMMIT} listener still is: there the publishing
+ * transaction is genuinely still open while the listener runs on another thread.</p>
  */
 final class AsyncAndTransactionalShouldNotBeCombinedRule extends AbstractArchitectureRule {
+
+    private static final String BEFORE_COMMIT_PHASE = "BEFORE_COMMIT";
+
+    // The default phase of @TransactionalEventListener, and the phase @ApplicationModuleListener fixes.
+    private static final String AFTER_COMMIT_PHASE = "AFTER_COMMIT";
 
     AsyncAndTransactionalShouldNotBeCombinedRule() {
         super(
@@ -1723,8 +1742,8 @@ final class AsyncAndTransactionalShouldNotBeCombinedRule extends AbstractArchite
                         "Async and transactional semantics on one method should be reviewed",
                         ArchitectureCategory.SPRING_STEREOTYPES,
                         "MEDIUM",
-                        "Detects methods annotated with both @Async and @Transactional. The transaction runs on the async worker thread, so the caller's transaction and security context do not propagate.",
-                        "Review the design: usually the transactional work belongs in a separate bean method that the @Async method calls, so the transaction is scoped correctly on the async thread.",
+                        "Detects methods annotated with both @Async and @Transactional. The transaction runs on the async worker thread, so the caller's transaction and security context do not propagate. Transactional event listeners that run after the publishing transaction completed are excluded, including Spring Modulith's @ApplicationModuleListener, because a separate transaction is the intended shape there; a BEFORE_COMMIT listener is still reported.",
+                        "Review the design: usually the transactional work belongs in a separate bean method that the @Async method calls, so the transaction is scoped correctly on the async thread. For an asynchronous BEFORE_COMMIT listener, move to the AFTER_COMMIT phase (or drop @Async) so the listener no longer runs beside the transaction it observes.",
                         "https://docs.spring.io/spring-framework/reference/data-access/transaction/declarative/annotations.html"));
     }
 
@@ -1735,18 +1754,69 @@ final class AsyncAndTransactionalShouldNotBeCombinedRule extends AbstractArchite
                     @Override
                     public void check(JavaClass javaClass, ConditionEvents events) {
                         for (JavaMethod method : ArchitectureRuleSupport.declaredMethods(javaClass)) {
-                            if (SpringStereotypes.ASYNC_ANNOTATED.test(method)
-                                    && SpringStereotypes.TRANSACTIONAL_ANNOTATED.test(method)) {
+                            if (!SpringStereotypes.ASYNC_ANNOTATED.test(method)
+                                    || !SpringStereotypes.TRANSACTIONAL_ANNOTATED.test(method)) {
+                                continue;
+                            }
+                            Optional<String> phase = transactionalEventListenerPhase(method);
+                            if (phase.isEmpty()) {
                                 events.add(
                                         SimpleConditionEvent.violated(
                                                 method,
                                                 "Method " + method.getFullName()
                                                         + " combines @Async and @Transactional; the transaction runs on the async thread and the caller's context does not propagate"));
+                            } else if (BEFORE_COMMIT_PHASE.equals(phase.get())) {
+                                events.add(
+                                        SimpleConditionEvent.violated(
+                                                method,
+                                                "Asynchronous transactional event listener " + method.getFullName()
+                                                        + " listens in the BEFORE_COMMIT phase; it runs on the async thread while the publishing transaction is still open, so its own transaction observes state that transaction has not committed"));
                             }
                         }
                     }
                 })
                 .as("Async and transactional semantics on one method should be reviewed");
+    }
+
+    /**
+     * Returns the transaction phase of the transactional event listener annotation on the method, or
+     * empty when the method is not a transactional event listener. The annotation is recognised both
+     * directly and through a composed annotation such as Spring Modulith's
+     * {@code @ApplicationModuleListener}, which is additionally matched by name so the exemption holds
+     * even when that annotation type cannot be resolved from the classpath.
+     */
+    private static Optional<String> transactionalEventListenerPhase(JavaMethod method) {
+        Optional<String> direct = method.tryGetAnnotationOfType(SpringStereotypes.TRANSACTIONAL_EVENT_LISTENER)
+                .map(AsyncAndTransactionalShouldNotBeCombinedRule::phaseOf);
+        if (direct.isPresent()) {
+            return direct;
+        }
+        for (JavaAnnotation<?> annotation : method.getAnnotations()) {
+            JavaClass annotationType = annotation.getRawType();
+            if (SpringStereotypes.APPLICATION_MODULE_LISTENER.equals(annotationType.getName())
+                    || SpringStereotypes.LEGACY_APPLICATION_MODULE_LISTENER.equals(annotationType.getName())) {
+                return Optional.of(AFTER_COMMIT_PHASE);
+            }
+            Optional<String> composed = annotationType
+                    .tryGetAnnotationOfType(SpringStereotypes.TRANSACTIONAL_EVENT_LISTENER)
+                    .map(AsyncAndTransactionalShouldNotBeCombinedRule::phaseOf);
+            if (composed.isPresent()) {
+                return composed;
+            }
+            if (annotationType.isMetaAnnotatedWith(SpringStereotypes.TRANSACTIONAL_EVENT_LISTENER)) {
+                return Optional.of(AFTER_COMMIT_PHASE);
+            }
+        }
+        return Optional.empty();
+    }
+
+    // An unset or unresolvable phase means the annotation's own default, AFTER_COMMIT.
+    private static String phaseOf(JavaAnnotation<?> annotation) {
+        Object phase = annotation.get("phase").orElse(null);
+        if (phase instanceof JavaEnumConstant enumConstant) {
+            return enumConstant.name();
+        }
+        return phase == null ? AFTER_COMMIT_PHASE : String.valueOf(phase);
     }
 }
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRulesTests.java
@@ -12,6 +12,10 @@ import jakarta.annotation.Resource;
 import jakarta.inject.Inject;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.PrintWriter;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
@@ -31,12 +35,16 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ServerWebExchange;
@@ -652,6 +660,31 @@ class ArchitectureRulesTests {
                 evaluate(new AsyncAndTransactionalShouldNotBeCombinedRule(), AsyncOnlyBean.class);
 
         assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void asyncAndTransactionalShouldNotBeCombinedPassesForPostCommitTransactionalEventListeners() {
+        // The @Async + @Transactional(REQUIRES_NEW) + @TransactionalEventListener triple, the real
+        // @ApplicationModuleListener it composes, and a hand-composed annotation meta-annotated with
+        // @TransactionalEventListener: in all three the publishing transaction has already committed, so a
+        // separate transaction on the async thread is the intended shape rather than a lost context.
+        ArchitectureRuleResultDto result = evaluate(
+                new AsyncAndTransactionalShouldNotBeCombinedRule(),
+                AsyncTransactionalEventListenerBean.class,
+                ApplicationModuleListenerBean.class,
+                ComposedTransactionalEventListenerBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.PASS);
+    }
+
+    @Test
+    void asyncAndTransactionalShouldNotBeCombinedFlagsBeforeCommitTransactionalEventListeners() {
+        ArchitectureRuleResultDto result =
+                evaluate(new AsyncAndTransactionalShouldNotBeCombinedRule(), BeforeCommitAsyncEventListenerBean.class);
+
+        assertThat(result.status()).isEqualTo(ArchitectureRuleSupport.VIOLATION);
+        assertThat(result.id()).isEqualTo("ARCH-SPRING-019");
+        assertThat(result.sampleViolations()).singleElement().asString().contains("BEFORE_COMMIT");
     }
 
     @Test
@@ -1409,6 +1442,46 @@ class ArchitectureRulesTests {
 
         @Async
         void doWork() {}
+    }
+
+    // The shape Spring Modulith's @ApplicationModuleListener composes, written out by hand.
+    private static class AsyncTransactionalEventListenerBean {
+
+        @Async
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        @TransactionalEventListener
+        void onSomethingHappened(String event) {}
+    }
+
+    private static class ApplicationModuleListenerBean {
+
+        // The composed annotation already implies both, but a redundant pair is written out here so the
+        // rule's direct-annotation detection fires and the exemption is what keeps the method silent.
+        @Async
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        @ApplicationModuleListener
+        void onSomethingHappened(String event) {}
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @TransactionalEventListener
+    private @interface AfterCommitListener {}
+
+    private static class ComposedTransactionalEventListenerBean {
+
+        @Async
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        @AfterCommitListener
+        void onSomethingHappened(String event) {}
+    }
+
+    private static class BeforeCommitAsyncEventListenerBean {
+
+        @Async
+        @Transactional(propagation = Propagation.REQUIRES_NEW)
+        @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+        void onSomethingHappened(String event) {}
     }
 
     private static class AsyncEventListenerBean {

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -562,6 +562,19 @@ Dismissed rules remove all of their instances from the score.
   not propagate.
 - **Recommendation**: review the design; usually the transactional work belongs in a separate bean method that the
   `@Async` method calls, so the transaction is scoped correctly on the async thread.
+- **Does not fire when**: the method is a transactional event listener that runs after the publishing transaction
+  completed — `@TransactionalEventListener` in its default `AFTER_COMMIT` phase, or in `AFTER_ROLLBACK` /
+  `AFTER_COMPLETION`. Spring Modulith's `@ApplicationModuleListener` is exactly that shape: it composes `@Async`,
+  `@Transactional(propagation = REQUIRES_NEW)` and `@TransactionalEventListener`, and the whole point is that the
+  listener does *not* join the publisher's transaction, which has already committed by the time the listener runs. The
+  listener annotation is recognised on the method itself and through a composed annotation, so a project's own
+  meta-annotation is exempt too, and `@ApplicationModuleListener` is additionally matched by name (both
+  `org.springframework.modulith.events` and the Spring Modulith 1.x `org.springframework.modulith` package) so the
+  exemption holds even when that annotation type cannot be resolved.
+- **Still fires for**: `@TransactionalEventListener(phase = BEFORE_COMMIT)` combined with `@Async`. There the publishing
+  transaction really is still open while the listener runs on another thread, so the listener's own transaction observes
+  state the publisher has not committed. The message names the phase; move the listener to `AFTER_COMMIT` or drop
+  `@Async`.
 
 ### ARCH-SPRING-020 - Async event listeners should return void
 


### PR DESCRIPTION
Closes #926.

## Problem

`ARCH-SPRING-019` fired on any method carrying both `@Async` and `@Transactional`. Spring Modulith's `@ApplicationModuleListener` composes exactly `@Async` + `@Transactional(propagation = REQUIRES_NEW)` + `@TransactionalEventListener`, so a Modulith application collected one MEDIUM finding per cross-module listener, telling it that the caller's transaction does not propagate — which is the point of that shape: the listener runs after the publishing transaction committed, so there is no transaction left to join.

## Change

The rule now reads the listener's transaction phase instead of judging the two annotations in isolation:

- **Silent** for a post-commit transactional event listener (`AFTER_COMMIT` — the default —, `AFTER_ROLLBACK`, `AFTER_COMPLETION`). The listener annotation is recognised on the method, through a composed annotation (so a project's own meta-annotation is exempt too), and by name for `@ApplicationModuleListener` in both `org.springframework.modulith.events` and the Spring Modulith 1.x `org.springframework.modulith` package, so the exemption holds even where that annotation type cannot be resolved.
- **Still reported** for `@TransactionalEventListener(phase = BEFORE_COMMIT)` combined with `@Async`, with a message naming the phase: there the publishing transaction really is still open while the listener runs on another thread.
- **Unchanged** for plain `@Async` + `@Transactional`.

Annotations are matched by name, so BootUI adds no Spring Modulith dependency to a host application. `spring-modulith-events-api` is pinned in **test scope only**, for a fixture that pins the exemption against Modulith's own composition rather than a hand-written imitation.

## Files

- `bootui-engine/.../architecture/ArchitectureRules.java` — phase-aware exemption, new stereotype constants, reworded description/recommendation (both surfaced in the Architecture panel and over MCP).
- `bootui-engine/src/test/.../ArchitectureRulesTests.java` — fixtures for the reported triple, a real `@ApplicationModuleListener`, a hand-composed meta-annotation, and the `BEFORE_COMMIT` true positive.
- `bootui-engine/pom.xml` — test-scoped, pinned `spring-modulith-events-api` with the usual "statically scanned, never executed" comment.
- `docs/ARCHITECTURE-CHECKS.md`, `CHANGELOG.md`.

## Validation

- `./mvnw -B -ntp -pl bootui-engine test` — 2384 tests, all green.
- Control run with the exemption disabled confirms the new PASS assertions are not vacuous (both fail without it).
- `./mvnw -B -ntp spotless:apply` / `spotless:check` — clean.

Engine-only change with no adapter, UI or contract surface, so no conformance or browser suite is required; the reworded rule text reaches Spring MVC, WebFlux and Quarkus identically.